### PR TITLE
353 Add edit programme details confirmation page

### DIFF
--- a/app/components/trainees/confirmation/programme_details/view.rb
+++ b/app/components/trainees/confirmation/programme_details/view.rb
@@ -24,7 +24,7 @@ module Trainees
         def programme_start_date
           return @not_provided_copy if trainee.programme_start_date.blank?
 
-          trainee.programme_start_date
+          trainee.programme_start_date.strftime("%-d %B %Y")
         end
       end
     end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -32,6 +32,7 @@ module Trainees
         trainee_diversity_disclosure_path,
         trainee_diversity_disability_disclosure_path,
         trainee_diversity_disability_detail_path,
+        trainee_programme_details_path,
       ].map { |path| path.split("/").last }
     end
   end

--- a/app/controllers/trainees/programme_details_controller.rb
+++ b/app/controllers/trainees/programme_details_controller.rb
@@ -19,7 +19,7 @@ module Trainees
       updater = ProgrammeDetails::Update.call(trainee: trainee,
                                               attributes: programme_details_params)
       if updater.successful?
-        redirect_to trainee_path(trainee)
+        redirect_to trainee_programme_details_confirm_path(trainee)
       else
         @programme_detail = updater.programme_detail
         render :edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
 
   resources :trainees, only: %i[index show new create update] do
     scope module: :trainees do
-      resource :programme_details, only: %i[edit update], path: "/programme-details"
+      resource :programme_details, concerns: :confirmable, only: %i[edit update], path: "/programme-details"
       resource :contact_details, concerns: :confirmable, only: %i[edit update], path: "/contact-details"
 
       namespace :degrees do

--- a/spec/components/trainees/confirmation/programme_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/programme_details/view_spec.rb
@@ -43,7 +43,7 @@ module Trainees
 
           it "renders the programme start date" do
             expect(component.find(".govuk-summary-list__row.programme-start-date .govuk-summary-list__value"))
-              .to have_text(trainee.programme_start_date)
+              .to have_text(trainee.programme_start_date.strftime("%-d %B %Y"))
           end
         end
       end

--- a/spec/features/trainees/edit_programme_details_spec.rb
+++ b/spec/features/trainees/edit_programme_details_spec.rb
@@ -6,6 +6,7 @@ feature "edit programme details", type: :feature do
     when_i_visit_the_programme_details_page
     and_i_enter_valid_parameters
     and_i_submit_the_form
+    and_i_confirm_my_details
     then_i_am_redirected_to_the_summary_page
     and_the_programme_details_are_updated
   end
@@ -65,6 +66,12 @@ feature "edit programme details", type: :feature do
       expect(@programme_details_page.main_age_range_other).to be_checked
       expect(@programme_details_page.additional_age_range.value).to eq(template.age_range)
     end
+  end
+
+  def and_i_confirm_my_details
+    @confirm_page ||= PageObjects::Trainees::ConfirmDetails.new
+    expect(@confirm_page).to be_displayed(id: @trainee.id, section: "programme-details")
+    @confirm_page.submit_button.click
   end
 
   def then_i_see_error_messages


### PR DESCRIPTION
### Context
https://trello.com/c/MAQqgkeA/353-s-confirm-trainee-programme-details-page

### Changes proposed in this pull request
* Added a confirmation page and summary card after the edit programme details section

### Guidance to review

![image](https://user-images.githubusercontent.com/25597009/98697617-05c2ec00-236d-11eb-8573-e8c9dd413803.png)

