### PR TITLE
Add customdomain qa.register-trainee-teachers.education.gov.uk

### DIFF
--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -18,3 +18,7 @@ data cloudfoundry_service postgres {
 data cloudfoundry_service redis {
   name = "redis"
 }
+
+data cloudfoundry_domain register_education_gov_uk {
+  name = "register-trainee-teachers.education.gov.uk"
+}

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -31,9 +31,14 @@ resource cloudfoundry_app web_app {
   timeout                    = var.app_start_timeout
   environment                = local.app_environment
   docker_credentials         = var.docker_credentials
-  routes {
-    route = cloudfoundry_route.web_app_route.id
+
+  dynamic "routes" {
+    for_each = local.web_app_routes
+    content {
+      route = routes.value
+    }
   }
+
   service_binding {
     service_instance = cloudfoundry_service_instance.postgres_instance.id
   }
@@ -70,6 +75,12 @@ resource cloudfoundry_route web_app_route {
   domain   = data.cloudfoundry_domain.cloudapps_digital.id
   space    = data.cloudfoundry_space.space.id
   hostname = local.web_app_name
+}
+
+resource cloudfoundry_route web_app_service_gov_uk_route {
+  domain   = data.cloudfoundry_domain.register_education_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = var.app_environment == "prod" ? "www" : var.app_environment
 }
 
 resource cloudfoundry_user_provided_service logging {

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -28,12 +28,13 @@ variable app_secrets_variable { type = map } #secrets from yml file
 variable app_config_variable { type = map } #from yml file
 
 locals {
-  postgres_service_name = "register-postgres-${var.app_environment}"
-  redis_service_name    = "register-redis-${var.app_environment}"
-  web_app_name          = "register-${var.app_environment}"
-  web_app_start_command = "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
-  app_environment = merge(var.app_config_variable, var.app_secrets_variable)
+  postgres_service_name    = "register-postgres-${var.app_environment}"
+  redis_service_name       = "register-redis-${var.app_environment}"
+  web_app_name             = "register-${var.app_environment}"
+  web_app_start_command    = "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
+  app_environment          = merge(var.app_config_variable, var.app_secrets_variable)
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "register-worker-${var.app_environment}"
   logging_service_name     = "register-logit-${var.app_environment}"
+  web_app_routes           = [cloudfoundry_route.web_app_service_gov_uk_route.id, cloudfoundry_route.web_app_route.id]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,7 +38,7 @@ variable paas_app_secrets_file { default = "./terraform/app_secrets.yml" }
 
 locals {
   paas_api_url = "https://api.london.cloud.service.gov.uk"
-  app_secrets = yamldecode(file(var.paas_app_secrets_file))
+  app_secrets  = yamldecode(file(var.paas_app_secrets_file))
 
   app_config = yamldecode(file(var.paas_app_config_file))[var.paas_app_environment]
 


### PR DESCRIPTION
### Context

Add custom domain for qa.register-trainee-teachers.education.gov.uk

### Changes proposed in this pull request

* Add custom domain for qa.register-trainee-teachers.education.gov.uk
* Create new route

### Guidance to review

