### PR TITLE
[558] Implement tab component

### DIFF
--- a/app/components/tab_navigation/script.js
+++ b/app/components/tab_navigation/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/tab_navigation/style.scss
+++ b/app/components/tab_navigation/style.scss
@@ -1,0 +1,107 @@
+@import "../base.scss";
+
+.app-tab-navigation {
+  margin-bottom: govuk-spacing(7);
+}
+
+.app-tab-navigation__list {
+  font-size: 0; // Removes white space when using inline-block on child element.
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  @include govuk-media-query($from: 375px) {
+    box-shadow: inset 0 -1px 0 $govuk-border-colour;
+    width: 100%;
+  }
+
+  // IE8 does not support box shadow, so use a standard border.
+  @include govuk-if-ie8 {
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+
+}
+
+.app-tab-navigation__item {
+  @include govuk-font(19);
+  box-shadow: inset 0 -1px 0 $govuk-border-colour;
+  display: block;
+  margin-top: -1px;
+
+  &:last-child {
+    box-shadow: none;
+  }
+
+  @include govuk-media-query($from: 375px) {
+    box-shadow: none;
+    display: inline-block;
+    margin-right: govuk-spacing(4);
+    margin-top: 0;
+  }
+
+}
+
+.app-tab-navigation__link {
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+  display: block;
+  padding-top: 12px;
+  padding-bottom: 17px;
+  padding-left: govuk-spacing(3);
+  position: relative;
+
+  @include govuk-media-query($from: 375px) {
+    padding-left: 0;
+  }
+
+  &:link,
+  &:visited {
+    color: $govuk-link-colour;
+  }
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+  }
+
+  &:focus {
+    color: govuk-colour("black"); // Focus colour on yellow should really be black.
+    position: relative; // Ensure focus sits above everything else.
+    box-shadow: none;
+  }
+
+  &:focus:before {
+    background-color: govuk-colour("black");
+    content: "";
+    display: block;
+    width: 100%;
+    position: absolute; bottom: 0; left: 0; right: 0;
+    height: 5px;
+  }
+
+}
+
+.app-tab-navigation__link[aria-current="page"] {
+  color: $govuk-link-active-colour;
+  position: relative;
+  text-decoration: none;
+
+  &:before {
+    background-color: $govuk-link-colour;
+    content: "";
+    display: block;
+    height: 100%;
+    position: absolute; bottom: 0; left: 0;
+    width: 5px;
+
+    @include govuk-media-query($from: 375px) {
+      height: 5px;
+      width: 100%;
+    }
+
+  }
+
+  &:focus:before {
+    background-color: govuk-colour("black");
+  }
+
+}

--- a/app/components/tab_navigation/view.html.erb
+++ b/app/components/tab_navigation/view.html.erb
@@ -1,0 +1,13 @@
+<nav class="app-tab-navigation" aria-label="Sub navigation">
+  <ul class="app-tab-navigation__list">
+    <% items.each do |item| %>
+      <li class="app-tab-navigation__item">
+        <% if item.fetch(:current, false) || current_page?(item.fetch(:url)) %>
+          <%= govuk_link_to item[:name], item[:url], class: "app-tab-navigation__link", aria: { current: "page" } %>
+        <% else %>
+          <%= govuk_link_to item[:name], item[:url], class: "app-tab-navigation__link" %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/components/tab_navigation/view.rb
+++ b/app/components/tab_navigation/view.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module TabNavigation
+  class View < GovukComponent::Base
+    attr_reader :items
+
+    def initialize(items:)
+      @items = items
+    end
+  end
+end

--- a/spec/components/tab_navigation/view_preview.rb
+++ b/spec/components/tab_navigation/view_preview.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module TabNavigation
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render_component(View.new(items: items))
+    end
+
+    def with_current_item_highlited
+      with_current = items.prepend(
+        { name: "Training details", url: mock_link, current: true },
+      )
+
+      render_component(View.new(items: with_current))
+    end
+
+  private
+
+    def items
+      [
+        { name: "Personal details", url: mock_link },
+        { name: "Timeline", url: mock_link },
+      ]
+    end
+
+    def mock_link
+      "https://www.gov.uk"
+    end
+  end
+end

--- a/spec/components/tab_navigation/view_spec.rb
+++ b/spec/components/tab_navigation/view_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module TabNavigation
+  describe View do
+    alias_method :component, :page
+
+    let(:mock_link) { "https://www.gov.uk" }
+
+    let(:items) do
+      [
+        { name: "Personal details", url: mock_link },
+        { name: "Timeline", url: mock_link },
+      ]
+    end
+
+    context "default" do
+      before do
+        render_inline(described_class.new(items: items))
+      end
+
+      it "renders the provided links" do
+        rendered_items = component.find_all(".app-tab-navigation__link")
+
+        expect(rendered_items.size).to eq(2)
+
+        items.each do |item|
+          expect(component).to have_link(item[:name], href: item[:url])
+        end
+      end
+    end
+
+    context "with current item" do
+      let(:active_item) { { name: "Training details", url: mock_link, current: true } }
+
+      before do
+        render_inline(described_class.new(items: items.prepend(active_item)))
+      end
+
+      it "renders the current item with the correct class" do
+        rendered_link = component.find(".app-tab-navigation__link", text: active_item[:name])
+        expect(rendered_link["aria-current"]).to eq("page")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/Zb9AOQwJ/558-tabs-component
- broken up from this ticket https://trello.com/c/zmX84s6I/463-edit-trainee-overview-details

### Changes proposed in this pull request

- Implement tabs navigation view component to be re-used across different areas of the app

<img width="1048" alt="Screenshot 2020-11-26 at 14 35 21" src="https://user-images.githubusercontent.com/616080/100363642-f42c4600-2ff4-11eb-9c66-bfd62b8382d7.png">

<img width="1103" alt="Screenshot 2020-11-26 at 14 35 36" src="https://user-images.githubusercontent.com/616080/100363650-f5f60980-2ff4-11eb-9d84-3c94cb402351.png">

### Guidance to review

Default view - https://dfe-twd-rttd-pr-215.herokuapp.com/view_components/tab_navigation/view/default
With highlighted item - https://dfe-twd-rttd-pr-215.herokuapp.com/view_components/tab_navigation/view/with_current_item_highlited