### PR TITLE
[193] Validations for personal details section

### DIFF
--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -1,8 +1,40 @@
 module Trainees
   class PersonalDetailsController < ApplicationController
+    before_action :build_nationalities, only: %w[edit update]
+
     def edit
-      @trainee = Trainee.find(params[:id])
+      @personal_details_form = PersonalDetailsForm.new(trainee: trainee)
+    end
+
+    def update
+      @personal_details_form = PersonalDetailsForm.new(trainee: trainee, params: personal_details_params)
+
+      if @personal_details_form.submit
+        redirect_to trainee_path(@personal_details_form.trainee)
+      else
+        render :edit
+      end
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.find(params[:trainee_id])
+    end
+
+    def build_nationalities
       @nationalities = Nationality.where(name: %w[british irish other])
+    end
+
+    def personal_details_params
+      params.require(:personal_details_form).permit(
+        :first_names,
+        :middle_names,
+        :last_name,
+        :date_of_birth,
+        :gender,
+        nationality_ids: [],
+      )
     end
   end
 end

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -1,17 +1,19 @@
 module Trainees
   class PersonalDetailsController < ApplicationController
     def edit
+      trainee
       nationalities
-      @personal_details_form = PersonalDetailsForm.new(trainee: trainee)
+      @personal_detail = PersonalDetail.new(trainee: trainee)
     end
 
     def update
       nationalities
-      @personal_details_form = PersonalDetailsForm.new(trainee: trainee, params: personal_details_params)
+      updater = PersonalDetails::Update.call(trainee: trainee, attributes: personal_details_params)
 
-      if @personal_details_form.submit
-        redirect_to trainee_path(@personal_details_form.trainee)
+      if updater.successful?
+        redirect_to trainee_path(updater.personal_detail.trainee)
       else
+        @personal_detail = updater.personal_detail
         render :edit
       end
     end
@@ -27,12 +29,8 @@ module Trainees
     end
 
     def personal_details_params
-      params.require(:personal_details_form).permit(
-        :first_names,
-        :middle_names,
-        :last_name,
-        :date_of_birth,
-        :gender,
+      params.require(:personal_detail).permit(
+        *PersonalDetail::FIELDS,
         nationality_ids: [],
       )
     end

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -1,12 +1,12 @@
 module Trainees
   class PersonalDetailsController < ApplicationController
-    before_action :build_nationalities, only: %w[edit update]
-
     def edit
+      nationalities
       @personal_details_form = PersonalDetailsForm.new(trainee: trainee)
     end
 
     def update
+      nationalities
       @personal_details_form = PersonalDetailsForm.new(trainee: trainee, params: personal_details_params)
 
       if @personal_details_form.submit
@@ -22,8 +22,8 @@ module Trainees
       @trainee ||= Trainee.find(params[:trainee_id])
     end
 
-    def build_nationalities
-      @nationalities = Nationality.where(name: %w[british irish other])
+    def nationalities
+      @nationalities ||= Nationality.where(name: %w[british irish other])
     end
 
     def personal_details_params

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -1,0 +1,46 @@
+class PersonalDetailsForm
+  include ActiveModel::Model
+  attr_accessor :trainee
+
+  PERSONAL_DETAIL_FIELDS = %w[
+    first_names
+    middle_names
+    last_name
+    date_of_birth
+    gender
+    nationality_ids
+  ].freeze
+
+  delegate :id, :persisted?, to: :trainee
+
+  attr_accessor(*PERSONAL_DETAIL_FIELDS)
+
+  validates :first_names, presence: true
+  validates :last_name, presence: true
+  validates :date_of_birth, presence: true
+  validates :gender, presence: true
+  validate :nationalities_cannot_be_empty
+
+  def initialize(trainee:, params: {})
+    @trainee = trainee
+    trainee.assign_attributes(params)
+    super(trainee.attributes.slice(*PERSONAL_DETAIL_FIELDS).merge(nationality_ids: trainee.nationality_ids))
+  end
+
+  def submit
+    return false unless valid?
+
+    trainee.save!
+  end
+
+private
+
+  def nationalities_cannot_be_empty
+    return unless trainee.nationalities.empty?
+
+    errors.add(
+      :nationality_ids,
+      I18n.t("activerecord.validations.trainee.nationalities.empty"),
+    )
+  end
+end

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -40,7 +40,7 @@ private
 
     errors.add(
       :nationality_ids,
-      I18n.t("activerecord.validations.trainee.nationalities.empty"),
+      :empty_nationalities,
     )
   end
 end

--- a/app/models/personal_detail.rb
+++ b/app/models/personal_detail.rb
@@ -1,8 +1,8 @@
-class PersonalDetailsForm
+class PersonalDetail
   include ActiveModel::Model
   attr_accessor :trainee
 
-  PERSONAL_DETAIL_FIELDS = %w[
+  FIELDS = %w[
     first_names
     middle_names
     last_name
@@ -13,7 +13,7 @@ class PersonalDetailsForm
 
   delegate :id, :persisted?, to: :trainee
 
-  attr_accessor(*PERSONAL_DETAIL_FIELDS)
+  attr_accessor(*FIELDS)
 
   validates :first_names, presence: true
   validates :last_name, presence: true
@@ -21,16 +21,9 @@ class PersonalDetailsForm
   validates :gender, presence: true
   validate :nationalities_cannot_be_empty
 
-  def initialize(trainee:, params: {})
+  def initialize(trainee:)
     @trainee = trainee
-    trainee.assign_attributes(params)
-    super(trainee.attributes.slice(*PERSONAL_DETAIL_FIELDS).merge(nationality_ids: trainee.nationality_ids))
-  end
-
-  def submit
-    return false unless valid?
-
-    trainee.save!
+    super(trainee.attributes.slice(*FIELDS).merge(nationality_ids: trainee.nationality_ids))
   end
 
 private

--- a/app/services/personal_details/update.rb
+++ b/app/services/personal_details/update.rb
@@ -1,0 +1,24 @@
+module PersonalDetails
+  class Update
+    attr_reader :trainee, :personal_detail, :successful
+
+    alias_method :successful?, :successful
+
+    class << self
+      def call(**args)
+        new(**args).call
+      end
+    end
+
+    def initialize(trainee:, attributes: {})
+      @trainee = trainee
+      trainee.assign_attributes(attributes)
+      @personal_detail = PersonalDetail.new(trainee: trainee)
+    end
+
+    def call
+      @successful = personal_detail.valid? && trainee.save!
+      self
+    end
+  end
+end

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -5,12 +5,12 @@
   ) %>
 <% end %>
 
-<h1 class="govuk-heading-l">Trainee personal details</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_for(@personal_detail, url: trainee_personal_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">Trainee personal details</h1>
       
       <%= f.govuk_text_field :first_names, label: { text: 'First names', size: 's' }, hint: { text: 'Or given names' }, width: 'three-quarters' %>
 

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: 'Back',
-    href: trainee_path(@personal_details_form.trainee)
+    href: trainee_path(@trainee)
   ) %>
 <% end %>
 
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_for(@personal_details_form, url: trainee_personal_details_path(@personal_details_form.trainee), method: :put, local: true) do |f| %>
+    <%= form_for(@personal_detail, url: trainee_personal_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
       
       <%= f.govuk_text_field :first_names, label: { text: 'First names', size: 's' }, hint: { text: 'Or given names' }, width: 'three-quarters' %>
@@ -37,4 +37,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Cancel", trainee_path(@personal_details_form.trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to("Cancel", trainee_path(@trainee)) %></p>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -10,6 +10,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_for(@personal_details_form, url: trainee_personal_details_path(@personal_details_form.trainee), method: :put, local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+      
       <%= f.govuk_text_field :first_names, label: { text: 'First names', size: 's' }, hint: { text: 'Or given names' }, width: 'three-quarters' %>
 
       <%= f.govuk_text_field :middle_names, label: { text: 'Middle names', size: 's' }, width: 'three-quarters' %>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: 'Back',
-    href: trainee_path(@trainee)
+    href: trainee_path(@personal_details_form.trainee)
   ) %>
 <% end %>
 
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @trainee, local: true do |f| %>
+    <%= form_for(@personal_details_form, url: trainee_personal_details_path(@personal_details_form.trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_text_field :first_names, label: { text: 'First names', size: 's' }, hint: { text: 'Or given names' }, width: 'three-quarters' %>
 
       <%= f.govuk_text_field :middle_names, label: { text: 'Middle names', size: 's' }, width: 'three-quarters' %>
@@ -35,4 +35,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Cancel", trainee_path(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to("Cancel", trainee_path(@personal_details_form.trainee)) %></p>

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -27,7 +27,7 @@
       component.slot(
         :row,
         task_name: 'Personal details',
-        path: personal_details_trainee_path(@trainee),
+        path: edit_trainee_personal_details_path(@trainee),
         status: 'completed'
       )
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,10 +14,20 @@ en:
     attributes:
       trainee:
         trainee_id: "Trainee ID"
-    validations:
-      trainee:
-        nationalities:
-          empty: Please select at least one nationality
-          format: Please enter your date of birth in the correct format
+  activemodel:
+    errors:
+      models:
+        personal_details_form:
+          attributes:
+            first_names:
+              blank: "You must enter a first name"
+            last_name:
+              blank: "You must enter a last name"
+            date_of_birth:
+              blank: "You must enter a date of birth"
+            gender:
+              blank: "You must select a gennder"
+            nationality_ids:
+              empty_nationalities: You must select at least one nationality
   page_headings:
     start_page: "Register trainee teachers"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,5 +14,10 @@ en:
     attributes:
       trainee:
         trainee_id: "Trainee ID"
+    validations:
+      trainee:
+        nationalities:
+          empty: Please select at least one nationality
+          format: Please enter your date of birth in the correct format
   page_headings:
     start_page: "Register trainee teachers"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,7 @@ en:
   activemodel:
     errors:
       models:
-        personal_details_form:
+        personal_detail:
           attributes:
             first_names:
               blank: "You must enter a first name"
@@ -26,7 +26,7 @@ en:
             date_of_birth:
               blank: "You must enter a date of birth"
             gender:
-              blank: "You must select a gennder"
+              blank: "You must select a gender"
             nationality_ids:
               empty_nationalities: You must select at least one nationality
   page_headings:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,10 +17,11 @@ Rails.application.routes.draw do
   resources :trainees, only: %i[index show new create update] do
     scope module: :trainees do
       resource :contact_details, only: %i[edit update], path: "/contact-details"
+      resource :personal_details, only: %i[edit update], path: "/personal-details"
     end
 
     member do
-      get "personal-details", to: "trainees/personal_details#edit"
+      get "previous-education", to: "trainees/previous_education#edit"
       get "training-details", to: "trainees/training_details#edit"
       get "course-details", to: "trainees/course_details#edit"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,6 @@ Rails.application.routes.draw do
     end
 
     member do
-      get "previous-education", to: "trainees/previous_education#edit"
       get "training-details", to: "trainees/training_details#edit"
       get "course-details", to: "trainees/course_details#edit"
     end

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -55,6 +55,10 @@ feature "edit personal details", type: :feature do
   end
 
   def then_i_see_error_messages
-    expect(page).to have_content(I18n.t("activerecord.validations.trainee.nationalities.empty"))
+    expect(page).to have_content(
+      I18n.t(
+        "activemodel.errors.models.personal_details_form.attributes.nationality_ids.empty_nationalities",
+      ),
+    )
   end
 end

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -6,8 +6,17 @@ feature "edit personal details", type: :feature do
     and_nationalities_exist_in_the_system
     when_i_visit_the_personal_details_page
     and_i_enter_valid_parameters
+    and_i_submit_the_form
     then_i_am_redirected_to_the_summary_page
     and_the_personal_details_are_updated
+  end
+
+  scenario "edit with invalid parameters" do
+    given_a_trainee_exists
+    and_nationalities_exist_in_the_system
+    when_i_visit_the_personal_details_page
+    and_i_submit_the_form
+    then_i_see_error_messages
   end
 
   def given_a_trainee_exists
@@ -29,6 +38,9 @@ feature "edit personal details", type: :feature do
     @personal_details_page.set_date_fields("dob", "01/01/1986")
     @personal_details_page.gender.choose("Male")
     @personal_details_page.nationality.check(@nationality.name.titleize)
+  end
+
+  def and_i_submit_the_form
     @personal_details_page.submit_button.click
   end
 
@@ -40,5 +52,9 @@ feature "edit personal details", type: :feature do
   def and_the_personal_details_are_updated
     when_i_visit_the_personal_details_page
     expect(@personal_details_page.first_names.value).to eq("Tim")
+  end
+
+  def then_i_see_error_messages
+    expect(page).to have_content(I18n.t("activerecord.validations.trainee.nationalities.empty"))
   end
 end

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -57,7 +57,7 @@ feature "edit personal details", type: :feature do
   def then_i_see_error_messages
     expect(page).to have_content(
       I18n.t(
-        "activemodel.errors.models.personal_details_form.attributes.nationality_ids.empty_nationalities",
+        "activemodel.errors.models.personal_detail.attributes.nationality_ids.empty_nationalities",
       ),
     )
   end

--- a/spec/models/personal_detail_spec.rb
+++ b/spec/models/personal_detail_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe PersonalDetail do
+  let(:trainee) { build(:trainee) }
+
+  subject { described_class.new(trainee: trainee) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:first_names) }
+    it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:date_of_birth) }
+    it { is_expected.to validate_presence_of(:gender) }
+
+    context "nationalities" do
+      before do
+        subject.valid?
+      end
+
+      it "returns an error if its empty" do
+        expect(subject.errors[:nationality_ids]).to include(
+          I18n.t(
+            "activemodel.errors.models.personal_detail.attributes.nationality_ids.empty_nationalities",
+          ),
+        )
+      end
+    end
+  end
+end

--- a/spec/services/personal_details/update_spec.rb
+++ b/spec/services/personal_details/update_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+module PersonalDetails
+  describe Update do
+    describe ".call" do
+      let(:trainee) { create(:trainee, nationalities: [create(:nationality)] ) }
+      let(:service) { described_class.new(trainee: trainee, attributes: attributes) }
+
+      context "when personal details are valid" do
+        let(:attributes) { { first_names: "Jon" } }
+
+        before do
+          service.call
+          trainee.reload
+        end
+
+        it "updates the trainee's personal details" do
+          expect(trainee.first_names).to eq(attributes[:first_names])
+        end
+
+        it "is successful" do
+          expect(service).to be_successful
+        end
+      end
+
+      context "when personal details are invalid" do
+        let(:attributes) { { first_names: nil } }
+
+        before do
+          service.call
+          trainee.reload
+        end
+
+        it "does not update the trainee's personal details" do
+          expect(trainee.first_names).to_not eq(attributes[:first_names])
+        end
+
+        it "is unsuccessful" do
+          expect(service).to_not be_successful
+        end
+      end
+    end
+  end
+end

--- a/spec/services/personal_details/update_spec.rb
+++ b/spec/services/personal_details/update_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module PersonalDetails
   describe Update do
     describe ".call" do
-      let(:trainee) { create(:trainee, nationalities: [create(:nationality)] ) }
+      let(:trainee) { create(:trainee, nationalities: [create(:nationality)]) }
       let(:service) { described_class.new(trainee: trainee, attributes: attributes) }
 
       context "when personal details are valid" do

--- a/spec/support/page_objects/trainees/personal_details.rb
+++ b/spec/support/page_objects/trainees/personal_details.rb
@@ -4,11 +4,11 @@ module PageObjects
       include PageObjects::Helpers
 
       set_url "/trainees/{id}/personal-details/edit"
-      element :first_names, "input[name='personal_details_form[first_names]']"
-      element :last_name, "input[name='personal_details_form[last_name]']"
-      element :dob_day, "input[name='personal_details_form[date_of_birth(3i)]']"
-      element :dob_month, "input[name='personal_details_form[date_of_birth(2i)]']"
-      element :dob_year, "input[name='personal_details_form[date_of_birth(1i)]']"
+      element :first_names, "#personal-detail-first-names-field"
+      element :last_name, "#personal-detail-last-name-field"
+      element :dob_day, "#personal_detail_date_of_birth_3i"
+      element :dob_month, "#personal_detail_date_of_birth_2i"
+      element :dob_year, "#personal_detail_date_of_birth_1i"
       element :gender, ".govuk-radios.gender"
       element :nationality, ".govuk-checkboxes.nationality"
       element :submit_button, "input[name='commit']"

--- a/spec/support/page_objects/trainees/personal_details.rb
+++ b/spec/support/page_objects/trainees/personal_details.rb
@@ -3,12 +3,12 @@ module PageObjects
     class PersonalDetails < PageObjects::Base
       include PageObjects::Helpers
 
-      set_url "/trainees/{id}/personal-details"
-      element :first_names, "#trainee-first-names-field"
-      element :last_name, "#trainee-last-name-field"
-      element :dob_day, "#trainee_date_of_birth_3i"
-      element :dob_month, "#trainee_date_of_birth_2i"
-      element :dob_year, "#trainee_date_of_birth_1i"
+      set_url "/trainees/{id}/personal-details/edit"
+      element :first_names, "input[name='personal_details_form[first_names]']"
+      element :last_name, "input[name='personal_details_form[last_name]']"
+      element :dob_day, "input[name='personal_details_form[date_of_birth(3i)]']"
+      element :dob_month, "input[name='personal_details_form[date_of_birth(2i)]']"
+      element :dob_year, "input[name='personal_details_form[date_of_birth(1i)]']"
       element :gender, ".govuk-radios.gender"
       element :nationality, ".govuk-checkboxes.nationality"
       element :submit_button, "input[name='commit']"


### PR DESCRIPTION
### Context

- https://trello.com/c/vtzaPbHw/193-spike-validations-for-trainee-sections

### Changes proposed in this pull request

<img width="992" alt="Screenshot 2020-10-09 at 15 49 58" src="https://user-images.githubusercontent.com/616080/95597914-2b479780-0a47-11eb-9b17-bf62a465499a.png">

- Refactor the personal detail routes
- Handle personal detail editing in its own controller (treat it as a separate resource)
- Introduce an `ActiveModel` object to validate personal detail fields in isolation to other sections

### Guidance to review

- Visit the review app https://dfe-twd-rttd-pr-64.herokuapp.com/
- Skip filling out trainee details initially
- Navigate to the personal details section and try to continue without filling out any details
- Assert validations are triggered

Depends on https://github.com/DFE-Digital/register-trainee-teacher-data/pull/60