### PR TITLE
Refactor page title component

### DIFF
--- a/app/components/page_title/view.rb
+++ b/app/components/page_title/view.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PageTitle::View < GovukComponent::Base
+  I18N_FORMAT = /^\S*\.\S*$/.freeze
+
   attr_accessor :title, :errors
 
   include ActiveModel
@@ -21,10 +23,10 @@ private
   end
 
   def build_title
-    title == "" ? "" : I18n.t("components.page_titles." + title)
+    title.match?(I18N_FORMAT) ? I18n.t("components.page_titles." + title) : title
   end
 
   def build_service_name
-    title == "" ? I18n.t("service_name") : " - " + I18n.t("service_name")
+    title.present? ? " - " + I18n.t("service_name") : I18n.t("service_name")
   end
 end

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,5 +1,5 @@
 
-<%= render_component PageTitle::View.new(title: "personas") %>
+<%= render_component PageTitle::View.new(title: "Personas") %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">

--- a/app/views/trainees/degrees/new.html.erb
+++ b/app/views/trainees/degrees/new.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.degrees.new") %>
+<%= render_component PageTitle::View.new(title: "trainees.degrees.edit") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/trainees/degrees/type/new.html.erb
+++ b/app/views/trainees/degrees/type/new.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.degrees.new") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
       <%= form_with(model: @degree, url: trainee_degrees_new_type_path, local: true) do |f| %>

--- a/app/views/trainees/diversity/confirm_details/show.html.erb
+++ b/app/views/trainees/diversity/confirm_details/show.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: I18n.t("components.confirmation.heading", section_title: confirm_section_title)) %>
+<%= render_component PageTitle::View.new(title: "trainees.diversity.confirm") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
@@ -10,7 +10,7 @@
 <%= render(
   partial: "trainees/confirm_details/form", 
   locals: { 
-    heading: "Confirm diversity information",
+    heading: t("components.page_titles.trainees.diversity.confirm"),
     confirm_detail: @confirm_detail, 
     trainee: @trainee,
     component: @confirmation_component,

--- a/app/views/trainees/diversity/disability_details/edit.html.erb
+++ b/app/views/trainees/diversity/disability_details/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.diversity.disabilities.edit") %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: "Back",
@@ -15,7 +17,7 @@
           :id,
           :name,
           :description,
-          legend: { text: "Which disabilities were shared?", tag: "h1", size: "l" },
+          legend: { text: t("components.page_titles.trainees.diversity.disabilities.edit"), tag: "h1", size: "l" },
           hint: { text: "Select all that apply" },
           classes: "disability" %>
 

--- a/app/views/trainees/diversity/disability_disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disability_disclosures/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.diversity.disability_disclosure.edit") %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: "Back",
@@ -10,7 +12,7 @@
     <%= form_with(model: @disability_disclosure, url: trainee_diversity_disability_disclosure_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
-        <%= f.govuk_radio_buttons_fieldset(:disability_disclosure, legend: { text: "Has the trainee shared that they are disabled?", tag: "h1", size: "l" }) do %>
+        <%= f.govuk_radio_buttons_fieldset(:disability_disclosure, legend: { text: t("components.page_titles.trainees.diversity.disability_disclosure.edit"), tag: "h1", size: "l" }) do %>
           <% format_disability_disclosure_options(Diversities::DISABILITY_DISCLOSURE_ENUMS.values).each_with_index do |disclosure_option, index| %>
             <%= f.govuk_radio_button(
               :disability_disclosure, 

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -1,3 +1,7 @@
+<%= render_component PageTitle::View.new(
+  title: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}"))
+) %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: "Back",
@@ -12,7 +16,11 @@
 
         <%= f.govuk_radio_buttons_fieldset(
           :ethnic_background,
-          legend: { text: "Which of the following best describes their #{I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")} background?", tag: "h1", size: "l" }) do %>
+          legend: { 
+            text: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")), 
+            tag: "h1", 
+            size: "l" }
+        ) do %>
 
           <% Diversities::BACKGROUNDS[@trainee.ethnic_group].each_with_index do |ethnic_background, index| %>
             <% if other_ethnic_background_option?(ethnic_background) %>

--- a/app/views/trainees/diversity/ethnic_groups/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_groups/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render_component PageTitle::View.new(title: "trainees.diversity.ethnic_group.edit") %>
+
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(
     text: "Back",
@@ -10,7 +12,7 @@
     <%= form_with(model: @ethnic_group, url: trainee_diversity_ethnic_group_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
-        <%= f.govuk_radio_buttons_fieldset(:ethnic_group, legend: { text: "What is their ethnic group?", tag: "h1", size: "l" }) do %>
+        <%= f.govuk_radio_buttons_fieldset(:ethnic_group, legend: { text: t("components.page_titles.trainees.diversity.ethnic_group.edit"), tag: "h1", size: "l" }) do %>
           <% format_ethnic_group_options(Diversities::ETHNIC_GROUP_ENUMS.values).each_with_index do |ethnic_option, index| %>
             <%= f.govuk_radio_button(
               :ethnic_group, 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,6 @@ en:
       add_a_degree: Add a degree
       add_another_degree: Add another degree
     page_titles:
-      personas: Personas 
       pages:
         accessibility: Accessibility
         cookies: Cookies on Register trainee teachers
@@ -31,7 +30,7 @@ en:
       trn_submissions:
         show: Successfully submitted
       check_details:
-        show: Review the trainee details
+        show: Review trainee record
       trainees:
         new: Add a trainee
         index: Trainee teachers
@@ -41,6 +40,15 @@ en:
         diversity:
           disclosures:
             edit: Has the trainee shared diversity information?
+          ethnic_group:
+            edit: What is their ethnic group?
+          ethnic_background:
+            edit: "Which of the following best describes their %{background} background?"
+          disability_disclosure:
+            edit: Has the trainee shared that they are disabled?
+          disabilities:
+            edit: Which disabilities were shared?
+          confirm: Confirm diversity information
         contact_details:
           edit: Contact details
         degrees:

--- a/spec/components/page_title/view_spec.rb
+++ b/spec/components/page_title/view_spec.rb
@@ -3,22 +3,33 @@
 require "rails_helper"
 
 RSpec.describe PageTitle::View do
-  def locale_setup
-    allow(I18n).to receive(:t).with("components.page_titles.trainee.new").and_return("New Trainee")
+  before do
     allow(I18n).to receive(:t).with("service_name").and_return("Cool Service")
   end
 
-  it "constructs a page title value" do
-    locale_setup
-    component = PageTitle::View.new(title: "trainee.new")
-    page_title = component.build_page_title
-    expect(page_title).to eq("New Trainee - Cool Service - GOV.UK")
+  context "given a string that is not in the format of an i18n path" do
+    it "constructs a page title using the provided value" do
+      component = PageTitle::View.new(title: "Some title")
+      page_title = component.build_page_title
+      expect(page_title).to eq("Some title - Cool Service - GOV.UK")
+    end
   end
 
-  it "constructs a page title value with an error" do
-    locale_setup
-    component = PageTitle::View.new(title: "trainee.new", errors: "Loads")
-    page_title = component.build_page_title
-    expect(page_title).to eq("Error: New Trainee - Cool Service - GOV.UK")
+  context "given an i18n key format" do
+    before do
+      allow(I18n).to receive(:t).with("components.page_titles.trainee.new").and_return("New Trainee")
+    end
+
+    it "constructs a page title value" do
+      component = PageTitle::View.new(title: "trainee.new")
+      page_title = component.build_page_title
+      expect(page_title).to eq("New Trainee - Cool Service - GOV.UK")
+    end
+
+    it "constructs a page title value with an error" do
+      component = PageTitle::View.new(title: "trainee.new", errors: "Loads")
+      page_title = component.build_page_title
+      expect(page_title).to eq("Error: New Trainee - Cool Service - GOV.UK")
+    end
   end
 end


### PR DESCRIPTION
### Changes proposed in this pull request

Previously, you had to provide an string in the format of an i18n look up which forced you to define your page title values in one location. This change makes it a little more flexible so that you can pass in a pre-resolved value and just render that in the tile.

- Introduces a regex matcher to match for a string in an i18n format.

Given a list of possible strings:

```
hello there # won't match

asdasdasd # won't match

aas23234 # won't match

hello.there # will match

h.my.friend # will match

hello there.friend # won't match

hello.friend.my.friend # will match
```

### Guidance to review

- Go through app and assert page titles are displaying correctly (even for confirmation pages as that was the source of broken titles)
