### PR TITLE
[306] Added puma ssl/https and related items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ tfplan
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+# Localhost ssl related
+config/localhost/https/localhost.key
+config/localhost/https/localhost.crt

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,4 +50,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  config.force_ssl = Settings.use_ssl
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -10,12 +10,14 @@ threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+
+listen_port = ENV.fetch("PORT") { Settings.port }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+env = ENV.fetch("RAILS_ENV") { "development" }
 
+environment env
 # Specifies the `pidfile` that Puma will use.
 # pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
@@ -36,3 +38,33 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+if env == "development" && Settings.use_ssl
+  cert = "#{Dir.pwd}/#{File.join('config', 'localhost', 'https', 'localhost.crt')}"
+  key = "#{Dir.pwd}/#{File.join('config', 'localhost', 'https', 'localhost.key')}"
+
+  unless File.exist?(cert) && File.exist?(key)
+    def generate_root_cert(root_key)
+      root_ca = OpenSSL::X509::Certificate.new
+      root_ca.version = 2 # cf. RFC 5280 - to make it a "v3" certificate
+      root_ca.serial = rand(100_000) # randomized for local development to prevent SEC_ERROR_REUSED_ISSUER_AND_SERIAL errors in firefox after a git-clean
+      root_ca.subject = OpenSSL::X509::Name.parse "/C=GB/L=London/O=DfE/CN=localhost"
+      root_ca.issuer = root_ca.subject # root CA's are "self-signed"
+      root_ca.public_key = root_key.public_key
+      root_ca.not_before = Time.zone.now
+      root_ca.not_after = root_ca.not_before + 2 * 365 * 24 * 60 * 60 # 2 years validity
+      root_ca.sign(root_key, OpenSSL::Digest::SHA256.new)
+      root_ca
+    end
+
+    root_key = OpenSSL::PKey::RSA.new(2048)
+    File.write(key, root_key, mode: "wb")
+
+    root_cert = generate_root_cert(root_key)
+    File.write(cert, root_cert, mode: "wb")
+  end
+
+  ssl_bind "0.0.0.0", listen_port, cert: cert, key: key, verify_mode: "none"
+else
+  port listen_port
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,6 @@
+use_ssl: true
+port: 5000
+
 basic_auth_required: true
 dttp:
   client_id: "application-registration-client-id-from-env"
@@ -10,6 +13,7 @@ dttp:
 features:
   home_text: false
 
+# Others
 nationalities:
   - afghan
   - albanian


### PR DESCRIPTION
### Context
puma ssl/https and related items

### Changes proposed in this pull request
Added puma ssl/https and related items
default  port from 3000 to 5000
zeroed ip (0.0.0.0)
default from HTTP to HTTPS
enforced ssl usage as default

### Guidance to review

Ported mainly from https://github.com/DFE-Digital/publish-teacher-training/blob/master/config/puma.rb 

These are the minimum security and infrastructures requirements for future work.

Port 5000 was selected to remove common default rails port collusion.