### PR TITLE
[924] Fetch QTS status

### DIFF
--- a/app/controllers/trainees/qts_recommendations_controller.rb
+++ b/app/controllers/trainees/qts_recommendations_controller.rb
@@ -6,6 +6,7 @@ module Trainees
       authorize trainee
 
       RecommendForQtsJob.perform_later(trainee.id)
+      RetrieveQtsJob.set(wait: RetrieveQtsJob::POLL_DELAY).perform_later(trainee.id)
 
       redirect_to recommended_trainee_outcome_details_path(trainee)
     end

--- a/app/jobs/retrieve_qts_job.rb
+++ b/app/jobs/retrieve_qts_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class RetrieveQtsJob < ApplicationJob
+  queue_as :default
+  retry_on Dttp::RetrieveQts::HttpError
+
+  class TraineeAttributeError < StandardError; end
+
+  POLL_DELAY = Settings.jobs.poll_delay_hours.hours
+  MAX_POLL_DURATION = Settings.jobs.max_poll_duration_days.days
+
+  def perform(trainee_id)
+    trainee = Trainee.find(trainee_id)
+
+    qts_awarded = Dttp::RetrieveQts.call(trainee: trainee)
+
+    if qts_awarded
+      trainee.award_qts!
+    elsif continue_polling?(trainee)
+      RetrieveQtsJob.set(wait: POLL_DELAY).perform_later(trainee.id)
+    end
+  end
+
+private
+
+  def continue_polling?(trainee)
+    if trainee.recommended_for_qts_at.nil?
+      raise TraineeAttributeError, "Trainee#recommended_for_qts_at is nil - it should be timestamped (id: #{trainee.id})"
+    end
+
+    trainee.recommended_for_qts_at > MAX_POLL_DURATION.ago
+  end
+end

--- a/app/jobs/retrieve_trn_job.rb
+++ b/app/jobs/retrieve_trn_job.rb
@@ -6,8 +6,8 @@ class RetrieveTrnJob < ApplicationJob
 
   class TraineeAttributeError < StandardError; end
 
-  POLL_DELAY = 6.hours
-  MAX_POLL_DURATION = 2.days
+  POLL_DELAY = Settings.jobs.poll_delay_hours.hours
+  MAX_POLL_DURATION = Settings.jobs.max_poll_duration_days.days
 
   def perform(trainee_id)
     trainee = Trainee.find(trainee_id)

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -82,6 +82,10 @@ class Trainee < ApplicationRecord
     end
 
     event :recommend_for_qts do
+      before do
+        self.recommended_for_qts_at = Time.zone.now
+      end
+
       transition %i[trn_received] => :recommended_for_qts
     end
 

--- a/app/services/dttp/retrieve_qts.rb
+++ b/app/services/dttp/retrieve_qts.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Dttp
+  class RetrieveQts
+    include ServicePattern
+
+    class HttpError < StandardError; end
+
+    attr_reader :trainee
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      response = Client.get("/contacts(#{trainee.dttp_id})?$select=dfe_qtsawardflag")
+      raise HttpError, response.body unless response.code == 200
+
+      JSON(response.body)["dfe_qtsawardflag"]
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,3 +32,7 @@ dfe_sign_in:
   profile: https://test-profile.signin.education.gov.uk
   # This value must be set otherwise sign in will fail
   secret: secret required value
+
+jobs:
+  poll_delay_hours: 6
+  max_poll_duration_days: 2

--- a/db/migrate/20210126154122_add_recommended_for_qts_at_to_trainees.rb
+++ b/db/migrate/20210126154122_add_recommended_for_qts_at_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRecommendedForQtsAtToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :recommended_for_qts_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_20_140248) do
+ActiveRecord::Schema.define(version: 2021_01_26_154122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 2021_01_20_140248) do
     t.string "additional_withdraw_reason"
     t.date "defer_date"
     t.string "slug", null: false
+    t.datetime "recommended_for_qts_at"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"
     t.index ["dttp_id"], name: "index_trainees_on_dttp_id"

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -38,4 +38,11 @@ describe "Settings" do
     include_examples expected_value_test, :profile, dfe_sign_in, "https://test-profile.signin.education.gov.uk"
     include_examples expected_value_test, :secret, dfe_sign_in, "secret required value"
   end
+
+  describe ".jobs" do
+    jobs = settings[:jobs]
+
+    include_examples expected_value_test, :poll_delay_hours, jobs, 6
+    include_examples expected_value_test, :max_poll_duration_days, jobs, 2
+  end
 end

--- a/spec/controllers/trainees/qts_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/qts_recommendations_controller_spec.rb
@@ -21,6 +21,14 @@ describe Trainees::QtsRecommendationsController do
       }.to have_enqueued_job(RecommendForQtsJob).with(trainee.id)
     end
 
+    it "queues a background job to poll for the trainee's QTS" do
+      Timecop.freeze(Time.zone.now) do
+        expect {
+          post :create, params: { trainee_id: trainee }
+        }.to have_enqueued_job(RetrieveQtsJob).at(RetrieveQtsJob::POLL_DELAY.from_now).with(trainee.id)
+      end
+    end
+
     it "redirects user to the recommended page" do
       post :create, params: { trainee_id: trainee }
       expect(response).to redirect_to(recommended_trainee_outcome_details_path(trainee))

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -85,6 +85,7 @@ FactoryBot.define do
 
     trait :recommended_for_qts do
       state { "recommended_for_qts" }
+      recommended_for_qts_at { Time.zone.now }
     end
 
     trait :withdrawn do

--- a/spec/jobs/retrieve_qts_job_spec.rb
+++ b/spec/jobs/retrieve_qts_job_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe RetrieveQtsJob do
+  include ActiveJob::TestHelper
+
+  let(:qts_flag) { nil }
+  let(:trainee) { create(:trainee, :recommended_for_qts) }
+
+  before do
+    allow(Dttp::RetrieveQts).to receive(:call).with(trainee: trainee).and_return(qts_flag)
+  end
+
+  context "QTS is awarded in DTTP" do
+    let(:qts_flag) { true }
+
+    it "transitions the trainee to qts_awarded" do
+      expect {
+        described_class.perform_now(trainee.id)
+        trainee.reload
+      }.to change(trainee, :state).to("qts_awarded")
+    end
+
+    it "doesn't queue another job" do
+      described_class.perform_now(trainee.id)
+      expect(RetrieveQtsJob).to_not have_been_enqueued
+    end
+  end
+
+  context "QTS is not awarded in DTTP" do
+    let(:qts_flag) { false }
+
+    it "queues another job to fetch the QTS 6 hours from now" do
+      Timecop.freeze(Time.zone.now) do
+        described_class.perform_now(trainee.id)
+        expect(RetrieveQtsJob).to have_been_enqueued.at(6.hours.from_now).with(trainee.id)
+      end
+    end
+
+    context "after 2 days of polling" do
+      let(:trainee) { create(:trainee, recommended_for_qts_at: 2.days.ago) }
+
+      it "doesn't queue another job after 2 days have passed with no QTS" do
+        described_class.perform_now(trainee.id)
+        expect(RetrieveQtsJob).to_not have_been_enqueued
+      end
+    end
+  end
+
+  context "the trainee attribute recommended_for_qts_at is nil" do
+    let(:trainee) { create(:trainee) }
+    let(:error_msg) { "Trainee#recommended_for_qts_at is nil - it should be timestamped (id: #{trainee.id})" }
+
+    it "raises a TraineeAttributeError" do
+      expect {
+        described_class.perform_now(trainee.id)
+      }.to raise_error(RetrieveQtsJob::TraineeAttributeError, error_msg)
+    end
+  end
+end

--- a/spec/services/dttp/retrieve_qts_spec.rb
+++ b/spec/services/dttp/retrieve_qts_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe RetrieveQts do
+    describe "#call" do
+      let(:contact_entity_id) { SecureRandom.uuid }
+      let(:trainee) { create(:trainee, :recommended_for_qts, dttp_id: contact_entity_id) }
+      let(:path) { "/contacts(#{contact_entity_id})?$select=dfe_qtsawardflag" }
+
+      subject { described_class.call(trainee: trainee) }
+
+      before do
+        allow(AccessToken).to receive(:fetch).and_return("token")
+        allow(Client).to receive(:get).with(path).and_return(dttp_response)
+      end
+
+      context "success response" do
+        let(:dttp_response) { double(code: 200, body: { dfe_qtsawardflag: qts_flag }.to_json) }
+
+        context "QTS is awarded" do
+          let(:qts_flag) { true }
+
+          it "returns the QTS flag" do
+            expect(subject).to eq(qts_flag)
+          end
+        end
+
+        context "QTS is not awarded" do
+          let(:qts_flag) { false }
+
+          it "returns the QTS flag" do
+            expect(subject).to eq(qts_flag)
+          end
+        end
+      end
+
+      context "HTTP error" do
+        let(:dttp_response) { double(code: 400, body: "error") }
+
+        it "raises a HttpError error with the response body as the message" do
+          expect(Client).to receive(:get).with(path).and_return(dttp_response)
+          expect {
+            subject
+          }.to raise_error(Dttp::RetrieveQts::HttpError, dttp_response.body)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/RtpR8Q8G/924-m-fetch-qts-status-once-submitted

### Changes proposed in this pull request

This PR includes:
- A `RetrieveQts` service that requests the `dfe_qtsawardflag` for a trainee from DTTP.
- A job `RetrieveQtsJob` that kicks off this service, polling every 6 hours for 2 days.
- A new column `recommended_for_qts_at` on trainees so we can use this to decide whether to continue polling