### PR TITLE
[469] Send diversity information to DTTP

### DIFF
--- a/app/components/trainees/confirmation/diversity/view.rb
+++ b/app/components/trainees/confirmation/diversity/view.rb
@@ -43,7 +43,7 @@ module Trainees
         def ethnic_group_content
           value = I18n.t("components.confirmation.diversity.ethnic_groups.#{trainee.ethnic_group}")
 
-          if trainee.ethnic_background.present? && trainee.ethnic_background != Diversities::NOT_PROVIDED_VALUE
+          if trainee.ethnic_background.present? && trainee.ethnic_background != Diversities::NOT_PROVIDED
             value += " (#{trainee.ethnic_background})"
           end
           value

--- a/app/lib/dttp/code_sets/disabilities.rb
+++ b/app/lib/dttp/code_sets/disabilities.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Dttp
+  module CodeSets
+    module Disabilities
+      MAPPING = {
+        ::Diversities::BLIND => { entity_id: "e798eae7-4ba5-e711-80da-005056ac45bb" },
+        ::Diversities::DEAF => { entity_id: "e598eae7-4ba5-e711-80da-005056ac45bb" },
+        ::Diversities::LEARNING_DIFFICULTY => { entity_id: "d998eae7-4ba5-e711-80da-005056ac45bb" },
+        ::Diversities::LONG_STANDING_ILLNESS => { entity_id: "df98eae7-4ba5-e711-80da-005056ac45bb" },
+        ::Diversities::MENTAL_HEALTH_CONDITION => { entity_id: "e198eae7-4ba5-e711-80da-005056ac45bb" },
+        ::Diversities::MULTIPLE_DISABILITIES => { entity_id: "d398eae7-4ba5-e711-80da-005056ac45bb" },
+        ::Diversities::NOT_PROVIDED => { entity_id: "ef98eae7-4ba5-e711-80da-005056ac45bb" },
+        ::Diversities::NO_KNOWN_DISABILITY => { entity_id: "c398eae7-4ba5-e711-80da-005056ac45bb" },
+        ::Diversities::OTHER => { entity_id: "ef98eae7-4ba5-e711-80da-005056ac45bb" },
+        ::Diversities::PHYSICAL_DISABILITY => { entity_id: "e398eae7-4ba5-e711-80da-005056ac45bb" },
+        ::Diversities::SOCIAL_IMPAIRMENT => { entity_id: "dd98eae7-4ba5-e711-80da-005056ac45bb" },
+      }.freeze
+    end
+  end
+end

--- a/app/lib/dttp/code_sets/ethnicities.rb
+++ b/app/lib/dttp/code_sets/ethnicities.rb
@@ -3,57 +3,27 @@
 module Dttp
   module CodeSets
     module Ethnicities
-      AFRICAN = "Black or Black British - African"
-      ARAB = "Arab"
-      BANGLADESHI = "Asian or Asian British - Bangladeshi"
-      CARIBBEAN = "Black or Black British - Caribbean"
-      CHINESE = "Chinese"
-      GYPSY_OR_TRAVELLER = "Gypsy or Traveller"
-      INDIAN = "Asian or Asian British - Indian"
-      INFORMATION_NOT_SAUGHT = "Information not yet sought"
-      INFORMATION_REFUSED = "Information refused"
-      IRISH_TRAVELLER = "Irish traveller"
-      NOT_KNOWN = "Not known"
-      OTHER_ASIAN = "Other Asian background"
-      OTHER_BLACK = "Other Black background"
-      OTHER_ETHNIC = "Other Ethnic background"
-      OTHER_MIXED = "Other Mixed background"
-      OTHER_WHITE = "Other White background"
-      PAKISTANI = "Asian or Asian British - Pakistani"
-      WHITE = "White"
-      WHITE_AND_ASIAN = "Mixed - White and Asian"
-      WHITE_AND_BLACK_AFRICAN = "Mixed - White and Black African"
-      WHITE_AND_BLACK_CARIBBEAN = "Mixed - White and Black Caribbean"
-      WHITE_BRITISH = "White - British"
-      WHITE_IRISH = "White - Irish"
-      WHITE_SCOTTISH = "White - Scottish"
-
-      MAPPING = [
-        { name: ARAB, code: 50, ethnic_minority: true },
-        { name: BANGLADESHI, code: 33, ethnic_minority: true },
-        { name: INDIAN, code: 31, ethnic_minority: true },
-        { name: PAKISTANI, code: 32, ethnic_minority: true },
-        { name: AFRICAN, code: 22, ethnic_minority: true },
-        { name: CARIBBEAN, code: 21, ethnic_minority: true },
-        { name: CHINESE, code: 34, ethnic_minority: true },
-        { name: GYPSY_OR_TRAVELLER, code: 15, ethnic_minority: false },
-        { name: INFORMATION_NOT_SAUGHT, code: 99, ethnic_minority: false },
-        { name: INFORMATION_REFUSED, code: 98, ethnic_minority: false },
-        { name: IRISH_TRAVELLER, code: 14, ethnic_minority: false },
-        { name: WHITE_AND_ASIAN, code: 43, ethnic_minority: true },
-        { name: WHITE_AND_BLACK_AFRICAN, code: 42, ethnic_minority: true },
-        { name: WHITE_AND_BLACK_CARIBBEAN, code: 41, ethnic_minority: true },
-        { name: NOT_KNOWN, code: 90, ethnic_minority: false },
-        { name: OTHER_ASIAN, code: 39, ethnic_minority: true },
-        { name: OTHER_BLACK, code: 29, ethnic_minority: true },
-        { name: OTHER_ETHNIC, code: 80, ethnic_minority: true },
-        { name: OTHER_MIXED, code: 49, ethnic_minority: true },
-        { name: OTHER_WHITE, code: 19, ethnic_minority: false },
-        { name: WHITE, code: 10, ethnic_minority: false },
-        { name: WHITE_BRITISH, code: 11, ethnic_minority: false },
-        { name: WHITE_IRISH, code: 12, ethnic_minority: false },
-        { name: WHITE_SCOTTISH, code: 13, ethnic_minority: false },
-      ].freeze
+      MAPPING = {
+        ::Diversities::AFRICAN => { hesa_code: 22, ethnic_minority: true, entity_id: "c00bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::ANOTHER_ASIAN_BACKGROUND => { hesa_code: 39, ethnic_minority: true, entity_id: "cc0bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::ANOTHER_BLACK_BACKGROUND => { hesa_code: 29, ethnic_minority: true, entity_id: "c20bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::ANOTHER_ETHNIC_BACKGROUND => { hesa_code: 80, ethnic_minority: true, entity_id: "d80bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::ANOTHER_MIXED_BACKGROUND => { hesa_code: 49, ethnic_minority: true, entity_id: "d40bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::ANOTHER_WHITE_BACKGROUND => { hesa_code: 19, ethnic_minority: false, entity_id: "bc0bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::ARAB => { hesa_code: 50, ethnic_minority: true, entity_id: "d60bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::ASIAN_AND_WHITE => { hesa_code: 43, ethnic_minority: true, entity_id: "d20bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::BANGLADESHI => { hesa_code: 33, ethnic_minority: true, entity_id: "c80bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::BLACK_AFRICAN_AND_WHITE => { hesa_code: 42, ethnic_minority: true, entity_id: "d00bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::BLACK_CARIBBEAN_AND_WHITE => { hesa_code: 41, ethnic_minority: true, entity_id: "ce0bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::CARIBBEAN => { hesa_code: 21, ethnic_minority: true, entity_id: "be0bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::CHINESE => { hesa_code: 34, ethnic_minority: true, entity_id: "ca0bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::INDIAN => { hesa_code: 31, ethnic_minority: true, entity_id: "c40bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::IRISH => { hesa_code: 12, ethnic_minority: false, entity_id: "b40bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::NOT_PROVIDED => { hesa_code: 90, ethnic_minority: false, entity_id: "da0bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::PAKISTANI => { hesa_code: 32, ethnic_minority: true, entity_id: "c60bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::TRAVELLER_OR_GYPSY => { hesa_code: 15, ethnic_minority: false, entity_id: "ba0bb892-2b9d-e711-80d9-005056ac45bb" },
+        ::Diversities::WHITE_BRITISH => { hesa_code: 11, ethnic_minority: false, entity_id: "b20bb892-2b9d-e711-80d9-005056ac45bb" },
+      }.freeze
     end
   end
 end

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -11,7 +11,7 @@
       <%= f.govuk_error_summary %>
 
         <%= f.govuk_radio_buttons_fieldset(
-          :ethnic_background, 
+          :ethnic_background,
           legend: { text: "Which of the following best describes their #{I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")} background?", tag: "h1", size: "l" }) do %>
 
           <% Diversities::BACKGROUNDS[@trainee.ethnic_group].each_with_index do |ethnic_background, index| %>
@@ -29,7 +29,7 @@
           <% end %>
 
           <%= f.govuk_radio_divider %>
-          <%= f.govuk_radio_button :ethnic_background, Diversities::NOT_PROVIDED_VALUE, label: { text: "Not provided" } %>
+          <%= f.govuk_radio_button :ethnic_background, Diversities::NOT_PROVIDED, label: {text: "Not provided" } %>
         <% end %>
 
       <%= f.govuk_submit %>

--- a/config/initializers/diversity_enums.rb
+++ b/config/initializers/diversity_enums.rb
@@ -1,6 +1,32 @@
 # frozen_string_literal: true
 
 module Diversities
+  NOT_PROVIDED = "Not provided"
+
+  BANGLADESHI = "Bangladeshi"
+  CHINESE = "Chinese"
+  INDIAN = "Indian"
+  PAKISTANI = "Pakistani"
+  ANOTHER_ASIAN_BACKGROUND = "Another Asian background"
+
+  AFRICAN = "African"
+  CARIBBEAN = "Caribbean"
+  ANOTHER_BLACK_BACKGROUND = "Another Black background"
+
+  ASIAN_AND_WHITE = "Asian and White"
+  BLACK_AFRICAN_AND_WHITE = "Black African and White"
+  BLACK_CARIBBEAN_AND_WHITE = "Black Caribbean and White"
+  ANOTHER_MIXED_BACKGROUND = "Another Mixed background"
+
+  WHITE_BRITISH = "British, English, Northern Irish, Scottish, or Welsh"
+
+  IRISH = "Irish"
+  TRAVELLER_OR_GYPSY = "Traveller or Gypsy"
+  ANOTHER_WHITE_BACKGROUND = "Another White background"
+
+  ARAB = "Arab"
+  ANOTHER_ETHNIC_BACKGROUND = "Another ethnic background"
+
   DIVERSITY_DISCLOSURE_ENUMS = {
     diversity_disclosed: "diversity_disclosed",
     diversity_not_disclosed: "diversity_not_disclosed",
@@ -22,23 +48,34 @@ module Diversities
   }.freeze
 
   BACKGROUNDS = {
-    ETHNIC_GROUP_ENUMS[:asian] => ["Bangladeshi", "Chinese", "Indian", "Pakistani", "Another Asian background"],
-    ETHNIC_GROUP_ENUMS[:black] => ["African", "Caribbean", "Another Black background"],
-    ETHNIC_GROUP_ENUMS[:mixed] => ["Asian and White", "Black African and White", "Black Caribbean and White", "Another Mixed background"],
-    ETHNIC_GROUP_ENUMS[:white] => ["British, English, Northern Irish, Scottish, or Welsh", "Irish", "Irish Traveller or Gypsy", "Another White background"],
-    ETHNIC_GROUP_ENUMS[:other] => ["Arab", "Another ethnic background"],
+    ETHNIC_GROUP_ENUMS[:asian] => [BANGLADESHI, CHINESE, INDIAN, PAKISTANI, ANOTHER_ASIAN_BACKGROUND],
+    ETHNIC_GROUP_ENUMS[:black] => [AFRICAN, CARIBBEAN, ANOTHER_BLACK_BACKGROUND],
+    ETHNIC_GROUP_ENUMS[:mixed] => [ASIAN_AND_WHITE, BLACK_AFRICAN_AND_WHITE, BLACK_CARIBBEAN_AND_WHITE, ANOTHER_MIXED_BACKGROUND],
+    ETHNIC_GROUP_ENUMS[:white] => [WHITE_BRITISH, IRISH, TRAVELLER_OR_GYPSY, ANOTHER_WHITE_BACKGROUND],
+    ETHNIC_GROUP_ENUMS[:other] => [ARAB, ANOTHER_ETHNIC_BACKGROUND],
   }.freeze
 
-  NOT_PROVIDED_VALUE = "Not provided"
+  OTHER = "Other"
+  BLIND = "Blind"
+  DEAF = "Deaf"
+  LEARNING_DIFFICULTY = "Learning difficulty"
+  LONG_STANDING_ILLNESS = "Long-standing illness"
+  MENTAL_HEALTH_CONDITION = "Mental health condition"
+  PHYSICAL_DISABILITY = "Physical disability or mobility issue"
+  SOCIAL_IMPAIRMENT = "Social or communication impairment"
+
+  # Internal only - DTTP related
+  NO_KNOWN_DISABILITY = "No known disability"
+  MULTIPLE_DISABILITIES = "Multiple disabilities"
 
   SEED_DISABILITIES = [
-    OpenStruct.new(name: "Blind", description: "(or a serious visual impairment which is not corrected by glasses)"),
-    OpenStruct.new(name: "Deaf", description: "(or a serious hearing impairment)"),
-    OpenStruct.new(name: "Learning difficulty", description: "(for example, dyslexia, dyspraxia or ADHD)"),
-    OpenStruct.new(name: "Long-standing illness", description: "(for example, cancer, HIV, diabetes, chronic heart disease or epilepsy)"),
-    OpenStruct.new(name: "Mental health condition", description: "(for example, depression, schizophrenia or anxiety disorder)"),
-    OpenStruct.new(name: "Physical disability or mobility issue", description: "(for example,impaired use of arms or legs, use of a wheelchair or crutches)"),
-    OpenStruct.new(name: "Social or communication impairment", description: "(for example Asperger’s, or another autistic spectrum disorder)"),
-    OpenStruct.new(name: "Other", description: nil),
+    OpenStruct.new(name: BLIND, description: "(or a serious visual impairment which is not corrected by glasses)"),
+    OpenStruct.new(name: DEAF, description: "(or a serious hearing impairment)"),
+    OpenStruct.new(name: LEARNING_DIFFICULTY, description: "(for example, dyslexia, dyspraxia or ADHD)"),
+    OpenStruct.new(name: LONG_STANDING_ILLNESS, description: "(for example, cancer, HIV, diabetes, chronic heart disease or epilepsy)"),
+    OpenStruct.new(name: MENTAL_HEALTH_CONDITION, description: "(for example, depression, schizophrenia or anxiety disorder)"),
+    OpenStruct.new(name: PHYSICAL_DISABILITY, description: "(for example,impaired use of arms or legs, use of a wheelchair or crutches)"),
+    OpenStruct.new(name: SOCIAL_IMPAIRMENT, description: "(for example Asperger’s, or another autistic spectrum disorder)"),
+    OpenStruct.new(name: OTHER, description: nil),
   ].freeze
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -55,6 +55,14 @@ FactoryBot.define do
       age_range { AGE_RANGES.sample[:name] }
       programme_start_date { Faker::Date.between(from: 2.years.ago, to: Time.zone.today) }
     end
+
+    trait :diversity_disclosed do
+      diversity_disclosure { Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed] }
+    end
+
+    trait :diversity_not_disclosed do
+      diversity_disclosure { Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed] }
+    end
   end
 end
 


### PR DESCRIPTION
### Context
https://trello.com/c/qmbXErW0/469-l-send-diversity-information-to-dttp

### Changes proposed in this pull request
Update `Dttp::TraineePresenter#to_dttp_params` to include the GUID fields`_dfe_ethnicityid_value` and `_dfe_disibilityid_value`. These values make sure DTTP knows the ethnicity and disability of the trainee if disclosed.

Note: Although the app allows for multiple disabilities, we can only send one to DTTP.

### Guidance to review
Study the logic that computes the 2 new fields as there a number of rules that determines their values.
