### PR TITLE
[xxxx] Fixed the DEPRECATION WARNING

### DIFF
--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -35,7 +35,7 @@ describe "heartbeat requests" do
 
       it "returns JSON" do
         get "/healthcheck"
-        expect(response.content_type).to eq("application/json")
+        expect(response.media_type).to eq("application/json")
       end
 
       it "returns the expected response report" do


### PR DESCRIPTION
### Context
```.................................DEPRECATION WARNING: Rails 6.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. (called from block (4 levels) in <main> at ~/repos/DfE/register-trainee-teacher-data/spec/requests/heartbeat_spec.rb:38)
............................*...............................................................................***...............```
### Changes proposed in this pull request

```..........................................................................................................................................***.......*..........```
### Guidance to review
:shipit: 
