### PR TITLE
[822] Update backlink text for draft records

### DIFF
--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -2,16 +2,16 @@
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
-    text: 'Back to overview',
+    text: @trainee.draft? ? 'Back to draft record' : 'Back to record',
     href: view_trainee(@trainee)
   ) %>
 <% end %>
 
 <%= render(
-  partial: "form", 
-  locals: { 
+  partial: "form",
+  locals: {
     heading: I18n.t("components.confirmation.heading", section_title: confirm_section_title),
-    confirm_detail: @confirm_detail, 
+    confirm_detail: @confirm_detail,
     trainee: @trainee,
     component: @confirmation_component,
     resource_confirm_update_path: trainee_section_update_path(trainee_section_key, @trainee),

--- a/app/views/trainees/diversity/confirm_details/show.html.erb
+++ b/app/views/trainees/diversity/confirm_details/show.html.erb
@@ -2,16 +2,16 @@
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
-    text: 'Back to overview',
+    text: @trainee.draft? ? 'Back to draft record' : 'Back to record',
     href: view_trainee(@trainee)
   ) %>
 <% end %>
 
 <%= render(
-  partial: "trainees/confirm_details/form", 
-  locals: { 
+  partial: "trainees/confirm_details/form",
+  locals: {
     heading: t("components.page_titles.trainees.diversity.confirm"),
-    confirm_detail: @confirm_detail, 
+    confirm_detail: @confirm_detail,
     trainee: @trainee,
     component: @confirmation_component,
     resource_confirm_update_path: trainee_section_update_path(trainee_section_key, @trainee),


### PR DESCRIPTION
### Context
Backlink should be different for draft and non-draft records

### Changes proposed in this pull request
Check the status of the record/trainee then show different content in the back link

### Guidance to review
### Non-draft record
<img width="1552" alt="Screenshot 2021-01-08 at 10 25 14" src="https://user-images.githubusercontent.com/3071606/104004655-e6ddac00-519b-11eb-9fee-2f99e8896a10.png">

### Draft record
<img width="1552" alt="Screenshot 2021-01-08 at 10 25 23" src="https://user-images.githubusercontent.com/3071606/104004608-d4637280-519b-11eb-9057-df6992e44d0f.png">
