### PR TITLE
[773] Remove rails-erd gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,9 +92,6 @@ group :development do
   gem "listen", ">= 3.0.5", "< 3.4"
   gem "web-console", ">= 3.3.0"
 
-  # Generates diagram charts for us
-  gem "rails-erd"
-
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   gem "spring-commands-rspec", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    choice (0.2.0)
     cliver (0.3.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
@@ -269,11 +268,6 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-erd (1.6.0)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-      choice (~> 0.2.0)
-      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     rails_semantic_logger (4.4.6)
@@ -338,8 +332,6 @@ GEM
       rubocop
     rubocop-rspec (1.42.0)
       rubocop (>= 0.87.0)
-    ruby-graphviz (1.2.5)
-      rexml
     ruby-progressbar (1.10.1)
     rubyzip (2.3.0)
     sass (3.7.4)
@@ -465,7 +457,6 @@ DEPENDENCIES
   puma (~> 5.1)
   pundit
   rails (~> 6.1.0)
-  rails-erd
   rails_semantic_logger (= 4.4.6)
   request_store (~> 1.5)
   rspec-rails (~> 4.0.1)

--- a/lib/tasks/auto_generate_diagram.rake
+++ b/lib/tasks/auto_generate_diagram.rake
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# NOTE: only doing this in development as some production environments (Heroku)
-# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
-# NOTE: to have a dev-mode tool do its thing in production.
-if Rails.env.development?
-  RailsERD.load_tasks
-end


### PR DESCRIPTION
### Context
After upgrading to Rails to 6.1 we got the following error from the rails-erd gem after running `rake db:migrate`:

```ruby
rake aborted!
NoMethodError: undefined method `parent' for RegisterTraineeTeachers::Application:Class
Did you mean?  present?
```

The team has also agreed that it's not needed at the moment and should only be reintroduced if there's a good case for it and it supports the latest version of rails.

https://trello.com/c/rg3lvFxw/773-remove-rails-erd-gem
