### PR TITLE
[761] Implement not provided for gender option

### DIFF
--- a/app/components/trainees/confirmation/personal_details/view.rb
+++ b/app/components/trainees/confirmation/personal_details/view.rb
@@ -28,7 +28,7 @@ module Trainees
         def gender
           return @not_provided_copy unless trainee.gender
 
-          trainee.gender.capitalize
+          I18n.t("components.confirmation.personal_detail.gender.#{trainee.gender}")
         end
 
         def nationality

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -17,7 +17,12 @@ class Trainee < ApplicationRecord
 
   enum record_type: { assessment_only: 0, provider_led: 1 }
   enum locale_code: { uk: 0, non_uk: 1 }
-  enum gender: { male: 0, female: 1, other: 2 }
+  enum gender: {
+    male: 0,
+    female: 1,
+    other: 2,
+    gender_not_provided: 3,
+  }
 
   enum diversity_disclosure: {
     Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed] => 0,

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -26,6 +26,8 @@
         <%= f.govuk_radio_button :gender, :male, label: { text: "Male" }, link_errors: true %>
         <%= f.govuk_radio_button :gender, :female, label: { text: "Female" } %>
         <%= f.govuk_radio_button :gender, :other, label: { text: "Other" } %>
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :gender, :gender_not_provided, label: { text: "Not provided" } %>
       <% end %>
 
       <%= f.govuk_check_boxes_fieldset :nationality_ids, legend: { text: "Nationality", size: 's' }, hint: { text: "Select all that apply" }, classes: "nationality" do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,12 @@ en:
           white_ethnic_group: White
           other_ethnic_group: Another ethnic group
           not_provided_ethnic_group: Not provided
+      personal_detail:
+        gender:
+          male: Male
+          female: Female
+          other: Other
+          gender_not_provided: Not provided
       withdrawal_details:
         heading: Check withdrawal details
         summary_title: Withdrawal details

--- a/spec/components/trainees/confirmation/personal_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/personal_details/view_spec.rb
@@ -50,7 +50,9 @@ module Trainees
 
           it "renders the gender" do
             expect(component.find(".govuk-summary-list__row.gender .govuk-summary-list__value"))
-              .to have_text(trainee.gender.capitalize)
+              .to have_text(
+                I18n.t("components.confirmation.personal_detail.gender.#{trainee.gender}"),
+              )
           end
 
           it "renders the nationality" do

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -8,7 +8,7 @@ describe Trainee do
 
     it { is_expected.to define_enum_for(:record_type).with_values(assessment_only: 0, provider_led: 1) }
     it { is_expected.to define_enum_for(:locale_code).with_values(uk: 0, non_uk: 1) }
-    it { is_expected.to define_enum_for(:gender).with_values(male: 0, female: 1, other: 2) }
+    it { is_expected.to define_enum_for(:gender).with_values(male: 0, female: 1, other: 2, gender_not_provided: 3) }
 
     it do
       is_expected.to define_enum_for(:diversity_disclosure).with_values(


### PR DESCRIPTION
### Context

- https://trello.com/c/gtPNgmnY/761-s-add-not-provided-to-gender-option-in-personal-details

### Changes proposed in this pull request

- Implement the not provided option when selecting the gender
- Sending this new option to DTTP will be handled in a separate ticket

![gender](https://user-images.githubusercontent.com/616080/103748510-28cfec00-4ffc-11eb-86cb-bbe6b1dd7512.gif)


### Guidance to review

- Head to the personal details section
- Assert you can select the not provided option and see it in the confirmation
