### PR TITLE
[376] enabled code coverage in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       run:  docker-compose exec -T web /bin/sh -c 'bundle exec rake lint:scss'
 
     - name: Run tests
-      run: docker-compose exec -T web /bin/sh -c 'bundle exec rake spec'
+      run: docker-compose exec --env COVERAGE=true -T web /bin/sh -c 'bundle exec rake spec'
 
     - name: Tag docker images
       run: docker tag ${{env.DOCKER_REPO}}:${{env.BRANCH_TAG}} ${{env.DOCKER_REPO}}:${{env.SHA_TAG}}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ if ENV.fetch("COVERAGE", false)
   require "simplecov"
 
   SimpleCov.coverage_dir("coverage/backend")
-  SimpleCov.minimum_coverage(86)
+  SimpleCov.minimum_coverage(99)
   SimpleCov.start("rails")
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ if ENV.fetch("COVERAGE", false)
   require "simplecov"
 
   SimpleCov.coverage_dir("coverage/backend")
-  SimpleCov.minimum_coverage(99)
+  SimpleCov.minimum_coverage(86)
   SimpleCov.start("rails")
 end
 


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Adds `COVERAGE` environment to Github action step so code coverage is checked after the tests are run and should fail if they drop the currently 86% mark. The test will fail if they do drop and block the PR from being merged

Example of a failed PR Github Action
https://github.com/DFE-Digital/register-trainee-teachers/pull/141/checks?check_run_id=1353502545#step:12:55

### Guidance to review
- PR will be rebased before merging