### PR TITLE
[783] Show trn on record details if present

### DIFF
--- a/app/components/trainees/record_details/view.html.erb
+++ b/app/components/trainees/record_details/view.html.erb
@@ -5,13 +5,9 @@
     {
       key: "Trainee ID",
       value: trainee_id,
-      action: govuk_link_to('Change<span class="govuk-visually-hidden"> trainee ID</span>'.html_safe,
-                              edit_trainee_trainee_id_path(trainee)),
+      action: govuk_link_to('Change<span class="govuk-visually-hidden"> trainee ID</span>'.html_safe, edit_trainee_trainee_id_path(trainee)),
     },
-    {
-      key: "Submitted for TRN",
-      value: submission_date,
-    },
+    trn_row,
     {
       key: "Last updated",
       value: last_updated_date,

--- a/app/components/trainees/record_details/view.rb
+++ b/app/components/trainees/record_details/view.rb
@@ -25,6 +25,20 @@ module Trainees
         render_text_with_hint(trainee.updated_at)
       end
 
+      def trn_row
+        if trainee.trn.present?
+          {
+            key: "TRN",
+            value: trainee.trn,
+          }
+        else
+          {
+            key: "Submitted for TRN",
+            value: submission_date,
+          }
+        end
+      end
+
     private
 
       def render_text_with_hint(date)


### PR DESCRIPTION
### Context
TRN on record details

### Changes proposed in this pull request
Show TRN is present else show TRN submitted date

### Guidance to review

### Submitted for TRN
- Navigate to `/trainees`
- Click on a trainee where the status is "TRN pending"
- TRN should be present
- 
<img width="1552" alt="Screenshot 2021-01-04 at 14 35 52" src="https://user-images.githubusercontent.com/3071606/103545958-34a39d00-4e9a-11eb-8889-919c871f2f5e.png">

### TRN received
- Navigate to `/trainees`
- Click on a trainee where the status is "TRN received"
- TRN should be present

<img width="1552" alt="Screenshot 2021-01-04 at 14 37 06" src="https://user-images.githubusercontent.com/3071606/103546059-57ce4c80-4e9a-11eb-825b-baffb01eb0f5.png">

