### PR TITLE
[838] Add state transitions for trainee

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,8 @@ gem "slack-notifier"
 
 gem "audited", "~> 4.9"
 
+gem "stateful_enum"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,6 +389,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stateful_enum (0.6.0)
     store_model (0.8.0)
       activerecord (>= 5.2)
     swd (1.2.0)
@@ -481,6 +482,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec (~> 1.0)
   spring-watcher-listen (~> 2.0.0)
+  stateful_enum
   store_model (~> 0.8)
   timecop (~> 0.9.2)
   tzinfo-data

--- a/app/jobs/retrieve_trn_job.rb
+++ b/app/jobs/retrieve_trn_job.rb
@@ -15,8 +15,7 @@ class RetrieveTrnJob < ApplicationJob
     trn = Dttp::RetrieveTrn.call(trainee: trainee)
 
     if trn
-      # TODO: make this a state transition
-      trainee.update!(trn: trn)
+      trainee.update_and_receive_trn!(trn)
     elsif continue_polling?(trainee)
       RetrieveTrnJob.set(wait: POLL_DELAY).perform_later(trainee.id)
     end

--- a/app/models/state_transition_error.rb
+++ b/app/models/state_transition_error.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class StateTransitionError < StandardError; end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -67,7 +67,35 @@ class Trainee < ApplicationRecord
     withdrawn: 4,
     deferred: 5,
     qts_awarded: 6,
-  }
+  } do
+    event :submit_for_trn do
+      before do
+        self.submitted_for_trn_at = Time.zone.now
+      end
+
+      transition %i[draft deferred] => :submitted_for_trn
+    end
+
+    event :receive_trn do
+      transition %i[submitted_for_trn deferred] => :trn_received
+    end
+
+    event :recommend_for_qts do
+      transition %i[trn_received] => :recommended_for_qts
+    end
+
+    event :withdraw do
+      transition %i[submitted_for_trn trn_received deferred] => :withdrawn
+    end
+
+    event :defer do
+      transition %i[submitted_for_trn trn_received] => :deferred
+    end
+
+    event :award_qts do
+      transition %i[recommended_for_qts] => :qts_awarded
+    end
+  end
 
   enum age_range: {
     AgeRange::THREE_TO_ELEVEN_PROGRAMME => 0,
@@ -96,6 +124,19 @@ class Trainee < ApplicationRecord
   scope :ordered_by_date, -> { order(updated_at: :desc) }
   scope :is_draft, -> { where(state: "draft") }
   scope :is_not_draft, -> { where.not(state: "draft") }
+
+  def update_and_submit_for_trn!(dttp_id, placement_assignment_dttp_id)
+    submit_for_trn!
+    update!(dttp_id: dttp_id, placement_assignment_dttp_id: placement_assignment_dttp_id)
+  end
+
+  def update_and_receive_trn!(new_trn = nil)
+    raise StateTransitionError, "Cannot transition to :trn_received without a trn" unless new_trn || trn
+
+    receive_trn!
+    # A deferred trainee will probably already have a trn - don't overwrite that!
+    update!(trn: new_trn) unless trn
+  end
 
   def dttp_id=(value)
     raise LockedAttributeError, "dttp_id update failed for trainee ID: #{id}, with value: #{value}" if dttp_id.present?

--- a/app/services/dttp/recommend_for_qts.rb
+++ b/app/services/dttp/recommend_for_qts.rb
@@ -17,6 +17,8 @@ module Dttp
       response = Client.patch("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})", body: body)
       raise Error, response.body if response.code != 204
 
+      trainee.recommend_for_qts!
+
       response
     end
   end

--- a/app/services/dttp/register_for_trn.rb
+++ b/app/services/dttp/register_for_trn.rb
@@ -22,10 +22,12 @@ module Dttp
       batch_response = batch_request.submit
 
       entity_ids = OdataParser.entity_ids(batch_response: batch_response)
-      # TODO: make this a state transition method
-      trainee.update!(dttp_id: entity_ids["contacts"],
-                      placement_assignment_dttp_id: entity_ids["dfe_placementassignments"],
-                      submitted_for_trn_at: Time.zone.now)
+
+      trainee.update_and_submit_for_trn!(
+        entity_ids["contacts"],
+        entity_ids["dfe_placementassignments"],
+      )
+
       entity_ids
     end
   end

--- a/spec/models/trainee/state_transitions_spec.rb
+++ b/spec/models/trainee/state_transitions_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Trainee state transitions" do
+  describe "#update_and_receive_trn!" do
+    let(:old_trn) { "123" }
+    let(:new_trn) { "abc" }
+
+    context "with a :submitted_for_trn trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn) }
+
+      it "transitions the trainee to :trn_received and updates the trn" do
+        trainee.update_and_receive_trn!(new_trn)
+        expect(trainee.state).to eq("trn_received")
+        expect(trainee.trn).to eq(new_trn)
+      end
+    end
+
+    context "with a :deferred trainee" do
+      context "with an existing trn" do
+        let(:trainee) { create(:trainee, :deferred, trn: old_trn) }
+
+        it "transitions the trainee to :trn_received" do
+          trainee.update_and_receive_trn!
+          expect(trainee.state).to eq("trn_received")
+          expect(trainee.trn).to eq(old_trn)
+        end
+      end
+
+      context "without an existing trn" do
+        let(:trainee) { create(:trainee, :deferred) }
+        it "raises an error if no trn is provided" do
+          expect {
+            trainee.update_and_receive_trn!
+          }.to raise_error(StateTransitionError)
+        end
+
+        it "transitions the trainee to :trn_received and updates the trn" do
+          trainee.update_and_receive_trn!(new_trn)
+          expect(trainee.state).to eq("trn_received")
+          expect(trainee.trn).to eq(new_trn)
+        end
+      end
+    end
+
+    context "with a :deferred trainee with an existing trn" do
+      let(:trainee) { create(:trainee, :deferred, trn: old_trn) }
+
+      it "transitions the trainee to :trn_received" do
+        trainee.update_and_receive_trn!
+        expect(trainee.state).to eq("trn_received")
+        expect(trainee.trn).to eq(old_trn)
+      end
+    end
+
+    (Trainee.states.keys - %w[submitted_for_trn deferred]).each do |state|
+      context "with a :#{state} trainee" do
+        let(:trainee) { create(:trainee, state) }
+
+        it "raises an error" do
+          expect {
+            trainee.update_and_receive_trn!(new_trn)
+          }.to raise_error(RuntimeError, "Invalid transition")
+        end
+      end
+    end
+  end
+
+  describe "#update_and_submit_for_trn!" do
+    let(:dttp_id) { SecureRandom.uuid }
+    let(:placement_assignment_dttp_id) { SecureRandom.uuid }
+
+    context "with a :draft trainee" do
+      let(:trainee) { create(:trainee, :draft) }
+
+      it "transitions the trainee to :submitted_for_trn and updates the dttp_id, placement_assignment_dttp_id and submitted_for_trn_at" do
+        trainee.update_and_submit_for_trn!(dttp_id, placement_assignment_dttp_id)
+        expect(trainee.state).to eq("submitted_for_trn")
+        expect(trainee.dttp_id).to eq(dttp_id)
+        expect(trainee.placement_assignment_dttp_id).to eq(placement_assignment_dttp_id)
+        expect(trainee.submitted_for_trn_at).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/services/dttp/recommend_for_qts_spec.rb
+++ b/spec/services/dttp/recommend_for_qts_spec.rb
@@ -6,7 +6,7 @@ module Dttp
   describe RecommendForQTS do
     describe "#call" do
       let(:trainee) do
-        TraineePresenter.new(trainee: create(:trainee,
+        TraineePresenter.new(trainee: create(:trainee, :trn_received,
                                              outcome_date: outcome_date,
                                              placement_assignment_dttp_id: placement_assignment_dttp_id))
       end


### PR DESCRIPTION
### Context

https://trello.com/c/bFXIiWcp/838-s-state-transitions

### Changes proposed in this pull request

This PR adds state transitions to Trainees:

- Adds stateful enum to the trainee model for managing trainee state https://github.com/amatsuda/stateful_enum, defining allowed transitions.
- Adds custom methods for `update_and_submitt_for_trn!` and `update_and_receive_trn!` on the trainee model, since there are associated updates that need to happen alongside these state transitions.

Calls the state transition methods for transitioning to:
- `submitted_for_trn`
- `trn_received`
- `recommended_for_qts`

### Guidance to review