### PR TITLE
[853] Return to origin page after completing an edit workflow

### DIFF
--- a/app/components/dynamic_back_link/view.rb
+++ b/app/components/dynamic_back_link/view.rb
@@ -2,8 +2,7 @@
 
 module DynamicBackLink
   class View < GovukComponent::Base
-    include TraineeHelper
-    include Breadcrumbable
+    attr_reader :trainee, :text
 
     def initialize(trainee, text: nil)
       @trainee = trainee
@@ -15,32 +14,7 @@ module DynamicBackLink
     end
 
     def path
-      return view_trainee(trainee) unless origin_pages.any?
-
-      # If you're currently on a 'confirm' page, then you're on an origin page
-      # that has a back button to the _previous_ origin page.
-      if on_origin_page?
-        # Therefore, return the origin page before this one if it's been stored.
-        return origin_pages.length < 2 ? view_trainee(trainee) : rails_path(origin_pages[-2])
-      end
-
-      rails_path(origin_pages.last)
-    end
-
-  private
-
-    attr_reader :trainee, :text
-
-    def rails_path(route)
-      public_send("#{route}_path", trainee)
-    end
-
-    def origin_pages
-      @origin_pages ||= origin_pages_for(trainee)
-    end
-
-    def on_origin_page?
-      current_page == origin_pages.last
+      OriginPage.new(trainee, session, request).path
     end
   end
 end

--- a/app/controllers/concerns/breadcrumbable.rb
+++ b/app/controllers/concerns/breadcrumbable.rb
@@ -2,30 +2,6 @@
 
 module Breadcrumbable
   def save_origin_page_for(trainee)
-    # Don't save it the same origin page on page refresh, for example.
-    unless current_page == origin_pages_for(trainee).last
-      origin_pages_for(trainee) << current_page
-    end
-
-    # We only need to keep track of the last two origin pages.
-    origin_pages_for(trainee).shift if origin_pages_for(trainee).length > 2
-  end
-
-  def origin_pages_for(trainee)
-    session[session_key_for(trainee)] ||= []
-  end
-
-  def current_page
-    routes = Rails.application.routes.router.recognize(request) do |route, _|
-      route.name
-    end
-
-    routes.first.last.name
-  end
-
-private
-
-  def session_key_for(trainee)
-    "origin_pages_for_#{trainee.id}"
+    OriginPage.new(trainee, session, request).save
   end
 end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -23,7 +23,7 @@ module Trainees
       end
 
       flash[:success] = "Trainee #{flash_message_title} updated"
-      redirect_to trainee_path(trainee)
+      redirect_to OriginPage.new(trainee, session, request).path
     end
 
   private

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -43,7 +43,7 @@ class TraineesController < ApplicationController
   def update
     authorize trainee
     trainee.update!(trainee_params)
-    redirect_to trainee_path(trainee)
+    redirect_to OriginPage.new(trainee, session, request).path
   end
 
 private

--- a/app/lib/origin_page.rb
+++ b/app/lib/origin_page.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class OriginPage
+  include TraineeHelper
+  include Rails.application.routes.url_helpers
+
+  MAX_PAGES = 2 # We only need to keep track of the last two origin pages.
+
+  def initialize(trainee, session, request)
+    @trainee = trainee
+    @session = session
+    @request = request
+    @origin_pages = origin_pages_for(trainee)
+  end
+
+  def save
+    # Don't save it the same origin page on page refresh, for example.
+    origin_pages << current_page unless origin_pages.include?(current_page)
+
+    origin_pages.shift if origin_pages.length > MAX_PAGES
+  end
+
+  def path
+    return view_trainee(trainee) unless origin_pages.any?
+
+    if on_origin_page?
+      # Return the origin page before this one if it's been stored
+      return origin_pages.length < MAX_PAGES ? view_trainee(trainee) : rails_path(origin_pages[-2])
+    end
+
+    rails_path(origin_pages.last)
+  end
+
+private
+
+  attr_reader :trainee, :session, :request, :origin_pages, :on_confirm_page
+
+  def origin_pages_for(trainee)
+    session["origin_pages_for_#{trainee.id}"] ||= []
+  end
+
+  def current_page
+    request_route.name
+  end
+
+  def rails_path(route)
+    public_send("#{route}_path", trainee)
+  end
+
+  def on_origin_page?
+    current_page == origin_pages.last || on_confirm_page?
+  end
+
+  def on_confirm_page?
+    request_route.ast.to_s.include?("confirm")
+  end
+
+  def request_route
+    Rails.application.routes.router.recognize(request) { |route, _| route.name }.first.last
+  end
+end

--- a/spec/components/dynamic_back_link/view_spec.rb
+++ b/spec/components/dynamic_back_link/view_spec.rb
@@ -6,84 +6,25 @@ module DynamicBackLink
   describe View do
     alias_method :component, :page
 
-    shared_examples "show page default" do
-      it "defaults to trainee show page" do
-        expect(component).to have_link(
-          "Back to record",
-          href: "/trainees/#{trainee.to_param}",
-        )
+    let(:session) { {} }
+
+    before do
+      render_inline(described_class.new(trainee))
+    end
+
+    context "draft trainee" do
+      let(:trainee) { create(:trainee, :draft) }
+
+      it "renders a back link" do
+        expect(component).to have_link("Back to draft record", href: "/trainees/#{trainee.to_param}/review-draft")
       end
     end
 
-    shared_examples "draft page default" do
-      it "defaults to trainee edit page" do
-        expect(component).to have_link(
-          "Back to draft record",
-          href: "/trainees/#{trainee.to_param}/review-draft",
-        )
-      end
-    end
+    context "draft trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn) }
 
-    context "with no origin pages saved" do
-      before do
-        render_inline(described_class.new(trainee))
-      end
-
-      context "and a draft trainee" do
-        let(:trainee) { create(:trainee, :draft) }
-        include_examples "draft page default"
-      end
-
-      context "and a non-draft trainee" do
-        let(:trainee) { create(:trainee, :submitted_for_trn) }
-        include_examples "show page default"
-      end
-    end
-
-    context "with origin pages saved" do
-      before do
-        allow_any_instance_of(Breadcrumbable).to receive(:current_page).and_return(current_page)
-        allow_any_instance_of(Breadcrumbable).to receive(:origin_pages_for).with(trainee).and_return(saved_origin_pages)
-        render_inline(described_class.new(trainee))
-      end
-
-      context "and you're currently on the only saved origin page" do
-        let(:current_page) { "trainee_personal_details_confirm" }
-        let(:saved_origin_pages) { %w[trainee_personal_details_confirm] }
-
-        context "and the trainee is draft" do
-          let(:trainee) { create(:trainee, :draft) }
-          include_examples "draft page default"
-        end
-
-        context "and the trainee is not draft" do
-          let(:trainee) { create(:trainee, :submitted_for_trn) }
-          include_examples "show page default"
-        end
-      end
-
-      context "and you're currently on the last saved origin page of many" do
-        let(:trainee) { create(:trainee) }
-        let(:current_page) { "trainee_personal_details_confirm" }
-        let(:saved_origin_pages) { %w[trainee trainee_personal_details_confirm] }
-
-        it "links to the previous origin page" do
-          expect(component).to have_link(
-            href: "/trainees/#{trainee.to_param}",
-          )
-        end
-      end
-
-      context "when you're a non-origin page" do
-        let(:trainee) { create(:trainee) }
-        let(:current_page) { "a_random_page" }
-        let(:saved_origin_pages) { %w[trainee trainee_personal_details_confirm] }
-
-        it "links to the last origin page" do
-          expect(component).to have_link(
-            href: "/trainees/#{trainee.to_param}/personal-details/confirm",
-          )
-        end
+      it "renders a back link" do
+        expect(component).to have_link("Back to record", href: "/trainees/#{trainee.to_param}")
       end
     end
   end

--- a/spec/features/trainees/degrees/adding_degree_spec.rb
+++ b/spec/features/trainees/degrees/adding_degree_spec.rb
@@ -44,15 +44,13 @@ RSpec.feature "Adding a degree" do
 
       scenario "the user confirms degree details" do
         and_confirm_my_details
-        then_i_am_redirected_to_the_record_page
-        and_i_visit_the_review_draft_page
+        then_i_am_redirected_to_the_review_draft_page
         then_the_degree_status_should_be(:completed)
       end
 
       scenario "the user does not confirm degree details" do
         and_i_click_continue
-        then_i_am_redirected_to_the_record_page
-        and_i_visit_the_review_draft_page
+        then_i_am_redirected_to_the_review_draft_page
         then_the_degree_status_should_be(:in_progress)
       end
     end
@@ -89,7 +87,7 @@ RSpec.feature "Adding a degree" do
       and_i_click_the_continue_button_on_the_degree_details_page
       then_i_am_redirected_to_the_trainee_degrees_confirmation_page
       and_confirm_my_details
-      then_i_am_redirected_to_the_record_page
+      then_i_am_redirected_to_the_review_draft_page
     end
 
     scenario "the user enters invalid details on Non-UK degree details page" do
@@ -181,10 +179,6 @@ private
   def when_i_visit_the_degree_details_page
     degree_details_page.load(trainee_id: trainee.slug, locale_code: @locale)
     expect(degree_details_page).to be_displayed(trainee_id: trainee.slug, locale_code: @locale)
-  end
-
-  def then_i_am_redirected_to_the_record_page
-    expect(current_path).to eq("/trainees/#{trainee.slug}")
   end
 
   def then_i_am_redirected_to_the_trainee_degrees_confirmation_page

--- a/spec/features/trainees/diversities/edit_disabilities_spec.rb
+++ b/spec/features/trainees/diversities/edit_disabilities_spec.rb
@@ -14,7 +14,7 @@ feature "edit disability details", type: :feature do
     and_i_choose_a_disability
     and_i_submit_the_form
     and_confirm_my_details
-    then_i_am_redirected_to_the_record_page
+    then_i_am_redirected_to_the_review_draft_page
     and_the_disability_details_are_updated
   end
 

--- a/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
@@ -21,7 +21,7 @@ feature "edit disability disclosure", type: :feature do
     and_i_choose_not_to_disclose
     and_i_submit_the_form
     and_confirm_my_details
-    then_i_am_redirected_to_the_record_page
+    then_i_am_redirected_to_the_review_draft_page
     and_the_disability_disclosure_is_updated
   end
 

--- a/spec/features/trainees/diversities/edit_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disclosure_spec.rb
@@ -20,7 +20,7 @@ feature "edit diversity disclosure", type: :feature do
     and_i_choose_not_to_disclose
     and_i_submit_the_form
     and_confirm_my_details
-    then_i_am_redirected_to_the_record_page
+    then_i_am_redirected_to_the_review_draft_page
     and_the_diversity_disclosure_is_updated
   end
 

--- a/spec/features/trainees/edit_contact_details_spec.rb
+++ b/spec/features/trainees/edit_contact_details_spec.rb
@@ -13,14 +13,14 @@ feature "edit contact details", type: :feature do
     and_i_enter_valid_parameters
     and_i_submit_the_form
     and_confirm_my_details
-    then_i_am_redirected_to_the_record_page
+    then_i_am_redirected_to_the_review_draft_page
     and_the_contact_details_are_updated
   end
 
   scenario "changing locale clears previous address" do
     and_i_enter_an_international_address
     and_confirm_my_details
-    then_i_am_redirected_to_the_record_page
+    then_i_am_redirected_to_the_review_draft_page
     and_the_old_address_is_cleared
   end
 

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -27,7 +27,7 @@ feature "edit personal details", type: :feature do
     and_i_enter_valid_parameters
     and_i_submit_the_form
     and_confirm_my_details(checked: false)
-    then_i_am_redirected_to_the_record_page
+    then_i_am_redirected_to_the_review_draft_page
     then_the_personal_details_section_should_be_in_progress
   end
 
@@ -65,7 +65,7 @@ private
     and_i_enter_valid_parameters
     and_i_submit_the_form
     and_confirm_my_details
-    then_i_am_redirected_to_the_record_page
+    then_i_am_redirected_to_the_review_draft_page
   end
 
   def given_other_nationality_is_provided
@@ -75,7 +75,7 @@ private
     and_i_enter_valid_parameters(other_nationality: true)
     and_i_submit_the_form
     and_confirm_my_details
-    then_i_am_redirected_to_the_record_page
+    then_i_am_redirected_to_the_review_draft_page
   end
 
   def and_nationalities_exist_in_the_system

--- a/spec/features/trainees/edit_programme_details_spec.rb
+++ b/spec/features/trainees/edit_programme_details_spec.rb
@@ -19,8 +19,7 @@ feature "programme details", type: :feature do
       and_i_enter_valid_parameters
       and_i_submit_the_form
       and_i_confirm_my_details(checked: false, section: programme_details_section)
-      then_i_am_redirected_to_the_record_page
-      and_i_visit_the_review_draft_page
+      then_i_am_redirected_to_the_review_draft_page
       and_the_section_should_be(:in_progress)
     end
 
@@ -29,8 +28,7 @@ feature "programme details", type: :feature do
       and_i_enter_valid_parameters
       and_i_submit_the_form
       and_i_confirm_my_details(section: programme_details_section)
-      then_i_am_redirected_to_the_record_page
-      and_i_visit_the_review_draft_page
+      then_i_am_redirected_to_the_review_draft_page
       and_the_section_should_be(:completed)
     end
   end
@@ -41,7 +39,7 @@ feature "programme details", type: :feature do
       and_i_enter_valid_parameters
       and_i_submit_the_form
       and_i_confirm_my_details(checked: false, section: programme_details_section)
-      then_i_am_redirected_to_the_record_page
+      then_i_am_redirected_to_the_review_draft_page
       and_the_programme_details_are_updated
     end
 
@@ -132,11 +130,6 @@ feature "programme details", type: :feature do
 
   def then_i_am_redirected_to_the_confirm_page
     expect(confirm_details_page).to be_displayed(id: trainee.slug, section: programme_details_section)
-  end
-
-  def and_i_visit_the_review_draft_page
-    review_draft_page.load(id: trainee.slug)
-    expect(review_draft_page).to be_displayed(id: trainee.slug)
   end
 
 private

--- a/spec/features/trainees/edit_training_details_spec.rb
+++ b/spec/features/trainees/edit_training_details_spec.rb
@@ -11,7 +11,7 @@ feature "edit training details" do
     given_a_trainee_exists
     when_i_visit_the_training_details_page
     and_i_update_the_training_details
-    then_i_am_redirected_to_the_record_page
+    then_i_am_redirected_to_the_review_draft_page
     and_the_training_details_are_updated
   end
 
@@ -23,10 +23,6 @@ feature "edit training details" do
   def and_i_update_the_training_details
     @training_details_page.trainee_id.set(new_trainee_id)
     @training_details_page.submit_button.click
-  end
-
-  def then_i_am_redirected_to_the_record_page
-    expect(record_page).to be_displayed(id: trainee.slug)
   end
 
   def and_the_training_details_are_updated

--- a/spec/lib/origin_page_spec.rb
+++ b/spec/lib/origin_page_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe OriginPage do
+  let(:review_draft_trainee_path) { "/trainees/#{trainee.slug}/review-draft" }
+  let(:trainee_personal_details_confirm_path) { "/trainees/#{trainee.slug}/personal-details/confirm" }
+  let(:session) { { "origin_pages_for_#{trainee.id}" => origin_pages } }
+
+  subject { described_class.new(trainee, session, request) }
+
+  describe "#path" do
+    context "trainee is in draft state" do
+      let(:trainee) { create(:trainee, :draft) }
+
+      context "GET request" do
+        let(:request) { double(path_info: request_path, head?: false, get?: true, patch?: false, put?: false) }
+
+        context "no origin pages saved" do
+          let(:request_path) { review_draft_trainee_path }
+          let(:origin_pages) { [] }
+
+          it "returns the path to trainee review draft page" do
+            expect(subject.path).to eq(review_draft_trainee_path)
+          end
+        end
+
+        context "1 origin page saved" do
+          let(:request_path) { review_draft_trainee_path }
+          let(:origin_pages) { %w[review_draft_trainee] }
+
+          it "returns the path to the last origin page" do
+            expect(subject.path).to eq(review_draft_trainee_path)
+          end
+        end
+
+        context "2 origin pages saved" do
+          let(:request_path) { trainee_personal_details_confirm_path }
+          let(:origin_pages) { %w[review_draft_trainee trainee_personal_details_confirm] }
+
+          it "returns the path to the first origin page" do
+            expect(subject.path).to eq(review_draft_trainee_path)
+          end
+        end
+      end
+
+      context "PUT request" do
+        let(:request_path) { trainee_personal_details_confirm_path }
+        let(:request) { double(path_info: request_path, head?: false, get?: false, patch?: false, put?: true) }
+
+        context "2 origin pages saved" do
+          let(:origin_pages) { %w[review_draft_trainee trainee_personal_details_confirm] }
+
+          context "last page visited was a confirmation page" do
+            it "returns the path to the page before the confirmation page" do
+              expect(subject.path).to eq(review_draft_trainee_path)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/features/trainee_steps.rb
+++ b/spec/support/features/trainee_steps.rb
@@ -42,5 +42,9 @@ module Features
       confirm_details_page.confirm.public_send(checked_option)
       confirm_details_page.submit_button.click
     end
+
+    def then_i_am_redirected_to_the_review_draft_page
+      expect(review_draft_page).to be_displayed(id: trainee.slug)
+    end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/lrgavNan/853-l-return-to-origin-page-after-completing-an-edit-workflow

### Changes proposed in this pull request
- Extracted the origin page logic from `DynamicBackLink::View` into a reusable object (`OriginPage`) so we can use it in the `Trainees::ConfirmDetailsController`
- Updated some feature specs to reflect the new behaviour

### Guidance to review
- Fire up the app locally and confirm the behaviour matches the requirements outlined in the card

