### PR TITLE
[781] Don't create placement data for new trainees

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -26,14 +26,14 @@ namespace :example_data do
         %i[submitted_for_trn with_placement_assignment with_programme_details diversity_not_disclosed],
         %i[trn_received with_placement_assignment with_programme_details diversity_disclosed],
         %i[trn_received with_placement_assignment with_programme_details diversity_not_disclosed],
-        %i[recommended_for_qts with_placement_assignment with_programme_details diversity_disclosed],
-        %i[recommended_for_qts with_placement_assignment with_programme_details diversity_not_disclosed],
+        %i[recommended_for_qts with_placement_assignment with_outcome_date with_programme_details diversity_disclosed],
+        %i[recommended_for_qts with_placement_assignment with_outcome_date with_programme_details diversity_not_disclosed],
         %i[withdrawn with_placement_assignment with_programme_details diversity_disclosed],
         %i[withdrawn with_placement_assignment with_programme_details diversity_not_disclosed],
         %i[deferred with_placement_assignment with_programme_details diversity_disclosed],
         %i[deferred with_placement_assignment with_programme_details diversity_not_disclosed],
-        %i[qts_awarded with_placement_assignment with_programme_details diversity_disclosed],
-        %i[qts_awarded with_placement_assignment with_programme_details diversity_not_disclosed],
+        %i[qts_awarded with_placement_assignment with_outcome_date with_programme_details diversity_disclosed],
+        %i[qts_awarded with_placement_assignment with_outcome_date with_programme_details diversity_not_disclosed],
       ]
 
       rand(50...100).times do

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -61,6 +61,9 @@ FactoryBot.define do
 
     trait :with_placement_assignment do
       placement_assignment_dttp_id { SecureRandom.uuid }
+    end
+
+    trait :with_outcome_date do
       outcome_date { Faker::Date.in_date_period }
     end
 


### PR DESCRIPTION
### Context
`trn_received` and `submitted_for_trn` should not have outcome date

### Changes proposed in this pull request
Don't add the outcome date to trainees without a TRN

### Guidance to review
- Run `bundle exec rake example_data:generate`
- Data without a TRN i.e. `submitted_for_trn` and `trn_received` should not have placement information
