### PR TITLE
[581] Defer students

### DIFF
--- a/app/components/trainees/deferral_details/view.html.erb
+++ b/app/components/trainees/deferral_details/view.html.erb
@@ -1,0 +1,11 @@
+<%= render SummaryCard::View.new(
+  title: t("components.confirmation.deferral_details.summary_title"),
+  heading_level: 2,
+  rows: [
+    {
+      key: t("components.confirmation.deferral_details.defer_date_label"),
+      value: defer_date,
+      action: govuk_link_to(t(:change), trainee_deferral_path(trainee)),
+    },
+  ])
+%>

--- a/app/components/trainees/deferral_details/view.rb
+++ b/app/components/trainees/deferral_details/view.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Trainees
+  module DeferralDetails
+    class View < GovukComponent::Base
+      include SummaryHelper
+
+      attr_reader :trainee
+
+      def initialize(trainee)
+        @trainee = trainee
+      end
+
+      def defer_date
+        date_for_summary_view(trainee.defer_date)
+      end
+    end
+  end
+end

--- a/app/components/trainees/record_actions/view.html.erb
+++ b/app/components/trainees/record_actions/view.html.erb
@@ -4,7 +4,7 @@
 
   <div class="record-actions__links">
     <p class="govuk-body govuk-!-margin-bottom-0">
-      <%= govuk_link_to t("views.trainees.edit.defer"), nil, class: "defer"  %> or
+      <%= govuk_link_to t("views.trainees.edit.defer"), trainee_deferral_path(@trainee), class: "defer"  %> or
       <%= govuk_link_to t("views.trainees.edit.withdraw"), trainee_withdrawal_path(@trainee), class: "withdraw"  %>
       <%= t("views.trainees.edit.this_trainee") %>
     </p>

--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Trainees
+  class ConfirmDeferralsController < ApplicationController
+    def show
+      authorize trainee
+    end
+
+    def update
+      authorize trainee
+      redirect_to edit_trainee_path(trainee)
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.find(params[:trainee_id])
+    end
+  end
+end

--- a/app/controllers/trainees/deferrals_controller.rb
+++ b/app/controllers/trainees/deferrals_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Trainees
+  class DeferralsController < ApplicationController
+    PARAM_CONVERSION = {
+      "defer_date(3i)" => "day",
+      "defer_date(2i)" => "month",
+      "defer_date(1i)" => "year",
+    }.freeze
+
+    def show
+      authorize trainee
+      @deferral = DeferralForm.new(trainee)
+    end
+
+    def update
+      authorize trainee
+      @deferral = DeferralForm.new(trainee)
+      @deferral.assign_attributes(trainee_params)
+
+      if @deferral.save
+        redirect_to trainee_confirm_deferral_path(trainee)
+      else
+        render :show
+      end
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.find(params[:trainee_id])
+    end
+
+    def trainee_params
+      params.require(:deferral_form).permit(:defer_date_string, *PARAM_CONVERSION.keys)
+            .transform_keys do |key|
+        PARAM_CONVERSION.keys.include?(key) ? PARAM_CONVERSION[key] : key
+      end
+    end
+  end
+end

--- a/app/forms/deferral_form.rb
+++ b/app/forms/deferral_form.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class DeferralForm
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations::Callbacks
+
+  attr_accessor :trainee, :day, :month, :year, :defer_date_string
+
+  delegate :id, :persisted?, to: :trainee
+
+  validate :defer_date_valid
+
+  after_validation :update_trainee
+
+  def initialize(trainee)
+    @trainee = trainee
+    super(fields)
+  end
+
+  def fields
+    {
+      defer_date_string: rehydrate_defer_date_string,
+      day: trainee.defer_date&.day,
+      month: trainee.defer_date&.month,
+      year: trainee.defer_date&.year,
+    }
+  end
+
+  def save
+    valid? && trainee.save
+  end
+
+  def defer_date
+    date_conversion[defer_date_string]
+  end
+
+private
+
+  def rehydrate_defer_date_string
+    return unless trainee.defer_date
+
+    case trainee.defer_date
+    when Time.zone.today
+      "today"
+    when Time.zone.yesterday
+      "yesterday"
+    else
+      "other"
+    end
+  end
+
+  def update_trainee
+    trainee.assign_attributes({ defer_date: defer_date }) if errors.empty?
+  end
+
+  def date_conversion
+    {
+      today: Time.zone.today,
+      yesterday: Time.zone.yesterday,
+      other: other_date,
+    }.with_indifferent_access
+  end
+
+  def other_date
+    date_hash = { year: year, month: month, day: day }
+    date_args = date_hash.values.map(&:to_i)
+
+    Date.valid_date?(*date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+  end
+
+  def defer_date_valid
+    if defer_date_string == "other" && [day, month, year].all?(&:blank?)
+      errors.add(:defer_date, :blank)
+    elsif !defer_date.is_a?(Date)
+      errors.add(:defer_date, :invalid)
+    end
+  end
+end

--- a/app/views/trainees/confirm_deferrals/show.html.erb
+++ b/app/views/trainees/confirm_deferrals/show.html.erb
@@ -1,0 +1,24 @@
+<%= render PageTitle::View.new(title: "trainees.deferral_details.confirm") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLink.new(text: t("back"), href:  trainee_deferral_path(@trainee)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <span class="govuk-caption-l">
+      <%= trainee_name(@trainee) %>
+    </span>
+    <h1 class="govuk-heading-l">Check deferral details</h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render Trainees::DeferralDetails::View.new(@trainee) %>
+
+    <%= form_with url: trainee_confirm_deferral_path(@trainee), method: :put, local: true do |f| %>
+      <%= f.govuk_submit "Defer this trainee" %>
+    <%- end -%>
+  </div>
+</div>

--- a/app/views/trainees/confirm_withdrawals/show.html.erb
+++ b/app/views/trainees/confirm_withdrawals/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.confirm_withdrawal.show") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(text: t("back"), href: edit_trainee_path(@trainee)) %>
+  <%= render GovukComponent::BackLink.new(text: t("back"), href: trainee_withdrawal_path(@trainee)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/deferrals/show.html.erb
+++ b/app/views/trainees/deferrals/show.html.erb
@@ -1,0 +1,28 @@
+<%= render PageTitle::View.new(title: "trainees.deferral.show", has_errors: @deferral.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLink.new(text: t(:back), href: edit_trainee_path(@trainee)) %>
+<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_for(@deferral, url: trainee_deferral_path(@trainee), local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">
+        <%= trainee_name(@trainee) %>
+      </span>
+
+      <%= f.govuk_radio_buttons_fieldset(:defer_date_string, legend: { text: "When did the trainee defer?", tag: "h1", size: "l" }, classes: "deferral-date") do %>
+        <%= f.govuk_radio_button :defer_date_string, :today, label: { text: t("views.forms.common.today") }, link_errors: true %>
+        <%= f.govuk_radio_button :defer_date_string, :yesterday, label: { text: t("views.forms.common.yesterday") } %>
+        <%= f.govuk_radio_button :defer_date_string, :other, label: { text: t("views.forms.common.specific_date") } do %>
+          <%= f.govuk_date_field :defer_date, legend: { text: t("views.forms.common.on_what_date"), size: 's' }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>
+
+<p class="govuk-body"><%= govuk_link_to("Cancel and return to record", edit_trainee_path(@trainee)) %></p>

--- a/app/views/trainees/edit.html.erb
+++ b/app/views/trainees/edit.html.erb
@@ -10,6 +10,6 @@
 
 <h2 class="govuk-heading-m">Programme details</h2>
 
-<div class="programme-details"> 
+<div class="programme-details">
   <%= render Trainees::Confirmation::ProgrammeDetails::View.new(trainee: @trainee) %>
 </div>

--- a/app/views/trainees/outcome_dates/edit.html.erb
+++ b/app/views/trainees/outcome_dates/edit.html.erb
@@ -20,7 +20,7 @@
         <%= f.govuk_radio_button :outcome_date_string, :today, label: { text: "Today" }, link_errors: true %>
         <%= f.govuk_radio_button :outcome_date_string, :yesterday, label: { text: "Yesterday" } %>
         <%= f.govuk_radio_button :outcome_date_string, :other, label: { text: "On another day" } do %>
-          <%= f.govuk_date_field :outcome_date, legend: { text: 'On what date?', size: 's' }, hint: { text: "For example, 3 12 2020" } %>
+          <%= f.govuk_date_field :outcome_date, legend: { text: t("views.forms.common.on_what_date"), size: 's' }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
         <% end %>
       <% end %>
 
@@ -30,3 +30,4 @@
 </div>
 
 <p class="govuk-body"><%= govuk_link_to("Cancel and return to record", edit_trainee_path(@trainee)) %></p>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,9 @@ en:
           transferred_to_another_provider: Transferred to another provider
           unknown: Unknown
           written_off_after_lapse_of_time: Written off after lapse of time
+      deferral_details:
+        summary_title: Deferral details
+        defer_date_label: Date of deferral
       not_provided: Not provided
       heading: Confirm %{section_title}
     programme_detail:
@@ -95,6 +98,10 @@ en:
           show: Withdraw trainee
         confirm_withdrawal:
           show: Check withdrawal details
+        deferral:
+          show: When did the trainee defer?
+        deferral_details:
+          confirm: Check deferral details
   views:
     trainees:
       edit:
@@ -279,5 +286,10 @@ en:
               blank: You must enter a reason
             withdraw_reason:
               invalid: You must choose a reason
+        deferral_form:
+          attributes:
+            defer_date:
+              blank: "You must enter a deferral date"
+              invalid: "You must enter a valid deferral date"
   page_headings:
     start_page: "Register trainee teachers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,9 @@ Rails.application.routes.draw do
 
       resource :confirm_withdrawal, only: %i[show update], path: "/withdraw/confirm"
       resource :withdrawal, only: %i[show update], path: "/withdraw"
+
+      resource :confirm_deferral, only: %i[show update], path: "/defer/confirm"
+      resource :deferral, only: %i[show update], path: "/defer"
     end
 
     member do

--- a/db/migrate/20201221173705_add_defer_date_to_trainees.rb
+++ b/db/migrate/20201221173705_add_defer_date_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeferDateToTrainees < ActiveRecord::Migration[6.0]
+  def change
+    add_column :trainees, :defer_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_17_112615) do
+ActiveRecord::Schema.define(version: 2020_12_21_173705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 2020_12_17_112615) do
     t.integer "withdraw_reason"
     t.datetime "withdraw_date"
     t.string "additional_withdraw_reason"
+    t.date "defer_date"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"
     t.index ["dttp_id"], name: "index_trainees_on_dttp_id"

--- a/spec/components/trainees/confirmation/deferral_details/view_preview.rb
+++ b/spec/components/trainees/confirmation/deferral_details/view_preview.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Confirmation
+    module DeferralDetails
+      class ViewPreview < ViewComponent::Preview
+        def default
+          render(Trainees::Confirmation::DeferralDetails::View.new(trainee: trainee))
+        end
+
+      private
+
+        def trainee
+          @trainee ||= OpenStruct.new({
+            withdraw_date: Faker::Date.in_date_period,
+          })
+        end
+      end
+    end
+  end
+end

--- a/spec/components/trainees/confirmation/deferral_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/deferral_details/view_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  module DeferralDetails
+    describe View do
+      include SummaryHelper
+
+      alias_method :component, :page
+
+      let(:trainee) { Trainee.new(id: 1, defer_date: Time.zone.yesterday) }
+
+      before do
+        render_inline(View.new(trainee))
+      end
+
+      it "renders the deferral end date" do
+        expect(component).to have_text(date_for_summary_view(trainee.defer_date))
+      end
+    end
+  end
+end

--- a/spec/features/trainees/deferral_trainee_spec.rb
+++ b/spec/features/trainees/deferral_trainee_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Deferring a trainee", type: :feature do
+  include SummaryHelper
+
+  before do
+    given_i_am_authenticated
+    given_a_trainee_exists
+    and_i_am_on_the_trainee_edit_page
+    and_i_click_on_defer
+  end
+
+  context "trainee withdrawal date" do
+    scenario "choosing today" do
+      when_i_choose_today
+      and_i_continue
+      then_i_am_redirected_to_deferral_confirmation_page
+      and_the_defer_date_is_updated
+    end
+
+    scenario "choosing yesterday" do
+      when_i_choose_yesterday
+      and_i_continue
+      then_i_am_redirected_to_deferral_confirmation_page
+      and_the_defer_date_is_updated
+    end
+
+    context "choosing another day" do
+      before do
+        when_i_choose_another_day
+      end
+
+      scenario "and filling out a valid date" do
+        and_i_enter_a_valid_date
+        and_i_continue
+        then_i_am_redirected_to_deferral_confirmation_page
+        and_the_defer_date_is_updated
+      end
+
+      scenario "and not filling out the date displays the correct error" do
+        and_i_continue
+        then_i_see_the_error_message_for_blank_date
+      end
+
+      scenario "and filling out an invalid date displays the correct error" do
+        defer_date_page.set_date_fields("defer_date", "32/01/2020")
+        and_i_continue
+        then_i_see_the_error_message_for_invalid_date
+      end
+    end
+  end
+
+  def when_i_choose_today
+    when_i_choose("Today")
+  end
+
+  def when_i_choose_yesterday
+    stub_dttp_placement_assignment_request(outcome_date: Time.zone.yesterday, status: 204)
+    when_i_choose("Yesterday")
+  end
+
+  def and_i_enter_a_valid_date
+    Faker::Date.in_date_period.tap do |defer_date|
+      defer_date_page.set_date_fields(:defer_date, defer_date.strftime("%d/%m/%Y"))
+    end
+  end
+
+  def and_i_am_on_the_trainee_edit_page
+    edit_page.load(id: trainee.id)
+  end
+
+  def and_i_click_on_defer
+    edit_page.defer.click
+  end
+
+  def when_i_choose(option)
+    defer_date_page.choose(option)
+  end
+
+  def when_i_choose_another_day
+    when_i_choose("On another day")
+  end
+
+  def and_i_continue
+    deferral_page.continue.click
+  end
+
+  def then_i_see_the_error_message_for_invalid_date
+    expect(page).to have_content(
+      I18n.t("activemodel.errors.models.deferral_form.attributes.defer_date.invalid"),
+    )
+  end
+
+  def then_i_see_the_error_message_for_blank_date
+    expect(page).to have_content(
+      I18n.t("activemodel.errors.models.deferral_form.attributes.defer_date.blank"),
+    )
+  end
+
+  def then_i_am_redirected_to_deferral_confirmation_page
+    expect(deferral_confirmation_page).to be_displayed(id: trainee.id)
+  end
+
+  def edit_page
+    @edit_page ||= PageObjects::Trainees::Edit.new
+  end
+
+  def defer_date_page
+    @edit_defer_date_page ||= PageObjects::Trainees::Deferral.new
+  end
+
+  def deferral_confirmation_page
+    @deferral_confirmation_page ||= PageObjects::Trainees::ConfirmDeferral.new
+  end
+
+  def deferral_page
+    @deferral_page ||= PageObjects::Trainees::Deferral.new
+  end
+
+  def and_the_defer_date_is_updated
+    trainee.reload
+    expect(page).to have_text(date_for_summary_view(trainee.defer_date))
+  end
+end

--- a/spec/support/page_objects/trainees/confirm_deferral_details.rb
+++ b/spec/support/page_objects/trainees/confirm_deferral_details.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class ConfirmDeferral < PageObjects::Base
+      set_url "/trainees/{id}/defer/confirm"
+      element :continue, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/edit.rb
+++ b/spec/support/page_objects/trainees/edit.rb
@@ -11,6 +11,8 @@ module PageObjects
       element :record_outcome, ".govuk-button"
       element :withdraw, ".govuk-link.withdraw"
 
+      element :defer, ".govuk-link.defer"
+
       section :record_detail, PageObjects::Sections::Summaries::RecordDetail, ".record-details"
       section :programme_detail, PageObjects::Sections::Summaries::ProgrammeDetail, ".programme-details"
 

--- a/spec/support/page_objects/trainees/edit_deferral_date.rb
+++ b/spec/support/page_objects/trainees/edit_deferral_date.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class Deferral < PageObjects::Base
+      include PageObjects::Helpers
+      set_url "/trainees/{trainee_id}/deferral-details/deferral-date/edit"
+
+      element :defer_date_radios, ".govuk-radios.deferral-date"
+
+      element :defer_date_day, "#deferral_form_defer_date_3i"
+      element :defer_date_month, "#deferral_form_defer_date_2i"
+      element :defer_date_year, "#deferral_form_defer_date_1i"
+
+      element :continue, ".govuk-button"
+    end
+  end
+end


### PR DESCRIPTION
### Context

The ability for providers to defer students who have been registered but not yet completed their programme. Not including DTTP interaction.

### Changes proposed in this pull request

- 2 new controllers to handle the deferral details and confirmation journeys

- All the views and components necessary to capture and display information

### Guidance to review

- Pull down the branch and fire up the server
- Create a trainee and complete all the sections
- Navigate to http://localhost:3000/trainees/{{trainee-id?}}/edit
- Click the defer button
- Have a play around, check that all the buttons work as expected 
- Check the correct validation error messages are displayed if an error is made
- Check that it matches the prototype