### PR TITLE
[619] MVP trainee timeline

### DIFF
--- a/app/components/trainees/timeline/script.js
+++ b/app/components/trainees/timeline/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/trainees/timeline/style.scss
+++ b/app/components/trainees/timeline/style.scss
@@ -1,0 +1,69 @@
+@import "../../base.scss";
+
+.app-timeline {
+  margin-bottom: govuk-spacing(4);
+  position: relative;
+
+  &:before {
+    background-color: govuk-colour("blue");
+    content: "";
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: govuk-spacing(2);
+    width: 5px;
+  }
+}
+
+.app-timeline--full {
+  margin-bottom: 0;
+  &:before {
+    height: calc(100% - 75px);
+  }
+}
+
+.app-timeline__item {
+  padding-bottom: govuk-spacing(6);
+  padding-left: govuk-spacing(4);
+  position: relative;
+
+  &:before {
+    background-color: govuk-colour("blue");
+    content: "";
+    height: 5px;
+    left: 0;
+    position: absolute;
+    top: govuk-spacing(2);
+    width: 15px;
+  }
+}
+
+.app-timeline__item:last-child {
+  &:after {
+    background-color: govuk-colour("blue");
+    content: "";
+    height: 5px;
+    left: -5px;
+    position: absolute;
+    bottom: -10px;
+    width: 15px;
+  }
+}
+
+.app-timeline__title {
+  @include govuk-font($size: 19, $weight: bold);
+  display: inline;
+}
+
+.app-timeline__actor_and_date {
+  @include govuk-font($size: 19);
+  color: $govuk-secondary-text-colour;
+  display: inline;
+  margin: 0;
+}
+
+.app-timeline__date {
+  @include govuk-font($size: 19);
+  color: $govuk-secondary-text-colour;
+  margin: 0;
+}

--- a/app/components/trainees/timeline/view.html.erb
+++ b/app/components/trainees/timeline/view.html.erb
@@ -1,0 +1,16 @@
+<h2 class="govuk-heading-m">Timeline</h2>
+<div class="app-timeline">
+  <% events.map do |event| %>
+    <div class="app-timeline__item">
+      <div class="app-timeline__header">
+        <h2 class="app-timeline__title"><%= event.title %></h2>
+      </div>
+      <p class="app-timeline__actor_and_date">
+        <%= event.actor %>,
+        <time datetime="<%= event.date.to_s(:govuk_date_and_time) %>">
+          <%= event.date.to_s(:govuk_date_and_time) %>
+        </time>
+      </p>
+    </div>
+  <% end %>
+</div>

--- a/app/components/trainees/timeline/view.rb
+++ b/app/components/trainees/timeline/view.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Timeline
+    class View < GovukComponent::Base
+      delegate :created_at, :submitted_for_trn_at, :provider, to: :trainee
+
+      def initialize(trainee)
+        @trainee = trainee
+      end
+
+      Event = Struct.new(:title, :actor, :date)
+
+    private
+
+      attr_reader :trainee
+
+      # TODO: Once we implement auditing, this will be an array of audit events.
+      # We'll iterate over a trainee's audit events, pull out ones we care about,
+      # and map them to timeline `Event`s accordingly.
+      def events
+        [
+          creation_event,
+          submitted_for_trn_event,
+        ].compact.sort_by(&:date).reverse
+      end
+
+      def creation_event
+        Event.new("Record created", temp_actor, created_at)
+      end
+
+      def submitted_for_trn_event
+        if submitted_for_trn_at
+          Event.new("Trainee submitted for TRN", temp_actor, submitted_for_trn_at)
+        end
+      end
+
+      # TODO: This will be pulled from the audit event. Until then, we don't
+      # actually know which user made the change, so this is a placeholder.
+      def temp_actor
+        provider.users.first.name
+      end
+    end
+  end
+end

--- a/app/controllers/trainees/timelines_controller.rb
+++ b/app/controllers/trainees/timelines_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Trainees
+  class TimelinesController < ApplicationController
+    def show
+      authorize trainee
+      render layout: "trainee_record"
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.find(params[:trainee_id])
+    end
+  end
+end

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -13,6 +13,7 @@
   <%= render TabNavigation::View.new(items: [
     { name: "Training details", url: edit_trainee_path(@trainee) },
     { name: "Personal details and education", url: trainee_personal_details_path(@trainee) },
+    { name: "Timeline", url: trainee_timeline_path(@trainee) },
   ]) %>
 
   <%= yield %>

--- a/app/views/trainees/timelines/show.html.erb
+++ b/app/views/trainees/timelines/show.html.erb
@@ -1,0 +1,1 @@
+<%= render Trainees::Timeline::View.new(@trainee) %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -4,3 +4,15 @@
 Date::DATE_FORMATS[:govuk]        = "%-d %B %Y" # 2 January 1998
 Date::DATE_FORMATS[:govuk_short]  = "%-d %b %Y" # 2 Jan 1998
 Date::DATE_FORMATS[:govuk_approx] = "%B %Y"     # January 1998
+
+Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
+  format = if time >= time.midday && time <= time.midday.end_of_minute
+             "%e %B %Y at %l%P (midday)"
+           elsif time >= time.midnight && time <= time.midnight.end_of_minute
+             "%e %B %Y at %l%P (midnight)"
+           else
+             "%e %B %Y at %l:%M%P"
+           end
+
+  time.strftime(format)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,8 @@ Rails.application.routes.draw do
 
       resource :confirm_deferral, only: %i[show update], path: "/defer/confirm"
       resource :deferral, only: %i[show update], path: "/defer"
+
+      resource :timeline, only: :show
     end
 
     member do

--- a/spec/components/trainees/filters/view_preview.rb
+++ b/spec/components/trainees/filters/view_preview.rb
@@ -14,7 +14,7 @@ module Trainees
         ActionController::Parameters.new({
           record_type: %w[assessment_only],
           subject: "Biology",
-        })
+        }).permit(:subject, :text_search, record_type: [], state: [])
       end
     end
   end

--- a/spec/components/trainees/timeline/view_preview.rb
+++ b/spec/components/trainees/timeline/view_preview.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module Trainees
+  module Timeline
+    class ViewPreview < ViewComponent::Preview
+      def created
+        render Trainees::Timeline::View.new(trainee)
+      end
+
+      def submitted_for_trn
+        render Trainees::Timeline::View.new(
+          trainee(submitted_for_trn_at: Time.zone.today),
+        )
+      end
+
+    private
+
+      def trainee(attrs = {})
+        Trainee.new(
+          provider: user.provider,
+          created_at: Time.zone.yesterday,
+          **attrs,
+        )
+      end
+
+      def user
+        @user ||= User.create!(
+          first_name: "Tom",
+          last_name: "Jones",
+          email: "tom@example.com",
+          provider: Provider.create(name: "Provider A"),
+        )
+      end
+    end
+  end
+end

--- a/spec/components/trainees/timeline/view_spec.rb
+++ b/spec/components/trainees/timeline/view_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  module Timeline
+    describe View do
+      alias_method :component, :page
+
+      let(:trainee) { create(:trainee, trait) }
+      let!(:user) { create(:user, provider: trainee.provider) }
+
+      before do
+        render_inline(described_class.new(trainee))
+      end
+
+      shared_examples "created" do
+        it "shows when the record was created" do
+          expect(component).to have_text("Record created")
+        end
+      end
+
+      shared_examples "submitted for trn" do
+        it "shows when the record was submitted for trn" do
+          expect(component).to have_text("Trainee submitted for TRN")
+        end
+      end
+
+      describe "when the trainee state is" do
+        context "created" do
+          let(:trait) { :draft }
+          include_examples "created"
+        end
+
+        context "submitted for trn" do
+          let(:trait) { :submitted_for_trn }
+          include_examples "created"
+          include_examples "submitted for trn"
+        end
+      end
+    end
+  end
+end

--- a/spec/config/initializers/date_formats_spec.rb
+++ b/spec/config/initializers/date_formats_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Time::DATE_FORMATS" do
+  describe ":govuk_date_and_time" do
+    it "formats time to indicate midday" do
+      date_and_time = Time.zone.local(2020, 12, 25, 12, 0, 59)
+      expect(date_and_time.to_s(:govuk_date_and_time)).to eq("25 December 2020 at 12pm (midday)")
+    end
+
+    it "formats time to indicate midnight" do
+      date_and_time = Time.zone.local(2020, 12, 25, 0, 0, 59)
+      expect(date_and_time.to_s(:govuk_date_and_time)).to eq("25 December 2020 at 12am (midnight)")
+    end
+
+    it "formats time with minutes otherwise" do
+      date_and_time = Time.zone.local(2020, 12, 25, 12, 1, 0)
+      expect(date_and_time.to_s(:govuk_date_and_time)).to eq("25 December 2020 at 12:01pm")
+    end
+  end
+end

--- a/spec/features/trainees/viewing_the_timeline_spec.rb
+++ b/spec/features/trainees/viewing_the_timeline_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "View the timeline" do
+  background do
+    given_i_am_authenticated
+    given_a_trainee_exists(state: :submitted_for_trn)
+  end
+
+  scenario "viewing the timeline of trainee" do
+    when_i_view_the_trainee_page
+    and_i_click_on_trainee_name
+    and_i_click_on_the_timeline_tab
+    then_i_should_see_the_trainee_timeline
+  end
+
+  def when_i_view_the_trainee_page
+    trainee_index_page.load
+  end
+
+  def and_i_click_on_trainee_name
+    trainee_index_page.trainee_name.first.click
+  end
+
+  def and_i_click_on_the_timeline_tab
+    edit_page.timeline_tab.click
+  end
+
+  def then_i_should_see_the_trainee_timeline
+    expect(timeline_page).to be_displayed(id: trainee.id)
+  end
+
+  def edit_page
+    @show_page ||= PageObjects::Trainees::Edit.new
+  end
+
+  def timeline_page
+    @timeline_page ||= PageObjects::Trainees::Timeline.new
+  end
+end

--- a/spec/support/page_objects/trainees/edit.rb
+++ b/spec/support/page_objects/trainees/edit.rb
@@ -5,6 +5,8 @@ module PageObjects
     class Edit < PageObjects::Base
       set_url "/trainees/{id}/edit"
 
+      element :timeline_tab, "a", text: "Timeline"
+
       element :trainee_name, ".govuk-heading-xl"
       element :trn_status, ".govuk-tag.trainee-status"
 

--- a/spec/support/page_objects/trainees/timeline.rb
+++ b/spec/support/page_objects/trainees/timeline.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class Timeline < PageObjects::Base
+      set_url "/trainees/{id}/timeline"
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/XvvrSVGO/619-build-mvp-of-the-timeline

### Changes proposed in this pull request

The PR:
- Creates a `Trainee::Timeline` view component, which is responsible for transforming events on the trainee into the correct format for the timeline, and rendering them.
- Links to the new timeline page from a tab on the trainee edit page.

<img width="1218" alt="Screenshot 2021-01-07 at 12 53 54" src="https://user-images.githubusercontent.com/18436946/103895483-68740200-50e8-11eb-9f8f-c184e2e7d1d4.png">

### Guidance to review
- As per the notes in the code:
  - Once we implement auditing, the events in the `Trainee::Timeline` component will come from audit events. For now I've picked out `created_at` and `submitted_for_trn` for something to render.
  - Currently we don't know which user made changes, - this will be pulled from the audit event. For now I've just assumed it was the first user for the provider, as a placeholder.
