### PR TITLE
Clean up error page content

### DIFF
--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -2,8 +2,8 @@
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">We're sorry, but something went wrong.</h1>
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h1 class="govuk-heading-l">We’re sorry, but something went wrong</h1>
       <p class="govuk-body">If you are the application owner check the logs for more information.</p>
     </div>
   </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -2,8 +2,8 @@
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h1 class="govuk-heading-l">The page you were looking for doesn’t exist</h1>
       <p class="govuk-body">You may have mistyped the address or the page may have moved.</p>
       <p class="govuk-body">If you are the application owner check the logs for more information.</p>
     </div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -2,9 +2,9 @@
 
 <main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
-      <p class="govuk-body">Maybe you tried to change something you didn't have access to.</p>
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h1 class="govuk-heading-l">The change you wanted was rejected</h1>
+      <p class="govuk-body">Maybe you tried to change something you didn’t have access to.</p>
       <p class="govuk-body">If you are the application owner check the logs for more information.</p>
     </div>
   </div>


### PR DESCRIPTION
Changes:
* Use `govuk-grid-column-two-thirds-from-desktop` by default
* Reduce `h1` size to be more consistent with other pages
* Use correct apostrophies
* Don't use full stops on headings
