### PR TITLE
[707] Allow users to become an admin to view and edit all trainees

### DIFF
--- a/app/components/personas/view.html.erb
+++ b/app/components/personas/view.html.erb
@@ -1,6 +1,6 @@
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-<h2 class="govuk-heading-l"><%= persona.name %></h2>
+<h2 class="govuk-heading-l"><%= persona.name %><%= ' (System Admin)' if persona.system_admin? %></h2>
 
 <div>
   <p class="govuk-body">
@@ -12,5 +12,5 @@
   <%= hidden_field_tag "email", persona.email %>
   <%= hidden_field_tag "first_name", persona.first_name %>
   <%= hidden_field_tag "last_name", persona.last_name %>
-  <%= f.submit "Login as " + persona.name, class: "govuk-button govuk-!-margin-bottom-2" %> 
+  <%= f.submit "Login as " + persona.name, class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  belongs_to :provider
+  belongs_to :provider, optional: true
 
   has_many :trainees, through: :provider
 

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -10,7 +10,7 @@ class TraineePolicy
     end
 
     def resolve
-      scope.where(provider_id: user.provider_id)
+      user.system_admin? ? scope.all : scope.where(provider_id: user.provider_id)
     end
   end
 
@@ -22,15 +22,15 @@ class TraineePolicy
   end
 
   def show?
-    user && user.provider_id == trainee.provider_id
+    user && (user.system_admin? || user.provider_id == trainee.provider_id)
   end
 
   def confirm?
-    user && user.provider_id == trainee.provider_id
+    user && (user.system_admin? || user.provider_id == trainee.provider_id)
   end
 
   def recommended?
-    user && user.provider_id == trainee.provider_id
+    user && (user.system_admin? || user.provider_id == trainee.provider_id)
   end
 
   def withdraw?

--- a/config/initializers/personas.rb
+++ b/config/initializers/personas.rb
@@ -4,9 +4,9 @@ PROVIDER_A = "Provider A"
 PROVIDER_B = "Provider B"
 
 PERSONAS = [
-  { first_name: "Adam", last_name: "Baker", email: "adam_baker@example.org", provider: PROVIDER_A },
-  { first_name: "Annie", last_name: "Bell", email: "annie_bell@example.org", provider: PROVIDER_A },
-  { first_name: "Bridget", last_name: "Campbell", email: "bridget_campbell@example.org", provider: PROVIDER_B },
+  { first_name: "Adam", last_name: "Baker", email: "adam_baker@example.org", system_admin: true },
+  { first_name: "Annie", last_name: "Bell", email: "annie_bell@example.org", provider: PROVIDER_A, system_admin: false },
+  { first_name: "Bridget", last_name: "Campbell", email: "bridget_campbell@example.org", provider: PROVIDER_B, system_admin: false },
 ].freeze
 
 PERSONA_EMAILS = PERSONAS.map { |persona| persona[:email] }

--- a/db/migrate/20210112121519_add_system_admin_boolean_to_users.rb
+++ b/db/migrate/20210112121519_add_system_admin_boolean_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSystemAdminBooleanToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :system_admin, :boolean, default: false
+    change_column_null :users, :provider_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_08_163200) do
+ActiveRecord::Schema.define(version: 2021_01_12_121519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -149,12 +149,13 @@ ActiveRecord::Schema.define(version: 2021_01_08_163200) do
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "email", null: false
-    t.bigint "provider_id", null: false
+    t.bigint "provider_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "dfe_sign_in_uid"
     t.datetime "last_signed_in_at"
     t.uuid "dttp_id"
+    t.boolean "system_admin", default: false
     t.index ["dfe_sign_in_uid"], name: "index_users_on_dfe_sign_in_uid", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["provider_id"], name: "index_users_on_provider_id"

--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-NEXT_YEAR = Time.zone.now.year.next
+NEXT_YEAR = Time.zone.now.year.next unless defined?(NEXT_YEAR)
 
 FactoryBot.define do
   factory :degree, class: Degree do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
     dttp_id { SecureRandom.uuid }
 
     provider
+
+    trait :system_admin do
+      system_admin { true }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,7 +12,7 @@ describe User do
   end
 
   describe "associations" do
-    it { is_expected.to belong_to(:provider) }
+    it { is_expected.to belong_to(:provider).optional }
   end
 
   describe "indexes" do

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe TraineePolicy do
+  let(:system_admin_user) { build(:user, :system_admin) }
   let(:provider) { create(:provider) }
   let(:provider_user) { build(:user, provider: provider) }
   let(:other_provider_user) { build(:user) }
@@ -12,6 +13,7 @@ describe TraineePolicy do
 
   permissions :show?, :create?, :update? do
     it { is_expected.to permit(provider_user, trainee) }
+    it { is_expected.to permit(system_admin_user, trainee) }
     it { is_expected.not_to permit(other_provider_user, trainee) }
   end
 
@@ -31,6 +33,13 @@ describe TraineePolicy do
       let(:trainee) { create(:trainee) }
 
       it { is_expected.not_to contain_exactly(trainee) }
+    end
+
+    context "system_admin user" do
+      let(:user) { system_admin_user }
+      let(:trainee) { create(:trainee) }
+
+      it { is_expected.to contain_exactly(trainee) }
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/u11n8lEG/707-m-systemadmin-role

### Changes proposed in this pull request
- Add boolean column `admin` to  users table
- Update `TraineePolicy::Scope` to use `User#system_admin?`
- Update rake task `example_data:generate` to set one persona as admin

**Keeping it very simple for now until we get requirements to build a multi-role system.**

### Guidance to review
- Run `rake db:migrate:reset db:seed example_data:generate`
- Visit http://0.0.0.0:3000/personas
- Choose "Admin" persona
- You should be able to see all trainees
- Click on any trainee and you should be able to view and edit
