### PR TITLE
Add PaaS app interaction instruction to REAME file

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,6 @@ dttp:
   scope: "https://dttp-dev.crm4.dynamics.com/.default"
   api_base_url: "https://dttp-dev.api.crm4.dynamics.com/api/data/v9.1"
 ```
+
+## PaaS Space Access and App interaction
+In order to login, change space roles and interact with PaaS based application, please follow this [instruction] https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/2409791489/Changing+set+and+unset+roles+and+interacting+with+App+on+PaaS


### PR DESCRIPTION
This is to help users (developers etc) set space roles, ssh and launch rails console on PaaS.

### Context

Add PaaS app interaction documentations to REAME file

### Changes proposed in this pull request

Update REAME file with link to confluence page, which describes how to interact with the apps on PaaS platform. This includes how to set roles, ssh and launch rails consoles etc.

### Guidance to review

