### PR TITLE
[460] Review Trainee Details before TRN Submission

### DIFF
--- a/app/controllers/trn_submissions_controller.rb
+++ b/app/controllers/trn_submissions_controller.rb
@@ -4,22 +4,20 @@ class TrnSubmissionsController < ApplicationController
   before_action :authenticate
 
   def show
-    authorize trainee_presenter.trainee
+    authorize trainee
   end
 
   def create
-    authorize trainee_presenter.trainee
+    authorize trainee
 
-    Dttp::ContactService::Create.call(trainee: trainee_presenter)
+    Dttp::ContactService::Create.call(trainee: Dttp::TraineePresenter.new(trainee: trainee))
 
-    redirect_to trn_submission_path(trainee_id: params[:trainee_id])
+    redirect_to trn_submission_path(trainee_id: trainee.id)
   end
 
 private
 
-  def trainee_presenter
-    @trainee_presenter ||= Trainee.find(params[:trainee_id]).then do |trainee|
-      Dttp::TraineePresenter.new(trainee: trainee)
-    end
+  def trainee
+    @trainee ||= Trainee.find(params[:trainee_id])
   end
 end

--- a/app/helpers/trn_submissions_helper.rb
+++ b/app/helpers/trn_submissions_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module TrnSubmissionsHelper
+  def trainee_name(trainee)
+    [trainee.first_names, trainee.middle_names, trainee.last_name]
+      .compact
+      .reject(&:empty?)
+      .join(" ")
+  end
+end

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -1,3 +1,15 @@
+<%= render_component PageTitle::View.new(title: "check_details.show") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render_component GovukComponent::BackLink.new(
+    text: 'Back to draft record',
+    href: trainee_path(@trainee),
+    html_attributes:{
+      id: "back-to-draft-record"
+    }
+  ) %>
+<% end %>
+
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l">
     Draft record for ...
@@ -14,13 +26,15 @@
 <h2 class="govuk-heading-m">
   About the trainee
 </h2>
+
 <%= render_component Trainees::Confirmation::PersonalDetails::View.new(trainee: @trainee) %>
 <%= render_component Trainees::Confirmation::ContactDetails::View.new(trainee: @trainee) %>
 <%= render_component Trainees::Confirmation::Diversity::View.new(trainee: @trainee) %>
 <%= render_component Trainees::Confirmation::Degrees::View.new(trainee: @trainee, show_add_another_degree_button: false) %>
 
-
 <%= form_with url: trn_submissions_path, method: :post, local: true do |f| %>
   <%= hidden_field_tag :trainee_id, @trainee.id %>
   <%= f.govuk_submit "Submit record and request TRN" %>
 <%- end -%>
+
+<p class="govuk-body"><%= govuk_link_to("Return to this draft record later", trainees_path, { id: "return-to-draft-later" }) %></p>

--- a/app/views/trn_submissions/show.html.erb
+++ b/app/views/trn_submissions/show.html.erb
@@ -1,26 +1,26 @@
 <%= render_component PageTitle::View.new(title: "trn_submissions.show") %>
 
+<%= content_for(:breadcrumbs) do %>
+  <%= render_component GovukComponent::BackLink.new(
+    text: 'All records',
+    href: trainees_path
+  ) %>
+<% end %>
+
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <div class="govuk-panel govuk-panel--confirmation trn-submission-success-panel">
-          <div class="govuk-grid-row">
-            <div class="trn-submission-success-panel__check">
-              &check;
-            </div>
-            <div class="trn-submission-success-panel__content">
-              <h1 class="govuk-panel__title">
-                Successfully submitted
-              </h1>
-              <div class="govuk-panel__body">
-                <span class="trn-submission-success-panel__emphasis">You have submitted the trainee for TRN registration</span> - we will update their status when we receive the TRN
-              </div>
-            </div>
-          </div>
-        </div>
-        <a class="govuk-link" href="/trainees">Back to trainee teacher list</a>
-      </div>
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div class="govuk-panel govuk-panel--confirmation trn-submission-success-panel govuk-!-margin-bottom-6">
+      <h1 class="govuk-panel__title">
+        Record submitted for <%= trainee_name(@trainee) %>
+      </h1>
     </div>
+
+    <p class="govuk-body">The Department for Education (DfE) will issue a teacher reference number (TRN) within 3 working days.</p>
+
+    <p class="govuk-body">DfE will contact trainees to give them their TRN.</p>
+
+    <%= govuk_link_to "Add another record", new_trainee_path, { class: "govuk-button" } %>
+
+    <p class="govuk-body">or <%= govuk_link_to("check trainee statuses and manage records", trainees_path) %></p>
   </div>
 </div>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -2,28 +2,8 @@
 @import "~govuk-frontend/govuk/all";
 
 .trn-submission-success-panel {
-  text-align: left;
-
-  &__check {
-    border-radius: 50%;
-    width: 50px;
-    height: 40px;
-    background-color: govuk-color("white");
-    color: govuk-colour("green");
-    font-size: 25px;
-    text-align: center;
-    padding-top: 10px;
-    float: left;
-    margin: 0 20px;
-  }
-
-  &__content {
-    float: left;
-    width: 80%;
-  }
-
-  &__emphasis {
-    font-weight: bold;
+  .govuk-panel__title {
+    @include govuk-font(36, bold);
   }
 }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
         index: Sign in
       trn_submissions:
         show: Successfully submitted
+      check_details:
+        show: Review the trainee details
       trainees:
         new: Add a trainee
         index: Trainee teachers

--- a/spec/controllers/trn_submissions_controller_spec.rb
+++ b/spec/controllers/trn_submissions_controller_spec.rb
@@ -11,7 +11,10 @@ describe TrnSubmissionsController do
     let(:trainee_data) { { some: "data" } }
     let(:decorated_trainee) { instance_double(Dttp::TraineePresenter, trainee: trainee) }
 
-    before { allow(controller).to receive(:current_user).and_return(user) }
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(trainee).to receive(:id).and_return(trainee_id)
+    end
 
     it "passes the decorated trainee to the create service" do
       allow(Trainee).to receive(:find).with(trainee_id.to_s).and_return(trainee)

--- a/spec/features/trainees/submit_for_trn_spec.rb
+++ b/spec/features/trainees/submit_for_trn_spec.rb
@@ -16,13 +16,35 @@ feature "submit for TRN" do
     )
   end
 
-  scenario "with a valid trainee" do
-    given_a_trainee_exists
-    when_i_am_viewing_the_summary_page
-    and_i_want_to_review_record_before_submitting_for_trn
-    then_i_review_the_trainee_data
-    and_i_click_the_submit_for_trn_button
-    and_i_am_redirected_to_the_success_page
+  describe "submission" do
+    scenario "with all sections completed" do
+      given_a_trainee_exists
+      when_i_am_viewing_the_summary_page
+      and_i_want_to_review_record_before_submitting_for_trn
+      then_i_review_the_trainee_data
+      and_i_click_the_submit_for_trn_button
+      and_i_am_redirected_to_the_success_page
+    end
+  end
+
+  describe "navigation" do
+    context "clicking back to draft record" do
+      scenario "returns the user to the summary page" do
+        given_a_trainee_exists
+        and_i_am_on_the_check_details_page
+        when_i_click_back_to_draft_record
+        then_i_am_redirected_to_the_summary_page
+      end
+    end
+
+    context "clicking return to draft record later" do
+      scenario "returns the user to the trainee records page" do
+        given_a_trainee_exists
+        and_i_am_on_the_check_details_page
+        when_i_click_return_to_draft_later
+        then_i_am_redirected_to_the_trainee_records_page
+      end
+    end
   end
 
   def when_i_am_viewing_the_summary_page
@@ -49,8 +71,24 @@ feature "submit for TRN" do
     @check_details_page ||= PageObjects::Trainees::CheckDetails::Show.new
   end
 
+  def and_i_am_on_the_check_details_page
+    check_details_page.load(id: trainee.id)
+  end
+
   def trn_success_page
     @trn_success_page ||= PageObjects::Trainees::TrnSuccess.new
+  end
+
+  def when_i_click_back_to_draft_record
+    check_details_page.back_to_draft_record.click
+  end
+
+  def when_i_click_return_to_draft_later
+    check_details_page.return_to_draft_later.click
+  end
+
+  def then_i_am_redirected_to_the_trainee_records_page
+    expect(trainee_index_page).to be_displayed
   end
 
   def stub_microsoft_oauth_success

--- a/spec/helpers/trn_submissions_helper_spec.rb
+++ b/spec/helpers/trn_submissions_helper_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TrnSubmissionsHelper do
+  include TrnSubmissionsHelper
+
+  describe "#trainee_name" do
+    let(:trainee) { build(:trainee) }
+
+    context "with middle name" do
+      it "returns the full name including middle name" do
+        expect(trainee_name(trainee)).to eq("#{trainee.first_names} #{trainee.middle_names} #{trainee.last_name}")
+      end
+    end
+
+    context "with no middle name" do
+      before do
+        trainee.middle_names = ""
+      end
+
+      it "returns the first name and last name only" do
+        expect(trainee_name(trainee)).to eq("#{trainee.first_names} #{trainee.last_name}")
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/check_details/show.rb
+++ b/spec/support/page_objects/trainees/check_details/show.rb
@@ -5,6 +5,9 @@ module PageObjects
     module CheckDetails
       class Show < PageObjects::Base
         set_url "/trainees/{id}/check-details"
+
+        element :back_to_draft_record, "#back-to-draft-record"
+        element :return_to_draft_later, "#return-to-draft-later"
         element :submit_button, "input[name='commit']"
       end
     end


### PR DESCRIPTION
### Context

- https://trello.com/c/ipVx8Hbi/460-l-review-trainee-details-before-trn-submission

### Changes proposed in this pull request

- Aligns the TRN feedback page closer to the prototype
- Clean up flow from review details page to trn feedback

![review](https://user-images.githubusercontent.com/616080/99689284-b7a19d00-2a7e-11eb-8757-4ac3803f94d1.gif)

![submitted](https://user-images.githubusercontent.com/616080/99689297-ba9c8d80-2a7e-11eb-8819-1386d80edcff.gif)

### Guidance to review

- The dttp values aren't mapped properly at the moment so this won't actually submit and create a contact (that's being handled in a different epic)
- You can create a trainee and review the details page
- You can manually see the trn success page by visiting `/trn_submissions/{id_of_trainee_created}`
