### PR TITLE
[804] Add backlinks for all edit flows

### DIFF
--- a/app/components/dynamic_back_link/view.html.erb
+++ b/app/components/dynamic_back_link/view.html.erb
@@ -1,4 +1,4 @@
 <%= render GovukComponent::BackLink.new(
-  text: text,
+  text: link_text,
   href: path
 ) %>

--- a/app/components/dynamic_back_link/view.rb
+++ b/app/components/dynamic_back_link/view.rb
@@ -5,12 +5,13 @@ module DynamicBackLink
     include TraineeHelper
     include Breadcrumbable
 
-    def initialize(trainee)
+    def initialize(trainee, text: nil)
       @trainee = trainee
+      @text = text
     end
 
-    def text
-      trainee.draft? ? "Back to draft record" : "Back to record"
+    def link_text
+      text.presence || (trainee.draft? ? "Back to draft record" : "Back to record")
     end
 
     def path
@@ -28,7 +29,7 @@ module DynamicBackLink
 
   private
 
-    attr_reader :trainee
+    attr_reader :trainee, :text
 
     def rails_path(route)
       public_send("#{route}_path", trainee)

--- a/app/controllers/trainees/check_details_controller.rb
+++ b/app/controllers/trainees/check_details_controller.rb
@@ -2,8 +2,11 @@
 
 module Trainees
   class CheckDetailsController < ApplicationController
+    include Breadcrumbable
+
     def show
       @trainee = Trainee.from_param(params[:id])
+      save_origin_page_for(@trainee)
     end
   end
 end

--- a/app/controllers/trainees/diversity/confirm_details_controller.rb
+++ b/app/controllers/trainees/diversity/confirm_details_controller.rb
@@ -3,8 +3,11 @@
 module Trainees
   module Diversity
     class ConfirmDetailsController < Trainees::ConfirmDetailsController
+      include Breadcrumbable
+
       def show
         authorize trainee
+        save_origin_page_for(trainee)
         @confirm_detail = ConfirmDetailForm.new(mark_as_completed: trainee.progress.diversity)
         @confirmation_component = Trainees::Confirmation::Diversity::View.new(trainee: trainee)
       end

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
     text: 'Back to draft record',
-    href: trainee_path(@trainee),
+    href: review_draft_trainee_path(@trainee),
     html_attributes:{
       id: "back-to-draft-record"
     }

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -1,10 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.contact_details.edit", has_errors: @contact_details.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(
-    text: "Back",
-    href: view_trainee(@trainee)
-  ) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
 <% end %>
 
 <h1 class="govuk-heading-l">Contact details</h1>

--- a/app/views/trainees/diversity/confirm_details/show.html.erb
+++ b/app/views/trainees/diversity/confirm_details/show.html.erb
@@ -1,10 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.diversity.confirm") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(
-    text: @trainee.draft? ? 'Back to draft record' : 'Back to record',
-    href: view_trainee(@trainee)
-  ) %>
+  <%= render DynamicBackLink::View.new(@trainee) %>
 <% end %>
 
 <%= render(

--- a/app/views/trainees/diversity/disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disclosures/edit.html.erb
@@ -1,10 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.diversity.disclosures.edit", has_errors: @disclosure.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(
-    text: "Back",
-    href: view_trainee(@trainee)
-  ) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -1,10 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.personal_details.edit", has_errors: @personal_detail.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(
-    text: 'Back',
-    href: view_trainee(@trainee)
-  ) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/programme_details/edit.html.erb
+++ b/app/views/trainees/programme_details/edit.html.erb
@@ -1,10 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.programme_details.edit", has_errors: @programme_detail.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(
-    text: 'Back',
-    href: view_trainee(@trainee)
-  ) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/spec/features/trainees/submit_for_trn_spec.rb
+++ b/spec/features/trainees/submit_for_trn_spec.rb
@@ -52,7 +52,7 @@ feature "submit for TRN" do
         given_a_trainee_exists
         and_i_am_on_the_check_details_page
         when_i_click_back_to_draft_record
-        then_i_am_redirected_to_the_record_page
+        then_i_am_redirected_to_the_review_draft_page
       end
     end
 
@@ -80,6 +80,10 @@ feature "submit for TRN" do
 
   def then_i_review_the_trainee_data
     expect(check_details_page).to be_displayed(id: trainee.slug)
+  end
+
+  def then_i_am_redirected_to_the_review_draft_page
+    expect(review_draft_page).to be_displayed(id: trainee.slug)
   end
 
   def and_i_click_the_submit_for_trn_button


### PR DESCRIPTION
### Context

https://trello.com/c/o7I1BbDF/804-back-links-from-trainee-review-page-return-to-the-review-page

### Changes proposed in this pull request

This PR makes the `/check-details` route an origin page, so it's saved in the session every time a user lands on it.

It also adds the dynamic links to all first pages of edit flows, so they return to the correct origin.

**Not included**
- Backlinks in degree section

### Guidance to review

**Review draft**
- Navigate to a draft trainee's `/review-draft` page.
- Click through into each edit flow
- Check that the backlinks go to `/review-draft`
- Click through to a confirm page for one edit flow
- Check that the backlink goes to `/review-draft`
- Click 'change' on the confirm page
- Check that the backlink goes to `/confirm`
- Check that the backlink on the confirm page now _still_ goes back to `/review-draft`


**Check details**
- Navigate to a draft trainee's `/check-details` page
- Repeat the above, but check the backlinks go to `check-details` where before they went to `/review-draft`

**Trainee show page**
- Navigate to a non-draft trainee's main show page
- Repeat the above, but check the backlinks go to the trainee show page where before they went to `/check-detailst`