### PR TITLE
Fixed warnings

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-if FeatureService.enabled?("use_dfe_sign_in")
+OmniAuth.config.logger = Rails.logger
 
-  OmniAuth.config.logger = Rails.logger
-
+if Settings.features.use_dfe_sign_in
   dfe_sign_in_issuer_uri = URI.parse(Settings.dfe_sign_in.issuer)
   dfe_sign_in_redirect_uri = URI.join(Settings.base_url, "/auth/dfe/callback")
 
@@ -29,13 +28,10 @@ if FeatureService.enabled?("use_dfe_sign_in")
   }
 
   Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options
-
 else
-
   Rails.application.config.middleware.use OmniAuth::Builder do
     provider :developer,
              fields: %i[uid email first_name last_name],
              uid_field: :uid
   end
-
 end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -77,7 +77,7 @@ describe Trainee do
         context "when record type is not present" do
           it "is not valid" do
             expect(subject).not_to be_valid
-            expect(subject.errors.keys).to include(:record_type)
+            expect(subject.errors.attribute_names).to include(:record_type)
           end
         end
 
@@ -86,7 +86,7 @@ describe Trainee do
 
           it "is not valid" do
             expect(subject).not_to be_valid
-            expect(subject.errors.keys).to include(:trainee_id)
+            expect(subject.errors.attribute_names).to include(:trainee_id)
           end
         end
 


### PR DESCRIPTION
### Context
Housekeeping before 2021

### Changes proposed in this pull request

Fixed `DEPRECATION WARNING: ActiveModel::Errors#keys is deprecated and will be removed in Rails 6.2.`
Fixed `DEPRECATION WARNING: Initialization autoloaded the constant FeatureService.`

### Guidance to review
Do not see those `DEPRECATION WARNING` when

`bundle exec rspec`
#### Before
![image](https://user-images.githubusercontent.com/470137/102994142-6588e700-4516-11eb-9086-682dd55518d4.png)
#### After

![image](https://user-images.githubusercontent.com/470137/102996741-83a51600-451b-11eb-8cd3-3d1329f2ed29.png)

