### PR TITLE
[384] Scoping trainees to current user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ gem "httparty", "~> 0.18"
 # Wrap jsonb columns with activemodel-like classes
 gem "store_model", "~> 0.8"
 
+gem "pundit"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,8 @@ GEM
     public_suffix (4.0.6)
     puma (5.0.4)
       nio4r (~> 2.0)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     rack (2.2.3)
     rack-proxy (0.6.5)
       rack
@@ -403,6 +405,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry-byebug
   puma (~> 5.0)
+  pundit
   rails (~> 6.0.3)
   rails-erd
   rails_semantic_logger (~> 4.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Pundit
+
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -1,8 +1,11 @@
 class TraineesController < ApplicationController
   before_action :authenticate
 
+  # TODO: move this into ApplicationController as we expand the policies
+  after_action :verify_policy_scoped, only: :index
+
   def index
-    @trainees = current_user.trainees.all
+    @trainees = policy_scope(Trainee)
   end
 
   def show

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -1,0 +1,14 @@
+class TraineePolicy
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.where(provider_id: user.provider_id)
+    end
+  end
+end

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe TraineePolicy::Scope do
+  let(:user) { create(:user, provider: provider) }
+  let(:provider) { create(:provider) }
+
+  subject { described_class.new(user, Trainee.all).resolve }
+
+  context "trainees belonging to the user's provider" do
+    let(:trainee) { create(:trainee, provider: provider) }
+
+    it { is_expected.to contain_exactly(trainee) }
+  end
+
+  context "trainees not belonging to the user's provider" do
+    let(:trainee) { create(:trainee) }
+
+    it { is_expected.not_to contain_exactly(trainee) }
+  end
+end


### PR DESCRIPTION
### Context

Trainees are associated with a provider and a user from a provider should only be able to see the trainees that they are associated with.

### Changes proposed in this pull request

* Install Pundit
* Add a policy scope for trainees that restricts access

### Guidance to review

