### PR TITLE
[xxx] Set DTTP scope URLs

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -3,6 +3,8 @@ base_url: https://www.register-trainee-teachers.education.gov.uk
 
 dttp:
   back_office_url: https://dttp.crm4.dynamics.com/
+  scope: https://dttp.crm4.dynamics.com/.default
+  api_base_url: https://dttp.crm4.dynamics.com/api/data/v9.1
 
 dfe_sign_in:
   # URL that the users are redirected to for signing in

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -3,6 +3,8 @@ base_url: https://qa.register-trainee-teachers.education.gov.uk
 
 dttp:
   back_office_url: https://dttp-test.crm4.dynamics.com/
+  scope: https://dttp-test.crm4.dynamics.com/.default
+  api_base_url: https://dttp-test.crm4.dynamics.com/api/data/v9.1
 
 features:
   home_text: true

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -3,6 +3,8 @@ base_url: https://staging.register-trainee-teachers.education.gov.uk
 
 dttp:
   back_office_url: https://dttp-ppad.crm4.dynamics.com/
+  scope: https://dttp-ppad.crm4.dynamics.com/.default
+  api_base_url: https://dttp-ppad.crm4.dynamics.com/api/data/v9.1
 
 dfe_sign_in:
   # URL that the users are redirected to for signing in


### PR DESCRIPTION
### Context

The config we have in QA, staging and prod isn't successfully connecting to DTTP. The auth token does work but the interaction with dynamics does not.

### Changes proposed in this pull request

Add scope into each environment settings as it isn't being set from the environment and is different for each dynamics instance.

### Guidance to review

If this looks ok we can deploy to QA to test and/or merge and fix forward if there are issues as we're not live. The config works locally.

