### PR TITLE
[834] Homepage

### DIFF
--- a/app/components/start_page_banner/view.html.erb
+++ b/app/components/start_page_banner/view.html.erb
@@ -8,12 +8,11 @@
         Register trainees with the Department for Education and record the outcome of their training.
       </p>
       <div class="app-start-page-banner__actions">
-        <%= render GovukComponent::StartNowButton.new( text: 'Get started',
-                                                                 href: trainees_path,
+        <%= render GovukComponent::StartNowButton.new( text: 'Sign in',
+                                                                 href: home_path,
                                                                  classes: 'app-button--inverted app-start-page-banner__button') %>
         <p class="govuk-body app-body--inverted">
-          or <a class="govuk-link app-link--inverted govuk-link--no-visited-state" href="/sign-in">sign in</a>
-          if you’ve used it before
+          or <a class="govuk-link app-link--inverted govuk-link--no-visited-state" href="/home">request an account</a>
         </p>
       </div>
     </div>

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
-  skip_before_action :authenticate
+  skip_before_action :authenticate, except: [:home]
 
   def show
     render template: "pages/#{params[:page]}"
+  end
+
+  def home
+    render :home
   end
 
   def accessibility

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
     if current_user
       DfESignInUsers::Update.call(user: current_user, dfe_sign_in_user: dfe_sign_in_user)
 
-      redirect_to trainees_path
+      redirect_to home_path
     else
       DfESignInUser.end_session!(session)
       redirect_to sign_in_user_not_found_path

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,0 +1,39 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+  <h1 class="govuk-heading-l">Register trainee teachers</h1>
+
+  <p class="govuk-body-l"> Register trainees with the Department for Education
+  and record the outcome of their training.</p>
+
+  <p class="govuk-body">
+    <%= render GovukComponent::StartNowButton.new(
+      text: "Add a trainee",
+      href: new_trainee_path ) %>
+  </p>
+  </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<div class="govuk-grid-row">
+  <div class ="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to "Trainee records", trainees_path, { class: "govuk-link govuk-link--no-visited-state" } %>
+    </h2>
+    <p class="govuk-body">Review and manage your trainee records.</p>
+  </div>
+
+  <div class ="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to "Give feedback", Settings.feedback_link_url, { class: "govuk-link govuk-link--no-visited-state" } %>
+    </h2>
+    <p class="govuk-body">This is a new service. Your views will help us improve it.</p>
+  </div>
+
+  <div class ="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to "Check what data you need", data_requirements_path, { class: "govuk-link govuk-link--no-visited-state" } %>
+    </h2>
+    <p class="govuk-body">The data you need to complete a trainee record.</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get :healthcheck, controller: :heartbeat
   get :sha, controller: :heartbeat
 
+  get "/home", to: "pages#home", as: :home
   get "/accessibility", to: "pages#accessibility", as: :accessibility
   get "/cookies", to: "pages#cookies", as: :cookies
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy

--- a/spec/components/start_page_banner/view_spec.rb
+++ b/spec/components/start_page_banner/view_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe StartPageBanner::View do
     @result ||= render_inline(StartPageBanner::View.new)
   end
 
-  it "renders a 'Get Started' button" do
-    expect(@result.css(".app-start-page-banner__button").text).to include("Get started")
+  it "renders a 'Sign in' button" do
+    expect(@result.css(".app-start-page-banner__button").text).to include("Sign in")
   end
 
-  it "renders 'sign in' link" do
-    expect(@result.css(".app-link--inverted").text).to include("sign in")
+  it "renders 'or request an account' link" do
+    expect(@result.css(".app-link--inverted").text).to include("request an account")
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -23,7 +23,7 @@ describe SessionsController, type: :controller do
 
       it "redirects to the trainees index page" do
         request_callback
-        expect(response).to redirect_to(trainees_path)
+        expect(response).to redirect_to(home_path)
       end
     end
 
@@ -51,7 +51,7 @@ describe SessionsController, type: :controller do
 
         it "redirects to the trainees index page" do
           request_callback
-          expect(response).to redirect_to(trainees_path)
+          expect(response).to redirect_to(home_path)
         end
 
         it "saved non existing user to database" do

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -10,7 +10,7 @@ describe "A user authenticates via DfE Sign-in" do
     then_i_am_redirected_to_the_sign_in_path
     and_i_sign_in_via_dfe_sign_in
 
-    then_i_am_redirected_to_the_trainee_path
+    then_i_am_redirected_to_the_home_path
     and_i_should_see_the_link_to_sign_out
     and_my_details_are_refreshed
 
@@ -50,8 +50,8 @@ private
     visit_sign_in_page
   end
 
-  def then_i_am_redirected_to_the_trainee_path
-    expect(page.current_path).to eq("/trainees")
+  def then_i_am_redirected_to_the_home_path
+    expect(page.current_path).to eq("/home")
   end
 
   def and_i_should_see_the_link_to_sign_out
@@ -69,7 +69,7 @@ private
 
   def when_i_signed_in_more_than_2_hours_ago
     Timecop.travel(Time.zone.now + 2.hours + 1.second) do
-      expect(page.current_path).to eq("/trainees")
+      expect(page.current_path).to eq("/home")
 
       trainee_page = PageObjects::Trainees::Index.new
       trainee_page.load


### PR DESCRIPTION
### Context

Homepage for the Register app. The user should be directed to this page when they login.

### Changes proposed in this pull request

- Add `home` method to `pages_controller`
- Add new default endpoint `/home`, after sign in 
- Create homepage
- Change links on index page

### Guidance to review

- Pull down the code and boot up the server
- Open the app and check that when you log in it redirects to /home
- Check the content is correct and the links work
- The `Check what data you need` link will need to be changed to `data_requirements_path` once [this](https://github.com/DFE-Digital/register-trainee-teachers/pull/386) PR is merged into master. < **DONE**


### Screenshot

![image](https://user-images.githubusercontent.com/50492247/104582642-0cfdc300-5658-11eb-9bdd-11247715427f.png)

