### PR TITLE
[473] Set cache control in assets header

### DIFF
--- a/config/initializers/assets_cache_header.rb
+++ b/config/initializers/assets_cache_header.rb
@@ -1,0 +1,8 @@
+# This will affect assets served from /app/assets
+Rails.application.config.static_cache_control = "public, max-age=31536000"
+
+# This will affect assets in /public, e.g. webpacker assets.
+Rails.application.config.public_file_server.headers = {
+  "Cache-Control" => "public, max-age=31536000",
+  "Expires" => 1.year.from_now.to_formatted_s(:rfc822),
+}


### PR DESCRIPTION
### Context
None of our assets were being cached by the browser because cache-control
was not being set. I set it to 1 year because our assets use a cache
busting technique so if we were to update their content the filename would
be different and therefore the browser would fetch and use the updated
assets.

Reference:
mikerogers.io/2019/11/02/how-to-set-cache-control-headers-for-rails-webpacker-and-sprockets-assets.html

### Changes proposed in this pull request

### Guidance to review

Visit https://dfe-twd-rttd-pr-175.herokuapp.com/

Check all asset headers and see if cache control is set to expire in a years time
![image](https://user-images.githubusercontent.com/3441519/99378354-3bad2680-28bf-11eb-826c-57ba0a5b859a.png)
