### PR TITLE
Add pentest environment to Terraform and  Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ review:
 	$(eval backend_key=-backend-config=key=$(env).terraform.tfstate)
 	$(eval export TF_VAR_paas_app_environment=$(env))
 
+pentest:
+	echo "setting Review $(env) environment"
+	$(eval env_config=pen)
+	$(eval backend_key=-backend-config=key=$(env).terraform.tfstate)
+	$(eval export TF_VAR_paas_app_environment=$(env))
 
 qa:
 	$(eval env=qa)

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -52,16 +52,17 @@ resource cloudfoundry_app web_app {
 
 
 resource cloudfoundry_app worker_app {
-  name              = local.worker_app_name
-  command           = local.worker_app_start_command
-  docker_image      = var.app_docker_image
-  health_check_type = "process"
-  instances         = var.worker_app_instances
-  memory            = var.worker_app_memory
-  space             = data.cloudfoundry_space.space.id
-  timeout           = var.app_start_timeout
-  environment       = local.app_environment
-  docker_credentials         = var.docker_credentials
+  name               = local.worker_app_name
+  command            = local.worker_app_start_command
+  docker_image       = var.app_docker_image
+  health_check_type  = "process"
+  instances          = var.worker_app_instances
+  memory             = var.worker_app_memory
+  space              = data.cloudfoundry_space.space.id
+  timeout            = var.app_start_timeout
+  environment        = local.app_environment
+  docker_credentials = var.docker_credentials
+  stopped            = var.worker_app_stopped
 
   service_binding {
     service_instance = cloudfoundry_service_instance.redis_instance.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -27,6 +27,8 @@ variable app_secrets_variable { type = map } #secrets from yml file
 
 variable app_config_variable { type = map } #from yml file
 
+variable worker_app_stopped { default = false }
+
 locals {
   postgres_service_name    = "register-postgres-${var.app_environment}"
   redis_service_name       = "register-redis-${var.app_environment}"

--- a/terraform/modules/statuscake/main.tf
+++ b/terraform/modules/statuscake/main.tf
@@ -1,5 +1,5 @@
 resource statuscake_test alert {
-  for_each = var.alerts
+  for_each       = var.alerts
   website_name   = each.value.website_name
   website_url    = each.value.website_url
   test_type      = each.value.test_type

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -47,6 +47,7 @@ module paas {
   docker_credentials          = local.docker_credentials
   app_secrets_variable        = local.app_secrets
   app_config_variable         = local.app_config
+  worker_app_stopped          = var.paas_worker_app_stopped
 }
 
 #authenticate into provider

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,6 +38,8 @@ variable infra_secrets_file { default = "./terraform/workspace-variables/infra_s
 
 variable env_config {}
 
+variable paas_worker_app_stopped { default = false }
+
 variable statuscake_alerts { type = map }
 
 

--- a/terraform/workspace-variables/app_config.yml
+++ b/terraform/workspace-variables/app_config.yml
@@ -20,3 +20,8 @@ review:
   <<: *default
   RAILS_ENV: review
   RACK_ENV: review
+
+pen:
+  <<: *default
+  RAILS_ENV: pen
+  RACK_ENV: pen

--- a/terraform/workspace-variables/pen.tfvars
+++ b/terraform/workspace-variables/pen.tfvars
@@ -1,6 +1,6 @@
 # PaaS
 #paas_app_environment not specified here, must be passed to terraform dymamically
-env_config                       = "review"
+env_config                       = "pen"
 paas_space_name                  = "bat-qa"
 paas_postgres_service_plan       = "tiny-unencrypted-11"
 paas_redis_service_plan          = "tiny-4_x"
@@ -10,5 +10,5 @@ paas_web_app_instances           = 1
 paas_web_app_memory              = 512
 paas_worker_app_instances        = 1
 paas_worker_app_memory           = 512
-paas_worker_app_stopped          = false
-statuscake_alerts = {}
+paas_worker_app_stopped          = true
+statuscake_alerts                = {}

--- a/terraform/workspace-variables/pen_backend.tfvars
+++ b/terraform/workspace-variables/pen_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s121d01-register"
+storage_account_name = "s121d01registerterraform"
+container_name       = "tfstate"
+#key not specified here, must be passed to terraform dymamically

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -10,6 +10,7 @@ paas_web_app_instances           = 1
 paas_web_app_memory              = 512
 paas_worker_app_instances        = 1
 paas_worker_app_memory           = 512
+paas_worker_app_stopped          = false
 
 statuscake_alerts = {
 

--- a/terraform/workspace-variables/qa.tfvars
+++ b/terraform/workspace-variables/qa.tfvars
@@ -10,6 +10,7 @@ paas_web_app_instances           = 1
 paas_web_app_memory              = 512
 paas_worker_app_instances        = 1
 paas_worker_app_memory           = 512
+paas_worker_app_stopped          = false
 
 statuscake_alerts = {
 

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -10,6 +10,7 @@ paas_web_app_instances           = 1
 paas_web_app_memory              = 512
 paas_worker_app_instances        = 1
 paas_worker_app_memory           = 512
+paas_worker_app_stopped          = false
 
 statuscake_alerts = {
 


### PR DESCRIPTION
This commit also introduced a new terraform variable (woker_app_stopped)
This is used in setting if the worker_app should be running or not.
The default is false. For Pentest, this is true

### Context

Add pentest environment to Terraform and  Makefile

### Changes proposed in this pull request

Add pentest environment to Terraform and  Makefile and introduce work_app_stopped variable

### Guidance to review

