### PR TITLE
[570] Update trainee task list headings

### DIFF
--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -15,12 +15,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
-    <h2 class="govuk-heading-m">Route into teaching</h2>
+    <h2 class="govuk-heading-m">Training details</h2>
 
     <%= render_component TaskList::View.new(classes: "record-setup") do |component|
       component.slot(
         :row,
-        task_name: 'Type of training',
+        task_name: 'Training details',
         path: "",
         status: 'completed'
       )
@@ -38,7 +38,7 @@
 
     end %>
 
-    <h2 class="govuk-heading-m">Trainee details</h2>
+    <h2 class="govuk-heading-m">About the trainee</h2>
 
     <%= render_component TaskList::View.new do |component|
       component.slot(
@@ -72,11 +72,6 @@
           progress_value: @trainee.progress.diversity
         ).status
       )
-    end %>
-
-    <h2 class="govuk-heading-m">Education</h2>
-
-    <%= render_component TaskList::View.new(classes: "education") do |component|
 
       component.slot(
         :row,
@@ -97,6 +92,5 @@
 
   <%= govuk_link_to "Review this record", check_details_trainee_path(@trainee), {class: "govuk-button", id: "check-details"} %>
 <% end %>
-
 
 <p class="govuk-body"><%= govuk_link_to("Return to this draft record later", "#") %></p>

--- a/spec/features/trainees/edit_trainee_record_spec.rb
+++ b/spec/features/trainees/edit_trainee_record_spec.rb
@@ -11,7 +11,7 @@ feature "edit trainee record", type: :feature do
     when_i_visit_the_trainee_edit_page
   end
 
-  describe "trainee details view" do
+  describe "about trainee view" do
     scenario "viewing the trainee's details" do
       then_i_see_the_trainee_name
       then_i_see_the_trn_status


### PR DESCRIPTION
### Context
Trainee task list headings as per prototype - https://register-prototype.herokuapp.com/new-record/overview

### Changes proposed in this pull request
Update headings and move degree into "About the trainee"

> All other changes will be completed in later PR's

### Before
![Screenshot 2020-12-02 at 12 15 22](https://user-images.githubusercontent.com/3071606/100871387-1a8c2e80-3498-11eb-8e85-f14d667ec39b.png)

### After
![Screenshot 2020-12-02 at 12 15 22](https://user-images.githubusercontent.com/3071606/100871394-1fe97900-3498-11eb-9bb9-0ee67494e861.png)

