### PR TITLE
[840] Withdraw a trainee on DTTP

### DIFF
--- a/app/controllers/trainees/confirm_withdrawals_controller.rb
+++ b/app/controllers/trainees/confirm_withdrawals_controller.rb
@@ -8,6 +8,10 @@ module Trainees
 
     def update
       authorize trainee
+
+      trainee.withdraw!
+      WithdrawJob.perform_later(trainee.id)
+
       flash[:success] = "Trainee withdrawn"
       redirect_to trainee_path(trainee)
     end

--- a/app/jobs/withdraw_job.rb
+++ b/app/jobs/withdraw_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class WithdrawJob < ApplicationJob
+  queue_as :default
+  retry_on Dttp::Withdraw::Error
+
+  def perform(trainee_id)
+    Dttp::Withdraw.call(trainee: Trainee.find(trainee_id))
+  end
+end

--- a/app/services/dttp/withdraw.rb
+++ b/app/services/dttp/withdraw.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Dttp
+  class Withdraw
+    include ServicePattern
+
+    class Error < StandardError; end
+
+    attr_reader :trainee
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      dttp_update(
+        "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})",
+        Dttp::Params::Status.new(status: DttpStatuses::REJECTED),
+      )
+    end
+
+  private
+
+    def dttp_update(path, body)
+      response = Client.patch(path, body: body.to_json)
+      raise Error, response.body if response.code != 204
+    end
+  end
+end

--- a/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Trainees::ConfirmWithdrawalsController do
+  include ActiveJob::TestHelper
+
+  let(:trainee) { create(:trainee, :trn_received) }
+  let(:current_user) { build(:user) }
+  let(:trainee_policy) { instance_double(TraineePolicy, update?: true) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(current_user)
+    allow(TraineePolicy).to receive(:new).with(current_user, trainee).and_return(trainee_policy)
+  end
+
+  describe "#update" do
+    it "it updates the placement assignment in DTTP to mark it as withdrawn" do
+      expect {
+        post :update, params: { trainee_id: trainee }
+      }.to have_enqueued_job(WithdrawJob).with(trainee.id)
+    end
+
+    context "trainee state" do
+      before do
+        post :update, params: { trainee_id: trainee }
+      end
+
+      it "transitions the trainee state to withdrawn" do
+        expect(trainee.reload).to be_withdrawn
+      end
+    end
+  end
+end

--- a/spec/services/dttp/withdraw_spec.rb
+++ b/spec/services/dttp/withdraw_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe Withdraw do
+    describe "#call" do
+      let(:trainee) do
+        create(:trainee, :trn_received, placement_assignment_dttp_id: placement_assignment_dttp_id)
+      end
+      let(:placement_assignment_dttp_id) { SecureRandom.uuid }
+      let(:path) { "/dfe_placementassignments(#{placement_assignment_dttp_id})" }
+
+      before do
+        allow(AccessToken).to receive(:fetch).and_return("token")
+      end
+
+      context "success" do
+        let(:dttp_response) { double(code: 204) }
+        let(:expected_body) do
+          Dttp::Params::Status.new(
+            status: DttpStatuses::REJECTED,
+          ).to_json
+        end
+
+        it "sends a PATCH request with status params" do
+          expect(Client).to receive(:patch).with(path, body: expected_body).and_return(dttp_response)
+
+          described_class.call(trainee: trainee)
+        end
+      end
+
+      context "error" do
+        let(:error_body) { "error" }
+        let(:dttp_response) { double(code: 405, body: error_body) }
+
+        it "raises an error exception" do
+          expect(Client).to receive(:patch).and_return(dttp_response)
+          expect {
+            described_class.call(trainee: trainee)
+          }.to raise_error(Dttp::Withdraw::Error, error_body)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

This PR builds from @gpeng 's draft PR #432 , so should be reviewed once we're happy with the changes there.

https://trello.com/c/2qKHILWU/840-withdraw-on-dttp

### Changes proposed in this pull request

This PR includes:

- A `WithdrawJob`, called from the `ConfirmWithdrawalsController`, which queues up a:
- `Dttp::Withdraw` service, which makes a `patch` call to DTTP to set the trainee status to `deferred`

### Not included:
- I haven't transferred the trainee internally to `withdrawn` since the architecture for this is being decided in a separate ticket (when we move all state transitions out of jobs).