### PR TITLE
233 Create page heading component

### DIFF
--- a/app/components/page_title/view.html.erb
+++ b/app/components/page_title/view.html.erb
@@ -1,0 +1,3 @@
+<%= content_for :page_title do %>
+  <%= build_page_title %>
+<% end %>

--- a/app/components/page_title/view.rb
+++ b/app/components/page_title/view.rb
@@ -1,0 +1,28 @@
+class PageTitle::View < GovukComponent::Base
+  attr_accessor :title, :errors
+
+  include ActiveModel
+
+  def initialize(title: "", errors: false)
+    @title = title
+    @errors = errors.present?
+  end
+
+  def build_page_title
+    [build_error + build_title + build_service_name, "GOV.UK"].join(" - ")
+  end
+
+private
+
+  def build_error
+    errors ? "Error: " : ""
+  end
+
+  def build_title
+    title == "" ? "" : I18n.t("components.page_titles." + title)
+  end
+
+  def build_service_name
+    title == "" ? I18n.t("service_name") : " - " + I18n.t("service_name")
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title>Register trainee teachers</title>
+    <title><%= yield :page_title %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new %>
+
 <%= content_for :start_page_banner do %>
   <%= render_component StartPageBanner::View.new %>
 <% end %>

--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: I18n.t("components.confirmation.heading", section_title: trainee_section_key.gsub(/-/, " "))) %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: 'Back to overview',

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.contact_details.edit") %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: "Back",

--- a/app/views/trainees/degrees/edit.html.erb
+++ b/app/views/trainees/degrees/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.degrees.edit") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 		<%= @degree.uk? ? (render "uk_degree_form") : (render "non_uk_degree_form") %>

--- a/app/views/trainees/degrees/new.html.erb
+++ b/app/views/trainees/degrees/new.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.degrees.new") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
       <%= form_with model: [@trainee, @degree], local: true do |f| %>

--- a/app/views/trainees/diversity/disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disclosures/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.diversity.disclosures.edit") %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: "Back",

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.index") %>
+
 <h1 class="govuk-heading-xl">Trainee teachers</h1>
 
 <p class="govuk-body">

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -1,3 +1,6 @@
+<%= render_component PageTitle::View.new(title: "trainees.new", 
+                                           errors: @trainee.errors) %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: 'Back',

--- a/app/views/trainees/not_supported_route.html.erb
+++ b/app/views/trainees/not_supported_route.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.not_supported_route") %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: 'Back',

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.personal_details.edit") %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: 'Back',

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -1,3 +1,6 @@
+<%= render_component PageTitle::View.new(title: "trainees.show", 
+                                           errors: @trainee.errors) %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: 'All records',

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.training_details.edit") %>
+
 <h2 class="govuk-heading-l">Add training details</h2>
 
 <%= form_with model: @trainee, local: true do |f| %>

--- a/app/views/trn_submissions/show.html.erb
+++ b/app/views/trn_submissions/show.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trn_submissions.show") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,29 @@
 en:
+  service_name: Register trainee teachers
   components:
     confirmation:
       not_provided: Not provided
       heading: Confirm %{section_title}
+    page_titles:
+      trn_submissions:
+        show: Successfully submitted
+      trainees:
+        new: Add a trainee
+        index: Trainee teachers
+        not_supported_route: Other routes not supported
+        show: Overview
+        diversity:
+          disclosures:
+            edit: Has the trainee shared diversity information?
+        contact_details:
+          edit: Contact details
+        degrees:
+          edit: Degree Details
+          new: Add undergraduate details
+        personal_details:
+          edit: Trainee personal details
+        training_details:
+          edit: Add training details
   views:
     diversity_disclosures:
       label_names:
@@ -27,11 +48,11 @@ en:
           white: White
           other_ethnic_group: Another ethnic group
         descriptions:
-          asian: (includes any Asian background, for example, Bangladeshi, Chinese, Indian, Pakistani) 
-          black: (includes any Black background) 
-          mixed: (includes any Mixed background) 
-          white: (includes any White background) 
-          other_ethnic_group: (includes any other ethnic group, for example, Arab) 
+          asian: (includes any Asian background, for example, Bangladeshi, Chinese, Indian, Pakistani)
+          black: (includes any Black background)
+          mixed: (includes any Mixed background)
+          white: (includes any White background)
+          other_ethnic_group: (includes any other ethnic group, for example, Arab)
   activerecord:
     attributes:
       trainee:

--- a/spec/components/page_title/view_preview.rb
+++ b/spec/components/page_title/view_preview.rb
@@ -1,0 +1,11 @@
+require "govuk/components"
+
+class PageTitle::ViewPreview < ViewComponent::Preview
+  def default_heading
+    render_component(PageTitle::View.new(title: "trainees.new"))
+  end
+
+  def heading_with_error
+    render_component(PageTitle::View.new(title: "trainees.new", errors: "Error"))
+  end
+end

--- a/spec/components/page_title/view_spec.rb
+++ b/spec/components/page_title/view_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe PageTitle::View do
+  def locale_setup
+    allow(I18n).to receive(:t).with("components.page_titles.trainee.new").and_return("New Trainee")
+    allow(I18n).to receive(:t).with("service_name").and_return("Cool Service")
+  end
+
+  it "constructs a page title value" do
+    locale_setup
+    component = PageTitle::View.new(title: "trainee.new")
+    page_title = component.build_page_title
+    expect(page_title).to eq("New Trainee - Cool Service - GOV.UK")
+  end
+
+  it "constructs a page title value with an error" do
+    locale_setup
+    component = PageTitle::View.new(title: "trainee.new", errors: "Loads")
+    page_title = component.build_page_title
+    expect(page_title).to eq("Error: New Trainee - Cool Service - GOV.UK")
+  end
+end

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -9,5 +9,6 @@ RSpec.feature "view pages" do
 
   scenario "navigate to start" do
     expect(start_page.page_title).to have_text(t("page_headings.start_page"))
+    expect(start_page).to have_title("Register trainee teachers - GOV.UK")
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/dbEPQ9Bo/233-m-update-page-titles-to-all-pages

One issue is for pages that don't have a clear `h1` tag on the page don't have a clear title that would be suitable - an example being the /trainees/1/course-details page.

### Changes proposed in this pull request
* Add page heading component, and replace h1 headings on pages where appropriate
* Add new locales info for each page heading
### Guidance to review
