### PR TITLE
[548] - Add Application Record card component

### DIFF
--- a/app/components/application_record_card/script.js
+++ b/app/components/application_record_card/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/application_record_card/style.scss
+++ b/app/components/application_record_card/style.scss
@@ -1,0 +1,86 @@
+@import "../base.scss";
+
+.app-application-card {
+  border-bottom: 1px solid govuk-colour('mid-grey');
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    align-items: stretch;
+  }
+}
+
+.app-application-card:first-of-type {
+  border-top: 1px solid govuk-colour('mid-grey');
+  padding-top: 15px;
+}
+
+// Trainee column
+.app-application-card_col:nth-last-child(3) {
+  @include govuk-media-query($from: tablet) {
+    width: 40%;
+    padding-right: 15px;
+  }
+}
+
+// Course details column
+.app-application-card_col:nth-last-child(2) {
+  @include govuk-media-query($until: tablet) {
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(2);
+  }
+  @include govuk-media-query($from: tablet) {
+    width: 25%;
+  }
+}
+
+// Status column
+.app-application-card_col:nth-last-child(1) {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: column;
+    width: 35%;
+    justify-content: space-between;
+    height: 100%;
+    text-align: right;
+  }
+}
+
+.app-application-card_col .govuk-tag {
+  align-self: flex-end;
+}
+
+.app-application-card__primary {
+  @include govuk-media-query($from: tablet) {
+    width: 60%;
+  }
+
+  p {
+    margin-bottom: 0;
+  }
+}
+
+.app-application-card__secondary {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 40%;
+    text-align: right;
+  }
+}
+
+.app-application-card__status {
+  margin-bottom: govuk-spacing(2);
+  margin-top: govuk-spacing(3);
+  @include govuk-media-query($from: tablet) {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+
+.app-application-card__subject, .app-application-card__route {
+  @include govuk-font(16);
+  @include govuk-responsive-margin(0, "bottom");
+}

--- a/app/components/application_record_card/view.html.erb
+++ b/app/components/application_record_card/view.html.erb
@@ -1,0 +1,22 @@
+<div class="app-application-card">
+  <div class="app-application-card_col">
+    <h<%= heading_level %> class="govuk-heading-m govuk-!-margin-bottom-3">
+      <%= govuk_link_to trainee_name, trainee_path(record.id) %>
+    </h<%= heading_level %>>
+  </div>
+
+  <div class="app-application-card_col">
+    <p class="govuk-body app-application-card__subject">
+      <%= subject %>
+    </p>
+    <p class="govuk-body govuk-hint app-application-card__route">
+      <%= route %>
+    </p>
+  </div>
+
+  <div class="app-application-card_col">
+    <%= render_component GovukComponent::Tag.new(text: status, colour: 'grey') %>
+  </div>
+</div>
+
+

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ApplicationRecordCard
+  class View < GovukComponent::Base
+    with_collection_parameter :record
+
+    attr_reader :record, :heading_level
+
+    def initialize(heading_level = 2, record:)
+      @record = record
+      @heading_level = heading_level
+    end
+
+    def trainee_name
+      return "Draft record" if record.blank? || record.first_names.blank? || record.last_name.blank?
+
+      [record.first_names, record.last_name].join(" ")
+    end
+
+    def subject
+      return "No subject provided" if record.subject.blank?
+
+      record.subject
+    end
+
+    def route
+      return "ERROR: No route provided" if record.record_type.blank?
+
+      record.record_type.humanize
+    end
+
+    def status
+      "Draft"
+    end
+  end
+end

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -24,7 +24,7 @@ module ApplicationRecordCard
     end
 
     def route
-      return "ERROR: No route provided" if record.record_type.blank?
+      return "No route provided" if record.record_type.blank?
 
       record.record_type.humanize
     end

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -8,35 +8,8 @@
   href: new_trainee_path ) %>
 </p>
 
-<table class="govuk-table" aria-describedby="report-title">
-  <thead>
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header"></th>
-      <th scope="col" class="govuk-table__header"></th>
-      <th scope="col" class="govuk-table__header"></th>
-      <th scope="col" class="govuk-table__header"></th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% if @trainees.present? %>
-      <% @trainees.each do |trainee| %>
-        <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header">
-            <%= govuk_link_to "#{trainee.first_names} #{trainee.last_name}", trainee_path(trainee.id) %>
-          </th>
-          <td class="govuk-table__cell">
-            <div class="govuk-hint govuk-!-margin-bottom-0">
-              <abbr title="Date of Birth">DOB:</abbr> <%= trainee.date_of_birth %>
-            </div> ID: <%= trainee.trainee_id %>
-          </td>
-          <td class="govuk-table__cell">
-            <div class="govuk-hint govuk-!-margin-bottom-0">
-              Salaried Direct(Salaried)
-            </div>
-          </td>
-          <td class="govuk-table__cell"> </td>
-        </tr>
-      <% end %>
-    <% end %>
-  </tbody>
-</table>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= render_component ApplicationRecordCard::View.with_collection(@trainees) %>
+  </div>
+</div>

--- a/spec/components/application_record_card/view_preview.rb
+++ b/spec/components/application_record_card/view_preview.rb
@@ -10,14 +10,14 @@ module ApplicationRecordCard
       render_component(ApplicationRecordCard::View.with_collection(mock_multiple_trainees))
     end
 
-    def no_data
+    def single_card_with_incomplete_data
       render_component(ApplicationRecordCard::View.new(record: Trainee.new(id: 1)))
     end
 
   private
 
     def mock_trainee
-      Trainee.new(id: 1)
+      Trainee.new(id: 1, first_names: "Tom", last_name: "Jones", record_type: "assessment_only", subject: "Primary")
     end
 
     def mock_multiple_trainees

--- a/spec/components/application_record_card/view_preview.rb
+++ b/spec/components/application_record_card/view_preview.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ApplicationRecordCard
+  class ViewPreview < ViewComponent::Preview
+    def single_card
+      render_component(ApplicationRecordCard::View.new(record: mock_trainee))
+    end
+
+    def multiple_cards
+      render_component(ApplicationRecordCard::View.with_collection(mock_multiple_trainees))
+    end
+
+    def no_data
+      render_component(ApplicationRecordCard::View.new(record: Trainee.new(id: 1)))
+    end
+
+  private
+
+    def mock_trainee
+      Trainee.new(id: 1)
+    end
+
+    def mock_multiple_trainees
+      [Trainee.new(id: 1, first_names: "Tom", last_name: "Jones", record_type: "assessment_only", subject: "Primary"),
+       Trainee.new(id: 1, first_names: "Paddington", last_name: "Bear", record_type: "assessment_only", subject: "Science"),
+       Trainee.new(id: 1),
+       Trainee.new(id: 1, first_names: "Tim", last_name: "Knight", record_type: "assessment_only", subject: "Maths"),
+       Trainee.new(id: 1, first_names: "Toby", last_name: "Rocker")]
+    end
+  end
+end

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -19,7 +19,7 @@ module ApplicationRecordCard
     end
 
     it "renders 'No route provided' if there is no route" do
-      expect(component.find(".app-application-card__route")).to have_text("ERROR: No route provided")
+      expect(component.find(".app-application-card__route")).to have_text("No route provided")
     end
 
     it "renders Status tag" do

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ApplicationRecordCard
+  describe View do
+    alias_method :component, :page
+
+    before do
+      render_inline(described_class.new(record: Trainee.new(id: 1)))
+    end
+
+    it "renders 'Draft record' if trainee does not have a first & Last name " do
+      expect(component.find("h2")).to have_text("Draft record")
+    end
+
+    it "renders 'No subject provided' if there is no subject" do
+      expect(component.find(".app-application-card__subject")).to have_text("No subject provided")
+    end
+
+    it "renders 'No route provided' if there is no route" do
+      expect(component.find(".app-application-card__route")).to have_text("ERROR: No route provided")
+    end
+
+    it "renders Status tag" do
+      expect(component).to have_selector(".govuk-tag")
+    end
+
+    context "when a trainee with all their details filled in" do
+      before do
+        render_inline(described_class.new(
+                        record: Trainee.new(
+                          id: 1, first_names: "Teddy",
+                          last_name: "Smith",
+                          subject: "Designer",
+                          record_type: "assessment_only"
+                        ),
+                      ))
+      end
+
+      it "renders trainee name " do
+        expect(component.find("h2")).to have_text("Teddy Smith")
+      end
+
+      it "renders subject" do
+        expect(component.find(".app-application-card__subject")).to have_text("Designer")
+      end
+
+      it "renders route if there is no route" do
+        expect(component.find(".app-application-card__route")).to have_text("Assessment only")
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -9,9 +9,9 @@ module PageObjects
 
       element :add_trainee_link, "a", text: "Add a trainee"
 
-      elements :trainee_data, ".govuk-table tbody tr"
+      elements :trainee_data, ".app-application-card"
 
-      elements :trainee_name, ".govuk-table tbody tr th .govuk-link"
+      elements :trainee_name, ".app-application-card .govuk-link"
     end
   end
 end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

- All records should have a link to be able to navigate back to them
- Closer to what we will use 
- Does not have filter/sort/grouping

### Guidance to review

- Login https://dfe-twd-rttd-pr-214.herokuapp.com and create a few trainee and then go back to the trainees list and check they are displayed as expected
- view the different examples https://dfe-twd-rttd-pr-214.herokuapp.com/view_components/application_record_card/view