### PR TITLE
[892] Renders home page if signed in user navigates to start page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,8 @@ group :development, :test do
   # Testing framework
   gem "rspec-rails", "~> 4.0.2"
 
+  gem "rails-controller-testing"
+
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 3.34"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,10 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -469,6 +473,7 @@ DEPENDENCIES
   puma (~> 5.1)
   pundit
   rails (~> 6.1.1)
+  rails-controller-testing
   rails_semantic_logger (= 4.4.6)
   request_store (~> 1.5)
   rspec-rails (~> 4.0.2)

--- a/app/components/start_page_banner/view.html.erb
+++ b/app/components/start_page_banner/view.html.erb
@@ -9,10 +9,10 @@
       </p>
       <div class="app-start-page-banner__actions">
         <%= render GovukComponent::StartNowButton.new( text: 'Sign in',
-                                                                 href: home_path,
+                                                                 href: sign_in_path,
                                                                  classes: 'app-button--inverted app-start-page-banner__button') %>
         <p class="govuk-body app-body--inverted">
-          or <a class="govuk-link app-link--inverted govuk-link--no-visited-state" href="/home">request an account</a>
+          or <a class="govuk-link app-link--inverted govuk-link--no-visited-state" href="/sign-in">request an account</a>
         </p>
       </div>
     </div>

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
-  skip_before_action :authenticate, except: [:home]
+  skip_before_action :authenticate
 
-  def show
-    render template: "pages/#{params[:page]}"
-  end
-
-  def home
-    render :home
+  def start
+    if authenticated?
+      render :home
+    else
+      render :start
+    end
   end
 
   def accessibility

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
     if current_user
       DfESignInUsers::Update.call(user: current_user, dfe_sign_in_user: dfe_sign_in_user)
 
-      redirect_to home_path
+      redirect_to root_path
     else
       DfESignInUser.end_session!(session)
       redirect_to sign_in_user_not_found_path

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
     <% if authenticated? %>
       <%= render NavigationBar::View.new(
         items: [
-          {name: "Home", url: home_path},
+          {name: "Home", url: root_path},
           {name: "Trainee records", url: trainees_path, current: trainee_link_is_current? }
         ],
         current_path: request.path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,11 +9,9 @@ Rails.application.routes.draw do
   get :healthcheck, controller: :heartbeat
   get :sha, controller: :heartbeat
 
-  get "/home", to: "pages#home", as: :home
   get "/accessibility", to: "pages#accessibility", as: :accessibility
   get "/cookies", to: "pages#cookies", as: :cookies
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
-  get "/pages/:page", to: "pages#show"
   get "/data-requirements", to: "pages#data_requirements"
 
   get "/404", to: "errors#not_found", via: :all
@@ -98,5 +96,5 @@ Rails.application.routes.draw do
 
   resources :trn_submissions, only: %i[create show], param: :trainee_id
 
-  root to: "pages#show", defaults: { page: "start" }
+  root to: "pages#start"
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -9,4 +9,26 @@ describe PagesController, type: :controller do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe "start page" do
+    context "when not signed in and navigate to start page" do
+      it "renders start page" do
+        get :start
+        expect(response).to render_template("start")
+      end
+    end
+  end
+
+  context "when signed in and navigate to start page" do
+    let(:current_user) { build(:user) }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(current_user)
+    end
+
+    it "renders home page" do
+      get :start
+      expect(response).to render_template("home")
+    end
+  end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -23,7 +23,7 @@ describe SessionsController, type: :controller do
 
       it "redirects to the trainees index page" do
         request_callback
-        expect(response).to redirect_to(home_path)
+        expect(response).to redirect_to(root_path)
       end
     end
 
@@ -51,7 +51,7 @@ describe SessionsController, type: :controller do
 
         it "redirects to the trainees index page" do
           request_callback
-          expect(response).to redirect_to(home_path)
+          expect(response).to redirect_to(root_path)
         end
 
         it "saved non existing user to database" do

--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
 
     trait :uk_degree_type do
       locale_code { :uk }
-      uk_degree { Dttp::CodeSets::DegreeTypes::MAPPING.keys.sample }
+      uk_degree { (Dttp::CodeSets::DegreeTypes::MAPPING.keys - Dttp::CodeSets::DegreeTypes::NON_UK).sample }
     end
 
     trait :uk_degree_with_details do

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -10,7 +10,7 @@ describe "A user authenticates via DfE Sign-in" do
     then_i_am_redirected_to_the_sign_in_path
     and_i_sign_in_via_dfe_sign_in
 
-    then_i_am_redirected_to_the_home_path
+    then_i_am_redirected_to_the_root_path
     and_i_should_see_the_link_to_sign_out
     and_my_details_are_refreshed
 
@@ -50,8 +50,8 @@ private
     visit_sign_in_page
   end
 
-  def then_i_am_redirected_to_the_home_path
-    expect(page.current_path).to eq("/home")
+  def then_i_am_redirected_to_the_root_path
+    expect(page.current_path).to eq("/")
   end
 
   def and_i_should_see_the_link_to_sign_out
@@ -69,7 +69,7 @@ private
 
   def when_i_signed_in_more_than_2_hours_ago
     Timecop.travel(Time.zone.now + 2.hours + 1.second) do
-      expect(page.current_path).to eq("/home")
+      expect(page.current_path).to eq("/")
 
       trainee_page = PageObjects::Trainees::Index.new
       trainee_page.load

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -4,38 +4,38 @@ require "rails_helper"
 
 feature "view pages" do
   scenario "navigate to start" do
-    given_i_am_on_the_home_page
+    given_i_am_on_the_start_page
     then_i_should_see_the_service_name
     and_i_should_see_the_phase_banner
   end
 
   scenario "navigate to accessibility statement" do
-    given_i_am_on_the_home_page
+    given_i_am_on_the_start_page
     and_i_click_on_the_accessibility_link_in_the_footer
     then_i_should_see_the_accessibility_statement
   end
 
   scenario "navigate to cookies policy" do
-    given_i_am_on_the_home_page
+    given_i_am_on_the_start_page
     and_i_click_on_the_cookies_link_in_the_footer
     then_i_should_see_the_cookies_policy
   end
 
   scenario "navigate to privacy policy" do
-    given_i_am_on_the_home_page
+    given_i_am_on_the_start_page
     and_i_click_on_the_privacy_link_in_the_footer
     then_i_should_see_the_privacy_policy
   end
 
   scenario "navigate to sign in" do
-    given_i_am_on_the_home_page
+    given_i_am_on_the_start_page
     when_i_click_on_sign_in
     then_the_start_page_is_displayed
   end
 
 private
 
-  def given_i_am_on_the_home_page
+  def given_i_am_on_the_start_page
     start_page.load
   end
 


### PR DESCRIPTION
### Context

If a user signed in and navigates to `/` manually, they would get to the start page and be able to see the navigation bar. They should not be able to get to this page if they are signed in. 

This PR dynamically allows the root path to be the start page if the user is not logged in, or the homepage if the user is logged in.

### Changes proposed in this pull request

- Replace `show` page controller method with `start` for consistency and to fix a bug.
- Add logic to render home page if logged in and navigate to start page.

### Guidance to review

- Navigate to https://rtt-review-pr-418.herokuapp.com
- Sign in
- Navigate to the root path, i.e `/` and ensure you are taken to the home page
- Sign out and repeat, ensure you are taken to the start page this time.

