### PR TITLE
[790] Hide/show filters on mobile

### DIFF
--- a/app/components/trainees/filters/script.js
+++ b/app/components/trainees/filters/script.js
@@ -1,1 +1,30 @@
 import './style.scss'
+import $ from 'jquery'
+import { FilterToggleButton } from 'moj/all.js'
+
+const prepareFilterToggle = () => {
+  const filterContainer = $('.moj-filter-layout__filter')
+
+  if (filterContainer.length) {
+    /* eslint-disable no-new */
+    new FilterToggleButton({
+      bigModeMediaQuery: '(min-width: 48.063em)',
+      startHidden: false,
+      toggleButton: {
+        container: $('.moj-action-bar__filter'),
+        showText: 'Show filters',
+        hideText: 'Hide filters',
+        classes: 'govuk-button--secondary'
+      },
+      closeButton: {
+        container: $('.moj-filter__header-action'),
+        text: 'Close'
+      },
+      filter: {
+        container: filterContainer
+      }
+    })
+  }
+}
+
+prepareFilterToggle()

--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -1,9 +1,11 @@
-<div class='moj-filter-layout abigail'>
+<div class='moj-filter-layout'>
   <div class="moj-filter-layout__filter app-filter">
     <div class="moj-filter">
       <div class="moj-filter__header">
         <div class="moj-filter__header-title">
           <h2 class="govuk-heading-m">Filters</h2>
+        </div>
+        <div class="moj-filter__header-action">
         </div>
       </div>
 
@@ -88,6 +90,10 @@
   </div>
 
   <div class='moj-filter-layout__content'>
+    <div class="moj-action-bar">
+      <div class="moj-action-bar__filter">
+      </div>
+    </div>
     <%= content %>
   </div>
 </div>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,14 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+
+environment.plugins.prepend(
+  'Provide',
+  new webpack.ProvidePlugin({
+    $: 'jquery',
+    jQuery: 'jquery',
+    jquery: 'jquery'
+  })
+)
+
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "accessible-autocomplete": "^2.0.3",
     "core-js": "^3.8.1",
     "govuk-frontend": "^3.10.2",
+    "jquery": "^3.5.1",
     "rails-ujs": "^5.2.4",
     "serialize-javascript": "^5.0.1",
     "set-value": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4473,6 +4473,11 @@ jest-worker@^26.3.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 js-base64@^2.1.8:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"


### PR DESCRIPTION
### Context

https://trello.com/c/EtC2pNGc/790-filters-hide-show-filters-button-on-mobile

### Changes proposed in this pull request

This PR implements the MOJ `FilterToggleButton` JavaScript which:
- Hides the filters and shows a 'Show filter' button on small screens
- Toggles the filters when this button is pressed
- Adds a 'Close' button on the filter sidebar when open

With no JS, the filters are visible all the time, above the list of trainees.

Note: We can't use the MOJ code without JQuery.

<img width="696" alt="Screenshot 2020-12-29 at 14 52 46" src="https://user-images.githubusercontent.com/18436946/103292384-928d3c00-49e5-11eb-8751-bc37a442fd21.png">
<img width="770" alt="Screenshot 2020-12-29 at 14 52 59" src="https://user-images.githubusercontent.com/18436946/103292398-9751f000-49e5-11eb-804b-5879cdebed48.png">

### Guidance to review

- Head to `/trainees`
- Check that the filters are hidden when the screen is smaller
- Click 'Show filter' to open the filters
- Click 'Close' to close the filters
- Disable JS and check that the filters are always visible