### PR TITLE
[785] Add placeholder and change to sentence case

### DIFF
--- a/app/components/trainees/record_actions/view.html.erb
+++ b/app/components/trainees/record_actions/view.html.erb
@@ -5,13 +5,7 @@
   <% if display_actions? %>
     <div class="record-actions__links">
       <p class="govuk-body govuk-!-margin-bottom-0">
-        <% if allow_defer? %>
-          <%= govuk_link_to t("views.trainees.edit.defer"), trainee_deferral_path(@trainee), class: "defer"  %> or
-        <% end %>
-
-        <% if allow_withdraw? %>
-          <%= govuk_link_to t("views.trainees.edit.withdraw"), trainee_withdrawal_path(@trainee), class: "withdraw"  %>
-        <% end %>
+        <%= defer_and_withdraw_links %>
         <%= t("views.trainees.edit.this_trainee") %>
       </p>
     </div>

--- a/app/components/trainees/record_actions/view.rb
+++ b/app/components/trainees/record_actions/view.rb
@@ -22,6 +22,30 @@ module Trainees
       def allow_withdraw?
         allow_defer? || trainee.deferred?
       end
+
+      def defer_and_withdraw_links
+        return defer_link + " or " + withdraw_link if choose_both_actions?
+        return defer_link if allow_defer?
+        return reinstate_link + " or " + withdraw_link if allow_withdraw?
+      end
+
+    private
+
+      def choose_both_actions?
+        allow_defer? && allow_withdraw?
+      end
+
+      def defer_link
+        govuk_link_to t("views.trainees.edit.defer"), trainee_deferral_path(@trainee), class: "defer"
+      end
+
+      def withdraw_link
+        govuk_link_to t("views.trainees.edit.withdraw"), trainee_withdrawal_path(@trainee), class: "withdraw"
+      end
+
+      def reinstate_link
+        govuk_link_to t("view.trainees.edit.reinstate"), trainees_path, class: "reinstate"
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,7 +109,8 @@ en:
     trainees:
       edit:
         defer: Defer
-        withdraw: Withdraw
+        withdraw: withdraw
+        reinstate: Reinstate
         this_trainee: this trainee
     trainee_summary:
       contact_details:

--- a/spec/components/trainees/record_actions/view_spec.rb
+++ b/spec/components/trainees/record_actions/view_spec.rb
@@ -11,37 +11,37 @@ RSpec.describe Trainees::RecordActions::View do
     context "draft" do
       let(:trait) { :draft }
 
-      it { is_expected.not_to include("Defer", "Withdraw") }
+      it { is_expected.not_to include("Defer", "withdraw") }
     end
 
     context "submitted for TRN" do
       let(:trait) { :submitted_for_trn }
 
-      it { is_expected.to include("Defer", "Withdraw") }
+      it { is_expected.to include("Defer", "withdraw") }
     end
 
     context "TRN received" do
       let(:trait) { :trn_received }
 
-      it { is_expected.to include("Defer", "Withdraw") }
+      it { is_expected.to include("Defer", "withdraw") }
     end
 
-    context "recommended for GTS" do
+    context "recommended for QTS" do
       let(:trait) { :recommended_for_qts }
 
-      it { is_expected.not_to include("Defer", "Withdraw") }
+      it { is_expected.not_to include("Defer", "withdraw") }
     end
 
     context "withdrawn" do
       let(:trait) { :withdrawn }
 
-      it { is_expected.not_to include("Defer", "Withdraw") }
+      it { is_expected.not_to include("Defer", "withdraw") }
     end
 
     context "QTS awarded" do
       let(:trait) { :qts_awarded }
 
-      it { is_expected.not_to include("Defer", "Withdraw") }
+      it { is_expected.not_to include("Defer", "withdraw") }
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/viF2PKvL/785-actions-with-defer-and-withdraw-should-be-sentence-case

### Changes proposed in this pull request
* 'Withdraw' is now lowercase 
* 'Reinstate' made a placeholder to avoid a lowercase 'withdraw' by itself. Links to /trainees until reinstate functionality is implemented
* Refactor to avoid too many conditionals/guard statements in view
* Fix tests and a typo

### Guidance to review
Select trainees that have different states to see how component is rendered

For trn received
<img width="621" alt="Screenshot 2020-12-30 at 16 52 10" src="https://user-images.githubusercontent.com/58793682/103368472-7f4e9f00-4abf-11eb-862e-574444b8f60b.png">
For deferred 
<img width="621" alt="Screenshot 2020-12-30 at 16 56 18" src="https://user-images.githubusercontent.com/58793682/103368629-f71cc980-4abf-11eb-936c-a14bedb2d8ff.png">



