### PR TITLE
Update PaaS org name to dfe

### DIFF
--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -1,5 +1,5 @@
 data cloudfoundry_org org {
-  name = "dfe-teacher-services"
+  name = "dfe"
 }
 
 data cloudfoundry_space space {


### PR DESCRIPTION
As part of the consolidation on other dfe services into PaaS,
there is the need rename the PaaS org name from "dfe-teacher-services" to "dfe"

### Context

As part of the consolidation on other dfe services into PaaS,
there is the need rename the PaaS org name from "dfe-teacher-services" to "dfe"

### Changes proposed in this pull request

data cloudfoundry_org org {
  name = "dfe"
}

### Guidance to review

