### PR TITLE
[446] Add progress/state tracking for programme-details section

### DIFF
--- a/app/controllers/trainees/programme_details_controller.rb
+++ b/app/controllers/trainees/programme_details_controller.rb
@@ -1,5 +1,7 @@
 module Trainees
   class ProgrammeDetailsController < ApplicationController
+    before_action :redirect_to_confirm, if: :section_completed?
+
     PROGRAMME_START_DATE_CONVERSION = {
       "programme_start_date(3i)" => "day",
       "programme_start_date(2i)" => "month",
@@ -44,6 +46,17 @@ module Trainees
         *PROGRAMME_DETAILS_PARAMS_KEYS,
       ).permit(*PROGRAMME_START_DATE_CONVERSION.keys)
       .transform_keys { |key| PROGRAMME_START_DATE_CONVERSION[key] }
+    end
+
+    def redirect_to_confirm
+      redirect_to(trainee_programme_details_confirm_path(trainee))
+    end
+
+    def section_completed?
+      ProgressService.call(
+        validator: ProgrammeDetail.new(trainee: trainee),
+        progress_value: trainee.progress.programme_details,
+      ).completed?
     end
   end
 end

--- a/app/models/programme_detail.rb
+++ b/app/models/programme_detail.rb
@@ -17,6 +17,10 @@ class ProgrammeDetail
   def initialize(trainee:)
     @trainee = trainee
 
+    super(fields)
+  end
+
+  def fields
     attributes = {
       subject: trainee.subject,
       day: trainee.programme_start_date&.day,
@@ -31,7 +35,7 @@ class ProgrammeDetail
       attributes[:main_age_range] = :other if age_range[:option] == :additional
     end
 
-    super(attributes)
+    attributes
   end
 
   def programme_start_date

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -29,7 +29,11 @@
         :row,
         task_name: 'Programme details',
         path: edit_trainee_programme_details_path(@trainee),
-        status: 'in progress'
+        classes: "programme-details",
+        status: ProgressService.call(
+          validator: ProgrammeDetail.new(trainee: @trainee),
+          progress_value: @trainee.progress.programme_details
+        ).status
       )
 
     end %>

--- a/spec/support/features/trainee_steps.rb
+++ b/spec/support/features/trainee_steps.rb
@@ -29,5 +29,12 @@ module Features
     def confirm_details_page
       @confirm_page ||= PageObjects::Trainees::ConfirmDetails.new
     end
+
+    def and_i_confirm_my_details(checked: true, section:)
+      checked_option = checked ? "check" : "uncheck"
+      expect(confirm_details_page).to be_displayed(id: trainee.id, section: section)
+      confirm_details_page.confirm.public_send(checked_option)
+      confirm_details_page.submit_button.click
+    end
   end
 end

--- a/spec/support/page_objects/sections/programme_details.rb
+++ b/spec/support/page_objects/sections/programme_details.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class ProgrammeDetails < PageObjects::Sections::Base
+      element :status, ".govuk-tag"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/summary.rb
+++ b/spec/support/page_objects/trainees/summary.rb
@@ -6,6 +6,7 @@ module PageObjects
     class Summary < PageObjects::Base
       set_url "/trainees/{id}"
 
+      section :programme_details, PageObjects::Sections::ProgrammeDetails, ".app-task-list__item.programme-details"
       section :personal_details, PageObjects::Sections::PersonalDetails, ".app-task-list__item.personal-details"
       section :contact_details, PageObjects::Sections::ContactDetails, ".contact-details"
       section :diversity_section, PageObjects::Sections::Diversity, ".app-task-list__item.diversity-details"


### PR DESCRIPTION
### Context

- https://trello.com/c/x9qJPXb5/446-programme-details-progress-state

### Changes proposed in this pull request

- Add the progress/state for the programme details section

### Guidance Review

- Visit the review app - https://dfe-twd-rttd-pr-176.herokuapp.com/
- Assert summary page shows 'Not started'
- Fill out some details but do not mark complete, assert label shows 'in progress'
- Mark complete, assert label shows 'completed'

