### PR TITLE
Create CustomDomain for Register app in Production

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -80,7 +80,7 @@ resource cloudfoundry_route web_app_route {
 resource cloudfoundry_route web_app_service_gov_uk_route {
   domain   = data.cloudfoundry_domain.register_education_gov_uk.id
   space    = data.cloudfoundry_space.space.id
-  hostname = var.app_environment == "prod" ? "www" : var.app_environment
+  hostname = var.app_environment == "production" ? "www" : var.app_environment
 }
 
 resource cloudfoundry_user_provided_service logging {


### PR DESCRIPTION
### Context

Create Custom Domain for Register application. This PR will crate and bind a custom route to the application. This will be along side the default route (https://register-production.london.cloudapps.digital/).

### Changes proposed in this pull request

resource cloudfoundry_route web_app_service_gov_uk_route {
  domain   = data.cloudfoundry_domain.register_education_gov_uk.id
  space    = data.cloudfoundry_space.space.id
  hostname = var.app_environment == "production" ? "www" : var.app_environment
}

### Guidance to review

