### PR TITLE
[774] Fix error styling on date error messages within Outcome, Deferral and Withdrawal

### DIFF
--- a/app/forms/deferral_form.rb
+++ b/app/forms/deferral_form.rb
@@ -70,7 +70,9 @@ private
   end
 
   def defer_date_valid
-    if defer_date_string == "other" && [day, month, year].all?(&:blank?)
+    if defer_date_string.nil?
+      errors.add(:defer_date_string, :blank)
+    elsif defer_date_string == "other" && [day, month, year].all?(&:blank?)
       errors.add(:defer_date, :blank)
     elsif !defer_date.is_a?(Date)
       errors.add(:defer_date, :invalid)

--- a/app/forms/outcome_date_form.rb
+++ b/app/forms/outcome_date_form.rb
@@ -66,15 +66,13 @@ private
     date_hash = { year: year, month: month, day: day }
     date_args = date_hash.values.map(&:to_i)
 
-    if Date.valid_date?(*date_args)
-      Date.new(*date_args)
-    else
-      Struct.new(*date_hash.keys).new(*date_hash.values)
-    end
+    Date.valid_date?(*date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
   end
 
   def outcome_date_valid
-    if outcome_date_string == "other" && [day, month, year].all?(&:blank?)
+    if outcome_date_string.nil?
+      errors.add(:outcome_date_string, :blank)
+    elsif outcome_date_string == "other" && [day, month, year].all?(&:blank?)
       errors.add(:outcome_date, :blank)
     elsif !outcome_date.is_a?(Date)
       errors.add(:outcome_date, :invalid)

--- a/app/forms/withdrawal_form.rb
+++ b/app/forms/withdrawal_form.rb
@@ -82,7 +82,9 @@ private
   end
 
   def withdraw_date_valid
-    if withdraw_date_string == "other" && [day, month, year].all?(&:blank?)
+    if withdraw_date_string.nil?
+      errors.add(:withdraw_date_string, :blank)
+    elsif withdraw_date_string == "other" && [day, month, year].all?(&:blank?)
       errors.add(:withdraw_date, :blank)
     elsif !withdraw_date.is_a?(Date)
       errors.add(:withdraw_date, :invalid)

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -21,7 +21,7 @@
         <% end %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:withdraw_reason,legend: { text: t("views.forms.withdrawal_reasons.headings.withdrawal_reason"), tag: "h1", size: "l" }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:withdraw_reason, legend: { text: t("views.forms.withdrawal_reasons.headings.withdrawal_reason"), tag: "h1", size: "l" }) do %>
         <% WithdrawalReasons::SPECIFIC.each_with_index do |withdrawal_reason, index| %>
           <%= f.govuk_radio_button(:withdraw_reason, withdrawal_reason,
                 label: { text: t("views.forms.withdrawal_reasons.labels.#{withdrawal_reason}") },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,26 +286,32 @@ en:
               before_or_same_as_start_date: "You must enter programme end date after the programme start date"
         outcome_date_form:
           attributes:
+            outcome_date_string:
+              blank: You must choose an outcome date
             outcome_date:
-              blank: "You must enter an outcome date"
-              invalid: "You must enter a valid outcome date"
+              blank: You must enter an outcome date
+              invalid: You must enter a valid outcome date
         degree_detail_form:
           attributes:
             degree_ids:
               empty_degrees: You must have at least one degree
         withdrawal_form:
           attributes:
+            withdraw_date_string:
+              blank: You must choose a withdrawal date
             withdraw_date:
-              blank: You must enter a withdraw date
-              invalid: You must enter a valid withdraw date
+              blank: You must enter a withdrawal date
+              invalid: You must enter a valid withdrawal date
             additional_withdraw_reason:
               blank: You must enter a reason
             withdraw_reason:
               invalid: You must choose a reason
         deferral_form:
           attributes:
+            defer_date_string:
+              blank: You must choose a deferral date
             defer_date:
-              blank: "You must enter a deferral date"
-              invalid: "You must enter a valid deferral date"
+              blank: You must enter a deferral date
+              invalid: You must enter a valid deferral date
   page_headings:
     start_page: "Register trainee teachers"

--- a/spec/features/trainees/defer_trainee_spec.rb
+++ b/spec/features/trainees/defer_trainee_spec.rb
@@ -12,7 +12,12 @@ feature "Deferring a trainee", type: :feature do
     and_i_click_on_defer
   end
 
-  context "trainee withdrawal date" do
+  context "trainee deferral date" do
+    scenario "submit empty form" do
+      and_i_continue
+      then_i_see_the_error_message_for_date_not_chosen
+    end
+
     scenario "choosing today" do
       when_i_choose_today
       and_i_continue
@@ -96,6 +101,12 @@ feature "Deferring a trainee", type: :feature do
   def then_i_see_the_error_message_for_blank_date
     expect(page).to have_content(
       I18n.t("activemodel.errors.models.deferral_form.attributes.defer_date.blank"),
+    )
+  end
+
+  def then_i_see_the_error_message_for_date_not_chosen
+    expect(page).to have_content(
+      I18n.t("activemodel.errors.models.deferral_form.attributes.defer_date_string.blank"),
     )
   end
 

--- a/spec/features/trainees/recording_training_outcome_spec.rb
+++ b/spec/features/trainees/recording_training_outcome_spec.rb
@@ -12,6 +12,11 @@ feature "Recording a training outcome", type: :feature do
     and_i_click_on_record_training_outcome
   end
 
+  scenario "submit empty form" do
+    and_i_submit_the_form
+    then_i_see_the_error_message_for_date_not_chosen
+  end
+
   scenario "choosing today records the outcome" do
     when_i_choose_today
     and_i_submit_the_form
@@ -85,6 +90,12 @@ feature "Recording a training outcome", type: :feature do
   def then_i_see_the_error_message_for(type)
     expect(page).to have_content(
       I18n.t("activemodel.errors.models.outcome_date_form.attributes.outcome_date.#{type}"),
+    )
+  end
+
+  def then_i_see_the_error_message_for_date_not_chosen
+    expect(page).to have_content(
+      I18n.t("activemodel.errors.models.outcome_date_form.attributes.outcome_date_string.blank"),
     )
   end
 

--- a/spec/features/trainees/withdraw_trainee_spec.rb
+++ b/spec/features/trainees/withdraw_trainee_spec.rb
@@ -15,8 +15,8 @@ feature "Withdrawing a trainee", type: :feature do
   context "validation errors" do
     scenario "no information provided" do
       and_i_continue
-      then_i_see_the_error_message_for_invalid_date
-      then_i_see_the_error_message_for_invalid_reason
+      then_i_see_the_error_message_for_date_not_chosen
+      then_i_see_the_error_message_for_reason_not_chosen
     end
 
     scenario "invalid date for another day" do
@@ -24,6 +24,12 @@ feature "Withdrawing a trainee", type: :feature do
       and_enter_an_invalid_date
       and_i_continue
       then_i_see_the_error_message_for_invalid_date
+    end
+
+    scenario "blank date for another day" do
+      when_i_choose_another_day
+      and_i_continue
+      then_i_see_the_error_message_for_blank_date
     end
   end
 
@@ -126,13 +132,25 @@ feature "Withdrawing a trainee", type: :feature do
     withdrawal_page.additional_withdraw_reason.set(additional_withdraw_reason)
   end
 
+  def then_i_see_the_error_message_for_date_not_chosen
+    expect(page).to have_content(
+      I18n.t("activemodel.errors.models.withdrawal_form.attributes.withdraw_date_string.blank"),
+    )
+  end
+
   def then_i_see_the_error_message_for_invalid_date
     expect(page).to have_content(
       I18n.t("activemodel.errors.models.withdrawal_form.attributes.withdraw_date.invalid"),
     )
   end
 
-  def then_i_see_the_error_message_for_invalid_reason
+  def then_i_see_the_error_message_for_blank_date
+    expect(page).to have_content(
+      I18n.t("activemodel.errors.models.withdrawal_form.attributes.withdraw_date.blank"),
+    )
+  end
+
+  def then_i_see_the_error_message_for_reason_not_chosen
     expect(withdrawal_page).to have_content(
       I18n.t("activemodel.errors.models.withdrawal_form.attributes.withdraw_reason.invalid"),
     )


### PR DESCRIPTION
### Context
https://trello.com/c/Fx0JvkQv/774-fix-error-styling-on-date-error-messages-within-outcome-deferral-and-withdrawal

### Changes proposed in this pull request
- Add another error type to cover the case where the user doesn't choose any date

### Guidance to review
Fire up the local server

#### Outcome Date form
- Select a trainee in draft state and and visit their edit page manually
- Click "Recommend for QTS"
- Submit form without choosing any of the options
- It should display error message "You must choose an outcome date"

#### Deferral Form
- Choise a trainee in pending TRN state
- Click "Defer"
- Submit form without choosing any of the options
- It should display error message "You must choose an deferral date"

#### Withdrawal Form
- Choise a trainee in pending TRN state
- Click "Withdraw"
- Submit form without choosing any of the options
- It should display error message "You must choose an withdrawal date"

## Example

### Before
<img width="582" alt="Screenshot 2021-01-04 at 12 22 25" src="https://user-images.githubusercontent.com/28728/103534812-84c53400-4e87-11eb-9750-afd9ebd2455d.png">

### After
<img width="586" alt="Screenshot 2021-01-04 at 12 23 37" src="https://user-images.githubusercontent.com/28728/103534903-af16f180-4e87-11eb-9667-ea4675a8338e.png">


