### PR TITLE
[695] Keyword search for trainees

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem "omniauth"
 gem "omniauth_openid_connect"
 gem "omniauth-rails_csrf_protection"
 
+# Full text search
+gem "pg_search", "~> 2.3"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,9 @@ GEM
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    pg_search (2.3.5)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -453,6 +456,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   pg (>= 0.18, < 2.0)
+  pg_search (~> 2.3)
   pry-byebug
   puma (~> 5.1)
   pundit

--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -41,6 +41,11 @@
             <%= submit_tag "Apply filters", class: "govuk-button" %>
 
             <div class="govuk-form-group">
+              <%= label_tag "text_search", "Search records", class: "govuk-label govuk-label--s" %>
+              <%= text_field_tag "text_search", filters[:text_search], spellcheck: false, class: "govuk-input" %>
+            </div>
+
+            <div class="govuk-form-group">
               <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                   Routes

--- a/app/components/trainees/filters/view.rb
+++ b/app/components/trainees/filters/view.rb
@@ -22,7 +22,7 @@ module Trainees
 
       def active_filters
         filters.deep_dup.reject! do |filter, value|
-          filter == "subject" && value == "All subjects"
+          value.empty? || (filter == "subject" && value == "All subjects")
         end
       end
 

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -53,6 +53,6 @@ private
   end
 
   def filters
-    @filters ||= params.permit(:subject, record_type: [], state: [])
+    @filters ||= params.permit(:subject, :text_search, record_type: [], state: [])
   end
 end

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -37,6 +37,12 @@ module Trainees
       trainees.where(subject: subject)
     end
 
+    def text_search(trainees, text_search)
+      return trainees if text_search&.empty?
+
+      trainees.with_name_trainee_id_or_trn_like(text_search)
+    end
+
     def filter_trainees
       # Tech note: If you're adding a new filter to the top of this list, make
       # sure that it acts on `trainees` and all other filters then act on
@@ -44,6 +50,7 @@ module Trainees
       filtered_trainees = record_type(trainees, filters[:record_type])
       filtered_trainees = state(filtered_trainees, filters[:state])
       filtered_trainees = subject(filtered_trainees, filters[:subject])
+      filtered_trainees = text_search(filtered_trainees, filters[:text_search])
       filtered_trainees
     end
   end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -100,4 +100,54 @@ describe Trainee do
       end
     end
   end
+
+  describe "#with_name_trainee_id_or_trn_like" do
+    let(:other_trainee) { create(:trainee) }
+    let(:matching_trainee) do
+      create(:trainee, middle_names: "Firstmiddle Secondmiddle", trn: "123")
+    end
+
+    subject { described_class.with_name_trainee_id_or_trn_like(search_term) }
+
+    shared_examples_for "a working search" do
+      it "returns the matching trainee" do
+        expect(subject).to contain_exactly(matching_trainee)
+      end
+    end
+
+    context "with an exactly matching first name" do
+      let(:search_term) { matching_trainee.first_names }
+      it_behaves_like "a working search"
+    end
+
+    context "with exactly matching (second) middle name" do
+      let(:search_term) { "Secondmiddle" }
+      it_behaves_like "a working search"
+    end
+
+    context "with exactly matching last name" do
+      let(:search_term) { matching_trainee.last_name }
+      it_behaves_like "a working search"
+    end
+
+    context "with a matching trainee id" do
+      let(:search_term) { matching_trainee.trn }
+      it_behaves_like "a working search"
+    end
+
+    context "with extra spaces in the search term" do
+      let(:search_term) { "Firstmiddle  Secondmiddle" }
+      it_behaves_like "a working search"
+    end
+
+    context "with incorrect case" do
+      let(:search_term) { "firstMiddle" }
+      it_behaves_like "a working search"
+    end
+
+    context "with partial search term" do
+      let(:search_term) { "First" }
+      it_behaves_like "a working search"
+    end
+  end
 end

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -17,6 +17,7 @@ module PageObjects
       element :clear_filters_link, "a", text: "Clear"
       element :apply_filters, "input[name='commit']"
 
+      element :text_search, "#text_search"
       element :assessment_only_checkbox, "#record_type-assessment_only"
       element :provider_led_checkbox, "#record_type-provider_led"
       element :subject, "#subject"


### PR DESCRIPTION
### Context

https://trello.com/c/HzoTQU3L/695-m-search-trainee-records-by-keyword

### Changes proposed in this pull request

This PR:
- Adds the gem [pg_search](https://github.com/Casecommons/pg_search)
- Configures the search to use a prefix tsearch on the following columns: `first_names`, `middle_names`, `last_name`, `trn` and `trainee_id`

This PR does not include and performance testing on the search / any optimisation using stored `tsvector` columns. the `tsvector` is created on the fly by pg_search.

### Guidance to review

To review:
- Head to `/trainees`
- Search trainees by entering a variety of search terms
- Check that the expected trainees are returned