### PR TITLE
Authenticate with DockerHub to pull image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,4 +122,5 @@ jobs:
         TF_VAR_paas_settings__dttp__client_id :  ${{ secrets.TF_VAR_PAAS_SETTINGS__DTTP__CLIENT_ID }}
         TF_VAR_paas_settings__dttp__tenant_id :  ${{ secrets.TF_VAR_PAAS_SETTINGS__DTTP__TENANT_ID }}
         TF_VAR_paas_settings__dttp__api_base_url :  ${{ secrets.TF_VAR_PAAS_SETTINGS__DTTP__API_BASE_URL }}
-
+        TF_VAR_paas_dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+        TF_VAR_paas_dockerhub_password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -22,6 +22,7 @@ resource cloudfoundry_app web_app {
   strategy                   = var.web_app_deployment_strategy
   timeout                    = var.app_start_timeout
   environment                = local.app_environment
+  docker_credentials         = var.docker_credentials
   routes {
     route = cloudfoundry_route.web_app_route.id
   }
@@ -31,7 +32,6 @@ resource cloudfoundry_app web_app {
   service_binding {
     service_instance = cloudfoundry_service_instance.redis_instance.id
   }
-
   service_binding {
     service_instance = cloudfoundry_user_provided_service.logging.id
   }
@@ -69,4 +69,3 @@ resource cloudfoundry_user_provided_service logging {
   space            = data.cloudfoundry_space.space.id
   syslog_drain_url = var.log_url
 }
-

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -21,6 +21,8 @@ variable worker_app_memory { default = 512 }
 
 variable log_url {}
 
+variable docker_credentials { type = map }
+
 variable settings__basic_auth__username {}
 variable settings__basic_auth__password {} #secrets
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -32,6 +32,7 @@ module paas {
   worker_app_instances        = var.paas_worker_app_instances
   worker_app_memory           = var.paas_worker_app_memory
   log_url                     = var.paas_log_url
+  docker_credentials          = local.docker_credentials
 
   settings__basic_auth__username = var.paas_settings__basic_auth__username
   settings__basic_auth__password = var.paas_settings__basic_auth__password

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,6 +28,10 @@ variable paas_worker_app_memory { default = 512 }
 
 variable paas_log_url {}
 
+variable dockerhub_username {}
+
+variable dockerhub_password {}
+
 variable paas_settings__basic_auth__username {} #secrets
 variable paas_settings__basic_auth__password {} #secrets
 variable paas_settings__dttp__client_id {}      #secrets
@@ -37,4 +41,8 @@ variable paas_settings__dttp__api_base_url {}   #secrets
 
 locals {
   paas_api_url = "https://api.london.cloud.service.gov.uk"
+  docker_credentials = {
+    username = var.dockerhub_username
+    password = var.dockerhub_password
+  }
 }


### PR DESCRIPTION
### Context
see https://docs.docker.com/docker-hub/download-rate-limit/

### Changes proposed in this pull request

Make PaaS authenticate with DockerHub before pulling image.

### Guidance to review


### Trello
https://trello.com/c/qG7Lio3h/365-pipeline-and-arm-template-changes-to-include-dockerhub-credentials-to-overcome-rate-limit

