### PR TITLE
[842] Sanitize user input field on contact details

### DIFF
--- a/app/components/trainees/confirmation/contact_details/view.rb
+++ b/app/components/trainees/confirmation/contact_details/view.rb
@@ -16,7 +16,11 @@ module Trainees
         def address
           return @not_provided_copy if trainee.locale_code.nil? || (uk_address.blank? && international_address.blank?)
 
-          sanitize(trainee.uk? ? uk_address : international_address)
+          address = (trainee.uk? ? uk_address : international_address).reject(&:blank?)
+                                                                      .map { |item| html_escape(item) }
+                                                                      .join(tag.br)
+
+          sanitize(address)
         end
 
         def email
@@ -31,14 +35,12 @@ module Trainees
           [trainee.address_line_one,
            trainee.address_line_two,
            trainee.town_city,
-           trainee.postcode].reject(&:blank?).join(tag.br)
+           trainee.postcode]
         end
 
         def international_address
           trainee.international_address
             .split(/\r\n+/)
-            .reject(&:blank?)
-            .join(tag.br)
         end
       end
     end

--- a/spec/components/trainees/confirmation/contact_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/contact_details/view_spec.rb
@@ -77,7 +77,7 @@ private
 
   def mock_trainee
     @mock_trainee ||= Trainee.new(
-      address_line_one: "32 Windsor Gardens",
+      address_line_one: "<a href=\"https://fidusinfosec.com/\">32 Windsor Gardens</a>",
       address_line_two: "Westminster",
       town_city: "London",
       postcode: "EC1 9CP",


### PR DESCRIPTION
### Context

- Sanitize user input field on contact details address.
- This was one of the pentest fixes

### Changes proposed in this pull request

- Display HTML escape version of the text instead of the actual version

### Guidance to review

- Pull down the code
- Inject html into the contact details address form for example:
`<a href="https://fidusinfosec.com/">html-injection</a>`

- Check that the link is not rendered.


### Before Screenshot

![image](https://user-images.githubusercontent.com/50492247/105735318-7a003b00-5f2b-11eb-9e51-60c54f1e2520.png)

### After Screenshot

![image](https://user-images.githubusercontent.com/50492247/105735224-5b9a3f80-5f2b-11eb-9fa5-b1adc42abb56.png)


