### PR TITLE
[829] Programme Details validations bugs

### DIFF
--- a/app/forms/programme_detail_form.rb
+++ b/app/forms/programme_detail_form.rb
@@ -18,6 +18,8 @@ class ProgrammeDetailForm
 
   after_validation :update_trainee
 
+  MAX_END_YEARS = 4
+
   def initialize(trainee)
     @trainee = trainee
 
@@ -99,6 +101,8 @@ private
   def programme_start_date_valid
     if [start_day, start_month, start_year].all?(&:blank?)
       errors.add(:programme_start_date, :blank)
+    elsif start_year.to_i > next_year
+      errors.add(:programme_start_date, :future)
     elsif !programme_start_date.is_a?(Date)
       errors.add(:programme_start_date, :invalid)
     elsif programme_start_date < 10.years.ago
@@ -109,8 +113,12 @@ private
   def programme_end_date_valid
     if [end_day, end_month, end_year].all?(&:blank?)
       errors.add(:programme_end_date, :blank)
+    elsif end_year.to_i > max_years
+      errors.add(:programme_end_date, :future)
     elsif !programme_end_date.is_a?(Date)
       errors.add(:programme_end_date, :invalid)
+    elsif programme_end_date < 10.years.ago
+      errors.add(:programme_end_date, :too_old)
     end
 
     additional_validation = errors.attribute_names.none? do |attribute_name|
@@ -120,5 +128,13 @@ private
     if additional_validation && programme_start_date >= programme_end_date
       errors.add(:programme_end_date, :before_or_same_as_start_date)
     end
+  end
+
+  def next_year
+    Time.zone.now.year.next
+  end
+
+  def max_years
+    next_year + MAX_END_YEARS
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -291,12 +291,15 @@ en:
             additional_age_range:
               blank: "You must select an age range"
             programme_start_date:
-              blank: "You must enter programme start date"
+              blank: "You must enter a programme start date"
+              future: "You must enter a programme start date that is not as far in the future"
               invalid: "You must enter a valid programme start date"
               too_old: "You must enter a valid programme start date"
             programme_end_date:
-              blank: "You must enter programme end date"
+              blank: "You must enter a programme end date"
+              future: "You must enter a programme end date that is not as far in the future"
               invalid: "You must enter a valid programme end date"
+              too_old: "You must enter a valid programme end date"
               before_or_same_as_start_date: "You must enter programme end date after the programme start date"
         outcome_date_form:
           attributes:

--- a/spec/forms/programme_detail_form_spec.rb
+++ b/spec/forms/programme_detail_form_spec.rb
@@ -123,6 +123,26 @@ describe ProgrammeDetailForm, type: :model do
           start_date = 10.years.ago
           include_examples date_error_message, :programme_start_date, :too_old,
                            start_date.day, start_date.month, start_date.year
+
+          context "the start date fields are too far in future" do
+            let(:start_date_attributes) do
+              { start_day: "12", start_month: "11", start_year: "2099" }
+            end
+
+            it "returns an error message for programme start date" do
+              expect(subject.errors.messages[:programme_start_date]).to include I18n.t("activemodel.errors.models.programme_detail_form.attributes.programme_start_date.future")
+            end
+          end
+
+          context "the start date fields are too far in past" do
+            let(:start_date_attributes) do
+              { start_day: "12", start_month: "11", start_year: "2000" }
+            end
+
+            it "returns an error message for programme start date" do
+              expect(subject.errors.messages[:programme_start_date]).to include I18n.t("activemodel.errors.models.programme_detail_form.attributes.programme_start_date.too_old")
+            end
+          end
         end
 
         describe "#programme_end_date_valid" do
@@ -157,6 +177,26 @@ describe ProgrammeDetailForm, type: :model do
                            start_date.day, start_date.month, start_date.year
           include_examples date_error_message, :programme_end_date, :before_or_same_as_start_date,
                            start_date.day, start_date.month, start_date.year - 1
+
+          context "the end date fields are too far in future" do
+            let(:end_date_attributes) do
+              { end_day: "12", end_month: "11", end_year: "3000" }
+            end
+
+            it "returns an error message for programme end date" do
+              expect(subject.errors.messages[:programme_end_date]).to include I18n.t("activemodel.errors.models.programme_detail_form.attributes.programme_end_date.future")
+            end
+          end
+
+          context "the end date fields are too far in past" do
+            let(:end_date_attributes) do
+              { end_day: "12", end_month: "11", end_year: "2001" }
+            end
+
+            it "returns an error message for programme end date" do
+              expect(subject.errors.messages[:programme_end_date]).to include I18n.t("activemodel.errors.models.programme_detail_form.attributes.programme_end_date.too_old")
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
### Context
https://trello.com/c/bg1ryDrd/829-year-3000-accepted-for-programme-end-date
https://trello.com/c/Jm5kHZl3/828-would-expect-both-of-these-to-throw-errors-for-invalid-dates
### Changes proposed in this pull request
* Add validation to check for any programme end date more than 5 years in future and more than than 10 years in past
* Add validation to check for any programme start date more than 1 year in future
* Add tests to form spec
### Guidance to review
Test programme details validations on new/existing record

![Programme Details validations](https://user-images.githubusercontent.com/58793682/104222680-89b35600-543a-11eb-9bd1-53149cf2675c.gif)


