### PR TITLE
[585] & [587] - A couple of AO fixes

### DIFF
--- a/app/views/trainees/not_supported_route.html.erb
+++ b/app/views/trainees/not_supported_route.html.erb
@@ -23,8 +23,7 @@
         <%= govuk_link_to "go back and change your answer", new_trainee_path  %>
       </li>
       <li>
-        <%#= TODO Need to find out and add DTTP link %>
-        <a class="govuk-link" href="#">use DTTP to register a different route</a>
+        <%= govuk_link_to "use DTTP to register a different route", Settings.dttp.back_office_url  %>
       </li>
     </ul>
   </div>

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -93,4 +93,4 @@
   <%= govuk_link_to "Review this record", check_details_trainee_path(@trainee), {class: "govuk-button", id: "check-details"} %>
 <% end %>
 
-<p class="govuk-body"><%= govuk_link_to("Return to this draft record later", "#") %></p>
+<p class="govuk-body"><%= govuk_link_to("Return to this draft record later", trainees_path) %></p>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,7 @@ base_url: https://localhost:5000
 
 basic_auth_required: true
 dttp:
+  back_office_url: https://dttp-dev.crm4.dynamics.com/
   client_id: "application-registration-client-id-from-env"
   scope: "https://dttp-dev.crm4.dynamics.com/.default"
   client_secret: "client-secret-from-env"

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,6 +1,9 @@
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://www.register-trainee-teachers.education.gov.uk
 
+dttp:
+  back_office_url: https://dttp.crm4.dynamics.com/
+
 dfe_sign_in:
   # URL that the users are redirected to for signing in
   issuer: https://oidc.signin.education.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,6 +1,9 @@
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://qa.register-trainee-teachers.education.gov.uk
 
+dttp:
+  back_office_url: https://dttp-test.crm4.dynamics.com/
+
 features:
   home_text: true
   use_dfe_sign_in: false

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,6 +1,9 @@
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://staging.register-trainee-teachers.education.gov.uk
 
+dttp:
+  back_office_url: https://dttp-ppad.crm4.dynamics.com/
+
 dfe_sign_in:
   # URL that the users are redirected to for signing in
   issuer: https://pp-oidc.signin.education.gov.uk


### PR DESCRIPTION
### Context

- https://trello.com/c/OgxGReJa/587-overview-page-return-to-this-draft-later-link
- https://trello.com/c/yzG0cUXb/585-other-route-add-link-to-dttp

### Changes proposed in this pull request

- Handle the DTTP link in the not supported view
- Handle the "return to draft later" link in the summary page

### Guidance to review

- Nothing major, just asserting the links in those views go to where they're supposed to

