### PR TITLE
[800] Implement flash messages

### DIFF
--- a/app/components/flash_banner/view.html.erb
+++ b/app/components/flash_banner/view.html.erb
@@ -1,0 +1,7 @@
+<% if !flash.empty? %>
+  <% flash_types.each do |type| %>
+    <% if flash[type] %>
+      <%= render(NotificationBanner::View.new(text: flash[type], type: type))%>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/flash_banner/view.rb
+++ b/app/components/flash_banner/view.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module FlashBanner
+  class View < GovukComponent::Base
+    attr_reader :flash
+
+    def initialize(flash:)
+      @flash = flash
+    end
+
+  private
+
+    def flash_types
+      %w[warning info success]
+    end
+  end
+end

--- a/app/components/notification_banner/view.html.erb
+++ b/app/components/notification_banner/view.html.erb
@@ -1,0 +1,12 @@
+<%= tag.div(class: [classes, type_class], role: role_attribute, aria: { labelledBy: title_id }, data: data_attributes) do %>
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="<%= title_id %>">
+      <%= title %>
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      <%= text %>
+    </p>
+  </div>
+<% end %>

--- a/app/components/notification_banner/view.rb
+++ b/app/components/notification_banner/view.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module NotificationBanner
+  class View < GovukComponent::Base
+    attr_reader :text, :title_id
+
+    SUCCESS_TYPE = "success"
+
+    SUCCESS_TITLE = "Success"
+    DEFAULT_TITLE = "Important"
+
+    SUCCESS_ROLE = "alert"
+    DEFAULT_ROLE = "region"
+
+    DEFAULT_CLASS = "govuk-notification-banner"
+
+    def initialize(
+      title_text: nil,
+      text: nil,
+      type: nil,
+      classes: [],
+      role: nil,
+      title_id: nil,
+      disable_auto_focus: false
+    )
+      super(classes: classes)
+      @title_text = title_text
+      @text = text
+      @type = type
+      @role = role
+      @title_id = title_id || "#{DEFAULT_CLASS}-title"
+      @disable_auto_focus = disable_auto_focus
+    end
+
+  private
+
+    attr_reader :title_text, :role, :type, :disable_auto_focus
+
+    def default_classes
+      [DEFAULT_CLASS]
+    end
+
+    def type_class
+      "#{DEFAULT_CLASS}--#{type}" if success_banner?
+    end
+
+    def title
+      return title_text if title_text
+      return SUCCESS_TITLE if success_banner?
+
+      DEFAULT_TITLE
+    end
+
+    def role_attribute
+      return role if role
+      # If type is success, add `role="alert"` to prioritise the information in
+      # the notification banner to users of assistive technologies
+      return SUCCESS_ROLE if success_banner?
+
+      # Otherwise add `role="region"` to make the notification banner a landmark
+      # to help users of assistive technologies to navigate to the banner
+      DEFAULT_ROLE
+    end
+
+    def data_attributes
+      attrs = { module: DEFAULT_CLASS }
+      attrs[:disable_auto_focus] = disable_auto_focus if disable_auto_focus
+      attrs
+    end
+
+    def success_banner?
+      type == SUCCESS_TYPE
+    end
+  end
+end

--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -8,6 +8,7 @@ module Trainees
 
     def update
       authorize trainee
+      flash[:success] = "Trainee deferred"
       redirect_to edit_trainee_path(trainee)
     end
 

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -15,6 +15,7 @@ module Trainees
       authorize trainee
       toggle_trainee_progress_field
       trainee.save!
+      flash[:success] = "Trainee #{flash_message_title} updated"
       redirect_to trainee_path(trainee)
     end
 
@@ -34,6 +35,13 @@ module Trainees
 
     def confirm_section_title
       trainee_section_key.gsub(/_/, " ")
+    end
+
+    def flash_message_title
+      I18n.t(
+        "components.confirmation.flash.#{trainee_section_key}",
+        default: confirm_section_title.pluralize,
+      )
     end
 
     def toggle_trainee_progress_field

--- a/app/controllers/trainees/confirm_withdrawals_controller.rb
+++ b/app/controllers/trainees/confirm_withdrawals_controller.rb
@@ -8,6 +8,7 @@ module Trainees
 
     def update
       authorize trainee
+      flash[:success] = "Trainee withdrawn"
       redirect_to edit_trainee_path(trainee)
     end
 

--- a/app/controllers/trainees/degrees_controller.rb
+++ b/app/controllers/trainees/degrees_controller.rb
@@ -35,6 +35,7 @@ module Trainees
 
     def destroy
       trainee.degrees.destroy(trainee.degrees.find(params[:id]))
+      flash[:success] = "Trainee degree deleted"
       redirect_to trainee_personal_details_path(@trainee)
     end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,6 +49,7 @@
     <main class="govuk-main-wrapper " id="main-content" role="main">
       <%= yield :start_page_banner %>
       <div class="govuk-width-container">
+        <%= render(FlashBanner::View.new(flash: flash)) %>
         <%= yield %>
       </div>
     </main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,9 @@ en:
         defer_date_label: Date of deferral
       not_provided: Not provided
       heading: Confirm %{section_title}
+      flash:
+        disability_disclosure: disclosure
+        information_disclosed: disclosure
     programme_detail:
       title: "%{record_type} programme details"
     degrees:

--- a/spec/components/flash_banner/view_preview.rb
+++ b/spec/components/flash_banner/view_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module FlashBanner
+  class ViewPreview < ViewComponent::Preview
+    def with_success
+      render(FlashBanner::View.new(flash: flash(:success)))
+    end
+
+    def with_warning
+      render(FlashBanner::View.new(flash: flash(:warning)))
+    end
+
+    def with_info
+      render(FlashBanner::View.new(flash: flash(:info)))
+    end
+
+  private
+
+    def flash(type)
+      flash = ActionDispatch::Flash::FlashHash.new
+      flash[type] = "Trainee #{type}"
+      flash
+    end
+  end
+end

--- a/spec/components/flash_banner/view_spec.rb
+++ b/spec/components/flash_banner/view_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FlashBanner
+  describe View do
+    alias_method :component, :page
+
+    let(:flash) { ActionDispatch::Flash::FlashHash.new }
+
+    %i[success warning info].each do |type|
+      context "when #{type} is set" do
+        let(:message) { "Trainee #{type}" }
+
+        before do
+          flash[type] = message
+          render_inline(described_class.new(flash: flash))
+        end
+
+        it "renders a #{type} flash" do
+          expected_title = type == :success ? "Success" : "Important"
+          expect(component).to have_text(expected_title)
+          expect(component).to have_text(message)
+        end
+      end
+    end
+  end
+end

--- a/spec/components/notification_banner/view_spec.rb
+++ b/spec/components/notification_banner/view_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module NotificationBanner
+  describe View do
+    alias_method :component, :page
+
+    context "with no arguments" do
+      before { render_inline(View.new) }
+
+      it "adds the default class" do
+        expect(component).to have_selector(".govuk-notification-banner")
+      end
+
+      it "doesn't add the success class" do
+        expect(component).to_not have_selector(".govuk-notification-banner--success")
+      end
+
+      it "has a default title of 'Important'" do
+        expect(component).to have_text("Important")
+      end
+
+      it "has a default role of 'region'" do
+        expect(banner["role"]).to eq("region")
+      end
+
+      it "has a default data attribute of data-module=govuk-notification-banner" do
+        expect(banner["data-module"]).to eq("govuk-notification-banner")
+      end
+
+      it "doesn't disable autofocus" do
+        expect(banner["data-disable-auto-focus"]).to be_nil
+      end
+    end
+
+    context "when type is success" do
+      before { render_inline(View.new(type: "success")) }
+
+      it "adds the success type class" do
+        expect(component).to have_selector(".govuk-notification-banner--success")
+      end
+
+      it "has a default title of 'Success'" do
+        expect(component).to have_text("Success")
+      end
+
+      it "has a default role of 'alert'" do
+        expect(banner["role"]).to eq("alert")
+      end
+    end
+
+    it "supports custom classes on the parent container" do
+      render_inline(View.new(classes: "test-css-class"))
+      expect(component).to have_selector(".test-css-class")
+    end
+
+    it "supports custom title and text" do
+      render_inline(View.new(title_text: "title", text: "text"))
+      expect(component).to have_text("title")
+      expect(component).to have_text("text")
+    end
+
+    it "supports a custom role" do
+      render_inline(View.new(role: "role"))
+      expect(banner["role"]).to eq("role")
+    end
+
+    it "supports a custom id on the title element and sets the ariaLabelledBy" do
+      render_inline(View.new(title_id: "test-id"))
+      expect(component).to have_selector(".govuk-notification-banner__title#test-id")
+      expect(banner["aria-labelledby"]).to eq "test-id"
+    end
+
+    it "supports disabling autofocus" do
+      render_inline(View.new(disable_auto_focus: true))
+      expect(banner["data-disable-auto-focus"]).to eq("true")
+    end
+
+    def banner
+      page.find(".govuk-notification-banner")
+    end
+  end
+end

--- a/spec/features/trainees/degrees/adding_degree_spec.rb
+++ b/spec/features/trainees/degrees/adding_degree_spec.rb
@@ -37,6 +37,7 @@ RSpec.feature "Adding a degree" do
 
       scenario "the user deletes a degree" do
         confirm_details_page.delete_button.click
+        then_i_see_a_flash_message
         and_i_visit_the_summary_page
         then_the_degree_status_should_be(:not_started)
       end
@@ -203,5 +204,9 @@ private
 
   def then_the_degree_status_should_be(status)
     expect(summary_page.degree_details.status.text).to eq(Progress::STATUSES[status])
+  end
+
+  def then_i_see_a_flash_message
+    expect(page).to have_text("Trainee degree deleted")
   end
 end

--- a/spec/features/trainees/diversities/edit_disabilities_spec.rb
+++ b/spec/features/trainees/diversities/edit_disabilities_spec.rb
@@ -15,6 +15,7 @@ feature "edit disability details", type: :feature do
     and_i_submit_the_form
     and_confirm_my_details
     then_i_am_redirected_to_the_summary_page
+    then_i_see_a_flash_message
     and_the_disability_details_are_updated
   end
 
@@ -56,5 +57,9 @@ feature "edit disability details", type: :feature do
         "activemodel.errors.models.diversities/disability_detail_form.attributes.disability_ids.empty_disabilities",
       ),
     )
+  end
+
+  def then_i_see_a_flash_message
+    expect(page).to have_text("Trainee disabilities updated")
   end
 end

--- a/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
@@ -22,6 +22,7 @@ feature "edit disability disclosure", type: :feature do
     and_i_submit_the_form
     and_confirm_my_details
     then_i_am_redirected_to_the_summary_page
+    then_i_see_a_flash_message
     and_the_disability_disclosure_is_updated
   end
 
@@ -69,5 +70,9 @@ private
     expect(page).to have_content(
       I18n.t("activemodel.errors.models.diversities/disability_disclosure_form.attributes.disability_disclosure.blank"),
     )
+  end
+
+  def then_i_see_a_flash_message
+    expect(page).to have_text("Trainee disclosure updated")
   end
 end

--- a/spec/features/trainees/diversities/edit_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disclosure_spec.rb
@@ -21,6 +21,7 @@ feature "edit diversity disclosure", type: :feature do
     and_i_submit_the_form
     and_confirm_my_details
     then_i_am_redirected_to_the_summary_page
+    then_i_see_a_flash_message
     and_the_diversity_disclosure_is_updated
   end
 
@@ -63,5 +64,9 @@ feature "edit diversity disclosure", type: :feature do
 
   def then_i_see_error_messages
     expect(page).to have_content(I18n.t("activemodel.errors.models.diversities/disclosure_form.attributes.diversity_disclosure.blank"))
+  end
+
+  def then_i_see_a_flash_message
+    expect(page).to have_text("Trainee disclosure updated")
   end
 end

--- a/spec/features/trainees/edit_contact_details_spec.rb
+++ b/spec/features/trainees/edit_contact_details_spec.rb
@@ -14,6 +14,7 @@ feature "edit contact details", type: :feature do
     and_i_submit_the_form
     and_confirm_my_details
     then_i_am_redirected_to_the_summary_page
+    then_i_see_a_flash_message
     and_the_contact_details_are_updated
   end
 
@@ -21,6 +22,7 @@ feature "edit contact details", type: :feature do
     and_i_enter_an_international_address
     and_confirm_my_details
     then_i_am_redirected_to_the_summary_page
+    then_i_see_a_flash_message
     and_the_old_address_is_cleared
   end
 
@@ -65,5 +67,9 @@ feature "edit contact details", type: :feature do
     expect(@contact_details_page.address_line_two.value).to be_nil
     expect(@contact_details_page.town_city.value).to be_nil
     expect(@contact_details_page.postcode.value).to be_nil
+  end
+
+  def then_i_see_a_flash_message
+    expect(page).to have_text("Trainee contact details updated")
   end
 end

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -7,16 +7,19 @@ feature "edit personal details", type: :feature do
 
   scenario "updates personal details with valid data" do
     given_valid_personal_details_are_provided
+    then_i_see_a_flash_message
     then_the_personal_details_are_updated
   end
 
   scenario "updates personal details with 'other' nationality" do
     given_other_nationality_is_provided
+    then_i_see_a_flash_message
     then_the_personal_details_are_updated
   end
 
   scenario "renders a completed status when valid personal details provided" do
     given_valid_personal_details_are_provided
+    then_i_see_a_flash_message
     then_the_personal_details_section_should_be_completed
   end
 
@@ -28,6 +31,7 @@ feature "edit personal details", type: :feature do
     and_i_submit_the_form
     and_confirm_my_details(checked: false)
     then_i_am_redirected_to_the_summary_page
+    then_i_see_a_flash_message
     then_the_personal_details_section_should_be_in_progress
   end
 
@@ -115,5 +119,9 @@ private
 
   def then_the_personal_details_section_should_be_in_progress
     expect(summary_page.personal_details.status.text).to eq(Progress::STATUSES[:in_progress])
+  end
+
+  def then_i_see_a_flash_message
+    expect(page).to have_text("Trainee personal details updated")
   end
 end

--- a/spec/features/trainees/edit_programme_details_spec.rb
+++ b/spec/features/trainees/edit_programme_details_spec.rb
@@ -40,6 +40,7 @@ feature "programme details", type: :feature do
       and_i_submit_the_form
       and_i_confirm_my_details(checked: false, section: programme_details_section)
       then_i_am_redirected_to_the_summary_page
+      then_i_see_a_flash_message
       and_the_programme_details_are_updated
     end
 
@@ -118,6 +119,10 @@ feature "programme details", type: :feature do
     expect(page).to have_content(
       I18n.t("#{translation_key_prefix}.programme_start_date.blank"),
     )
+  end
+
+  def then_i_see_a_flash_message
+    expect(page).to have_text("Trainee programme details updated")
   end
 
   def template

--- a/spec/features/trainees/edit_trainee_record_spec.rb
+++ b/spec/features/trainees/edit_trainee_record_spec.rb
@@ -32,6 +32,7 @@ feature "edit trainee record", type: :feature do
     scenario "removing a degree" do
       and_i_visit_the_personal_details
       and_i_remove_the_degree
+      then_i_see_a_flash_message
       then_i_should_not_see_any_degree
     end
   end
@@ -83,5 +84,9 @@ feature "edit trainee record", type: :feature do
 
   def then_i_should_not_see_any_degree
     expect(@edit_page.degree_detail.find_all(".govuk-summary-list__row")).to be_empty
+  end
+
+  def then_i_see_a_flash_message
+    expect(page).to have_text("Trainee degree deleted")
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/U8u99a02/800-m-add-flash-messages-to-service?menu=filter&filter=label:Dev

### Changes proposed in this pull request

This PR adds a flash message component and renders a flash message in certain controllers as per the list on the Trello card.

The confirm pages using the generic confirm controller should all have sensible flash messages, which are specific to what the user is confirming.

Two situations on the card list - reinstating a trainee and deleting a draft - have not been implemented yet.

<img width="1552" alt="Screenshot 2021-01-05 at 15 25 23" src="https://user-images.githubusercontent.com/18436946/103671861-689ec100-4f73-11eb-8540-21a5e7da081f.png">

### Guidance to review

- Go down the list of scenarios as stated in the Trello card and test that the correct flash message appears in the correct location on the next page.

I thought it was worth adding support for 'warning' and 'info' flash messages as this is quite standard, however I haven't (yet?) added any. Currently we're not handling update failures anywhere in the code.