### PR TITLE
[644] Fix error styling on autocompletes

### DIFF
--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -7,10 +7,20 @@ const showAllValuesOption = component => Boolean(component.getAttribute('data-sh
 const defaultValueOption = component => component.getAttribute('data-default-value') || ''
 
 const setupAutoComplete = (component) => {
+  const selectEl = component.querySelector('select')
+
   accessibleAutocomplete.enhanceSelectElement({
     defaultValue: defaultValueOption(component),
-    selectElement: component.querySelector('select'),
+    selectElement: selectEl,
     showAllValues: showAllValuesOption(component)
+  })
+
+  // Fixes a bug whereby if the user enters a search term with no results
+  // accesible-autocomplete defaults to the last valid input and there is no
+  // error to handle.
+  component.querySelector('input').addEventListener('keyup', () => {
+    const noResults = component.querySelector('.autocomplete__option--no-results')
+    if (noResults) selectEl.value = ''
   })
 }
 

--- a/app/components/form_components/autocomplete/style.scss
+++ b/app/components/form_components/autocomplete/style.scss
@@ -140,3 +140,16 @@
 .autocomplete__option {
   padding: govuk-spacing(1);
 }
+
+.govuk-form-group--error {
+
+  .autocomplete__input {
+    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+  }
+
+  // Remove error colour when focused
+  .autocomplete__input:focus,
+  .autocomplete__input--focused {
+    border-color: $govuk-input-border-colour;
+  }
+}


### PR DESCRIPTION
### Context

https://trello.com/c/5JlSUwAW/644-s-error-styling-for-autocomplete

### Changes proposed in this pull request

This PR fixes two issues:

1. No error styling on an autocomplete in an error state (e.g. empty)
2. When a user entered an invalid search term (i.e. a search term that returns no results) the last valid input was submitted in the form. This meant that no errors would be shown.

Now, the error styling looks like this:

![Screenshot 2020-12-15 at 16 58 33](https://user-images.githubusercontent.com/18436946/102246665-ecc2d300-3ef6-11eb-859e-21c2801ceb21.png)

Note: I've applied the fix globally to all autocompletes assuming they have the same issue, but I haven't checked them all.

### Guidance to review

- Head to `trainees/:id/programme-details` as an example autocomplete
- Fill in the form **correctly** to begin with and click 'Continue'
- Go back to edit the form
- Replace your 'Subject' with a random search term that has no results
- Leave the random string in the autoselect input
- Click 'Continue'
- Check that there is an error and it is styled correctly
