### PR TITLE
Remove http party in smoke test bundling as it's already in Gemfile

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Bundle smoke test gem
         run: |
           echo 'gem "rspec"' >> Gemfile
-          echo 'gem "httparty"' >> Gemfile
           bundle
 
       - uses: softprops/turnstyle@v1


### PR DESCRIPTION
### Context

- Removes the dynamic bundling of `httpparty` from the smoke test step as it's already in Gemfile

