### PR TITLE
[719] Add feedback link component

### DIFF
--- a/app/components/feedback_link/view.html.erb
+++ b/app/components/feedback_link/view.html.erb
@@ -1,0 +1,9 @@
+<% if enabled %>
+  <div class="govuk-inset-text">
+    <h2 class="govuk-heading-s">How are you finding this process?</h2>
+    <%= govuk_link_to "Give feedback to help improve the process of recommending trainees for QTS", feedback_link_url, { class: "govuk-body" } %>
+  </div>
+<% end %>
+
+
+

--- a/app/components/feedback_link/view.rb
+++ b/app/components/feedback_link/view.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FeedbackLink
+  class View < GovukComponent::Base
+    attr_reader :feedback_link_url, :enabled
+
+    def initialize(enabled: true, feedback_link_url:)
+      @enabled = enabled
+      @feedback_link_url = feedback_link_url
+    end
+  end
+end

--- a/app/views/trainees/outcome_details/recommended.html.erb
+++ b/app/views/trainees/outcome_details/recommended.html.erb
@@ -13,7 +13,7 @@
       <h1 class="govuk-panel__title">
         Trainee recommended for QTS
       </h1>
-    </div>    
+    </div>
     <p class="govuk-body">
       The Department for Education will award QTS where appropriate within 3
       working days.
@@ -21,4 +21,9 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Check trainee statuses from your list of records.", trainees_path) %></p>
+<p class="govuk-body govuk-!-margin-bottom-9"><%= govuk_link_to("Check trainee statuses from your list of records.", trainees_path) %></p>
+
+<%= render FeedbackLink::View.new(
+  enabled: Settings.features.enable_feedback_link,
+  feedback_link_url: Settings.feedback_link_url)
+%>

--- a/app/views/trn_submissions/show.html.erb
+++ b/app/views/trn_submissions/show.html.erb
@@ -21,6 +21,13 @@
 
     <%= govuk_link_to "Add another record", new_trainee_path, { class: "govuk-button" } %>
 
-    <p class="govuk-body">or <%= govuk_link_to("check trainee statuses and manage records", trainees_path) %></p>
+    <p class="govuk-body govuk-!-margin-bottom-9">or <%= govuk_link_to("check trainee statuses and manage records", trainees_path) %></p>
+
+    <%= render FeedbackLink::View.new(
+      enabled: Settings.features.enable_feedback_link,
+      feedback_link_url: Settings.feedback_link_url)
+    %>
   </div>
 </div>
+
+

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,9 @@ port: 5000
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://localhost:5000
 
+# The url for the google doc feedback link
+feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSfhdvlUkg7oxPjl1C6FcJ2pnlc1OQ82r7o3ZMNKthhVAt_h5g/viewform?usp=sf_link"
+
 basic_auth_required: true
 dttp:
   back_office_url: https://dttp-dev.crm4.dynamics.com/
@@ -18,6 +21,7 @@ features:
   use_ssl: true
   use_dfe_sign_in: true
   allow_user_creation: false
+  enable_feedback_link: true
 
 dfe_sign_in:
   # Our service name

--- a/spec/components/feedback_link/view_preview.rb
+++ b/spec/components/feedback_link/view_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module FeedbackLink
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render(FeedbackLink::View.new(enabled: true, feedback_link_url: "https://www.google.com"))
+    end
+  end
+end

--- a/spec/components/feedback_link/view_spec.rb
+++ b/spec/components/feedback_link/view_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module FeedbackLink
+  describe View do
+    alias_method :component, :page
+
+    describe "feedback link" do
+      before do
+        render_inline(described_class.new(enabled: enabled,
+                                          feedback_link_url: "https://www.google.com"))
+      end
+
+      context "when enabled" do
+        let(:enabled) { true }
+
+        it "renders the feedback link" do
+          expect(component).to have_link(
+            "Give feedback to help improve the process of recommending trainees for QTS",
+            href: "https://www.google.com",
+          )
+        end
+      end
+
+      context "when not enabled" do
+        let(:enabled) { false }
+
+        it "does not render the component" do
+          expect(component).to_not have_css(".govuk-inset-text")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

A link to a google form where users can leave feedback. 

### Changes proposed in this pull request

- Add feature flag for feedback link.
- Add feature flag component.
- Add setting for feature flag URL.

### Guidance to review

 #### 1 
- Boot up the server.
- Select a trainee in a `draft` state and fill out all the details.
- Click `Submit record and request TRN`.
- Check that the feedback link directs to the google form.

#### 2 
- Select a trainee in a `QTS recommended` state.
- Click `Recommend for QTS`, then `Today` and `Recommend for QTS`.
- Check that the feedback link is there.

#### 3

- In `settings.yml` change `enable_feedback_link:` to `false`
- Check that the link no longer appears on both pages 

#### Screenshot 
![image](https://user-images.githubusercontent.com/50492247/104039374-33da7600-51ce-11eb-9a9c-39197a99380b.png)


