### PR TITLE
[782] Prevent editing base on trainee state

### DIFF
--- a/app/components/summary_card/view.rb
+++ b/app/components/summary_card/view.rb
@@ -2,13 +2,29 @@
 
 class SummaryCard::View < ViewComponent::Base
   include ViewComponent::Slotable
+
   with_content_areas :header_actions
 
-  attr_accessor :title, :heading_level, :rows
+  attr_accessor :trainee, :title, :heading_level
 
-  def initialize(title:, heading_level: 2, rows:)
+  def initialize(trainee:, title:, heading_level: 2, rows:)
+    @trainee = trainee
     @title = title
     @heading_level = heading_level
     @rows = rows
+  end
+
+  def rows
+    @rows.map do |row|
+      row.tap do |r|
+        r.delete(:action) if prevent_action?
+      end
+    end
+  end
+
+private
+
+  def prevent_action?
+    trainee.recommended_for_qts? || trainee.qts_awarded? || trainee.withdrawn?
   end
 end

--- a/app/components/trainees/confirmation/contact_details/view.html.erb
+++ b/app/components/trainees/confirmation/contact_details/view.html.erb
@@ -1,4 +1,4 @@
-<%= render SummaryCard::View.new(title: 'Contact details',
+<%= render SummaryCard::View.new(trainee: trainee, title: 'Contact details',
     heading_level: 2,
     rows: [
       {

--- a/app/components/trainees/confirmation/degrees/view.html.erb
+++ b/app/components/trainees/confirmation/degrees/view.html.erb
@@ -1,6 +1,6 @@
 <% if degrees.present? %>
   <% degrees.each do |degree| %>
-    <%= render SummaryCard::View.new(title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree)) do |component| %>
+    <%= render SummaryCard::View.new(trainee: trainee, title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree)) do |component| %>
       <% if show_delete_button %>
         <% component.with(:header_actions) do %>
           <%= form_with model: [trainee, degree], method: :delete, local: true do |f| %>

--- a/app/components/trainees/confirmation/diversity/view.html.erb
+++ b/app/components/trainees/confirmation/diversity/view.html.erb
@@ -1,4 +1,4 @@
-<%= render SummaryCard::View.new(
+<%= render SummaryCard::View.new(trainee: trainee,
     title: 'Diversity information',
     heading_level: 2,
     rows: diversity_information_rows

--- a/app/components/trainees/confirmation/personal_details/view.html.erb
+++ b/app/components/trainees/confirmation/personal_details/view.html.erb
@@ -1,4 +1,4 @@
-<%= render SummaryCard::View.new(title: 'Personal details',
+<%= render SummaryCard::View.new(trainee: trainee, title: 'Personal details',
     heading_level: 2,
     rows: [
       {

--- a/app/components/trainees/confirmation/programme_details/view.html.erb
+++ b/app/components/trainees/confirmation/programme_details/view.html.erb
@@ -1,4 +1,4 @@
-<%= render SummaryCard::View.new(title: summary_title,
+<%= render SummaryCard::View.new(trainee: trainee, title: summary_title,
     heading_level: 2,
     rows: [
       {

--- a/app/components/trainees/confirmation/record/view.html.erb
+++ b/app/components/trainees/confirmation/record/view.html.erb
@@ -1,4 +1,4 @@
-<%= render SummaryCard::View.new(
+<%= render SummaryCard::View.new(trainee: trainee,
   title: 'Type of training',
   heading_level: 2,
   rows: [

--- a/app/components/trainees/confirmation/trainee_id/view.html.erb
+++ b/app/components/trainees/confirmation/trainee_id/view.html.erb
@@ -1,4 +1,4 @@
-<%= render SummaryCard::View.new(title: 'Contact details',
+<%= render SummaryCard::View.new(trainee: trainee, title: 'Contact details',
     heading_level: 2,
     rows: [
       {

--- a/app/components/trainees/confirmation/withdrawal_details/view.html.erb
+++ b/app/components/trainees/confirmation/withdrawal_details/view.html.erb
@@ -1,4 +1,4 @@
-<%= render SummaryCard::View.new(
+<%= render SummaryCard::View.new(trainee: trainee,
   title: t("components.confirmation.withdrawal_details.summary_title"),
   heading_level: 2,
   rows: [

--- a/app/components/trainees/deferral_details/view.html.erb
+++ b/app/components/trainees/deferral_details/view.html.erb
@@ -1,4 +1,4 @@
-<%= render SummaryCard::View.new(
+<%= render SummaryCard::View.new(trainee: trainee,
   title: t("components.confirmation.deferral_details.summary_title"),
   heading_level: 2,
   rows: [

--- a/app/components/trainees/outcome_details/view.html.erb
+++ b/app/components/trainees/outcome_details/view.html.erb
@@ -1,4 +1,4 @@
-<%= render SummaryCard::View.new(
+<%= render SummaryCard::View.new(trainee: trainee,
   title: "Outcome details",
   heading_level: 2,
   rows: [

--- a/app/components/trainees/record_details/view.html.erb
+++ b/app/components/trainees/record_details/view.html.erb
@@ -1,4 +1,4 @@
-<%= render SummaryCard::View.new(
+<%= render SummaryCard::View.new(trainee: trainee,
   title: "Record details",
   heading_level: 2,
   rows: [

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -84,7 +84,7 @@ namespace :example_data do
         next if trainee.draft?
 
         [1, 2].sample.times do
-          trainee.degrees << FactoryBot.build(:degree)
+          trainee.degrees << FactoryBot.build(:degree, %i[uk_degree_with_details non_uk_degree_with_details].sample)
         end
       end
     end

--- a/spec/components/summary_card/view_spec.rb
+++ b/spec/components/summary_card/view_spec.rb
@@ -3,35 +3,38 @@
 require "rails_helper"
 
 RSpec.describe SummaryCard::View do
-  rows = [
-    { key: "Character", value: "Lando Calrissian" },
-    { key: "Location", value: "In a galaxy" },
-    { key: "Transport", value: "Falcon", action: '<a href="#mike" class="govuk-link">Change</a>'.html_safe },
-  ]
+  let(:trainee) { build(:trainee) }
+  let(:rows) do
+    [
+      { key: "Character", value: "Lando Calrissian" },
+      { key: "Location", value: "In a galaxy" },
+      { key: "Transport", value: "Falcon", action: '<a href="#mike" class="govuk-link">Change</a>'.html_safe },
+    ]
+  end
 
-  before(:all) do
-    @result ||= render_inline(SummaryCard::View.new(title: "Lando Calrissian", heading_level: 6, rows: rows))
+  subject do
+    render_inline(SummaryCard::View.new(trainee: trainee, title: "Lando Calrissian", heading_level: 6, rows: rows))
   end
 
   it "renders a summary list component for rows" do
-    expect(@result.css(".govuk-summary-list__value").text).to include("Lando Calrissian")
-    expect(@result.css(".govuk-summary-list__key").text).to include("Character")
+    expect(subject.css(".govuk-summary-list__value").text).to include("Lando Calrissian")
+    expect(subject.css(".govuk-summary-list__key").text).to include("Character")
   end
 
   it "renders content at the top of a summary card" do
-    expect(@result.text).to include("In a galaxy")
+    expect(subject.text).to include("In a galaxy")
   end
 
   it "renders a summary card header component with a title only" do
-    expect(@result.css(".app-summary-card__title").text).to include("Lando Calrissian")
+    expect(subject.css(".app-summary-card__title").text).to include("Lando Calrissian")
   end
 
   it "renders a summary card header component with a custom heading level" do
-    expect(@result.css(".app-summary-card__title").text).to include("Lando Calrissian")
-    expect(@result.css("h6.app-summary-card__title")).to be_present
+    expect(subject.css(".app-summary-card__title").text).to include("Lando Calrissian")
+    expect(subject.css("h6.app-summary-card__title")).to be_present
   end
 
   it "renders a link alongside rows with an action value" do
-    expect(@result.css(".govuk-link").text).to include("Change")
+    expect(subject.css(".govuk-link").text).to include("Change")
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/ailqjhyA/782-prevent-editing-of-withdrawn-trainees

### Changes proposed in this pull request
Modify `app/components/summary_card/view.html.erb` to hide change links when the trainee is in the following states:
-  Recommended for QTS
- Award for QTS
- Withdrawn

### Guidance to review
- Make sure you have example data loaded: `rake example_data:generate`
- Fire up the server locally and visit `/trainees`
- Choose a trainee with the following states: Recommended for QTS, Award for QTS, Withdrawn and confirm that the change links are not displayed
- For all other states, the change links should appear
