### PR TITLE
[419] Use GITHUB_ENV instead of set_env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,12 @@ jobs:
       run: |
         GIT_SHA_SHORT=$(echo ${GITHUB_SHA} | cut -c 1-7)
         GIT_BRANCH="${GITHUB_REF##*/}"
-        echo "::set-env name=GIT_SHA_SHORT::$GIT_SHA_SHORT"
-        echo "::set-env name=GIT_BRANCH::$GIT_BRANCH"
-        echo "::set-env name=SHA_TAG::$GIT_SHA_SHORT"
+        echo "GIT_SHA_SHORT=$GIT_SHA_SHORT" >> $GITHUB_ENV
+        echo "GIT_BRANCH=$GIT_BRANCH" >> $GITHUB_ENV
+        echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
+        echo "SHA_TAG=$GIT_SHA_SHORT" >> $GITHUB_ENV
         echo "::set-output name=SHA_TAG::$GIT_SHA_SHORT"
-        echo "::set-env name=BRANCH_TAG::$GIT_BRANCH"
+
 
     - name: Login to docker hub
       run: echo "${{secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN}}" | docker login -u ${{secrets.DOCKERHUB_USERNAME}} --password-stdin
@@ -77,7 +78,7 @@ jobs:
         docker push ${{env.DOCKER_REPO}}:${{env.SHA_TAG}}
 
   #master
-  deploy_to_paas:
+  deploy_to_paas_QA:
 
     name: Deploy to Paas
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Context

Changing from the use of set-env to $GITHUB_ENV; as set-env is about to be depreated.

This will also stop the warning from appearing.

### Changes proposed in this pull request

Changing from the use of set-env to $GITHUB_ENV; as set-env is about to be depreated.

### Guidance to review

