### PR TITLE
Change docker image name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ on:
   push:
 
 env:
-  DOCKER_REPO: dfedigital/register-trainee-teacher-data
-  DOCKER_IMAGE: register-trainee-teacher-data
+  DOCKER_REPO: dfedigital/register-trainee-teachers
+  DOCKER_IMAGE: register-trainee-teachers
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
        matrix: ${{ fromJson(needs.prepare-matrix.outputs.environments) }}
        max-parallel: 1
     env:
-        DOCKER_REPO: dfedigital/register-trainee-teacher-data
+        DOCKER_REPO: dfedigital/register-trainee-teachers
 
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ destroy: terraform-init
 terraform-init:
 	terraform init -reconfigure -backend-config=terraform/workspace-variables/$(env_config)_backend.tfvars $(backend_key) terraform
 	$(if $(tag), , $(error Missing environment variable "tag"))
-	$(eval export TF_VAR_paas_app_docker_image=dfedigital/register-trainee-teacher-data:$(tag))
+	$(eval export TF_VAR_paas_app_docker_image=dfedigital/register-trainee-teachers:$(tag))
 	$(if $(passcode), , $(error Missing environment variable "passcode", retrieve from https://login.london.cloud.service.gov.uk/passcode))
 	$(eval export TF_VAR_paas_sso_passcode=$(passcode))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     build:
       context: .
       cache_from:
-        - dfedigital/register-trainee-teacher-data:${BRANCH_TAG:-latest}
-    image: dfedigital/register-trainee-teacher-data:${BRANCH_TAG:-latest}
+        - dfedigital/register-trainee-teachers:${BRANCH_TAG:-latest}
+    image: dfedigital/register-trainee-teachers:${BRANCH_TAG:-latest}
     command: ash -c "bundle exec rails server -p 3001 -b '0.0.0.0'"
     ports:
       - 3001:3001
@@ -31,7 +31,7 @@ services:
       - REDIS_URL=redis://redis:6379
 
   bg-jobs:
-    image: dfedigital/register-trainee-teacher-data:${BRANCH_TAG:-latest}
+    image: dfedigital/register-trainee-teachers:${BRANCH_TAG:-latest}
     command: bundle exec sidekiq -c 5 -C config/sidekiq.yml
     depends_on:
       - web
@@ -41,6 +41,5 @@ services:
       - DB_HOSTNAME=db
       - DB_USERNAME=postgres
       - DB_PASSWORD=developmentpassword
-      - SETTINGS__APPLICATION=register-trainee-teacher-data-bg-jobs
+      - SETTINGS__APPLICATION=register-trainee-teachers-bg-jobs
       - REDIS_URL=redis://redis:6379
-


### PR DESCRIPTION
### Context

Changed docker image name from `dfedigital/register-trainee-teacher-data` to `dfedigital/register-trainee-teachers`. This is a strategic shift in order to align with other changes elsewhere

### Changes proposed in this pull request

Changed docker image name inline with other changes elsewhere i.e. from `dfedigital/register-trainee-teacher-data` to `dfedigital/register-trainee-teachers`.


### Guidance to review

