### PR TITLE
[784] Show trn number in heading on trainees edit

### DIFF
--- a/app/components/trainees/record_header/view.html.erb
+++ b/app/components/trainees/record_header/view.html.erb
@@ -1,0 +1,14 @@
+<div class="trainee-record-header">
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
+    <%= trainee_name(trainee)%>
+
+    <%= render StatusTag::View.new(trainee: trainee) %>
+
+  </h1>
+
+  <% if show_trn? %>
+    <span class="govuk-caption-l">
+      <%= "TRN: #{trn}" %>
+    </span>
+  <% end %>
+</div>

--- a/app/components/trainees/record_header/view.rb
+++ b/app/components/trainees/record_header/view.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Trainees
+  module RecordHeader
+    class View < GovukComponent::Base
+      include TraineeHelper
+
+      attr_reader :trainee
+
+      def initialize(trainee:)
+        @trainee = trainee
+      end
+
+      delegate :trn, to: :trainee
+
+      def show_trn?
+        trn.present?
+      end
+    end
+  end
+end

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -8,13 +8,7 @@
     ) %>
   <% end %>
 
-  <div class="trainee-record-header">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
-      <%= trainee_name(@trainee) %>
-
-      <%= render StatusTag::View.new(trainee: @trainee) %>
-    </h1>
-  </div>
+  <%= render Trainees::RecordHeader::View.new(trainee: @trainee) %>
 
   <%= render TabNavigation::View.new(items: [
     { name: "Training details", url: edit_trainee_path(@trainee) },

--- a/spec/components/trainees/record_details/view_spec.rb
+++ b/spec/components/trainees/record_details/view_spec.rb
@@ -22,7 +22,7 @@ module Trainees
         end
       end
 
-      context "when data has been provided" do
+      context "when trainee_id data has been provided" do
         before do
           render_inline(View.new(trainee))
         end

--- a/spec/components/trainees/record_header/view_preview.rb
+++ b/spec/components/trainees/record_header/view_preview.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module Trainees
+  module RecordHeader
+    class ViewPreview < ViewComponent::Preview
+      def with_trn
+        render(Trainees::RecordHeader::View.new(trainee: mock_trainee("0123456789")))
+      end
+
+      def with_no_trn
+        render(Trainees::RecordHeader::View.new(trainee: mock_trainee(nil)))
+      end
+
+    private
+
+      def mock_trainee(trn)
+        @mock_trainee ||= Trainee.new(
+          first_names: "Dave",
+          middle_names: "Hendricks",
+          last_name: "Smith",
+          trn: trn,
+        )
+      end
+    end
+  end
+end

--- a/spec/components/trainees/record_header/view_spec.rb
+++ b/spec/components/trainees/record_header/view_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  module RecordHeader
+    describe View do
+      alias_method :component, :page
+
+      let(:trainee) do
+        build(:trainee,
+              first_names: first_names,
+              middle_names: middle_names,
+              last_name: last_name,
+              trn: trn)
+      end
+
+      let(:first_names) { "Dave" }
+      let(:middle_names) { "Hendricks" }
+      let(:last_name) { "Smith" }
+      let(:trn) { nil }
+
+      describe "trainee name" do
+        before do
+          render_inline(described_class.new(trainee: trainee))
+        end
+
+        it "renders the trainee name" do
+          expect(component.find(".govuk-heading-xl")).to have_text("Dave Hendricks Smith")
+        end
+
+        context "where a name is nil" do
+          let(:middle_names) { nil }
+          it "renders the trainee name" do
+            expect(component.find(".govuk-heading-xl")).to have_text("Dave Smith")
+          end
+        end
+
+        context "where a name is an empty string" do
+          let(:middle_names) { "" }
+          it "renders the trainee name" do
+            expect(component.find(".govuk-heading-xl")).to have_text("Dave Smith")
+          end
+        end
+      end
+
+      describe "trn" do
+        before do
+          render_inline(described_class.new(trainee: trainee))
+        end
+
+        context "where a trn is present" do
+          let(:trn) { "0123456789" }
+
+          it "renders the trn" do
+            expect(component.find(".govuk-caption-l")).to have_text(trn)
+          end
+        end
+
+        context "where a trn is not present" do
+          it "does not render the trn" do
+            expect(component).to_not have_css(".govuk-caption-l")
+          end
+        end
+      end
+
+      describe "status tag" do
+        before do
+          allow(StatusTag::View).to receive(:new).with(trainee: trainee).and_return(double(render_in: "liverpool"))
+          render_inline(described_class.new(trainee: trainee))
+        end
+
+        it "is rendered" do
+          expect(component).to have_text("liverpool")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

If a trainee has been assigned a trn number it is now visible on the trainees edit page.

### Changes proposed in this pull request

- Added a view component
- Added the trn number and status tag to the component  
- Added record header to trainee layout
- Fixed spec description to make tests more consistent

### Guidance to review

- Boot up the server and navigate to `trainees/?/edit`
- Check the trn number is visible if the trainee has been assigned one (e.g a QTS awarded record)
- Check the trn number is not visible if the trainee has not been assigned one (e.g a draft record) 