### PR TITLE
[206] Add validation to record setup page

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -15,8 +15,12 @@ class TraineesController < ApplicationController
     if trainee_params[:record_type] == "other"
       redirect_to trainees_not_supported_route_path
     else
-      trainee = Trainee.create!(trainee_params)
-      redirect_to trainee_path(trainee)
+      @trainee = Trainee.new(trainee_params)
+      if @trainee.save
+        redirect_to trainee_path(@trainee)
+      else
+        render :new
+      end
     end
   end
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -1,4 +1,7 @@
 class Trainee < ApplicationRecord
+  validates :record_type, presence: { message: "You must select a route" }
+  validates :trainee_id, length: { maximum: 100, message: "Your entry must not exceed 100 characters" }
+
   enum record_type: { assessment_only: 0 }
   enum locale_code: { uk: 0, non_uk: 1 }
 

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -5,14 +5,15 @@
   ) %>
 <% end %>
 
-<h1 class="govuk-heading-l">
-  Add a trainee
-</h1>
-
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @trainee, local: true do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        Add a trainee
+      </h1>
 
       <%= f.govuk_radio_buttons_fieldset(:record_type, legend: { size: 's', text: "What type of route is this?", tag: 'span'} ) do %>
         <%= f.govuk_radio_button :record_type, :assessment_only, label: { text: "Assessment Only (AO)" }, link_errors: true %>

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -27,5 +27,39 @@ describe Trainee do
         expect { trainee.dttp_id = uuid }.to raise_error(LockedAttributeError)
       end
     end
+
+    describe "validation" do
+      context "when record type is present" do
+        subject { build(:trainee, record_type: "assessment_only") }
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+
+      context "when record type is not present" do
+        it "is not valid" do
+          expect(subject).not_to be_valid
+          expect(subject.errors.keys).to include(:record_type)
+        end
+      end
+
+      context "when trainee id is over 100 characters" do
+        subject { build(:trainee, trainee_id: SecureRandom.alphanumeric(101)) }
+
+        it "is not valid" do
+          expect(subject).not_to be_valid
+          expect(subject.errors.keys).to include(:trainee_id)
+        end
+      end
+
+      context "when trainee id is under 100 characters" do
+        subject { build(:trainee, trainee_id: SecureRandom.alphanumeric(99)) }
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
* https://trello.com/c/7cREOM2M/206-add-validation-to-record-setup-page

Validations for record set up page. This is branching off https://github.com/DFE-Digital/register-trainee-teacher-data/pull/61 

### Changes proposed in this pull request
Validations that render error messages for not selecting a route type or entering a trainee id over 100 characters long. Does not have validation for uniqueness as per ticket. 

### Guidance to review
Check review app 

<img width="855" alt="Screenshot 2020-10-08 at 18 26 07" src="https://user-images.githubusercontent.com/58793682/95493008-c717cb80-0993-11eb-8839-86d7c01d76a2.png">

