### PR TITLE
[849] Add HTTP status and headers to error

### DIFF
--- a/app/lib/dttp/batch_request.rb
+++ b/app/lib/dttp/batch_request.rb
@@ -20,7 +20,7 @@ module Dttp
 
     def submit
       response = Client.post("/$batch", body: body, headers: headers)
-      raise Error, response.body.gsub("\r", "") if response.code != 200
+      raise Error, "body: #{response.body.gsub('\r', '')}, status: #{response.code}, headers: #{response.headers}" if response.code != 200
 
       response
     end

--- a/spec/lib/dttp/batch_request_spec.rb
+++ b/spec/lib/dttp/batch_request_spec.rb
@@ -38,10 +38,11 @@ module Dttp
 
         context "unsuccessful" do
           let(:error_body) { "error" }
-          let(:dttp_response) { double(code: 400, body: error_body) }
+          let(:headers) { "test=header" }
+          let(:dttp_response) { double(code: 400, body: error_body, headers: headers) }
 
           it "raises an error" do
-            expect { subject.submit }.to raise_error(BatchRequest::Error, error_body)
+            expect { subject.submit }.to raise_error(BatchRequest::Error, "body: #{error_body}, status: 400, headers: #{headers}")
           end
         end
 


### PR DESCRIPTION
### Context

We raise a BatchRequest::Error when a batch job fails. DTTP returns an
empty body in some error conditions and it's difficult to diagnose the
issue. This will help.

### Changes proposed in this pull request

* Add status and headers to the BatchRequest::Error

### Guidance to review

The ticket is concerned with clearing the sidekiq queues following an incident. There are only jobs left in the retry sets which I want to preserve so as I can diagnose what is wrong with them. Hopefully this PR will help.
