### PR TITLE
[631] Pin semantic logger back to 4.4.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "sentry-raven"
 
 # Logging
 gem "amazing_print", "~> 1.2"
-gem "rails_semantic_logger", "~> 4.4"
+gem "rails_semantic_logger", "4.4.4"
 
 # Thread-safe global state
 gem "request_store", "~> 1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
       ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_semantic_logger (4.4.5)
+    rails_semantic_logger (4.4.4)
       rack
       railties (>= 3.2)
       semantic_logger (~> 4.4)
@@ -463,7 +463,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.0.3)
   rails-erd
-  rails_semantic_logger (~> 4.4)
+  rails_semantic_logger (= 4.4.4)
   request_store (~> 1.5)
   rspec-rails (~> 4.0.1)
   rubocop-govuk


### PR DESCRIPTION
### Context

- https://trello.com/c/JjVfEA2q/631-bring-back-rails-logs-in-development

### Changes proposed in this pull request

- Revert previously bumped version

### Guidance to review

- Check logs show locally 

