### PR TITLE
Fix instances in review apps config

### DIFF
--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -8,7 +8,7 @@ paas_app_start_timeout           = "60"
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances           = 1
 paas_web_app_memory              = 512
-paas_worker_app_instances        = 10
+paas_worker_app_instances        = 1
 paas_worker_app_memory           = 512
 
 statuscake_alerts = {}


### PR DESCRIPTION
### Context
Review apps are misconfigured and create 10 app instances

### Changes proposed in this pull request
Change to 1

### Guidance to review
Deploy a review app, it should have only 1 instance