### PR TITLE
[xxx] Disable basic auth

### DIFF
--- a/app/controllers/concerns/basic_authenticable.rb
+++ b/app/controllers/concerns/basic_authenticable.rb
@@ -4,7 +4,7 @@
 module BasicAuthenticable
   class << self
     def required?
-      Settings.basic_auth_required
+      Settings.features.basic_auth
     end
 
     def authenticate(username, password)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,7 +6,6 @@ base_url: https://localhost:5000
 # The url for the google doc feedback link
 feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSfhdvlUkg7oxPjl1C6FcJ2pnlc1OQ82r7o3ZMNKthhVAt_h5g/viewform?usp=sf_link"
 
-basic_auth_required: true
 dttp:
   back_office_url: https://dttp-dev.crm4.dynamics.com/
   client_id: "application-registration-client-id-from-env"
@@ -22,6 +21,7 @@ features:
   use_dfe_sign_in: true
   allow_user_creation: false
   enable_feedback_link: true
+  basic_auth: true
 
 dfe_sign_in:
   # Our service name

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,7 +1,7 @@
-basic_auth_required: false
 dttp:
   api_base_url: "https://dttp-dev.api.crm4.dynamics.com"
 
 features:
   allow_user_creation: true
   use_dfe_sign_in: false
+  basic_auth: false

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -11,3 +11,6 @@ dfe_sign_in:
   issuer: https://oidc.signin.education.gov.uk
   # URL of the users profile
   profile: https://profile.signin.education.gov.uk
+
+features:
+  basic_auth: false

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -11,3 +11,6 @@ dfe_sign_in:
   issuer: https://pp-oidc.signin.education.gov.uk
   # URL of the users profile
   profile: https://pp-profile.signin.education.gov.uk
+
+features:
+  basic_auth: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,6 +1,7 @@
-basic_auth_required: false
 dttp:
   api_base_url: "https://test-api-base-uri.com"
 slack:
   default_channel: "test-channel"
   webhook_url: "https://test-slack-webhook-url.com"
+features:
+  basic_auth: false


### PR DESCRIPTION
* Make the basic_auth setting a feature flag
* Remove basic_auth from staging and production

Signin is enabled in these environments now so we no longer need basic
authentication

### Context

### Changes proposed in this pull request

### Guidance to review

