### PR TITLE
[581] Add option for selecting 'Other nationalities'

### DIFF
--- a/app/components/base.scss
+++ b/app/components/base.scss
@@ -1,2 +1,6 @@
 @import "../webpacker/styles/govuk_style_setup";
 @import "~govuk-frontend/govuk/base";
+
+.personal-detail-form-other-nationality__remove-link {
+  float: right;
+}

--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -4,6 +4,8 @@ import { nodeListForEach } from 'govuk-frontend/govuk/common'
 
 const $allAutocompleteElements = document.querySelectorAll('[data-module="app-autocomplete"]')
 const showAllValuesOption = component => Boolean(component.getAttribute('data-show-all-values'))
+const disableAutoselectOption = component => Boolean(component.getAttribute('data-disable-autoselect'))
+const disableConfirmOnBlurOption = component => Boolean(component.getAttribute('data-disable-confirm-on-blur'))
 const defaultValueOption = component => component.getAttribute('data-default-value') || ''
 
 const setupAutoComplete = (component) => {
@@ -12,7 +14,9 @@ const setupAutoComplete = (component) => {
   accessibleAutocomplete.enhanceSelectElement({
     defaultValue: defaultValueOption(component),
     selectElement: selectEl,
-    showAllValues: showAllValuesOption(component)
+    showAllValues: showAllValuesOption(component),
+    autoselect: !disableAutoselectOption(component),
+    confirmOnBlur: !disableConfirmOnBlurOption(component)
   })
 
   // Fixes a bug whereby if the user enters a search term with no results

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -8,6 +8,8 @@ module Trainees
       "date_of_birth(1i)" => "year",
     }.freeze
 
+    NATIONALITIES = %w[british irish].freeze
+
     def show
       authorize trainee
       render layout: "trainee_record"
@@ -16,12 +18,14 @@ module Trainees
     def edit
       authorize trainee
       nationalities
+      other_nationalities
       @personal_detail = PersonalDetailForm.new(trainee)
     end
 
     def update
       authorize trainee
       nationalities
+      other_nationalities
       personal_detail = PersonalDetailForm.new(trainee, personal_details_params)
 
       if personal_detail.save
@@ -39,13 +43,22 @@ module Trainees
     end
 
     def nationalities
-      @nationalities ||= Nationality.where(name: %w[british irish other])
+      @nationalities ||= Nationality.where(name: NATIONALITIES)
+    end
+
+    def other_nationalities
+      @other_nationality ||= Nationality.find_by(name: "other")
+      @other_nationalities ||= Nationality.where.not(name: NATIONALITIES)
     end
 
     def personal_details_params
       params.require(:personal_detail_form).permit(
         *PersonalDetailForm::FIELDS,
         *DOB_CONVERSION.keys,
+        :other,
+        :other_nationality1,
+        :other_nationality2,
+        :other_nationality3,
         nationality_ids: [],
       ).transform_keys do |key|
         DOB_CONVERSION.keys.include?(key) ? DOB_CONVERSION[key] : key

--- a/app/helpers/nationalities_helper.rb
+++ b/app/helpers/nationalities_helper.rb
@@ -1,15 +1,24 @@
 # frozen_string_literal: true
 
 module NationalitiesHelper
-  def format_default_nationalities(nationalities)
+  def format_nationalities(nationalities, description: true, empty_option: false)
     formatted_nationalities = []
 
+    formatted_nationalities << OpenStruct.new(id: "", name: "") if empty_option
+
     nationalities.each do |nationality|
-      formatted_nationalities << OpenStruct.new(
+      formatted_nationality = OpenStruct.new(
         id: nationality.id,
         name: nationality.name.titleize,
-        description: I18n.t("views.default_nationalities.#{nationality.name}.description"),
       )
+
+      if description
+        formatted_nationality.description = I18n.t(
+          "views.default_nationalities.#{nationality.name}.description",
+        )
+      end
+
+      formatted_nationalities << formatted_nationality
     end
 
     formatted_nationalities

--- a/app/views/trainees/personal_details/_nationality_select_field.html.erb
+++ b/app/views/trainees/personal_details/_nationality_select_field.html.erb
@@ -1,0 +1,9 @@
+<%= render_component FormComponents::Autocomplete::View.new(
+  form_field: form.govuk_collection_select(field, format_nationalities(nationalities, empty_option: true, description: false), :id, :name, label: { text: "Other nationality", size: "s", aria: { label: "#{(index + 1).ordinalize} additional nationality" } }),
+  classes: "govuk-!-margin-bottom-6",
+  html_attributes: {
+    "data-show-all-values" => true,
+    "data-disable-autoselect" => true,
+    "data-disable-confirm-on-blur" => true,
+    }) %>
+    

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -28,15 +28,23 @@
         <%= f.govuk_radio_button :gender, :other, label: { text: "Other" } %>
       <% end %>
 
-      <%= f.govuk_collection_check_boxes :nationality_ids,
-          format_default_nationalities(@nationalities),
-          :id,
-          :name,
-          :description,
-          legend: { text: "Nationality", size: 's' },
-          hint: { text: 'Select all that apply' },
-          classes: "nationality" %>
+      <%= f.govuk_check_boxes_fieldset :nationality_ids, legend: { text: "Nationality", size: 's' }, hint: { text: "Select all that apply" }, classes: "nationality" do %>
+        <% format_nationalities(@nationalities).each do |nationality| %>
+          <%= f.govuk_check_box(
+              :nationality_ids,
+              nationality.id,
+              multiple: true,
+              link_errors: true,
+              label: { text: nationality.name },
+              hint: { text: nationality.description }) %>
+        <% end %>
 
+        <%= f.govuk_check_box(:other, 1, 0, multiple: false, link_errors: true) do %>
+          <% [:other_nationality1, :other_nationality2, :other_nationality3].each_with_index do |field, index|%>
+            <%= render "nationality_select_field", form: f, field: field, index: index, nationalities: @other_nationalities %>
+          <% end %>
+        <% end %>
+      <% end %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,6 +1,7 @@
 import '../scripts/govuk_assets_import'
 import '../styles/application.scss'
 import '../scripts/components'
+import '../scripts/global/nationality_select'
 import { initAll } from 'govuk-frontend'
 
 initAll()

--- a/app/webpacker/scripts/global/nationality_select.js
+++ b/app/webpacker/scripts/global/nationality_select.js
@@ -1,0 +1,114 @@
+const prepareNationalitySelect = () => {
+  const secondInputEl = document.getElementById(
+    'personal-detail-form-other-nationality2-field'
+  )
+  if (!secondInputEl) return
+
+  const thirdInputEl = document.getElementById(
+    'personal-detail-form-other-nationality3-field'
+  )
+
+  const secondFormLabel = document.querySelector(
+    '[for=personal-detail-form-other-nationality2-field]'
+  )
+  const thirdFormLabel = document.querySelector(
+    '[for=personal-detail-form-other-nationality3-field]'
+  )
+
+  const secondSelectEl = document.getElementById(
+    'personal-detail-form-other-nationality2-field-select'
+  )
+  const thirdSelectEl = document.getElementById(
+    'personal-detail-form-other-nationality2-field-select'
+  )
+
+  let addNationalityButton = null
+
+  const addNthNationalityHiddenSpan = (removeLink, nthNationality) => {
+    const nthNationalitySpan = document.createElement('span')
+    nthNationalitySpan.classList.add('govuk-visually-hidden')
+    nthNationalitySpan.innerHTML = `${nthNationality} nationality`
+    removeLink.appendChild(nthNationalitySpan)
+  }
+
+  const handleRemoveLinkClick = (labelEl, inputEl, selectEl) => {
+    addNationalityButton.style.display = ''
+    labelEl.parentElement.style.display = 'none'
+    inputEl.value = ''
+    selectEl.value = ''
+  }
+
+  const addRemoveLink = (labelEl, inputEl, selectEl) => {
+    const removeLink = document.createElement('a')
+    removeLink.innerHTML = 'Remove'
+    removeLink.classList.add('govuk-link', 'personal-detail-form-other-nationality__remove-link')
+    removeLink.href = '#'
+    labelEl.appendChild(removeLink)
+
+    if (labelEl === secondFormLabel) {
+      addNthNationalityHiddenSpan(removeLink, 'Second')
+    } else {
+      addNthNationalityHiddenSpan(removeLink, 'Third')
+    }
+
+    removeLink.addEventListener('click', function () {
+      handleRemoveLinkClick(labelEl, inputEl, selectEl)
+    })
+  }
+
+  const handleAddNationalityClick = () => {
+    if (
+      secondFormLabel.parentElement.style.display === 'none' &&
+      thirdFormLabel.parentElement.style.display === 'none'
+    ) {
+      secondFormLabel.parentElement.style.display = ''
+    } else if (secondFormLabel.parentElement.style.display === 'none') {
+      secondFormLabel.parentElement.style.display = ''
+      addNationalityButton.style.display = 'none'
+    } else {
+      thirdFormLabel.parentElement.style.display = ''
+      addNationalityButton.style.display = 'none'
+    }
+  }
+
+  const addAddNationalityButton = (parentSelector) => {
+    const parent = document.querySelector(parentSelector)
+    addNationalityButton = document.createElement('button')
+    addNationalityButton.innerHTML = 'Add another nationality'
+    addNationalityButton.id = 'add-nationality-button'
+    addNationalityButton.classList.add(
+      'govuk-button',
+      'govuk-button--secondary'
+    )
+    parent.appendChild(addNationalityButton)
+
+    if (secondInputEl.value && thirdInputEl.value) {
+      addNationalityButton.style.display = 'none'
+    }
+
+    addNationalityButton.addEventListener('click', function (e) {
+      e.preventDefault()
+      handleAddNationalityClick()
+    })
+  }
+
+  const hideSection = (selectEl, labelEl) => {
+    if (selectEl.value === '') {
+      labelEl.parentElement.style.display = 'none'
+    }
+  }
+
+  addRemoveLink(secondFormLabel, secondInputEl, secondSelectEl)
+
+  addRemoveLink(thirdFormLabel, thirdInputEl, thirdSelectEl)
+
+  addAddNationalityButton(
+    '#personal-detail-form-other-1-conditional'
+  )
+
+  hideSection(secondInputEl, secondFormLabel)
+
+  hideSection(thirdInputEl, thirdFormLabel)
+}
+
+prepareNationalitySelect()

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,8 @@ en:
               blank: "You must select a gender"
             nationality_ids:
               empty_nationalities: You must select at least one nationality
+            other_nationality1:
+              blank: If you have an additional nationality, select it from the list
         contact_detail_form:
           attributes:
             locale_code:

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -10,6 +10,11 @@ feature "edit personal details", type: :feature do
     then_the_personal_details_are_updated
   end
 
+  scenario "updates personal details with 'other' nationality" do
+    given_other_nationality_is_provided
+    then_the_personal_details_are_updated
+  end
+
   scenario "renders a completed status when valid personal details provided" do
     given_valid_personal_details_are_provided
     then_the_personal_details_section_should_be_completed
@@ -46,8 +51,19 @@ private
     then_i_am_redirected_to_the_summary_page
   end
 
+  def given_other_nationality_is_provided
+    given_a_trainee_exists
+    and_nationalities_exist_in_the_system
+    when_i_visit_the_personal_details_page
+    and_i_enter_valid_parameters(other_nationality: true)
+    and_i_submit_the_form
+    and_confirm_my_details
+    then_i_am_redirected_to_the_summary_page
+  end
+
   def and_nationalities_exist_in_the_system
-    @nationality ||= create(:nationality, name: "british")
+    @british ||= create(:nationality, name: "british")
+    @french ||= create(:nationality, name: "french")
   end
 
   def when_i_visit_the_personal_details_page
@@ -55,12 +71,17 @@ private
     @personal_details_page.load(id: trainee.id)
   end
 
-  def and_i_enter_valid_parameters
+  def and_i_enter_valid_parameters(other_nationality: false)
     @personal_details_page.first_names.set("Tim")
     @personal_details_page.last_name.set("Smith")
     @personal_details_page.set_date_fields("dob", "01/01/1986")
     @personal_details_page.gender.choose("Male")
-    @personal_details_page.nationality.check(@nationality.name.titleize)
+    if other_nationality
+      @personal_details_page.nationality.check("Other")
+      @personal_details_page.other_nationality.select(@french.name.titleize)
+    else
+      @personal_details_page.nationality.check(@british.name.titleize)
+    end
   end
 
   def and_confirm_my_details(checked: true)

--- a/spec/helpers/nationalities_helper_spec.rb
+++ b/spec/helpers/nationalities_helper_spec.rb
@@ -5,23 +5,23 @@ require "rails_helper"
 describe NationalitiesHelper do
   include NationalitiesHelper
 
-  describe "#format_default_nationalities" do
+  describe "#format_nationalities" do
     let(:nationality) { build(:nationality, name: name) }
 
-    let(:expected_nationality) do
-      OpenStruct.new(
-        id: nationality.id,
-        name: nationality.name.titleize,
-        description: t("views.default_nationalities.#{nationality.name}.description"),
-      )
-    end
-
     context "default nationalities" do
+      let(:expected_nationality) do
+        OpenStruct.new(
+          id: nationality.id,
+          name: nationality.name.titleize,
+          description: t("views.default_nationalities.#{nationality.name}.description"),
+        )
+      end
+
       context "english" do
         let(:name) { "english" }
 
         it "returns formatted versions of given nationality records" do
-          expect(format_default_nationalities([nationality])).to include(expected_nationality)
+          expect(format_nationalities([nationality])).to include(expected_nationality)
         end
       end
 
@@ -29,7 +29,7 @@ describe NationalitiesHelper do
         let(:name) { "irish" }
 
         it "returns formatted versions of given nationality records" do
-          expect(format_default_nationalities([nationality])).to include(expected_nationality)
+          expect(format_nationalities([nationality])).to include(expected_nationality)
         end
       end
 
@@ -37,8 +37,41 @@ describe NationalitiesHelper do
         let(:name) { "other" }
 
         it "returns formatted versions of given nationality records" do
-          expect(format_default_nationalities([nationality])).to include(expected_nationality)
+          expect(format_nationalities([nationality])).to include(expected_nationality)
         end
+      end
+    end
+
+    context "with description: false" do
+      let(:name) { "english" }
+
+      let(:expected_nationality) do
+        OpenStruct.new(
+          id: nationality.id,
+          name: nationality.name.titleize,
+        )
+      end
+
+      it "returns formatted versions of given nationality records" do
+        expect(format_nationalities([nationality], description: false)).to include(expected_nationality)
+      end
+    end
+
+    context "with empty_option: true" do
+      let(:name) { "english" }
+      let(:empty_option) { OpenStruct.new(id: "", name: "") }
+
+      let(:expected_nationality) do
+        OpenStruct.new(
+          id: nationality.id,
+          name: nationality.name.titleize,
+          description: t("views.default_nationalities.#{nationality.name}.description"),
+        )
+      end
+
+      it "returns formatted versions of given nationality records with an empty option first" do
+        format_nationalities = format_nationalities([nationality], empty_option: true)
+        expect(format_nationalities).to eq([empty_option, expected_nationality])
       end
     end
   end

--- a/spec/support/page_objects/trainees/personal_details.rb
+++ b/spec/support/page_objects/trainees/personal_details.rb
@@ -13,6 +13,7 @@ module PageObjects
       element :dob_year, "#personal_detail_form_date_of_birth_1i"
       element :gender, ".govuk-radios.gender"
       element :nationality, ".govuk-checkboxes.nationality"
+      element :other_nationality, "#personal-detail-form-other-nationality1-field"
       element :continue_button, "input[name='commit'][value='Continue']"
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/GuDw2U0E/591-personal-details-nationalities-no-option-to-record-which-other-nationalities-the-trainee-has

### Changes proposed in this pull request

This PR adds the ability for a user to record 'Other nationalities' for a trainee:

![Screenshot 2020-12-15 at 10 41 17](https://user-images.githubusercontent.com/18436946/102204710-16153c00-3ec2-11eb-9ac1-0cc769ad08cf.png)

### Guidance to review

- Head to `/trainees/{id}/personal-detail/edit`

With JS:
- Check 'Other' in the nationalities form group
- Click 'Continue'
- Check that there is an error if you attempt to submit with no 'Other' nationality selected
- Choose a nationality from the dropdown
- Click the 'Add another nationality' button
- Choose another nationality
- Click 'Continue'
- Check that the correct nationalities have been saved
- Check that you can 'Change' and edit nationalities (including remove)

With no JS:
- Disable JS in your browser
- Check that there are three working 'Other nationality' select fields
