### PR TITLE
666 add delete degree option

### DIFF
--- a/app/components/trainees/confirmation/degrees/view.rb
+++ b/app/components/trainees/confirmation/degrees/view.rb
@@ -6,7 +6,7 @@ module Trainees
       class View < GovukComponent::Base
         attr_accessor :degrees, :trainee, :show_add_another_degree_button, :show_delete_button
 
-        def initialize(trainee:, show_add_another_degree_button: true, show_delete_button: false)
+        def initialize(trainee:, show_add_another_degree_button: true, show_delete_button: true)
           @trainee = trainee
           @degrees = trainee.degrees
           @show_add_another_degree_button = show_add_another_degree_button

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -24,7 +24,8 @@
 <%= render_component Trainees::Confirmation::PersonalDetails::View.new(trainee: @trainee) %>
 <%= render_component Trainees::Confirmation::ContactDetails::View.new(trainee: @trainee) %>
 <%= render_component Trainees::Confirmation::Diversity::View.new(trainee: @trainee) %>
-<%= render_component Trainees::Confirmation::Degrees::View.new(trainee: @trainee, show_add_another_degree_button: false) %>
+<%= render_component Trainees::Confirmation::Degrees::View.new(trainee: @trainee, show_add_another_degree_button: false, show_delete_button: true) %>
+
 
 <h2 class="govuk-heading-m">
   About their training

--- a/spec/features/trainees/degrees/adding_degree_spec.rb
+++ b/spec/features/trainees/degrees/adding_degree_spec.rb
@@ -35,6 +35,12 @@ RSpec.feature "Adding a degree" do
         then_i_am_redirected_to_the_trainee_degrees_confirmation_page
       end
 
+      scenario "the user deletes a degree" do
+        confirm_details_page.delete_button.click
+        and_i_visit_the_summary_page
+        then_the_degree_status_should_be(:not_started)
+      end
+
       scenario "the user confirms degree details" do
         and_confirm_my_details
         then_i_am_redirected_to_the_summary_page
@@ -157,11 +163,11 @@ private
   def and_confirm_my_details
     expect(confirm_details_page).to be_displayed(id: trainee.id, section: "degrees")
     confirm_details_page.confirm.click
-    confirm_details_page.submit_button.click
+    confirm_details_page.continue_button.click
   end
 
   def and_i_click_continue
-    confirm_details_page.submit_button.click
+    confirm_details_page.continue_button.click
   end
 
   def degree_details_page

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -72,7 +72,7 @@ private
   end
 
   def and_i_submit_the_form
-    @personal_details_page.submit_button.click
+    @personal_details_page.continue_button.click
   end
 
   def then_the_personal_details_are_updated

--- a/spec/support/page_objects/trainees/check_details/show.rb
+++ b/spec/support/page_objects/trainees/check_details/show.rb
@@ -8,7 +8,7 @@ module PageObjects
 
         element :back_to_draft_record, "#back-to-draft-record"
         element :return_to_draft_later, "#return-to-draft-later"
-        element :submit_button, "input[name='commit']"
+        element :submit_button, "input[name='commit'][value ='Submit record and request TRN']"
       end
     end
   end

--- a/spec/support/page_objects/trainees/confirm_details.rb
+++ b/spec/support/page_objects/trainees/confirm_details.rb
@@ -6,6 +6,8 @@ module PageObjects
       set_url "/trainees/{id}/{section}/confirm"
       element :confirm, "input[name='confirm_detail[mark_as_completed]']"
       element :submit_button, "input[name='commit']"
+      element :continue_button, "input[name='commit'][value='Continue']"
+      element :delete_button, "input[name='commit'][value='Delete degree']"
     end
   end
 end

--- a/spec/support/page_objects/trainees/personal_details.rb
+++ b/spec/support/page_objects/trainees/personal_details.rb
@@ -13,7 +13,7 @@ module PageObjects
       element :dob_year, "#personal_detail_date_of_birth_1i"
       element :gender, ".govuk-radios.gender"
       element :nationality, ".govuk-checkboxes.nationality"
-      element :submit_button, "input[name='commit']"
+      element :continue_button, "input[name='commit'][value='Continue']"
     end
   end
 end


### PR DESCRIPTION
### Context

Adding delete functionality to the confirmation page.

### Changes proposed in this pull request

- Used the `show_delete_button` to render the delete button on the confirmation page
- Rename the page objects to be more logical and pass the tests 

### Guidance to review

- Pull down the branch and boot up the server
- Create a trainee and fill in all the details
- Navigate to `/trainees/id/check-details`
- Navigate to `/trainees/id/degrees/confirm`
- Ensure that clicking on the delete button removes the degree.

