### PR TITLE
[808] Example data nationalities and disabilities are broken

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -80,7 +80,7 @@ namespace :example_data do
         trainee = FactoryBot.create(:trainee, *traits, trainee_attributes)
 
         [1, 1, 1, 1, 1, 2].sample.times do # multiple nationalities are less common
-          trainee.nationalities << FactoryBot.build(:nationality)
+          trainee.nationalities << Nationality.all.sample
         end
 
         next if trainee.draft?

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -5,6 +5,5 @@ FactoryBot.define do
     sequence :name do |n|
       "Provider #{n}"
     end
-    dttp_id { Dttp::CodeSets::Institutions::MAPPING.values.sample[:entity_id] }
   end
 end


### PR DESCRIPTION
### Context

The example data for nationalities wasn't using existing records. It is now.

Disabilities seem to be fine as long as the db/seed is run before example data.

### Changes proposed in this pull request

* Sample nationalities instead of creating new ones
* Remove the `dttp_id` setting from the factory. We're not making it required currently and don't use it in the tests. We don't want it in the example data either.

### Guidance to review

NB. Will reset your local DB.

* `rake db:schema:load`
* `rake db:seed`
* `rake example_data:generate`

