### PR TITLE
[645] Check outcome details

### DIFF
--- a/app/components/trainees/outcome_details/view.html.erb
+++ b/app/components/trainees/outcome_details/view.html.erb
@@ -5,6 +5,8 @@
     {
       key: "Date standards met",
       value: outcome_date,
+      action: govuk_link_to('Change<span class="govuk-visually-hidden"> outcome date</span>'.html_safe,
+                            edit_trainee_outcome_date_path(trainee))
     },
   ])
 %>

--- a/app/controllers/trainees/outcome_dates_controller.rb
+++ b/app/controllers/trainees/outcome_dates_controller.rb
@@ -19,10 +19,14 @@ module Trainees
       @outcome.assign_attributes(trainee_params)
 
       if @outcome.save
-        redirect_to edit_trainee_path(trainee)
+        redirect_to confirm_trainee_outcome_date_path(trainee)
       else
         render :edit
       end
+    end
+
+    def confirm
+      authorize trainee
     end
 
   private

--- a/app/views/trainees/outcome_dates/confirm.html.erb
+++ b/app/views/trainees/outcome_dates/confirm.html.erb
@@ -1,0 +1,26 @@
+<%= render_component PageTitle::View.new(title: "trainees.outcome_date.confirm") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render_component GovukComponent::BackLink.new(
+    text: 'Back',
+    href: edit_trainee_outcome_date_path(@trainee)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <span class="govuk-caption-l">
+      <%= trainee_name(@trainee) %>
+    </span>
+    <h1 class="govuk-heading-l">Check outcome details</h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render_component Trainees::OutcomeDetails::View.new(@trainee) %>
+    <%= govuk_link_to "Recommend for QTS", edit_trainee_path(@trainee), class: "govuk-button" %>
+  </div>
+</div>
+
+<p class="govuk-body"><%= govuk_link_to("Cancel and return to record", edit_trainee_path(@trainee)) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
           new: Add undergraduate details
         outcome_date:
           edit: When did they meet the standards?
+          confirm: Check outcome details
         personal_details:
           edit: Trainee personal details
         trainee_ids:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,11 @@ Rails.application.routes.draw do
         resource :disability_detail, concerns: :confirmable, only: %i[edit update], path: "/disabilities"
       end
 
-      resource :outcome_date, only: %i[edit update], path: "/outcome-date"
+      resource :outcome_date, only: %i[edit update], path: "/outcome-date" do
+        member do
+          get "confirm", to: "outcome_dates#confirm"
+        end
+      end
     end
 
     member do

--- a/spec/features/trainees/recording_training_outcome_spec.rb
+++ b/spec/features/trainees/recording_training_outcome_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 feature "Recording a training outcome", type: :feature do
+  include SummaryHelper
+
   before do
     given_i_am_authenticated
     given_a_trainee_exists
@@ -13,13 +15,15 @@ feature "Recording a training outcome", type: :feature do
   scenario "choosing today records the outcome" do
     when_i_choose("Today")
     when_i_submit_the_form
-    then_i_am_redirected_to_the_edit_page
+    then_i_am_redirected_to_the_confirm_page
+    then_the_outcome_date_is_updated
   end
 
   scenario "choosing yesterday records the outcome" do
     when_i_choose("Yesterday")
     when_i_submit_the_form
-    then_i_am_redirected_to_the_edit_page
+    then_i_am_redirected_to_the_confirm_page
+    then_the_outcome_date_is_updated
   end
 
   context "choosing 'On another day'" do
@@ -41,7 +45,8 @@ feature "Recording a training outcome", type: :feature do
     scenario "and filling out a valid date" do
       outcome_date_page.set_date_fields("outcome_date", "31/01/2020")
       when_i_submit_the_form
-      then_i_am_redirected_to_the_edit_page
+      then_i_am_redirected_to_the_confirm_page
+      then_the_outcome_date_is_updated
     end
   end
 
@@ -67,8 +72,13 @@ feature "Recording a training outcome", type: :feature do
     )
   end
 
-  def then_i_am_redirected_to_the_edit_page
-    expect(edit_page).to be_displayed(id: trainee.id)
+  def then_i_am_redirected_to_the_confirm_page
+    expect(confirm_page).to be_displayed(id: trainee.id)
+  end
+
+  def then_the_outcome_date_is_updated
+    trainee.reload
+    expect(page).to have_text(date_for_summary_view(trainee.outcome_date))
   end
 
   def edit_page
@@ -77,5 +87,9 @@ feature "Recording a training outcome", type: :feature do
 
   def outcome_date_page
     @edit_outcome_date_page ||= PageObjects::Trainees::EditOutcomeDate.new
+  end
+
+  def confirm_page
+    @confirm_page ||= PageObjects::Trainees::ConfirmOutcomeDate.new
   end
 end

--- a/spec/support/page_objects/trainees/confirm_outcome_date.rb
+++ b/spec/support/page_objects/trainees/confirm_outcome_date.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class ConfirmOutcomeDate < PageObjects::Base
+      set_url "/trainees/{id}/outcome-date/confirm"
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/2p01YIWQ/645-s-redirect-set-qts-assessment-date-form-to-check-outcome-details-page

### Changes proposed in this pull request

This PR redirects the user after they've recorded the outcome date, to a page where they can confirm the outcome details:

<img width="1214" alt="Screenshot 2020-12-07 at 14 36 27" src="https://user-images.githubusercontent.com/18436946/101363709-9ec82280-3899-11eb-9cd7-e9c5448c31a4.png">

### Guidance to review

- As it stands, the 'Recommend for QTS' button simply redirects back to the trainee edit page. It will eventually:
  - Kick off the actual recommendation
  - Redirect the user to a 'Trainee recommended for QTS' page

To review:

- Visit https://rtt-review-pr-257.herokuapp.com/ and complete a new trainee
- Head to https://rtt-review-pr-257.herokuapp.com/trainees/:id/edit
- Click the green 'Record training outcome' button and fill in the 'When did they meet the standards?' form
- Check that:
  - you're redirected to the confirm page
  - the correct outcome date is populated
  - the 'change' link takes you back to the edit outcome date form, with the correct option pre-populated