### PR TITLE
Correct negative margin on start page banner within smaller viewports

### DIFF
--- a/app/components/start_page_banner/style.scss
+++ b/app/components/start_page_banner/style.scss
@@ -7,6 +7,10 @@
     margin-top: -(govuk-spacing(2));
   }
 
+  .govuk-phase-banner {
+    border-bottom-color: govuk-colour("light-blue");
+  }
+
   .govuk-phase-banner__text,
   .govuk-link {
     color: govuk-colour("white");
@@ -21,7 +25,7 @@
 .app-start-page-banner {
   background-color: $govuk-brand-colour;
   color: govuk-colour("white");
-  margin-top: -(govuk-spacing(6));
+  margin-top: -(govuk-spacing(4));
 
   @include govuk-media-query($from: tablet) {
     margin-top: -(govuk-spacing(7));


### PR DESCRIPTION
### Context

We have [nicked your design for the phase banner](https://github.com/DFE-Digital/apply-for-teacher-training/pull/3575) for Manage’s own start page. In return, we can contribute some bug fixes. #oneteambat

### Changes proposed in this pull request

* Use light blue border colour for phase banner when shown inside start page banner
* Fix incorrect negative margin on start page banner at smaller sizes (which also hides the bottom border on the phase banner)

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/813383/101020449-70c7a300-3566-11eb-89af-3528445a8873.png) | ![after](https://user-images.githubusercontent.com/813383/101020436-6d341c00-3566-11eb-8e0d-b9e7c69a2b3a.png) |

### Guidance to review

