### PR TITLE
[722] Conditionally show trainee status and QTS button

### DIFF
--- a/app/components/trainees/record_actions/view.html.erb
+++ b/app/components/trainees/record_actions/view.html.erb
@@ -1,15 +1,22 @@
-<div class="record-actions">
-  <%= govuk_button_link_to "Recommend for QTS", edit_trainee_outcome_details_outcome_date_path(trainee),
-                           { class: "govuk-!-margin-bottom-0" }  %>
+<% if display_actions? %>
+  <div class="record-actions">
 
-  <% if display_actions? %>
+    <% if can_recommend_for_qts? %>
+      <%= govuk_button_link_to t("views.trainees.edit.recommend_for_qts"), edit_trainee_outcome_details_outcome_date_path(trainee),
+                              { class: "govuk-!-margin-bottom-0" } %>
+    <% else %>
+      <div class="govuk-inset-text govuk-!-margin-0">
+        <%= t("views.trainees.edit.status_summary.#{trainee.state}") %>
+      </div>
+    <% end %>
+
     <div class="record-actions__links">
       <p class="govuk-body govuk-!-margin-bottom-0">
-        <%= defer_and_withdraw_links %>
+        <%= action_links %>
         <%= t("views.trainees.edit.this_trainee") %>
       </p>
     </div>
-  <% end %>
-</div>
+  </div>
 
-<hr class='govuk-section-break govuk-section-break--m govuk-section-break--visible'>
+  <hr class='govuk-section-break govuk-section-break--m govuk-section-break--visible'>
+<% end %>

--- a/app/components/trainees/record_actions/view.rb
+++ b/app/components/trainees/record_actions/view.rb
@@ -12,28 +12,20 @@ module Trainees
       end
 
       def display_actions?
-        allow_defer? || allow_withdraw?
+        trainee.submitted_for_trn? || trainee.trn_received? || trainee.deferred?
       end
 
-      def allow_defer?
-        trainee.submitted_for_trn? || trainee.trn_received?
+      def can_recommend_for_qts?
+        trainee.trn_received?
       end
 
-      def allow_withdraw?
-        allow_defer? || trainee.deferred?
-      end
+      def action_links
+        return reinstate_link + " or " + withdraw_link if trainee.deferred?
 
-      def defer_and_withdraw_links
-        return defer_link + " or " + withdraw_link if choose_both_actions?
-        return defer_link if allow_defer?
-        return reinstate_link + " or " + withdraw_link if allow_withdraw?
+        defer_link + " or " + withdraw_link
       end
 
     private
-
-      def choose_both_actions?
-        allow_defer? && allow_withdraw?
-      end
 
       def defer_link
         govuk_link_to t("views.trainees.edit.defer"), trainee_deferral_path(@trainee), class: "defer"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,10 @@ en:
         withdraw: withdraw
         reinstate: Reinstate
         this_trainee: this trainee
+        recommend_for_qts: Recommend for QTS
+        status_summary:
+          submitted_for_trn: This record is pending a TRN
+          deferred: This record is deferred
     trainee_summary:
       contact_details:
         heading: Contact Details

--- a/spec/components/trainees/record_actions/view_spec.rb
+++ b/spec/components/trainees/record_actions/view_spec.rb
@@ -4,44 +4,55 @@ require "rails_helper"
 
 RSpec.describe Trainees::RecordActions::View do
   let(:trainee) { build(:trainee, trait, id: 1) }
+  let(:button_text) { "Recommend for QTS" }
 
   subject { render_inline(described_class.new(trainee)).text }
 
   context "trainee state" do
+    shared_examples "no actions" do
+      it { is_expected.not_to include("Defer", "withdraw") }
+      it { is_expected.not_to include(button_text) }
+    end
+
+    shared_examples "no button" do
+      it { is_expected.not_to include(button_text) }
+    end
+
     context "draft" do
       let(:trait) { :draft }
-
-      it { is_expected.not_to include("Defer", "withdraw") }
+      include_examples "no actions"
     end
 
     context "submitted for TRN" do
       let(:trait) { :submitted_for_trn }
-
-      it { is_expected.to include("Defer", "withdraw") }
+      it { is_expected.to include("This record is pending a TRN", "Defer", "withdraw") }
+      include_examples "no button"
     end
 
     context "TRN received" do
       let(:trait) { :trn_received }
-
-      it { is_expected.to include("Defer", "withdraw") }
+      it { is_expected.to include(button_text, "Defer", "withdraw") }
     end
 
     context "recommended for QTS" do
       let(:trait) { :recommended_for_qts }
-
-      it { is_expected.not_to include("Defer", "withdraw") }
+      include_examples "no actions"
     end
 
     context "withdrawn" do
       let(:trait) { :withdrawn }
+      include_examples "no actions"
+    end
 
-      it { is_expected.not_to include("Defer", "withdraw") }
+    context "deferred" do
+      let(:trait) { :deferred }
+      it { is_expected.to include("This record is deferred", "Reinstate", "withdraw") }
+      include_examples "no button"
     end
 
     context "QTS awarded" do
       let(:trait) { :qts_awarded }
-
-      it { is_expected.not_to include("Defer", "withdraw") }
+      include_examples "no actions"
     end
   end
 end

--- a/spec/features/trainees/recording_training_outcome_spec.rb
+++ b/spec/features/trainees/recording_training_outcome_spec.rb
@@ -7,7 +7,7 @@ feature "Recording a training outcome", type: :feature do
 
   before do
     given_i_am_authenticated
-    given_a_trainee_exists
+    given_a_trainee_exists(state: :trn_received)
     and_i_am_on_the_trainee_edit_page
     and_i_click_on_record_training_outcome
   end


### PR DESCRIPTION
### Context

https://trello.com/c/YbJYFLUV/722-s-conditionally-render-the-recommend-for-qts-action-bar

### Changes proposed in this pull request

This PR adds more conditional checks to the record actions component based on the trainee's state.

As per the prototype, the following rules should apply:

| Trainee status      | Record actions LHS             | Record actions RHS   |
|---------------------|--------------------------------|----------------------|
| Draft               | N/A                            | N/A                  |
| submitted_for_trn   | “This record is pending a TRN” | Defer / Withdraw     |
| trn_received        | "Recommend for QTS" button     | Defer / Withdraw     |
| recommended_for_qts | No action bar                  | No action bar        |
| withdrawn           | No action bar                  | No action bar        |
| deferred            | "This record is deferred"      | Reinstate / Withdraw |
| qts_awarded         | No action bar                  | No action bar        |

#### Action links
Whilst I was in the code, I tidied up the logic around the defer / reinstate / withdraw buttons. I believe that (if displayed) they are _always_ 'Defer or withdraw' unless the trainee is currently deferred. I've simplified the code to reflect this.

I also renamed the method, since it doesn't always return a defer link

### Guidance to review

Go through each of the trainee states and:
- find a trainee in that state
- head to `/trainees/:id/edit`
- check that the action bar itself, the LHS content and the RHS content are rendered as per the table above
