### PR TITLE
[429] add sha endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       run: docker pull $DOCKER_REPO:$BRANCH_TAG || true
 
     - name: "docker-compose build"
-      run:  docker-compose build
+      run:  docker-compose build --build-arg COMMIT_SHA=$GITHUB_SHA
 
     - name: Bring images up
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN yarn install --frozen-lockfile
 
 COPY . .
 
+ARG COMMIT_SHA
+ENV COMMIT_SHA=$COMMIT_SHA
+
 RUN bundle exec rake assets:precompile
 
 CMD bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -20,6 +20,10 @@ class HeartbeatController < ActionController::API
            }
   end
 
+  def sha
+    render json: { sha: ENV["COMMIT_SHA"] }
+  end
+
 private
 
   def database_alive?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   get :ping, controller: :heartbeat
   get :healthcheck, controller: :heartbeat
+  get :sha, controller: :heartbeat
 
   get "/pages/:page", to: "pages#show"
 

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -110,4 +110,14 @@ describe "heartbeat requests" do
       end
     end
   end
+
+  describe "GET /sha" do
+    it "returns the sha from the env var COMMIT_SHA" do
+      allow(ENV).to receive(:[]).with("COMMIT_SHA").and_return("deadbeef")
+
+      get "/sha"
+
+      expect(response.body).to eq '{"sha":"deadbeef"}'
+    end
+  end
 end


### PR DESCRIPTION
### Context

Sometimes it's crucial to know what the latest commit is in the deployed env.

### Changes proposed in this pull request

Add a `/sha` endpoint which returns the SHA of the latest commit that's deployed out.

### Guidance to review

~~The SHA returned in `/sha` should match the latest commit. EZ!~~

Nope, not so EZ. This is failing in the preview app, probably because Heroku doesn't use the Docker image to deploy but relies on taking the version straight from Git. 🤦 
