### PR TITLE
add architectural decision records (ADRs)

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ newer versions of tools.
 4. Run `bundle exec rails server` to launch the app on http://localhost:3000
 5. Run `./bin/webpack-dev-server` in a separate shell for faster compilation of assets
 
+## Architectural Decision Record
+
+See the [docs/adr](docs/adr) directory for a list of the Architectural Decision
+Record (ADR). We use [adr-tools](https://github.com/npryce/adr-tools) to manage
+our ADRs, see the link for how to install (hint: `brew install adr-tools` or use
+ASDF).
+
 ## Running specs, linter(without auto correct) and annotate models and serializers
 
 ```

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2020-11-23
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/adr/0002-use-adr-tools-with-custom-template.md
+++ b/docs/adr/0002-use-adr-tools-with-custom-template.md
@@ -1,0 +1,56 @@
+# 2. Use adr-tools with custom template
+
+Date: 2020-11-23
+
+## Status
+
+Accepted
+
+## Context
+
+It's handy to use tooling to create ADRs. There are a couple of options available.
+
+## Options
+
+### 1. npryce's adr-tools
+
+These appear to be the original tools for managing tools. See
+[npryce/adr-tools](https://github.com/npryce/adr-tools) on GitHub.
+
+#### Pros
+
+- simple, well understood
+- bash scripts
+- flexible enough for us (can customise homedir, templates)
+- also being used by Apply
+
+#### Cons
+
+- unknown
+
+### 2. Markdown Architectural Decision Records (madr)
+
+These are a branch of npryce's adr-tools. See
+[adr/madr](https://github.com/adr/madr). They seem to have added a whole bunch
+of extra stuff that I'm not sure we need, although I do like some of the ideas
+in their ADR template which I want to re-use in our own template.
+
+#### Pros
+
+- flexible
+
+#### Cons
+
+- seems quite a bit more complicated (not necessarily in usage, didn't get that
+  far, just looking at their plethora of repos)
+- lots of extra features we may not need
+- JavaScript based, so more complicated than just a bunch of bash scripts
+
+## Decision
+
+Use npryce's adr-tools.
+
+## Consequences
+
+We're more in-line with Apply. Devs will want to install `adr-tools` to be able
+to work with ADRs.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,4 @@
+# Architecture Decision Records
+
+* [1. Record architecture decisions](0001-record-architecture-decisions.md)
+* [2. Use adr-tools with custom template](0002-use-adr-tools-with-custom-template.md)


### PR DESCRIPTION
Added using adr-tools (https://github.com/npryce/adr-tools).

### Context

Copied over from ttapi.

### Changes proposed in this pull request

Add ADR framework and decisions to use ADRs.

### Guidance to review

