### PR TITLE
[571] - Update snipets of degree content to be aware of existing degrees

### DIFF
--- a/app/components/trainees/confirmation/degrees/view.html.erb
+++ b/app/components/trainees/confirmation/degrees/view.html.erb
@@ -14,8 +14,6 @@
 
 <% if show_add_another_degree_button %>
   <div class="govuk-form-group">
-    <%= govuk_link_to("Add another degree",
-                        trainee_degrees_new_type_path(trainee),
-                        class:"govuk-button govuk-button--secondary") %>
+    <%= govuk_link_to(degree_button_text, trainee_degrees_new_type_path(trainee), class:"govuk-button govuk-button--secondary") %>
   </div>
 <% end %>

--- a/app/components/trainees/confirmation/degrees/view.rb
+++ b/app/components/trainees/confirmation/degrees/view.rb
@@ -75,6 +75,12 @@ module Trainees
             ]
           end
         end
+
+        def degree_button_text
+          return t("components.degrees.add_a_degree") if degrees.empty?
+
+          t("components.degrees.add_another_degree")
+        end
       end
     end
   end

--- a/app/views/trainees/degrees/type/new.html.erb
+++ b/app/views/trainees/degrees/type/new.html.erb
@@ -2,15 +2,20 @@
   <div class="govuk-grid-column-two-thirds">
       <%= form_with(model: @degree, url: trainee_degrees_new_type_path, local: true) do |f| %>
           <%= f.govuk_error_summary %>
-          <h2 class="govuk-heading-l">Add undergraduate degree</h2>
 
-          <p class="govuk-body">
-            If the trainee has any other degrees, you can add them next.
-          </p>
+          <% if @trainee.degrees.size > 1 %>
+            <h2 class="govuk-heading-l">Add another degree</h2>
+          <% else %>
+            <h2 class="govuk-heading-l">Add undergraduate degree</h2>
+
+            <p class="govuk-body">
+              If the trainee has any other degrees, you can add them next.
+            </p>
+          <% end %>
 
           <% question = [ 
-          OpenStruct.new(name: "Yes", value: "uk" ),
-          OpenStruct.new(name: "No", value: "non_uk")
+            OpenStruct.new(name: "Yes", value: "uk" ),
+            OpenStruct.new(name: "No", value: "non_uk")
           ] %>
 
           <%= f.govuk_collection_radio_buttons :locale_code,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,9 @@ en:
       heading: Confirm %{section_title}
     programme_detail:
       title: "%{record_type} programme details"
+    degrees:
+      add_a_degree: Add a degree
+      add_another_degree: Add another degree
     page_titles:
       personas: Personas 
       pages:

--- a/spec/components/trainees/confirmation/degrees/view_spec.rb
+++ b/spec/components/trainees/confirmation/degrees/view_spec.rb
@@ -85,9 +85,19 @@ RSpec.describe Trainees::Confirmation::Degrees::View do
     end
   end
 
-  describe "Add another degree" do
-    it "always renders 'Add another degree' button" do
-      expect(component).to have_css(".govuk-button.govuk-button--secondary")
+  describe "Degree button text" do
+    context "when there are no degrees" do
+      let(:trainee) { create(:trainee) }
+
+      it "renders 'Add a degree' button" do
+        expect(component.find(degree_button_selector)).to have_text(t("components.degrees.add_a_degree"))
+      end
+    end
+
+    context "when there are degrees" do
+      it "renders 'Add another degree' button" do
+        expect(component.find(degree_button_selector)).to have_text(t("components.degrees.add_another_degree"))
+      end
     end
 
     context "suppress the 'Add another degree' button" do
@@ -96,7 +106,7 @@ RSpec.describe Trainees::Confirmation::Degrees::View do
       end
 
       it "does not render 'Add another degree' button" do
-        expect(component).not_to have_css(".govuk-button.govuk-button--secondary")
+        expect(component).not_to have_css(degree_button_selector)
       end
     end
   end
@@ -123,5 +133,9 @@ private
       build(:degree, :non_uk_degree_with_details),
       build(:degree, :non_uk_degree_with_details),
     ])
+  end
+
+  def degree_button_selector
+    ".govuk-button.govuk-button--secondary"
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/HVmDSXXz/571-update-content-on-the-add-another-degree-journey-in-the-build

### Changes proposed in this pull request

When no degrees but adding a new one:

<img width="1063" alt="Screenshot 2020-12-03 at 14 02 34" src="https://user-images.githubusercontent.com/616080/101028248-9ce82180-3570-11eb-9b98-cee069e6a047.png">

When you have degrees and attempt to add a new one:

<img width="1083" alt="Screenshot 2020-12-03 at 14 03 10" src="https://user-images.githubusercontent.com/616080/101028422-a8d3e380-3570-11eb-8475-bcf1b36249af.png">

When editing a trainee record and you remove all degrees, the text on the button:

<img width="1191" alt="Screenshot 2020-12-03 at 14 01 54" src="https://user-images.githubusercontent.com/616080/101028739-c1dc9480-3570-11eb-97ef-9c36293b1c67.png">

Instead of "add another degree"

### Guidance to review

- Visit https://rtt-review-pr-238.herokuapp.com/ and add a new degree, assert ui is identical to image 1
- Add another degree, assert ui is identical to image 2
- Head to https://rtt-review-pr-238.herokuapp.com/trainees/:id/edit, (replace :id with the trainee id you created) remove all degrees and assert ui is identical to image 3