### PR TITLE
[841] Defer a trainee

### DIFF
--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -8,6 +8,9 @@ module Trainees
 
     def update
       authorize trainee
+
+      DeferJob.perform_later(trainee.id)
+
       flash[:success] = "Trainee deferred"
       redirect_to trainee_path(trainee)
     end

--- a/app/jobs/defer_job.rb
+++ b/app/jobs/defer_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class DeferJob < ApplicationJob
+  queue_as :default
+  retry_on Dttp::Defer::Error
+
+  def perform(trainee_id)
+    Dttp::Defer.call(trainee: Trainee.find(trainee_id))
+  end
+end

--- a/app/lib/dttp/code_sets/statuses.rb
+++ b/app/lib/dttp/code_sets/statuses.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Dttp
+  module CodeSets
+    module Statuses
+      MAPPING = {
+        "Awaiting QTS" => { entity_id: "1b5af972-9e1b-e711-80c7-0050568902d3" },
+        "Awarded EYTS" => { entity_id: "2d5af972-9e1b-e711-80c7-0050568902d3" },
+        "Awarded QTS" => { entity_id: "195af972-9e1b-e711-80c7-0050568902d3" },
+        "Draft record" => { entity_id: "2b5af972-9e1b-e711-80c7-0050568902d3" },
+        "EYTS Revoked" => { entity_id: "2f5af972-9e1b-e711-80c7-0050568902d3" },
+        "Left course before the end" => { entity_id: "235af972-9e1b-e711-80c7-0050568902d3" },
+        "Prospective trainee - TREFNO requested" => { entity_id: "275af972-9e1b-e711-80c7-0050568902d3" },
+        "QTS revoked" => { entity_id: "155af972-9e1b-e711-80c7-0050568902d3" },
+        "Standards met" => { entity_id: "1f5af972-9e1b-e711-80c7-0050568902d3" },
+        "Standards not met" => { entity_id: "215af972-9e1b-e711-80c7-0050568902d3" },
+        "Trainee deferred" => { entity_id: "1d5af972-9e1b-e711-80c7-0050568902d3" },
+        "Trainee did not start course" => { entity_id: "255af972-9e1b-e711-80c7-0050568902d3" },
+        "Trainee rejected/revoked from ITT Studies" => { entity_id: "175af972-9e1b-e711-80c7-0050568902d3" },
+        "Yet to complete the course" => { entity_id: "295af972-9e1b-e711-80c7-0050568902d3" },
+      }.freeze
+    end
+  end
+end

--- a/app/lib/dttp/mappable.rb
+++ b/app/lib/dttp/mappable.rb
@@ -37,5 +37,9 @@ module Dttp
     def dttp_ethnicity_id(ethnicity)
       CodeSets::Ethnicities::MAPPING.dig(ethnicity, :entity_id)
     end
+
+    def dttp_status_id(status)
+      CodeSets::Statuses::MAPPING.dig(status, :entity_id)
+    end
   end
 end

--- a/app/services/dttp/defer.rb
+++ b/app/services/dttp/defer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Dttp
+  class Defer
+    include ServicePattern
+    include Mappable
+
+    class Error < StandardError; end
+
+    attr_reader :trainee
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      body = { "dfe_TraineeStatusId@odata.bind" => "/dfe_traineestatuses(#{dttp_status_id('Trainee deferred')})" }
+
+      dttp_update("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})", body)
+
+      trainee.defer!
+    end
+
+  private
+
+    def dttp_update(path, body)
+      response = Client.patch(path, body: body.to_json)
+      raise Error, response.body if response.code != 204
+    end
+  end
+end

--- a/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Trainees::ConfirmDeferralsController do
+  include ActiveJob::TestHelper
+
+  let(:trainee) { create(:trainee) }
+  let(:current_user) { build(:user) }
+  let(:trainee_policy) { instance_double(TraineePolicy, update?: true) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(current_user)
+    allow(TraineePolicy).to receive(:new).with(current_user, trainee).and_return(trainee_policy)
+  end
+
+  describe "#update" do
+    it "it updates the placement assignment in DTTP to mark it as deferred" do
+      expect {
+        post :update, params: { trainee_id: trainee }
+      }.to have_enqueued_job(DeferJob).with(trainee.id)
+    end
+  end
+end

--- a/spec/services/dttp/defer_spec.rb
+++ b/spec/services/dttp/defer_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe Defer do
+    describe "#call" do
+      let(:trainee) do
+        create(:trainee, :trn_received, placement_assignment_dttp_id: placement_assignment_dttp_id)
+      end
+      let(:placement_assignment_dttp_id) { SecureRandom.uuid }
+      let(:path) { "/dfe_placementassignments(#{placement_assignment_dttp_id})" }
+
+      before do
+        allow(AccessToken).to receive(:fetch).and_return("token")
+      end
+
+      context "success" do
+        let(:dttp_response) { double(code: 204) }
+
+        it "sends a PATCH request to set entity property 'dfe_TraineeStatusId@odata.bind' and transitions trainee to deferred" do
+          body = { "dfe_TraineeStatusId@odata.bind" => "/dfe_traineestatuses(1d5af972-9e1b-e711-80c7-0050568902d3)" }.to_json
+          expect(Client).to receive(:patch).with(path, body: body).and_return(dttp_response)
+          described_class.call(trainee: trainee)
+          expect(trainee.state).to eq("deferred")
+        end
+      end
+
+      context "error" do
+        let(:error_body) { "error" }
+        let(:dttp_response) { double(code: 405, body: error_body) }
+
+        it "raises an error exception and does not transition trainee to deferred" do
+          expect(Client).to receive(:patch).and_return(dttp_response)
+          expect {
+            described_class.call(trainee: trainee)
+          }.to raise_error(Dttp::Defer::Error, error_body)
+          expect(trainee.state).to eq("trn_received")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/JbM6e46P/841-defer-on-dttp

### Changes proposed in this pull request

This PR builds upon the work completed in this spike: https://github.com/DFE-Digital/register-trainee-teachers/pull/423

It includes:
- A `DeferJob`, called from the `ConfirmDeferralsController`, which queues up a:
- `Dttp::Defer` service, which:
  - Makes a `patch` call to DTTP to set the trainee status to deferred
  - Internally transitions our trainee to 'deferred' on success
- Tests for the above

### Guidance to review

Guidance for checking the call to DTTP can be found in this original PR: https://github.com/DFE-Digital/register-trainee-teachers/pull/423