### PR TITLE
Upgrade to Rails 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "2.7.2"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem "rails", "~> 6.0.3"
+gem "rails", "~> 6.1.0"
 
 # Use postgresql as the database for Active Record
 gem "pg", ">= 0.18", "< 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+PATH
+  remote: ../govuk-components
+  specs:
+    govuk-components (0.8.0)
+      rails (>= 6.0, < 6.1)
+      view_component (~> 2.22.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -156,9 +163,6 @@ GEM
     foreman (0.87.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-components (0.8.0)
-      rails (~> 6.0.3, >= 6.0.3)
-      view_component (~> 2.22.1)
     govuk_design_system_formbuilder (2.1.5)
       actionview (>= 5.2)
       activemodel (>= 5.2)
@@ -449,7 +453,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
-  govuk-components
+  govuk-components!
   govuk_design_system_formbuilder
   httparty (~> 0.18)
   launchy


### PR DESCRIPTION
### Context

Rails 6.1 has been released.

Draft placeholder PR.

Some gems aren't compatible yet:

canonical-rails
govuk-components - [PR](https://github.com/DFE-Digital/govuk-components/pull/79)



