### PR TITLE
[694] Filtering trainees by route and subject

### DIFF
--- a/app/components/base.scss
+++ b/app/components/base.scss
@@ -1,6 +1,4 @@
 @import "../webpacker/styles/govuk_style_setup";
 @import "~govuk-frontend/govuk/base";
 
-.personal-detail-form-other-nationality__remove-link {
-  float: right;
-}
+$moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";

--- a/app/components/trainees/filters/script.js
+++ b/app/components/trainees/filters/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/trainees/filters/style.scss
+++ b/app/components/trainees/filters/style.scss
@@ -1,0 +1,79 @@
+@import "../../base.scss";
+@import "~@ministryofjustice/frontend/moj/settings/assets";
+@import "~@ministryofjustice/frontend/moj/settings/measurements";
+@import "~@ministryofjustice/frontend/moj/helpers/all";
+@import "~@ministryofjustice/frontend/moj/objects/width-container";
+@import "~@ministryofjustice/frontend/moj/objects/filter-layout";
+@import "~@ministryofjustice/frontend/moj/objects/scrollable-pane";
+@import "~@ministryofjustice/frontend/moj/components/filter/filter";
+
+.moj-filter-layout__content {
+  overflow-x: hidden;
+  .moj-action-bar {
+    height: 60px;
+  }
+}
+
+.moj-action-bar__filter {
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}
+
+.filter-toggle-button {
+  float: right;
+  margin-bottom: govuk-spacing(1);
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}
+
+.moj-action-bar__filter:after {
+  background: none;
+}
+
+@media (min-width: 48.0625em) {
+  .moj-filter-layout__filter {
+    max-width: 300px;
+  }
+}
+
+.moj-filter__header {
+  background: govuk-colour('white');
+  box-shadow: none;
+  border: 1px solid $govuk-border-colour;
+  border-bottom: 0;
+  padding-top: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
+}
+
+.moj-filter__selected {
+  box-shadow: none;
+  border: 1px solid $govuk-border-colour;
+  border-top: 0;
+  border-bottom: 0;
+  padding-top: govuk-spacing(5);
+  padding-bottom: govuk-spacing(5);
+}
+
+.moj-filter__options {
+  box-shadow: none;
+}
+
+.app-filter {
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(3);
+  }
+}
+
+// Apply GOV.UK focus styles - only needed with js.
+.js-enabled .app-filter:focus {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+}
+
+// Fix for focus issue - see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640
+
+// We're catching the focus on a second element rather than having the filter component itself flash with focus when checkbox labels are clicked.
+.moj-filter__options:focus {
+  outline: none;
+}

--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -1,0 +1,88 @@
+<div class='moj-filter-layout abigail'>
+  <div class="moj-filter-layout__filter app-filter">
+    <div class="moj-filter">
+      <div class="moj-filter__header">
+        <div class="moj-filter__header-title">
+          <h2 class="govuk-heading-m">Filters</h2>
+        </div>
+      </div>
+
+      <div class="moj-filter__content">
+
+        <% if !active_filters.empty? %>
+        <div class="moj-filter__selected">
+          <div class="moj-filter__selected-heading">
+            <div class="moj-filter__heading-title">
+              <h2 class="govuk-heading-m">Selected filters</h2>
+            </div>
+            <div class="moj-filter__heading-action">
+              <p class="govuk-body">
+              <%= govuk_link_to 'Clear', trainees_path, class: 'govuk-link--no-visited-state' %>
+              </p>
+            </div>
+          </div>
+
+          <% active_filters.each do |filter, value| %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= filter.humanize %></h3>
+            <ul class="moj-filter-tags">
+              <% tags_for_active_filter(filter, value).each do |tag| %>
+                <li>
+                  <%= link_to(tag[:title], tag[:remove_link], class: "moj-filter__tag") %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        </div>
+      <% end %>
+
+        <div class="moj-filter__options">
+
+          <form method="get">
+            <%= submit_tag "Apply filters", class: "govuk-button" %>
+
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                  Routes
+                </legend>
+                <div class="govuk-checkboxes govuk-checkboxes--small">
+                  <% Trainee.record_types.map do |record_type, _| %>
+                    <div class="govuk-checkboxes__item">
+                      <%= check_box_tag 'record_type[]', record_type, checked?(:record_type, record_type), id: "record_type-#{record_type}", class: "govuk-checkboxes__input"%>
+                      <%= label_tag "record_type-#{record_type}", label_for('record_type', record_type), class: "govuk-label govuk-checkboxes__label" %>
+                    </div>
+                  <% end %>
+                </div>
+              </fieldset>
+            </div>
+
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                  Status
+                </legend>
+                <div class="govuk-checkboxes govuk-checkboxes--small">
+                  <% Trainee.states.map do |state, _| %>
+                    <div class="govuk-checkboxes__item">
+                      <%= check_box_tag 'state[]', state, checked?(:state, state), id: "state-#{state}", class: "govuk-checkboxes__input"%>
+                      <%= label_tag "state-#{state}", label_for('state', state), class: "govuk-label govuk-checkboxes__label" %>
+                    </div>
+                  <% end %>
+                </div>
+              </fieldset>
+            </div>
+
+            <div class="govuk-form-group">
+              <%= label_tag "subject", "Subject", class: "govuk-label govuk-label--m" %>
+              <%= select_tag :subject, options_from_collection_for_select(filter_programme_subjects_options, :name, :name, filters[:subject]), class: "govuk-select" %>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class='moj-filter-layout__content'>
+    <%= content %>
+  </div>
+</div>

--- a/app/components/trainees/filters/view.rb
+++ b/app/components/trainees/filters/view.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Filters
+    class View < GovukComponent::Base
+      include ProgrammeDetailsHelper
+      attr_accessor :filters
+
+      def initialize(filters)
+        @filters = filters
+      end
+
+    private
+
+      def label_for(attribute, value)
+        I18n.t("activerecord.attributes.trainee.#{attribute.pluralize}.#{value}")
+      end
+
+      def checked?(filter, value)
+        filters[filter]&.include?(value)
+      end
+
+      def active_filters
+        filters.deep_dup.reject! do |filter, value|
+          filter == "subject" && value == "All subjects"
+        end
+      end
+
+      def tags_for_active_filter(filter, value)
+        case value
+        when String
+          [{ title: value, remove_link: remove_select_tag_link(filter) }]
+        else
+          value.each_with_object([]) do |v, arr|
+            arr << {
+              title: label_for(filter, v),
+              remove_link: remove_checkbox_tag_link(filter, v),
+            }
+          end
+        end
+      end
+
+      def remove_checkbox_tag_link(filter, value)
+        new_filters = active_filters
+        new_filters[filter].reject! { |v| v == value }
+        "?" + new_filters.to_query
+      end
+
+      def remove_select_tag_link(filter)
+        new_filters = active_filters.reject { |f| f == filter }
+        "?" + new_filters.to_query
+      end
+    end
+  end
+end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -2,7 +2,10 @@
 
 class TraineesController < ApplicationController
   def index
-    @trainees = policy_scope(Trainee)
+    @trainees = Trainees::Filter.call(
+      trainees: policy_scope(Trainee),
+      filters: filters,
+    )
   end
 
   def show
@@ -47,5 +50,9 @@ private
 
   def trainee_params
     params.require(:trainee).permit(:record_type, :trainee_id)
+  end
+
+  def filters
+    @filters ||= params.permit(:subject, record_type: [], state: [])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def to_options(array)
+  def to_options(array, first_value: nil)
     result = array.map do |name|
       OpenStruct.new(name: name)
     end
-    result.unshift(OpenStruct.new(name: nil))
+    result.unshift(OpenStruct.new(name: first_value))
     result
   end
 

--- a/app/helpers/programme_details_helper.rb
+++ b/app/helpers/programme_details_helper.rb
@@ -7,6 +7,10 @@ module ProgrammeDetailsHelper
     to_options(programme_subjects)
   end
 
+  def filter_programme_subjects_options
+    to_options(programme_subjects, first_value: "All subjects")
+  end
+
   def main_age_ranges_options
     age_ranges(option: :main)
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -8,7 +8,7 @@ class Trainee < ApplicationRecord
   validates :record_type, presence: { message: "You must select a route" }
   validates :trainee_id, length: { maximum: 100, message: "Your entry must not exceed 100 characters" }
 
-  enum record_type: { assessment_only: 0 }
+  enum record_type: { assessment_only: 0, provider_led: 1 }
   enum locale_code: { uk: 0, non_uk: 1 }
   enum gender: { male: 0, female: 1, other: 2 }
 

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Trainees
+  class Filter
+    include ServicePattern
+
+    def initialize(trainees:, filters:)
+      @trainees = trainees
+      @filters = filters
+    end
+
+    def call
+      return trainees if filters.empty?
+
+      filter_trainees
+    end
+
+  private
+
+    attr_reader :trainees, :filters
+
+    def record_type(trainees, record_type)
+      return trainees if record_type.blank?
+
+      trainees.where(record_type: record_type)
+    end
+
+    def state(trainees, state)
+      return trainees if state.blank?
+
+      trainees.where(state: state)
+    end
+
+    def subject(trainees, subject)
+      return trainees if subject.blank? || subject == "All subjects"
+
+      trainees.where(subject: subject)
+    end
+
+    def filter_trainees
+      # Tech note: If you're adding a new filter to the top of this list, make
+      # sure that it acts on `trainees` and all other filters then act on
+      # `filtered_trainees`
+      filtered_trainees = record_type(trainees, filters[:record_type])
+      filtered_trainees = state(filtered_trainees, filters[:state])
+      filtered_trainees = subject(filtered_trainees, filters[:subject])
+      filtered_trainees
+    end
+  end
+end

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -4,12 +4,20 @@
 
 <p class="govuk-body">
   <%= render GovukComponent::StartNowButton.new(
-  text: 'Add a trainee',
+  text: "Add a trainee",
   href: new_trainee_path ) %>
 </p>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
+<%= render Trainees::Filters::View.new(@filters) do %>
+  <% if @trainees.any? %>
     <%= render ApplicationRecordCard::View.with_collection(@trainees) %>
-  </div>
-</div>
+  <% elsif !@filters.empty? %>
+    <h2 class="govuk-heading-m">No records found.</h2>
+    <p class="govuk-body">
+      Try
+      <%= link_to "clearing your search and filters.", trainees_path %>
+    </p>
+  <% else %>
+    <p class="govuk-body">You don't have any records yet.</p>
+  <% end %>
+<% end %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -1,5 +1,6 @@
 @import "./govuk_style_setup";
 @import "~govuk-frontend/govuk/all";
+@import "~@ministryofjustice/frontend/moj/all";
 
 .trn-submission-success-panel,
 .qts-submission-success-panel {
@@ -27,7 +28,6 @@ a[href="#"] {
   }
 }
 
-
 .trainee-record-header {
   margin-bottom: govuk-spacing(6);
 }
@@ -54,4 +54,8 @@ a[href="#"] {
   &:active {
     top: 0;
   }
+}
+
+.personal-detail-form-other-nationality__remove-link {
+  float: right;
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,18 @@ en:
     attributes:
       trainee:
         trainee_id: "Trainee ID"
+        record_types:
+          assessment_only: Assessment only
+          provider_led: Provider-led
+        states:
+          draft: Draft
+          submitted_for_trn: Pending TRN
+          trn_received: TRN received
+          recommended_for_qts: QTS recommended
+          withdrawn: Withdrawn
+          deferred: Deferred
+          qts_awarded: QTS awarded
+
     errors:
       models:
         degree:

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,8 +10,7 @@ default: &default
   webpack_compile_output: false
 
   # Additional paths webpack should lookup modules
-  # ['app/assets', 'engine/foo/app/assets']
-  additional_paths: ["app/components", "node_modules/govuk-frontend/govuk"]
+  additional_paths: ["app/components", "node_modules/govuk-frontend/govuk", "node_modules/@ministryofjustice/frontend"]
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "js:lint": "standard"
   },
   "dependencies": {
+    "@ministryofjustice/frontend": "^0.0.22",
     "@rails/webpacker": "^5.2.1",
     "accessible-autocomplete": "^2.0.3",
     "core-js": "^3.8.1",

--- a/spec/components/trainees/filters/view_preview.rb
+++ b/spec/components/trainees/filters/view_preview.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+module Trainees
+  module Filters
+    class ViewPreview < ViewComponent::Preview
+      def default_view
+        render Trainees::Filters::View.new(filter_mock)
+      end
+
+    private
+
+      def filter_mock
+        ActionController::Parameters.new({
+          record_type: %w[assessment_only],
+          subject: "Biology",
+        })
+      end
+    end
+  end
+end

--- a/spec/components/trainees/filters/view_spec.rb
+++ b/spec/components/trainees/filters/view_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Trainees::Filters::View do
+  let(:selected_text) { "Selected filters" }
+  let(:permitted_filters) { filters.permit(:subject, record_type: []) }
+  let(:result) { render_inline described_class.new(permitted_filters) }
+
+  context "when no filters are applied" do
+    let(:filters) { ActionController::Parameters.new({}) }
+
+    it "all of the checkboxes are unchecked" do
+      expect(result.css("#record_type-assessment_only").attr("checked")).to eq(nil)
+      expect(result.css("#record_type-provider_led").attr("checked")).to eq(nil)
+    end
+
+    it "does not show a 'Selected filters' dialogue" do
+      expect(result.text).not_to include(selected_text)
+    end
+  end
+
+  context "when checkboxes have been pre-selected" do
+    let(:filters) do
+      ActionController::Parameters.new({ record_type: %w[assessment_only] })
+    end
+
+    it "marks the correct ones as selected" do
+      expect(result.css("#record_type-assessment_only").attr("checked").value).to eq("checked")
+      expect(result.css("#record_type-provider_led").attr("checked")).to eq(nil)
+    end
+
+    it "shows a 'Selected filters' dialogue" do
+      expect(result.text).to include(selected_text)
+    end
+  end
+
+  context "when a subject has been pre-selected" do
+    let(:filters) do
+      ActionController::Parameters.new({ subject: "Business studies" })
+    end
+
+    it "retains the input" do
+      selected_value = result.css('#subject option[@selected="selected"]').attr("value").value
+      expect(selected_value).to eq("Business studies")
+    end
+
+    it "shows a 'Selected filters' dialogue" do
+      expect(result.text).to include(selected_text)
+    end
+  end
+
+  context "when 'All subjects' has been selected" do
+    let(:filters) do
+      ActionController::Parameters.new({ subject: "All subjects" })
+    end
+
+    it "does not show a 'Selected filters' dialogue" do
+      expect(result.text).to_not include(selected_text)
+    end
+  end
+end

--- a/spec/features/trainees/filtering_trainees_spec.rb
+++ b/spec/features/trainees/filtering_trainees_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Filtering trainees" do
+  before do
+    given_i_am_authenticated
+    given_trainees_exist_in_the_system
+    when_i_visit_the_trainees_page
+    then_all_trainees_are_visible
+  end
+
+  scenario "can filter by route" do
+    when_i_filter_by_route(:assessment_only)
+    then_only_assessment_only_trainees_are_visible
+    then_the_tag_is_visible_for("Assessment only")
+    then_the_checkbox_should_still_be_checked_for("assessment_only")
+    when_i_unfilter_by_route("assessment_only")
+    then_all_trainees_are_visible
+    when_i_filter_by_route("provider_led")
+    then_the_tag_is_visible_for("Provider-led")
+    then_only_provider_led_trainees_are_visible
+    when_i_filter_by_route("assessment_only")
+    then_all_trainees_are_visible
+    then_the_tag_is_visible_for("Assessment only", "Provider-led")
+    when_i_remove_a_tag_for("Assessment only")
+    then_only_provider_led_trainees_are_visible
+  end
+
+  scenario "can filter by subject" do
+    when_i_filter_by_subject("Biology")
+    then_only_biology_trainees_are_visible
+    then_the_tag_is_visible_for("Biology")
+    then_the_select_should_still_show("Biology")
+    when_i_remove_a_tag_for("Biology")
+    then_all_trainees_are_visible
+    when_i_filter_by_subject("All subjects")
+    then_all_trainees_are_visible
+  end
+
+  scenario "can filter by route and subject" do
+    when_i_filter_by_route("assessment_only")
+    when_i_filter_by_subject("Biology")
+    then_only_assessment_only_biology_trainees_are_visible
+  end
+
+  scenario "can clear filters" do
+    when_i_filter_by_route("assessment_only")
+    then_only_assessment_only_trainees_are_visible
+    when_i_clear_filters
+    then_all_trainees_are_visible
+  end
+
+private
+
+  def given_trainees_exist_in_the_system
+    @assessment_only_trainee ||= create(:trainee, record_type: "assessment_only")
+    @provider_led_trainee ||= create(:trainee, record_type: "provider_led")
+    @biology_trainee ||= create(:trainee, subject: "Biology")
+    @history_trainee ||= create(:trainee, subject: "History")
+    Trainee.update_all(provider_id: @current_user.provider.id)
+  end
+
+  def trainees_page
+    @trainees_page ||= PageObjects::Trainees::Index.new
+  end
+
+  def when_i_visit_the_trainees_page
+    trainees_page.load
+    expect(trainees_page).to be_displayed
+  end
+
+  def when_i_filter_by_route(value)
+    trainees_page.public_send("#{value}_checkbox").set(true)
+    trainees_page.apply_filters.click
+  end
+
+  def when_i_unfilter_by_route(value)
+    trainees_page.public_send("#{value}_checkbox").set(false)
+    trainees_page.apply_filters.click
+  end
+
+  def when_i_remove_a_tag_for(value)
+    click_link(value)
+    trainees_page.apply_filters.click
+  end
+
+  def when_i_filter_by_subject(value)
+    trainees_page.subject.select(value)
+    trainees_page.apply_filters.click
+  end
+
+  def when_i_clear_filters
+    trainees_page.clear_filters_link.click
+  end
+
+  def then_the_checkbox_should_still_be_checked_for(value)
+    checkbox = trainees_page.public_send("#{value}_checkbox")
+    expect(checkbox.checked?).to be(true)
+  end
+
+  def then_the_select_should_still_show(value)
+    select = trainees_page.subject
+    expect(select.value).to eq value
+  end
+
+  def then_all_trainees_are_visible
+    Trainee.all.each { |trainee| expect(page).to have_text(trainee.first_names) }
+  end
+
+  def then_only_assessment_only_trainees_are_visible
+    expect(page).to have_text(@assessment_only_trainee.first_names)
+    expect(page).to_not have_text(@provider_led_trainee.first_names)
+  end
+
+  def then_only_provider_led_trainees_are_visible
+    expect(page).to_not have_text(@assessment_only_trainee.first_names)
+    expect(page).to have_text(@provider_led_trainee.first_names)
+  end
+
+  def then_only_biology_trainees_are_visible
+    expect(page).to have_text(@biology_trainee.first_names)
+    expect(page).to_not have_text(@history_trainee.first_names)
+  end
+
+  def then_only_assessment_only_biology_trainees_are_visible
+    expect(page).to have_text(@biology_trainee.first_names)
+    [@assessment_only_trainee, @provider_led_trainee, @history_trainee].each do |t|
+      expect(page).to_not have_text(t.first_names)
+    end
+  end
+
+  def then_the_tag_is_visible_for(*values)
+    expect(trainees_page.filter_tags).to have_text(values.join(" "))
+  end
+end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -6,7 +6,7 @@ describe Trainee do
   context "fields" do
     subject { build(:trainee) }
 
-    it { is_expected.to define_enum_for(:record_type).with_values(assessment_only: 0) }
+    it { is_expected.to define_enum_for(:record_type).with_values(assessment_only: 0, provider_led: 1) }
     it { is_expected.to define_enum_for(:locale_code).with_values(uk: 0, non_uk: 1) }
     it { is_expected.to define_enum_for(:gender).with_values(male: 0, female: 1, other: 2) }
 

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -12,6 +12,14 @@ module PageObjects
       elements :trainee_data, ".app-application-card"
 
       elements :trainee_name, ".app-application-card .govuk-link"
+
+      element :filter_tags, ".moj-filter-tags"
+      element :clear_filters_link, "a", text: "Clear"
+      element :apply_filters, "input[name='commit']"
+
+      element :assessment_only_checkbox, "#record_type-assessment_only"
+      element :provider_led_checkbox, "#record_type-provider_led"
+      element :subject, "#subject"
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,6 +899,13 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@ministryofjustice/frontend@^0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-0.0.22.tgz#b88b21c11b859fbfb55fe267489d612125261553"
+  integrity sha512-ywOxscbxFxjarrOUcDhEJ5WH4ebL1sGG8usH5HquFTTS5cpf0EwbBm1uUjzE9yOcVSl7VS2RmNNUfK8Ycgq0Zg==
+  dependencies:
+    moment "^2.27.0"
+
 "@npmcli/move-file@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.0.1.tgz#de103070dac0f48ce49cf6693c23af59c0f70464"
@@ -5043,6 +5050,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moment@^2.27.0:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Context

https://trello.com/c/bqW6rtSv/694-l-search-trainee-records-using-filters
https://trello.com/c/t8bqngK8/765-s-add-trainee-status-filter

### Changes proposed in this pull request

This PR allows users to filter on trainees by:

1. Route (assessment only vs provider led)
2. Status
3. Subject

![Screenshot 2020-12-21 at 16 11 13](https://user-images.githubusercontent.com/18436946/102797134-2d16cb00-43a7-11eb-9b5a-d3a9450abb2b.png)

### Guidance to review

- Head to the index page `/trainees`
- Check that all trainees are shown when no filters are applied
- Test out the filters one by one, checking that:
  - the correct trainees are shown, and
  - the correct tags are shown
- Test clearing all filters works
- Test that removing individual tags works 