### PR TITLE
Stop deployment on smoke Test failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,6 +111,10 @@ jobs:
           timeoutSeconds:  300
           intervalSeconds: 15
 
+      - name: Stop when smoke tests fail
+        if: steps.wait_for_smoke_tests.outputs.conclusion == 'failure'
+        run: exit 1
+
       - name: Update ${{ matrix.environment }} status
         if: ${{ always() }}
         uses: bobheadxi/deployments@v0.4.2


### PR DESCRIPTION
At the moment, deployment continues, even after a smoke test failure

### Context

Stop deployment on smoke Test failure

### Changes proposed in this pull request

Add smoke test check condition in deploy workflow 

### Guidance to review

