### PR TITLE
[590] & [589] Fix DOB validations

### DIFF
--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -2,6 +2,12 @@
 
 module Trainees
   class PersonalDetailsController < ApplicationController
+    DOB_CONVERSION = {
+      "date_of_birth(3i)" => "day",
+      "date_of_birth(2i)" => "month",
+      "date_of_birth(1i)" => "year",
+    }.freeze
+
     def show
       authorize trainee
       render layout: "trainee_record"
@@ -16,8 +22,7 @@ module Trainees
     def update
       authorize trainee
       nationalities
-      trainee.assign_attributes(personal_details_params)
-      personal_detail = PersonalDetail.new(trainee)
+      personal_detail = PersonalDetail.new(trainee, personal_details_params)
 
       if personal_detail.save
         redirect_to trainee_personal_details_confirm_path(personal_detail.trainee)
@@ -40,8 +45,11 @@ module Trainees
     def personal_details_params
       params.require(:personal_detail).permit(
         *PersonalDetail::FIELDS,
+        *DOB_CONVERSION.keys,
         nationality_ids: [],
-      )
+      ).transform_keys do |key|
+        DOB_CONVERSION.keys.include?(key) ? DOB_CONVERSION[key] : key
+      end
     end
   end
 end

--- a/app/models/personal_detail.rb
+++ b/app/models/personal_detail.rb
@@ -5,34 +5,51 @@ class PersonalDetail
   include ActiveModel::AttributeAssignment
   include ActiveModel::Validations::Callbacks
 
-  attr_accessor :trainee
-
   FIELDS = %w[
     first_names
     middle_names
     last_name
-    date_of_birth
     gender
     nationality_ids
   ].freeze
 
   delegate :id, :persisted?, to: :trainee
 
-  attr_accessor(*FIELDS)
+  attr_accessor(*FIELDS, :trainee, :day, :month, :year)
 
   validates :first_names, presence: true
   validates :last_name, presence: true
   validates :date_of_birth, presence: true
   validates :gender, presence: true, inclusion: { in: Trainee.genders.keys }
+
+  validate :date_of_birth_valid
+  validate :date_of_birth_not_in_future
   validate :nationalities_cannot_be_empty
 
-  def initialize(trainee)
+  after_validation :update_trainee_attributes
+
+  def initialize(trainee, attributes = {})
     @trainee = trainee
+    @attributes = attributes
     super(fields)
   end
 
   def fields
-    trainee.attributes.slice(*FIELDS).merge(nationality_ids: trainee.nationality_ids)
+    trainee.attributes.merge(attributes).slice(*FIELDS).merge(
+      nationality_ids: nationalities,
+      **date_of_birth_hash,
+    )
+  end
+
+  def date_of_birth
+    date_hash = { year: year, month: month, day: day }
+    date_args = date_hash.values.map(&:to_i)
+
+    if Date.valid_date?(*date_args)
+      Date.new(*date_args)
+    else
+      Struct.new(*date_hash.keys).new(*date_hash.values)
+    end
   end
 
   def save
@@ -43,8 +60,41 @@ private
 
   attr_reader :attributes
 
+  def update_trainee_attributes
+    if errors.empty?
+      trainee.assign_attributes(
+        fields.except(:day, :month, :year).symbolize_keys.merge(
+          date_of_birth: date_of_birth,
+          nationality_ids: nationalities,
+        ),
+      )
+    end
+  end
+
+  def date_of_birth_hash
+    {
+      day: trainee.date_of_birth&.day,
+      month: trainee.date_of_birth&.month,
+      year: trainee.date_of_birth&.year,
+    }.merge(attributes.slice(:day, :month, :year).to_h.symbolize_keys)
+  end
+
+  def nationalities
+    return trainee.nationality_ids if attributes[:nationality_ids].blank?
+
+    attributes[:nationality_ids].reject(&:blank?).map(&:to_i)
+  end
+
+  def date_of_birth_valid
+    errors.add(:date_of_birth, :invalid) unless date_of_birth.is_a?(Date)
+  end
+
+  def date_of_birth_not_in_future
+    errors.add(:date_of_birth, :future) if date_of_birth.is_a?(Date) && date_of_birth > Time.zone.today
+  end
+
   def nationalities_cannot_be_empty
-    return unless trainee.nationalities.empty?
+    return unless nationalities.empty?
 
     errors.add(:nationality_ids, :empty_nationalities)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,8 @@ en:
               blank: "You must enter a last name"
             date_of_birth:
               blank: "You must enter a date of birth"
+              invalid: "You must enter a valid date"
+              future: "You must enter a date of birth that is in the past, for example 31 3 1980"
             gender:
               blank: "You must select a gender"
             nationality_ids:


### PR DESCRIPTION
### Context

- https://trello.com/c/rJg1d5ao/590-personal-details-date-of-birth-saving-the-wrong-day-instead-of-throwing-a-validation-error-message
- https://trello.com/c/dR0nkzrM/589-personal-detail-date-of-birth-validations-invalid-day

### Changes proposed in this pull request

- Rejigs the `PersonalDetail` so that the date of birth value is validated properly
- Will hydrate/validate model values based on state of Trainee passed in or additional attributes provided

Validates correct date format:

<img width="1159" alt="Screenshot 2020-12-08 at 16 15 55" src="https://user-images.githubusercontent.com/616080/101509420-a9092000-3970-11eb-87e4-a26472ad38fd.png">

Validates dates are in the past:

<img width="1139" alt="Screenshot 2020-12-08 at 16 16 39" src="https://user-images.githubusercontent.com/616080/101509524-c2aa6780-3970-11eb-968b-5eef35646679.png">

### Guidance to review

- https://rtt-review-pr-266.herokuapp.com/trainees/1/personal-details/edit
- Attempt to save with empty or invalid dob and assert errors are shown