### PR TITLE
[792] Clean up applied filters before rending

### DIFF
--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -11,7 +11,7 @@
 
       <div class="moj-filter__content">
 
-        <% if !active_filters.empty? %>
+      <% if filters %>
         <div class="moj-filter__selected">
           <div class="moj-filter__selected-heading">
             <div class="moj-filter__heading-title">
@@ -24,10 +24,10 @@
             </div>
           </div>
 
-          <% active_filters.each do |filter, value| %>
+          <% filters.each do |filter, value| %>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= filter_label_for(filter) %></h3>
             <ul class="moj-filter-tags">
-              <% tags_for_active_filter(filter, value).each do |tag| %>
+              <% tags_for_filter(filter, value).each do |tag| %>
                 <li>
                   <%= link_to(tag[:title], tag[:remove_link], class: "moj-filter__tag", draggable: "false") %>
                 </li>
@@ -44,7 +44,7 @@
 
             <div class="govuk-form-group">
               <%= label_tag "text_search", "Search records", class: "govuk-label govuk-label--s" %>
-              <%= text_field_tag "text_search", filters[:text_search], spellcheck: false, class: "govuk-input" %>
+              <%= text_field_tag "text_search", (filters[:text_search] if filters), spellcheck: false, class: "govuk-input" %>
             </div>
 
             <div class="govuk-form-group">
@@ -81,7 +81,7 @@
 
             <div class="govuk-form-group">
               <%= label_tag "subject", "Subject", class: "govuk-label govuk-label--s" %>
-              <%= select_tag :subject, options_from_collection_for_select(filter_programme_subjects_options, :name, :name, filters[:subject]), class: "govuk-select" %>
+              <%= select_tag :subject, options_from_collection_for_select(filter_programme_subjects_options, :name, :name, (filters[:subject] if filters)), class: "govuk-select" %>
             </div>
           </form>
         </div>

--- a/app/components/trainees/filters/view.rb
+++ b/app/components/trainees/filters/view.rb
@@ -21,16 +21,10 @@ module Trainees
       end
 
       def checked?(filter, value)
-        filters[filter]&.include?(value)
+        filters && filters[filter]&.include?(value)
       end
 
-      def active_filters
-        filters.deep_dup.reject! do |filter, value|
-          value.empty? || (filter == "subject" && value == "All subjects")
-        end
-      end
-
-      def tags_for_active_filter(filter, value)
+      def tags_for_filter(filter, value)
         case value
         when String
           [{ title: title_html(filter, value), remove_link: remove_select_tag_link(filter) }]
@@ -45,13 +39,13 @@ module Trainees
       end
 
       def remove_checkbox_tag_link(filter, value)
-        new_filters = active_filters
+        new_filters = filters.deep_dup
         new_filters[filter].reject! { |v| v == value }
         "?" + new_filters.to_query
       end
 
       def remove_select_tag_link(filter)
-        new_filters = active_filters.reject { |f| f == filter }
+        new_filters = filters.reject { |f| f == filter }
         "?" + new_filters.to_query
       end
 

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -2,13 +2,15 @@
 
 class TraineesController < ApplicationController
   def index
+    @filters = TraineeFilter.new(params: filter_params).filters
+
     @draft_trainees = Trainees::Filter.call(
       trainees: policy_scope(Trainee.is_draft.ordered_by_date),
-      filters: filters,
+      filters: @filters,
     )
     @trainees = Trainees::Filter.call(
       trainees: policy_scope(Trainee.is_not_draft.ordered_by_date),
-      filters: filters,
+      filters: @filters,
     )
   end
 
@@ -56,7 +58,7 @@ private
     params.require(:trainee).permit(:record_type, :trainee_id)
   end
 
-  def filters
-    @filters ||= params.permit(:subject, :text_search, record_type: [], state: [])
+  def filter_params
+    params.permit(:subject, :text_search, record_type: [], state: [])
   end
 end

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class TraineeFilter
+  def initialize(params:)
+    @params = params
+  end
+
+  def filters
+    return if params.empty?
+
+    return if merged_filters.empty?
+
+    merged_filters
+  end
+
+private
+
+  attr_reader :params
+
+  def merged_filters
+    @merged_filters ||= text_search.merge(
+      **record_type, **state, **subject, **text_search,
+    ).with_indifferent_access
+  end
+
+  def record_type
+    return {} unless record_type_options.any?
+
+    { "record_type" => record_type_options }
+  end
+
+  def record_type_options
+    Trainee.record_types.keys.each_with_object([]) do |option, arr|
+      arr << option if params[:record_type]&.include?(option)
+    end
+  end
+
+  def state
+    return {} unless state_options.any?
+
+    { "state" => state_options }
+  end
+
+  def state_options
+    Trainee.states.keys.each_with_object([]) do |option, arr|
+      arr << option if params[:state]&.include?(option)
+    end
+  end
+
+  def subject
+    return {} unless params[:subject].present? && params[:subject] != "All subjects"
+
+    { "subject" => params[:subject].capitalize }
+  end
+
+  def text_search
+    return {} if params[:text_search].blank?
+
+    { "text_search" => params[:text_search] }
+  end
+end

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -10,7 +10,7 @@ module Trainees
     end
 
     def call
-      return trainees if filters.empty?
+      return trainees unless filters
 
       filter_trainees
     end
@@ -32,13 +32,13 @@ module Trainees
     end
 
     def subject(trainees, subject)
-      return trainees if subject.blank? || subject == "All subjects"
+      return trainees if subject.blank?
 
       trainees.where(subject: subject)
     end
 
     def text_search(trainees, text_search)
-      return trainees if text_search&.empty?
+      return trainees if text_search.blank?
 
       trainees.with_name_trainee_id_or_trn_like(text_search)
     end

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -30,7 +30,7 @@
         <%= render ApplicationRecordCard::View.with_collection(@trainees) %>
       </div>
     <% end %>
-  <% elsif !@filters.empty? %>
+  <% elsif @filters %>
     <h2 class="govuk-heading-m">No records found.</h2>
     <p class="govuk-body">
       Try

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,9 +102,10 @@ en:
         deferral_details:
           confirm: Check deferral details
     filter:
-      state: Status
       record_type: Training route
+      state: Status
       subject: Subject
+      text_search: Text search
   views:
     trainees:
       edit:

--- a/spec/components/trainees/filters/view_spec.rb
+++ b/spec/components/trainees/filters/view_spec.rb
@@ -4,11 +4,10 @@ require "rails_helper"
 
 RSpec.describe Trainees::Filters::View do
   let(:selected_text) { "Selected filters" }
-  let(:permitted_filters) { filters.permit(:subject, record_type: []) }
-  let(:result) { render_inline described_class.new(permitted_filters) }
+  let(:result) { render_inline described_class.new(filters) }
 
   context "when no filters are applied" do
-    let(:filters) { ActionController::Parameters.new({}) }
+    let(:filters) { nil }
 
     it "all of the checkboxes are unchecked" do
       expect(result.css("#record_type-assessment_only").attr("checked")).to eq(nil)
@@ -21,9 +20,7 @@ RSpec.describe Trainees::Filters::View do
   end
 
   context "when checkboxes have been pre-selected" do
-    let(:filters) do
-      ActionController::Parameters.new({ record_type: %w[assessment_only] })
-    end
+    let(:filters) { { record_type: %w[assessment_only] }.with_indifferent_access }
 
     it "marks the correct ones as selected" do
       expect(result.css("#record_type-assessment_only").attr("checked").value).to eq("checked")
@@ -36,9 +33,7 @@ RSpec.describe Trainees::Filters::View do
   end
 
   context "when a subject has been pre-selected" do
-    let(:filters) do
-      ActionController::Parameters.new({ subject: "Business studies" })
-    end
+    let(:filters) { { subject: "Business studies" }.with_indifferent_access }
 
     it "retains the input" do
       selected_value = result.css('#subject option[@selected="selected"]').attr("value").value
@@ -47,16 +42,6 @@ RSpec.describe Trainees::Filters::View do
 
     it "shows a 'Selected filters' dialogue" do
       expect(result.text).to include(selected_text)
-    end
-  end
-
-  context "when 'All subjects' has been selected" do
-    let(:filters) do
-      ActionController::Parameters.new({ subject: "All subjects" })
-    end
-
-    it "does not show a 'Selected filters' dialogue" do
-      expect(result.text).to_not include(selected_text)
     end
   end
 end

--- a/spec/models/trainee_filter_spec.rb
+++ b/spec/models/trainee_filter_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TraineeFilter do
+  let(:permitted_params) do
+    ActionController::Parameters.new(params)
+    .permit(:subject, :text_search, record_type: [], state: [])
+  end
+
+  subject { TraineeFilter.new(params: permitted_params) }
+  returns_nil = "returns nil"
+
+  shared_examples returns_nil do
+    it returns_nil do
+      expect(subject.filters).to be_nil
+    end
+  end
+
+  describe "#filters" do
+    context "with fully valid parameters" do
+      let(:params) do
+        {
+          subject: "Biology",
+          text_search: "search terms",
+          record_type: %w[assessment_only],
+          state: %w[draft],
+        }
+      end
+
+      it "returns the correct filter hash" do
+        expect(subject.filters).to eq(permitted_params.to_h)
+      end
+    end
+
+    context "with lowercase subject" do
+      let(:subject_filter) { "japanese" }
+      let(:params) { { subject: subject_filter } }
+
+      it "applies the capitalized subject as stored in the DB" do
+        expect(subject.filters).to eq({ "subject" => subject_filter.capitalize })
+      end
+    end
+
+    context "with 'All subjects'" do
+      let(:params) { { subject: "All subjects" } }
+      include_examples returns_nil
+    end
+
+    context "with invalid record type" do
+      let(:params) { { record_type: %w[not_a_record_type] } }
+      include_examples returns_nil
+    end
+
+    context "with invalid state" do
+      let(:params) { { record_type: %w[not_a_state] } }
+      include_examples returns_nil
+    end
+
+    context "with empty params" do
+      let(:params) { {} }
+      include_examples returns_nil
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/ObQKrk7D/791-filters-handle-bad-manual-query-string-inputs

### Changes proposed in this pull request

This PR introduces a new `TraineeFilter` model that is responsible for 'cleaning up' the parameters before passing to the view component to render. The view now receives a hash of cleaned up, active filters.

This means that:
1. the view is no longer responsible for deciding whether a filter is active or not 👍
2. the check for "All subjects" is now applied in one place only (the new `TraineeFilter` model) and not in two places (the view component and the filter service) 👍 

The `TraineeFilter` model applies different logic to each filter param based on the filter itself. For enum checkboxes, it removes options that aren't defined (i.e. if someone tampers with the query string directly and inputs bad params).

### Guidance to review

- Head to `/trainees`
- Apply a checkbox filter e.g. Status
- Change the query string to be filtering for a trainee state that doesn't actually exist
- Check that it doesn't break! i.e. doesn't attempt to filter for an invalid enum
