### PR TITLE
[618] Add page for unknown but authenticated user

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,7 +18,7 @@ class SessionsController < ApplicationController
       redirect_to trainees_path
     else
       DfESignInUser.end_session!(session)
-      redirect_to sign_in_path
+      redirect_to sign_in_user_not_found_path
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,25 @@ module ApplicationHelper
     result.unshift(OpenStruct.new(name: nil))
     result
   end
+
+  def govuk_button_link_to(body, url, html_options = {})
+    original_html_option_class = html_options[:class]
+    html_options[:class] = css_classes("govuk-button", original_html_option_class)
+    html_options[:role] = "button" unless html_options.key?(:role)
+    html_options[:draggable] = false unless html_options.key?(:draggable)
+
+    return link_to(url, html_options) { yield } if block_given?
+
+    link_to(body, url, html_options)
+  end
+
+private
+
+  def css_classes(css_class, current_class)
+    if current_class
+      "#{css_class} #{current_class}"
+    else
+      css_class
+    end
+  end
 end

--- a/app/views/sign_in/new.html.erb
+++ b/app/views/sign_in/new.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <h1 class="govuk-heading-l">Ask for an account to register trainee teachers</h1>
+
+    <p class="govuk-body"> Although you have a DfE Sign-in account, you also need an account
+                             for this service.</p>
+
+    <p class="govuk-body"> Contact us at 
+    <%= govuk_mail_to "becomingateacher@digital.education.gov.uk", 
+                      "becomingateacher@digital.education.gov.uk" %> to ask for an account. 
+    </p>
+    
+    <%= govuk_button_link_to("Return home", root_path) %>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
   get "/sign-in" => "sign_in#index"
   get "/sign-out" => "sign_out#index"
 
+  get "/sign-in/user-not-found", to: "sign_in#new"
+
   if FeatureService.enabled?("use_dfe_sign_in")
     get "/auth/dfe/callback" => "sessions#callback"
     get "/auth/dfe/sign-out" => "sessions#signout"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -34,9 +34,9 @@ describe SessionsController, type: :controller do
         expect(session[:dfe_sign_in_user]).to be_nil
       end
 
-      it "redirects to the sign in page" do
+      it "redirects to the sign in user not found page" do
         request_callback
-        expect(response).to redirect_to(sign_in_path)
+        expect(response).to redirect_to(sign_in_user_not_found_path)
       end
 
       describe "save the new user", "feature_allow_user_creation": true do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ApplicationHelper do
+  include ApplicationHelper
+
+  describe "#govuk_button_link_to" do
+    it "returns an anchor tag with the govuk-button class and button role" do
+      anchor_tag = helper.govuk_button_link_to("Hoot", "https://localhost:0103/owl/hoot")
+
+      expect(anchor_tag).to eq('<a class="govuk-button" role="button" draggable="false" href="https://localhost:0103/owl/hoot">Hoot</a>')
+    end
+
+    it "returns an anchor tag with additional HTML options" do
+      anchor_tag = helper.govuk_button_link_to("Cluck", "https://localhost:0103/chicken/cluck", class: "govuk-button--start")
+
+      expect(anchor_tag).to eq('<a class="govuk-button govuk-button--start" role="button" draggable="false" href="https://localhost:0103/chicken/cluck">Cluck</a>')
+    end
+  end
+end


### PR DESCRIPTION
### Context
A authenticated but unknown user after logging in from DfE Sign-in will be directed to a new page that tells them to
notify us if they wish to log in to Register.
* https://trello.com/c/BY0VkPD0/618-signin-user-doesnt-exist-in-register-journey

### Changes proposed in this pull request
New page the user is redirected to after their session is ended
Fix controller test
View helper added from Apply (with changes) 

### Guidance to review
Make sure allow_user_creation boolean is false or it'll create a user in table

https://rtt-review-pr-239.herokuapp.com/sign-in/user-not-found

<img width="293" alt="Screenshot 2020-12-03 at 14 48 43" src="https://user-images.githubusercontent.com/58793682/101043912-b55b3a80-3576-11eb-8b13-0d7f84bc4618.png">

![image](https://user-images.githubusercontent.com/58793682/101346015-daee8980-387f-11eb-8851-b1b0d6d266bd.png)






