### PR TITLE
[924] Adding and listing providers

### DIFF
--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -22,6 +22,11 @@
         <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation" data-module="govuk-button">Menu</button>
         <nav>
           <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+            <% if user_system_admin? %>
+              <li class="govuk-header__navigation-item">
+                <%= govuk_link_to "System admin", providers_path, class: "govuk-header__link" %>
+              </li>
+            <% end %>
             <li class="govuk-header__navigation-item">
               <%= govuk_link_to "Sign out", sign_out_path, class: "govuk-header__link" %>
             </li>

--- a/app/components/header/view.rb
+++ b/app/components/header/view.rb
@@ -13,4 +13,8 @@ class Header::View < GovukComponent::Base
   def user_signed_in?
     @current_user.present?
   end
+
+  def user_system_admin?
+    @current_user.system_admin?
+  end
 end

--- a/app/components/provider_card/script.js
+++ b/app/components/provider_card/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/provider_card/style.scss
+++ b/app/components/provider_card/style.scss
@@ -1,0 +1,7 @@
+@import "../base.scss";
+
+.provider-card {
+  border-bottom: 1px solid govuk-colour("mid-grey");
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+}

--- a/app/components/provider_card/view.html.erb
+++ b/app/components/provider_card/view.html.erb
@@ -1,0 +1,8 @@
+<div class="provider-card">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
+    <%= govuk_link_to provider.name, provider_path(provider) %>
+  </h2>
+  <p class="govuk-body govuk-hint">
+    <%= pluralize(provider.users.count, 'user') %>
+  </p>
+</div>

--- a/app/components/provider_card/view.rb
+++ b/app/components/provider_card/view.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ProviderCard
+  class View < GovukComponent::Base
+    include SanitizeHelper
+
+    with_collection_parameter :provider
+
+    attr_reader :provider
+
+    def initialize(provider:)
+      @provider = provider
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,10 @@ class SessionsController < ApplicationController
 
     if FeatureService.enabled?("allow_user_creation") && current_user.nil?
       @current_user = User.new(
-        provider: Provider.create_or_find_by(name: "DfE"),
+        provider: Provider.create_or_find_by(
+          name: "DfE",
+          dttp_id: "00000000-0000-0000-0000-000000000000",
+        ),
       )
     end
 

--- a/app/controllers/system_admin/providers_controller.rb
+++ b/app/controllers/system_admin/providers_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class ProvidersController < ApplicationController
+    layout "platform_admin"
+
+    def index
+      @providers = authorize Provider.all.order(:name)
+    end
+
+    def new
+      @provider = authorize Provider.new
+    end
+
+    def create
+      @provider = authorize Provider.new(provider_params)
+
+      if @provider.save
+        redirect_to providers_path
+      else
+        render :new
+      end
+    end
+
+    def show
+      @provider = authorize Provider.find(params[:id])
+    end
+
+  private
+
+    def provider_params
+      params.require(:provider).permit(:name, :dttp_id)
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,6 +5,7 @@ class Provider < ApplicationRecord
   has_many :trainees
 
   validates :name, presence: true
+  validates :dttp_id, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
 
   audited
   has_associated_audits

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ProviderPolicy
+  attr_reader :user
+
+  def initialize(user, provider)
+    @user = user
+    @provider = provider
+  end
+
+  def show?
+    user.system_admin?
+  end
+
+  alias_method :create?, :show?
+  alias_method :new?, :show?
+  alias_method :index?, :show?
+end

--- a/app/views/layouts/platform_admin.html.erb
+++ b/app/views/layouts/platform_admin.html.erb
@@ -1,0 +1,13 @@
+<%= extends_layout :application do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter">
+      <h2 class="govuk-heading-m">System admin</h2>
+      <ul class="govuk-list">
+        <%= govuk_link_to("Providers", providers_path) %>
+      </ul>
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      <%= yield %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/system_admin/providers/index.html.erb
+++ b/app/views/system_admin/providers/index.html.erb
@@ -1,0 +1,17 @@
+<%= render PageTitle::View.new(title: "providers.index") %>
+
+<h1 class="govuk-heading-xl">Providers</h1>
+
+<p class="govuk-body">
+  <%= render GovukComponent::StartNowButton.new(
+  text: "Add a provider",
+  href: new_provider_path ) %>
+</p>
+
+<% if @providers.any? %>
+  <div class="govuk-!-margin-bottom-8">
+    <%= render ProviderCard::View.with_collection(@providers) %>
+  </div>
+<% else %>
+  <h2 class="govuk-heading-m">There are no providers yet</h2>
+<% end %>

--- a/app/views/system_admin/providers/new.html.erb
+++ b/app/views/system_admin/providers/new.html.erb
@@ -1,0 +1,19 @@
+<%= render PageTitle::View.new(title: "providers.new", has_errors: @provider.errors.present?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: @provider, local: true do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        Add a provider
+      </h1>
+
+      <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20 %>
+      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20 %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/system_admin/providers/show.html.erb
+++ b/app/views/system_admin/providers/show.html.erb
@@ -1,0 +1,1 @@
+<%= render PageTitle::View.new(title: @provider.name, has_errors: @provider.errors.present?) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,9 @@ en:
           show: When did the trainee defer?
         deferral_details:
           confirm: Check deferral details
+      providers:
+        index: Providers
+        new: Add a provider
     filter:
       record_type: Training route
       state: Status
@@ -225,6 +228,12 @@ en:
               invalid: "You must enter a valid graduation year"
             country:
               blank: "You must select the country where the degree was obtained"
+        provider:
+          attributes:
+            name:
+              blank: You must provide a provider name
+            dttp_id:
+              invalid: You must enter a DTTP ID in the correct format, like b77c821a-c12a-4133-8036-6ef1db146f9e
   activemodel:
     errors:
       validators:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,10 @@ Rails.application.routes.draw do
     resource :confirm_details, as: :confirm, only: %i[show update], path: "/confirm"
   end
 
+  scope module: :system_admin, path: "system-admin" do
+    resources :providers, except: %i[edit update destroy]
+  end
+
   resources :trainees, except: :destroy do
     scope module: :trainees do
       resource :programme_details, concerns: :confirmable, only: %i[edit update], path: "/programme-details"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -17,7 +17,10 @@ namespace :example_data do
                                            system_admin: persona_attributes[:system_admin])
 
       if persona_attributes[:provider]
-        provider = Provider.find_or_create_by!(name: persona_attributes[:provider])
+        provider = Provider.find_or_create_by!(
+          name: persona_attributes[:provider],
+          dttp_id: "00000000-0000-0000-0000-000000000000",
+        )
         persona.update!(provider: provider)
       end
 

--- a/spec/components/provider_card/view_preview.rb
+++ b/spec/components/provider_card/view_preview.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ProviderCard
+  class ViewPreview < ViewComponent::Preview
+    def single_card
+      render(ProviderCard::View.new(provider: mock_provider(id: 1, name: "Provider A")))
+    end
+
+    def multiple_cards
+      render(ProviderCard::View.with_collection(mock_multiple_providers))
+    end
+
+  private
+
+    def mock_provider(id:, name:, user_count: 0)
+      provider = Provider.new(id: id, name: name, dttp_id: SecureRandom.uuid)
+
+      user_count.times do |i|
+        provider.users.new(
+          id: i,
+          first_name: "Jenny",
+          last_name: "Bloggs",
+          email: "test@example.com",
+        )
+      end
+
+      provider
+    end
+
+    def mock_multiple_providers
+      [
+        mock_provider(id: 1, name: "Provider A", user_count: 1),
+        mock_provider(id: 2, name: "Provider B", user_count: 2),
+        mock_provider(id: 3, name: "Provider C"),
+      ]
+    end
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence :name do |n|
       "Provider #{n}"
     end
+    dttp_id { SecureRandom.uuid }
   end
 end

--- a/spec/features/providers/creating_a_new_provider_spec.rb
+++ b/spec/features/providers/creating_a_new_provider_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Creating a new provider" do
+  let(:user) { create(:user, system_admin: true) }
+  let(:dttp_id) { SecureRandom.uuid }
+
+  before do
+    given_i_am_authenticated(user: user)
+    when_i_visit_the_provider_index_page
+    and_i_click_on_add_provider_button
+  end
+
+  scenario "submitting with valid parameters" do
+    and_i_fill_in_name
+    and_i_fill_in_dttp_id
+    and_i_submit_the_form
+    then_i_should_see_the_provider_index_page
+  end
+
+  scenario "submitting with invalid parameters" do
+    and_i_submit_the_form
+    then_i_see_error_messages
+  end
+
+private
+
+  def when_i_visit_the_provider_index_page
+    provider_index_page.load
+  end
+
+  def and_i_click_on_add_provider_button
+    @new_provider_page ||= PageObjects::Providers::New.new
+    provider_index_page.add_provider_link.click
+  end
+
+  def and_i_fill_in_name
+    @new_provider_page.name.set("Provider A")
+  end
+
+  def and_i_fill_in_dttp_id
+    @new_provider_page.dttp_id.set(dttp_id)
+  end
+
+  def and_i_submit_the_form
+    @new_provider_page.submit.click
+  end
+
+  def then_i_should_see_the_provider_index_page
+    expect(@provider_index_page).to be_displayed
+  end
+
+  def then_i_see_error_messages
+    translation_key_prefix = "activerecord.errors.models.provider.attributes"
+
+    expect(page).to have_text(
+      I18n.t("#{translation_key_prefix}.name.blank"),
+    )
+    expect(page).to have_text(
+      I18n.t("#{translation_key_prefix}.dttp_id.invalid"),
+    )
+  end
+
+  def provider_index_page
+    @provider_index_page ||= PageObjects::Providers::Index.new
+  end
+end

--- a/spec/features/providers/viewing_providers_spec.rb
+++ b/spec/features/providers/viewing_providers_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "View providers" do
+  context "as a system admin" do
+    let(:user) { create(:user, system_admin: true) }
+
+    before do
+      given_i_am_authenticated(user: user)
+      when_i_visit_the_provider_index_page
+    end
+
+    scenario "i can view the providers" do
+      then_i_see_the_provider
+      when_i_click_on_provider_name
+    end
+  end
+
+  def when_i_visit_the_provider_index_page
+    provider_index_page.load
+  end
+
+  def then_i_see_the_provider
+    expect(provider_index_page).to have_provider_card
+  end
+
+  def when_i_click_on_provider_name
+    provider_index_page.provider_card.name.click
+  end
+
+  def provider_index_page
+    @provider_index_page ||= PageObjects::Providers::Index.new
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 describe Provider do
   context "fields" do
     it "validates" do
-      expect(subject).to validate_presence_of(:name)
+      expect(subject).to validate_presence_of(:name).with_message("You must provide a provider name")
+      expect(subject).to validate_presence_of(:dttp_id).with_message("You must enter a DTTP ID in the correct format, like b77c821a-c12a-4133-8036-6ef1db146f9e")
     end
   end
 

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ProviderPolicy do
+  let(:system_admin_user) { build(:user, :system_admin) }
+  let(:other_user) { create(:user) }
+
+  subject { described_class }
+
+  permissions :index?, :show?, :new?, :create? do
+    it { is_expected.to permit(system_admin_user) }
+    it { is_expected.not_to permit(other_user) }
+  end
+end

--- a/spec/support/page_objects/providers/index.rb
+++ b/spec/support/page_objects/providers/index.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "../sections/provider_card"
+
+module PageObjects
+  module Providers
+    class Index < PageObjects::Base
+      set_url "/system-admin/providers"
+
+      element :add_provider_link, "a", text: "Add a provider"
+
+      section :provider_card, PageObjects::Sections::ProviderCard, ".provider-card"
+    end
+  end
+end

--- a/spec/support/page_objects/providers/new.rb
+++ b/spec/support/page_objects/providers/new.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Providers
+    class New < PageObjects::Base
+      set_url "system-admin/providers/new"
+
+      element :name, "#provider-name-field"
+      element :dttp_id, "#provider-dttp-id-field"
+
+      element :submit, 'input.govuk-button[type="submit"]'
+    end
+  end
+end

--- a/spec/support/page_objects/sections/provider_card.rb
+++ b/spec/support/page_objects/sections/provider_card.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class ProviderCard < PageObjects::Sections::Base
+      element :name, ".govuk-link"
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/VDJ1ZLMM/930-m-basic-ui-for-adding-providers

### Changes proposed in this pull request

This PR includes:
- A providers index page, listing all providers and links to their (empty) show pages
- A link to add a new provider
- A new provider page with basic form
- A `ProviderPolicy` that restricts all routes to system admins
- A link in the nav bar to 'Platform admin' that shows only for system admins
- A platform admin layout

Plus: A Very Basic Design!

### Guidance to review

**Firstly:**
- Sign in as a system admin
- Click on the 'Platform admin' link in the nav bar
- Check the providers are listed correctly
- Click the button 'Add a provider'
- Fill out the form
- Check validations
- Check that a new provider is created

**Secondly:**
- Sign in as a non-system admin
- Check that the link in the nav bar is hidden
- Check that you can't access the provider pages via URL
