### PR TITLE
[888] active section for navigation bar

### DIFF
--- a/app/components/navigation_bar/view.html.erb
+++ b/app/components/navigation_bar/view.html.erb
@@ -1,18 +1,15 @@
-<% if user_signed_in? %>
-  <div class="moj-primary-navigation">
+ <div class="moj-primary-navigation">
     <div class="moj-primary-navigation__container">
       <div class="moj-primary-navigation__nav">
         <nav class="moj-primary-navigation" aria-label="Primary navigation">
           <ul class="moj-primary-navigation__list">
+            <% items.each do |item| %>
             <li class="moj-primary-navigation__item">
-              <%= govuk_link_to "Home", home_path, { class: "moj-primary-navigation__link" } %>
+              <%= item_link(item) %>
             </li>
-            <li class ="moj-primary-navigation__item">
-              <%= govuk_link_to "Trainee records", trainees_path, { class: "moj-primary-navigation__link" } %>
-            </li>
+          <% end %>
           </ul>
         </nav>
       </div>
     </div>
   </div>
-<% end %>

--- a/app/components/navigation_bar/view.rb
+++ b/app/components/navigation_bar/view.rb
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
 
 class NavigationBar::View < GovukComponent::Base
-  def initialize(current_user)
-    @current_user = current_user
+  attr_reader :items, :current_path
+
+  def initialize(items:, current_path:)
+    @items = items
+    @current_path = current_path
   end
 
-  def user_signed_in?
-    @current_user.present?
+  def item_link(item)
+    link_params = { class: "moj-primary-navigation__link" }
+    link_params.merge!(aria: { current: "page" }) if show_current_link?(item)
+    govuk_link_to(item[:name], item[:url], link_params)
+  end
+
+private
+
+  def show_current_link?(item)
+    item.fetch(:current, false) || current_path == item.fetch(:url)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   include Pundit
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
 
+  helper_method :current_user, :authenticated?
+
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
 private

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module NavigationHelper
+  def trainee_link_is_current?
+    url = request.path_info
+    url.include?("/trainees")
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,15 @@
 
     <%= render(Header::View.new(I18n.t('service_name'), @current_user)) %>
 
-    <%= render NavigationBar::View.new(@current_user) %>
+    <% if authenticated? %>
+      <%= render NavigationBar::View.new(
+        items: [
+          {name: "Home", url: home_path},
+          {name: "Trainee records", url: trainees_path, current: trainee_link_is_current? }
+        ],
+        current_path: request.path,
+      ) %>
+    <% end %>
 
     <div class="app-phase-banner">
       <div class="govuk-width-container">

--- a/spec/components/navigation_bar/view_spec.rb
+++ b/spec/components/navigation_bar/view_spec.rb
@@ -6,28 +6,77 @@ module NavigationBar
   describe View do
     alias_method :component, :page
 
+    let(:item_url) { "https://www.gov.uk" }
+    let(:current_path) { item_url }
+
     before do
-      render_inline(described_class.new(user))
+      render_inline(described_class.new(items: items, current_path: current_path))
     end
 
-    context "when user is not signed in" do
-      let(:user) { nil }
-
-      it "does not render the navigation bar" do
-        expect(component).to_not have_css(".moj-primary-navigation")
-      end
-    end
-
-    context "when user is signed in" do
-      let(:user) { build(:user) }
-
-      it "renders the navigation bar" do
-        expect(component).to have_css(".moj-primary-navigation")
+    context "multiple links" do
+      let(:items) do
+        [
+          { name: "Home", url: item_url },
+          { name: "Trainee records", url: item_url },
+        ]
       end
 
       it "has two change links" do
         expect(component).to have_link("Home")
         expect(component).to have_link("Trainee records")
+      end
+    end
+
+    context "where item current is true" do
+      let(:current_item) { { name: "Bulk actions", url: item_url, current: true } }
+      let(:current_path) { "http://www.google.com" }
+      let(:items) { [current_item] }
+
+      it "renders the link with aria-current" do
+        rendered_link = component.find(".moj-primary-navigation__link", text: current_item[:name])
+        expect(rendered_link["aria-current"]).to eq("page")
+      end
+    end
+
+    context "where item current is false" do
+      let(:non_current_item) { { name: "Trainee records", url: item_url, current: false } }
+      let(:items) { [non_current_item] }
+
+      context "when not on the current url" do
+        let(:current_path) { "http://www.google.com" }
+
+        it "renders the link without aria-current" do
+          rendered_link = component.find(".moj-primary-navigation__link", text: non_current_item[:name])
+          expect(rendered_link["aria-current"]).to eq(nil)
+        end
+      end
+
+      context "when on the current url" do
+        it "renders the link with aria-current" do
+          rendered_link = component.find(".moj-primary-navigation__link", text: non_current_item[:name])
+          expect(rendered_link["aria-current"]).to eq("page")
+        end
+      end
+    end
+
+    context "where item current is not set" do
+      let(:no_current_item) { { name: "Trainee records", url: item_url } }
+      let(:items) { [no_current_item] }
+
+      context "when not on the current url" do
+        let(:current_path) { "http://www.google.com" }
+
+        it "renders the link without aria-current" do
+          rendered_link = component.find(".moj-primary-navigation__link", text: no_current_item[:name])
+          expect(rendered_link["aria-current"]).to eq(nil)
+        end
+      end
+
+      context "when on the current url" do
+        it "renders the link with aria-current" do
+          rendered_link = component.find(".moj-primary-navigation__link", text: no_current_item[:name])
+          expect(rendered_link["aria-current"]).to eq("page")
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

We have a nav bar. It has links. They need a blue bar under them if they're active.

### Changes proposed in this pull request

Add active link styling when the page is current or the link is explicitly marked as current. This allows us to underline 'Trainees' for all trainee pages.

### Guidance to review

