### PR TITLE
[369] Fix Trainees::DegreesController#create

### DIFF
--- a/app/controllers/trainees/degrees_controller.rb
+++ b/app/controllers/trainees/degrees_controller.rb
@@ -11,7 +11,7 @@ module Trainees
     def create
       @degree = trainee.degrees.build(degree_params.merge(locale_code_params))
       if @degree.save(context: @degree.locale_code.to_sym)
-        redirect_to trainee_path(@trainee)
+        redirect_to trainee_degrees_confirm_path(@trainee)
       else
         render :new
       end

--- a/spec/controllers/trainees/degrees_controller_spec.rb
+++ b/spec/controllers/trainees/degrees_controller_spec.rb
@@ -3,19 +3,29 @@ require "rails_helper"
 RSpec.describe Trainees::DegreesController, type: :controller do
   describe "#create" do
     let(:trainee) { create(:trainee) }
-    let(:post_method) do
-      post(:create, params: { trainee_id: trainee.id,
-                              degree:
-      { locale_code: :uk,
-        uk_degree: "Bachelor of Arts",
-        degree_subject: "History",
-        institution: "The University of Warwick",
-        graduation_year: 2014,
-        degree_grade: "Upper second-class honours (2:1)" } })
+    let(:degree) { build(:degree, :uk_degree_with_details) }
+
+    let(:degree_params) do
+      {
+        locale_code: degree.locale_code,
+        uk_degree: degree.uk_degree,
+        degree_subject: degree.degree_subject,
+        institution: degree.institution,
+        graduation_year: degree.graduation_year,
+        degree_grade: degree.degree_grade,
+      }
     end
 
-    it "saves the degree of the trainee to db" do
-      expect { post_method }.to change { trainee.reload.degrees.size }.from(0).to(1)
+    before do
+      post(:create, params: { trainee_id: trainee.id, degree: degree_params })
+    end
+
+    it "creates a new degree record associated with the trainee" do
+      expect(trainee.degrees.first).to have_attributes(degree_params)
+    end
+
+    it "redirects to trainee degree confirmation page" do
+      expect(response).to redirect_to(trainee_degrees_confirm_path(trainee))
     end
   end
 end

--- a/spec/features/trainees/degrees/adding_degree_spec.rb
+++ b/spec/features/trainees/degrees/adding_degree_spec.rb
@@ -19,6 +19,8 @@ RSpec.feature "Adding a degree" do
       when_i_visit_the_degree_details_page
       and_i_fill_in_the_form
       and_i_click_the_continue_button_on_the_degree_details_page
+      then_i_am_redirected_to_the_trainee_degrees_confirmation_page
+      and_confirm_my_details
       then_i_am_redirected_to_the_summary_page
     end
 
@@ -38,6 +40,8 @@ RSpec.feature "Adding a degree" do
       when_i_visit_the_degree_details_page
       and_i_fill_in_the_form
       and_i_click_the_continue_button_on_the_degree_details_page
+      then_i_am_redirected_to_the_trainee_degrees_confirmation_page
+      and_confirm_my_details
       then_i_am_redirected_to_the_summary_page
     end
 
@@ -127,6 +131,16 @@ private
 
   def then_i_am_redirected_to_the_summary_page
     expect(current_path).to eq("/trainees/#{trainee.id}")
+  end
+
+  def then_i_am_redirected_to_the_trainee_degrees_confirmation_page
+    expect(current_path).to eq("/trainees/#{trainee.id}/degrees/confirm")
+  end
+
+  def and_confirm_my_details
+    @confirm_page ||= PageObjects::Trainees::ConfirmDetails.new
+    expect(@confirm_page).to be_displayed(id: @trainee.id, section: "degrees")
+    @confirm_page.submit_button.click
   end
 
   def degree_details_page


### PR DESCRIPTION
When a degree has been created the user is redirected to the confirm page.

### Context
https://trello.com/c/s7vr81ZY/369-create-degree-should-redirect-to-confirm-page

### Changes proposed in this pull request
Change redirect URL

