### PR TITLE
[787] Fix filter label bug

### DIFF
--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -23,7 +23,7 @@
           </div>
 
           <% active_filters.each do |filter, value| %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= filter.humanize %></h3>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= filter_label_for(filter) %></h3>
             <ul class="moj-filter-tags">
               <% tags_for_active_filter(filter, value).each do |tag| %>
                 <li>

--- a/app/components/trainees/filters/view.rb
+++ b/app/components/trainees/filters/view.rb
@@ -54,6 +54,10 @@ module Trainees
         new_filters = active_filters.reject { |f| f == filter }
         "?" + new_filters.to_query
       end
+
+      def filter_label_for(filter)
+        I18n.t("components.filter.#{filter}")
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,10 @@ en:
           show: When did the trainee defer?
         deferral_details:
           confirm: Check deferral details
+    filter:
+      state: Status
+      record_type: Training route
+      subject: Subject
   views:
     trainees:
       edit:
@@ -175,7 +179,6 @@ en:
           withdrawn: Withdrawn
           deferred: Deferred
           qts_awarded: QTS awarded
-
     errors:
       models:
         degree:


### PR DESCRIPTION
### Context
* https://trello.com/c/KjRNQRY5/787-filters-ensure-that-filter-tag-labels-are-consistent-with-prototype
State was being rendered instead of Status, as per the params. State => 'draft' etc
### Changes proposed in this pull request

Keys in params translated so state is now translated to status. 
Record type filter label changed to Training Route reflecting change in prototype
Any new view changes with filter labels now easily changeable 

### Guidance to review
Start up app with personas on. Apply filters on /trainees page to see if bug fixed. 
