### PR TITLE
Active section for navigation bar

### DIFF
--- a/app/components/navigation_bar/view.html.erb
+++ b/app/components/navigation_bar/view.html.erb
@@ -1,16 +1,11 @@
-<% if user_signed_in? %>
-  <div class="moj-primary-navigation">
+ <div class="moj-primary-navigation">
     <div class="moj-primary-navigation__container">
       <div class="moj-primary-navigation__nav">
         <nav class="moj-primary-navigation" aria-label="Primary navigation">
           <ul class="moj-primary-navigation__list">
-          <% items.each do |item| %>
+            <% items.each do |item| %>
             <li class="moj-primary-navigation__item">
-              <% if item.fetch(:current, false) || current_page?(item.fetch(:url)) %>
-                <%= govuk_link_to item[:name], item[:url], class: "moj-primary-navigation__link", aria: { current: "page" }%>
-              <% else %>
-                <%= govuk_link_to item[:name], item[:url], class: "moj-primary-navigation__link"%>
-              <% end %>
+              <%= item_link(item) %>
             </li>
           <% end %>
           </ul>
@@ -18,4 +13,3 @@
       </div>
     </div>
   </div>
-<% end %>

--- a/app/components/navigation_bar/view.html.erb
+++ b/app/components/navigation_bar/view.html.erb
@@ -4,12 +4,15 @@
       <div class="moj-primary-navigation__nav">
         <nav class="moj-primary-navigation" aria-label="Primary navigation">
           <ul class="moj-primary-navigation__list">
+          <% items.each do |item| %>
             <li class="moj-primary-navigation__item">
-              <%= govuk_link_to "Home", home_path, { class: "moj-primary-navigation__link" } %>
+              <% if item.fetch(:current, false) || current_page?(item.fetch(:url)) %>
+                <%= govuk_link_to item[:name], item[:url], class: "moj-primary-navigation__link", aria: { current: "page" }%>
+              <% else %>
+                <%= govuk_link_to item[:name], item[:url], class: "moj-primary-navigation__link"%>
+              <% end %>
             </li>
-            <li class ="moj-primary-navigation__item">
-              <%= govuk_link_to "Trainee records", trainees_path, { class: "moj-primary-navigation__link" } %>
-            </li>
+          <% end %>
           </ul>
         </nav>
       </div>

--- a/app/components/navigation_bar/view.rb
+++ b/app/components/navigation_bar/view.rb
@@ -3,12 +3,19 @@
 class NavigationBar::View < GovukComponent::Base
   attr_reader :items
 
-  def initialize(current_user, items:)
-    @current_user = current_user
+  def initialize(items:)
     @items = items
   end
 
-  def user_signed_in?
-    @current_user.present?
+  def item_link(item)
+    link_params = { class: "moj-primary-navigation__link" }
+    link_params.merge!(aria: { current: "page" }) if show_current_link?(item)
+    govuk_link_to(item[:name], item[:url], link_params)
+  end
+
+private
+
+  def show_current_link?(item)
+    item.fetch(:current, false) || current_page?(item.fetch(:url))
   end
 end

--- a/app/components/navigation_bar/view.rb
+++ b/app/components/navigation_bar/view.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class NavigationBar::View < GovukComponent::Base
-  def initialize(current_user)
+  attr_reader :items
+
+  def initialize(current_user, items:)
     @current_user = current_user
+    @items = items
   end
 
   def user_signed_in?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   include Pundit
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
 
+  helper_method :current_user, :authenticated?
+
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
 private

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module NavigationHelper
+  def trainee_link_is_current?
+    url = request.path_info
+    if url.include?("/trainees")
+      true
+    else
+      false
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,10 +35,12 @@
 
     <%= render(Header::View.new(I18n.t('service_name'), @current_user)) %>
 
-    <%= render NavigationBar::View.new(@current_user, items: [
-      {name: "Home", url: home_path },
-      {name: "Trainee records", url: trainees_path}
-    ]) %>
+    <% if authenticated? %>
+      <%= render NavigationBar::View.new(items: [
+        {name: "Home", url: home_path},
+        {name: "Trainee records", url: trainees_path, current: trainee_link_is_current? }
+      ]) %>
+    <% end %>
 
     <div class="app-phase-banner">
       <div class="govuk-width-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,10 @@
 
     <%= render(Header::View.new(I18n.t('service_name'), @current_user)) %>
 
-    <%= render NavigationBar::View.new(@current_user) %>
+    <%= render NavigationBar::View.new(@current_user, items: [
+      {name: "Home", url: home_path },
+      {name: "Trainee records", url: trainees_path}
+    ]) %>
 
     <div class="app-phase-banner">
       <div class="govuk-width-container">

--- a/spec/components/navigation_bar/view_spec.rb
+++ b/spec/components/navigation_bar/view_spec.rb
@@ -3,58 +3,83 @@
 require "rails_helper"
 
 module NavigationBar
+  include ApplicationHelper
+
   describe View do
     alias_method :component, :page
 
     let(:mock_link) { "https://www.gov.uk" }
-    let(:items) do
-      [
-        { name: "Home", url: mock_link },
-        { name: "Trainee records", url: mock_link },
-      ]
-    end
 
     before do
-      render_inline(described_class.new(user, items: items))
+      render_inline(described_class.new(items: items))
     end
 
-    context "when user is not signed in" do
-      let(:user) { nil }
-
-      it "does not render the navigation bar" do
-        expect(component).to_not have_css(".moj-primary-navigation")
-      end
-    end
-
-    context "when user is signed in" do
-      let(:user) { build(:user) }
-
-      it "renders the navigation bar" do
-        expect(component).to have_css(".moj-primary-navigation")
+    context "multiple links" do
+      let(:items) do
+        [
+          { name: "Home", url: mock_link },
+          { name: "Trainee records", url: mock_link },
+        ]
       end
 
       it "has two change links" do
         expect(component).to have_link("Home")
         expect(component).to have_link("Trainee records")
       end
+    end
 
-      context "with current item" do
-        let(:active_item) { { name: "Bulk actions", url: mock_link, current: true } }
 
-        before do
-          render_inline(described_class.new(:user, items: items.prepend(active_item)))
-        end
 
-        it "renders the current item with the correct class" do
-          rendered_link = component.find(".moj-primary-navigation__link", text: active_item[:name])
-          expect(rendered_link["aria-current"]).to eq("page")
+
+
+
+
+
+
+
+    context "where item current is true" do
+      let(:current_item) { { name: "Bulk actions", url: mock_link, current: true } }
+      let(:items) { [current_item] }
+
+      it "renders the link with aria-current" do
+        rendered_link = component.find(".moj-primary-navigation__link", text: current_item[:name])
+        expect(rendered_link["aria-current"]).to eq("page")
+      end
+    end
+
+    context "where item current is false" do
+      let(:non_current_item) { { name: "Trainee records", url: mock_link, current: false} }
+      let(:items) { [non_current_item] }
+
+      context "when not on the current url" do
+        it "renders the link without aria-current" do
+          rendered_link = component.find(".moj-primary-navigation__link", text: non_current_item[:name])
+          expect(rendered_link["aria-current"]).to eq(nil)
         end
       end
 
-      context "where item current is true"
+      context "when on the current url" do
+        before do
+          allow(ApplicationHelper.helpers).to receive(:current_page?).with(mock_link).and_return(true)
+        end
 
-      context "where item current is false"
-      context "where item current is not set"
+        it "renders the link with aria-current" do
+          rendered_link = component.find(".moj-primary-navigation__link", text: non_current_item[:name])
+          expect(rendered_link["aria-current"]).to eq("page")
+        end
+      end
+    end
+
+    context "where item current is not set" do
+      let(:item) { { name: "Trainee records", url: mock_link } }
+
+      context "when not on the current url" do
+
+      end
+
+      context "when on the current url" do
+
+      end
     end
   end
 end

--- a/spec/components/navigation_bar/view_spec.rb
+++ b/spec/components/navigation_bar/view_spec.rb
@@ -50,6 +50,11 @@ module NavigationBar
           expect(rendered_link["aria-current"]).to eq("page")
         end
       end
+
+      context "where item current is true"
+
+      context "where item current is false"
+      context "where item current is not set"
     end
   end
 end

--- a/spec/components/navigation_bar/view_spec.rb
+++ b/spec/components/navigation_bar/view_spec.rb
@@ -6,8 +6,16 @@ module NavigationBar
   describe View do
     alias_method :component, :page
 
+    let(:mock_link) { "https://www.gov.uk" }
+    let(:items) do
+      [
+        { name: "Home", url: mock_link },
+        { name: "Trainee records", url: mock_link },
+      ]
+    end
+
     before do
-      render_inline(described_class.new(user))
+      render_inline(described_class.new(user, items: items))
     end
 
     context "when user is not signed in" do
@@ -28,6 +36,19 @@ module NavigationBar
       it "has two change links" do
         expect(component).to have_link("Home")
         expect(component).to have_link("Trainee records")
+      end
+
+      context "with current item" do
+        let(:active_item) { { name: "Bulk actions", url: mock_link, current: true } }
+
+        before do
+          render_inline(described_class.new(:user, items: items.prepend(active_item)))
+        end
+
+        it "renders the current item with the correct class" do
+          rendered_link = component.find(".moj-primary-navigation__link", text: active_item[:name])
+          expect(rendered_link["aria-current"]).to eq("page")
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

- Logic for the active section on the Navigation bar which changes depending on which page you are on (Home or Trainee records)

### Changes proposed in this pull request

- Add logic to navigation bar component to render the blue bar on the active tab

### Guidance to review

- Pull down the code
- Sign in 
- Check that the blue bar is on the 'Home' tab within the navigation bar
- Click on the 'Trainee records' tab and check the blue bar changes dynamically

### Screenshots

![image](https://user-images.githubusercontent.com/50492247/104944306-eb317280-59ae-11eb-90b4-772cc16395ba.png)

![image](https://user-images.githubusercontent.com/50492247/104944340-f71d3480-59ae-11eb-89e8-b3a24994884a.png)

