### PR TITLE
[798] Improve graduation validation

### DIFF
--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -7,11 +7,24 @@ class Degree < ApplicationRecord
   validates :non_uk_degree, presence: true, on: :non_uk
   validates :subject, presence: true, on: %i[uk non_uk]
   validates :institution, presence: true, on: :uk
-  validates :graduation_year, presence: true, on: %i[uk non_uk],
-                              inclusion: { in: 1900..Time.zone.today.year }
+  validates :graduation_year, presence: true, on: %i[uk non_uk]
+  validate :graduation_year_valid, if: -> { graduation_year.present? }
   validates :grade, presence: true, on: :uk
 
   belongs_to :trainee
 
   enum locale_code: { uk: 0, non_uk: 1 }
+
+  MAX_GRAD_YEARS = 60
+
+  def graduation_year_valid
+    errors.add(:graduation_year, :future) if graduation_year > next_year
+    errors.add(:graduation_year, :invalid) unless graduation_year.between?(next_year - MAX_GRAD_YEARS, next_year)
+  end
+
+private
+
+  def next_year
+    Time.zone.now.year.next
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,7 +196,8 @@ en:
               blank: "You must select a grade"
             graduation_year:
               blank: "You must set a graduation year"
-              inclusion: "You must set a graduation year"
+              future: "You must enter a graduation year that is in the past, for example 2014"
+              invalid: "You must enter a valid graduation year"
             country:
               blank: "You must select the country where the degree was obtained"
   activemodel:

--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+NEXT_YEAR = Time.zone.now.year.next
+
 FactoryBot.define do
   factory :degree, class: Degree do
     association :trainee
@@ -17,7 +19,7 @@ FactoryBot.define do
       subject { Dttp::CodeSets::DegreeSubjects::MAPPING.keys.sample }
       institution { Dttp::CodeSets::Institutions::MAPPING.keys.sample }
       grade { Dttp::CodeSets::Grades::MAPPING.keys.sample }
-      graduation_year { (1900..Time.zone.today.year).to_a.sample }
+      graduation_year { rand(NEXT_YEAR - Degree::MAX_GRAD_YEARS..NEXT_YEAR) }
     end
 
     trait :non_uk_degree_type do
@@ -32,7 +34,7 @@ FactoryBot.define do
       subject { Dttp::CodeSets::DegreeSubjects::MAPPING.keys.sample }
       country { Dttp::CodeSets::Countries::MAPPING.keys.sample }
       grade { Dttp::CodeSets::Grades::MAPPING.keys.sample }
-      graduation_year { (1900..Time.zone.today.year).to_a.sample }
+      graduation_year { rand(NEXT_YEAR - Degree::MAX_GRAD_YEARS..NEXT_YEAR) }
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/fO03oOUh/798-s-improve-graduation-validation
### Changes proposed in this pull request
* Validations to stop a graduation year more than 1 year in future and more than 60 years in past. More precise validation messages. 
* Model tests on Degree
### Guidance to review

Need for another validation, say to specify that they need to enter numbers? Though if they do it will be caught anyway. 

![screencapture-localhost-5000-trainees-260-degrees-2021-01-05-18_41_03](https://user-images.githubusercontent.com/58793682/103685813-bd4b3780-4f85-11eb-820e-516f1b22631a.png)

![screencapture-localhost-5000-trainees-260-degrees-2021-01-05-18_44_35](https://user-images.githubusercontent.com/58793682/103686120-3b0f4300-4f86-11eb-8d79-b9b1c1753490.png)
