### PR TITLE
[504] Suppress the "Add another degree" button

### DIFF
--- a/app/components/trainees/confirmation/degrees/view.html.erb
+++ b/app/components/trainees/confirmation/degrees/view.html.erb
@@ -9,8 +9,10 @@
   <% end %>
 <% end %>
 
-<div class="govuk-form-group">
-  <%= govuk_link_to("Add another degree",
-                      trainee_degrees_new_type_path(trainee),
-                      class:"govuk-button govuk-button--secondary") %>
-</div>
+<% if show_add_another_degree_button %>
+  <div class="govuk-form-group">
+    <%= govuk_link_to("Add another degree",
+                        trainee_degrees_new_type_path(trainee),
+                        class:"govuk-button govuk-button--secondary") %>
+  </div>
+<% end %>

--- a/app/components/trainees/confirmation/degrees/view.rb
+++ b/app/components/trainees/confirmation/degrees/view.rb
@@ -2,11 +2,12 @@ module Trainees
   module Confirmation
     module Degrees
       class View < GovukComponent::Base
-        attr_accessor :degrees, :trainee
+        attr_accessor :degrees, :trainee, :show_add_another_degree_button
 
-        def initialize(trainee:)
+        def initialize(trainee:, show_add_another_degree_button: true)
           @trainee = trainee
           @degrees = trainee.degrees
+          @show_add_another_degree_button = show_add_another_degree_button
         end
 
         def degree_title(degree)

--- a/spec/components/trainees/confirmation/degrees/view_preview.rb
+++ b/spec/components/trainees/confirmation/degrees/view_preview.rb
@@ -23,6 +23,13 @@ module Trainees
           render_component(Trainees::Confirmation::Degrees::View.new(trainee: mock_trainee(degrees: mixture_of_uk_and_non_uk_degrees)))
         end
 
+        def with_no_option_to_add_another_degree
+          render_component(Trainees::Confirmation::Degrees::View.new(
+                             trainee: mock_trainee(degrees: mixture_of_uk_and_non_uk_degrees),
+                             show_add_another_degree_button: false,
+                           ))
+        end
+
       private
 
         def mock_trainee(degrees:)

--- a/spec/components/trainees/confirmation/degrees/view_spec.rb
+++ b/spec/components/trainees/confirmation/degrees/view_spec.rb
@@ -83,6 +83,22 @@ RSpec.describe Trainees::Confirmation::Degrees::View do
     end
   end
 
+  describe "Add another degree" do
+    it "always renders 'Add another degree' button" do
+      expect(component).to have_css(".govuk-button.govuk-button--secondary")
+    end
+
+    context "suppress the 'Add another degree' button" do
+      before do
+        render_inline(Trainees::Confirmation::Degrees::View.new(trainee: trainee, show_add_another_degree_button: false))
+      end
+
+      it "does not render 'Add another degree' button" do
+        expect(component).not_to have_css(".govuk-button.govuk-button--secondary")
+      end
+    end
+  end
+
 private
 
   def mock_trainee_with_single_uk_degree


### PR DESCRIPTION
### Context
In some instances, we might not want the degree component to give the user
an option to add additional degrees. This commit adds a `show_add_another_degree_button`
param. By default, this is set to true, so that it works without having to worry
about trying to update the section confirmation page which is a generic
page that other sections use but those section confirmation components will
not have this extra param.


### Changes proposed in this pull request

### Guidance to review

