### PR TITLE
[814] - Handle sending "other" and "not provided" gender options to DTTP

### DIFF
--- a/app/presenters/dttp/trainee_presenter.rb
+++ b/app/presenters/dttp/trainee_presenter.rb
@@ -2,8 +2,10 @@
 
 module Dttp
   class TraineePresenter
-    FEMALE_GENDER_CODE = 1
-    MALE_GENDER_CODE = 2
+    MALE_GENDER_CODE = 1
+    FEMALE_GENDER_CODE = 2
+    OTHER_GENDER_CODE = 389_040_000
+    GENDER_NOT_PROVIDED_CODE = nil
 
     delegate_missing_to :trainee
 
@@ -70,7 +72,12 @@ module Dttp
     end
 
     def gender_code
-      male? ? MALE_GENDER_CODE : FEMALE_GENDER_CODE
+      {
+        male: MALE_GENDER_CODE,
+        female: FEMALE_GENDER_CODE,
+        other: OTHER_GENDER_CODE,
+        gender_not_provided: GENDER_NOT_PROVIDED_CODE,
+      }[trainee.gender.to_sym]
     end
 
     def dttp_disability

--- a/spec/presenters/dttp/trainee_presenter_spec.rb
+++ b/spec/presenters/dttp/trainee_presenter_spec.rb
@@ -93,7 +93,7 @@ module Dttp
             "address1_postalcode" => trainee.postcode,
             "birthdate" => trainee.date_of_birth.to_s,
             "emailaddress1" => trainee.email,
-            "gendercode" => 1,
+            "gendercode" => 2,
             "dfe_CreatedById@odata.bind" => "/contacts(#{trainee_creator_dttp_id})",
             "parentcustomerid_account@odata.bind" => "/accounts(#{trainee.provider.dttp_id})",
             "dfe_trnassessmentdate" => time_now_in_zone.in_time_zone.iso8601,


### PR DESCRIPTION
### Context

- https://trello.com/c/WN03X3qr/814-handle-sending-other-and-not-provided-gender-options-to-dttp

### Changes proposed in this pull request

- Builds on this PR https://github.com/DFE-Digital/register-trainee-teachers/pull/355
- This PR sets up the work to send the trainee gender values properly to DTTP
- The not provided option is currently mapped to the "other" value as we don't have the codeset for this option. This will be updated once we have the codeset. 

### Guidance to review

- Complete a trainee and submit for TRN
- Assert the submission is still successful