### PR TITLE
[866] Add navigation bar

### DIFF
--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -1,4 +1,4 @@
-<header class="govuk-header" role="banner" data-module="govuk-header">
+<header class="govuk-header app-header--full-border" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo app-header__logo">
       <%= link_to "/", class: "govuk-header__link govuk-header__link--homepage" do %>

--- a/app/components/navigation_bar/view.html.erb
+++ b/app/components/navigation_bar/view.html.erb
@@ -1,0 +1,18 @@
+<% if user_signed_in? %>
+  <div class="moj-primary-navigation">
+    <div class="moj-primary-navigation__container">
+      <div class="moj-primary-navigation__nav">
+        <nav class="moj-primary-navigation" aria-label="Primary navigation">
+          <ul class="moj-primary-navigation__list">
+            <li class="moj-primary-navigation__item">
+              <%= govuk_link_to "Home", home_path, { class: "moj-primary-navigation__link" } %>
+            </li>
+            <li class ="moj-primary-navigation__item">
+              <%= govuk_link_to "Trainee records", trainees_path, { class: "moj-primary-navigation__link" } %>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/components/navigation_bar/view.rb
+++ b/app/components/navigation_bar/view.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class NavigationBar::View < GovukComponent::Base
+  def initialize(current_user)
+    @current_user = current_user
+  end
+
+  def user_signed_in?
+    @current_user.present?
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,8 @@
 
     <%= render(Header::View.new(I18n.t('service_name'), @current_user)) %>
 
+    <%= render NavigationBar::View.new(@current_user) %>
+
     <div class="app-phase-banner">
       <div class="govuk-width-container">
         <div class="govuk-phase-banner">

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -59,3 +59,7 @@ a[href="#"] {
 .personal-detail-form-other-nationality__remove-link {
   float: right;
 }
+
+.app-header--full-border {
+  border-bottom-color: $govuk-brand-colour;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,7 +171,7 @@ en:
       disability_disclosures:
         labels:
           disabled: "Yes, they shared that they’re disabled"
-          not_disabled: "They shared that they’re not disabled"
+          no_disability: "They shared that they’re not disabled"
       withdrawal_reasons:
         headings:
           withdrawal_date: When did the trainee withdraw?

--- a/spec/components/navigation_bar/view_preview.rb
+++ b/spec/components/navigation_bar/view_preview.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module NavigationBar
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render NavigationBar::View.new(nil)
+    end
+
+    def with_a_user_signed_in
+      render NavigationBar::View.new({ first_name: "Ted" })
+    end
+  end
+end

--- a/spec/components/navigation_bar/view_spec.rb
+++ b/spec/components/navigation_bar/view_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module NavigationBar
+  describe View do
+    alias_method :component, :page
+
+    before do
+      render_inline(described_class.new(user))
+    end
+
+    context "when user is not signed in" do
+      let(:user) { nil }
+
+      it "does not render the navigation bar" do
+        expect(component).to_not have_css(".moj-primary-navigation")
+      end
+    end
+
+    context "when user is signed in" do
+      let(:user) { build(:user) }
+
+      it "renders the navigation bar" do
+        expect(component).to have_css(".moj-primary-navigation")
+      end
+
+      it "has two change links" do
+        expect(component).to have_link("Home")
+        expect(component).to have_link("Trainee records")
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/diversities/disability_disclosure.rb
+++ b/spec/support/page_objects/trainees/diversities/disability_disclosure.rb
@@ -6,7 +6,7 @@ module PageObjects
       class DisabilityDisclosure < PageObjects::Base
         set_url "/trainees/{id}/diversity/disability-disclosure/edit"
         element :disabled, "#diversities-disability-disclosure-form-disability-disclosure-disabled-field"
-        element :not_disabled, "#diversities-disability-disclosure-form-disability-disclosure-not-disabled-field"
+        element :no_disability, "#diversities-disability-disclosure-form-disability-disclosure-no-disability-field"
         element :disability_not_provided, "#diversities-disability-disclosure-form-disability-disclosure-disability-not-provided-field"
         element :submit_button, "input[name='commit']"
       end


### PR DESCRIPTION
### Context

Add a navigation bar which is only visible to users that have signed in. The dynamic blue line underneath the links will be part of a separate PR.

### Changes proposed in this pull request

- Add navigation bar component
- Add logic to make navigation bar only present if signed in
- Add links on navigation bar
- Extend blue bar to full page
- Fix flakey test

### Guidance to review

- Boot up the server
- Check that the navigation bar is not visible before signing in
- Sign in and check the navigation bar is always present
- Check the links on the navigation bar work (the bulk actions page is not ready yet)

### Screenshot

![image](https://user-images.githubusercontent.com/50492247/104763606-11140880-575e-11eb-8977-bc2abd00e430.png)