### PR TITLE
[550] Update Trainee ID

### DIFF
--- a/app/components/trainees/confirmation/programme_details/view.html.erb
+++ b/app/components/trainees/confirmation/programme_details/view.html.erb
@@ -16,7 +16,7 @@
       {
         key: "Programme start date",
         value: programme_start_date,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> progamme start date</span>'.html_safe,
+        action: govuk_link_to('Change<span class="govuk-visually-hidden"> programme start date</span>'.html_safe,
                               edit_trainee_programme_details_path(trainee))
       },
     ]

--- a/app/components/trainees/record_details/view.html.erb
+++ b/app/components/trainees/record_details/view.html.erb
@@ -5,6 +5,8 @@
     {
       key: "Trainee ID",
       value: trainee_id,
+      action: govuk_link_to('Change<span class="govuk-visually-hidden"> trainee ID</span>'.html_safe,
+                              edit_trainee_trainee_id_path(trainee)),
     },
     {
       key: "Submitted for TRN",

--- a/app/controllers/trainees/trainee_ids_controller.rb
+++ b/app/controllers/trainees/trainee_ids_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Trainees
+  class TraineeIdsController < ApplicationController
+    def edit
+      authorize trainee
+    end
+
+    def update
+      authorize trainee
+      trainee.update!(trainee_params)
+      redirect_to edit_trainee_path(trainee)
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.find(params[:trainee_id])
+    end
+
+    def trainee_params
+      params.require(:trainee).permit(:trainee_id)
+    end
+  end
+end

--- a/app/views/trainees/trainee_ids/edit.html.erb
+++ b/app/views/trainees/trainee_ids/edit.html.erb
@@ -1,0 +1,17 @@
+<%= render_component PageTitle::View.new(title: "trainees.trainee_ids.edit") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render_component GovukComponent::BackLink.new(
+    text: 'Back',
+    href: edit_trainee_path(@trainee)
+  ) %>
+<% end %>
+
+<%= form_with model: @trainee, url: trainee_trainee_id_path, local: true do |f| %>
+
+      <%= f.govuk_text_field :trainee_id, label: { text: 'Trainee ID (optional)', size:'l' }, hint: { text: 'Your internal identifier for this trainee or candidate'}, width: 20 %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>
+
+<p class="govuk-body"><%= govuk_link_to("Cancel and return to record", edit_trainee_path(@trainee)) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,8 @@ en:
           new: Add undergraduate details
         personal_details:
           edit: Trainee personal details
+        trainee_ids:
+          edit: Trainee ID
         training_details:
           edit: Add training details
         programme_details:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     scope module: :trainees do
       resource :programme_details, concerns: :confirmable, only: %i[edit update], path: "/programme-details"
       resource :contact_details, concerns: :confirmable, only: %i[edit update], path: "/contact-details"
+      resource :trainee_id, only: %i[edit update]
 
       namespace :degrees do
         get "/new/type", to: "type#new"

--- a/spec/components/trainees/record_details/view_spec.rb
+++ b/spec/components/trainees/record_details/view_spec.rb
@@ -9,7 +9,7 @@ module Trainees
 
       alias_method :component, :page
 
-      let(:trainee) { build(:trainee, created_at: Time.zone.today, updated_at: Time.zone.today) }
+      let(:trainee) { create(:trainee, created_at: Time.zone.today, updated_at: Time.zone.today) }
 
       context "when trainee_id data has not been provided" do
         before do

--- a/spec/features/trainees/edit_trainee_id_spec.rb
+++ b/spec/features/trainees/edit_trainee_id_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "edit Trainee ID" do
+  let(:new_trainee_id) { trainee.trainee_id + "new" }
+
+  background do
+    given_i_am_authenticated
+    given_a_trainee_exists
+    when_i_visit_the_edit_trainee_id_page
+    when_i_change_the_trainee_id
+    when_i_click_continue
+  end
+
+  scenario "updates the Trainee ID" do
+    then_i_am_redirected_to_the_trainee_edit_page
+    then_the_trainee_id_is_updated
+  end
+
+  def when_i_visit_the_edit_trainee_id_page
+    @edit_page ||= PageObjects::Trainees::EditTraineeId.new
+    @edit_page.load(trainee_id: trainee.id)
+  end
+
+  def when_i_change_the_trainee_id
+    @edit_page.trainee_id_input.set(new_trainee_id)
+  end
+
+  def when_i_click_continue
+    @edit_page.continue.click
+  end
+
+  def then_i_am_redirected_to_the_trainee_edit_page
+    expect(page.current_path).to eq("/trainees/#{trainee.id}/edit")
+  end
+
+  def then_the_trainee_id_is_updated
+    when_i_visit_the_edit_trainee_id_page
+    expect(@edit_page.trainee_id_input.value).to eq(new_trainee_id)
+  end
+end

--- a/spec/support/page_objects/trainees/edit_trainee_id.rb
+++ b/spec/support/page_objects/trainees/edit_trainee_id.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class EditTraineeId < PageObjects::Base
+      set_url "/trainees/{trainee_id}/trainee_id/edit"
+
+      element :trainee_id_input, "#trainee-trainee-id-field"
+      element :continue, ".govuk-button"
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/z3abIZCV/550-s-implement-form-to-update-trainee-id-from-edit-trainee-record-page

### Changes proposed in this pull request

This PR allows users to edit the Trainee ID from the the trainee edit page. It includes:

- A new form for editing the trainee ID individually. This does not include any validations, mirroring the functionality from when a trainee is created, and redirects back to the edit page.
- A link to this new form from the trainee edit page.

![Screenshot 2020-12-01 at 14 00 23](https://user-images.githubusercontent.com/18436946/100750201-96757080-33dd-11eb-839d-baa25f697408.png)

### Guidance to review

