### PR TITLE
[672] Page title on qts pages with errors missing "Error: "

### DIFF
--- a/app/components/page_title/view.rb
+++ b/app/components/page_title/view.rb
@@ -3,13 +3,11 @@
 class PageTitle::View < GovukComponent::Base
   I18N_FORMAT = /^\S*\.\S*$/.freeze
 
-  attr_accessor :title, :errors
+  attr_accessor :title
 
-  include ActiveModel
-
-  def initialize(title: "", errors: false)
+  def initialize(title: "", has_errors: false)
     @title = title
-    @errors = errors.present?
+    @has_errors = has_errors
   end
 
   def build_page_title
@@ -18,8 +16,10 @@ class PageTitle::View < GovukComponent::Base
 
 private
 
+  attr_reader :has_errors
+
   def build_error
-    errors ? "Error: " : ""
+    has_errors ? "Error: " : ""
   end
 
   def build_title

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.contact_details.edit") %>
+<%= render_component PageTitle::View.new(title: "trainees.contact_details.edit", has_errors: @contact_details.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(

--- a/app/views/trainees/degrees/edit.html.erb
+++ b/app/views/trainees/degrees/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.degrees.edit") %>
+<%= render_component PageTitle::View.new(title: "trainees.degrees.edit", has_errors: @degree.errors.present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/trainees/degrees/new.html.erb
+++ b/app/views/trainees/degrees/new.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.degrees.edit") %>
+<%= render_component PageTitle::View.new(title: "trainees.degrees.edit", has_errors: @degree.errors.present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">

--- a/app/views/trainees/degrees/type/new.html.erb
+++ b/app/views/trainees/degrees/type/new.html.erb
@@ -1,33 +1,33 @@
-<%= render_component PageTitle::View.new(title: "trainees.degrees.new") %>
+<%= render_component PageTitle::View.new(title: "trainees.degrees.new", has_errors: @degree.errors.present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-      <%= form_with(model: @degree, url: trainee_degrees_new_type_path, local: true) do |f| %>
-          <%= f.govuk_error_summary %>
+    <%= form_with(model: @degree, url: trainee_degrees_new_type_path, local: true) do |f| %>
+      <%= f.govuk_error_summary %>
 
-          <% if @trainee.degrees.size > 1 %>
-            <h2 class="govuk-heading-l">Add another degree</h2>
-          <% else %>
-            <h2 class="govuk-heading-l">Add undergraduate degree</h2>
+      <% if @trainee.degrees.size > 1 %>
+        <h2 class="govuk-heading-l">Add another degree</h2>
+      <% else %>
+        <h2 class="govuk-heading-l">Add undergraduate degree</h2>
 
-            <p class="govuk-body">
-              If the trainee has any other degrees, you can add them next.
-            </p>
-          <% end %>
-
-          <% question = [
-            OpenStruct.new(name: "UK degree", value: "uk" ),
-            OpenStruct.new(name: "Non-UK degree", value: "non_uk")
-          ] %>
-
-          <%= f.govuk_collection_radio_buttons :locale_code,
-              question,
-              :value,
-              :name,
-              legend: { text: 'Is this a UK degree?' } %>
-
-        <%= f.govuk_submit("Continue") %>
-
+        <p class="govuk-body">
+          If the trainee has any other degrees, you can add them next.
+        </p>
       <% end %>
+
+      <% question = [
+        OpenStruct.new(name: "UK degree", value: "uk" ),
+        OpenStruct.new(name: "Non-UK degree", value: "non_uk")
+      ] %>
+
+      <%= f.govuk_collection_radio_buttons :locale_code,
+          question,
+          :value,
+          :name,
+          legend: { text: 'Is this a UK degree?' } %>
+
+      <%= f.govuk_submit("Continue") %>
+
+    <% end %>
   </div>
 </div>

--- a/app/views/trainees/diversity/disability_details/edit.html.erb
+++ b/app/views/trainees/diversity/disability_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.diversity.disabilities.edit") %>
+<%= render_component PageTitle::View.new(title: "trainees.diversity.disabilities.edit", has_errors: @disability_detail.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(

--- a/app/views/trainees/diversity/disability_disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disability_disclosures/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.diversity.disability_disclosure.edit") %>
+<%= render_component PageTitle::View.new(title: "trainees.diversity.disability_disclosure.edit", has_errors: @disability_disclosure.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(

--- a/app/views/trainees/diversity/disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disclosures/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.diversity.disclosures.edit") %>
+<%= render_component PageTitle::View.new(title: "trainees.diversity.disclosures.edit", has_errors: @disclosure.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -1,5 +1,6 @@
 <%= render_component PageTitle::View.new(
-  title: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}"))
+  title: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")),
+  has_errors: @ethnic_background.errors.present?
 ) %>
 
 <%= content_for(:breadcrumbs) do %>

--- a/app/views/trainees/diversity/ethnic_groups/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_groups/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.diversity.ethnic_group.edit") %>
+<%= render_component PageTitle::View.new(title: "trainees.diversity.ethnic_group.edit", has_errors: @ethnic_group.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -1,5 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.new",
-                                           errors: @trainee.errors) %>
+<%= render_component PageTitle::View.new(title: "trainees.new", has_errors: @trainee.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(

--- a/app/views/trainees/outcome_dates/edit.html.erb
+++ b/app/views/trainees/outcome_dates/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.outcome_date.edit") %>
+<%= render_component PageTitle::View.new(title: "trainees.outcome_date.edit", has_errors: @outcome.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.personal_details.edit") %>
+<%= render_component PageTitle::View.new(title: "trainees.personal_details.edit", has_errors: @personal_detail.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(

--- a/app/views/trainees/programme_details/edit.html.erb
+++ b/app/views/trainees/programme_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.programme_details.edit") %>
+<%= render_component PageTitle::View.new(title: "trainees.programme_details.edit", has_errors: @programme_detail.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -1,5 +1,4 @@
-<%= render_component PageTitle::View.new(title: "trainees.show",
-                                           errors: @trainee.errors) %>
+<%= render_component PageTitle::View.new(title: "trainees.show", has_errors: @trainee.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render_component GovukComponent::BackLink.new(

--- a/spec/components/page_title/view_spec.rb
+++ b/spec/components/page_title/view_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe PageTitle::View do
     end
   end
 
+  context "when has_errors is true" do
+    it "constructs a page title value with an error" do
+      component = PageTitle::View.new(title: "Some title", has_errors: true)
+      page_title = component.build_page_title
+      expect(page_title).to eq("Error: Some title - Cool Service - GOV.UK")
+    end
+  end
+
   context "given an i18n key format" do
     before do
       allow(I18n).to receive(:t).with("components.page_titles.trainee.new").and_return("New Trainee")
@@ -24,12 +32,6 @@ RSpec.describe PageTitle::View do
       component = PageTitle::View.new(title: "trainee.new")
       page_title = component.build_page_title
       expect(page_title).to eq("New Trainee - Cool Service - GOV.UK")
-    end
-
-    it "constructs a page title value with an error" do
-      component = PageTitle::View.new(title: "trainee.new", errors: "Loads")
-      page_title = component.build_page_title
-      expect(page_title).to eq("Error: New Trainee - Cool Service - GOV.UK")
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/Yp9449HN/672-page-title-on-qts-pages-with-errors-missing-error

### Changes proposed in this pull request

- Refactor page title component's handling of error titles
- Update all pages with error messages to display titles correctly

### Guidance to review

- Head to the review app
- Try to submit any section with invalid data, assert title has error prepended 

