### PR TITLE
[769] Added more validation to programme dates

### DIFF
--- a/app/forms/programme_detail_form.rb
+++ b/app/forms/programme_detail_form.rb
@@ -101,6 +101,8 @@ private
       errors.add(:programme_start_date, :blank)
     elsif !programme_start_date.is_a?(Date)
       errors.add(:programme_start_date, :invalid)
+    elsif programme_start_date < 10.years.ago
+      errors.add(:programme_start_date, :over_10_years)
     end
   end
 
@@ -109,6 +111,14 @@ private
       errors.add(:programme_end_date, :blank)
     elsif !programme_end_date.is_a?(Date)
       errors.add(:programme_end_date, :invalid)
+    end
+
+    additional_validation = errors.attribute_names.none? do |attribute_name|
+      %i[programme_start_date programme_end_date].include?(attribute_name)
+    end
+
+    if additional_validation && programme_start_date >= programme_end_date
+      errors.add(:programme_end_date, :before_or_same_as_start_date)
     end
   end
 end

--- a/app/forms/programme_detail_form.rb
+++ b/app/forms/programme_detail_form.rb
@@ -102,7 +102,7 @@ private
     elsif !programme_start_date.is_a?(Date)
       errors.add(:programme_start_date, :invalid)
     elsif programme_start_date < 10.years.ago
-      errors.add(:programme_start_date, :over_10_years)
+      errors.add(:programme_start_date, :invalid)
     end
   end
 

--- a/app/forms/programme_detail_form.rb
+++ b/app/forms/programme_detail_form.rb
@@ -102,7 +102,7 @@ private
     elsif !programme_start_date.is_a?(Date)
       errors.add(:programme_start_date, :invalid)
     elsif programme_start_date < 10.years.ago
-      errors.add(:programme_start_date, :invalid)
+      errors.add(:programme_start_date, :too_old)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,9 +277,11 @@ en:
             programme_start_date:
               blank: "You must enter programme start date"
               invalid: "You must enter a valid programme start date"
+              over_10_years: "You must enter programme start date within 10 years ago"
             programme_end_date:
               blank: "You must enter programme end date"
               invalid: "You must enter a valid programme end date"
+              before_or_same_as_start_date: "You must enter programme end date after the programme start date"
         outcome_date_form:
           attributes:
             outcome_date:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,7 +277,6 @@ en:
             programme_start_date:
               blank: "You must enter programme start date"
               invalid: "You must enter a valid programme start date"
-              over_10_years: "You must enter programme start date within 10 years ago"
             programme_end_date:
               blank: "You must enter programme end date"
               invalid: "You must enter a valid programme end date"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,6 +277,7 @@ en:
             programme_start_date:
               blank: "You must enter programme start date"
               invalid: "You must enter a valid programme start date"
+              too_old: "You must enter a valid programme start date"
             programme_end_date:
               blank: "You must enter programme end date"
               invalid: "You must enter a valid programme end date"

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -65,17 +65,23 @@ module ApplicationRecordCard
     end
 
     context "when a trainee with all their details filled in" do
+      let(:trainee) do
+        Timecop.freeze(Time.zone.local(2020, 1, 1)) do
+          build(
+            :trainee,
+            id: 1, first_names: "Teddy",
+            last_name: "Smith",
+            subject: "Designer",
+            record_type: "assessment_only",
+            trainee_id: "132456",
+            created_at: Time.zone.now
+          )
+        end
+      end
+
       before do
         render_inline(described_class.new(
-                        record: build(
-                          :trainee,
-                          id: 1, first_names: "Teddy",
-                          last_name: "Smith",
-                          subject: "Designer",
-                          record_type: "assessment_only",
-                          trainee_id: "132456",
-                          created_at: Timecop.freeze(Time.zone.local(2020, 1, 1))
-                        ),
+                        record: trainee,
                       ))
       end
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -46,8 +46,8 @@ FactoryBot.define do
     trait :with_programme_details do
       subject { Dttp::CodeSets::ProgrammeSubjects::MAPPING.keys.sample }
       age_range { Dttp::CodeSets::AgeRanges::MAPPING.keys.sample }
-      programme_start_date { Faker::Date.between(from: 2.years.ago, to: Time.zone.today) }
-      programme_end_date { Faker::Date.between(from: 2.years.ago, to: Time.zone.today) }
+      programme_start_date { Faker::Date.between(from: 10.years.ago, to: 2.days.ago) }
+      programme_end_date { Faker::Date.between(from: programme_start_date + 1.day, to: Time.zone.today) }
     end
 
     trait :diversity_disclosed do

--- a/spec/forms/programme_detail_form_spec.rb
+++ b/spec/forms/programme_detail_form_spec.rb
@@ -121,7 +121,7 @@ describe ProgrammeDetailForm, type: :model do
                            "foo", "foo", "foo"
 
           start_date = 10.years.ago
-          include_examples date_error_message, :programme_start_date, :over_10_years,
+          include_examples date_error_message, :programme_start_date, :invalid,
                            start_date.day, start_date.month, start_date.year
         end
 

--- a/spec/forms/programme_detail_form_spec.rb
+++ b/spec/forms/programme_detail_form_spec.rb
@@ -70,83 +70,93 @@ describe ProgrammeDetailForm, type: :model do
         end
       end
 
-      describe "#programme_start_date_valid" do
-        context "the start date fields are all blank" do
-          let(:attributes) do
-            { start_day: "", start_month: "", start_year: "" }
+      context "date attributes" do
+        let(:attributes) do
+          {
+            **end_date_attributes,
+            **start_date_attributes,
+          }
+        end
+
+        date_error_message = "date error message"
+
+        shared_examples date_error_message do |attribute_name, translation_key_suffix, day, month, year|
+          if attribute_name == :programme_start_date
+            let(:start_date_attributes) do
+              { start_day: day, start_month: month, start_year: year }
+            end
+          else
+            let(:end_date_attributes) do
+              { end_day: day, end_month: month, end_year: year }
+            end
           end
 
-          it "returns an error start date is blank" do
-            expect(subject.errors[:programme_start_date]).to include(
-              I18n.t(
-                "#{translation_key_prefix}.programme_start_date.blank",
-              ),
+          let(:translation) do
+            I18n.t(
+              "#{translation_key_prefix}.#{attribute_name}.#{translation_key_suffix}",
             )
           end
-        end
 
-        context "the start date fields are 12/11/2020" do
-          let(:attributes) do
-            { start_day: "12", start_month: "11", start_year: "2020" }
-          end
-
-          it "does not return an error message for programme start date" do
-            expect(subject.errors[:programme_start_date]).to be_empty
+          it "returns an error message for #{attribute_name.to_s.humanize} due to #{translation_key_suffix.to_s.humanize(capitalize: false)}" do
+            expect(subject.errors[attribute_name]).to include(translation)
           end
         end
 
-        context "the start date fields are are gibberish" do
-          let(:attributes) do
-            { start_day: "foo", start_month: "foo", start_year: "foo" }
+        describe "#programme_start_date_valid" do
+          let(:end_date_attributes) { {} }
+
+          context "the start date fields are 12/11/2020" do
+            let(:start_date_attributes) do
+              { start_day: "12", start_month: "11", start_year: "2020" }
+            end
+
+            it "does not return an error message for programme start date" do
+              expect(subject.errors[:programme_start_date]).to be_empty
+            end
           end
 
-          it "return an error message programme start is invalid" do
-            expect(subject.errors[:programme_start_date]).to include(
-              I18n.t(
-                "#{translation_key_prefix}.programme_start_date.invalid",
-              ),
-            )
-          end
-        end
-      end
+          include_examples date_error_message, :programme_start_date, :blank,
+                           "", "", ""
+          include_examples date_error_message, :programme_start_date, :invalid,
+                           "foo", "foo", "foo"
 
-      describe "#programme_end_date_valid" do
-        context "the end date fields are all blank" do
-          let(:attributes) do
-            { end_day: "", end_month: "", end_year: "" }
-          end
-
-          it "returns an error end date is blank" do
-            expect(subject.errors[:programme_end_date]).to include(
-              I18n.t(
-                "#{translation_key_prefix}.programme_end_date.blank",
-              ),
-            )
-          end
+          start_date = 10.years.ago
+          include_examples date_error_message, :programme_start_date, :over_10_years,
+                           start_date.day, start_date.month, start_date.year
         end
 
-        context "the end date fields are 12/11/2020" do
-          let(:attributes) do
-            { end_day: "12", end_month: "11", end_year: "2020" }
+        describe "#programme_end_date_valid" do
+          start_date = 1.month.ago
+
+          let(:start_date_attributes) do
+            {
+              start_day: start_date.day,
+              start_month: start_date.month,
+              start_year: start_date.year,
+            }
           end
 
-          it "does not return an error message for end date" do
-            expect(subject.errors[:programme_end_date]).to be_empty
+          context "the end date fields are after start date" do
+            let(:end_date_attributes) do
+              {
+                end_day: start_date.day,
+                end_month: start_date.month,
+                end_year: start_date.year + 1,
+              }
+            end
+            it "does not return an error message for end date" do
+              expect(subject.errors[:programme_end_date]).to be_empty
+            end
           end
-        end
 
-        context "the end date fields are are gibberish" do
-          let(:attributes) do
-            { end_day: "foo", end_month: "foo", end_year: "foo" }
-          end
-
-          it "returns an error message programme end is invalid" do
-            expect(subject.errors[:programme_end_date]).to include(
-              I18n.t(
-                "#{translation_key_prefix}.programme_end_date.invalid",
-              ),
-            )
-          end
+          include_examples date_error_message, :programme_end_date, :blank,
+                           "", "", ""
+          include_examples date_error_message, :programme_end_date, :invalid,
+                           "foo", "foo", "foo"
+          include_examples date_error_message, :programme_end_date, :before_or_same_as_start_date,
+                           start_date.day, start_date.month, start_date.year
+          include_examples date_error_message, :programme_end_date, :before_or_same_as_start_date,
+                           start_date.day, start_date.month, start_date.year - 1
         end
       end
     end
@@ -158,17 +168,21 @@ describe ProgrammeDetailForm, type: :model do
         end
 
         context "valid attributes" do
-          let(:date) do
-            Date.new(1999, 12, 31)
+          let(:valid_start_date) do
+            Faker::Date.between(from: 10.years.ago, to: 2.days.ago)
+          end
+
+          let(:valid_end_date) do
+            Faker::Date.between(from: valid_start_date + 1.day, to: Time.zone.today)
           end
 
           let(:attributes) do
-            { start_day: date.day.to_s,
-              start_month: date.month.to_s,
-              start_year: date.year.to_s,
-              end_day: date.day.to_s,
-              end_month: date.month.to_s,
-              end_year: date.year.to_s,
+            { start_day: valid_start_date.day.to_s,
+              start_month: valid_start_date.month.to_s,
+              start_year: valid_start_date.year.to_s,
+              end_day: valid_end_date.day.to_s,
+              end_month: valid_end_date.month.to_s,
+              end_year: valid_end_date.year.to_s,
               main_age_range: "11 to 19 programme",
               subject: "Psychology" }
           end
@@ -180,7 +194,9 @@ describe ProgrammeDetailForm, type: :model do
               .and change { trainee.age_range }
               .from(nil).to(attributes[:main_age_range])
               .and change { trainee.programme_start_date }
-              .from(nil).to(date)
+              .from(nil).to(Date.parse(valid_start_date.to_s))
+              .and change { trainee.programme_end_date }
+              .from(nil).to(Date.parse(valid_end_date.to_s))
           end
         end
       end

--- a/spec/forms/programme_detail_form_spec.rb
+++ b/spec/forms/programme_detail_form_spec.rb
@@ -121,7 +121,7 @@ describe ProgrammeDetailForm, type: :model do
                            "foo", "foo", "foo"
 
           start_date = 10.years.ago
-          include_examples date_error_message, :programme_start_date, :invalid,
+          include_examples date_error_message, :programme_start_date, :too_old,
                            start_date.day, start_date.month, start_date.year
         end
 

--- a/spec/services/programme_details/update_spec.rb
+++ b/spec/services/programme_details/update_spec.rb
@@ -10,16 +10,21 @@ module ProgrammeDetails
       context "when programme details are valid" do
         let(:trainee) { create(:trainee) }
 
-        let(:date) do
-          Date.new(1999, 12, 31)
+        let(:valid_start_date) do
+          Date.parse(5.years.ago.to_s)
         end
+
+        let(:valid_end_date) do
+          Date.parse(4.years.ago.to_s)
+        end
+
         let(:attributes) do
-          { start_day: date.day.to_s,
-            start_month: date.month.to_s,
-            start_year: date.year.to_s,
-            end_day: date.day.to_s,
-            end_month: date.month.to_s,
-            end_year: date.year.to_s,
+          { start_day: valid_start_date.day,
+            start_month: valid_start_date.month,
+            start_year: valid_start_date.year,
+            end_day: valid_end_date.day,
+            end_month: valid_end_date.month,
+            end_year: valid_end_date.year,
             main_age_range: "other",
             additional_age_range: "14 - 19 diploma",
             subject: "Philosophy" }
@@ -33,8 +38,8 @@ module ProgrammeDetails
         it "updates the trainee's programme details" do
           expect(trainee.subject).to eq(attributes[:subject])
           expect(trainee.age_range).to eq(attributes[:additional_age_range])
-          expect(trainee.programme_start_date).to eq(date)
-          expect(trainee.programme_end_date).to eq(date)
+          expect(trainee.programme_start_date).to eq(valid_start_date)
+          expect(trainee.programme_end_date).to eq(valid_end_date)
         end
 
         it "is successful" do
@@ -66,6 +71,7 @@ module ProgrammeDetails
           expect(trainee.subject).to_not eq(nil)
           expect(trainee.age_range).to_not eq(nil)
           expect(trainee.programme_start_date).to_not eq(nil)
+          expect(trainee.programme_end_date).to_not eq(nil)
         end
 
         it "is unsuccessful" do


### PR DESCRIPTION
### Context
Validation for programme dates

### Changes proposed in this pull request
Validation for start date to be within 10 years
Validation for end date to be after start date


### Guidance to review
#### 10 years ago
![image](https://user-images.githubusercontent.com/470137/103084812-d512db00-45d7-11eb-8ff2-cfc887ab23e9.png)



#### Same date
![image](https://user-images.githubusercontent.com/470137/103017112-0ab5b680-453b-11eb-86e9-5ab2eef79627.png)

#### Before start date

![image](https://user-images.githubusercontent.com/470137/103017180-2325d100-453b-11eb-9f8f-f7a614c0e777.png)


