### PR TITLE
[872] fix scope warnings

### DIFF
--- a/app/components/trainees/confirmation/diversity/view.rb
+++ b/app/components/trainees/confirmation/diversity/view.rb
@@ -52,7 +52,7 @@ module Trainees
         def disability_selection
           if trainee.disabled?
             "They shared that they’re disabled"
-          elsif trainee.not_disabled?
+          elsif trainee.no_disability?
             "They shared that they’re not disabled"
           else
             "Not provided"

--- a/app/controllers/trainees/diversity/disability_disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disability_disclosures_controller.rb
@@ -36,7 +36,7 @@ module Trainees
       end
 
       def redirect_to_relevant_step
-        if trainee.disability_not_provided? || trainee.not_disabled?
+        if trainee.disability_not_provided? || trainee.no_disability?
           redirect_to(trainee_diversity_disability_disclosure_confirm_path(trainee))
         else
           redirect_to(edit_trainee_diversity_disability_detail_path(trainee))

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -5,11 +5,11 @@ class TraineesController < ApplicationController
     @filters = TraineeFilter.new(params: filter_params).filters
 
     @draft_trainees = Trainees::Filter.call(
-      trainees: policy_scope(Trainee.is_draft.ordered_by_date),
+      trainees: policy_scope(Trainee.draft.ordered_by_date),
       filters: @filters,
     )
     @trainees = Trainees::Filter.call(
-      trainees: policy_scope(Trainee.is_not_draft.ordered_by_date),
+      trainees: policy_scope(Trainee.not_draft.ordered_by_date),
       filters: @filters,
     )
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -94,8 +94,6 @@ class Trainee < ApplicationRecord
                   using: { tsearch: { prefix: true } }
 
   scope :ordered_by_date, -> { order(updated_at: :desc) }
-  scope :is_draft, -> { where(state: "draft") }
-  scope :is_not_draft, -> { where.not(state: "draft") }
 
   def dttp_id=(value)
     raise LockedAttributeError, "dttp_id update failed for trainee ID: #{id}, with value: #{value}" if dttp_id.present?

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -33,7 +33,7 @@ class Trainee < ApplicationRecord
 
   enum disability_disclosure: {
     Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled] => 0,
-    Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_disabled] => 1,
+    Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability] => 1,
     Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] => 2,
   }
 

--- a/app/presenters/dttp/trainee_presenter.rb
+++ b/app/presenters/dttp/trainee_presenter.rb
@@ -100,7 +100,7 @@ module Dttp
     end
 
     def trainee_not_disabled?
-      disability_disclosure == Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_disabled]
+      disability_disclosure == Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability]
     end
 
     def degree

--- a/app/services/diversities/disability_disclosures/update.rb
+++ b/app/services/diversities/disability_disclosures/update.rb
@@ -27,7 +27,7 @@ module Diversities
       attr_reader :attributes
 
       def not_disabled?
-        attributes[:disability_disclosure] == Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_disabled]
+        attributes[:disability_disclosure] == Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability]
       end
 
       def disability_not_provided?

--- a/config/initializers/diversity_enums.rb
+++ b/config/initializers/diversity_enums.rb
@@ -34,7 +34,7 @@ module Diversities
 
   DISABILITY_DISCLOSURE_ENUMS = {
     disabled: "disabled",
-    not_disabled: "not_disabled",
+    no_disability: "no_disability",
     not_provided: "disability_not_provided",
   }.freeze
 

--- a/spec/components/trainees/confirmation/diversity/view_preview.rb
+++ b/spec/components/trainees/confirmation/diversity/view_preview.rb
@@ -63,7 +63,7 @@ module Trainees
             id: 1,
             diversity_disclosure: Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed],
             ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:not_provided],
-            not_disabled?: true,
+            no_disability?: true,
           })
         end
 

--- a/spec/components/trainees/confirmation/diversity/view_spec.rb
+++ b/spec/components/trainees/confirmation/diversity/view_spec.rb
@@ -89,14 +89,14 @@ RSpec.describe Trainees::Confirmation::Diversity::View do
 
     it "returns a message stating the user is not disabled" do
       allow(trainee).to receive(:disabled?).and_return(false)
-      allow(trainee).to receive(:not_disabled?).and_return(true)
+      allow(trainee).to receive(:no_disability?).and_return(true)
       component = Trainees::Confirmation::Diversity::View.new(trainee: trainee)
       expect(component.disability_selection).to eq "They shared that they’re not disabled"
     end
 
     it "returns a message stating the user did not provide details" do
       allow(trainee).to receive(:disabled?).and_return(false)
-      allow(trainee).to receive(:not_disabled?).and_return(false)
+      allow(trainee).to receive(:no_disability?).and_return(false)
       component = Trainees::Confirmation::Diversity::View.new(trainee: trainee)
       expect(component.disability_selection).to eq "Not provided"
     end

--- a/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
@@ -44,7 +44,7 @@ private
   end
 
   def and_i_choose_not_to_disclose
-    @disability_disclosure_page.public_send(%w[disability_not_provided not_disabled].sample).choose
+    @disability_disclosure_page.public_send(%w[disability_not_provided no_disability].sample).choose
   end
 
   def and_i_submit_the_form

--- a/spec/forms/diversities/form_validator_spec.rb
+++ b/spec/forms/diversities/form_validator_spec.rb
@@ -98,7 +98,7 @@ module Diversities
             let(:disability_disclosure) { instance_double(DisabilityDisclosureForm) }
 
             before do
-              trainee.disability_disclosure = DISABILITY_DISCLOSURE_ENUMS[:not_disabled]
+              trainee.disability_disclosure = DISABILITY_DISCLOSURE_ENUMS[:no_disability]
               expect(DisabilityDisclosureForm).to receive(:new).and_return(disability_disclosure)
             end
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -20,7 +20,7 @@ describe Trainee do
     it do
       is_expected.to define_enum_for(:disability_disclosure).with_values(
         Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled] => 0,
-        Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_disabled] => 1,
+        Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability] => 1,
         Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] => 2,
       )
     end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -160,24 +160,6 @@ describe Trainee do
     end
   end
 
-  context "trainee status" do
-    let(:draft_trainee) { create(:trainee, :draft) }
-    let(:trainee_submitted_for_trn) { create(:trainee, :submitted_for_trn) }
-    let(:trainee_with_qts_awarded) { create(:trainee, :qts_awarded) }
-
-    describe "#is_draft" do
-      it "returns all trainees that are draft" do
-        expect(Trainee.is_draft).to match_array([draft_trainee])
-      end
-    end
-
-    describe "#is_not_draft" do
-      it "returns all records that are not draft" do
-        expect(Trainee.is_not_draft).to match_array([trainee_submitted_for_trn, trainee_with_qts_awarded])
-      end
-    end
-  end
-
   describe "auditing" do
     it { should be_audited.associated_with(:provider) }
   end

--- a/spec/presenters/dttp/trainee_presenter_spec.rb
+++ b/spec/presenters/dttp/trainee_presenter_spec.rb
@@ -176,7 +176,7 @@ module Dttp
             end
 
             context "not disabled" do
-              let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_disabled] }
+              let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability] }
               let(:dttp_disability) { Diversities::NO_KNOWN_DISABILITY }
 
               it "returns a hash with a foreign key of DTTP's 'No known disability' entity" do

--- a/spec/services/diversities/disability_disclosures/update_spec.rb
+++ b/spec/services/diversities/disability_disclosures/update_spec.rb
@@ -28,7 +28,7 @@ module Diversities
         end
 
         context "when trainee is not disabled or disability is not provided" do
-          let(:attributes) { { disability_disclosure: DISABILITY_DISCLOSURE_ENUMS[:not_disabled] } }
+          let(:attributes) { { disability_disclosure: DISABILITY_DISCLOSURE_ENUMS[:no_disability] } }
 
           before(:each) do
             trainee.disabilities << create(:disability)


### PR DESCRIPTION
### Context

Enums create a negative scope by prepending `not_` to the enum value. Creating an enum with `not_` as the prefix when there is also a non 'not' version causes a warning that it will overwrite the scope.

### Changes proposed in this pull request

* Rename `not_disabled` to `no_disability` in `Trainee`
* Remove `is_not_draft` and `is_draft` and use the enum generated versions

### Guidance to review

