### PR TITLE
[xxx] Fix error summary link focus

### DIFF
--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -11,7 +11,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">Trainee personal details</h1>
-      
+
       <%= f.govuk_text_field :first_names, label: { text: 'First names', size: 's' }, hint: { text: 'Or given names' }, width: 'three-quarters' %>
 
       <%= f.govuk_text_field :middle_names, label: { text: 'Middle names', size: 's' }, width: 'three-quarters' %>
@@ -21,17 +21,17 @@
       <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: 'Date of birth', size: 's' }, hint: { text: 'For example, 31 3 1980' } %>
 
       <%= f.govuk_radio_buttons_fieldset(:gender, legend: { text: "Gender", size: "s" }, classes: "gender") do %>
-        <%= f.govuk_radio_button :gender, :male, label: { text: "Male" } %>
+        <%= f.govuk_radio_button :gender, :male, label: { text: "Male" }, link_errors: true %>
         <%= f.govuk_radio_button :gender, :female, label: { text: "Female" } %>
         <%= f.govuk_radio_button :gender, :other, label: { text: "Other" } %>
       <% end %>
 
-      <%= f.govuk_collection_check_boxes :nationality_ids, 
-          format_default_nationalities(@nationalities), 
-          :id, 
-          :name, 
-          :description, 
-          legend: { text: "Nationality", size: 's' }, 
+      <%= f.govuk_collection_check_boxes :nationality_ids,
+          format_default_nationalities(@nationalities),
+          :id,
+          :name,
+          :description,
+          legend: { text: "Nationality", size: 's' },
           hint: { text: 'Select all that apply' },
           classes: "nationality" %>
 


### PR DESCRIPTION
### Context
On the personal details page, when a user did not select a gender and
tried to click on the link in the error summary, the users focus would
not be set to the first option for the gender field.
![focus-bug](https://user-images.githubusercontent.com/3441519/96408585-ba894380-11db-11eb-96d3-0a71e396132b.gif)

### Changes proposed in this pull request

### Guidance to review

- Visit https://dfe-twd-rttd-pr-97.herokuapp.com/trainees/1/personal-details, 
- fill in all the details except for the gender and click save.
- Click on the error summary link at the top of the page.
- page scrolls down to gender and the first option gets the yellow focus.

![focus-fixed](https://user-images.githubusercontent.com/3441519/96408954-6e8ace80-11dc-11eb-96ea-ce323edd1530.gif)
