### PR TITLE
Change button text to match action

### DIFF
--- a/app/components/trainees/record_actions/view.html.erb
+++ b/app/components/trainees/record_actions/view.html.erb
@@ -1,5 +1,5 @@
 <div class="record-actions">
-  <%= govuk_button_link_to "Record training outcome", edit_trainee_outcome_details_outcome_date_path(trainee),
+  <%= govuk_button_link_to "Recommend for QTS", edit_trainee_outcome_details_outcome_date_path(trainee),
                            { class: "govuk-!-margin-bottom-0" }  %>
 
   <div class="record-actions__links">


### PR DESCRIPTION
As we're not doing work around outcomes just yet, change the button text to more closely match the action users are doing.

![Screenshot 2020-12-23 at 17 39 13](https://user-images.githubusercontent.com/2204224/103023419-d4c9ff80-4545-11eb-89ab-507e83799801.png)
