### PR TITLE
377 Change site prism page heading tag

### DIFF
--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "view pages" do
   end
 
   scenario "navigate to start" do
-    expect(start_page.page_title).to have_text(t("page_headings.start_page"))
+    expect(start_page.page_heading).to have_text(t("page_headings.start_page"))
     expect(start_page).to have_title("Register trainee teachers - GOV.UK")
   end
 end

--- a/spec/support/page_objects/start.rb
+++ b/spec/support/page_objects/start.rb
@@ -2,6 +2,6 @@ module PageObjects
   class Start < PageObjects::Base
     set_url "/"
 
-    element :page_title, ".govuk-heading-xl"
+    element :page_heading, ".govuk-heading-xl"
   end
 end

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -3,7 +3,7 @@ module PageObjects
     class Index < PageObjects::Base
       set_url "/trainees"
 
-      element :page_title, ".govuk-heading-xl"
+      element :page_heading, ".govuk-heading-xl"
 
       element :add_trainee_link, "a", text: "Add a trainee"
 

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -3,7 +3,7 @@ module PageObjects
     class New < PageObjects::Base
       set_url "/trainees/new"
 
-      element :page_title, ".govuk-heading-xl"
+      element :page_heading, ".govuk-heading-xl"
 
       element :assessment_only, "#trainee-record-type-assessment-only-field"
       element :other, "#trainee-record-type-other-field"

--- a/spec/support/page_objects/trainees/not_supported_route.rb
+++ b/spec/support/page_objects/trainees/not_supported_route.rb
@@ -3,7 +3,7 @@ module PageObjects
     class NotSupportedRoute < PageObjects::Base
       set_url "/trainees/not-supported-route"
 
-      element :page_title, ".govuk-heading-xl"
+      element :page_heading, ".govuk-heading-xl"
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/wkIZc6F9/377-s-rename-all-site-prism-object-elements-from-pagetitle-to-pageheading

### Changes proposed in this pull request
Changed the site prism page_title tag to page_heading for heading elements

### Guidance to review