### PR TITLE
[501] Add Accessibility, Cookie  & Privacy Policy pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,4 +4,8 @@ class PagesController < ApplicationController
   def show
     render template: "pages/#{params[:page]}"
   end
+
+  def accessibility
+    render :accessibility
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,4 +12,8 @@ class PagesController < ApplicationController
   def cookies
     render :cookies
   end
+
+  def privacy_policy
+    render :privacy_policy
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,4 +8,8 @@ class PagesController < ApplicationController
   def accessibility
     render :accessibility
   end
+
+  def cookies
+    render :cookies
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,6 +44,7 @@
       meta_links: {
         Accessibility: accessibility_path,
         Cookies: cookies_path,
+        "Privacy policy": privacy_policy_path,
       },
       meta_heading: 'Supporting links')
     %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
     <%= render_component GovukComponent::Footer.new(
       meta_links: {
         Accessibility: accessibility_path,
+        Cookies: cookies_path,
       },
       meta_heading: 'Supporting links')
     %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,25 +40,11 @@
       </div>
     </main>
 
-    <footer class="govuk-footer " role="contentinfo">
-      <div class="govuk-width-container ">
-        <div class="govuk-footer__meta">
-          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-
-            <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-              />
-            </svg>
-            <span class="govuk-footer__licence-description">
-              All content is available under the
-              <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
-          </div>
-          <div class="govuk-footer__meta-item">
-            <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
-          </div>
-        </div>
-      </div>
-    </footer>
+    <%= render_component GovukComponent::Footer.new(
+      meta_links: {
+        Accessibility: accessibility_path,
+      },
+      meta_heading: 'Supporting links')
+    %>
   </body>
 </html>

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -1,0 +1,68 @@
+<%= render_component PageTitle::View.new(title: "pages.accessibility") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">Accessibility statement for <%= I18n.t('service_name') %></h1>
+
+    <p class="govuk-body">This service is run by the Becoming a Teacher team at the Department for Education.
+      We want as many people as possible to be able to use the service. For example, that means users should be able to:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>change colours, contrast levels and fonts</li>
+      <li>zoom in up to 300% without the text spilling off the screen</li>
+      <li>navigate most of the service using just a keyboard</li>
+      <li>navigate most of the service using speech recognition software</li>
+      <li>
+        listen to most of the content on the service using a screen reader (including the most recent versions of JAWS,
+        NVDA and VoiceOver)
+      </li>
+    </ul>
+
+    <p class="govuk-body">We’ve also made the text on the service as simple as possible to understand.</p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to "AbilityNet", "https://mcmw.abilitynet.org.uk/" %> has advice on making your device easier to
+      use if you have a disability.
+    </p>
+
+    <h2 class="govuk-heading-m">Technical information about this service’s accessibility</h2>
+
+    <p class="govuk-body">
+      The Becoming a Teacher team (DfE) is committed to making <%= I18n.t('service_name') %> accessible,
+      in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility
+      Regulations 2018.
+    </p>
+
+    <p class="govuk-body">
+      The service was designed using the <%= govuk_link_to "GOV.UK Design System", "https://design-system.service.gov.uk/accessibility/" %>,
+      which conforms to the WCAG 2.1 AA standard. To ensure the service fully meets the WCAG 2.1 AA standard,
+      we are currently arranging an accessibility audit. We will update this page following the audit,
+      and publish details of any accessibility issues identified.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      Reporting accessibility problems with <%= I18n.t('service_name') %>
+    </h2>
+
+    <p class="govuk-body">
+      If you think we’re not meeting accessibility requirements, or you’d like to access any information in a
+      different format (such as accessible PDF, large print, easy read, audio recording or braille), contact
+      <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.
+      Include ‘Accessibility issues’ in the subject line of your email.
+    </p>
+
+    <h2 class="govuk-heading-m">Enforcement procedure</h2>
+
+    <p class="govuk-body">
+      The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies
+      (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
+      If you’re not happy with how we respond to your complaint,
+      <%= govuk_link_to "contact the Equality Advisory and Support Service (EASS)", "https://www.equalityadvisoryservice.com/" %>.
+    </p>
+
+    <p class="govuk-body">
+      This statement was prepared on 17 November 2019.
+    </p>
+  </div>
+</div>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,0 +1,14 @@
+<%= render_component PageTitle::View.new(title: "pages.cookies") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">Cookies on <%= t('service_name') %></h1>
+    <p class="govuk-body">This service puts small files (known as ‘cookies’) onto your computer, phone or tablet to collect information about how you use the service.</p>
+    <h2 class="govuk-heading-m">What cookies we use</h2>
+    <p class="govuk-body">We only use essential cookies.</p>
+    <h3 class="govuk-heading-s">A cookie to give you access to your account</h3>
+    <p class="govuk-body">"Register_trainee_teachers_session" is a cookie that reminds the service who you are when you’re signed in.</p>
+    <p class="govuk-body">It enables you to access the information in your account, such as your trainee records.</p>
+    <p class="govuk-body">It expires when you sign out, or after 6 hours on the service.</p>
+  </div>
+</div>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,0 +1,208 @@
+<%= render_component PageTitle::View.new(title: "pages.privacy_policy") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <span class="govuk-caption-l">Privacy policy</span>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9"><%= t("components.page_titles.pages.privacy_policy") %></h1>
+
+    <p class="govuk-body">
+      This service allows you to share trainee data with the Department for Education (DfE).
+    </p>
+
+    <p class="govuk-body">
+      However, by using the service, you’ll also be sharing some information about you.
+    </p>
+
+    <p class="govuk-inset-text">
+      This privacy policy is about your personal data, as opposed to your trainee data.
+    </p>
+
+    <p class="govuk-body">
+      With regard to your trainee data, remember to meet your obligations under the General
+      Data Protection Legislation (GDPR) as a data controller for their information.
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      You can
+      <%= govuk_link_to "read about your data protection obligations by visiting the Information Commissioner’s Office (ICO) website",
+                        "https://ico.org.uk/for-organisations/" %>.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      In this privacy policy
+    </h2>
+
+    <ul class="govuk-list app-list--dash govuk-!-margin-bottom-8">
+      <li>
+        <%= govuk_link_to "What personal data we collect and why", "#what-personal-data-we-collect-and-why"  %>
+      </li>
+      <li>
+        <%= govuk_link_to "Our lawful basis for processing your personal data", "#our-lawful-basis-for-processing-your-personal-data"  %>
+      </li>
+      <li>
+        <%= govuk_link_to "How we use third parties to process your data", "#how-we-use-third-parties-to-process-your-data" %>
+      </li>
+      <li>
+        <%= govuk_link_to "How long we keep your personal data", "#how-long-we-keep-your-personal-data" %>
+      </li>
+      <li>
+        <%= govuk_link_to "Raise a concern", "#raise-a-concern" %>
+      </li>
+      <li>
+        <%= govuk_link_to "Keep up to date", "#keep-up-to-date" %>
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-m" id="what-personal-data-we-collect-and-why">
+      What personal data we collect and why
+    </h2>
+
+    <p class="govuk-body">
+      We (DfE) use your personal data to run and improve Register trainee teachers.
+    </p>
+
+    <p class="govuk-body">
+      We collect your name and email address so that we can:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>enable you to access Register trainee teachers</li>
+      <li>validate your role in your organisation</li>
+      <li>send important updates about the service</li>
+      <li>get in touch with you about any queries you raise</li>
+      <li>ask if you would like to take part in user research</li>
+      <li>record a timeline of your activity so that you can review trainee progress</li>
+      <li>create log files of your activity and any error messages you come across</li>
+    </ul>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      If you take part in user research, you may choose to share additional information about you.
+    </p>
+
+    <h2 class="govuk-heading-m" id="our-lawful-basis-for-processing-your-personal-data">
+      Our lawful basis for processing your personal data
+    </h2>
+
+    <p class="govuk-body">
+      Running and improving the service is a public task, as defined in data protection law. However, we ask
+      for your consent to take part in user research.
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= govuk_link_to "Read about consent and public task on the Information Commissioner’s Office (ICO) website",
+                        "https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/" %>
+    </p>
+
+    <h2 class="govuk-heading-m" id="how-we-use-third-parties-to-process-your-data">
+      How we use third parties to process your data
+    </h2>
+
+    <p class="govuk-body">
+      Some of your personal information is processed by other types of services, listed below. They allow us
+      to run and improve Register trainee teachers.
+    </p>
+
+    <p class="govuk-body">
+      As the data controller for your information, we take responsibility for choosing third party data processors
+      who have the necessary safeguards in place to keep your personal data safe.
+    </p>
+
+    <h3 class="govuk-heading-s">
+      Customer service management systems
+    </h3>
+
+    <p class="govuk-body">We use Zendesk to manage and respond to your queries.</p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to "Visit the Zendesk website to find out how they use and look after your data (“service data”)",
+                        "https://www.zendesk.co.uk/company/privacy-and-data-protection/#faq-general-1" %>
+    </p>
+
+    <h3 class="govuk-heading-s">Website hosting services</h3>
+
+    <p class="govuk-body">We use GOV.UK PaaS to enable us to run the service.</p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to "Visit the GOV.UK PaaS website to find out how they use and look after your data (“end user data”)",
+                        "https://www.cloud.service.gov.uk/privacy-notice/#what-data-we-collect-from-end-users" %>
+    </p>
+
+    <h3 class="govuk-heading-s">Error and activity logging services</h3>
+
+    <p class="govuk-body">
+      We need to keep some records so that we can identify and fix problems with the service. We use Sentry to
+      monitor errors and Logit to keep activity logs.
+    </p>
+
+    <p class="govuk-body">
+      We do not identify you from these records unless needed - for example, to investigate an issue you raise.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to "Visit the Sentry website to read about their security practices", "https://sentry.io/security/" %>
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to "Visit the Logit website to read about their security practices", "https://logit.io/security" %>
+    </p>
+
+    <h3 class="govuk-heading-s">User research tools</h3>
+
+    <p class="govuk-body">
+      If you agree to take part in user research, we’ll ask if you consent to use Lookback to carry out and
+      record a video session with you.</p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= govuk_link_to "Visit Lookback’s website to read about how they use your data (as a “participant”)", "https://lookback.io/privacy/" %>
+    </p>
+
+    <h2 class="govuk-heading-m" id="how-long-we-keep-your-personal-data">How long we keep your personal data</h2>
+
+    <p class="govuk-body">We keep your personal data for as long as you use the service.</p>
+
+    <p class="govuk-body">
+      We may also keep it for some time after you stop using the service. This is so that we can analyse any
+      feedback you provided to improve the service.
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      We’ll keep your data for no longer than 7 years after you stop using the service.
+    </p>
+
+    <h2 class="govuk-heading-m" id="raise-a-concern">Raise a concern</h2>
+
+    <p class="govuk-body">
+      You have rights under the Data Protection Act 2018, such as the right to ask for your data to be erased.
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to "Find out about your rights by visiting the Information Commissioner’s Office (ICO) website", "https://ico.org.uk/" %>
+    </p>
+
+    <p class="govuk-body">
+      Contact the <%= t('service_name') %> team at
+      <%= govuk_mail_to "registerateacher@digital.education.gov.uk" , "registerateacher@digital.education.gov.uk", subject: "My personal data" %>
+      if you have any concerns about your personal data.
+    </p>
+
+    <p class="govuk-body">
+      You can also
+      <%= govuk_link_to "get in touch with the Department for Education’s data protection officer through the online contact form",
+                        "https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen" %>.
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= govuk_link_to "Refer to the Department for Education’s personal information charter to read more about the standards you can expect from us when we look after your personal data",
+                        "https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" %>
+    </p>
+
+    <h2 class="govuk-heading-m" id="keep-up-to-date">Keep up to date</h2>
+
+    <p class="govuk-body">
+      We periodically review this policy. We’ll notify you if we change how we use your personal data.
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">It was last updated on 17 November 2020.</p>
+
+  </div>
+</div>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -38,3 +38,18 @@ a[href="#"] {
     font-weight: $govuk-font-weight-bold;
   }
 }
+
+
+// Dashed list (used in Contents links list)
+
+.app-list--dash li {
+  position: relative;
+
+  &::before {
+    color: $govuk-secondary-text-colour;
+    content: "\2013";
+    left: -16px;
+    position: absolute;
+    top: 0;
+  }
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
     page_titles:
       pages:
         accessibility: Accessibility
+        cookies: Cookies on Register trainee teachers
       trn_submissions:
         show: Successfully submitted
       trainees:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
       pages:
         accessibility: Accessibility
         cookies: Cookies on Register trainee teachers
+        privacy_policy: How we use your personal data when you use Register trainee teachers
       trn_submissions:
         show: Successfully submitted
       trainees:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
       not_provided: Not provided
       heading: Confirm %{section_title}
     page_titles:
+      pages:
+        accessibility: Accessibility
       trn_submissions:
         show: Successfully submitted
       trainees:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get :sha, controller: :heartbeat
 
   get "/accessibility", to: "pages#accessibility", as: :accessibility
+  get "/cookies", to: "pages#cookies", as: :cookies
   get "/pages/:page", to: "pages#show"
 
   get "/404", to: "errors#not_found", via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   get "/accessibility", to: "pages#accessibility", as: :accessibility
   get "/cookies", to: "pages#cookies", as: :cookies
+  get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
   get "/pages/:page", to: "pages#show"
 
   get "/404", to: "errors#not_found", via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get :healthcheck, controller: :heartbeat
   get :sha, controller: :heartbeat
 
+  get "/accessibility", to: "pages#accessibility", as: :accessibility
   get "/pages/:page", to: "pages#show"
 
   get "/404", to: "errors#not_found", via: :all

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -20,6 +20,12 @@ feature "view pages" do
     then_i_should_see_the_cookies_policy
   end
 
+  scenario "navigate to privacy policy" do
+    given_i_am_on_the_home_page
+    and_i_click_on_the_privacy_link_in_the_footer
+    then_i_should_see_the_privacy_policy
+  end
+
 private
 
   def given_i_am_on_the_home_page
@@ -39,6 +45,10 @@ private
     start_page.footer.cookies_link.click
   end
 
+  def and_i_click_on_the_privacy_link_in_the_footer
+    start_page.footer.privacy_link.click
+  end
+
   def then_i_should_see_the_accessibility_statement
     expect(accessibility_page).to be_displayed
     expect(accessibility_page.page_heading).to have_text("Accessibility statement for #{I18n.t('service_name')}")
@@ -47,6 +57,11 @@ private
   def then_i_should_see_the_cookies_policy
     expect(cookies_page).to be_displayed
     expect(cookies_page.page_heading).to have_text("Cookies")
+  end
+
+  def then_i_should_see_the_privacy_policy
+    expect(privacy_policy_page).to be_displayed
+    expect(privacy_policy_page.page_heading).to have_text(t("components.page_titles.pages.privacy_policy"))
   end
 
   def start_page
@@ -59,5 +74,9 @@ private
 
   def cookies_page
     @cookies_page ||= PageObjects::Cookies.new
+  end
+
+  def privacy_policy_page
+    @privacy_policy_page ||= PageObjects::PrivacyPolicy.new
   end
 end

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -14,6 +14,12 @@ feature "view pages" do
     then_i_should_see_the_accessibility_statement
   end
 
+  scenario "navigate to cookies policy" do
+    given_i_am_on_the_home_page
+    and_i_click_on_the_cookies_link_in_the_footer
+    then_i_should_see_the_cookies_policy
+  end
+
 private
 
   def given_i_am_on_the_home_page
@@ -29,9 +35,18 @@ private
     start_page.footer.accessibility_link.click
   end
 
+  def and_i_click_on_the_cookies_link_in_the_footer
+    start_page.footer.cookies_link.click
+  end
+
   def then_i_should_see_the_accessibility_statement
     expect(accessibility_page).to be_displayed
     expect(accessibility_page.page_heading).to have_text("Accessibility statement for #{I18n.t('service_name')}")
+  end
+
+  def then_i_should_see_the_cookies_policy
+    expect(cookies_page).to be_displayed
+    expect(cookies_page.page_heading).to have_text("Cookies")
   end
 
   def start_page
@@ -40,5 +55,9 @@ private
 
   def accessibility_page
     @accessibility_page ||= PageObjects::Accessibility.new
+  end
+
+  def cookies_page
+    @cookies_page ||= PageObjects::Cookies.new
   end
 end

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -2,15 +2,43 @@
 
 require "rails_helper"
 
-RSpec.feature "view pages" do
-  let(:start_page) { PageObjects::Start.new }
+feature "view pages" do
+  scenario "navigate to start" do
+    given_i_am_on_the_home_page
+    then_i_should_see_the_service_name
+  end
 
-  before do
+  scenario "navigate to accessibility statement" do
+    given_i_am_on_the_home_page
+    and_i_click_on_the_accessibility_link_in_the_footer
+    then_i_should_see_the_accessibility_statement
+  end
+
+private
+
+  def given_i_am_on_the_home_page
     start_page.load
   end
 
-  scenario "navigate to start" do
+  def then_i_should_see_the_service_name
     expect(start_page.page_heading).to have_text(t("page_headings.start_page"))
     expect(start_page).to have_title("Register trainee teachers - GOV.UK")
+  end
+
+  def and_i_click_on_the_accessibility_link_in_the_footer
+    start_page.footer.accessibility_link.click
+  end
+
+  def then_i_should_see_the_accessibility_statement
+    expect(accessibility_page).to be_displayed
+    expect(accessibility_page.page_heading).to have_text("Accessibility statement for #{I18n.t('service_name')}")
+  end
+
+  def start_page
+    @start_page ||= PageObjects::Start.new
+  end
+
+  def accessibility_page
+    @accessibility_page ||= PageObjects::Accessibility.new
   end
 end

--- a/spec/support/page_objects/base.rb
+++ b/spec/support/page_objects/base.rb
@@ -11,4 +11,10 @@ module PageObjects
   end
 
   class Base < SitePrism::Page; end
+
+  class Accessibility < PageObjects::Base
+    set_url "/accessibility"
+
+    element :page_heading, ".govuk-heading-l"
+  end
 end

--- a/spec/support/page_objects/base.rb
+++ b/spec/support/page_objects/base.rb
@@ -17,4 +17,10 @@ module PageObjects
 
     element :page_heading, ".govuk-heading-l"
   end
+
+  class Cookies < PageObjects::Base
+    set_url "/cookies"
+
+    element :page_heading, ".govuk-heading-l"
+  end
 end

--- a/spec/support/page_objects/base.rb
+++ b/spec/support/page_objects/base.rb
@@ -23,4 +23,10 @@ module PageObjects
 
     element :page_heading, ".govuk-heading-l"
   end
+
+  class PrivacyPolicy < PageObjects::Base
+    set_url "/privacy-policy"
+
+    element :page_heading, ".govuk-heading-l"
+  end
 end

--- a/spec/support/page_objects/start.rb
+++ b/spec/support/page_objects/start.rb
@@ -5,5 +5,9 @@ module PageObjects
     set_url "/"
 
     element :page_heading, ".govuk-heading-xl"
+
+    section :footer, "footer" do
+      element :accessibility_link, ".govuk-footer__link", text: "Accessibility"
+    end
   end
 end

--- a/spec/support/page_objects/start.rb
+++ b/spec/support/page_objects/start.rb
@@ -8,6 +8,7 @@ module PageObjects
 
     section :footer, "footer" do
       element :accessibility_link, ".govuk-footer__link", text: "Accessibility"
+      element :cookies_link, ".govuk-footer__link", text: "Cookies"
     end
   end
 end

--- a/spec/support/page_objects/start.rb
+++ b/spec/support/page_objects/start.rb
@@ -9,6 +9,7 @@ module PageObjects
     section :footer, "footer" do
       element :accessibility_link, ".govuk-footer__link", text: "Accessibility"
       element :cookies_link, ".govuk-footer__link", text: "Cookies"
+      element :privacy_link, ".govuk-footer__link", text: "Privacy policy"
     end
   end
 end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
- Replaces hardcoded footer with GOV.UK Components Footer (there is a bug with the styling of the license footer link but I have submitted a PR to fix it https://github.com/DFE-Digital/govuk-components/pull/69)
- Adds draft accessibility statement
- Adds draft cookie policy page, this will need to be reviewed once we have finished adding dfe signin or start relying on cookies for specific features
- Adds draft privacy policy

### Guidance to review

Visit https://dfe-twd-rttd-pr-180.herokuapp.com/
- Click on Accessibility link in the footer
- See the Accessibility statement page https://dfe-twd-rttd-pr-180.herokuapp.com/accessibility
- Click on Cookies link in the footer
- See the Cookies policy page https://dfe-twd-rttd-pr-180.herokuapp.com/cookies
- Click on Privacy policy link in the footer
- See the Privacy policy page https://dfe-twd-rttd-pr-180.herokuapp.com/privacy-policy