### PR TITLE
[812] & [803] Backlinks architecture & confirm pages backlinks

### DIFF
--- a/app/components/dynamic_back_link/view.html.erb
+++ b/app/components/dynamic_back_link/view.html.erb
@@ -1,0 +1,4 @@
+<%= render GovukComponent::BackLink.new(
+  text: text,
+  href: path
+) %>

--- a/app/components/dynamic_back_link/view.rb
+++ b/app/components/dynamic_back_link/view.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module DynamicBackLink
+  class View < GovukComponent::Base
+    include TraineeHelper
+    include Breadcrumbable
+
+    def initialize(trainee)
+      @trainee = trainee
+    end
+
+    def text
+      trainee.draft? ? "Back to draft record" : "Back to record"
+    end
+
+    def path
+      return view_trainee(trainee) unless origin_pages.any?
+
+      # If you're currently on a 'confirm' page, then you're on an origin page
+      # that has a back button to the _previous_ origin page.
+      if on_origin_page?
+        # Therefore, return the origin page before this one if it's been stored.
+        return origin_pages.length < 2 ? view_trainee(trainee) : rails_path(origin_pages[-2])
+      end
+
+      rails_path(origin_pages.last)
+    end
+
+  private
+
+    attr_reader :trainee
+
+    def rails_path(route)
+      public_send("#{route}_path", trainee)
+    end
+
+    def origin_pages
+      @origin_pages ||= origin_pages_for(trainee)
+    end
+
+    def on_origin_page?
+      current_page == origin_pages.last
+    end
+  end
+end

--- a/app/controllers/concerns/breadcrumbable.rb
+++ b/app/controllers/concerns/breadcrumbable.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Breadcrumbable
+  def save_origin_page_for(trainee)
+    # Don't save it the same origin page on page refresh, for example.
+    unless current_page == origin_pages_for(trainee).last
+      origin_pages_for(trainee) << current_page
+    end
+
+    # We only need to keep track of the last two origin pages.
+    origin_pages_for(trainee).shift if origin_pages_for(trainee).length > 2
+  end
+
+  def origin_pages_for(trainee)
+    session[session_key_for(trainee)] ||= []
+  end
+
+  def current_page
+    routes = Rails.application.routes.router.recognize(request) do |route, _|
+      route.name
+    end
+
+    routes.flatten.last.name
+  end
+
+private
+
+  def session_key_for(trainee)
+    "origin_pages_for_#{trainee.id}"
+  end
+end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -2,11 +2,14 @@
 
 module Trainees
   class ConfirmDetailsController < ApplicationController
+    include Breadcrumbable
+
     helper_method :trainee_section_key
     helper_method :confirm_section_title
 
     def show
       authorize trainee
+      save_origin_page_for(trainee)
       @confirm_detail = ConfirmDetailForm.new(mark_as_completed: trainee.progress.public_send(trainee_section_key))
       @confirmation_component = component_klass(trainee_section_key).new(trainee: trainee)
     end

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class PersonalDetailsController < ApplicationController
+    include Breadcrumbable
+
     DOB_CONVERSION = {
       "date_of_birth(3i)" => "day",
       "date_of_birth(2i)" => "month",
@@ -12,6 +14,7 @@ module Trainees
 
     def show
       authorize trainee
+      save_origin_page_for(trainee)
       render layout: "trainee_record"
     end
 

--- a/app/controllers/trainees/review_draft_controller.rb
+++ b/app/controllers/trainees/review_draft_controller.rb
@@ -2,8 +2,11 @@
 
 module Trainees
   class ReviewDraftController < ApplicationController
+    include Breadcrumbable
+
     def show
       authorize trainee
+      save_origin_page_for(trainee)
       @pre_submission_checker = Trns::SubmissionChecker.call(trainee: trainee)
     end
 

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TraineesController < ApplicationController
+  include Breadcrumbable
+
   def index
     @filters = TraineeFilter.new(params: filter_params).filters
 
@@ -16,6 +18,7 @@ class TraineesController < ApplicationController
 
   def show
     authorize trainee
+    save_origin_page_for(trainee)
     render layout: "trainee_record"
   end
 

--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -1,10 +1,7 @@
 <%= render PageTitle::View.new(title: I18n.t("components.confirmation.heading", section_title: confirm_section_title)) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(
-    text: @trainee.draft? ? 'Back to draft record' : 'Back to record',
-    href: view_trainee(@trainee)
-  ) %>
+  <%= render DynamicBackLink::View.new(@trainee) %>
 <% end %>
 
 <%= render(

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -1,10 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.training_details.edit") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(
-    text: 'Back',
-    href: view_trainee(@trainee)
-  ) %>
+  <%= render DynamicBackLink::View.new(@trainee) %>
 <% end %>
 
 <%= form_with model: @trainee, local: true do |f| %>

--- a/spec/components/dynamic_back_link/view_spec.rb
+++ b/spec/components/dynamic_back_link/view_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module DynamicBackLink
+  describe View do
+    alias_method :component, :page
+
+    shared_examples "show page default" do
+      it "defaults to trainee show page" do
+        expect(component).to have_link(
+          "Back to record",
+          href: "/trainees/#{trainee.to_param}",
+        )
+      end
+    end
+
+    shared_examples "draft page default" do
+      it "defaults to trainee edit page" do
+        expect(component).to have_link(
+          "Back to draft record",
+          href: "/trainees/#{trainee.to_param}/review-draft",
+        )
+      end
+    end
+
+    context "with no origin pages saved" do
+      before do
+        render_inline(described_class.new(trainee))
+      end
+
+      context "and a draft trainee" do
+        let(:trainee) { create(:trainee, :draft) }
+        include_examples "draft page default"
+      end
+
+      context "and a non-draft trainee" do
+        let(:trainee) { create(:trainee, :submitted_for_trn) }
+        include_examples "show page default"
+      end
+    end
+
+    context "with origin pages saved" do
+      before do
+        allow_any_instance_of(Breadcrumbable).to receive(:current_page).and_return(current_page)
+        allow_any_instance_of(Breadcrumbable).to receive(:origin_pages_for).with(trainee).and_return(saved_origin_pages)
+        render_inline(described_class.new(trainee))
+      end
+
+      context "and you're currently on the only saved origin page" do
+        let(:current_page) { "trainee_personal_details_confirm" }
+        let(:saved_origin_pages) { %w[trainee_personal_details_confirm] }
+
+        context "and the trainee is draft" do
+          let(:trainee) { create(:trainee, :draft) }
+          include_examples "draft page default"
+        end
+
+        context "and the trainee is not draft" do
+          let(:trainee) { create(:trainee, :submitted_for_trn) }
+          include_examples "show page default"
+        end
+      end
+
+      context "and you're currently on the last saved origin page of many" do
+        let(:trainee) { create(:trainee) }
+        let(:current_page) { "trainee_personal_details_confirm" }
+        let(:saved_origin_pages) { %w[trainee trainee_personal_details_confirm] }
+
+        it "links to the previous origin page" do
+          expect(component).to have_link(
+            href: "/trainees/#{trainee.to_param}",
+          )
+        end
+      end
+
+      context "when you're a non-origin page" do
+        let(:trainee) { create(:trainee) }
+        let(:current_page) { "a_random_page" }
+        let(:saved_origin_pages) { %w[trainee trainee_personal_details_confirm] }
+
+        it "links to the last origin page" do
+          expect(component).to have_link(
+            href: "/trainees/#{trainee.to_param}/personal-details/confirm",
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/trainees/personal_details_controller_spec.rb
+++ b/spec/controllers/trainees/personal_details_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Trainees::PersonalDetailsController do
+  let(:trainee) { create(:trainee) }
+  let(:user) { build(:user) }
+  let(:trainee_policy) { instance_double(TraineePolicy, show?: true, edit?: true) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(TraineePolicy).to receive(:new).with(user, trainee).and_return(trainee_policy)
+  end
+
+  describe "#show" do
+    before { get(:show, params: { trainee_id: trainee }) }
+
+    it "saves the origin page" do
+      expect(session["origin_pages_for_#{trainee.id}"]).to eq(%w[trainee_personal_details])
+    end
+  end
+end

--- a/spec/controllers/trainees_controller_spec.rb
+++ b/spec/controllers/trainees_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TraineesController do
+  let(:trainee) { create(:trainee) }
+  let(:user) { build(:user) }
+  let(:trainee_policy) { instance_double(TraineePolicy, show?: true) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(TraineePolicy).to receive(:new).with(user, trainee).and_return(trainee_policy)
+  end
+
+  describe "#show" do
+    before { get(:show, params: { id: trainee }) }
+
+    it "saves the origin page" do
+      expect(session["origin_pages_for_#{trainee.id}"]).to eq(%w[trainee])
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/UTN91Fxw/812-spike-work-out-the-back-link-functionality
https://trello.com/c/JRnNQEKZ/803-back-links-from-confirm-pages-return-to-the-confirm-page

### Changes proposed in this pull request

This PR explores creating dynamic backlinks by storing 'origin pages' in the user's session.

#### The main problem:
- There are currently many different **origin pages** from which a user can start an **edit journey**
- The first backlink, and the one on the confirm page for that journey (itself a possible origin page), should link to the **origin page**
- However, since these edit journeys are spread across multiple steps, we need a way of 'remembering' where the user came from.

#### The trickier problem:
- The user starts from a **first origin** page
- They go through the edit journey [backlink to **first origin**]
- They arrives on the confirm page **second origin** [backlink to **first origin** still]
- They re-enter the edit journey by clicking 'change' [backlink to **second origin**]
- They arrive on the confirm page for the second time [backlink to **first origin**]

The second time we arrive on the confirm page, we need to have remembered the original origin, therefore we must store something like an array of origins.
 

#### The idea:
- Whenever a user arrives on an origin page, we store the location in the session using our `Breadcrumb` module
- **UNLESS** that location was also the last stored in the session, then we ignore it
- Where a `DynamicBacklink` component is used, we check the session for where we should link to:
  - Normally, that's the last stored origin
  - **UNLESS** the current page == last stored origin (i.e. we're on a confirm page), then we link to the previous origin page.

#### The issue with the idea:
- The origin pages are stored in the session with a key that includes the trainee's ID. This means that if a user is working on multiple trainees at once, the backlinks will not get mixed up between trainees.
- **HOWEVER** this doesn't solve for users working on the _same_ trainee across multiple tabs. I feel like this is much less of an issue than the above - is it a common way of working?

### Guidance to review

Have a look, see what you think!

#### Things to think about:

**Clearing sessions**
- Should we clear sessions? When would that happen? Maybe we always just keep the last two.

**Arriving in an edit journey mid-way**
- At the moment we link to the first step of an edit flow when we click 'change', but the prototype sometimes links to a mid-way step.
- All backlinks in an edit flow would need to be `DynamicBacklink`s and they would need to be _even more_ dynamic (deciding to link to the correct origin page or back to the previous step 🤯).
-  This solution doesn't quite solve for this, we'd need to store _every_ location and which of those are origins?
