### PR TITLE
[440] - Add progress/state for diversity section

### DIFF
--- a/app/controllers/trainees/diversity/base_controller.rb
+++ b/app/controllers/trainees/diversity/base_controller.rb
@@ -1,0 +1,20 @@
+module Trainees
+  module Diversity
+    class BaseController < ApplicationController
+      before_action :redirect_to_confirm, if: :section_completed?
+
+    private
+
+      def redirect_to_confirm
+        redirect_to(trainee_diversity_disclosure_confirm_path(trainee))
+      end
+
+      def section_completed?
+        ProgressService.call(
+          validator: Diversities::DiversityFlow.new(trainee),
+          progress_value: trainee.progress.diversity,
+        ).completed?
+      end
+    end
+  end
+end

--- a/app/controllers/trainees/diversity/disability_details_controller.rb
+++ b/app/controllers/trainees/diversity/disability_details_controller.rb
@@ -1,6 +1,6 @@
 module Trainees
   module Diversity
-    class DisabilityDetailsController < ApplicationController
+    class DisabilityDetailsController < BaseController
       def edit
         disabilities
         @disability_detail = Diversities::DisabilityDetail.new(trainee: trainee)

--- a/app/controllers/trainees/diversity/disability_disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disability_disclosures_controller.rb
@@ -1,6 +1,6 @@
 module Trainees
   module Diversity
-    class DisabilityDisclosuresController < ApplicationController
+    class DisabilityDisclosuresController < BaseController
       def edit
         @disability_disclosure = Diversities::DisabilityDisclosure.new(trainee: trainee)
       end

--- a/app/controllers/trainees/diversity/disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disclosures_controller.rb
@@ -1,6 +1,6 @@
 module Trainees
   module Diversity
-    class DisclosuresController < ApplicationController
+    class DisclosuresController < BaseController
       def edit
         @disclosure = Diversities::Disclosure.new(trainee: trainee)
       end

--- a/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
@@ -1,6 +1,6 @@
 module Trainees
   module Diversity
-    class EthnicBackgroundsController < ApplicationController
+    class EthnicBackgroundsController < BaseController
       def edit
         @ethnic_background = Diversities::EthnicBackground.new(trainee: trainee)
       end

--- a/app/controllers/trainees/diversity/ethnic_groups_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_groups_controller.rb
@@ -1,6 +1,6 @@
 module Trainees
   module Diversity
-    class EthnicGroupsController < ApplicationController
+    class EthnicGroupsController < BaseController
       def edit
         @ethnic_group = Diversities::EthnicGroup.new(trainee: trainee)
       end

--- a/app/models/diversities/diversity_flow.rb
+++ b/app/models/diversities/diversity_flow.rb
@@ -1,0 +1,71 @@
+module Diversities
+  class DiversityFlow
+    include ActiveModel::Model
+
+    FIELDS = {
+      disclosure_section: Diversities::Disclosure::FIELDS,
+      ethnic_group_section: Diversities::EthnicGroup::FIELDS,
+      ethnic_background_section: Diversities::EthnicBackground::FIELDS,
+      disability_disclosure_section: Diversities::DisabilityDisclosure::FIELDS,
+    }.freeze
+
+    attr_accessor(*(FIELDS.keys + FIELDS.values.flatten + %i[trainee disability_ids]))
+
+    delegate :id, :persisted?, to: :trainee
+
+    validate :disclosure
+    validate :ethnic_group, if: -> { trainee.ethnic_group.present? }
+    validate :ethnic_background, if: -> { trainee.ethnic_background.present? }
+    validate :disability_disclosure, if: -> { trainee.disability_disclosure.present? }
+    validate :disabilities, if: -> { trainee.disabled? }
+
+    def initialize(trainee)
+      @trainee = trainee
+      super(fields)
+    end
+
+    def fields
+      trainee.attributes.slice(*FIELDS.values.flatten).merge(disability_ids: trainee.disability_ids)
+    end
+
+  private
+
+    def disclosure
+      return if validator_is_valid?(Disclosure)
+
+      add_error_for(:disclosure_section)
+    end
+
+    def ethnic_group
+      return if validator_is_valid?(EthnicGroup)
+
+      add_error_for(:ethnic_group_section)
+    end
+
+    def ethnic_background
+      return if validator_is_valid?(EthnicBackground)
+
+      add_error_for(:ethnic_background_section)
+    end
+
+    def disability_disclosure
+      return if validator_is_valid?(DisabilityDisclosure)
+
+      add_error_for(:disability_disclosure_section)
+    end
+
+    def disabilities
+      return if validator_is_valid?(DisabilityDetail)
+
+      add_error_for(:disability_ids)
+    end
+
+    def validator_is_valid?(error_klass)
+      error_klass.new(trainee: trainee).valid?
+    end
+
+    def add_error_for(key)
+      errors.add(key, :not_valid)
+    end
+  end
+end

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -59,7 +59,11 @@
         :row,
         task_name: 'Diversity information',
         path: edit_trainee_diversity_disclosure_path(@trainee),
-        status: 'not started'
+        classes: "diversity-details",
+        status: ProgressService.call(
+          validator: Diversities::DiversityFlow.new(@trainee), 
+          progress_value: @trainee.progress.diversity
+        ).status
       )
     end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,18 @@ en:
           attributes:
             disability_ids:
               empty_disabilities: You must select at least one disability
+        diversities/diversity_flow:
+          attributes:
+            disclosure_section:
+              not_valid: The disclosure section is not valid for this trainee
+            ethnic_group_section:
+              not_valid: The ethnic group section is not valid for this trainee
+            ethnic_background_section:
+              not_valid: The ethnic background section is not valid for this trainee
+            disability_disclosure_section:
+              not_valid: The disability disclosure section is not valid for this trainee
+            disability_ids:
+              not_valid: Trainee has been disclosed as disabled but no disabilities exist
         programme_detail:
           attributes:
             subject:

--- a/spec/features/trainees/diversities/diversity_progress_spec.rb
+++ b/spec/features/trainees/diversities/diversity_progress_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+feature "completing the diversity section", type: :feature do
+  background do
+    given_i_am_authenticated
+    given_a_trainee_exists(diversity_disclosure: nil, ethnic_group: nil, disability_disclosure: nil)
+  end
+
+  scenario "renders a 'not started' status when diversity details provided" do
+    and_i_visit_the_summary_page
+    then_the_diversity_section_should_be(:not_started)
+  end
+
+  scenario "renders an 'in progress' status when diversity information partially provided" do
+    given_valid_diversity_information
+    when_i_visit_the_diversity_section
+    and_unconfirm_my_details
+    and_i_visit_the_summary_page
+    then_the_diversity_section_should_be(:in_progress)
+  end
+
+  scenario "renders a completed status when valid diversity information provided" do
+    given_valid_diversity_information
+    and_i_visit_the_summary_page
+    then_the_diversity_section_should_be(:completed)
+  end
+
+  scenario "redirects to confirm page when section is completed" do
+    given_valid_diversity_information
+    when_i_visit_the_diversity_section
+    then_i_am_redirected_to_the_confirm_page
+  end
+
+private
+
+  def given_valid_diversity_information
+    @trainee.diversity_disclosure = Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed]
+    @trainee.ethnic_group = Diversities::ETHNIC_GROUP_ENUMS[:asian]
+    @trainee.ethnic_background = "some background"
+    @trainee.disability_disclosure = Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled]
+    @trainee.disabilities = [create(:disability, name: "deaf")]
+    @trainee.progress.diversity = true
+    @trainee.save!
+  end
+
+  def and_i_visit_the_summary_page
+    @summary_page ||= PageObjects::Trainees::Summary.new
+    @summary_page.load(id: @trainee.id)
+    expect(@summary_page).to be_displayed(id: @trainee.id)
+  end
+
+  def then_the_diversity_section_should_be(status)
+    expect(@summary_page.diversity_section.status.text).to eq(Progress::STATUSES[status])
+  end
+
+  def when_i_visit_the_diversity_section
+    @summary_page ||= PageObjects::Trainees::Summary.new
+    @summary_page.load(id: @trainee.id)
+    @summary_page.diversity_section.link.click
+  end
+
+  def then_i_am_redirected_to_the_confirm_page
+    @confirm_page ||= PageObjects::Trainees::Diversities::ConfirmDetails.new
+    expect(@confirm_page).to be_displayed(id: @trainee.id, section: "information-disclosed")
+  end
+
+  def and_unconfirm_my_details
+    @confirm_page ||= PageObjects::Trainees::Diversities::ConfirmDetails.new
+    @confirm_page.confirm.uncheck
+    @confirm_page.submit_button.click
+  end
+end

--- a/spec/models/diversities/diversity_flow_spec.rb
+++ b/spec/models/diversities/diversity_flow_spec.rb
@@ -1,0 +1,189 @@
+require "rails_helper"
+
+module Diversities
+  describe DiversityFlow do
+    let(:trainee) do
+      build(:trainee, diversity_disclosure: nil, ethnic_group: nil, ethnic_background: nil, disability_disclosure: nil)
+    end
+
+    subject { described_class.new(trainee) }
+
+    describe "validations" do
+      context "when trainee has disclosed diversity" do
+        let(:disclosure) { instance_double(Disclosure) }
+
+        before do
+          trainee.diversity_disclosure = DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed]
+          expect(Disclosure).to receive(:new).and_return(disclosure)
+        end
+
+        context "when Disclosure is valid" do
+          let(:validity) { true }
+
+          before do
+            allow(disclosure).to receive(:valid?).and_return(true)
+          end
+
+          it { is_expected.to be_valid }
+
+          context "ethnic group" do
+            let(:ethnic_group) { instance_double(EthnicGroup) }
+
+            before do
+              trainee.ethnic_group = ETHNIC_GROUP_ENUMS.values.sample
+              expect(EthnicGroup).to receive(:new).and_return(ethnic_group)
+            end
+
+            context "when EthnicGroup is valid" do
+              before do
+                allow(ethnic_group).to receive(:valid?).and_return(true)
+              end
+
+              it { is_expected.to be_valid }
+
+              context "ethnic background" do
+                let(:ethnic_background) { instance_double(EthnicBackground) }
+
+                before do
+                  trainee.ethnic_background = "some background"
+                  expect(EthnicBackground).to receive(:new).and_return(ethnic_background)
+                end
+
+                context "when EthnicBackground is valid" do
+                  before do
+                    allow(ethnic_background).to receive(:valid?).and_return(true)
+                  end
+
+                  it { is_expected.to be_valid }
+                end
+
+                context "when EthnicBackground is invalid" do
+                  before do
+                    allow(ethnic_background).to receive(:valid?).and_return(false)
+                  end
+
+                  it "returns an error for the ethnic_background_section key" do
+                    subject.valid?
+
+                    expect(subject.errors[:ethnic_background_section]).to include(
+                      I18n.t(
+                        "activemodel.errors.models.diversities/diversity_flow.attributes.ethnic_background_section.not_valid",
+                      ),
+                    )
+                  end
+                end
+              end
+            end
+
+            context "when EthnicGroup is invalid" do
+              before do
+                allow(ethnic_group).to receive(:valid?).and_return(false)
+              end
+
+              it "returns an error for the ethnic_group_section key" do
+                subject.valid?
+
+                expect(subject.errors[:ethnic_group_section]).to include(
+                  I18n.t(
+                    "activemodel.errors.models.diversities/diversity_flow.attributes.ethnic_group_section.not_valid",
+                  ),
+                )
+              end
+            end
+          end
+
+          context "disability disclosure" do
+            let(:disability_disclosure) { instance_double(DisabilityDisclosure) }
+
+            before do
+              trainee.disability_disclosure = DISABILITY_DISCLOSURE_ENUMS[:not_disabled]
+              expect(DisabilityDisclosure).to receive(:new).and_return(disability_disclosure)
+            end
+
+            context "when DisabilityDisclosure is valid" do
+              before do
+                allow(disability_disclosure).to receive(:valid?).and_return(true)
+              end
+
+              it { is_expected.to be_valid }
+
+              context "when trainee is disabled" do
+                let(:disability_detail) { instance_double(DisabilityDetail) }
+
+                before do
+                  trainee.disability_disclosure = DISABILITY_DISCLOSURE_ENUMS[:disabled]
+                  expect(DisabilityDetail).to receive(:new).and_return(disability_detail)
+                end
+
+                context "when DisabilityDetail is valid" do
+                  before do
+                    allow(disability_detail).to receive(:valid?).and_return(true)
+                  end
+
+                  it { is_expected.to be_valid }
+                end
+
+                context "when DisabilityDetail is invalid" do
+                  before do
+                    allow(disability_detail).to receive(:valid?).and_return(false)
+                  end
+
+                  it "returns an error for the disability_ids key" do
+                    subject.valid?
+
+                    expect(subject.errors[:disability_ids]).to include(
+                      I18n.t(
+                        "activemodel.errors.models.diversities/diversity_flow.attributes.disability_ids.not_valid",
+                      ),
+                    )
+                  end
+                end
+              end
+            end
+
+            context "when DisabilityDisclosure is invalid" do
+              before do
+                allow(disability_disclosure).to receive(:valid?).and_return(false)
+              end
+
+              it "returns an error for the disability_disclosure_section key" do
+                subject.valid?
+
+                expect(subject.errors[:disability_disclosure_section]).to include(
+                  I18n.t(
+                    "activemodel.errors.models.diversities/diversity_flow.attributes.disability_disclosure_section.not_valid",
+                  ),
+                )
+              end
+            end
+          end
+        end
+
+        context "when Disclosure is valid and not disclosed" do
+          before do
+            trainee.diversity_disclosure = DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed]
+            allow(disclosure).to receive(:valid?).and_return(true)
+          end
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when Disclosure is invalid" do
+          before do
+            allow(disclosure).to receive(:valid?).and_return(false)
+          end
+
+          it "returns an error for the disclosure_section key" do
+            subject.valid?
+
+            expect(subject.errors[:disclosure_section]).to include(
+              I18n.t(
+                "activemodel.errors.models.diversities/diversity_flow.attributes.disclosure_section.not_valid",
+              ),
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/sections/diversity.rb
+++ b/spec/support/page_objects/sections/diversity.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class Diversity < PageObjects::Sections::Base
+      element :link, ".govuk-link"
+      element :status, ".govuk-tag"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/summary.rb
+++ b/spec/support/page_objects/trainees/summary.rb
@@ -1,4 +1,5 @@
 require_relative "../sections/personal_details"
+require_relative "../sections/diversity"
 
 module PageObjects
   module Trainees
@@ -7,6 +8,7 @@ module PageObjects
 
       section :personal_details, PageObjects::Sections::PersonalDetails, ".app-task-list__item.personal-details"
       section :contact_details, PageObjects::Sections::ContactDetails, ".contact-details"
+      section :diversity_section, PageObjects::Sections::Diversity, ".app-task-list__item.diversity-details"
       section :training_details, PageObjects::Sections::TrainingDetails, ".training-details"
       element :degree_link, ".education .degree-link .govuk-link"
 


### PR DESCRIPTION
### Context

- https://trello.com/b/BBEuhbHM/publish-register-sprint-board

### Changes proposed in this pull request

- Add progress/state tracking for the diversity section
- Since this section has a few different scenarios, we need to be able to show the right status for each situation. I've created an ActiveModel PORO, as a sort of wrapper, which conditionally validates each section depending on what information has been provided. 

This should for eg return `completed` if the trainee has not disclosed diversity information but still marked the section as completed etc. 

### Guidance to review

- Visit the review app - https://dfe-twd-rttd-pr-171.herokuapp.com/
- Head to the diversity section and attempt a few scenarios:

1) Not disclosing information
2) Disclosing info with no background but with disabilities 
3) etc

Assert that the status is shown correctly for that section depending on the scenario taken.

