### PR TITLE
[778] Clean up defer/withdraw trainee

### DIFF
--- a/app/components/trainees/record_actions/view.html.erb
+++ b/app/components/trainees/record_actions/view.html.erb
@@ -2,13 +2,20 @@
   <%= govuk_button_link_to "Recommend for QTS", edit_trainee_outcome_details_outcome_date_path(trainee),
                            { class: "govuk-!-margin-bottom-0" }  %>
 
-  <div class="record-actions__links">
-    <p class="govuk-body govuk-!-margin-bottom-0">
-      <%= govuk_link_to t("views.trainees.edit.defer"), trainee_deferral_path(@trainee), class: "defer"  %> or
-      <%= govuk_link_to t("views.trainees.edit.withdraw"), trainee_withdrawal_path(@trainee), class: "withdraw"  %>
-      <%= t("views.trainees.edit.this_trainee") %>
-    </p>
-  </div>
+  <% if display_actions? %>
+    <div class="record-actions__links">
+      <p class="govuk-body govuk-!-margin-bottom-0">
+        <% if allow_defer? %>
+          <%= govuk_link_to t("views.trainees.edit.defer"), trainee_deferral_path(@trainee), class: "defer"  %> or
+        <% end %>
+
+        <% if allow_withdraw? %>
+          <%= govuk_link_to t("views.trainees.edit.withdraw"), trainee_withdrawal_path(@trainee), class: "withdraw"  %>
+        <% end %>
+        <%= t("views.trainees.edit.this_trainee") %>
+      </p>
+    </div>
+  <% end %>
 </div>
 
 <hr class='govuk-section-break govuk-section-break--m govuk-section-break--visible'>

--- a/app/components/trainees/record_actions/view.rb
+++ b/app/components/trainees/record_actions/view.rb
@@ -10,6 +10,18 @@ module Trainees
       def initialize(trainee)
         @trainee = trainee
       end
+
+      def display_actions?
+        allow_defer? || allow_withdraw?
+      end
+
+      def allow_defer?
+        trainee.submitted_for_trn? || trainee.trn_received?
+      end
+
+      def allow_withdraw?
+        allow_defer? || trainee.deferred?
+      end
     end
   end
 end

--- a/app/controllers/trainees/deferrals_controller.rb
+++ b/app/controllers/trainees/deferrals_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class DeferralsController < ApplicationController
+    before_action :authorize_trainee
+
     PARAM_CONVERSION = {
       "defer_date(3i)" => "day",
       "defer_date(2i)" => "month",
@@ -9,12 +11,12 @@ module Trainees
     }.freeze
 
     def show
-      authorize trainee
       @deferral = DeferralForm.new(trainee)
     end
 
     def update
-      authorize trainee
+      authorize(trainee, :defer?)
+
       @deferral = DeferralForm.new(trainee)
       @deferral.assign_attributes(trainee_params)
 
@@ -29,6 +31,10 @@ module Trainees
 
     def trainee
       @trainee ||= Trainee.find(params[:trainee_id])
+    end
+
+    def authorize_trainee
+      authorize(trainee)
     end
 
     def trainee_params

--- a/app/controllers/trainees/withdrawals_controller.rb
+++ b/app/controllers/trainees/withdrawals_controller.rb
@@ -15,6 +15,8 @@ module Trainees
     end
 
     def update
+      authorize(trainee, :withdraw?)
+
       @withdrawal_form = WithdrawalForm.new(trainee)
       @withdrawal_form.assign_attributes(trainee_params)
 

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -33,6 +33,14 @@ class TraineePolicy
     user && user.provider_id == trainee.provider_id
   end
 
+  def withdraw?
+    defer? || trainee.deferred?
+  end
+
+  def defer?
+    trainee.submitted_for_trn? || trainee.trn_received?
+  end
+
   alias_method :create?, :show?
   alias_method :update?, :show?
   alias_method :edit?, :show?

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../../app/services/feature_service"
+
 if FeatureService.enabled?("use_dfe_sign_in")
 
   OmniAuth.config.logger = Rails.logger

--- a/spec/components/trainees/record_actions/view_preview.rb
+++ b/spec/components/trainees/record_actions/view_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module Trainees
+  module RecordActions
+    class ViewPreview < ViewComponent::Preview
+      def trn_requested_or_received
+        trainee.state = %i[submitted_for_trn trn_received].sample
+        render Trainees::RecordActions::View.new(trainee)
+      end
+
+      def deferred
+        trainee.state = :deferred
+        render Trainees::RecordActions::View.new(trainee)
+      end
+
+    private
+
+      def trainee
+        @trainee ||= Trainee.new(id: 1)
+      end
+    end
+  end
+end

--- a/spec/components/trainees/record_actions/view_spec.rb
+++ b/spec/components/trainees/record_actions/view_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Trainees::RecordActions::View do
+  let(:trainee) { build(:trainee, trait, id: 1) }
+
+  subject { render_inline(described_class.new(trainee)).text }
+
+  context "trainee state" do
+    context "draft" do
+      let(:trait) { :draft }
+
+      it { is_expected.not_to include("Defer", "Withdraw") }
+    end
+
+    context "submitted for TRN" do
+      let(:trait) { :submitted_for_trn }
+
+      it { is_expected.to include("Defer", "Withdraw") }
+    end
+
+    context "TRN received" do
+      let(:trait) { :trn_received }
+
+      it { is_expected.to include("Defer", "Withdraw") }
+    end
+
+    context "recommended for GTS" do
+      let(:trait) { :recommended_for_qts }
+
+      it { is_expected.not_to include("Defer", "Withdraw") }
+    end
+
+    context "withdrawn" do
+      let(:trait) { :withdrawn }
+
+      it { is_expected.not_to include("Defer", "Withdraw") }
+    end
+
+    context "QTS awarded" do
+      let(:trait) { :qts_awarded }
+
+      it { is_expected.not_to include("Defer", "Withdraw") }
+    end
+  end
+end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -64,6 +64,10 @@ FactoryBot.define do
       outcome_date { Faker::Date.in_date_period }
     end
 
+    trait :draft do
+      state { "draft" }
+    end
+
     trait :submitted_for_trn do
       state { "submitted_for_trn" }
       submitted_for_trn_at { Time.zone.now }

--- a/spec/features/trainees/defer_trainee_spec.rb
+++ b/spec/features/trainees/defer_trainee_spec.rb
@@ -7,7 +7,7 @@ feature "Deferring a trainee", type: :feature do
 
   before do
     given_i_am_authenticated
-    given_a_trainee_exists
+    given_a_trainee_exists_to_be_deferred
     and_i_am_on_the_trainee_edit_page
     and_i_click_on_defer
   end
@@ -101,6 +101,10 @@ feature "Deferring a trainee", type: :feature do
 
   def then_i_am_redirected_to_deferral_confirmation_page
     expect(deferral_confirmation_page).to be_displayed(id: trainee.id)
+  end
+
+  def given_a_trainee_exists_to_be_deferred
+    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample)
   end
 
   def edit_page

--- a/spec/features/trainees/withdraw_trainee_spec.rb
+++ b/spec/features/trainees/withdraw_trainee_spec.rb
@@ -2,12 +2,12 @@
 
 require "rails_helper"
 
-feature "Recording withdrawing training", type: :feature do
+feature "Withdrawing a trainee", type: :feature do
   include SummaryHelper
 
   background do
     given_i_am_authenticated
-    given_a_trainee_exists
+    given_a_trainee_exists_to_be_withdrawn
     and_i_am_on_the_trainee_edit_page
     and_i_click_on_withdraw
   end
@@ -163,6 +163,10 @@ feature "Recording withdrawing training", type: :feature do
   def and_the_additional_reason_is_displayed
     trainee.reload
     expect(withdrawal_confirmation_page).to have_text(additional_withdraw_reason)
+  end
+
+  def given_a_trainee_exists_to_be_withdrawn
+    given_a_trainee_exists(%i[submitted_for_trn trn_received deferred].sample)
   end
 
   def edit_page

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -77,7 +77,7 @@ describe Trainee do
         context "when record type is not present" do
           it "is not valid" do
             expect(subject).not_to be_valid
-            expect(subject.errors.keys).to include(:record_type)
+            expect(subject.errors.attribute_names).to include(:record_type)
           end
         end
 
@@ -86,7 +86,7 @@ describe Trainee do
 
           it "is not valid" do
             expect(subject).not_to be_valid
-            expect(subject.errors.keys).to include(:trainee_id)
+            expect(subject.errors.attribute_names).to include(:trainee_id)
           end
         end
 


### PR DESCRIPTION
### Context
https://trello.com/c/XI93jaHF/779-clean-up-withdraw-trainee
https://trello.com/c/qaNHqDxl/778-clean-up-defer-trainee

### Changes proposed in this pull request
- Add logic to the view component to show/hide links based on trainee state
- Add policy methods to authorise deferrals and withdrawals
- Fix deprecated warnings

### Guidance to review
Since it's not possible to put trainees into various states easily the next best thing is to fire up the server locally and visit `/view_components/trainees/record_actions/view` to see the component in various states.

