### PR TITLE
[825] Remove checkbox from confirm page for non-draft trainees

### DIFF
--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -13,8 +13,12 @@ module Trainees
 
     def update
       authorize trainee
-      toggle_trainee_progress_field
-      trainee.save!
+
+      if trainee.draft?
+        toggle_trainee_progress_field
+        trainee.save!
+      end
+
       flash[:success] = "Trainee #{flash_message_title} updated"
       redirect_to trainee_path(trainee)
     end

--- a/app/views/trainees/confirm_details/_form.html.erb
+++ b/app/views/trainees/confirm_details/_form.html.erb
@@ -5,10 +5,11 @@
     <%= render(component) %>
 
     <%= form_with(model: @confirm_detail, url: resource_confirm_update_path, method: :put, local: true) do |f| %>
-      <%= f.govuk_check_boxes_fieldset :mark_as_completed, multiple: false, legend: { text: '' } do %>
-        <%= f.govuk_check_box :mark_as_completed, 1, 0, multiple: false, link_errors: true, label: { text: "I have completed this section " } %>
+      <% if @trainee.draft? %>
+        <%= f.govuk_check_boxes_fieldset :mark_as_completed, multiple: false, legend: { text: '' } do %>
+          <%= f.govuk_check_box :mark_as_completed, 1, 0, multiple: false, link_errors: true, label: { text: "I have completed this section " } %>
+        <% end %>
       <% end %>
-
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -43,6 +43,22 @@ feature "edit personal details", type: :feature do
     then_i_see_error_messages
   end
 
+  context "as a non-draft trainee" do
+    before do
+      given_a_trainee_exists(state: :submitted_for_trn)
+      and_nationalities_exist_in_the_system
+      when_i_visit_the_personal_details_page
+      and_i_enter_valid_parameters
+      and_i_submit_the_form
+    end
+
+    it "it doesn't ask me to complete the section" do
+      then_the_confirm_page_has_no_checkbox
+      and_i_click_continue
+      then_i_am_redirected_to_the_summary_page
+    end
+  end
+
 private
 
   def given_valid_personal_details_are_provided
@@ -90,10 +106,17 @@ private
 
   def and_confirm_my_details(checked: true)
     checked_option = checked ? "check" : "uncheck"
-    @confirm_page ||= PageObjects::Trainees::ConfirmDetails.new
-    expect(@confirm_page).to be_displayed(id: trainee.id, section: "personal-details")
-    @confirm_page.confirm.public_send(checked_option)
-    @confirm_page.submit_button.click
+    expect(confirm_page).to be_displayed(id: trainee.id, section: "personal-details")
+    confirm_page.confirm.public_send(checked_option)
+    and_i_click_continue
+  end
+
+  def then_the_confirm_page_has_no_checkbox
+    expect(confirm_page).to_not have_text("I have completed this section")
+  end
+
+  def and_i_click_continue
+    confirm_page.submit_button.click
   end
 
   def and_i_submit_the_form
@@ -123,5 +146,9 @@ private
 
   def then_i_see_a_flash_message
     expect(page).to have_text("Trainee personal details updated")
+  end
+
+  def confirm_page
+    @confirm_page ||= PageObjects::Trainees::ConfirmDetails.new
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/zHxUX9ZE/825-confirm-checkbox-should-not-be-visible-on-confirmation-screen-for-non-draft-records

### Changes proposed in this pull request

This PR hides the checkbox for completing a section from the confirmation pages for non-draft trainees.

It also (for now) just wraps the controller code that needs this param in an `if ... else` statement. I'm not sure whether I'm happy with using the same controller for draft and non-draft trainees if they're doing different things, but I'd rather wait until we address the issue of persisting unsaved data through to the confirm stage as these controllers may have to change!

### Guidance to review

- With a draft trainee, check that the confirm pages still have the checkbox
- With a non-draft trainee, check the the confirm pages do not have the checkbox, and that pressing continue still works.