### PR TITLE
[669] & [671] Fix error summary and record outcome button markup

### DIFF
--- a/app/components/trainees/record_actions/view.html.erb
+++ b/app/components/trainees/record_actions/view.html.erb
@@ -1,2 +1,2 @@
-<%= govuk_link_to "Record training outcome", edit_trainee_outcome_details_outcome_date_path(trainee), { class: "govuk-button govuk-!-margin-bottom-0" }  %>
+<%= govuk_button_link_to "Record training outcome", edit_trainee_outcome_details_outcome_date_path(trainee), { class: "govuk-button govuk-!-margin-bottom-0" }  %>
 <hr class='govuk-section-break govuk-section-break--m govuk-section-break--visible'>

--- a/app/components/trainees/record_actions/view.html.erb
+++ b/app/components/trainees/record_actions/view.html.erb
@@ -1,2 +1,2 @@
-<%= govuk_button_link_to "Record training outcome", edit_trainee_outcome_details_outcome_date_path(trainee), { class: "govuk-button govuk-!-margin-bottom-0" }  %>
+<%= govuk_button_link_to "Record training outcome", edit_trainee_outcome_details_outcome_date_path(trainee), { class: "govuk-!-margin-bottom-0" }  %>
 <hr class='govuk-section-break govuk-section-break--m govuk-section-break--visible'>

--- a/app/components/trainees/record_actions/view.rb
+++ b/app/components/trainees/record_actions/view.rb
@@ -3,6 +3,8 @@
 module Trainees
   module RecordActions
     class View < GovukComponent::Base
+      include ApplicationHelper
+
       attr_reader :trainee
 
       def initialize(trainee)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,10 +10,13 @@ module ApplicationHelper
   end
 
   def govuk_button_link_to(body, url, html_options = {})
-    original_html_option_class = html_options[:class]
-    html_options[:class] = css_classes("govuk-button", original_html_option_class)
-    html_options[:role] = "button" unless html_options.key?(:role)
-    html_options[:draggable] = false unless html_options.key?(:draggable)
+    html_options = {
+      role: "button",
+      data: { module: "govuk-button" },
+      draggable: false,
+    }.merge(html_options)
+
+    html_options[:class] = prepend_css_class("govuk-button", html_options[:class])
 
     return link_to(url, html_options) { yield } if block_given?
 
@@ -22,7 +25,7 @@ module ApplicationHelper
 
 private
 
-  def css_classes(css_class, current_class)
+  def prepend_css_class(css_class, current_class)
     if current_class
       "#{css_class} #{current_class}"
     else

--- a/app/views/trainees/outcome_dates/edit.html.erb
+++ b/app/views/trainees/outcome_dates/edit.html.erb
@@ -9,11 +9,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <span class="govuk-caption-l">
-      <%= trainee_name(@trainee) %>
-    </span>
     <%= form_for(@outcome, url: trainee_outcome_details_outcome_date_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">
+        <%= trainee_name(@trainee) %>
+      </span>
 
       <%= f.govuk_radio_buttons_fieldset(:outcome_date_string, legend: { text: "When did they meet the standards?", tag: "h1", size: "l" }, classes: "outcome-date") do %>
         <%= f.govuk_radio_button :outcome_date_string, :today, label: { text: "Today" }, link_errors: true %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,16 +6,26 @@ describe ApplicationHelper do
   include ApplicationHelper
 
   describe "#govuk_button_link_to" do
-    it "returns an anchor tag with the govuk-button class and button role" do
-      anchor_tag = helper.govuk_button_link_to("Hoot", "https://localhost:0103/owl/hoot")
+    context "default behaviour" do
+      subject { helper.govuk_button_link_to("Hoot", "https://localhost:0103/owl/hoot") }
 
-      expect(anchor_tag).to eq('<a class="govuk-button" role="button" draggable="false" href="https://localhost:0103/owl/hoot">Hoot</a>')
+      it "returns an anchor tag with the govuk-button class and button role" do
+        expected_output = '<a role="button" data-module="govuk-button" draggable="false" class="govuk-button" href="https://localhost:0103/owl/hoot">Hoot</a>'
+
+        expect(subject).to eq(expected_output)
+      end
     end
 
-    it "returns an anchor tag with additional HTML options" do
-      anchor_tag = helper.govuk_button_link_to("Cluck", "https://localhost:0103/chicken/cluck", class: "govuk-button--start")
+    context "with options" do
+      subject do
+        helper.govuk_button_link_to("Cluck", "https://localhost:0103/chicken/cluck", class: "govuk-button--start")
+      end
 
-      expect(anchor_tag).to eq('<a class="govuk-button govuk-button--start" role="button" draggable="false" href="https://localhost:0103/chicken/cluck">Cluck</a>')
+      it "returns the correct markup with the extra options applied" do
+        expected_output = '<a role="button" data-module="govuk-button" draggable="false" class="govuk-button govuk-button--start" href="https://localhost:0103/chicken/cluck">Cluck</a>'
+
+        expect(subject).to eq(expected_output)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/4w9Fqfo8/669-error-summary-should-be-first-in-page-above-caption
- https://trello.com/c/DpRIb71L/671-need-to-make-sure-all-links-styled-as-buttons-are-using-correct-markup

### Changes proposed in this pull request

- Fix the error summary position in the outcome details form
- Fix the markup produced for the Record training outcome button

### Guidance to review

Error:

<img width="1134" alt="Screenshot 2020-12-11 at 13 37 04" src="https://user-images.githubusercontent.com/616080/101909828-f6c29a00-3bb5-11eb-99a1-e84ba792af60.png">

Markup:

```html
<a role="button" data-module="govuk-button" draggable="false" class="govuk-button govuk-button govuk-!-margin-bottom-0" href="/trainees/1/outcome-details/outcome-date/edit">Record training outcome</a>
```

