### PR TITLE
[943] Fix origin page save bug

### DIFF
--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -23,6 +23,7 @@ module Trainees
       end
 
       flash[:success] = "Trainee #{flash_message_title} updated"
+
       redirect_to OriginPage.new(trainee, session, request).path
     end
 

--- a/app/lib/dttp/code_sets/statuses.rb
+++ b/app/lib/dttp/code_sets/statuses.rb
@@ -4,20 +4,20 @@ module Dttp
   module CodeSets
     module Statuses
       MAPPING = {
-        "Awaiting QTS" => { entity_id: "1b5af972-9e1b-e711-80c7-0050568902d3" },
-        "Awarded EYTS" => { entity_id: "2d5af972-9e1b-e711-80c7-0050568902d3" },
-        "Awarded QTS" => { entity_id: "195af972-9e1b-e711-80c7-0050568902d3" },
-        "Draft record" => { entity_id: "2b5af972-9e1b-e711-80c7-0050568902d3" },
-        "EYTS Revoked" => { entity_id: "2f5af972-9e1b-e711-80c7-0050568902d3" },
-        "Left course before the end" => { entity_id: "235af972-9e1b-e711-80c7-0050568902d3" },
-        "Prospective trainee - TREFNO requested" => { entity_id: "275af972-9e1b-e711-80c7-0050568902d3" },
-        "QTS revoked" => { entity_id: "155af972-9e1b-e711-80c7-0050568902d3" },
-        "Standards met" => { entity_id: "1f5af972-9e1b-e711-80c7-0050568902d3" },
-        "Standards not met" => { entity_id: "215af972-9e1b-e711-80c7-0050568902d3" },
-        "Trainee deferred" => { entity_id: "1d5af972-9e1b-e711-80c7-0050568902d3" },
-        "Trainee did not start course" => { entity_id: "255af972-9e1b-e711-80c7-0050568902d3" },
-        "Trainee rejected/revoked from ITT Studies" => { entity_id: "175af972-9e1b-e711-80c7-0050568902d3" },
-        "Yet to complete the course" => { entity_id: "295af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::AWAITING_QTS => { entity_id: "1b5af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::AWARDED_EYTS => { entity_id: "2d5af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::AWARDED_QTS => { entity_id: "195af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::DRAFT_RECORD => { entity_id: "2b5af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::EYTS_REVOKED => { entity_id: "2f5af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::LEFT_COURSE_BEFORE_END => { entity_id: "235af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED => { entity_id: "275af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::QTS_REVOKED => { entity_id: "155af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::STANDARDS_MET => { entity_id: "1f5af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::STANDARDS_NOT_MET => { entity_id: "215af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::DEFERRED => { entity_id: "1d5af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::DID_NOT_START => { entity_id: "255af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::REJECTED => { entity_id: "175af972-9e1b-e711-80c7-0050568902d3" },
+        DttpStatuses::YET_TO_COMPLETE_COURSE => { entity_id: "295af972-9e1b-e711-80c7-0050568902d3" },
       }.freeze
     end
   end

--- a/app/lib/dttp/params/contact.rb
+++ b/app/lib/dttp/params/contact.rb
@@ -47,7 +47,6 @@ module Dttp
           "gendercode" => GENDER_CODES[trainee.gender.to_sym],
           "dfe_EthnicityId@odata.bind" => "/dfe_ethnicities(#{contact_dttp_ethnicity_id})",
           "dfe_DisibilityId@odata.bind" => "/dfe_disabilities(#{contact_dttp_disability_id})",
-          "parentcustomerid_account@odata.bind" => "/accounts(#{trainee.provider.dttp_id})",
         }
       end
 

--- a/app/lib/dttp/params/contact.rb
+++ b/app/lib/dttp/params/contact.rb
@@ -35,6 +35,7 @@ module Dttp
 
       def build_params
         {
+          "dfe_ContactTypeId@odata.bind" => "/dfe_contacttypes(faba11c7-07d9-e711-80e1-005056ac45bb)", # trainee type
           "firstname" => trainee.first_names,
           "lastname" => trainee.last_name,
           "address1_line1" => trainee.address_line_one,

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -34,6 +34,7 @@ module Dttp
           "dfe_programmestartdate" => trainee.programme_start_date.in_time_zone.iso8601,
           "dfe_programmeenddate" => trainee.programme_end_date.in_time_zone.iso8601,
           "dfe_sendforsiregistration" => true,
+          "dfe_ProviderId@odata.bind" => "/accounts(#{trainee.provider.dttp_id})",
         }.merge(qualifying_degree.uk? ? uk_specific_params : non_uk_specific_params)
       end
 

--- a/app/lib/dttp/params/status.rb
+++ b/app/lib/dttp/params/status.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Dttp
+  module Params
+    class Status
+      include Mappable
+
+      attr_reader :status
+
+      def initialize(status:)
+        @status = status
+      end
+
+      def to_json(*_args)
+        params.to_json
+      end
+
+      def params
+        { "dfe_TraineeStatusId@odata.bind" => "/dfe_traineestatuses(#{dttp_status_id(status)})" }
+      end
+    end
+  end
+end

--- a/app/lib/origin_page.rb
+++ b/app/lib/origin_page.rb
@@ -15,9 +15,11 @@ class OriginPage
 
   def save
     # Don't save it the same origin page on page refresh, for example.
-    origin_pages << current_page unless origin_pages.include?(current_page)
+    return if origin_pages.include?(current_page)
 
-    origin_pages.shift if origin_pages.length > MAX_PAGES
+    # if there are MAX_PAGES pages we want to replace the last one
+    origin_pages.pop if origin_pages.length == MAX_PAGES
+    origin_pages << current_page
   end
 
   def path

--- a/app/services/dttp/defer.rb
+++ b/app/services/dttp/defer.rb
@@ -3,7 +3,6 @@
 module Dttp
   class Defer
     include ServicePattern
-    include Mappable
 
     class Error < StandardError; end
 
@@ -14,9 +13,10 @@ module Dttp
     end
 
     def call
-      body = { "dfe_TraineeStatusId@odata.bind" => "/dfe_traineestatuses(#{dttp_status_id(DttpStatuses::DEFERRED)})" }
-
-      dttp_update("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})", body)
+      dttp_update(
+        "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})",
+        Dttp::Params::Status.new(status: DttpStatuses::DEFERRED),
+      )
 
       trainee.defer!
     end

--- a/app/services/dttp/defer.rb
+++ b/app/services/dttp/defer.rb
@@ -14,7 +14,7 @@ module Dttp
     end
 
     def call
-      body = { "dfe_TraineeStatusId@odata.bind" => "/dfe_traineestatuses(#{dttp_status_id('Trainee deferred')})" }
+      body = { "dfe_TraineeStatusId@odata.bind" => "/dfe_traineestatuses(#{dttp_status_id(DttpStatuses::DEFERRED)})" }
 
       dttp_update("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})", body)
 

--- a/app/services/dttp/register_for_trn.rb
+++ b/app/services/dttp/register_for_trn.rb
@@ -13,7 +13,6 @@ module Dttp
     end
 
     def call
-      contact_payload = Params::Contact.new(trainee, trainee_creator_dttp_id).to_json
       contact_change_set_id = batch_request.add_change_set(entity: "contacts", payload: contact_payload)
 
       placement_assignment_payload = Params::PlacementAssignment.new(trainee, contact_change_set_id).to_json
@@ -27,6 +26,11 @@ module Dttp
         batch_request.add_change_set(entity: "dfe_degreequalifications", payload: degree_qualification_payload)
       end
 
+      batch_request.add_change_set(
+        entity: "contacts",
+        payload: status_payload,
+      )
+
       batch_response = batch_request.submit
 
       entity_ids = OdataParser.entity_ids(batch_response: batch_response)
@@ -34,6 +38,18 @@ module Dttp
       trainee.trn_requested!(entity_ids["contacts"].first, entity_ids["dfe_placementassignments"].first)
 
       entity_ids
+    end
+
+  private
+
+    def contact_payload
+      Params::Contact.new(trainee, trainee_creator_dttp_id).to_json
+    end
+
+    def status_payload
+      Params::Status.new(
+        status: DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED,
+      ).to_json
     end
   end
 end

--- a/config/initializers/dttp_statuses.rb
+++ b/config/initializers/dttp_statuses.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DttpStatuses
+  AWAITING_QTS = "Awaiting QTS"
+  AWARDED_EYTS = "Awarded EYTS"
+  AWARDED_QTS = "Awarded QTS"
+  DRAFT_RECORD = "Draft record"
+  EYTS_REVOKED = "EYTS Revoked"
+  LEFT_COURSE_BEFORE_END = "Left course before the end"
+  PROSPECTIVE_TRAINEE_TRN_REQUESTED = "Prospective trainee - TREFNO requested"
+  QTS_REVOKED = "QTS revoked"
+  STANDARDS_MET = "Standards met"
+  STANDARDS_NOT_MET = "Standards not met"
+  DEFERRED = "Trainee deferred"
+  DID_NOT_START = "Trainee did not start course"
+  REJECTED = "Trainee rejected/revoked from ITT Studies"
+  YET_TO_COMPLETE_COURSE = "Yet to complete the course"
+end

--- a/spec/lib/dttp/params/contact_spec.rb
+++ b/spec/lib/dttp/params/contact_spec.rb
@@ -18,6 +18,7 @@ module Dttp
       describe "#params" do
         it "returns a hash with all the DTTP basic contact fields" do
           expect(subject).to include({
+            "dfe_ContactTypeId@odata.bind" => "/dfe_contacttypes(faba11c7-07d9-e711-80e1-005056ac45bb)",
             "firstname" => trainee.first_names,
             "lastname" => trainee.last_name,
             "address1_line1" => trainee.address_line_one,

--- a/spec/lib/dttp/params/contact_spec.rb
+++ b/spec/lib/dttp/params/contact_spec.rb
@@ -29,7 +29,6 @@ module Dttp
             "emailaddress1" => trainee.email,
             "gendercode" => Dttp::Params::Contact::GENDER_CODES[:female],
             "dfe_CreatedById@odata.bind" => "/contacts(#{trainee_creator_dttp_id})",
-            "parentcustomerid_account@odata.bind" => "/accounts(#{trainee.provider.dttp_id})",
             "dfe_trnassessmentdate" => time_now_in_zone.in_time_zone.iso8601,
           })
         end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -6,7 +6,8 @@ module Dttp
   module Params
     describe PlacementAssignment do
       let(:time_now_in_zone) { Time.zone.now }
-      let(:trainee) { create(:trainee, :with_programme_details, dttp_id: dttp_contact_id) }
+      let(:provider) { create(:provider, dttp_id: dttp_provider_id) }
+      let(:trainee) { create(:trainee, :with_programme_details, dttp_id: dttp_contact_id, provider: provider) }
 
       let(:contact_change_set_id) { SecureRandom.uuid }
       let(:dttp_contact_id) { SecureRandom.uuid }
@@ -16,6 +17,7 @@ module Dttp
       let(:dttp_degree_institution_entity_id) { SecureRandom.uuid }
       let(:dttp_degree_grade_entity_id) { SecureRandom.uuid }
       let(:dttp_country_entity_id) { SecureRandom.uuid }
+      let(:dttp_provider_id) { SecureRandom.uuid }
 
       before do
         allow(Time).to receive(:now).and_return(time_now_in_zone)
@@ -54,6 +56,7 @@ module Dttp
               "dfe_ClassofUGDegreeId@odata.bind" => "/dfe_classofdegrees(#{dttp_degree_grade_entity_id})",
               "dfe_sendforsiregistration" => true,
               "dfe_sendforregistrationdate" => time_now_in_zone.iso8601,
+              "dfe_ProviderId@odata.bind" => "/accounts(#{dttp_provider_id})",
             })
           end
         end
@@ -72,6 +75,7 @@ module Dttp
               "dfe_CountryofStudyId@odata.bind" => "/dfe_countries(#{dttp_country_entity_id})",
               "dfe_sendforsiregistration" => true,
               "dfe_sendforregistrationdate" => time_now_in_zone.iso8601,
+              "dfe_ProviderId@odata.bind" => "/accounts(#{dttp_provider_id})",
             })
           end
         end

--- a/spec/lib/dttp/params/status_spec.rb
+++ b/spec/lib/dttp/params/status_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  module Params
+    describe Status do
+      subject { described_class.new(status: status).params }
+
+      describe "#params" do
+        let(:status) { DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED }
+
+        let(:expected_hash) do
+          { "dfe_TraineeStatusId@odata.bind" => "/dfe_traineestatuses(#{Dttp::CodeSets::Statuses::MAPPING[status][:entity_id]})" }
+        end
+
+        it { is_expected.to eq(expected_hash) }
+      end
+    end
+  end
+end

--- a/spec/services/dttp/defer_spec.rb
+++ b/spec/services/dttp/defer_spec.rb
@@ -17,10 +17,15 @@ module Dttp
 
       context "success" do
         let(:dttp_response) { double(code: 204) }
+        let(:expected_body) do
+          Dttp::Params::Status.new(
+            status: DttpStatuses::DEFERRED,
+          ).to_json
+        end
 
-        it "sends a PATCH request to set entity property 'dfe_TraineeStatusId@odata.bind' and transitions trainee to deferred" do
-          body = { "dfe_TraineeStatusId@odata.bind" => "/dfe_traineestatuses(1d5af972-9e1b-e711-80c7-0050568902d3)" }.to_json
-          expect(Client).to receive(:patch).with(path, body: body).and_return(dttp_response)
+        it "sends a PATCH request with status params and transitions trainee to deferred" do
+          expect(Client).to receive(:patch).with(path, body: expected_body).and_return(dttp_response)
+
           described_class.call(trainee: trainee)
           expect(trainee.state).to eq("deferred")
         end

--- a/spec/services/dttp/register_for_trn_spec.rb
+++ b/spec/services/dttp/register_for_trn_spec.rb
@@ -25,6 +25,10 @@ module Dttp
         Params::DegreeQualification.new(degree, contact_change_set_id, placement_assignment_change_set_id).to_json
       end
 
+      let(:status_payload) do
+        Params::Status.new(status: DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED).to_json
+      end
+
       let(:dttp_response) do
         <<~DTTP_RESPONSE
           OData-EntityId: /contacts(#{contact_entity_id})
@@ -53,6 +57,9 @@ module Dttp
 
         expect(batch_request).to receive(:add_change_set).with(entity: "dfe_degreequalifications",
                                                                payload: degree_qualification_payload)
+
+        expect(batch_request).to receive(:add_change_set).with(entity: "contacts",
+                                                               payload: status_payload)
 
         expect(batch_request).to receive(:submit).and_return(dttp_response)
 


### PR DESCRIPTION
### Context

We have a bug when if a user clicks a change link on an origin page e.g. review draft trainee, confirms that edit, returns to review draft trainee and then clicks a different change link they get stuck between two confirmation pages when the submit the second edit.

The recently introduced `OriginPage` stores a two element array of origin pages in the session. This array was being built incorrectly.

```
visit review_draft_trainee
origin_pages = [review_draft_trainee]

click the Personal details link and end up at the confirmation
origin_pages = [review_draft_trainee, confirm_personal_details]

Submit and return to review
origin_pages = [review_draft_trainee, confirm_personal_details]

click the Contact details link and end up at the confirmation
origin_pages = [confirm_contact_details, confirm_personal_details] <- this is now wrong. We've lost the reference to the original origin page.

submit confirm contact details and we're stuck on the confirm pages
```

### Changes proposed in this pull request

* Replace the last element of the array not the first
* Add tests for the `OriginPage#save` method
* Add tests for the draft/non draft contexts. (this is another bug that is already fixed but had no test coverage)

Fixed version:

```
visit review_draft_trainee
origin_pages = [review_draft_trainee]

click the Personal details and end up at the confirmation
origin_pages = [review_draft_trainee, confirm_personal_details]

Submit and return to review
origin_pages = [review_draft_trainee, confirm_personal_details]

click the Contact details link and end up at the confirmation
origin_pages = [review_draft_trainee, confirm_contact_details] <- We now replace the last instead of the first. All is well in the world.

submit confirm contact details and return to review_draft_trainee
```

### Guidance to review

Non-Draft:

* Open a non-draft record (trainees#show)
* Click a change link
* Go through the edit workflow and submit confirm
* Return to the trainee show page 
* Click a different change link
* Go through the edit workflow and submit confirm
* You should return to the trainee show page

Draft:

* Open a draft record
* Click a change link
* Go through the edit workflow and submit confirm
* Return to the draft trainee review page
* Click a different change link
* Go through the edit workflow and submit confirm
* You should return to the draft trainee review page


