### PR TITLE
[XXX] Fix view component preview index page

### DIFF
--- a/spec/components/personas/view_preview.rb
+++ b/spec/components/personas/view_preview.rb
@@ -1,4 +1,4 @@
-module Persona
+module Personas
   class ViewPreview < ViewComponent::Preview
     def single_profile
       render_component(Personas::View.new(persona: mock_persona))


### PR DESCRIPTION
### Context
I noticed a weird issue on Heroku and Paas instance where the `/view_components`
page randomly produced a 500 error, after refreshing the page again it
would display only the first couple of components. I looked in the logs
and couldn't find anything explaining why this problem was happening.
I could not reproduce this in development, so it had to be an issue in production
env.

I put my local instance into production mode and dig some debugging. Deep
in the trenches, I found there was an error but it was being suppressed.
The error related to not being able to find/load the `Persona` module. It
turned out the `personas/view_preview.rb` was referencing `Persona` instead
of `Personas`.

I will feed this issue back to the view_components development team because
I would have thought this kind of error should have been surfaced but what
was odd was the fact in development mode everything worked as expected.


### Changes proposed in this pull request

### Guidance to review

visit https://dfe-twd-rttd-pr-190.herokuapp.com/view_components - all components displayed