### PR TITLE
[827] Add display logic for flash messages

### DIFF
--- a/app/components/flash_banner/view.html.erb
+++ b/app/components/flash_banner/view.html.erb
@@ -1,5 +1,5 @@
-<% if !flash.empty? %>
-  <% flash_types.each do |type| %>
+<% if display? %>
+  <% FLASH_TYPES.each do |type| %>
     <% if flash[type] %>
       <%= render(NotificationBanner::View.new(text: flash[type], type: type))%>
     <% end %>

--- a/app/components/flash_banner/view.rb
+++ b/app/components/flash_banner/view.rb
@@ -2,16 +2,28 @@
 
 module FlashBanner
   class View < GovukComponent::Base
-    attr_reader :flash
+    attr_reader :flash, :trainee, :referer
 
-    def initialize(flash:)
+    FLASH_TYPES = %i[success warning info].freeze
+
+    def initialize(flash:, trainee:, referer:)
       @flash = flash
+      @trainee = trainee
+      @referer = referer
+    end
+
+    def display?
+      flash.any? && (non_draft_trainee? || degree_deleted?)
     end
 
   private
 
-    def flash_types
-      %w[warning info success]
+    def non_draft_trainee?
+      !trainee&.draft?
+    end
+
+    def degree_deleted?
+      referer&.include?("degrees/confirm")
     end
   end
 end

--- a/app/components/notification_banner/view.rb
+++ b/app/components/notification_banner/view.rb
@@ -4,8 +4,6 @@ module NotificationBanner
   class View < GovukComponent::Base
     attr_reader :text, :title_id
 
-    SUCCESS_TYPE = "success"
-
     SUCCESS_TITLE = "Success"
     DEFAULT_TITLE = "Important"
 
@@ -69,7 +67,7 @@ module NotificationBanner
     end
 
     def success_banner?
-      type == SUCCESS_TYPE
+      type == :success
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
     <main class="govuk-main-wrapper " id="main-content" role="main">
       <%= yield :start_page_banner %>
       <div class="govuk-width-container">
-        <%= render(FlashBanner::View.new(flash: flash)) %>
+        <%= render(FlashBanner::View.new(flash: flash, trainee: @trainee, referer: request.referer)) %>
         <%= yield %>
       </div>
     </main>

--- a/spec/components/notification_banner/view_spec.rb
+++ b/spec/components/notification_banner/view_spec.rb
@@ -35,7 +35,7 @@ module NotificationBanner
     end
 
     context "when type is success" do
-      before { render_inline(View.new(type: "success")) }
+      before { render_inline(View.new(type: :success)) }
 
       it "adds the success type class" do
         expect(component).to have_selector(".govuk-notification-banner--success")

--- a/spec/features/trainees/diversities/edit_disabilities_spec.rb
+++ b/spec/features/trainees/diversities/edit_disabilities_spec.rb
@@ -15,7 +15,6 @@ feature "edit disability details", type: :feature do
     and_i_submit_the_form
     and_confirm_my_details
     then_i_am_redirected_to_the_summary_page
-    then_i_see_a_flash_message
     and_the_disability_details_are_updated
   end
 
@@ -57,9 +56,5 @@ feature "edit disability details", type: :feature do
         "activemodel.errors.models.diversities/disability_detail_form.attributes.disability_ids.empty_disabilities",
       ),
     )
-  end
-
-  def then_i_see_a_flash_message
-    expect(page).to have_text("Trainee disabilities updated")
   end
 end

--- a/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
@@ -22,7 +22,6 @@ feature "edit disability disclosure", type: :feature do
     and_i_submit_the_form
     and_confirm_my_details
     then_i_am_redirected_to_the_summary_page
-    then_i_see_a_flash_message
     and_the_disability_disclosure_is_updated
   end
 
@@ -70,9 +69,5 @@ private
     expect(page).to have_content(
       I18n.t("activemodel.errors.models.diversities/disability_disclosure_form.attributes.disability_disclosure.blank"),
     )
-  end
-
-  def then_i_see_a_flash_message
-    expect(page).to have_text("Trainee disclosure updated")
   end
 end

--- a/spec/features/trainees/diversities/edit_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disclosure_spec.rb
@@ -21,7 +21,6 @@ feature "edit diversity disclosure", type: :feature do
     and_i_submit_the_form
     and_confirm_my_details
     then_i_am_redirected_to_the_summary_page
-    then_i_see_a_flash_message
     and_the_diversity_disclosure_is_updated
   end
 
@@ -64,9 +63,5 @@ feature "edit diversity disclosure", type: :feature do
 
   def then_i_see_error_messages
     expect(page).to have_content(I18n.t("activemodel.errors.models.diversities/disclosure_form.attributes.diversity_disclosure.blank"))
-  end
-
-  def then_i_see_a_flash_message
-    expect(page).to have_text("Trainee disclosure updated")
   end
 end

--- a/spec/features/trainees/edit_contact_details_spec.rb
+++ b/spec/features/trainees/edit_contact_details_spec.rb
@@ -14,7 +14,6 @@ feature "edit contact details", type: :feature do
     and_i_submit_the_form
     and_confirm_my_details
     then_i_am_redirected_to_the_summary_page
-    then_i_see_a_flash_message
     and_the_contact_details_are_updated
   end
 
@@ -22,7 +21,6 @@ feature "edit contact details", type: :feature do
     and_i_enter_an_international_address
     and_confirm_my_details
     then_i_am_redirected_to_the_summary_page
-    then_i_see_a_flash_message
     and_the_old_address_is_cleared
   end
 
@@ -67,9 +65,5 @@ feature "edit contact details", type: :feature do
     expect(@contact_details_page.address_line_two.value).to be_nil
     expect(@contact_details_page.town_city.value).to be_nil
     expect(@contact_details_page.postcode.value).to be_nil
-  end
-
-  def then_i_see_a_flash_message
-    expect(page).to have_text("Trainee contact details updated")
   end
 end

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -7,19 +7,16 @@ feature "edit personal details", type: :feature do
 
   scenario "updates personal details with valid data" do
     given_valid_personal_details_are_provided
-    then_i_see_a_flash_message
     then_the_personal_details_are_updated
   end
 
   scenario "updates personal details with 'other' nationality" do
     given_other_nationality_is_provided
-    then_i_see_a_flash_message
     then_the_personal_details_are_updated
   end
 
   scenario "renders a completed status when valid personal details provided" do
     given_valid_personal_details_are_provided
-    then_i_see_a_flash_message
     then_the_personal_details_section_should_be_completed
   end
 
@@ -31,7 +28,6 @@ feature "edit personal details", type: :feature do
     and_i_submit_the_form
     and_confirm_my_details(checked: false)
     then_i_am_redirected_to_the_summary_page
-    then_i_see_a_flash_message
     then_the_personal_details_section_should_be_in_progress
   end
 
@@ -45,7 +41,7 @@ feature "edit personal details", type: :feature do
 
   context "as a non-draft trainee" do
     before do
-      given_a_trainee_exists(state: :submitted_for_trn)
+      given_a_trainee_exists(:submitted_for_trn)
       and_nationalities_exist_in_the_system
       when_i_visit_the_personal_details_page
       and_i_enter_valid_parameters
@@ -56,6 +52,7 @@ feature "edit personal details", type: :feature do
       then_the_confirm_page_has_no_checkbox
       and_i_click_continue
       then_i_am_redirected_to_the_summary_page
+      then_i_see_a_flash_message
     end
   end
 

--- a/spec/features/trainees/edit_programme_details_spec.rb
+++ b/spec/features/trainees/edit_programme_details_spec.rb
@@ -40,7 +40,6 @@ feature "programme details", type: :feature do
       and_i_submit_the_form
       and_i_confirm_my_details(checked: false, section: programme_details_section)
       then_i_am_redirected_to_the_summary_page
-      then_i_see_a_flash_message
       and_the_programme_details_are_updated
     end
 

--- a/spec/features/trainees/edit_trainee_record_spec.rb
+++ b/spec/features/trainees/edit_trainee_record_spec.rb
@@ -7,7 +7,7 @@ feature "edit trainee record", type: :feature do
 
   background do
     given_i_am_authenticated
-    given_a_trainee_exists(degrees: [create(:degree, :uk_degree_with_details)])
+    given_a_trainee_exists_with_a_degree
     when_i_visit_the_trainee_edit_page
   end
 
@@ -32,9 +32,12 @@ feature "edit trainee record", type: :feature do
     scenario "removing a degree" do
       and_i_visit_the_personal_details
       and_i_remove_the_degree
-      then_i_see_a_flash_message
       then_i_should_not_see_any_degree
     end
+  end
+
+  def given_a_trainee_exists_with_a_degree
+    given_a_trainee_exists(degrees: [create(:degree, :uk_degree_with_details)])
   end
 
   def then_i_see_the_trainee_name
@@ -84,9 +87,5 @@ feature "edit trainee record", type: :feature do
 
   def then_i_should_not_see_any_degree
     expect(@edit_page.degree_detail.find_all(".govuk-summary-list__row")).to be_empty
-  end
-
-  def then_i_see_a_flash_message
-    expect(page).to have_text("Trainee degree deleted")
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/7UKKp2tp/827-flash-messages-should-not-appear-when-making-most-changes-on-draft-records

### Changes proposed in this pull request
- Update `FlashBanner::View` to only display flash messages if the trainee is in a non-draft state - the only exception is deleting degrees.
- Remove flash message assertions in some feature files as it's no longer applicable

### Guidance to review
- Visit a draft trainee pageand make various changes. Expect to see no flash messages unless you delete a degree.
- Visit a non-draft trainee page and any changes made will cause a flash message to be displayed

