### PR TITLE
[733] Custom email validation

### DIFF
--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Rules and regex taken from https://github.com/alphagov/notifications-utils/blob/fd3ba3db8cfaf4ad5308aaf5efdcd4e0cf3730e8/notifications_utils/recipients.py
+# which in turn was adapted from https://github.com/JoshData/python-email-validator/blob/primary/email_validator/__init__.py
+# with minor tweaks for SES compatibility (we are a lot stricter with the local
+# part than neccessary, not allowing double quotes or semicolons to prevent SES
+# Technical Failures)
+
+class EmailFormatValidator
+  EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~\-]+@([^.@][^@\s]+)$/.freeze
+  PART_REGEX = /^(xn-|[a-z0-9]+)(-[a-z0-9]+)*$/i.freeze
+  TLD_REGEX = /^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$/.freeze
+
+  MAX_LENGTH = 320
+  MAX_HOSTNAME_LENGTH = 253
+  MAX_PART_LENGTH = 63
+
+  MIN_PARTS = 2
+
+  def initialize(record)
+    @record = record
+    @email = record.email
+  end
+
+  def validate
+    return unless email
+
+    record.errors.add(:email, error_message) unless valid?
+  end
+
+private
+
+  attr_reader :record, :email
+
+  def valid?
+    matches_regex? &&
+      length_valid? &&
+      no_consecutive_periods? &&
+      hostname_valid?
+  end
+
+  def matches_regex?
+    EMAIL_REGEX.match?(email)
+  end
+
+  def length_valid?
+    email.length <= MAX_LENGTH
+  end
+
+  def no_consecutive_periods?
+    !email.include?("..")
+  end
+
+  def hostname_valid?
+    hostname_length_valid? &&
+      parts_length_valid? &&
+      parts_match_regex?
+  end
+
+  def hostname_length_valid?
+    hostname.length <= MAX_HOSTNAME_LENGTH
+  end
+
+  def parts_length_valid?
+    parts.length >= MIN_PARTS &&
+      parts.all? { |part| part.length <= MAX_PART_LENGTH }
+  end
+
+  def parts_match_regex?
+    parts.all? { |part| PART_REGEX.match?(part) } &&
+      TLD_REGEX.match?(parts[-1])
+  end
+
+  def hostname
+    @hostname ||= EMAIL_REGEX.match(email)[1]
+  end
+
+  def parts
+    @parts ||= hostname.split(".")
+  end
+
+  def error_message
+    I18n.t("activemodel.errors.validators.email.invalid")
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,6 +204,8 @@ en:
       validators:
         postcode:
           invalid: "You must enter a valid postcode (for example, BN1 1AA)"
+        email:
+          invalid: "You must enter an email address in the correct format, like name@example.com"
       models:
         personal_detail_form:
           attributes:

--- a/spec/features/trainees/filtering_trainees_spec.rb
+++ b/spec/features/trainees/filtering_trainees_spec.rb
@@ -137,45 +137,45 @@ private
   end
 
   def then_all_trainees_are_visible
-    Trainee.all.each { |trainee| expect(page).to have_text(trainee.first_names) }
+    Trainee.all.each { |trainee| expect(page).to have_text(full_name(trainee)) }
   end
 
   def then_only_assessment_only_trainees_are_visible
-    expect(page).to have_text(@assessment_only_trainee.first_names)
-    expect(page).to_not have_text(@provider_led_trainee.first_names)
+    expect(page).to have_text(full_name(@assessment_only_trainee))
+    expect(page).to_not have_text(full_name(@provider_led_trainee))
   end
 
   def then_only_provider_led_trainees_are_visible
-    expect(page).to_not have_text(@assessment_only_trainee.first_names)
-    expect(page).to have_text(@provider_led_trainee.first_names)
+    expect(page).to_not have_text(full_name(@assessment_only_trainee))
+    expect(page).to have_text(full_name(@provider_led_trainee))
   end
 
   def then_only_biology_trainees_are_visible
-    expect(page).to have_text(@biology_trainee.first_names)
-    expect(page).to_not have_text(@history_trainee.first_names)
+    expect(page).to have_text(full_name(@biology_trainee))
+    expect(page).to_not have_text(full_name(@history_trainee))
   end
 
   def then_only_assessment_only_biology_trainees_are_visible
-    expect(page).to have_text(@biology_trainee.first_names)
+    expect(page).to have_text(full_name(@biology_trainee))
     [
       @assessment_only_trainee,
       @provider_led_trainee,
       @history_trainee,
       @searchable_trainee,
-    ].each do |t|
-      expect(page).to_not have_text(t.first_names)
+    ].each do |trainee|
+      expect(page).to_not have_text(full_name(trainee))
     end
   end
 
   def then_only_the_searchable_trainee_is_visible
-    expect(page).to have_text(@searchable_trainee.first_names)
+    expect(page).to have_text(full_name(@searchable_trainee))
     [
       @assessment_only_trainee,
       @provider_led_trainee,
       @history_trainee,
       @biology_trainee,
-    ].each do |t|
-      expect(page).to_not have_text(t.first_names)
+    ].each do |trainee|
+      expect(page).to_not have_text(full_name(trainee))
     end
   end
 
@@ -183,5 +183,9 @@ private
     values.each do |value|
       expect(trainees_page.filter_tags).to have_text(value)
     end
+  end
+
+  def full_name(trainee)
+    [trainee.first_names, trainee.last_name].join(" ")
   end
 end

--- a/spec/forms/contact_detail_form_spec.rb
+++ b/spec/forms/contact_detail_form_spec.rb
@@ -50,26 +50,13 @@ describe ContactDetailForm, type: :model do
           .to be_empty
       end
     end
+  end
 
-    describe "email" do
-      it "must fail if only @" do
-        trainee.email = "@"
-        expect(subject).not_to be_valid
-        expect(subject.errors[:email])
-          .to include(I18n.t("activemodel.errors.models.contact_detail_form.attributes.email.invalid"))
-      end
-
-      it "must fail if it does not contain @" do
-        trainee.email = "myname.com"
-        expect(subject).not_to be_valid
-        expect(subject.errors[:email])
-          .to include(I18n.t("activemodel.errors.models.contact_detail_form.attributes.email.invalid"))
-      end
-
-      it "accepts a valid email address" do
-        trainee.email = "my_name@doman.com"
-        expect(subject).to be_valid
-      end
+  describe "formatting emails" do
+    it "strips whitespace from emails" do
+      trainee.email = "test @example.com"
+      subject.save # rubocop:disable Rails/SaveBang
+      expect(trainee.email).to eq("test@example.com")
     end
   end
 end

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe EmailFormatValidator do
+  let(:trainee) { build :trainee }
+  subject { ContactDetailForm.new(trainee) }
+
+  before { subject.email = email }
+
+  context "with a valid email" do
+    let(:email) { "valid@example.com" }
+
+    it "does not add an error" do
+      expect(subject).to be_valid
+    end
+  end
+
+  context "with an invalid email" do
+    error_test = "error test"
+
+    shared_examples_for error_test do
+      it "adds an error" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:email]).not_to be_blank
+      end
+    end
+
+    context "that is only @" do
+      let(:email) { "@" }
+      include_examples error_test
+    end
+
+    context "that doesn't contain @" do
+      let(:email) { "invalid" }
+      include_examples error_test
+    end
+
+    context "that doesn't match the email regex" do
+      let(:email) { "invalid@b" }
+      include_examples error_test
+    end
+
+    context "that is too long" do
+      let(:email) { "#{SecureRandom.alphanumeric(321)}@example.com" }
+      include_examples error_test
+    end
+
+    context "that has two consecutive periods" do
+      let(:email) { "invalid..@example.com" }
+      include_examples error_test
+    end
+
+    context "that has a hostname that is too long" do
+      valid_part = SecureRandom.alphanumeric(63)
+      let(:email) { "invalid@#{Array.new(4, valid_part).join('.')}.com" }
+      include_examples error_test
+    end
+
+    context "that has a hostname with fewer than two parts" do
+      let(:email) { "invalid@example" }
+      include_examples error_test
+    end
+
+    context "that has a hostname with a part that is too long" do
+      let(:email) { "invalid@#{SecureRandom.alphanumeric(64)}.com" }
+      include_examples error_test
+    end
+
+    context "that has a hostname with a part that doesn't match the regex" do
+      let(:email) { "invalid@example.#.com" }
+      include_examples error_test
+    end
+
+    context "that has a hostname with a final part that doesn't match the TLD regex" do
+      let(:email) { "invalid@example.a" }
+      include_examples error_test
+    end
+  end
+end

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -22,7 +22,6 @@ describe PostcodeValidator do
     let(:postcode) { "not really a postcode" }
 
     it "adds an error" do
-      subject.postcode = "not really a postcode"
       expect(subject).not_to be_valid
       expect(subject.errors[:postcode]).not_to be_blank
     end


### PR DESCRIPTION
### Context

https://trello.com/c/yjuxEF68/733-contact-details-add-better-email-validation

### Changes proposed in this pull request

This PR adds custom email validation using the same rules as set out in `validate_email_address` here:
https://github.com/alphagov/notifications-utils/blob/fd3ba3db8cfaf4ad5308aaf5efdcd4e0cf3730e8/notifications_utils/recipients.py#L483-523

and using the regexes defined here:
https://github.com/alphagov/notifications-utils/blob/494484aa44edeac7b103cfad1ac795cf0271b525/notifications_utils/__init__.py 

The rules should be relatively self-explanatory by reading the method names in the custom validator class.

Not included (yet?):
- the removal of obscure whitespace characters (e.g. zero width space, non breaking space)
- converting unicode into its accurate ascii and checking for unicode errors

**Bonus**
This PR also includes a fix for a flakey test suite whereby we were checking that the correct trainees are rendered based on their first name being visible. However, names like 'Russ' also ring positive when subjects like 'Russian' are displayed on the page! I've changed the test to check for their full name.

### Guidance to review
- Head to `/trainees/:id/contact-details/edit`
- Try some bad emails
- Check that they fail
- Try a correct email, but with a space included
- Check that the space is stripped and the correct email is saved
