### PR TITLE
Make check-in files available during Smoke-Test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,13 +11,31 @@ jobs:
     name: smoke-tests-${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
     steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby 2.7.2
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+
+      - name: Install bundler
+        run: |
+          gem install bundler
+
+      - name: Bundle smoke test gem
+        run: |
+          echo 'gem "rspec"' >> Gemfile
+          echo 'gem "httparty"' >> Gemfile
+          bundle
+
       - uses: softprops/turnstyle@v1
         name: Wait for other runs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Smoke Tests ${{ github.event.inputs.environment }}
-        run: RAILS_ENV=${{ github.event.inputs.environment }} bundle exec rspec --tag smoke
+        run: RAILS_ENV=${{ github.event.inputs.environment }} ./bin/bundle exec rspec spec/smoke
 
       - name: 'Nofiy #twd_publish_register_tech on failure'
         if: failure()

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---require spec_helper
---tag ~smoke

--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ group :development, :test do
 
   # Testing framework
   gem "rspec-rails", "~> 4.0.2"
+
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 3.34"
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "sidekiq/testing"
 require "rspec/rails"
 require "webmock/rspec"
+require "pundit/rspec"
+require "audited-rspec"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 

--- a/spec/smoke/health_check_spec.rb
+++ b/spec/smoke/health_check_spec.rb
@@ -1,25 +1,18 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require "spec_helper_smoke"
 
-describe "system health check spec", :smoke do
+describe "system health check spec", smoke: true do
   describe "GET /healthcheck" do
     let(:endpoint) { "#{Settings.base_url}/healthcheck" }
 
+    subject(:response) { HTTParty.get(endpoint) }
+
     it "returns HTTP success" do
-      get(endpoint)
-
-      expect(response.status).to eq(200)
-    end
-
-    it "returns JSON" do
-      get(endpoint)
-      expect(response.media_type).to eq("application/json")
+      expect(response.code).to eq(200)
     end
 
     it "returns the expected response report" do
-      get(endpoint)
-
       expect(response.body).to eq(
         {
           checks: {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ if ENV.fetch("COVERAGE", false)
 end
 
 RSpec.configure do |config|
+  config.filter_run_excluding smoke: true
+
   config.expect_with :rspec do |expectations|
     expectations.syntax = :expect
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -32,6 +34,3 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end
-
-require "pundit/rspec"
-require "audited-rspec"

--- a/spec/spec_helper_smoke.rb
+++ b/spec/spec_helper_smoke.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+ENV["RAILS_ENV"] ||= "test"
+
+require "rspec/core"
+require "config"
+require "httparty"
+
+Config.load_and_set_settings(Config.setting_files("config", ENV["RAILS_ENV"]))


### PR DESCRIPTION
This also involves configuring ruby

### Context

Make check-in files available during Smoke-Test and create a suitable ruby environment

### Changes proposed in this pull request


Make check-in files available during Smoke-Test and create a suitable ruby environment

### Guidance to review

