### PR TITLE
[519] Allow users to Check trainee records before submitting for TRN

### DIFF
--- a/app/controllers/trainees/programme_details_controller.rb
+++ b/app/controllers/trainees/programme_details_controller.rb
@@ -16,7 +16,7 @@ module Trainees
 
     def edit
       authorize trainee
-      @programme_detail = ProgrammeDetail.new(trainee: trainee)
+      @programme_detail = ProgrammeDetail.new(trainee)
     end
 
     def update
@@ -57,7 +57,7 @@ module Trainees
 
     def section_completed?
       ProgressService.call(
-        validator: ProgrammeDetail.new(trainee: trainee),
+        validator: ProgrammeDetail.new(trainee),
         progress_value: trainee.progress.programme_details,
       ).completed?
     end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -9,6 +9,7 @@ class TraineesController < ApplicationController
 
   def show
     authorize trainee
+    @pre_submission_checker = Trns::SubmissionChecker.call(trainee)
   end
 
   def new

--- a/app/models/programme_detail.rb
+++ b/app/models/programme_detail.rb
@@ -16,7 +16,7 @@ class ProgrammeDetail
 
   after_validation :update_trainee
 
-  def initialize(trainee:)
+  def initialize(trainee)
     @trainee = trainee
 
     super(fields)

--- a/app/services/programme_details/update.rb
+++ b/app/services/programme_details/update.rb
@@ -15,7 +15,7 @@ module ProgrammeDetails
     def initialize(trainee:, attributes: {})
       @trainee = trainee
 
-      @programme_detail = ProgrammeDetail.new(trainee: trainee)
+      @programme_detail = ProgrammeDetail.new(trainee)
       @programme_detail.assign_attributes(attributes)
     end
 

--- a/app/services/trns/submission_checker.rb
+++ b/app/services/trns/submission_checker.rb
@@ -13,9 +13,6 @@ module Trns
       { validator: ProgrammeDetail, progress_key: :programme_details },
     ].freeze
 
-    class PreSubmissionError < StandardError
-    end
-
     class << self
       def call(trainee)
         new(trainee).call

--- a/app/services/trns/submission_checker.rb
+++ b/app/services/trns/submission_checker.rb
@@ -35,16 +35,12 @@ module Trns
   private
 
     def is_submission_ready?
-      VALIDATORS.each do |validator_hash|
+      VALIDATORS.all? do |validator_hash|
         validator = validator_hash[:validator].new(trainee)
         progress_value = trainee.progress.public_send(validator_hash[:progress_key])
 
-        raise PreSubmissionError, validator_hash[:validator].to_s unless progress_is_completed?(validator, progress_value)
+        progress_is_completed?(validator, progress_value)
       end
-
-      true
-    rescue PreSubmissionError
-      false
     end
 
     def progress_is_completed?(validator, progress_value)

--- a/app/services/trns/submission_checker.rb
+++ b/app/services/trns/submission_checker.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Trns
+  class SubmissionChecker
+    attr_reader :trainee, :successful
+    alias_method :successful?, :successful
+
+    VALIDATORS = [
+      { validator: PersonalDetail, progress_key: :personal_details },
+      { validator: ContactDetail, progress_key: :contact_details },
+      { validator: DegreeDetail, progress_key: :degrees },
+      { validator: Diversities::DiversityFlow, progress_key: :diversity },
+      { validator: ProgrammeDetail, progress_key: :programme_details },
+    ].freeze
+
+    class PreSubmissionError < StandardError
+    end
+
+    class << self
+      def call(trainee)
+        new(trainee).call
+      end
+    end
+
+    def initialize(trainee)
+      @trainee = trainee
+    end
+
+    def call
+      @successful = is_submission_ready?
+
+      self
+    end
+
+  private
+
+    def is_submission_ready?
+      VALIDATORS.each do |validator_hash|
+        validator = validator_hash[:validator].new(trainee)
+        progress_value = trainee.progress.public_send(validator_hash[:progress_key])
+
+        raise PreSubmissionError, validator_hash[:validator].to_s unless progress_is_completed?(validator, progress_value)
+      end
+
+      true
+    rescue PreSubmissionError
+      false
+    end
+
+    def progress_is_completed?(validator, progress_value)
+      ProgressService.call(validator: validator, progress_value: progress_value).completed?
+    end
+  end
+end

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -31,7 +31,7 @@
         path: edit_trainee_programme_details_path(@trainee),
         classes: "programme-details",
         status: ProgressService.call(
-          validator: ProgrammeDetail.new(trainee: @trainee),
+          validator: ProgrammeDetail.new(@trainee),
           progress_value: @trainee.progress.programme_details
         ).status
       )
@@ -92,9 +92,11 @@
   </div>
 </div>
 
-<h2 class="govuk-heading-m">Review and submit</h2>
+<% if @pre_submission_checker.successful? %>
+  <h2 class="govuk-heading-m">Review and submit</h2>
 
-<%= govuk_link_to "Review this record", check_details_trainee_path(@trainee), {class: "govuk-button", id: "check-details"} %>
+  <%= govuk_link_to "Review this record", check_details_trainee_path(@trainee), {class: "govuk-button", id: "check-details"} %>
+<% end %>
 
 
 <p class="govuk-body"><%= govuk_link_to("Return to this draft record later", "#") %></p>

--- a/spec/models/programme_detail_spec.rb
+++ b/spec/models/programme_detail_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe ProgrammeDetail do
   let(:trainee) { build(:trainee) }
 
-  subject { described_class.new(trainee: trainee) }
+  subject { described_class.new(trainee) }
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:subject) }

--- a/spec/services/trns/submission_checker_spec.rb
+++ b/spec/services/trns/submission_checker_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trns
+  describe SubmissionChecker do
+    describe ".call" do
+      let(:full_trainee) do
+        create(
+          :trainee,
+          :with_programme_details,
+          ethnic_background: "some background",
+          nationalities: [create(:nationality)],
+          disabilities: [create(:disability)],
+          degrees: [create(:degree, :uk_degree_with_details)],
+        )
+      end
+
+      subject { described_class.new(full_trainee) }
+
+      context "when all sections are valid and complete" do
+        before do
+          SubmissionChecker::VALIDATORS.each do |validator_hash|
+            allow(full_trainee.progress).to receive(validator_hash[:progress_key]).and_return(true)
+          end
+
+          subject.call
+        end
+
+        it "is successful" do
+          expect(subject).to be_successful
+        end
+      end
+
+      context "when any section is invalid or incomplete" do
+        before do
+          subject.call
+        end
+
+        it "is unsuccessful" do
+          expect(subject).to_not be_successful
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/iwKvqYDr/519-allow-users-to-check-trainee-records-before-submitting-for-trn

### Changes proposed in this pull request

- Hides the review details button on the summary page if sections haven't been completed
- Implement a service to check the progress for all sections

![hidden](https://user-images.githubusercontent.com/616080/100073311-44f54080-2e35-11eb-85e0-668955650688.gif)

![shown](https://user-images.githubusercontent.com/616080/100073415-65bd9600-2e35-11eb-802a-58582500b059.gif)


### Guidance to review

- Visit the trainee summary page, assert review details button is hidden
- Complete all sections, assert the review details button is shown

