### PR TITLE
[932] Enable personas in pentest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,8 @@ group :test do
   gem "webmock"
 end
 
-group :development, :test, :review, :qa do
+# Required for example_data so needed in review, qa and pen too
+group :development, :test, :review, :qa, :pen do
   gem "factory_bot_rails"
   gem "faker"
 end

--- a/config/settings/pen.yml
+++ b/config/settings/pen.yml
@@ -5,5 +5,5 @@ dttp:
   back_office_url: https://dttp-test.crm4.dynamics.com/
 
 features:
-  home_text: true
-  use_dfe_sign_in: true
+  use_dfe_sign_in: false
+  basic_auth: true


### PR DESCRIPTION
### Context

We are going to use the pentest environment for an accessibility audit. This configures the environment for basic auth and personas.

### Changes proposed in this pull request

* Enable persona login
* Enable basic_auth

### Guidance to review

