### PR TITLE
Update docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine
+FROM ruby:2.7.2-alpine3.12
 
 RUN apk add --update --no-cache tzdata && \
   cp /usr/share/zoneinfo/Europe/London /etc/localtime && \


### PR DESCRIPTION
### Context

The docker-compose up is failing because the existing docker image version, it now referrencing new version of components (nodejs), which is different from the once specificed in the  package.json

### Changes proposed in this pull request

Change base docker ref FROM ruby:2.7.2-alpine FROM ruby:2.7.2-alpine3.12

### Guidance to review

