### PR TITLE
[588] Update overview links

### DIFF
--- a/app/components/task_list/view.html.erb
+++ b/app/components/task_list/view.html.erb
@@ -1,7 +1,7 @@
 <%= tag.ol(class: classes, **html_attributes) do %>
   <% rows.each do |row| %>
     <%= tag.li(class: row.classes, **row.html_attributes) do %>
-      <a href="<%= row.path  %>" class="govuk-link app-task-list__key">
+      <a href="<%= row.get_path  %>" class="govuk-link app-task-list__key">
         <%= row.task_name %>
       </a>
       <% if any_row_has_status? %>

--- a/app/components/task_list/view.rb
+++ b/app/components/task_list/view.rb
@@ -16,14 +16,21 @@ private
   end
 
   class Row < GovukComponent::Slot
-    attr_accessor :task_name, :path, :status
+    attr_accessor :task_name, :status
 
-    def initialize(task_name:, path:, status:, classes: [], html_attributes: {})
+    def initialize(task_name:, path:, confirm_path: nil, status:, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
 
       @task_name = task_name
       @path = path
+      @confirm_path = confirm_path
       @status = status
+    end
+
+    def get_path
+      return @path unless @confirm_path
+
+      status == "not started" ? @path : @confirm_path
     end
 
     def get_status_colour

--- a/app/components/task_list/view.rb
+++ b/app/components/task_list/view.rb
@@ -30,7 +30,7 @@ private
     def get_path
       return @path unless @confirm_path
 
-      status == "not started" ? @path : @confirm_path
+      status == Progress::STATUSES[:not_started] ? @path : @confirm_path
     end
 
     def get_status_colour

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -29,6 +29,7 @@
         :row,
         task_name: 'Programme details',
         path: edit_trainee_programme_details_path(@trainee),
+        confirm_path: trainee_programme_details_confirm_path(@trainee),
         classes: "programme-details",
         status: ProgressService.call(
           validator: ProgrammeDetail.new(@trainee),
@@ -45,6 +46,7 @@
         :row,
         task_name: 'Personal details',
         path: edit_trainee_personal_details_path(@trainee),
+        confirm_path: trainee_personal_details_confirm_path(@trainee),
         classes: "personal-details",
         status: ProgressService.call(
           validator: PersonalDetail.new(@trainee),
@@ -56,6 +58,7 @@
         :row,
         task_name: 'Contact details',
         path: edit_trainee_contact_details_path(@trainee),
+        confirm_path: trainee_contact_details_confirm_path(@trainee),
         status: ProgressService.call(
           validator: ContactDetail.new(@trainee),
           progress_value: @trainee.progress.contact_details
@@ -66,6 +69,7 @@
         :row,
         task_name: 'Diversity information',
         path: edit_trainee_diversity_disclosure_path(@trainee),
+        confirm_path: trainee_diversity_disclosure_confirm_path(@trainee),
         classes: "diversity-details",
         status: ProgressService.call(
           validator: Diversities::DiversityFlow.new(@trainee),
@@ -76,7 +80,8 @@
       component.slot(
         :row,
         task_name: 'Degree',
-        path: @trainee.degrees.present?  ? trainee_degrees_confirm_path(@trainee) : trainee_degrees_new_type_path(@trainee),
+        path: trainee_degrees_new_type_path(@trainee),
+        confirm_path: trainee_degrees_confirm_path(@trainee),
         status: ProgressService.call(
           validator: DegreeDetail.new(@trainee),
           progress_value: @trainee.progress.degrees


### PR DESCRIPTION
### Context

https://trello.com/c/nE38P3og/588-overview-page-section-links-need-to-be-updated

### Changes proposed in this pull request

This PR updates each section link in the trainee overview page so that the following is true:

Status = not started -> links to the beginning of the journey for that section
Status = in progress -> links to the confirmation page
Status = completed -> links to the confirmation page

### Guidance to review

I thought about letting the `Row` component calculate the path based on a `key` passed in, but I decided that a separate `confirm_path` was probably the least surprising option.
