### PR TITLE
[936] Store a reference to the DTTP degree IDs when TRN is requested

### DIFF
--- a/app/lib/dttp/odata_parser.rb
+++ b/app/lib/dttp/odata_parser.rb
@@ -6,9 +6,17 @@ module Dttp
 
     class << self
       def entity_ids(batch_response:)
-        batch_response.scan(/(\w+)\((#{UUID_PATTERN})\)/).uniq.each_with_object({}) do |(entity_name, entity_id), h|
-          h[entity_name] = (h[entity_name] || []) + [entity_id]
+        content_ids = batch_response.scan(/Content\-ID: (#{UUID_PATTERN})/).flatten
+        entities = batch_response.scan(/(\w+)\((#{UUID_PATTERN})\)/).uniq
+
+        content_id_entity_id_map = {}
+
+        entities.each_with_index do |(entity_name, entity_id), index|
+          content_id_entity_id_map[entity_name] ||= []
+          content_id_entity_id_map[entity_name] << { content_id: content_ids[index], entity_id: entity_id }
         end
+
+        content_id_entity_id_map
       end
 
       def entity_id(trainee_id, response)

--- a/app/services/dttp/register_for_trn.rb
+++ b/app/services/dttp/register_for_trn.rb
@@ -13,27 +13,53 @@ module Dttp
     end
 
     def call
-      contact_payload = Params::Contact.new(trainee, trainee_creator_dttp_id).to_json
-      contact_change_set_id = batch_request.add_change_set(entity: "contacts", payload: contact_payload)
-
-      placement_assignment_payload = Params::PlacementAssignment.new(trainee, contact_change_set_id).to_json
-      placement_assignment_change_set_id = batch_request.add_change_set(entity: "dfe_placementassignments",
-                                                                        payload: placement_assignment_payload)
-
-      trainee.degrees.each do |degree|
-        degree_qualification_payload = Params::DegreeQualification.new(degree,
-                                                                       contact_change_set_id,
-                                                                       placement_assignment_change_set_id).to_json
-        batch_request.add_change_set(entity: "dfe_degreequalifications", payload: degree_qualification_payload)
-      end
+      contact_change_set_id = build_contact_change_set
+      placement_assignment_change_set_id = build_placement_assignment_change_set(contact_change_set_id)
+      degree_change_set_ids = build_degree_qualification_change_sets(contact_change_set_id,
+                                                                     placement_assignment_change_set_id)
 
       batch_response = batch_request.submit
 
       entity_ids = OdataParser.entity_ids(batch_response: batch_response)
 
-      trainee.trn_requested!(entity_ids["contacts"].first, entity_ids["dfe_placementassignments"].first)
+      trainee.trn_requested!(entity_ids["contacts"].first[:entity_id],
+                             entity_ids["dfe_placementassignments"].first[:entity_id])
+
+      degree_change_set_ids.each do |degree, content_id|
+        result = entity_ids["dfe_degreequalifications"].find { |item| item[:content_id] == content_id }
+        degree.update!(dttp_id: result[:entity_id])
+      end
 
       entity_ids
+    end
+
+  private
+
+    def build_contact_change_set
+      contact_payload = Params::Contact.new(trainee, trainee_creator_dttp_id).to_json
+      batch_request.add_change_set(entity: "contacts", payload: contact_payload)
+    end
+
+    def build_placement_assignment_change_set(contact_change_set_id)
+      placement_assignment_payload = Params::PlacementAssignment.new(trainee, contact_change_set_id).to_json
+      batch_request.add_change_set(entity: "dfe_placementassignments", payload: placement_assignment_payload)
+    end
+
+    def build_degree_qualification_change_sets(contact_change_set_id, placement_assignment_change_set_id)
+      degree_change_set_ids = {}
+
+      trainee.degrees.each do |degree|
+        degree_qualification_payload = Params::DegreeQualification.new(degree,
+                                                                       contact_change_set_id,
+                                                                       placement_assignment_change_set_id).to_json
+
+        change_set_id = batch_request.add_change_set(entity: "dfe_degreequalifications",
+                                                     payload: degree_qualification_payload)
+
+        degree_change_set_ids[degree] = change_set_id
+      end
+
+      degree_change_set_ids
     end
   end
 end

--- a/db/migrate/20210127104805_add_dttp_id_to_degrees.rb
+++ b/db/migrate/20210127104805_add_dttp_id_to_degrees.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDttpIdToDegrees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :degrees, :dttp_id, :uuid
+    add_index :degrees, :dttp_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_26_154122) do
+ActiveRecord::Schema.define(version: 2021_01_27_104805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,8 @@ ActiveRecord::Schema.define(version: 2021_01_26_154122) do
     t.string "country"
     t.text "other_grade"
     t.string "slug", null: false
+    t.uuid "dttp_id"
+    t.index ["dttp_id"], name: "index_degrees_on_dttp_id"
     t.index ["locale_code"], name: "index_degrees_on_locale_code"
     t.index ["slug"], name: "index_degrees_on_slug", unique: true
     t.index ["trainee_id"], name: "index_degrees_on_trainee_id"

--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -34,6 +34,7 @@ FactoryBot.define do
       non_uk_degree_type
 
       subject { Dttp::CodeSets::DegreeSubjects::MAPPING.keys.sample }
+      grade { Dttp::CodeSets::Grades::MAPPING.keys.sample }
       country { Dttp::CodeSets::Countries::MAPPING.keys.sample }
       graduation_year { rand(NEXT_YEAR - Degree::MAX_GRAD_YEARS..NEXT_YEAR) }
     end

--- a/spec/lib/dttp/odata_parser_spec.rb
+++ b/spec/lib/dttp/odata_parser_spec.rb
@@ -86,11 +86,11 @@ module Dttp
 
       it "returns a hash of key/value pairs where the key is the entity name and the value the entity ID" do
         expect(subject).to include({
-          "contacts" => %w[243fc7f1-6035-eb11-a813-000d3ada6b1f],
-          "dfe_placementassignments" => %w[273fc7f1-6035-eb11-a813-000d3ada6b1f],
-          "dfe_degreequalifications" => %w[
-            62ebc247-3a57-eb11-a812-000d3ada6b1f
-            67ebc247-3a57-eb11-a812-000d3ada6b1f
+          "contacts" => [{ content_id: "06910a13-3875-4d7b-9dbf-d3d651a18e45", entity_id: "243fc7f1-6035-eb11-a813-000d3ada6b1f" }],
+          "dfe_placementassignments" => [{ content_id: "939906f2-bbe3-4080-9ed0-1aa6660dfabb", entity_id: "273fc7f1-6035-eb11-a813-000d3ada6b1f" }],
+          "dfe_degreequalifications" => [
+            { content_id: "5dc36062-2080-4515-b1cf-cff69726389d", entity_id: "62ebc247-3a57-eb11-a812-000d3ada6b1f" },
+            { content_id: "2f645f14-bae8-4b5f-93df-b76d4a774a8c", entity_id: "67ebc247-3a57-eb11-a812-000d3ada6b1f" },
           ],
         })
       end

--- a/spec/services/dttp/register_for_trn_spec.rb
+++ b/spec/services/dttp/register_for_trn_spec.rb
@@ -14,6 +14,7 @@ module Dttp
 
       let(:contact_change_set_id) { SecureRandom.uuid }
       let(:placement_assignment_change_set_id) { SecureRandom.uuid }
+      let(:degree_qualification_change_set_id) { SecureRandom.uuid }
 
       let(:contact_entity_id) { SecureRandom.uuid }
       let(:placement_assignment_entity_id) { SecureRandom.uuid }
@@ -27,8 +28,11 @@ module Dttp
 
       let(:dttp_response) do
         <<~DTTP_RESPONSE
+          Content-ID: #{contact_change_set_id}
           OData-EntityId: /contacts(#{contact_entity_id})
+          Content-ID: #{placement_assignment_change_set_id}
           OData-EntityId: /dfe_placementassignments(#{placement_assignment_entity_id})
+          Content-ID: #{degree_qualification_change_set_id}
           OData-EntityId: /dfe_degreequalifications(#{degree_qualification_entity_id})
         DTTP_RESPONSE
       end
@@ -41,26 +45,40 @@ module Dttp
       end
 
       it "submits a batch request to create contact, placement assignment and degree qualification entities and updates trainee record" do
-        expect(batch_request).to receive(:add_change_set).with(entity: "contacts",
-                                                               payload: contact_payload).and_return(
-                                                                 contact_change_set_id,
-                                                               )
+        expect(batch_request).to receive(:add_change_set).with(
+          entity: "contacts",
+          payload: contact_payload,
+        ).and_return(
+          contact_change_set_id,
+        )
 
-        expect(batch_request).to receive(:add_change_set).with(entity: "dfe_placementassignments",
-                                                               payload: placement_assignment_payload).and_return(
-                                                                 placement_assignment_change_set_id,
-                                                               )
+        expect(batch_request).to receive(:add_change_set).with(
+          entity: "dfe_placementassignments",
+          payload: placement_assignment_payload,
+        ).and_return(
+          placement_assignment_change_set_id,
+        )
 
-        expect(batch_request).to receive(:add_change_set).with(entity: "dfe_degreequalifications",
-                                                               payload: degree_qualification_payload)
+        expect(batch_request).to receive(:add_change_set).with(
+          entity: "dfe_degreequalifications",
+          payload: degree_qualification_payload,
+        ).and_return(
+          degree_qualification_change_set_id,
+        )
 
         expect(batch_request).to receive(:submit).and_return(dttp_response)
 
         expect {
           described_class.call(trainee: trainee, trainee_creator_dttp_id: trainee_creator_dttp_id)
-        }.to change(trainee, :dttp_id).to(contact_entity_id).and change(trainee, :placement_assignment_dttp_id).to(
+        }.to change(trainee, :dttp_id).to(
+          contact_entity_id,
+        ).and change(trainee, :placement_assignment_dttp_id).to(
           placement_assignment_entity_id,
-        ).and change(trainee, :submitted_for_trn_at).to(time_now)
+        ).and change(trainee, :submitted_for_trn_at).to(
+          time_now,
+        ).and change(degree, :dttp_id).to(
+          degree_qualification_entity_id,
+        )
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/16qjBAbg/936-s-store-a-reference-to-the-dttp-degree-ids-when-a-trainee-is-submitted

### Changes proposed in this pull request
- New migration file to add `dttp_id` field to degrees table
- Changed the data struture returned by `Dttp::OdataParser.entity_ids` to make it easier for `Dttp::RegisterForTrn` to find the DTTP ID for a particular degree
- Updated `Dttp::RegisterForTrn` to save the DTTP ID for each degree after batch request is finished

### Guidance to review
Try it out manually (make sure to comment out line 49 in `Dttp::Params::Contact` because we don't have a valid DTTP ID for the provider created via FactoryBot)

```ruby
require_relative "config/environment"
require "factory_bot_rails"
require "faker"

trainee = FactoryBot.create(:trainee,
                            :with_programme_details,
                            :diversity_disclosed,
                            :with_placement_assignment)

trainee.degrees << FactoryBot.create(:degree, :uk_degree_with_details)
trainee.degrees << FactoryBot.create(:degree, :non_uk_degree_with_details)

puts "============= Before Submit ============="
trainee.degrees.each do |degree|
  puts "Degree (#{degree.locale_code}) - DTTP ID: #{degree.dttp_id}"
end

batch_response = Dttp::RegisterForTrn.call(trainee: trainee, trainee_creator_dttp_id: "98c63edb-b0a6-e811-812c-5065f38bc301")

puts "\n============= Before Submit ============="
trainee.degrees.each do |degree|
  puts "Degree (#{degree.locale_code}) - DTTP ID: #{degree.dttp_id}"
end

puts "\n\n#{batch_response}"
```
