### PR TITLE
[638] Background job to submit DTTP batch request

### DIFF
--- a/app/controllers/trn_submissions_controller.rb
+++ b/app/controllers/trn_submissions_controller.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
 class TrnSubmissionsController < ApplicationController
-  def show
-    authorize trainee
-  end
+  before_action :authorize_trainee
 
   def create
-    authorize trainee
-
-    Dttp::BatchCreate.call(trainee: Dttp::TraineePresenter.new(trainee: trainee))
+    Dttp::CreateJob.perform_later(trainee.id)
 
     redirect_to trn_submission_path(trainee_id: trainee.id)
   end
@@ -17,5 +13,9 @@ private
 
   def trainee
     @trainee ||= Trainee.find(params[:trainee_id])
+  end
+
+  def authorize_trainee
+    authorize(trainee)
   end
 end

--- a/app/jobs/dttp/create_job.rb
+++ b/app/jobs/dttp/create_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Dttp
+  class CreateJob < ApplicationJob
+    queue_as :default
+    retry_on Dttp::BatchRequest::Error
+
+    def perform(trainee_id)
+      Dttp::BatchCreate.call(trainee: Trainee.find(trainee_id))
+    end
+  end
+end

--- a/app/services/dttp/batch_create.rb
+++ b/app/services/dttp/batch_create.rb
@@ -7,7 +7,7 @@ module Dttp
     attr_reader :trainee, :batch_request
 
     def initialize(trainee:)
-      @trainee = trainee
+      @trainee = Dttp::TraineePresenter.new(trainee: trainee)
       @batch_request = BatchRequest.new
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_07_122253) do
+ActiveRecord::Schema.define(version: 2020_12_08_121221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 2020_12_07_122253) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "dfe_sign_in_uid"
     t.datetime "last_signed_in_at"
+    t.uuid "dttp_id"
     t.index ["dfe_sign_in_uid"], name: "index_users_on_dfe_sign_in_uid", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["provider_id"], name: "index_users_on_provider_id"

--- a/spec/services/dttp/batch_create_spec.rb
+++ b/spec/services/dttp/batch_create_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 module Dttp
   describe BatchCreate do
     describe "#call" do
-      let(:trainee) { TraineePresenter.new(trainee: create(:trainee, :with_programme_details)) }
-      let(:batch_request) { double }
+      let(:trainee) { create(:trainee, :with_programme_details) }
+      let(:trainee_presenter) { TraineePresenter.new(trainee: trainee) }
+      let(:batch_request) { instance_double(BatchRequest) }
       let(:contact_change_set_id) { SecureRandom.uuid }
       let(:contact_entity_id) { SecureRandom.uuid }
 
@@ -18,12 +19,12 @@ module Dttp
 
       it "submits a batch request to create contact and placement assignment entities and updates trainee record" do
         expect(batch_request).to receive(:add_change_set).with(entity: "contacts",
-                                                               payload: trainee.contact_params.to_json).and_return(
+                                                               payload: trainee_presenter.contact_params.to_json).and_return(
                                                                  contact_change_set_id,
                                                                )
 
         expect(batch_request).to receive(:add_change_set).with(entity: "dfe_placementassignments",
-                                                               payload: trainee.placement_assignment_params(
+                                                               payload: trainee_presenter.placement_assignment_params(
                                                                  contact_change_set_id,
                                                                ).to_json)
 


### PR DESCRIPTION
### Context
https://trello.com/c/xn1BLS8B/638-m-use-a-background-job-to-submit-dttp-batch-request

### Changes proposed in this pull request
- New ActiveJob object `Dttp::CreateJob` to run `Dttp::BatchCreate` in the background

