### PR TITLE
[748] - Free text ethnicity not shown in summary list

### DIFF
--- a/app/components/trainees/confirmation/diversity/view.rb
+++ b/app/components/trainees/confirmation/diversity/view.rb
@@ -44,7 +44,7 @@ module Trainees
           value = I18n.t("components.confirmation.diversity.ethnic_groups.#{trainee.ethnic_group}")
 
           if trainee.ethnic_background.present? && trainee.ethnic_background != Diversities::NOT_PROVIDED
-            value += " (#{trainee.ethnic_background})"
+            value += " (#{trainee_ethnic_background})"
           end
           value
         end
@@ -94,6 +94,10 @@ module Trainees
 
         def disability_name_for(disability)
           disability.name.downcase
+        end
+
+        def trainee_ethnic_background
+          trainee.additional_ethnic_background.presence || trainee.ethnic_background
         end
       end
     end

--- a/spec/components/trainees/confirmation/diversity/view_spec.rb
+++ b/spec/components/trainees/confirmation/diversity/view_spec.rb
@@ -46,19 +46,37 @@ RSpec.describe Trainees::Confirmation::Diversity::View do
   end
 
   describe "#ethnic_group_content" do
-    before do
-      allow(I18n).to receive(:t).with("components.confirmation.diversity.ethnic_groups.#{trainee.ethnic_group}").and_return("New ethnic group")
+    let(:trainee) { build(:trainee, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:asian]) }
+    let(:expected_locale_key) { t("components.confirmation.diversity.ethnic_groups.asian_ethnic_group") }
+
+    subject { Trainees::Confirmation::Diversity::View.new(trainee: trainee) }
+
+    it "returns the ethnic_group if the ethnic_background is not provided" do
+      expect(subject.ethnic_group_content).to eq(expected_locale_key)
     end
 
-    it "returns just the ethnic if not ethnic group is present or no provided" do
-      component = Trainees::Confirmation::Diversity::View.new(trainee: trainee)
-      expect(component.ethnic_group_content).to eq "New ethnic group"
-    end
+    context "ethnic background" do
+      let(:ethnic_background) { Diversities::ANOTHER_ETHNIC_BACKGROUND }
+      let(:trainee) { build(:trainee, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:other], ethnic_background: ethnic_background) }
+      let(:expected_locale_key) { t("components.confirmation.diversity.ethnic_groups.other_ethnic_group") }
 
-    it "returns the ethnic background" do
-      trainee.ethnic_background = "Ethnic background"
-      component = Trainees::Confirmation::Diversity::View.new(trainee: trainee)
-      expect(component.ethnic_group_content).to eq "New ethnic group (Ethnic background)"
+      context "when ethnic_background provided" do
+        it "returns the ethnic_background alongside the ethnic_group" do
+          expect(subject.ethnic_group_content).to eq("#{expected_locale_key} (#{ethnic_background})")
+        end
+      end
+
+      context "when additional_ethnic_background provided" do
+        let(:additional_background) { "some additional background" }
+
+        before do
+          trainee.additional_ethnic_background = additional_background
+        end
+
+        it "returns the additional_ethnic_background alongside the ethnic_group" do
+          expect(subject.ethnic_group_content).to eq("#{expected_locale_key} (#{additional_background})")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/swCSTg2K/748-freetext-ethnicity-not-shown-in-summary-list

### Changes proposed in this pull request

- Fixes the free text ethnic background field not displaying properly if you've selected to provide some other ethnic group/background.

<img width="811" alt="Screenshot 2020-12-18 at 14 11 31" src="https://user-images.githubusercontent.com/616080/102623930-2be16600-413b-11eb-93d3-fd4368b6e9ad.png">

### Guidance to review

