### PR TITLE
[670] Fix error stying on outcome date

### DIFF
--- a/app/models/outcome_date.rb
+++ b/app/models/outcome_date.rb
@@ -75,9 +75,9 @@ private
 
   def outcome_date_valid
     if outcome_date_string == "other" && [day, month, year].all?(&:blank?)
-      errors.add(:outcome_date_string, :blank)
+      errors.add(:outcome_date, :blank)
     elsif !outcome_date.is_a?(Date)
-      errors.add(:outcome_date_string, :invalid)
+      errors.add(:outcome_date, :invalid)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,7 +216,7 @@ en:
               invalid: "You must enter a valid programme end date"
         outcome_date:
           attributes:
-            outcome_date_string:
+            outcome_date:
               blank: "You must enter an outcome date"
               invalid: "You must enter a valid outcome date"
         degree_detail:

--- a/spec/features/trainees/recording_training_outcome_spec.rb
+++ b/spec/features/trainees/recording_training_outcome_spec.rb
@@ -84,7 +84,7 @@ feature "Recording a training outcome", type: :feature do
 
   def then_i_see_the_error_message_for(type)
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.outcome_date.attributes.outcome_date_string.#{type}"),
+      I18n.t("activemodel.errors.models.outcome_date.attributes.outcome_date.#{type}"),
     )
   end
 


### PR DESCRIPTION
### Context

https://trello.com/c/d4eLaHp9/670-errors-on-the-conditional-date-are-showing-on-the-parent-not-the-item-with-the-error

### Changes proposed in this pull request

Errors regarding the outcome date field for appear on the date field itself, rather than the radio button group as a whole.

![Screenshot 2020-12-15 at 14 30 23](https://user-images.githubusercontent.com/18436946/102228400-90ee4f00-3ee2-11eb-8448-2f1b07eadcf6.png)

### Guidance to review

- Visit `/trainees/:id/outcome-details/outcome-date`
- Select 'On another day' and enter either an invalid date or leave it empty
- Check that the error text appears just about the date field, and that the date field itself is styled red.