### PR TITLE
[891] Enforce readonly mode on the slug field once set

### DIFF
--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -5,6 +5,7 @@ module Sluggable
   SLUG_LENGTH = 24
 
   included do
+    attr_readonly :slug
     has_secure_token :slug
 
     after_initialize :generate_slug, if: -> { slug.blank? }

--- a/spec/models/degree_spec.rb
+++ b/spec/models/degree_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe Degree, type: :model do
       subject { create(:degree) }
 
       it { is_expected.to validate_uniqueness_of(:slug).case_insensitive }
+
+      context "immutability" do
+        let(:original_slug) { subject.slug.dup }
+
+        before do
+          original_slug
+          subject.regenerate_slug
+          subject.reload
+        end
+
+        it "is immutable once created" do
+          expect(subject.slug).to eq(original_slug)
+        end
+      end
     end
   end
 end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -51,6 +51,20 @@ describe Trainee do
       subject { create(:trainee) }
 
       it { is_expected.to validate_uniqueness_of(:slug).case_insensitive }
+
+      context "immutability" do
+        let(:original_slug) { subject.slug.dup }
+
+        before do
+          original_slug
+          subject.regenerate_slug
+          subject.reload
+        end
+
+        it "is immutable once created" do
+          expect(subject.slug).to eq(original_slug)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/qb2yJcYO/891-make-slugs-immutable

### Changes proposed in this pull request

- Makes the slug field readonly mode once it's been set

### Guidance to review

- Fire up the rails console and load an existing trainee with a slug
- Run `#regenerate_slug` on the trainee/degree
- Reload and assert the old slug is still present

