### PR TITLE
[792] Split and order trainees by date

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -2,8 +2,12 @@
 
 class TraineesController < ApplicationController
   def index
+    @draft_trainees = Trainees::Filter.call(
+      trainees: policy_scope(Trainee.is_draft.ordered_by_date),
+      filters: filters,
+    )
     @trainees = Trainees::Filter.call(
-      trainees: policy_scope(Trainee),
+      trainees: policy_scope(Trainee.is_not_draft.ordered_by_date),
       filters: filters,
     )
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -66,6 +66,10 @@ class Trainee < ApplicationRecord
                   against: %i[first_names middle_names last_name trainee_id trn],
                   using: { tsearch: { prefix: true } }
 
+  scope :ordered_by_date, -> { order(updated_at: :desc) }
+  scope :is_draft, -> { where(state: "draft") }
+  scope :is_not_draft, -> { where.not(state: "draft") }
+
   def dttp_id=(value)
     raise LockedAttributeError, "dttp_id update failed for trainee ID: #{id}, with value: #{value}" if dttp_id.present?
 

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -9,8 +9,27 @@
 </p>
 
 <%= render Trainees::Filters::View.new(@filters) do %>
-  <% if @trainees.any? %>
-    <%= render ApplicationRecordCard::View.with_collection(@trainees) %>
+  <% if @draft_trainees.any? || @trainees.any? %>
+    <% if @draft_trainees.any? %>
+      <div class="govuk-!-margin-bottom-8 app-draft-records">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+            <h2 class="govuk-heading-m">Draft records (<%= @draft_trainees.count %>)</h2>
+          </div>
+        </div>
+        <%= render ApplicationRecordCard::View.with_collection(@draft_trainees) %>
+      </div>
+    <% end %>
+    <% if @trainees.any? %>
+      <div class="govuk-!-margin-bottom-8 app-non-draft-records">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+            <h2 class="govuk-heading-m">Records (<%= @trainees.count %>)</h2>
+          </div>
+        </div>
+        <%= render ApplicationRecordCard::View.with_collection(@trainees) %>
+      </div>
+    <% end %>
   <% elsif !@filters.empty? %>
     <h2 class="govuk-heading-m">No records found.</h2>
     <p class="govuk-body">

--- a/spec/features/trainees/viewing_an_existing_trainee_spec.rb
+++ b/spec/features/trainees/viewing_an_existing_trainee_spec.rb
@@ -8,12 +8,17 @@ feature "View trainees" do
   scenario "viewing the personal details of trainee" do
     given_a_trainee_exists
     when_i_view_the_trainee_index_page
+    then_i_see_the_draft_trainee_data
     and_i_click_on_trainee_name
     then_i_should_see_the_trainee_details
   end
 
   def when_i_view_the_trainee_index_page
     trainee_index_page.load
+  end
+
+  def then_i_see_the_draft_trainee_data
+    expect(trainee_index_page).to have_draft_trainee_data
   end
 
   def and_i_click_on_trainee_name

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -150,4 +150,31 @@ describe Trainee do
       it_behaves_like "a working search"
     end
   end
+
+  describe "#ordered_by_date" do
+    let(:trainee_one) { create(:trainee, updated_at: 1.day.ago) }
+    let(:trainee_two) { create(:trainee, updated_at: 1.hour.ago) }
+
+    it "orders the trainess by updated_at in descending order" do
+      expect(Trainee.ordered_by_date).to eq([trainee_two, trainee_one])
+    end
+  end
+
+  context "trainee status" do
+    let(:draft_trainee) { create(:trainee, :draft) }
+    let(:trainee_submitted_for_trn) { create(:trainee, :submitted_for_trn) }
+    let(:trainee_with_qts_awarded) { create(:trainee, :qts_awarded) }
+
+    describe "#is_draft" do
+      it "returns all trainees that are draft" do
+        expect(Trainee.is_draft).to match_array([draft_trainee])
+      end
+    end
+
+    describe "#is_not_draft" do
+      it "returns all records that are not draft" do
+        expect(Trainee.is_not_draft).to match_array([trainee_submitted_for_trn, trainee_with_qts_awarded])
+      end
+    end
+  end
 end

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -9,6 +9,8 @@ module PageObjects
 
       element :add_trainee_link, "a", text: "Add a trainee"
 
+      element :draft_trainee_data, ".app-draft-records"
+
       elements :trainee_data, ".app-application-card"
 
       elements :trainee_name, ".app-application-card .govuk-link"


### PR DESCRIPTION
### Context
- Improve UI of records i.e. draft vs complete and ordering

### Changes proposed in this pull request
- Spilt trainee records by draft and non-draft
- Order trainees by updated at first

### Guidance to review
## After
![localhost_5000_trainees(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/103284077-2fde7500-49d2-11eb-8451-bbae6c852b55.png)

