### PR TITLE
[489] Sign out link

### DIFF
--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -23,12 +23,7 @@
         <nav>
           <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
             <li class="govuk-header__navigation-item">
-              <%# TODO Update the path once it has been created %>
-              <%= govuk_link_to "Your account", "#2", class: "govuk-header__link" %>
-            </li>
-            <li class="govuk-header__navigation-item">
-              <%# TODO Update the path once it has been created %>
-              <%= govuk_link_to "Sign out", "#2", class: "govuk-header__link" %>
+              <%= govuk_link_to "Sign out", sign_out_path, class: "govuk-header__link" %>
             </li>
           </ul>
         </nav>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,6 @@ private
   end
 
   def authenticate
-    redirect_to sign_in_index_path unless authenticated?
+    redirect_to sign_in_path unless authenticated?
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,6 @@
 
 class SessionsController < ApplicationController
   skip_before_action :authenticate
-  protect_from_forgery except: :bypass_callback
 
   def callback
     DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
@@ -19,9 +18,11 @@ class SessionsController < ApplicationController
       redirect_to trainees_path
     else
       DfESignInUser.end_session!(session)
-      redirect_to sign_in_index_path
+      redirect_to sign_in_path
     end
   end
 
-  alias_method :bypass_callback, :callback
+  def signout
+    redirect_to root_path
+  end
 end

--- a/app/controllers/sign_out_controller.rb
+++ b/app/controllers/sign_out_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SignOutController < ApplicationController
+  def index
+    DfESignInUser.end_session!(session)
+    redirect_to dfe_sign_in_user.logout_url
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,12 +20,16 @@ Rails.application.routes.draw do
 
   get "/trainees/not-supported-route", to: "trainees/not_supported_routes#index"
 
+  get "/sign-in" => "sign_in#index"
+  get "/sign-out" => "sign_out#index"
+
   if FeatureService.enabled?("use_dfe_sign_in")
     get "/auth/dfe/callback" => "sessions#callback"
-    get "/auth/dfe/sign-out" => "sessions#redirect_after_dsi_signout"
+    get "/auth/dfe/sign-out" => "sessions#signout"
   else
     get "/personas", to: "personas#index"
-    post "/auth/developer/callback", to: "sessions#bypass_callback"
+    get "/auth/developer/sign-out", to: "sessions#signout"
+    post "/auth/developer/callback", to: "sessions#callback"
   end
 
   concern :confirmable do
@@ -72,8 +76,6 @@ Rails.application.routes.draw do
   end
 
   resources :trn_submissions, only: %i[create show], param: :trainee_id
-
-  resources :sign_in, path: "/sign-in", only: [:index]
 
   root to: "pages#show", defaults: { page: "start" }
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,7 +22,7 @@ dfe_sign_in:
   # Our service name
   identifier: rtt
   # URL that the users are redirected to for signing in
-  issuer: https://test-oidc.signin.education.gov.uk/
+  issuer: https://test-oidc.signin.education.gov.uk
   # URL of the users profile
   profile: https://test-profile.signin.education.gov.uk
   # This value must be set otherwise sign in will fail

--- a/spec/components/header/view_spec.rb
+++ b/spec/components/header/view_spec.rb
@@ -14,7 +14,7 @@ module Header
       expect(component.find(".govuk-header__product-name")).to have_text("Test Service")
     end
 
-    it "does not render Sign out/your account links" do
+    it "does not render Sign out link" do
       expect(component).not_to have_selector(".app-header__content")
     end
 
@@ -25,8 +25,8 @@ module Header
         render_inline(described_class.new("Test Service", user))
       end
 
-      it "render Sign out/your account links" do
-        expect(component.find_all(".app-header__content .govuk-header__link").length).to eq(2)
+      it "renders the Sign out link" do
+        expect(component.find_all(".app-header__content .govuk-header__link").length).to eq(1)
       end
     end
   end

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -34,7 +34,7 @@ describe "Settings" do
     dfe_sign_in = settings[:dfe_sign_in]
 
     include_examples expected_value_test, :identifier, dfe_sign_in, "rtt"
-    include_examples expected_value_test, :issuer, dfe_sign_in, "https://test-oidc.signin.education.gov.uk/"
+    include_examples expected_value_test, :issuer, dfe_sign_in, "https://test-oidc.signin.education.gov.uk"
     include_examples expected_value_test, :profile, dfe_sign_in, "https://test-profile.signin.education.gov.uk"
     include_examples expected_value_test, :secret, dfe_sign_in, "secret required value"
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -34,9 +34,9 @@ describe SessionsController, type: :controller do
         expect(session[:dfe_sign_in_user]).to be_nil
       end
 
-      it "redirects to the sign in index page" do
+      it "redirects to the sign in page" do
         request_callback
-        expect(response).to redirect_to(sign_in_index_path)
+        expect(response).to redirect_to(sign_in_path)
       end
 
       describe "save the new user", "feature_allow_user_creation": true do

--- a/spec/controllers/sign_out_controller_spec.rb
+++ b/spec/controllers/sign_out_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SignOutController, type: :controller do
+  include DfESignInUserHelper
+
+  let(:user) { create(:user) }
+
+  let(:dfe_sign_in_user) do
+    {
+      "email" => user.email,
+      "last_active_at" => Time.zone.now,
+      "id_token" => "id_token",
+      "provider" => provider,
+    }
+  end
+
+  let(:request_index) do
+    session["dfe_sign_in_user"] = dfe_sign_in_user
+    get :index
+  end
+
+  describe "#signout" do
+    context "existing DfE user" do
+      let(:provider) { "dfe" }
+      it "redirects to the session/end " do
+        request_index
+        expect(response).to redirect_to(dfe_logout_url)
+      end
+    end
+
+    context "developer user" do
+      let(:provider) { "developer" }
+      it "redirects to the developer/sign-out" do
+        request_index
+        expect(response).to redirect_to("/auth/developer/sign-out")
+      end
+    end
+  end
+
+private
+
+  def dfe_logout_url
+    uri = URI("#{Settings.dfe_sign_in.issuer}/session/end")
+    uri.query = {
+      id_token_hint: "id_token",
+      post_logout_redirect_uri: "#{Settings.base_url}/auth/dfe/sign-out",
+    }.to_query
+    uri.to_s
+  end
+end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -7,7 +7,7 @@ describe "authentication", type: :request do
     context "without been authenticated" do
       it "redirects back to the sign in page" do
         get trainees_path
-        expect(response).to redirect_to(sign_in_index_path)
+        expect(response).to redirect_to(sign_in_path)
       end
     end
   end

--- a/spec/services/dfe_sign_in_users/update_spec.rb
+++ b/spec/services/dfe_sign_in_users/update_spec.rb
@@ -35,7 +35,7 @@ module DfESignInUsers
         end
       end
 
-      context "when programme details are invalid" do
+      context "when the user's details are invalid" do
         let(:user) { create(:user) }
 
         let(:dfe_sign_in_user) do

--- a/spec/support/dfe_sign_in_user_helper.rb
+++ b/spec/support/dfe_sign_in_user_helper.rb
@@ -30,7 +30,7 @@ private
         "urls" => { "website" => nil },
       },
       "credentials" => {
-        "id_token" => "",
+        "id_token" => "id_token",
         "token" => "DFE_SIGN_IN_TOKEN",
         "refresh_token" => nil,
         "expires_in" => 3600,


### PR DESCRIPTION
### Context

* https://trello.com/c/5UB3cgVo/489-s-sign-out-link

Adds a sign out link to end session of user, whether they are from DfE Sign In or internal dev use. User will be redirected to home/root page. 

### Changes proposed in this pull request

Routes to enable sign out
Sign out controller and methods on dfe sign in model that ends session and redirects depending on user type
Controller test to verify correct behaviour
Fix to previous tests that had outdated routes/slight errors.

### Guidance to review
Test each env so that you are successfully logged out and are unable to log in without entering credentials again
Toggle use_dfe_sign_in boolean in development.local



