### PR TITLE
[899] Fix Dttp::BatchRequest headers

### DIFF
--- a/app/lib/dttp/batch_request.rb
+++ b/app/lib/dttp/batch_request.rb
@@ -4,13 +4,13 @@ module Dttp
   class BatchRequest
     class Error < StandardError; end
 
-    attr_reader :batch_id, :change_set_id, :headers, :change_sets
+    attr_reader :batch_id, :change_set_id, :additional_headers, :change_sets
 
     def initialize(batch_id: SecureRandom.uuid, change_set_id: SecureRandom.uuid)
       @batch_id = batch_id
       @change_set_id = change_set_id
       @change_sets = []
-      @headers = { "Content-Type" => "multipart/mixed;boundary=batch_#{batch_id}" }
+      @additional_headers = { "Content-Type" => "multipart/mixed;boundary=batch_#{batch_id}" }
     end
 
     def add_change_set(entity:, payload:, content_id: SecureRandom.uuid)
@@ -19,7 +19,7 @@ module Dttp
     end
 
     def submit
-      response = Client.post("/$batch", body: body, headers: headers)
+      response = Client.post("/$batch", body: body, headers: Client.headers.merge(additional_headers))
       raise Error, "body: #{response.body.gsub('\r', '')}, status: #{response.code}, headers: #{response.headers}" if response.code != 200
 
       response

--- a/spec/lib/dttp/batch_request_spec.rb
+++ b/spec/lib/dttp/batch_request_spec.rb
@@ -48,7 +48,13 @@ module Dttp
 
         context "successful" do
           let(:dttp_response) { double(code: 200) }
-          let(:expected_headers) { { "Content-Type" => "multipart/mixed;boundary=batch_#{batch_id}" } }
+          let(:expected_headers) do
+            {
+              "Content-Type" => "multipart/mixed;boundary=batch_#{batch_id}",
+              "Accept" => "application/json",
+              "Authorization" => "Bearer token",
+            }
+          end
 
           let(:expected_body) do
             <<~BODY


### PR DESCRIPTION
### Context

When we create a `Dttp::BatchRequest` we need to add an extra header value. The existing code was passing this in which overwrote the default values set in `Dttp::Client`.

### Changes proposed in this pull request

Merge the extra value with the default values and pass them to ensure that the access token is included.

### Guidance to review

This is a bit tricky to run locally so we can test on QA if the code looks ok. 

If you're feeling particularly adventurous.

* Get the id of a Contact that is a `dfe_portaluser` from DTTP.
* Get the id of the Account that they are associated with (the value in `_dfe_contacttypeid_value`)
* Create a provider and set their `dttp_id` to the account ID.
* Add a user belonging to that provider and set their `dttp_id` to the contact ID.
* Create a trainee that is ready to submit and associated with the provider.

* In the console...

`Dttp::RegisterForTrn.call(trainee: <the trainee>, trainee_creator_dttp_id: <the dttp_id of the user>)`

* Confirm that the batch request doesn't error and the trainee ends up in DTTP.


