### PR TITLE
[777] Update edit trainee page heading and title

### DIFF
--- a/app/components/application_record_card/view.html.erb
+++ b/app/components/application_record_card/view.html.erb
@@ -16,7 +16,7 @@
   </div>
 
   <div class="app-application-card_col">
-    <%= render GovukComponent::Tag.new(text: status, colour: status_colour) %>
+    <%= render StatusTag::View.new(trainee: record) %>
     <%= updated_at %>
   </div>
 </div>

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -39,25 +39,6 @@ module ApplicationRecordCard
       sanitize(tag.p(date_text.prepend("Updated: "), class: class_list))
     end
 
-    def status
-      {
-        submitted_for_trn: "pending trn",
-        recommended_for_qts: "qts recommended",
-      }[record.state.to_sym] || record.state.gsub("_", " ")
-    end
-
-    def status_colour
-      {
-        draft: "grey",
-        submitted_for_trn: "turquoise",
-        trn_received: "blue",
-        recommended_for_qts: "purple",
-        qts_awarded: "",
-        deferred: "yellow",
-        withdrawn: "red",
-      }[record.state.to_sym]
-    end
-
     def trainee_id
       return if record.trainee_id.blank?
 

--- a/app/components/status_tag/view.html.erb
+++ b/app/components/status_tag/view.html.erb
@@ -1,0 +1,1 @@
+<%= render GovukComponent::Tag.new(text: status, colour: status_colour, classes: "trainee-status") %>

--- a/app/components/status_tag/view.rb
+++ b/app/components/status_tag/view.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class StatusTag::View < ViewComponent::Base
+  def initialize(trainee:)
+    @trainee = trainee
+  end
+
+private
+
+  attr_accessor :trainee
+
+  def status
+    {
+      submitted_for_trn: "pending trn",
+      recommended_for_qts: "qts recommended",
+    }[trainee.state.to_sym] || trainee.state.gsub("_", " ")
+  end
+
+  def status_colour
+    {
+      draft: "grey",
+      submitted_for_trn: "turquoise",
+      trn_received: "blue",
+      recommended_for_qts: "purple",
+      qts_awarded: "",
+      deferred: "yellow",
+      withdrawn: "red",
+    }[trainee.state.to_sym]
+  end
+end

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -1,5 +1,5 @@
 <%= extends_layout :application do %>
-  <%= render PageTitle::View.new(title: "trainees.edit") %>
+  <%= render PageTitle::View.new(title: trainee_name(@trainee)) %>
 
   <%= content_for(:breadcrumbs) do %>
     <%= render GovukComponent::BackLink.new(
@@ -12,7 +12,7 @@
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
       <%= trainee_name(@trainee) %>
 
-      <%= render GovukComponent::Tag.new(text: "Pending TRN", colour: "turquoise") %>
+      <%= render StatusTag::View.new(trainee: @trainee) %>
     </h1>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,7 +62,6 @@ en:
         index: Trainee records
         not_supported_route: Other routes not supported
         show: Overview
-        edit: Edit trainee
         diversity:
           disclosures:
             edit: Has the trainee shared diversity information?

--- a/spec/features/trainees/edit_trainee_record_spec.rb
+++ b/spec/features/trainees/edit_trainee_record_spec.rb
@@ -41,7 +41,7 @@ feature "edit trainee record", type: :feature do
   end
 
   def then_i_see_the_trn_status
-    expect(@edit_page.trn_status.text).to eq("Pending TRN")
+    expect(@edit_page.trn_status.text).to eq(trainee.state)
   end
 
   def when_i_visit_the_trainee_edit_page

--- a/spec/support/page_objects/trainees/edit.rb
+++ b/spec/support/page_objects/trainees/edit.rb
@@ -6,7 +6,7 @@ module PageObjects
       set_url "/trainees/{id}/edit"
 
       element :trainee_name, ".govuk-heading-xl"
-      element :trn_status, ".govuk-tag.govuk-tag--turquoise"
+      element :trn_status, ".govuk-tag.trainee-status"
 
       element :record_outcome, ".govuk-button"
       element :withdraw, ".govuk-link.withdraw"


### PR DESCRIPTION
### Context

https://trello.com/c/2Qd2u1LS/777-use-correct-status-in-heading-of-traineesedit

### Changes proposed in this pull request

This PR:
- Changes the page title to be the trainee's name as per the prototype
- Makes the state tag dynamic, reusing some code from the index page

### Guidance to review

On the trainee edit page:
- Check that the trainee's name is the page title.
- Check that the correct status is shown in the heading tag.