### PR TITLE
[776] Add conditional links to trainee pages

### DIFF
--- a/app/components/application_record_card/view.html.erb
+++ b/app/components/application_record_card/view.html.erb
@@ -1,7 +1,7 @@
 <div class="app-application-card">
   <div class="app-application-card_col">
     <h<%= heading_level %> class="govuk-heading-m govuk-!-margin-bottom-3">
-      <%= govuk_link_to trainee_name, trainee_path(record.id) %>
+      <%= govuk_link_to trainee_name, view_trainee(record) %>
     </h<%= heading_level %>>
     <%= trainee_id %>
   </div>

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -3,6 +3,7 @@
 module ApplicationRecordCard
   class View < GovukComponent::Base
     include SanitizeHelper
+    include TraineeHelper
 
     with_collection_parameter :record
 

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -7,4 +7,12 @@ module TraineeHelper
       .reject(&:empty?)
       .join(" ")
   end
+
+  def view_trainee(trainee)
+    if trainee.draft?
+      trainee_path(trainee.id)
+    else
+      edit_trainee_path(trainee.id)
+    end
+  end
 end

--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
     text: 'Back to overview',
-    href: trainee_path(@trainee)
+    href: view_trainee(@trainee)
   ) %>
 <% end %>
 

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
     text: "Back",
-    href: trainee_path(@trainee)
+    href: view_trainee(@trainee)
   ) %>
 <% end %>
 
@@ -51,4 +51,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Cancel", trainee_path(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to("Cancel", view_trainee(@trainee)) %></p>

--- a/app/views/trainees/diversity/confirm_details/show.html.erb
+++ b/app/views/trainees/diversity/confirm_details/show.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
     text: 'Back to overview',
-    href: trainee_path(@trainee)
+    href: view_trainee(@trainee)
   ) %>
 <% end %>
 

--- a/app/views/trainees/diversity/disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disclosures/edit.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
     text: "Back",
-    href: trainee_path(@trainee)
+    href: view_trainee(@trainee)
   ) %>
 <% end %>
 

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
     text: 'Back',
-    href: trainee_path(@trainee)
+    href: view_trainee(@trainee)
   ) %>
 <% end %>
 
@@ -50,4 +50,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Cancel", trainee_path(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to("Cancel", view_trainee(@trainee)) %></p>

--- a/app/views/trainees/programme_details/edit.html.erb
+++ b/app/views/trainees/programme_details/edit.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
     text: 'Back',
-    href: trainee_path(@trainee)
+    href: view_trainee(@trainee)
   ) %>
 <% end %>
 
@@ -57,4 +57,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Cancel", trainee_path(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to("Cancel", view_trainee(@trainee)) %></p>

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
     text: 'Back',
-    href: trainee_path(@trainee)
+    href: view_trainee(@trainee)
   ) %>
 <% end %>
 

--- a/spec/helpers/trainee_helper_spec.rb
+++ b/spec/helpers/trainee_helper_spec.rb
@@ -24,4 +24,25 @@ describe TraineeHelper do
       end
     end
   end
+
+  describe "#view_trainee" do
+    STATES = Trainee.states.keys.map(&:to_sym) - [:draft]
+    subject { view_trainee(trainee) }
+
+    context "with a draft trainee" do
+      let(:trainee) { create(:trainee) }
+      it "returns the trainee_path" do
+        expect(subject).to eq(trainee_path(trainee))
+      end
+    end
+
+    STATES.each do |state|
+      context "with a #{state} trainee" do
+        let(:trainee) { create(:trainee, state) }
+        it "returns the edit_trainee_path" do
+          expect(subject).to eq(edit_trainee_path(trainee))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/zQ2Yeg6s/776-refine-ui-based-on-trainee-status

### Changes proposed in this pull request

This PR creates a view helper which decides which trainee page to link you to depending on the trainee's state.

If we decide later down the line to change the route `/edit` to something else (as has been discussed) then this means we only have to change it in one place 👍 

### Guidance to review

This is a little tricky to test in a deployed environment, since we're not yet moving trainees through states. So I suggest:
- Pull down code locally
- Test links for a draft trainee link to the trainee show page
- Manipulate a trainee to be in a state other than draft
- Test that links send you to the trainee edit page

#### Links to test
- When you click on a trainee from the trainee index page
- When you're editing sections and click 'Back'
- When you're confirming sections and click 'Back'