### PR TITLE
[821] - Trainee Slugs

### DIFF
--- a/app/components/trainees/confirmation/diversity/view.rb
+++ b/app/components/trainees/confirmation/diversity/view.rb
@@ -18,7 +18,7 @@ module Trainees
               key: "Diversity information",
               value: I18n.t("components.confirmation.diversity.diversity_disclosure.#{trainee.diversity_disclosure}"),
               action: govuk_link_to('Change<span class="govuk-visually-hidden"> diversity information</span>'.html_safe,
-                                    edit_trainee_diversity_disclosure_path(trainee.id)),
+                                    edit_trainee_diversity_disclosure_path(trainee)),
             },
           ]
 
@@ -27,14 +27,14 @@ module Trainees
               key: "Ethnicity",
               value: ethnic_group_content,
               action: govuk_link_to('Change<span class="govuk-visually-hidden"> ethnicity</span>'.html_safe,
-                                    edit_trainee_diversity_ethnic_group_path(trainee.id)),
+                                    edit_trainee_diversity_ethnic_group_path(trainee)),
             }
 
             rows << {
               key: "Disability",
               value: tag.p(disability_selection, class: "govuk-body") + selected_disability_options,
               action: govuk_link_to('Change<span class="govuk-visually-hidden"> disability</span>'.html_safe,
-                                    edit_trainee_diversity_disability_disclosure_path(trainee.id)),
+                                    edit_trainee_diversity_disability_disclosure_path(trainee)),
             }
           end
           rows

--- a/app/controllers/trainees/check_details_controller.rb
+++ b/app/controllers/trainees/check_details_controller.rb
@@ -3,7 +3,7 @@
 module Trainees
   class CheckDetailsController < ApplicationController
     def show
-      @trainee = Trainee.find(params[:id])
+      @trainee = Trainee.from_param(params[:id])
     end
   end
 end

--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -15,7 +15,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
   end
 end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -26,7 +26,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
     def component_klass(key)

--- a/app/controllers/trainees/confirm_withdrawals_controller.rb
+++ b/app/controllers/trainees/confirm_withdrawals_controller.rb
@@ -15,7 +15,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
   end
 end

--- a/app/controllers/trainees/contact_details_controller.rb
+++ b/app/controllers/trainees/contact_details_controller.rb
@@ -24,7 +24,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
     def contact_details_params

--- a/app/controllers/trainees/deferrals_controller.rb
+++ b/app/controllers/trainees/deferrals_controller.rb
@@ -30,7 +30,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/degrees/type_controller.rb
+++ b/app/controllers/trainees/degrees/type_controller.rb
@@ -25,7 +25,7 @@ module Trainees
       end
 
       def trainee
-        @trainee ||= Trainee.find(params[:trainee_id])
+        @trainee ||= Trainee.from_param(params[:trainee_id])
       end
     end
   end

--- a/app/controllers/trainees/degrees_controller.rb
+++ b/app/controllers/trainees/degrees_controller.rb
@@ -57,7 +57,7 @@ module Trainees
     end
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
   end
 end

--- a/app/controllers/trainees/diversity/disability_details_controller.rb
+++ b/app/controllers/trainees/diversity/disability_details_controller.rb
@@ -26,7 +26,7 @@ module Trainees
     private
 
       def trainee
-        @trainee ||= Trainee.find(params[:trainee_id])
+        @trainee ||= Trainee.from_param(params[:trainee_id])
       end
 
       def disabilities

--- a/app/controllers/trainees/diversity/disability_disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disability_disclosures_controller.rb
@@ -26,7 +26,7 @@ module Trainees
     private
 
       def trainee
-        @trainee ||= Trainee.find(params[:trainee_id])
+        @trainee ||= Trainee.from_param(params[:trainee_id])
       end
 
       def disability_disclosure_params

--- a/app/controllers/trainees/diversity/disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disclosures_controller.rb
@@ -23,7 +23,7 @@ module Trainees
     private
 
       def trainee
-        @trainee ||= Trainee.find(params[:trainee_id])
+        @trainee ||= Trainee.from_param(params[:trainee_id])
       end
 
       def disclosure_param

--- a/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
@@ -24,7 +24,7 @@ module Trainees
     private
 
       def trainee
-        @trainee ||= Trainee.find(params[:trainee_id])
+        @trainee ||= Trainee.from_param(params[:trainee_id])
       end
 
       def ethnic_background_params

--- a/app/controllers/trainees/diversity/ethnic_groups_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_groups_controller.rb
@@ -23,7 +23,7 @@ module Trainees
     private
 
       def trainee
-        @trainee ||= Trainee.find(params[:trainee_id])
+        @trainee ||= Trainee.from_param(params[:trainee_id])
       end
 
       def ethnic_group_param

--- a/app/controllers/trainees/outcome_dates_controller.rb
+++ b/app/controllers/trainees/outcome_dates_controller.rb
@@ -28,7 +28,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
     def trainee_params

--- a/app/controllers/trainees/outcome_details_controller.rb
+++ b/app/controllers/trainees/outcome_details_controller.rb
@@ -13,7 +13,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
   end
 end

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -39,7 +39,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
     def nationalities

--- a/app/controllers/trainees/programme_details_controller.rb
+++ b/app/controllers/trainees/programme_details_controller.rb
@@ -35,7 +35,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
     def programme_details_params

--- a/app/controllers/trainees/qts_recommendations_controller.rb
+++ b/app/controllers/trainees/qts_recommendations_controller.rb
@@ -7,13 +7,13 @@ module Trainees
 
       RecommendForQtsJob.perform_later(trainee.id)
 
-      redirect_to recommended_trainee_outcome_details_path(trainee_id: trainee.id)
+      redirect_to recommended_trainee_outcome_details_path(trainee)
     end
 
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
   end
 end

--- a/app/controllers/trainees/review_draft_controller.rb
+++ b/app/controllers/trainees/review_draft_controller.rb
@@ -10,7 +10,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:id])
+      @trainee ||= Trainee.from_param(params[:id])
     end
   end
 end

--- a/app/controllers/trainees/timelines_controller.rb
+++ b/app/controllers/trainees/timelines_controller.rb
@@ -10,7 +10,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
   end
 end

--- a/app/controllers/trainees/trainee_ids_controller.rb
+++ b/app/controllers/trainees/trainee_ids_controller.rb
@@ -19,7 +19,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
     def trainee_params

--- a/app/controllers/trainees/training_details_controller.rb
+++ b/app/controllers/trainees/training_details_controller.rb
@@ -9,7 +9,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:id])
+      @trainee ||= Trainee.from_param(params[:id])
     end
   end
 end

--- a/app/controllers/trainees/withdrawals_controller.rb
+++ b/app/controllers/trainees/withdrawals_controller.rb
@@ -30,7 +30,7 @@ module Trainees
   private
 
     def trainee
-      @trainee ||= Trainee.find(params[:trainee_id])
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
     def authorize_trainee

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -46,7 +46,7 @@ class TraineesController < ApplicationController
 private
 
   def trainee
-    @trainee ||= Trainee.find(params[:id])
+    @trainee ||= Trainee.from_param(params[:id])
   end
 
   def trainee_params

--- a/app/controllers/trn_submissions_controller.rb
+++ b/app/controllers/trn_submissions_controller.rb
@@ -7,13 +7,13 @@ class TrnSubmissionsController < ApplicationController
     RegisterForTrnJob.perform_later(trainee.id, current_user.dttp_id)
     RetrieveTrnJob.set(wait: RetrieveTrnJob::POLL_DELAY).perform_later(trainee.id)
 
-    redirect_to trn_submission_path(trainee_id: trainee.id)
+    redirect_to trn_submission_path(trainee)
   end
 
 private
 
   def trainee
-    @trainee ||= Trainee.find(params[:trainee_id])
+    @trainee ||= Trainee.from_param(params[:trainee_id])
   end
 
   def authorize_trainee

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -10,9 +10,9 @@ module TraineeHelper
 
   def view_trainee(trainee)
     if trainee.draft?
-      review_draft_trainee_path(trainee.id)
+      review_draft_trainee_path(trainee)
     else
-      trainee_path(trainee.id)
+      trainee_path(trainee)
     end
   end
 end

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Sluggable
+  extend ActiveSupport::Concern
+  SLUG_LENGTH = 24
+
+  included do
+    attr_readonly :slug
+
+    has_secure_token :slug
+
+    after_initialize :generate_slug, if: -> { slug.blank? }
+  end
+
+  def to_param
+    slug
+  end
+
+  def generate_slug
+    self.slug = SecureRandom.base58(SLUG_LENGTH)
+  end
+
+  class_methods do
+    def from_param(param)
+      find_by!(slug: param)
+    end
+  end
+end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Trainee < ApplicationRecord
+  include Sluggable
   include PgSearch::Model
 
   belongs_to :provider
@@ -14,6 +15,7 @@ class Trainee < ApplicationRecord
 
   validates :record_type, presence: { message: "You must select a route" }
   validates :trainee_id, length: { maximum: 100, message: "Your entry must not exceed 100 characters" }
+  validates :slug, presence: true, uniqueness: { case_sensitive: false }
 
   enum record_type: { assessment_only: 0, provider_led: 1 }
   enum locale_code: { uk: 0, non_uk: 1 }

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -34,7 +34,7 @@
 <%= render Trainees::Confirmation::ProgrammeDetails::View.new(trainee: @trainee) %>
 
 <%= form_with url: trn_submissions_path, method: :post, local: true do |f| %>
-  <%= hidden_field_tag :trainee_id, @trainee.id %>
+  <%= hidden_field_tag :trainee_id, @trainee.slug %>
   <%= f.govuk_submit "Submit record and request TRN" %>
 <%- end -%>
 

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_for(@contact_details, url: trainee_contact_details_path(@contact_details), method: :put, local: true) do |f| %>
+    <%= form_for(@contact_details, url: trainee_contact_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset(:locale_code, legend: { text: "Where does the trainee live?", size: "s" }, classes: "locale") do %>

--- a/app/views/trainees/outcome_details/confirm.html.erb
+++ b/app/views/trainees/outcome_details/confirm.html.erb
@@ -21,7 +21,7 @@
     <%= render Trainees::OutcomeDetails::View.new(@trainee) %>
 
     <%= form_with url: trainee_qts_recommendations_path, method: :post, local: true do |f| %>
-      <%= hidden_field_tag :trainee_id, @trainee.id %>
+      <%= hidden_field_tag :trainee_id, @trainee.slug %>
       <%= f.govuk_submit "Recommend for QTS" %>
     <%- end -%>
   </div>

--- a/db/migrate/20210118123651_add_slug_to_trainees.rb
+++ b/db/migrate/20210118123651_add_slug_to_trainees.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSlugToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :slug, :string
+    add_index :trainees, :slug, unique: true
+  end
+end

--- a/db/migrate/20210118132920_regenerate_slugs_on_trainees.rb
+++ b/db/migrate/20210118132920_regenerate_slugs_on_trainees.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RegenerateSlugsOnTrainees < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.all.each(&:regenerate_slug)
+  end
+
+  def down
+    Trainee.update_all(slug: nil)
+  end
+end

--- a/db/migrate/20210118133452_change_slug_nullability_on_trainees.rb
+++ b/db/migrate/20210118133452_change_slug_nullability_on_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeSlugNullabilityOnTrainees < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :trainees, :slug, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_12_121519) do
+ActiveRecord::Schema.define(version: 2021_01_18_133452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_121519) do
     t.datetime "withdraw_date"
     t.string "additional_withdraw_reason"
     t.date "defer_date"
+    t.string "slug", null: false
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"
     t.index ["dttp_id"], name: "index_trainees_on_dttp_id"
@@ -142,6 +143,7 @@ ActiveRecord::Schema.define(version: 2021_01_12_121519) do
     t.index ["progress"], name: "index_trainees_on_progress", using: :gin
     t.index ["provider_id"], name: "index_trainees_on_provider_id"
     t.index ["record_type"], name: "index_trainees_on_record_type"
+    t.index ["slug"], name: "index_trainees_on_slug", unique: true
     t.index ["state"], name: "index_trainees_on_state"
   end
 

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -6,7 +6,7 @@ module ApplicationRecordCard
   describe View do
     alias_method :component, :page
 
-    let(:trainee) { Trainee.new(id: 1, created_at: Time.zone.now) }
+    let(:trainee) { Trainee.new(created_at: Time.zone.now) }
 
     before do
       render_inline(described_class.new(record: trainee))
@@ -47,7 +47,7 @@ module ApplicationRecordCard
         { state: :withdrawn, colour: "red", text: "withdrawn" },
       ].each do |state_expectation|
         context "when state is #{state_expectation[:state]}" do
-          let(:trainee) { build(:trainee, state_expectation[:state], id: 1, created_at: Time.zone.now) }
+          let(:trainee) { build(:trainee, state_expectation[:state], created_at: Time.zone.now) }
 
           it "renders '#{state_expectation[:text]}'" do
             expect(component).to have_selector(".govuk-tag", text: state_expectation[:text])
@@ -69,12 +69,13 @@ module ApplicationRecordCard
         Timecop.freeze(Time.zone.local(2020, 1, 1)) do
           build(
             :trainee,
-            id: 1, first_names: "Teddy",
+            id: 1,
+            first_names: "Teddy",
             last_name: "Smith",
             subject: "Designer",
             record_type: "assessment_only",
             trainee_id: "132456",
-            created_at: Time.zone.now
+            created_at: Time.zone.now,
           )
         end
       end

--- a/spec/components/trainees/confirmation/contact_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/contact_details/view_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe Trainees::Confirmation::ContactDetails::View do
 
   context "when no contact details data supplied for existing trainee" do
     before(:all) do
-      @result ||= render_inline(Trainees::Confirmation::ContactDetails::View.new(trainee: Trainee.new(id: 1)))
+      @result ||= render_inline(
+        Trainees::Confirmation::ContactDetails::View.new(
+          trainee: Trainee.new,
+        ),
+      )
     end
 
     it "renders blank rows for address, email" do
@@ -72,12 +76,13 @@ RSpec.describe Trainees::Confirmation::ContactDetails::View do
 private
 
   def mock_trainee
-    @mock_trainee ||= Trainee.new(id: 1,
-                                  address_line_one: "32 Windsor Gardens",
-                                  address_line_two: "Westminster",
-                                  town_city: "London",
-                                  postcode: "EC1 9CP",
-                                  international_address: "Champ de Mars\r\n5 Avenue Anatole",
-                                  email: "Paddington@bear.com")
+    @mock_trainee ||= Trainee.new(
+      address_line_one: "32 Windsor Gardens",
+      address_line_two: "Westminster",
+      town_city: "London",
+      postcode: "EC1 9CP",
+      international_address: "Champ de Mars\r\n5 Avenue Anatole",
+      email: "Paddington@bear.com",
+    )
   end
 end

--- a/spec/components/trainees/confirmation/deferral_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/deferral_details/view_spec.rb
@@ -9,7 +9,7 @@ module Trainees
 
       alias_method :component, :page
 
-      let(:trainee) { Trainee.new(id: 1, defer_date: Time.zone.yesterday) }
+      let(:trainee) { Trainee.new(defer_date: Time.zone.yesterday) }
 
       before do
         render_inline(View.new(trainee))

--- a/spec/controllers/trainees/degrees/type_controller_spec.rb
+++ b/spec/controllers/trainees/degrees/type_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Trainees::Degrees::TypeController, type: :controller do
     let(:user) { create(:user, provider: trainee.provider) }
     let(:trainee) { create(:trainee) }
     let(:response) do
-      post(:create, params: { trainee_id: trainee.id,
+      post(:create, params: { trainee_id: trainee,
                               degree:
       { locale_code: locale_code } })
     end
@@ -19,14 +19,14 @@ RSpec.describe Trainees::Degrees::TypeController, type: :controller do
     context "uk" do
       let(:locale_code) { "uk" }
       it "redirects " do
-        expect(response).to redirect_to(new_trainee_degree_path(trainee_id: trainee.id, locale_code: locale_code))
+        expect(response).to redirect_to(new_trainee_degree_path(trainee_id: trainee, locale_code: locale_code))
       end
     end
 
     context "non_uk" do
       let(:locale_code) { "non_uk" }
       it "redirects" do
-        expect(response).to redirect_to(new_trainee_degree_path(trainee_id: trainee.id, locale_code: locale_code))
+        expect(response).to redirect_to(new_trainee_degree_path(trainee_id: trainee, locale_code: locale_code))
       end
     end
   end

--- a/spec/controllers/trainees/degrees_controller_spec.rb
+++ b/spec/controllers/trainees/degrees_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Trainees::DegreesController, type: :controller do
 
     before do
       allow(controller).to receive(:current_user).and_return(user)
-      post(:create, params: { trainee_id: trainee.id, degree: degree_params })
+      post(:create, params: { trainee_id: trainee, degree: degree_params })
     end
 
     it "creates a new degree record associated with the trainee" do

--- a/spec/controllers/trainees/qts_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/qts_recommendations_controller_spec.rb
@@ -17,13 +17,13 @@ describe Trainees::QtsRecommendationsController do
   describe "#create" do
     it "it updates the placement assignment in DTTP to mark it ready for QTS" do
       expect {
-        post :create, params: { trainee_id: trainee.id }
+        post :create, params: { trainee_id: trainee }
       }.to have_enqueued_job(RecommendForQtsJob).with(trainee.id)
     end
 
     it "redirects user to the recommended page" do
-      post :create, params: { trainee_id: trainee.id }
-      expect(response).to redirect_to(recommended_trainee_outcome_details_path(trainee_id: trainee.id))
+      post :create, params: { trainee_id: trainee }
+      expect(response).to redirect_to(recommended_trainee_outcome_details_path(trainee))
     end
   end
 end

--- a/spec/controllers/trn_submissions_controller_spec.rb
+++ b/spec/controllers/trn_submissions_controller_spec.rb
@@ -17,14 +17,14 @@ describe TrnSubmissionsController do
 
     it "queues a background job to register trainee for TRN" do
       expect {
-        post :create, params: { trainee_id: trainee.id }
+        post :create, params: { trainee_id: trainee }
       }.to have_enqueued_job(RegisterForTrnJob).with(trainee.id, current_user.dttp_id)
     end
 
     it "queues a background job to poll for the trainee's TRN" do
       Timecop.freeze(Time.zone.now) do
         expect {
-          post :create, params: { trainee_id: trainee.id }
+          post :create, params: { trainee_id: trainee }
         }.to have_enqueued_job(RetrieveTrnJob).at(RetrieveTrnJob::POLL_DELAY.from_now).with(trainee.id)
       end
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     middle_names { Faker::Name.middle_name }
     last_name { Faker::Name.last_name }
     gender { Trainee.genders.keys.sample }
+    slug { SecureRandom.base58(Sluggable::SLUG_LENGTH) }
 
     diversity_disclosure { Diversities::DIVERSITY_DISCLOSURE_ENUMS.values.sample }
     ethnic_group { Diversities::ETHNIC_GROUP_ENUMS.values.sample }

--- a/spec/features/trainees/defer_trainee_spec.rb
+++ b/spec/features/trainees/defer_trainee_spec.rb
@@ -73,7 +73,7 @@ feature "Deferring a trainee", type: :feature do
   end
 
   def and_i_am_on_the_trainee_record_page
-    record_page.load(id: trainee.id)
+    record_page.load(id: trainee.slug)
   end
 
   def and_i_click_on_defer
@@ -111,7 +111,7 @@ feature "Deferring a trainee", type: :feature do
   end
 
   def then_i_am_redirected_to_deferral_confirmation_page
-    expect(deferral_confirmation_page).to be_displayed(id: trainee.id)
+    expect(deferral_confirmation_page).to be_displayed(id: trainee.slug)
   end
 
   def given_a_trainee_exists_to_be_deferred

--- a/spec/features/trainees/degrees/adding_degree_spec.rb
+++ b/spec/features/trainees/degrees/adding_degree_spec.rb
@@ -103,13 +103,13 @@ RSpec.feature "Adding a degree" do
 private
 
   def and_i_visit_the_review_draft_page
-    review_draft_page.load(id: trainee.id)
-    expect(review_draft_page).to be_displayed(id: trainee.id)
+    review_draft_page.load(id: trainee.slug)
+    expect(review_draft_page).to be_displayed(id: trainee.slug)
   end
 
   def and_i_visit_the_record_page
-    record_page.load(id: trainee.id)
-    expect(record_page).to be_displayed(id: trainee.id)
+    record_page.load(id: trainee.slug)
+    expect(record_page).to be_displayed(id: trainee.slug)
   end
 
   def and_i_click_the_degree_on_the_review_draft_page
@@ -117,7 +117,7 @@ private
   end
 
   def when_i_visit_the_type_page
-    type_page.load(trainee_id: trainee.id)
+    type_page.load(trainee_id: trainee.slug)
   end
 
   def and_i_click_the_continue_button_on_the_type_page
@@ -179,20 +179,20 @@ private
   end
 
   def when_i_visit_the_degree_details_page
-    degree_details_page.load(trainee_id: trainee.id, locale_code: @locale)
-    expect(degree_details_page).to be_displayed(trainee_id: trainee.id, locale_code: @locale)
+    degree_details_page.load(trainee_id: trainee.slug, locale_code: @locale)
+    expect(degree_details_page).to be_displayed(trainee_id: trainee.slug, locale_code: @locale)
   end
 
   def then_i_am_redirected_to_the_record_page
-    expect(current_path).to eq("/trainees/#{trainee.id}")
+    expect(current_path).to eq("/trainees/#{trainee.slug}")
   end
 
   def then_i_am_redirected_to_the_trainee_degrees_confirmation_page
-    expect(current_path).to eq("/trainees/#{trainee.id}/degrees/confirm")
+    expect(current_path).to eq("/trainees/#{trainee.slug}/degrees/confirm")
   end
 
   def and_confirm_my_details
-    expect(confirm_details_page).to be_displayed(id: trainee.id, section: "degrees")
+    expect(confirm_details_page).to be_displayed(id: trainee.slug, section: "degrees")
     confirm_details_page.confirm.click
     confirm_details_page.continue_button.click
   end

--- a/spec/features/trainees/degrees/editing_degree_spec.rb
+++ b/spec/features/trainees/degrees/editing_degree_spec.rb
@@ -70,13 +70,13 @@ private
   end
 
   def when_i_visit_the_edit_degree_details_page
-    edit_degree_details_page.load(trainee_id: trainee.id,
+    edit_degree_details_page.load(trainee_id: trainee.slug,
                                   id: trainee.degrees.first.id)
   end
 
   def then_i_am_redirected_to_confirm_page
-    degrees_confirm.load(trainee_id: trainee.id)
-    expect(degrees_confirm).to be_displayed(trainee_id: trainee.id)
+    degrees_confirm.load(trainee_id: trainee.slug)
+    expect(degrees_confirm).to be_displayed(trainee_id: trainee.slug)
   end
 
   def then_i_see_the_error_summary

--- a/spec/features/trainees/diversities/diversity_progress_spec.rb
+++ b/spec/features/trainees/diversities/diversity_progress_spec.rb
@@ -42,14 +42,14 @@ private
 
   def and_i_visit_the_review_draft_page
     @review_draft_page ||= PageObjects::Trainees::ReviewDraft.new
-    @review_draft_page.load(id: @trainee.id)
-    expect(@review_draft_page).to be_displayed(id: @trainee.id)
+    @review_draft_page.load(id: @trainee.slug)
+    expect(@review_draft_page).to be_displayed(id: @trainee.slug)
   end
 
   def and_i_visit_the_record_page
     @record_page ||= PageObjects::Trainees::ReviewDraft.new
-    @record_page.load(id: @trainee.id)
-    expect(@record_page).to be_displayed(id: @trainee.id)
+    @record_page.load(id: @trainee.slug)
+    expect(@record_page).to be_displayed(id: @trainee.slug)
   end
 
   def then_the_diversity_section_should_be(status)
@@ -59,12 +59,12 @@ private
 
   def when_i_visit_the_diversity_confirmation_page
     @confirm_page ||= PageObjects::Trainees::Diversities::ConfirmDetails.new
-    @confirm_page.load(id: @trainee.id, section: "information-disclosed")
+    @confirm_page.load(id: @trainee.slug, section: "information-disclosed")
   end
 
   def then_i_am_redirected_to_the_confirm_page
     @confirm_page ||= PageObjects::Trainees::Diversities::ConfirmDetails.new
-    expect(@confirm_page).to be_displayed(id: @trainee.id, section: "information-disclosed")
+    expect(@confirm_page).to be_displayed(id: @trainee.slug, section: "information-disclosed")
   end
 
   def and_unconfirm_my_details

--- a/spec/features/trainees/diversities/edit_disabilities_spec.rb
+++ b/spec/features/trainees/diversities/edit_disabilities_spec.rb
@@ -29,7 +29,7 @@ feature "edit disability details", type: :feature do
 
   def when_i_visit_the_disability_details_page
     @disabilities_page ||= PageObjects::Trainees::Diversities::Disabilities.new
-    @disabilities_page.load(id: trainee.id)
+    @disabilities_page.load(id: trainee.slug)
   end
 
   def and_i_choose_a_disability
@@ -42,7 +42,7 @@ feature "edit disability details", type: :feature do
 
   def and_confirm_my_details
     @confirm_page ||= PageObjects::Trainees::Diversities::ConfirmDetails.new
-    expect(@confirm_page).to be_displayed(id: trainee.id, section: "disabilities")
+    expect(@confirm_page).to be_displayed(id: trainee.slug, section: "disabilities")
     @confirm_page.submit_button.click
   end
 

--- a/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
@@ -35,7 +35,7 @@ private
 
   def when_i_visit_the_disability_disclosure_page
     @disability_disclosure_page ||= PageObjects::Trainees::Diversities::DisabilityDisclosure.new
-    @disability_disclosure_page.load(id: trainee.id)
+    @disability_disclosure_page.load(id: trainee.slug)
   end
 
   def and_i_choose_to_disclose
@@ -52,13 +52,13 @@ private
 
   def and_confirm_my_details
     @confirm_page ||= PageObjects::Trainees::Diversities::ConfirmDetails.new
-    expect(@confirm_page).to be_displayed(id: trainee.id, section: "disability-disclosure")
+    expect(@confirm_page).to be_displayed(id: trainee.slug, section: "disability-disclosure")
     @confirm_page.submit_button.click
   end
 
   def then_i_am_redirected_to_the_disabilities_page
     @disabilities_page ||= PageObjects::Trainees::Diversities::Disabilities.new
-    expect(@disabilities_page).to be_displayed(id: trainee.id)
+    expect(@disabilities_page).to be_displayed(id: trainee.slug)
   end
 
   def and_the_disability_disclosure_is_updated

--- a/spec/features/trainees/diversities/edit_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disclosure_spec.rb
@@ -31,7 +31,7 @@ feature "edit diversity disclosure", type: :feature do
 
   def when_i_visit_the_diversity_disclosure_page
     @disclosure_page ||= PageObjects::Trainees::Diversities::Disclosure.new
-    @disclosure_page.load(id: trainee.id)
+    @disclosure_page.load(id: trainee.slug)
   end
 
   def and_i_choose_to_disclose
@@ -48,13 +48,13 @@ feature "edit diversity disclosure", type: :feature do
 
   def and_confirm_my_details
     @confirm_page ||= PageObjects::Trainees::Diversities::ConfirmDetails.new
-    expect(@confirm_page).to be_displayed(id: trainee.id, section: "information-disclosed")
+    expect(@confirm_page).to be_displayed(id: trainee.slug, section: "information-disclosed")
     @confirm_page.submit_button.click
   end
 
   def then_i_am_redirected_to_the_ethnic_group_page
     @ethnic_group ||= PageObjects::Trainees::Diversities::EthnicGroup.new
-    expect(@ethnic_group).to be_displayed(id: trainee.id)
+    expect(@ethnic_group).to be_displayed(id: trainee.slug)
   end
 
   def and_the_diversity_disclosure_is_updated

--- a/spec/features/trainees/diversities/edit_ethnic_background_spec.rb
+++ b/spec/features/trainees/diversities/edit_ethnic_background_spec.rb
@@ -49,7 +49,7 @@ feature "edit ethnic background", type: :feature do
 
   def when_i_visit_the_diversity_ethnic_background_page
     @ethnic_background_page ||= PageObjects::Trainees::Diversities::EthnicBackground.new
-    @ethnic_background_page.load(id: @trainee.id)
+    @ethnic_background_page.load(id: @trainee.slug)
   end
 
   def and_i_choose_a_background(background)
@@ -62,7 +62,7 @@ feature "edit ethnic background", type: :feature do
 
   def then_i_am_redirected_to_the_disability_disclosure_page
     @disability_disclosure_page ||= PageObjects::Trainees::Diversities::DisabilityDisclosure.new
-    expect(@disability_disclosure_page).to be_displayed(id: trainee.id)
+    expect(@disability_disclosure_page).to be_displayed(id: trainee.slug)
   end
 
   def and_the_diversity_ethnic_background_is_updated_with(background)

--- a/spec/features/trainees/diversities/edit_ethnic_group_spec.rb
+++ b/spec/features/trainees/diversities/edit_ethnic_group_spec.rb
@@ -75,7 +75,7 @@ feature "edit ethnic group", type: :feature do
 
   def when_i_visit_the_diversity_ethnic_group_page
     @ethnic_group_page ||= PageObjects::Trainees::Diversities::EthnicGroup.new
-    @ethnic_group_page.load(id: trainee.id)
+    @ethnic_group_page.load(id: trainee.slug)
   end
 
   def and_i_choose(option)
@@ -90,12 +90,12 @@ feature "edit ethnic group", type: :feature do
 
   def then_i_am_redirected_to_the_ethnic_background_page
     @ethnic_background_page ||= PageObjects::Trainees::Diversities::EthnicBackground.new
-    expect(@ethnic_background_page).to be_displayed(id: trainee.id)
+    expect(@ethnic_background_page).to be_displayed(id: trainee.slug)
   end
 
   def then_i_am_redirected_to_the_disability_disclosure_page
     @disability_disclosure_page ||= PageObjects::Trainees::Diversities::DisabilityDisclosure.new
-    expect(@disability_disclosure_page).to be_displayed(id: trainee.id)
+    expect(@disability_disclosure_page).to be_displayed(id: trainee.slug)
   end
 
   def and_the_diversity_ethnic_group_is_updated_with(selected_group)

--- a/spec/features/trainees/edit_contact_details_spec.rb
+++ b/spec/features/trainees/edit_contact_details_spec.rb
@@ -26,7 +26,7 @@ feature "edit contact details", type: :feature do
 
   def when_i_visit_the_contact_details_page
     @contact_details_page ||= PageObjects::Trainees::ContactDetails.new
-    @contact_details_page.load(id: trainee.id)
+    @contact_details_page.load(id: trainee.slug)
   end
 
   def and_i_enter_valid_parameters
@@ -41,7 +41,7 @@ feature "edit contact details", type: :feature do
 
   def and_confirm_my_details
     @confirm_page ||= PageObjects::Trainees::ConfirmDetails.new
-    expect(@confirm_page).to be_displayed(id: trainee.id, section: "contact-details")
+    expect(@confirm_page).to be_displayed(id: trainee.slug, section: "contact-details")
     @confirm_page.submit_button.click
   end
 

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -85,7 +85,7 @@ private
 
   def when_i_visit_the_personal_details_page
     @personal_details_page ||= PageObjects::Trainees::PersonalDetails.new
-    @personal_details_page.load(id: trainee.id)
+    @personal_details_page.load(id: trainee.slug)
   end
 
   def and_i_enter_valid_parameters(other_nationality: false)
@@ -103,7 +103,7 @@ private
 
   def and_confirm_my_details(checked: true)
     checked_option = checked ? "check" : "uncheck"
-    expect(confirm_page).to be_displayed(id: trainee.id, section: "personal-details")
+    expect(confirm_page).to be_displayed(id: trainee.slug, section: "personal-details")
     confirm_page.confirm.public_send(checked_option)
     and_i_click_continue
   end
@@ -134,12 +134,12 @@ private
   end
 
   def then_the_personal_details_section_should_be_completed
-    review_draft_page.load(id: trainee.id)
+    review_draft_page.load(id: trainee.slug)
     expect(review_draft_page.personal_details.status.text).to eq(Progress::STATUSES[:completed])
   end
 
   def then_the_personal_details_section_should_be_in_progress
-    review_draft_page.load(id: trainee.id)
+    review_draft_page.load(id: trainee.slug)
     expect(review_draft_page.personal_details.status.text).to eq(Progress::STATUSES[:in_progress])
   end
 

--- a/spec/features/trainees/edit_programme_details_spec.rb
+++ b/spec/features/trainees/edit_programme_details_spec.rb
@@ -10,7 +10,7 @@ feature "programme details", type: :feature do
 
   describe "tracking the progress" do
     scenario "renders a 'not started' status when no details provided" do
-      review_draft_page.load(id: trainee.id)
+      review_draft_page.load(id: trainee.slug)
       and_the_section_should_be(:not_started)
     end
 
@@ -54,7 +54,7 @@ feature "programme details", type: :feature do
 
   def when_i_visit_the_programme_details_page
     @programme_details_page ||= PageObjects::Trainees::ProgrammeDetails.new
-    @programme_details_page.load(id: trainee.id)
+    @programme_details_page.load(id: trainee.slug)
   end
 
   def and_i_enter_valid_parameters
@@ -76,11 +76,11 @@ feature "programme details", type: :feature do
   end
 
   def and_i_visit_the_record_page
-    record_page.load(id: trainee.id)
+    record_page.load(id: trainee.slug)
   end
 
   def then_i_am_redirected_to_the_record_page
-    expect(record_page).to be_displayed(id: trainee.id)
+    expect(record_page).to be_displayed(id: trainee.slug)
   end
 
   def and_the_programme_details_are_updated
@@ -131,12 +131,12 @@ feature "programme details", type: :feature do
   end
 
   def then_i_am_redirected_to_the_confirm_page
-    expect(confirm_details_page).to be_displayed(id: trainee.id, section: programme_details_section)
+    expect(confirm_details_page).to be_displayed(id: trainee.slug, section: programme_details_section)
   end
 
   def and_i_visit_the_review_draft_page
-    review_draft_page.load(id: trainee.id)
-    expect(review_draft_page).to be_displayed(id: trainee.id)
+    review_draft_page.load(id: trainee.slug)
+    expect(review_draft_page).to be_displayed(id: trainee.slug)
   end
 
 private

--- a/spec/features/trainees/edit_trainee_id_spec.rb
+++ b/spec/features/trainees/edit_trainee_id_spec.rb
@@ -22,7 +22,7 @@ feature "edit Trainee ID" do
 
   def when_i_visit_the_edit_trainee_id_page
     @edit_page ||= PageObjects::Trainees::EditTraineeId.new
-    @edit_page.load(trainee_id: trainee.id)
+    @edit_page.load(trainee_id: trainee.slug)
   end
 
   def when_i_change_the_trainee_id
@@ -34,7 +34,7 @@ feature "edit Trainee ID" do
   end
 
   def then_i_am_taken_to_the_confirmation_page
-    expect(page.current_path).to eq("/trainees/#{trainee.id}/trainee-id/confirm")
+    expect(page.current_path).to eq("/trainees/#{trainee.slug}/trainee-id/confirm")
   end
 
   def when_i_confirm
@@ -43,7 +43,7 @@ feature "edit Trainee ID" do
   end
 
   def then_i_am_redirected_to_the_trainee_edit_page
-    expect(page.current_path).to eq("/trainees/#{trainee.id}")
+    expect(page.current_path).to eq("/trainees/#{trainee.slug}")
   end
 
   def then_the_trainee_id_is_updated

--- a/spec/features/trainees/edit_trainee_record_spec.rb
+++ b/spec/features/trainees/edit_trainee_record_spec.rb
@@ -50,7 +50,7 @@ feature "edit trainee record", type: :feature do
 
   def when_i_visit_the_trainee_record_page
     @record_page ||= PageObjects::Trainees::Record.new
-    @record_page.load(id: trainee.id)
+    @record_page.load(id: trainee.slug)
   end
 
   def then_i_see_the_record_details

--- a/spec/features/trainees/edit_training_details_spec.rb
+++ b/spec/features/trainees/edit_training_details_spec.rb
@@ -17,7 +17,7 @@ feature "edit training details" do
 
   def when_i_visit_the_training_details_page
     @training_details_page ||= PageObjects::Trainees::TrainingDetails.new
-    @training_details_page.load(id: trainee.id)
+    @training_details_page.load(id: trainee.slug)
   end
 
   def and_i_update_the_training_details
@@ -26,7 +26,7 @@ feature "edit training details" do
   end
 
   def then_i_am_redirected_to_the_record_page
-    expect(record_page).to be_displayed(id: trainee.id)
+    expect(record_page).to be_displayed(id: trainee.slug)
   end
 
   def and_the_training_details_are_updated

--- a/spec/features/trainees/recommending_for_qts_spec.rb
+++ b/spec/features/trainees/recommending_for_qts_spec.rb
@@ -21,7 +21,7 @@ feature "Recommending for QTS", type: :feature do
   end
 
   def when_i_record_the_outcome_date
-    outcome_date_page.load(trainee_id: trainee.id)
+    outcome_date_page.load(trainee_id: trainee.slug)
     outcome_date_page.choose("Today")
     outcome_date_page.continue.click
   end

--- a/spec/features/trainees/recording_training_outcome_spec.rb
+++ b/spec/features/trainees/recording_training_outcome_spec.rb
@@ -72,7 +72,7 @@ feature "Recording a training outcome", type: :feature do
   end
 
   def and_i_am_on_the_trainee_record_page
-    record_page.load(id: trainee.id)
+    record_page.load(id: trainee.slug)
   end
 
   def and_i_click_on_record_training_outcome
@@ -100,7 +100,7 @@ feature "Recording a training outcome", type: :feature do
   end
 
   def then_i_am_redirected_to_the_confirm_page
-    expect(confirm_page).to be_displayed(id: trainee.id)
+    expect(confirm_page).to be_displayed(id: trainee.slug)
   end
 
   def and_the_outcome_date_is_updated

--- a/spec/features/trainees/submit_for_trn_spec.rb
+++ b/spec/features/trainees/submit_for_trn_spec.rb
@@ -67,7 +67,7 @@ feature "submit for TRN" do
   end
 
   def when_i_am_viewing_the_review_draft_page
-    review_draft_page.load(id: trainee.id)
+    review_draft_page.load(id: trainee.slug)
   end
 
   def and_i_want_to_review_record_before_submitting_for_trn
@@ -79,7 +79,7 @@ feature "submit for TRN" do
   end
 
   def then_i_review_the_trainee_data
-    expect(check_details_page).to be_displayed(id: trainee.id)
+    expect(check_details_page).to be_displayed(id: trainee.slug)
   end
 
   def and_i_click_the_submit_for_trn_button
@@ -87,7 +87,7 @@ feature "submit for TRN" do
   end
 
   def and_i_am_redirected_to_the_success_page
-    expect(trn_success_page).to be_displayed(trainee_id: trainee.id)
+    expect(trn_success_page).to be_displayed(trainee_id: trainee.slug)
   end
 
   def check_details_page
@@ -95,7 +95,7 @@ feature "submit for TRN" do
   end
 
   def and_i_am_on_the_check_details_page
-    check_details_page.load(id: trainee.id)
+    check_details_page.load(id: trainee.slug)
   end
 
   def trn_success_page

--- a/spec/features/trainees/viewing_an_existing_trainee_spec.rb
+++ b/spec/features/trainees/viewing_an_existing_trainee_spec.rb
@@ -27,6 +27,6 @@ feature "View trainees" do
 
   def then_i_should_see_the_trainee_details
     @review_draft_page ||= PageObjects::Trainees::ReviewDraft.new
-    expect(@review_draft_page).to be_displayed(id: trainee.id)
+    expect(@review_draft_page).to be_displayed(id: trainee.slug)
   end
 end

--- a/spec/features/trainees/viewing_the_timeline_spec.rb
+++ b/spec/features/trainees/viewing_the_timeline_spec.rb
@@ -28,7 +28,7 @@ feature "View the timeline" do
   end
 
   def then_i_should_see_the_trainee_timeline
-    expect(timeline_page).to be_displayed(id: trainee.id)
+    expect(timeline_page).to be_displayed(id: trainee.slug)
   end
 
   def record_page

--- a/spec/features/trainees/withdraw_trainee_spec.rb
+++ b/spec/features/trainees/withdraw_trainee_spec.rb
@@ -99,7 +99,7 @@ feature "Withdrawing a trainee", type: :feature do
   end
 
   def and_i_am_on_the_trainee_record_page
-    record_page.load(id: trainee.id)
+    record_page.load(id: trainee.slug)
   end
 
   def when_i_choose(option)
@@ -168,7 +168,7 @@ feature "Withdrawing a trainee", type: :feature do
   end
 
   def then_i_am_redirected_to_withdrawal_confirmation_page
-    expect(withdrawal_confirmation_page).to be_displayed(id: trainee.id)
+    expect(withdrawal_confirmation_page).to be_displayed(id: trainee.slug)
   end
 
   def and_the_withdraw_date_and_reason_is_updated

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -46,6 +46,27 @@ describe Trainee do
     it { is_expected.to have_many(:disabilities).through(:trainee_disabilities) }
   end
 
+  context "validations" do
+    context "slug" do
+      subject { create(:trainee) }
+
+      it { is_expected.to validate_uniqueness_of(:slug).case_insensitive }
+
+      context "immutability" do
+        let(:original_slug) { subject.slug.dup }
+
+        before do
+          subject.regenerate_slug
+          subject.reload
+        end
+
+        it "is immutable once created" do
+          expect(subject.slug).to eq(original_slug)
+        end
+      end
+    end
+  end
+
   context "class methods" do
     describe ".dttp_id" do
       let(:uuid) { "2795182a-43b2-4543-bf83-ad95fbfce7fd" }

--- a/spec/support/features/trainee_steps.rb
+++ b/spec/support/features/trainee_steps.rb
@@ -17,7 +17,7 @@ module Features
     end
 
     def then_i_am_redirected_to_the_record_page
-      expect(record_page).to be_displayed(id: trainee.id)
+      expect(record_page).to be_displayed(id: trainee.slug)
     end
 
     def trainee_index_page
@@ -38,7 +38,7 @@ module Features
 
     def and_i_confirm_my_details(checked: true, section:)
       checked_option = checked ? "check" : "uncheck"
-      expect(confirm_details_page).to be_displayed(id: trainee.id, section: section)
+      expect(confirm_details_page).to be_displayed(id: trainee.slug, section: section)
       confirm_details_page.confirm.public_send(checked_option)
       confirm_details_page.submit_button.click
     end


### PR DESCRIPTION
### Context

- Implement a slug field to be used as the trainee id instead of the current integer-based `id`
- Builds on the work done in this spike https://github.com/DFE-Digital/register-trainee-teachers/pull/358

### Changes proposed in this pull request

- Fixes broken tests
- Make the slug unique and required
- A couple of migrations to create the field, set the slug on current records and make the field not nullable
- Slugs for the degrees will be dealt with in a different ticket.
- Make slugs immutable with `attr_readonly` will allow a value to be set on a new record but avoids updating a specific field.

### Guidance to review

- Fire up the app locally and run through the app as normal. Assert the trainee's slug is used instead of the `id` in URLs.

