### PR TITLE
[867] SPIKE - add defer service for dttp

### DIFF
--- a/app/services/dttp/defer.rb
+++ b/app/services/dttp/defer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Dttp
+  class Defer
+    include ServicePattern
+
+    class Error < StandardError; end
+
+    attr_reader :trainee
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      body = { "dfe_TraineeStatusId@odata.bind" => "/dfe_traineestatuses(1d5af972-9e1b-e711-80c7-0050568902d3)" }
+
+      dttp_update("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})", body)
+    end
+
+  private
+
+    def dttp_update(path, body)
+      response = Client.patch(path, body: body.to_json)
+      raise Error, response.body if response.code != 204
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/Dl2iaFfC/867-spike-what-field-value-do-we-set-for-withdraw-and-defer-on-dttp

This PR has a service which will update a trainee's status on dttp to "Trainee Deferred". It doesn't currently have sufficient tests, but it is functional. 

There may be additional DTTP fields that should be updated alongside this, but it looks like this `dfe_TraineeStatusId` is the core field that determines their current status. 

### Guidance to review

You can run the code below to create a trainee in DTTP, and update their status to deferred 

```ruby
require_relative "config/environment"
require "factory_bot_rails"
require "faker"

FactoryBot.find_definitions rescue nil

trainee = FactoryBot.create(:trainee, :with_programme_details, :diversity_disclosed, :with_placement_assignment)

trainee.degrees << FactoryBot.create(:degree, :uk_degree_with_details)

trainee.provider.dttp_id = "9c76f34a-2887-e711-80d8-005056ac45bb"

entity_ids = Dttp::RegisterForTrn.call(trainee: trainee, trainee_creator_dttp_id: "98c63edb-b0a6-e811-812c-5065f38bc301")

puts entity_ids

result = Dttp::Defer.call(trainee: trainee)

trainee.destroy!
```

You can then search for them on DTTP, and their status will be updated. 

