### PR TITLE
add quoting to env vars in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Download app configuration file
         working-directory: terraform
         run: |
-          echo $APP_SECRETS | base64 -d >> ./workspace-variables/app_secrets.yml
-          echo $INFRA_SECRETS | base64 -d >> ./workspace-variables/infra_secrets.yml
+          echo "$APP_SECRETS" | base64 -d >> ./workspace-variables/app_secrets.yml
+          echo "$INFRA_SECRETS" | base64 -d >> ./workspace-variables/infra_secrets.yml
         env:
           APP_SECRETS:   ${{ secrets[format('APP_SECRETS_{0}', env.DEPLOY_ENV)] }}
           INFRA_SECRETS: ${{ secrets[format('INFRA_SECRETS_{0}', env.DEPLOY_ENV)] }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ nodejs 12.18.3
 ruby 2.7.2
 yarn 1.22.4
 bundler 2.1.4
+terraform 0.13.5

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,27 @@
+help:
+	@echo "Environment setup targets:"
+	@echo "  review     - configure for review app"
+	@echo "  qa"
+	@echo "  staging"
+	@echo "  production"
+	@echo ""
+	@echo "Commands:"
+	@echo "  deploy-plan - Print out the plan for the deploy, does not deploy."
+	@echo ""
+	@echo "Command Options:"
+	@echo "      env      - name of the environment being setup, set this when creating review apps"
+	@echo "      tag      - git sha of a built image, see builds in GitHub Actions"
+	@echo "      passcode - your authentication code for GOVUK PaaS, retrieve from"
+	@echo "                 https://login.london.cloud.service.gov.uk/passcode"
+	@echo ""
+	@echo "Examples:"
+	@echo "  Create a review app"
+	@echo "    You will need to retrieve the authentication code from GOVUK PaaS"
+	@echo "    visit https://login.london.cloud.service.gov.uk/passcode. Then run"
+	@echo "    deploy-plan to test:"
+	@echo ""
+	@echo "        make review env=REVIEW_APP_NAME deploy-plan tag=GIT_REF passcode=AUTHCODE"
+
 review:
 	echo "setting Review $(env) environment"
 	$(eval env_config=review)

--- a/terraform/modules/statuscake/main.tf
+++ b/terraform/modules/statuscake/main.tf
@@ -1,13 +1,13 @@
 resource statuscake_test alert {
-
-  website_name   = var.alerts["alert"]["website_name"]
-  website_url    = var.alerts["alert"]["website_url"]
-  test_type      = var.alerts["alert"]["test_type"]
-  check_rate     = var.alerts["alert"]["check_rate"]
-  contact_group  = var.alerts["alert"]["contact_group"]
-  trigger_rate   = var.alerts["alert"]["trigger_rate"]
-  custom_header  = var.alerts["alert"]["custom_header"]
-  status_codes   = var.alerts["alert"]["status_codes"]
+  for_each = var.alerts
+  website_name   = each.value.website_name
+  website_url    = each.value.website_url
+  test_type      = each.value.test_type
+  check_rate     = each.value.check_rate
+  contact_group  = each.value.contact_group
+  trigger_rate   = each.value.trigger_rate
+  custom_header  = each.value.custom_header
+  status_codes   = each.value.status_codes
   confirmations  = 1
-  node_locations = var.alerts["alert"]["node_locations"]
+  node_locations = each.value.node_locations
 }


### PR DESCRIPTION
### Context

These were breaking when the bas64 value included newlines in it, which
are valid in base64 payloads.

### Changes proposed in this pull request

Quote the necessary variables before passing to `base64 -d`

### Guidance to review

Testing will be performed on this PR/branch.
