### PR TITLE
[886] Implement slugs on degrees

### DIFF
--- a/app/controllers/trainees/degrees_controller.rb
+++ b/app/controllers/trainees/degrees_controller.rb
@@ -9,7 +9,7 @@ module Trainees
 
     def edit
       authorize trainee
-      @degree = trainee.degrees.find(params[:id])
+      @degree = trainee.degrees.find_by(slug: params[:id])
     end
 
     def create
@@ -24,7 +24,7 @@ module Trainees
 
     def update
       authorize trainee
-      @degree = trainee.degrees.find(params[:id])
+      @degree = trainee.degrees.find_by(slug: params[:id])
       @degree.assign_attributes(degree_params)
       if @degree.save(context: @degree.locale_code.to_sym)
         redirect_to trainee_degrees_confirm_path(trainee)
@@ -34,7 +34,7 @@ module Trainees
     end
 
     def destroy
-      trainee.degrees.destroy(trainee.degrees.find(params[:id]))
+      trainee.degrees.destroy(trainee.degrees.find_by(slug: params[:id]))
       flash[:success] = "Trainee degree deleted"
       redirect_to trainee_personal_details_path(@trainee)
     end

--- a/app/controllers/trainees/degrees_controller.rb
+++ b/app/controllers/trainees/degrees_controller.rb
@@ -9,7 +9,7 @@ module Trainees
 
     def edit
       authorize trainee
-      @degree = trainee.degrees.find_by(slug: params[:id])
+      @degree = trainee.degrees.from_param(params[:id])
     end
 
     def create
@@ -24,7 +24,7 @@ module Trainees
 
     def update
       authorize trainee
-      @degree = trainee.degrees.find_by(slug: params[:id])
+      @degree = trainee.degrees.from_param(params[:id])
       @degree.assign_attributes(degree_params)
       if @degree.save(context: @degree.locale_code.to_sym)
         redirect_to trainee_degrees_confirm_path(trainee)
@@ -34,7 +34,7 @@ module Trainees
     end
 
     def destroy
-      trainee.degrees.destroy(trainee.degrees.find_by(slug: params[:id]))
+      trainee.degrees.destroy(trainee.degrees.from_param(params[:id]))
       flash[:success] = "Trainee degree deleted"
       redirect_to trainee_personal_details_path(@trainee)
     end

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -5,11 +5,11 @@ module Sluggable
   SLUG_LENGTH = 24
 
   included do
-    attr_readonly :slug
-
     has_secure_token :slug
 
     after_initialize :generate_slug, if: -> { slug.blank? }
+
+    validates :slug, presence: true, uniqueness: { case_sensitive: false }
   end
 
   def to_param

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Degree < ApplicationRecord
+  include Sluggable
+
   validates :locale_code, presence: true
   validates :uk_degree, presence: true, on: :uk
   validates :country, presence: true, on: :non_uk

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -15,7 +15,6 @@ class Trainee < ApplicationRecord
 
   validates :record_type, presence: { message: "You must select a route" }
   validates :trainee_id, length: { maximum: 100, message: "Your entry must not exceed 100 characters" }
-  validates :slug, presence: true, uniqueness: { case_sensitive: false }
 
   enum record_type: { assessment_only: 0, provider_led: 1 }
   enum locale_code: { uk: 0, non_uk: 1 }

--- a/db/migrate/20210120140220_add_slug_to_degrees.rb
+++ b/db/migrate/20210120140220_add_slug_to_degrees.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSlugToDegrees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :degrees, :slug, :string
+    add_index :degrees, :slug, unique: true
+  end
+end

--- a/db/migrate/20210120140234_regenerate_slugs_on_degrees.rb
+++ b/db/migrate/20210120140234_regenerate_slugs_on_degrees.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RegenerateSlugsOnDegrees < ActiveRecord::Migration[6.1]
+  def up
+    Degree.all.each(&:regenerate_slug)
+  end
+
+  def down
+    Degree.update_all(slug: nil)
+  end
+end

--- a/db/migrate/20210120140248_change_slug_nullability_on_degrees.rb
+++ b/db/migrate/20210120140248_change_slug_nullability_on_degrees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeSlugNullabilityOnDegrees < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :degrees, :slug, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_18_133452) do
+ActiveRecord::Schema.define(version: 2021_01_20_140248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,7 +50,9 @@ ActiveRecord::Schema.define(version: 2021_01_18_133452) do
     t.string "grade"
     t.string "country"
     t.text "other_grade"
+    t.string "slug", null: false
     t.index ["locale_code"], name: "index_degrees_on_locale_code"
+    t.index ["slug"], name: "index_degrees_on_slug", unique: true
     t.index ["trainee_id"], name: "index_degrees_on_trainee_id"
   end
 

--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
 
     uk_degree_type
 
+    slug { SecureRandom.base58(Sluggable::SLUG_LENGTH) }
+
     trait :uk_degree_type do
       locale_code { :uk }
       uk_degree { Dttp::CodeSets::DegreeTypes::MAPPING.keys.sample }

--- a/spec/features/trainees/degrees/editing_degree_spec.rb
+++ b/spec/features/trainees/degrees/editing_degree_spec.rb
@@ -71,7 +71,7 @@ private
 
   def when_i_visit_the_edit_degree_details_page
     edit_degree_details_page.load(trainee_id: trainee.slug,
-                                  id: trainee.degrees.first.id)
+                                  id: trainee.degrees.first.slug)
   end
 
   def then_i_am_redirected_to_confirm_page

--- a/spec/models/degree_spec.rb
+++ b/spec/models/degree_spec.rb
@@ -60,5 +60,11 @@ RSpec.describe Degree, type: :model do
         end
       end
     end
+
+    context "slug" do
+      subject { create(:degree) }
+
+      it { is_expected.to validate_uniqueness_of(:slug).case_insensitive }
+    end
   end
 end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -51,19 +51,6 @@ describe Trainee do
       subject { create(:trainee) }
 
       it { is_expected.to validate_uniqueness_of(:slug).case_insensitive }
-
-      context "immutability" do
-        let(:original_slug) { subject.slug.dup }
-
-        before do
-          subject.regenerate_slug
-          subject.reload
-        end
-
-        it "is immutable once created" do
-          expect(subject.slug).to eq(original_slug)
-        end
-      end
     end
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/bVWfzF3w/886-add-slugs-to-degrees

### Changes proposed in this pull request

- Build on the work done in this PR https://github.com/DFE-Digital/register-trainee-teachers/pull/405/files to add slugs to degrees
- Note, we've taken out the immutability changes out of this PR and will add to a separate PR right after this one. This is so we can run the migrations to set existing records which may be in the QA environment then enforce the readonly mode in subsequent PR otherwise the data changes in the migrations in this PR won't change anything.

### Guidance to review

<img width="1357" alt="Screenshot 2021-01-20 at 15 36 04" src="https://user-images.githubusercontent.com/616080/105198534-a6841380-5b35-11eb-8997-3cdaef762d7e.png">

