### PR TITLE
[586] Fix training details link in summary page

### DIFF
--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -21,7 +21,7 @@
       component.slot(
         :row,
         task_name: 'Training details',
-        path: "",
+        path: training_details_trainee_path(@trainee),
         status: 'completed'
       )
 

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -1,28 +1,14 @@
 <%= render_component PageTitle::View.new(title: "trainees.training_details.edit") %>
 
-<h2 class="govuk-heading-l">Add training details</h2>
+<%= content_for(:breadcrumbs) do %>
+  <%= render_component GovukComponent::BackLink.new(
+    text: 'Back',
+    href: trainee_path(@trainee)
+  ) %>
+<% end %>
 
 <%= form_with model: @trainee, local: true do |f| %>
+  <%= f.govuk_text_field :trainee_id, label: { text: 'Trainee ID (optional)', tag: 'h1', size: 'l' }, hint: { text: 'Your internal identifier for this trainee or candidate'}, width: 20 %>
 
-  <%= f.govuk_date_field :start_date, legend: { text: 'Start date' } %>
-
-  <% full_time_part_time_options = [OpenStruct.new(name: "Full time", value: "full_time"),
-                             OpenStruct.new(name: "Part time", value: "part_time")] %>
-
-  <%= f.govuk_collection_radio_buttons :full_time_part_time,
-      full_time_part_time_options,
-      :value,
-      :name,
-      legend: { text: 'Full time/Part time' } %>
-
-  <% teaching_scholars_options = [OpenStruct.new(name: "No", value: false),
-                               OpenStruct.new(name: "Yes", value: true)] %>
-
-  <%= f.govuk_collection_radio_buttons :teaching_scholars,
-        teaching_scholars_options,
-        :value,
-        :name,
-        legend: { text: 'Teaching scholars' } %>
-
-  <%= f.govuk_submit "Add training details to training record" %>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,7 +59,7 @@ en:
         trainee_ids:
           edit: Trainee ID
         training_details:
-          edit: Add training details
+          edit: Edit training details
         programme_details:
           edit: Programme details
   views:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
     end
 
     member do
-      get "training-details", to: "trainees/training_details#edit"
+      get "training-details", to: "trainees/training_details#edit", as: :training_details
       get "course-details", to: "trainees/course_details#edit"
       get "check-details", to: "trainees/check_details#show"
     end

--- a/spec/features/trainees/edit_training_details_spec.rb
+++ b/spec/features/trainees/edit_training_details_spec.rb
@@ -3,13 +3,16 @@
 require "rails_helper"
 
 feature "edit training details" do
+  let(:new_trainee_id) { trainee.trainee_id + "new" }
+
   background { given_i_am_authenticated }
 
   scenario "edit with valid parameters" do
     given_a_trainee_exists
     when_i_visit_the_training_details_page
-    and_i_enter_valid_parameters
+    and_i_update_the_training_details
     then_i_am_redirected_to_the_summary_page
+    and_the_training_details_are_updated
   end
 
   def when_i_visit_the_training_details_page
@@ -17,14 +20,17 @@ feature "edit training details" do
     @training_details_page.load(id: trainee.id)
   end
 
-  def and_i_enter_valid_parameters
-    @training_details_page.set_date_fields("start_date", "10/01/2021")
-    @training_details_page.full_time.click
-    @training_details_page.teaching_scholars_yes.click
+  def and_i_update_the_training_details
+    @training_details_page.trainee_id.set(new_trainee_id)
     @training_details_page.submit_button.click
   end
 
   def then_i_am_redirected_to_the_summary_page
-    expect(page.current_path).to eq("/trainees/#{trainee.id}")
+    expect(summary_page).to be_displayed(id: trainee.id)
+  end
+
+  def and_the_training_details_are_updated
+    when_i_visit_the_training_details_page
+    expect(@training_details_page.trainee_id.value).to eq(new_trainee_id)
   end
 end

--- a/spec/support/page_objects/trainees/training_details.rb
+++ b/spec/support/page_objects/trainees/training_details.rb
@@ -6,14 +6,9 @@ module PageObjects
       include PageObjects::Helpers
 
       set_url "/trainees/{id}/training-details"
+
+      element :trainee_id, "#trainee-trainee-id-field"
       element :submit_button, "input[name='commit']"
-      element :start_date_day, "#trainee_start_date_3i"
-      element :start_date_month, "#trainee_start_date_2i"
-      element :start_date_year, "#trainee_start_date_1i"
-      element :part_time, "#trainee-full-time-part-time-part-time-field"
-      element :full_time, "#trainee-full-time-part-time-full-time-field"
-      element :teaching_scholars_yes, "#trainee-teaching-scholars-true-field"
-      element :teaching_scholars_no, "#trainee-teaching-scholars-field"
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/b/BBEuhbHM/publish-register-sprint-board

### Changes proposed in this pull request

Under "Route into teaching" there is a link called "Type of training". Previously, it didn't take the user to any page. This PR fixes this and allows the provider to see a limited view of details (trainee id only) they can use to update this field and return back to the summary page.

![training](https://user-images.githubusercontent.com/616080/101175516-29601600-363d-11eb-8c86-531921a73fd4.gif)

### Guidance to review

