### PR TITLE
[463] Add the trainee edit record page

### DIFF
--- a/app/components/trainees/confirmation/programme_details/view.html.erb
+++ b/app/components/trainees/confirmation/programme_details/view.html.erb
@@ -1,4 +1,4 @@
-<%= render_component SummaryCard::View.new(title: 'Programme Details',
+<%= render_component SummaryCard::View.new(title: summary_title,
     heading_level: 2,
     rows: [
       {

--- a/app/components/trainees/confirmation/programme_details/view.rb
+++ b/app/components/trainees/confirmation/programme_details/view.rb
@@ -4,7 +4,7 @@ module Trainees
   module Confirmation
     module ProgrammeDetails
       class View < GovukComponent::Base
-        include SummariesHelper
+        include SummaryHelper
 
         attr_accessor :trainee
 

--- a/app/components/trainees/confirmation/programme_details/view.rb
+++ b/app/components/trainees/confirmation/programme_details/view.rb
@@ -4,11 +4,17 @@ module Trainees
   module Confirmation
     module ProgrammeDetails
       class View < GovukComponent::Base
+        include SummariesHelper
+
         attr_accessor :trainee
 
         def initialize(trainee:)
           @trainee = trainee
           @not_provided_copy = I18n.t("components.confirmation.not_provided")
+        end
+
+        def summary_title
+          I18n.t("components.programme_detail.title", record_type: format_record_type)
         end
 
         def subject
@@ -26,7 +32,13 @@ module Trainees
         def programme_start_date
           return @not_provided_copy if trainee.programme_start_date.blank?
 
-          trainee.programme_start_date.strftime("%-d %B %Y")
+          date_for_summary_view(trainee.programme_start_date)
+        end
+
+      private
+
+        def format_record_type
+          trainee.record_type.humanize
         end
       end
     end

--- a/app/components/trainees/record_details/view.html.erb
+++ b/app/components/trainees/record_details/view.html.erb
@@ -1,0 +1,23 @@
+<%= render_component SummaryCard::View.new(
+  title: "Record details",
+  heading_level: 2,
+  rows: [
+    {
+      key: "Trainee ID",
+      value: trainee_id,
+    },
+    {
+      key: "Submitted for TRN",
+      value: submission_date,
+    },
+    {
+      key: "Last updated",
+      value: last_updated_date,
+    },
+
+    {
+      key: "Record created",
+      value: date_for_summary_view(trainee.created_at),
+    },
+  ])
+%>

--- a/app/components/trainees/record_details/view.rb
+++ b/app/components/trainees/record_details/view.rb
@@ -4,7 +4,7 @@ module Trainees
   module RecordDetails
     class View < GovukComponent::Base
       include SanitizeHelper
-      include SummariesHelper
+      include SummaryHelper
 
       attr_reader :trainee
 

--- a/app/components/trainees/record_details/view.rb
+++ b/app/components/trainees/record_details/view.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Trainees
+  module RecordDetails
+    class View < GovukComponent::Base
+      include SanitizeHelper
+      include SummariesHelper
+
+      attr_reader :trainee
+
+      def initialize(trainee)
+        @trainee = trainee
+        @not_provided_copy = I18n.t("components.confirmation.not_provided")
+      end
+
+      def trainee_id
+        trainee.trainee_id.presence || @not_provided_copy
+      end
+
+      def submission_date
+        render_text_with_hint(Time.zone.yesterday)
+      end
+
+      def last_updated_date
+        render_text_with_hint(trainee.updated_at)
+      end
+
+    private
+
+      def render_text_with_hint(date)
+        hint_text = tag.span(time_ago_in_words(date).concat(" ago"), class: "govuk-hint")
+
+        sanitize(tag.p(date_for_summary_view(date), class: "govuk-body") + hint_text)
+      end
+    end
+  end
+end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -30,6 +30,10 @@ class TraineesController < ApplicationController
     end
   end
 
+  def edit
+    authorize trainee
+  end
+
   def update
     authorize trainee
     trainee.update!(trainee_params)

--- a/app/helpers/summaries_helper.rb
+++ b/app/helpers/summaries_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SummariesHelper
+  def date_for_summary_view(date)
+    date.strftime("%-d %B %Y")
+  end
+end

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SummariesHelper
+module SummaryHelper
   def date_for_summary_view(date)
     date.strftime("%-d %B %Y")
   end

--- a/app/views/trainees/edit.html.erb
+++ b/app/views/trainees/edit.html.erb
@@ -1,0 +1,32 @@
+<%= render_component PageTitle::View.new(title: "trainees.edit") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render_component GovukComponent::BackLink.new(
+    text: 'All records',
+    href: trainees_path
+  ) %>
+<% end %>
+
+<div class="trainee-record-header">
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
+    <%= trainee_name(@trainee) %>
+
+    <%= render_component GovukComponent::Tag.new(text: "Pending TRN", colour: "turquoise") %>
+  </h1>
+</div>
+
+<h2 class="govuk-heading-m">
+  Trainee record
+</h2>
+
+<div class="record-details">
+  <%= render_component Trainees::RecordDetails::View.new(@trainee) %>
+</div>
+
+<h2 class="govuk-heading-m">
+  Programme details
+</h2>
+
+<div class="programme-details"> 
+  <%= render_component Trainees::Confirmation::ProgrammeDetails::View.new(trainee: @trainee) %>
+</div>

--- a/app/views/trainees/edit.html.erb
+++ b/app/views/trainees/edit.html.erb
@@ -15,6 +15,11 @@
   </h1>
 </div>
 
+<%= render_component TabNavigation::View.new(items: [
+  { name: "Training details", url: edit_trainee_path(@trainee) },
+  { name: "Personal details", url: trainee_path(@trainee) },
+]) %>
+
 <h2 class="govuk-heading-m">
   Trainee record
 </h2>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -21,7 +21,6 @@ a[href="#"] {
 
 
 // Dashed list (used in Contents links list)
-
 .app-list--dash li {
   position: relative;
 
@@ -31,5 +30,17 @@ a[href="#"] {
     left: -16px;
     position: absolute;
     top: 0;
+  }
+}
+
+
+.trainee-record-header {
+  margin-bottom: govuk-spacing(6);
+}
+
+.trainee-record-header .govuk-tag {
+  @include govuk-media-query($from: tablet) {
+    position: relative;
+    top: -5px;
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,8 @@ en:
           not_provided_ethnic_group: Not provided
       not_provided: Not provided
       heading: Confirm %{section_title}
+    programme_detail:
+      title: "%{record_type} programme details"
     page_titles:
       personas: Personas 
       pages:
@@ -32,6 +34,7 @@ en:
         index: Trainee teachers
         not_supported_route: Other routes not supported
         show: Overview
+        edit: Edit trainee
         diversity:
           disclosures:
             edit: Has the trainee shared diversity information?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
     resource :confirm_details, as: :confirm, only: %i[show update], path: "/confirm"
   end
 
-  resources :trainees, only: %i[index show new create update] do
+  resources :trainees, except: :destroy do
     scope module: :trainees do
       resource :programme_details, concerns: :confirmable, only: %i[edit update], path: "/programme-details"
       resource :contact_details, concerns: :confirmable, only: %i[edit update], path: "/contact-details"

--- a/spec/components/trainees/record_details/view_preview.rb
+++ b/spec/components/trainees/record_details/view_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module Trainees
+  module RecordDetails
+    class ViewPreview < ViewComponent::Preview
+      def default
+        render_component(Trainees::RecordDetails::View.new(mock_trainee("ABC-1234-XYZ")))
+      end
+
+      def with_no_trainee_id
+        render_component(Trainees::RecordDetails::View.new(mock_trainee(nil)))
+      end
+
+    private
+
+      def mock_trainee(trainee_id)
+        @mock_trainee ||= Trainee.new(
+          id: 1,
+          record_type: :assessment_only,
+          trainee_id: trainee_id,
+          created_at: Time.zone.today,
+          updated_at: Time.zone.today,
+        )
+      end
+    end
+  end
+end

--- a/spec/components/trainees/record_details/view_spec.rb
+++ b/spec/components/trainees/record_details/view_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Trainees
   module RecordDetails
     describe View do
-      include SummariesHelper
+      include SummaryHelper
 
       alias_method :component, :page
 

--- a/spec/components/trainees/record_details/view_spec.rb
+++ b/spec/components/trainees/record_details/view_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  module RecordDetails
+    describe View do
+      include SummariesHelper
+
+      alias_method :component, :page
+
+      let(:trainee) { build(:trainee, created_at: Time.zone.today, updated_at: Time.zone.today) }
+
+      context "when trainee_id data has not been provided" do
+        before do
+          trainee.trainee_id = nil
+          render_inline(View.new(trainee))
+        end
+
+        it "tells the user that no data has been entered for trainee ID" do
+          expect(component.find(".govuk-summary-list__row.trainee-id .govuk-summary-list__value")).to have_text(t("components.confirmation.not_provided"))
+        end
+      end
+
+      context "when data has been provided" do
+        before do
+          render_inline(View.new(trainee))
+        end
+
+        it "renders the trainee ID" do
+          expect(component.find(row_for("trainee-id"))).to have_text(trainee.trainee_id)
+        end
+
+        it "renders the trn submission date" do
+          expect(component.find(row_for("submitted-for-trn"))).to have_text(date_for_summary_view(Time.zone.yesterday))
+        end
+
+        it "renders the trainee record last updated date" do
+          expect(component.find(row_for("last-updated"))).to have_text(date_for_summary_view(trainee.updated_at))
+        end
+
+        it "renders the trainee record created date" do
+          expect(component.find(row_for("record-created"))).to have_text(date_for_summary_view(trainee.created_at))
+        end
+      end
+
+    private
+
+      def row_for(selector)
+        ".govuk-summary-list__row.#{selector} .govuk-summary-list__value"
+      end
+    end
+  end
+end

--- a/spec/features/trainees/edit_trainee_record_spec.rb
+++ b/spec/features/trainees/edit_trainee_record_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "edit trainee record", type: :feature do
+  include TrnSubmissionsHelper
+
+  background do
+    given_i_am_authenticated
+    given_a_trainee_exists
+    when_i_visit_the_trainee_edit_page
+  end
+
+  describe "trainee details view" do
+    scenario "viewing the trainee's details" do
+      then_i_see_the_trainee_name
+      then_i_see_the_trn_status
+      then_i_see_the_record_details
+      then_i_see_the_programme_details
+    end
+  end
+
+  def then_i_see_the_trainee_name
+    expect(@edit_page.trainee_name.text).to include(trainee_name(trainee))
+  end
+
+  def then_i_see_the_trn_status
+    expect(@edit_page.trn_status.text).to eq("Pending TRN")
+  end
+
+  def when_i_visit_the_trainee_edit_page
+    @edit_page ||= PageObjects::Trainees::Edit.new
+    @edit_page.load(id: trainee.id)
+  end
+
+  def then_i_see_the_record_details
+    expect(@edit_page).to have_record_detail
+  end
+
+  def then_i_see_the_programme_details
+    expect(@edit_page).to have_programme_detail
+  end
+end

--- a/spec/support/page_objects/sections/summaries/programme_detail.rb
+++ b/spec/support/page_objects/sections/summaries/programme_detail.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../base"
+
+module PageObjects
+  module Sections
+    module Summaries
+      class ProgrammeDetail < PageObjects::Sections::Base
+        element :subject_row, ".govuk-summary-list__row.subject"
+        element :age_range_row, ".govuk-summary-list__row.age-range"
+        element :start_date_row, ".govuk-summary-list__row.programme-start-date"
+        element :end_date_row, ".govuk-summary-list__row.programme-end-date"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/sections/summaries/record_detail.rb
+++ b/spec/support/page_objects/sections/summaries/record_detail.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../base"
+
+module PageObjects
+  module Sections
+    module Summaries
+      class RecordDetail < PageObjects::Sections::Base
+        element :trainee_id_row, ".govuk-summary-list__row.trainee-id"
+        element :trn_submission_row, ".govuk-summary-list__row.submitted-for-trn"
+        element :last_updated_row, ".govuk-summary-list__row.last-updated"
+        element :record_created_row, ".govuk-summary-list__row.record-created"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/edit.rb
+++ b/spec/support/page_objects/trainees/edit.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class Edit < PageObjects::Base
+      set_url "/trainees/{id}/edit"
+
+      element :trainee_name, ".govuk-heading-xl"
+      element :trn_status, ".govuk-tag.govuk-tag--turquoise"
+
+      section :record_detail, PageObjects::Sections::Summaries::RecordDetail, ".record-details"
+      section :programme_detail, PageObjects::Sections::Summaries::ProgrammeDetail, ".programme-details"
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/zmX84s6I/463-edit-trainee-overview-details

### Changes proposed in this pull request

This PR sets up the foundation for editing the trainee record post trn submission to mainly display the following information:

- TRN Status
- Trainee Record overview
- Programme Details overview

There are a few things which have been broken up and will be handled in separate tickets so some information is rendered statically for now ie (trn submission information and programme detail end date will be added in other tickets)

<img width="1287" alt="Screenshot 2020-11-25 at 16 27 20" src="https://user-images.githubusercontent.com/616080/100255839-f2eb1280-2f3b-11eb-8b4b-a07a60bd942b.png">

### Guidance to review
