### PR TITLE
[608] Mark the trainee as ready for TRN

### DIFF
--- a/app/lib/dttp/batch_request.rb
+++ b/app/lib/dttp/batch_request.rb
@@ -29,26 +29,26 @@ module Dttp
 
     def body
       payload = "--batch_#{batch_id}\n"
-      payload += "Content-Type: multipart/mixed;boundary=changeset_#{change_set_id}\n"
+      payload += "Content-Type: multipart/mixed;boundary=changeset_#{change_set_id}\n\n"
 
-      change_sets.each { |change_set| payload += change_set_body(change_set) }
+      change_sets.each { |change_set| payload += change_set_body(change_set) + "\n" }
 
       payload += "--changeset_#{change_set_id}--\n"
       payload + "--batch_#{batch_id}--\n"
     end
 
     def change_set_body(change_set)
-      %(
---changeset_#{change_set_id}
-Content-Type: application/http
-Content-Transfer-Encoding: binary
-Content-ID: #{change_set[:content_id]}
+      <<~BODY
+        --changeset_#{change_set_id}
+        Content-Type: application/http
+        Content-Transfer-Encoding: binary
+        Content-ID: #{change_set[:content_id]}
 
-POST #{Client.base_uri}/#{change_set[:entity]} HTTP/1.1
-Content-Type: application/json;odata.metadata=minimal
+        POST #{Client.base_uri}/#{change_set[:entity]} HTTP/1.1
+        Content-Type: application/json;odata.metadata=minimal
 
-#{change_set[:payload]}
-)
+        #{change_set[:payload]}
+      BODY
     end
   end
 end

--- a/app/presenters/dttp/trainee_presenter.rb
+++ b/app/presenters/dttp/trainee_presenter.rb
@@ -7,7 +7,7 @@ module Dttp
 
     delegate_missing_to :trainee
 
-    attr_reader :trainee, :user
+    attr_reader :trainee
 
     def initialize(trainee:)
       @trainee = trainee
@@ -28,6 +28,7 @@ module Dttp
         "dfe_DisibilityId@odata.bind" => "/dfe_disabilities(#{dttp_disability_id})",
         "parentcustomerid_account@odata.bind" => "/accounts(#{provider.dttp_id})",
         "dfe_CreatedById@odata.bind" => "/contacts(#{trainee_creator_dttp_id})",
+        "dfe_trnassessmentdate" => today_iso_time,
       }
     end
 
@@ -43,6 +44,8 @@ module Dttp
         "dfe_programmestartdate" => programme_start_date.in_time_zone.iso8601,
         "dfe_CoursePhaseId@odata.bind" => "/dfe_coursephases(#{dttp_course_phase_id})",
         "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{dttp_programme_subject_id})",
+        "dfe_sendforsiregistration" => true,
+        "dfe_sendforregistrationdate" => today_iso_time,
       }
     end
 
@@ -59,6 +62,10 @@ module Dttp
         "dfe_SubjectofUGDegreeId@odata.bind" => "/dfe_jacses(#{dttp_degree_subject_id})",
         "dfe_CountryofStudyId@odata.bind" => "/dfe_countries(#{dttp_degree_country_id})",
       }
+    end
+
+    def today_iso_time
+      Time.zone.now.iso8601
     end
 
     def gender_code

--- a/db/migrate/20201208121221_add_dttp_id_to_users.rb
+++ b/db/migrate/20201208121221_add_dttp_id_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDttpIdToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :dttp_id, :uuid
+  end
+end

--- a/spec/lib/dttp/batch_request_spec.rb
+++ b/spec/lib/dttp/batch_request_spec.rb
@@ -50,31 +50,33 @@ module Dttp
           let(:expected_headers) { { "Content-Type" => "multipart/mixed;boundary=batch_#{batch_id}" } }
 
           let(:expected_body) do
-            %(--batch_#{batch_id}
-Content-Type: multipart/mixed;boundary=changeset_#{change_set_id}
+            <<~BODY
+              --batch_#{batch_id}
+              Content-Type: multipart/mixed;boundary=changeset_#{change_set_id}
 
---changeset_#{change_set_id}
-Content-Type: application/http
-Content-Transfer-Encoding: binary
-Content-ID: #{change_set_1[:content_id]}
+              --changeset_#{change_set_id}
+              Content-Type: application/http
+              Content-Transfer-Encoding: binary
+              Content-ID: #{change_set_1[:content_id]}
 
-POST #{Dttp::Client.base_uri}/#{change_set_1[:entity]} HTTP/1.1
-Content-Type: application/json;odata.metadata=minimal
+              POST #{Dttp::Client.base_uri}/#{change_set_1[:entity]} HTTP/1.1
+              Content-Type: application/json;odata.metadata=minimal
 
-#{change_set_1[:payload]}
+              #{change_set_1[:payload]}
 
---changeset_#{change_set_id}
-Content-Type: application/http
-Content-Transfer-Encoding: binary
-Content-ID: #{change_set_2[:content_id]}
+              --changeset_#{change_set_id}
+              Content-Type: application/http
+              Content-Transfer-Encoding: binary
+              Content-ID: #{change_set_2[:content_id]}
 
-POST #{Dttp::Client.base_uri}/#{change_set_2[:entity]} HTTP/1.1
-Content-Type: application/json;odata.metadata=minimal
+              POST #{Dttp::Client.base_uri}/#{change_set_2[:entity]} HTTP/1.1
+              Content-Type: application/json;odata.metadata=minimal
 
-#{change_set_2[:payload]}
---changeset_#{change_set_id}--
---batch_#{batch_id}--
-)
+              #{change_set_2[:payload]}
+
+              --changeset_#{change_set_id}--
+              --batch_#{batch_id}--
+            BODY
           end
 
           it "sends a batch request with the correct headers and body" do

--- a/spec/presenters/dttp/trainee_presenter_spec.rb
+++ b/spec/presenters/dttp/trainee_presenter_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 module Dttp
   describe TraineePresenter do
+    let(:time_now_in_zone) { Time.zone.now }
     let(:trainee_creator_dttp_id) { SecureRandom.uuid }
 
     subject { described_class.new(trainee: trainee) }
@@ -48,6 +49,8 @@ module Dttp
             "dfe_SubjectofUGDegreeId@odata.bind" => "/dfe_jacses(#{dttp_degree_subject_entity_id})",
             "dfe_AwardingInstitutionId@odata.bind" => "/accounts(#{dttp_degree_institution_entity_id})",
             "dfe_ClassofUGDegreeId@odata.bind" => "/dfe_classofdegrees(#{dttp_degree_grade_entity_id})",
+            "dfe_sendforsiregistration" => true,
+            "dfe_sendforregistrationdate" => time_now_in_zone.iso8601,
           })
         end
       end
@@ -63,6 +66,8 @@ module Dttp
             "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{dttp_programme_subject_entity_id})",
             "dfe_SubjectofUGDegreeId@odata.bind" => "/dfe_jacses(#{dttp_degree_subject_entity_id})",
             "dfe_CountryofStudyId@odata.bind" => "/dfe_countries(#{dttp_country_entity_id})",
+            "dfe_sendforsiregistration" => true,
+            "dfe_sendforregistrationdate" => time_now_in_zone.iso8601,
           })
         end
       end
@@ -70,6 +75,10 @@ module Dttp
 
     describe "#contact_params" do
       let(:trainee) { build(:trainee, gender: "female") }
+
+      before do
+        allow(Time).to receive(:now).and_return(time_now_in_zone)
+      end
 
       context "basic information" do
         it "returns a hash with all the DTTP basic contact fields" do
@@ -85,6 +94,7 @@ module Dttp
             "gendercode" => 1,
             "dfe_CreatedById@odata.bind" => "/contacts(#{trainee_creator_dttp_id})",
             "parentcustomerid_account@odata.bind" => "/accounts(#{trainee.provider.dttp_id})",
+            "dfe_trnassessmentdate" => time_now_in_zone.in_time_zone.iso8601,
           })
         end
       end


### PR DESCRIPTION
### Context
https://trello.com/c/LnzRuMik/608-s-mark-the-trainee-as-ready-for-trn

### Changes proposed in this pull request
* Add `dfe_trnassessmentdate` to contact params
* Add `dfe_sendforregistration` and `dfe_sendforregistrationdate` to placement_assignemnt params, set to Today's date

### Guidance to review

Run this script

```ruby
# frozen_string_literal: true

require_relative "config/environment"
require "factory_bot_rails"
require "faker"

FactoryBot.find_definitions rescue nil

trainee_creator_dttp_id = "98c63edb-b0a6-e811-812c-5065f38bc301"

trainee_attributes = {
  age_range: "3 to 11 programme", # "efa15e61-8ec0-e611-80be-00155d010316"
  subject: "Art and design", # "ee8274df-181e-e711-80c8-0050568902d3"
}

trainee = FactoryBot.create(:trainee, :with_programme_details, :diversity_disclosed, trainee_attributes)

degree_attributes = {
  subject: "Accountancy", # "ee8274df-181e-e711-80c8-0050568902d3"
  institution: "Aberystwyth University", # "443e2cff-6f42-e811-80ff-3863bb3640b8"
  grade: "First-class Honours", # "fe2fca5f-766d-e711-80d2-005056ac45bb"
  country: "Ireland",
}

trainee.degrees << FactoryBot.create(:degree, :non_uk_degree_with_details, degree_attributes)

trainee = Dttp::TraineePresenter.new(trainee: trainee)
entity_ids = Dttp::BatchCreate.call(trainee: trainee, trainee_creator_dttp_id: trainee_creator_dttp_id)
puts entity_ids

trainee.destroy!
```

Then check in DTTP that the contact and placement IDs given have the params set accordingly
