### PR TITLE
[245] SPIKE Adding Autocomplete select fields

### DIFF
--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -3,7 +3,7 @@ import accessibleAutocomplete from 'accessible-autocomplete'
 import { nodeListForEach } from 'govuk-frontend/govuk/common'
 
 const $allAutocompleteElements = document.querySelectorAll('[data-module="app-autocomplete"]')
-const showAllValuesOption = component =>  Boolean(component.getAttribute('data-show-all-values'))
+const showAllValuesOption = component => Boolean(component.getAttribute('data-show-all-values'))
 const defaultValueOption = component => component.getAttribute('data-default-value') || ''
 
 const setupAutoComplete = (component) => {

--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -1,0 +1,17 @@
+import './style.scss'
+import accessibleAutocomplete from 'accessible-autocomplete'
+import { nodeListForEach } from 'govuk-frontend/govuk/common'
+
+const $allAutocompleteElements = document.querySelectorAll('[data-module="app-autocomplete"]')
+const showAllValuesOption = component => (component.getAttribute('data-show-all-values') && 'true') === 'true'
+const defaultValueOption = component => component.getAttribute('data-default-value') || ''
+
+const setupAutoComplete = (component) => {
+  accessibleAutocomplete.enhanceSelectElement({
+    defaultValue: defaultValueOption(component),
+    selectElement: component.querySelector('select'),
+    showAllValues: showAllValuesOption(component)
+  })
+}
+
+nodeListForEach($allAutocompleteElements, setupAutoComplete)

--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -3,7 +3,7 @@ import accessibleAutocomplete from 'accessible-autocomplete'
 import { nodeListForEach } from 'govuk-frontend/govuk/common'
 
 const $allAutocompleteElements = document.querySelectorAll('[data-module="app-autocomplete"]')
-const showAllValuesOption = component => (component.getAttribute('data-show-all-values') && 'true') === 'true'
+const showAllValuesOption = component =>  Boolean(component.getAttribute('data-show-all-values'))
 const defaultValueOption = component => component.getAttribute('data-default-value') || ''
 
 const setupAutoComplete = (component) => {

--- a/app/components/form_components/autocomplete/style.scss
+++ b/app/components/form_components/autocomplete/style.scss
@@ -1,0 +1,145 @@
+@import "../../base.scss";
+//@import "~accessible-autocomplete";
+
+
+
+.autocomplete__wrapper {
+  @include govuk-typography-common();
+  position: relative;
+}
+
+.autocomplete__hint,
+.autocomplete__input {
+  -webkit-appearance: none;
+  border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+  border-radius: 0;
+  box-sizing: border-box;
+  margin-bottom: 0;
+  width: 100%;
+}
+
+.autocomplete__input {
+  background-color: transparent;
+  padding: govuk-spacing(1);
+  position: relative;
+}
+
+.autocomplete__hint {
+  color: govuk-colour("mid-grey");
+  position: absolute;
+}
+
+.autocomplete__input--focused {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+
+  @include govuk-if-ie8 {
+    border-width: $govuk-border-width-form-element * 2;
+  }
+}
+
+.autocomplete__input--show-all-values {
+  padding-right: (govuk-spacing(1) + 24px + govuk-spacing(2));
+  cursor: pointer;
+}
+
+.autocomplete__dropdown-arrow-down {
+  display: inline-block;
+  height: 24px;
+  position: absolute;
+  right: govuk-spacing(2);
+  top: govuk-spacing(2);
+  width: 24px;
+  pointer-events: none; // https://github.com/alphagov/accessible-autocomplete/issues/202
+}
+
+.autocomplete__menu {
+  background-color: govuk-colour("white");
+  border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+  border-top: 0;
+  color: $govuk-text-colour;
+  margin: 0;
+  max-height: 342px;
+  overflow-x: hidden;
+  padding: 0;
+  width: 100%;
+  width: calc(100% - #{govuk-spacing(1)});
+}
+
+.autocomplete__menu--visible {
+  display: block;
+}
+
+.autocomplete__menu--hidden {
+  display: none;
+}
+
+.autocomplete__menu--overlay {
+  box-shadow: rgba(0,0,0,.256863) 0 2px 6px;
+  left: 0;
+  position: absolute;
+  top: 100%;
+  z-index: 100;
+}
+
+.autocomplete__menu--inline {
+  position: relative;
+}
+
+.autocomplete__option {
+  border-bottom: solid govuk-colour("mid-grey");
+  border-width: 1px 0;
+  cursor: pointer;
+  display: block;
+  position: relative;
+}
+
+.autocomplete__option > * {
+  pointer-events: none;
+}
+
+.autocomplete__option:first-of-type {
+  border-top-width: 0;
+}
+
+.autocomplete__option:last-of-type {
+  border-bottom-width: 0;
+}
+
+.autocomplete__option--odd {
+  background-color: govuk-colour("light-grey");
+}
+
+.autocomplete__option--hint {
+  color: $govuk-secondary-text-colour;
+}
+
+.autocomplete__option--focused,
+.autocomplete__option:hover {
+  background-color: govuk-colour("blue");
+  border-color: govuk-colour("blue");
+  color: govuk-colour("white");
+  outline: 0;
+
+  .autocomplete__option--hint {
+    color: govuk-colour("white");
+  }
+}
+
+.autocomplete__option--no-results {
+  background-color: govuk-colour("light-grey");
+  color: govuk-colour("dark-grey");
+  cursor: not-allowed;
+}
+
+.autocomplete__hint,
+.autocomplete__input,
+.autocomplete__option {
+  @include govuk-font(19);
+}
+
+.autocomplete__hint,
+.autocomplete__option {
+  padding: govuk-spacing(1);
+}

--- a/app/components/form_components/autocomplete/style.scss
+++ b/app/components/form_components/autocomplete/style.scss
@@ -1,7 +1,4 @@
 @import "../../base.scss";
-//@import "~accessible-autocomplete";
-
-
 
 .autocomplete__wrapper {
   @include govuk-typography-common();

--- a/app/components/form_components/autocomplete/view.html.erb
+++ b/app/components/form_components/autocomplete/view.html.erb
@@ -1,0 +1,3 @@
+<%= tag.div(class: classes, **html_attributes) do %>
+  <%= form_field.html_safe %>
+<% end %>

--- a/app/components/form_components/autocomplete/view.rb
+++ b/app/components/form_components/autocomplete/view.rb
@@ -1,0 +1,24 @@
+module FormComponents
+  module Autocomplete
+    class View < GovukComponent::Base
+      attr_accessor :form_field
+
+      def initialize(form_field:, classes: [], html_attributes: {})
+        super(classes: classes, html_attributes: default_html_attributes.merge(html_attributes))
+        @form_field = form_field
+      end
+
+    private
+
+      def default_classes
+        %w[]
+      end
+
+      def default_html_attributes
+        {
+          "data-module" => "app-autocomplete",
+        }
+      end
+    end
+  end
+end

--- a/app/views/trainees/degrees/_non_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_non_uk_degree_form.html.erb
@@ -1,29 +1,40 @@
 <%= form_with model: [ @trainee, @degree ], local: true do |f| %>
-  <%= f.hidden_field :locale_code, value: "non_uk" %>     
+  <%= f.hidden_field :locale_code, value: "non_uk" %>
   <%= f.govuk_error_summary %>
-  <h2 class="govuk-heading-l">Non-UK Degree Details</h2>
 
-    <%= f.govuk_collection_select :country, degree_countries_options, :name,
-        :name, label: { text: "Country where the degree was obtained", size: 's' } %>
+  <h1 class="govuk-heading-l">Non-UK Degree Details</h1>
 
-    <div class="govuk-form-group">
-			<%= f.govuk_radio_buttons_fieldset :non_uk_degree, legend: { text: "Select the NARIC comparable UK degree", size: 's'} do %>
-				<% NARIC_NON_UK.each do |name| %>
-					<%= f.govuk_radio_button :non_uk_degree, name,
-																		label: { text: name }, link_errors: true %>
-				<% end %>
-				<%= f.govuk_radio_divider %>
-				<%= f.govuk_radio_button :non_uk_degree, :non_naric, label: { text: "NARIC not provided"} %>
-			<% end %>
-    </div>
+  <%= render_component FormComponents::Autocomplete::View.new(
+    form_field: f.govuk_collection_select(:country, degree_countries_options, :name,
+                                          :name, label: { text: "Country where the degree was obtained", size: 's' }),
+    html_attributes: {
+      "data-show-all-values" => false,
+    }
+  ) %>
 
-    <%= f.govuk_collection_select :degree_subject, degree_subjects_options, 
-					:name, :name, label: { text: 'Degree subject', size: 's' },
-					hint: { text: 'Search for the closest matching subject' } %>
-			
-    <%= f.govuk_text_field :graduation_year, 
-					label: { text: "Graduation Year", size: 's' }, 
-					width: "one-quarter"  %>
+  <div class="govuk-form-group">
+    <%= f.govuk_radio_buttons_fieldset :non_uk_degree, legend: { text: "Select the NARIC comparable UK degree", size: 's'} do %>
+      <% NARIC_NON_UK.each do |name| %>
+        <%= f.govuk_radio_button :non_uk_degree, name,
+                                  label: { text: name }, link_errors: true %>
+      <% end %>
+      <%= f.govuk_radio_divider %>
+      <%= f.govuk_radio_button :non_uk_degree, :non_naric, label: { text: "NARIC not provided"} %>
+    <% end %>
+  </div>
+
+  <%= render_component FormComponents::Autocomplete::View.new(
+    form_field: f.govuk_collection_select(:degree_subject, degree_subjects_options,
+                                          :name, :name, label: { text: 'Degree subject', size: 's' },
+                                          hint: { text: 'Search for the closest matching subject' }),
+    html_attributes: {
+      "data-show-all-values" => false,
+    }
+  ) %>
+
+  <%= f.govuk_text_field :graduation_year,
+        label: { text: "Graduation Year", size: 's' },
+        width: "one-quarter"  %>
 
 	<%= f.govuk_submit %>
 <% end %>

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -3,34 +3,50 @@
   <h2 class="govuk-heading-l">UK Degree Details</h2>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_collection_select(:uk_degree, hesa_degree_types_options, :name,
-        :name, label: { text: "Enter degree type", size: 's'},
-        hint: { text: "For example, BA, BSc or other (please specify)" } ) %>
-    
-  <%= f.govuk_collection_select :degree_subject, degree_subjects_options, 
-        :name, :name, label: { text: 'Degree subject', size: 's' },
-        hint: { text: 'Search for the closest matching subject' } %>
+  <%= render_component FormComponents::Autocomplete::View.new(
+    form_field: f.govuk_collection_select(:uk_degree, hesa_degree_types_options, :name,
+                                          :name, label: { text: "Enter degree type", size: 's'},
+                                          hint: { text: "For example, BA, BSc or other (please specify)" } ),
+    html_attributes: {
+      "data-show-all-values"=> true,
+    }
+  ) %>
 
-  <%= f.govuk_collection_select :institution, institutions_options, :name, 
-        :name, label: { text: "Institution", size: 's' } %>
+  <%= render_component FormComponents::Autocomplete::View.new(
+    form_field: f.govuk_collection_select(:degree_subject, degree_subjects_options,
+                                          :name, :name, label: { text: 'Degree subject', size: 's' },
+                                          hint: { text: 'Search for the closest matching subject' }),
+    html_attributes: {
+      "data-show-all-values" => true,
+    }
+  )%>
 
-  <%= f.govuk_text_field :graduation_year, 
-        label: { text: "Graduation Year", size: 's' }, 
+  <%= render_component FormComponents::Autocomplete::View.new(
+    form_field: f.govuk_collection_select(:institution, institutions_options, :name,
+                                          :name, label: { text: "Institution", size: 's' },
+                                          ),
+    html_attributes: {
+      "data-show-all-values" => true,
+    }
+  ) %>
+
+  <%= f.govuk_text_field :graduation_year,
+        label: { text: "Graduation Year", size: 's' },
         width: "one-quarter"  %>
 
-  <%= f.govuk_radio_buttons_fieldset(:degree_grade, 
-        legend: { text: "Degree grade", size: 's' }, 
+  <%= f.govuk_radio_buttons_fieldset(:degree_grade,
+        legend: { text: "Degree grade", size: 's' },
         classes: "degree-grade" ) do %>
 
     <% DEGREE_GRADES.map do |name| %>
       <%= f.govuk_radio_button :degree_grade, name, label: { text: name }, link_errors: true %>
     <% end %>
     <%= f.govuk_radio_divider %>
-    <%= f.govuk_radio_button :degree_grade, :still_studying, 
+    <%= f.govuk_radio_button :degree_grade, :still_studying,
           label: { text: "The trainee is still studying for their degree"} %>
   <% end %>
   <%= f.govuk_submit %>
 <% end %>
-  
 
-   
+
+

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@rails/webpacker": "^5.2.1",
+    "accessible-autocomplete": "^2.0.3",
     "core-js": "^3.6.5",
     "govuk-frontend": "^3.9.1",
     "rails-ujs": "^5.2.4",

--- a/spec/components/form_components/autocomplete/view_preview.rb
+++ b/spec/components/form_components/autocomplete/view_preview.rb
@@ -1,0 +1,41 @@
+module FormComponents
+  module Autocomplete
+    class ViewPreview < ViewComponent::Preview
+      def enhancing_select_list
+        render_component(FormComponents::Autocomplete::View.new(form_field: setup_form))
+      end
+
+      def with_custom_class
+        render_component(FormComponents::Autocomplete::View.new(form_field: setup_form, classes: "app-testing-class"))
+      end
+
+      def with_custom_html_attributes
+        render_component(FormComponents::Autocomplete::View.new(form_field: setup_form, html_attributes: { "test-html-attribute" => "testing" }))
+      end
+
+      def with_show_all_values
+        render_component(FormComponents::Autocomplete::View.new(form_field: setup_form, html_attributes: { "data-show-all-values" => true }))
+      end
+
+      def with_default_value
+        render_component(FormComponents::Autocomplete::View.new(form_field: setup_form, html_attributes: { "data-default-value" => "France" }))
+      end
+
+    private
+
+      def setup_form
+        '<div class="govuk-form-group">
+          <label class="govuk-label" for="select-1">
+            Select a country
+          </label>
+          <select class="govuk-select" id="select-1" name="select-1">
+            <option value="">Select a country</option>
+            <option value="fr">France</option>
+            <option value="de">Germany</option>
+            <option value="gb">United Kingdom</option>
+          </select>
+        </div>'
+      end
+    end
+  end
+end

--- a/spec/components/form_components/autocomplete/view_spec.rb
+++ b/spec/components/form_components/autocomplete/view_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+module FormComponents
+  module Autocomplete
+    describe View do
+      alias_method :component, :page
+
+      it "supports custom classes on the parent container" do
+        render_inline(View.new(form_field: setup_form, classes: "test-css-class"))
+        expect(component).to have_selector(".test-css-class")
+      end
+
+      it "supports custom html attributes on the parent container" do
+        render_inline(View.new(form_field: setup_form, html_attributes: { "test-attribute" => "my-custom-attribute" }))
+        expect(component).to have_selector('[test-attribute="my-custom-attribute"]')
+      end
+
+    private
+
+      def setup_form
+        '<div class="govuk-form-group">
+          <label class="govuk-label" for="select-1">
+            Select a country
+          </label>
+          <select class="govuk-select" id="select-1" name="select-1">
+            <option value="">Select a country</option>
+            <option value="fr">France</option>
+            <option value="de">Germany</option>
+            <option value="gb">United Kingdom</option>
+          </select>
+        </div>'
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,6 +1166,13 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+accessible-autocomplete@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.3.tgz#3ed8d529b227b77e99ab509eec5d2c8d1b8bea8b"
+  integrity sha512-bUswBs/mDH17dUFRAJMTtcGafJ++w1YLPPFjdfJj3lnuBsLpByAw2gmr8qxXX8oc7tzoKS3Ay5FKOPM+WMBxIw==
+  dependencies:
+    preact "^8.3.1"
+
 acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
@@ -6438,6 +6445,11 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+preact@^8.3.1:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
+  integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
### Context
The idea with this component is that it would be used within a form.
Instead of the component trying to build out the select list and include
all the styling for the default select list, it was decided that it's best
to pass in a string of html. A div is wrapped around the passed in html
string and returned to the view.

Any autocomplete config options you would like to apply to the component
can be added by using the `classes` or `html_attributes` parameters.

`classes` takes a string that would be added to the parent div container.

`html_attributes` takes a hash which gets added to the parent div container

At the moment the only autocomplete options supported are:
- defaultValue
- showAllValues

It should be easy to add extra autocomplete options by adding the
option lookup to script.js and adding it to the autocomplete init
function call in script.js

No JS tests have been included in this spike because we need to setup
Jest and configure it to use webpacker because running the js unit tests.
This will be added in the future but in the meantime, the component can
be manually tested using the preview components.


### Changes proposed in this pull request

### Guidance to review

- Try out the view component example found here https://dfe-twd-rttd-pr-94.herokuapp.com/view_components/form_components/autocomplete/view
- Try creating a new trainee and add some degrees and you should see the autocomplete component being used on those pages.
