### PR TITLE
Reduce scope of inverted link style on app start page

### DIFF
--- a/app/components/start_page_banner/style.scss
+++ b/app/components/start_page_banner/style.scss
@@ -12,7 +12,7 @@
   }
 
   .govuk-phase-banner__text,
-  .govuk-link {
+  .govuk-phase-banner__text .govuk-link {
     color: govuk-colour("white");
   }
 
@@ -26,6 +26,10 @@
   background-color: $govuk-brand-colour;
   color: govuk-colour("white");
   margin-top: -(govuk-spacing(4));
+
+  .govuk-link {
+    color: govuk-colour("white");
+  }
 
   @include govuk-media-query($from: tablet) {
     margin-top: -(govuk-spacing(7));


### PR DESCRIPTION
### Context

The scope of `.app-start-page .govuk-link` is too broad; all links on the start page will be turned white. Currently this only effects a link in the footer, but when I applied these styles to the Manage page, most of the links on the page disappeared!

### Changes proposed in this pull request

Reduce the scope of style that overrides the colour of `govuk-link`. 

| Before | After |
| - | - |
| <img width="630" alt="Screenshot 2020-12-03 at 18 04 00" src="https://user-images.githubusercontent.com/813383/101069727-4986cb00-3592-11eb-82bb-bcfcc2f232ef.png"> | <img width="620" alt="Screenshot 2020-12-03 at 18 02 18" src="https://user-images.githubusercontent.com/813383/101069723-47bd0780-3592-11eb-947c-45e7a75c2bd1.png"> |

### Guidance to review

