### PR TITLE
[846] Add audited events to timeline

### DIFF
--- a/app/components/trainees/timeline/view.html.erb
+++ b/app/components/trainees/timeline/view.html.erb
@@ -6,7 +6,7 @@
         <h2 class="app-timeline__title"><%= event.title %></h2>
       </div>
       <p class="app-timeline__actor_and_date">
-        <%= event.actor %>,
+        <%= event.username %>,
         <time datetime="<%= event.date.to_s(:govuk_date_and_time) %>">
           <%= event.date.to_s(:govuk_date_and_time) %>
         </time>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,16 @@ en:
       state: Status
       subject: Subject
       text_search: Text search
+    timeline:
+      titles:
+        created: Record created
+        draft: Trainee marked as draft
+        submitted_for_trn: Trainee submitted for TRN
+        trn_received: Received TRN for trainee
+        recommended_for_qts: Trainee recommended for QTS
+        withdrawn: Trainee withdrawn
+        deferred: Trainee deferred
+        qts_awarded: Trainee awarded QTS
   views:
     trainees:
       edit:

--- a/spec/components/trainees/timeline/view_preview.rb
+++ b/spec/components/trainees/timeline/view_preview.rb
@@ -10,18 +10,16 @@ module Trainees
       end
 
       def submitted_for_trn
-        render Trainees::Timeline::View.new(
-          trainee(submitted_for_trn_at: Time.zone.today),
-        )
+        trainee.submit_for_trn!
+        render Trainees::Timeline::View.new(trainee)
       end
 
     private
 
-      def trainee(attrs = {})
-        Trainee.new(
+      def trainee
+        @trainee ||= Trainee.create!(
+          record_type: "assessment_only",
           provider: user.provider,
-          created_at: Time.zone.yesterday,
-          **attrs,
         )
       end
 
@@ -30,7 +28,7 @@ module Trainees
           first_name: "Tom",
           last_name: "Jones",
           email: "tom@example.com",
-          provider: Provider.create(name: "Provider A"),
+          provider: Provider.create!(name: "Provider A"),
         )
       end
     end

--- a/spec/components/trainees/timeline/view_spec.rb
+++ b/spec/components/trainees/timeline/view_spec.rb
@@ -7,36 +7,111 @@ module Trainees
     describe View do
       alias_method :component, :page
 
-      let(:trainee) { create(:trainee, trait) }
-      let!(:user) { create(:user, provider: trainee.provider) }
-
-      before do
-        render_inline(described_class.new(trainee))
-      end
-
-      shared_examples "created" do
-        it "shows when the record was created" do
-          expect(component).to have_text("Record created")
-        end
-      end
-
-      shared_examples "submitted for trn" do
-        it "shows when the record was submitted for trn" do
-          expect(component).to have_text("Trainee submitted for TRN")
-        end
-      end
+      let(:trainee) { create(:trainee) }
 
       describe "when the trainee state is" do
         context "created" do
-          let(:trait) { :draft }
-          include_examples "created"
+          before do
+            render_inline(described_class.new(trainee))
+          end
+          it "shows when the record was created" do
+            expect(component).to have_text(expected_title(:created))
+          end
         end
 
         context "submitted for trn" do
-          let(:trait) { :submitted_for_trn }
-          include_examples "created"
-          include_examples "submitted for trn"
+          before do
+            trainee.submit_for_trn!
+            render_inline(described_class.new(trainee))
+          end
+          it "shows state changes until submitted_for_trn" do
+            expect(component).to have_text(expected_title(:created))
+            expect(component).to have_text(expected_title(:submitted_for_trn))
+          end
         end
+
+        context "trn_received" do
+          before do
+            methods = %i[submit_for_trn! receive_trn!]
+            call_methods!(methods, trainee)
+            render_inline(described_class.new(trainee))
+          end
+          it "shows state changes until trn_received" do
+            expect(component).to have_text(expected_title(:created))
+            expect(component).to have_text(expected_title(:submitted_for_trn))
+            expect(component).to have_text(expected_title(:trn_received))
+          end
+        end
+
+        context "recommended_for_qts" do
+          before do
+            methods = %i[submit_for_trn! receive_trn! recommend_for_qts!]
+            call_methods!(methods, trainee)
+            render_inline(described_class.new(trainee))
+          end
+          it "shows state changes until recommended_for_qts" do
+            expect(component).to have_text(expected_title(:created))
+            expect(component).to have_text(expected_title(:submitted_for_trn))
+            expect(component).to have_text(expected_title(:trn_received))
+            expect(component).to have_text(expected_title(:recommended_for_qts))
+          end
+        end
+
+        context "withdrawn" do
+          before do
+            methods = %i[submit_for_trn! receive_trn! withdraw!]
+            call_methods!(methods, trainee)
+            render_inline(described_class.new(trainee))
+          end
+          it "shows state changes until withdrawn" do
+            expect(component).to have_text(expected_title(:created))
+            expect(component).to have_text(expected_title(:submitted_for_trn))
+            expect(component).to have_text(expected_title(:trn_received))
+            expect(component).to have_text(expected_title(:withdrawn))
+          end
+        end
+
+        context "deferred" do
+          before do
+            methods = %i[submit_for_trn! receive_trn! defer!]
+            call_methods!(methods, trainee)
+            render_inline(described_class.new(trainee))
+          end
+          it "shows state changes until deferred" do
+            expect(component).to have_text(expected_title(:created))
+            expect(component).to have_text(expected_title(:submitted_for_trn))
+            expect(component).to have_text(expected_title(:trn_received))
+            expect(component).to have_text(expected_title(:deferred))
+          end
+        end
+
+        context "qts_awarded" do
+          before do
+            methods = %i[submit_for_trn! receive_trn! recommend_for_qts! award_qts!]
+            call_methods!(methods, trainee)
+            render_inline(described_class.new(trainee))
+          end
+
+          it "shows state changes until qts_awarded" do
+            expect(component).to have_text(expected_title(:created))
+            expect(component).to have_text(expected_title(:submitted_for_trn))
+            expect(component).to have_text(expected_title(:trn_received))
+            expect(component).to have_text(expected_title(:qts_awarded))
+          end
+        end
+      end
+
+      # Helper method to transfer the trainee through the various states in
+      # order.
+      def call_methods!(methods, trainee)
+        methods.each_with_object(trainee) do |method, t|
+          t.public_send(method)
+          t
+        end
+      end
+
+      def expected_title(value)
+        I18n.t("components.timeline.titles.#{value}")
       end
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/CqbL1jQ7/846-l-add-audited-events-to-timeline-component

### Changes proposed in this pull request

Pulls events from the audit log for trainees onto the timeline.

Notes:
- The 'Record created' timeline entry is now being pulled from the audit log (rather than the `created_at` timestamp) so that we can grab the user who created it.
  - We _could_ fallback on the `created_at` timestamp if there's no audit, but there should always be an audit going forward.
- Because all the trainee transitions happen in background jobs there will be no user in the audits i.e. we don't know who kicked off the job.
  - We could track this by passing the `current_user` to the bg job and then 'comment' the audit, but this is probably out of scope for this ticket.
  - For now, I'm falling back on the provider's name.

<img width="832" alt="Screenshot 2021-01-19 at 12 31 35" src="https://user-images.githubusercontent.com/18436946/105035243-92b3b100-5a52-11eb-87f7-268fda433228.png">



### Guidance to review

**If you have trainees that have transitioned through states _after_ the audit gem was configured:**
- Head to `/trainees/:id/timeline`
- Check that the correct state transitions are visible

**If not:**

- Create a trainee
- Manually transition them through some states (you'll need to do this from the command line)
- Head to `/trainees/:id/timeline`
- Check that the correct state transitions are visible
