### PR TITLE
[923] Make state transitions when jobs are queued

### DIFF
--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -9,6 +9,7 @@ module Trainees
     def update
       authorize trainee
 
+      trainee.defer!
       DeferJob.perform_later(trainee.id)
 
       flash[:success] = "Trainee deferred"

--- a/app/controllers/trainees/qts_recommendations_controller.rb
+++ b/app/controllers/trainees/qts_recommendations_controller.rb
@@ -4,6 +4,7 @@ module Trainees
   class QtsRecommendationsController < ApplicationController
     def create
       authorize trainee
+      trainee.recommend_for_qts!
 
       RecommendForQtsJob.perform_later(trainee.id)
       RetrieveQtsJob.set(wait: RetrieveQtsJob::POLL_DELAY).perform_later(trainee.id)

--- a/app/controllers/trn_submissions_controller.rb
+++ b/app/controllers/trn_submissions_controller.rb
@@ -4,6 +4,8 @@ class TrnSubmissionsController < ApplicationController
   before_action :authorize_trainee
 
   def create
+    trainee.submit_for_trn!
+
     RegisterForTrnJob.perform_later(trainee.id, current_user.dttp_id)
     RetrieveTrnJob.set(wait: RetrieveTrnJob::POLL_DELAY).perform_later(trainee.id)
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -129,7 +129,6 @@ class Trainee < ApplicationRecord
   scope :ordered_by_date, -> { order(updated_at: :desc) }
 
   def trn_requested!(dttp_id, placement_assignment_dttp_id)
-    submit_for_trn!
     update!(dttp_id: dttp_id, placement_assignment_dttp_id: placement_assignment_dttp_id)
   end
 

--- a/app/services/dttp/defer.rb
+++ b/app/services/dttp/defer.rb
@@ -17,8 +17,6 @@ module Dttp
         "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})",
         Dttp::Params::Status.new(status: DttpStatuses::DEFERRED),
       )
-
-      trainee.defer!
     end
 
   private

--- a/app/services/dttp/recommend_for_qts.rb
+++ b/app/services/dttp/recommend_for_qts.rb
@@ -17,8 +17,6 @@ module Dttp
       response = Client.patch("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})", body: body)
       raise Error, response.body if response.code != 204
 
-      trainee.recommend_for_qts!
-
       response
     end
   end

--- a/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe Trainees::ConfirmDeferralsController do
   include ActiveJob::TestHelper
 
-  let(:trainee) { create(:trainee) }
+  let(:trainee) { create(:trainee, :trn_received) }
   let(:current_user) { build(:user) }
   let(:trainee_policy) { instance_double(TraineePolicy, update?: true) }
 
@@ -19,6 +19,16 @@ describe Trainees::ConfirmDeferralsController do
       expect {
         post :update, params: { trainee_id: trainee }
       }.to have_enqueued_job(DeferJob).with(trainee.id)
+    end
+
+    context "trainee state" do
+      before do
+        post :update, params: { trainee_id: trainee }
+      end
+
+      it "transitions the trainee state to defferred" do
+        expect(trainee.reload).to be_deferred
+      end
     end
   end
 end

--- a/spec/controllers/trainees/qts_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/qts_recommendations_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe Trainees::QtsRecommendationsController do
   include ActiveJob::TestHelper
 
-  let(:trainee) { create(:trainee) }
+  let(:trainee) { create(:trainee, :trn_received) }
   let(:current_user) { build(:user) }
   let(:trainee_policy) { instance_double(TraineePolicy, create?: true) }
 
@@ -32,6 +32,16 @@ describe Trainees::QtsRecommendationsController do
     it "redirects user to the recommended page" do
       post :create, params: { trainee_id: trainee }
       expect(response).to redirect_to(recommended_trainee_outcome_details_path(trainee))
+    end
+
+    context "trainee state" do
+      before do
+        post :create, params: { trainee_id: trainee }
+      end
+
+      it "transitions the trainee state to recommended_for_qts" do
+        expect(trainee.reload).to be_recommended_for_qts
+      end
     end
   end
 end

--- a/spec/controllers/trn_submissions_controller_spec.rb
+++ b/spec/controllers/trn_submissions_controller_spec.rb
@@ -28,5 +28,15 @@ describe TrnSubmissionsController do
         }.to have_enqueued_job(RetrieveTrnJob).at(RetrieveTrnJob::POLL_DELAY.from_now).with(trainee.id)
       end
     end
+
+    context "trainee state" do
+      before do
+        post :create, params: { trainee_id: trainee }
+      end
+
+      it "transitions the trainee state to submitted_for_trn" do
+        expect(trainee.reload).to be_submitted_for_trn
+      end
+    end
   end
 end

--- a/spec/features/trainees/recommending_for_qts_spec.rb
+++ b/spec/features/trainees/recommending_for_qts_spec.rb
@@ -16,7 +16,7 @@ feature "Recommending for QTS", type: :feature do
   end
 
   def and_a_trainee_exists_ready_for_qts
-    given_a_trainee_exists(:with_placement_assignment)
+    given_a_trainee_exists(:with_placement_assignment, :trn_received)
     stub_dttp_placement_assignment_request(outcome_date: Time.zone.today, status: 204)
   end
 

--- a/spec/models/trainee/state_transitions_spec.rb
+++ b/spec/models/trainee/state_transitions_spec.rb
@@ -76,11 +76,24 @@ describe "Trainee state transitions" do
 
       it "transitions the trainee to :submitted_for_trn and updates the dttp_id, placement_assignment_dttp_id and submitted_for_trn_at" do
         trainee.trn_requested!(dttp_id, placement_assignment_dttp_id)
-        expect(trainee.state).to eq("submitted_for_trn")
         expect(trainee.dttp_id).to eq(dttp_id)
         expect(trainee.placement_assignment_dttp_id).to eq(placement_assignment_dttp_id)
-        expect(trainee.submitted_for_trn_at).to_not be_nil
       end
+    end
+  end
+
+  describe "#submit_for_trn" do
+    let(:time_now) { Time.zone.now }
+
+    subject { create(:trainee) }
+
+    before do
+      allow(Time).to receive(:now).and_return(time_now)
+      subject.submit_for_trn!
+    end
+
+    it "sets the #submitted_for_trn_at" do
+      expect(subject.submitted_for_trn_at).to eq(time_now)
     end
   end
 end

--- a/spec/services/dttp/defer_spec.rb
+++ b/spec/services/dttp/defer_spec.rb
@@ -27,7 +27,6 @@ module Dttp
           expect(Client).to receive(:patch).with(path, body: expected_body).and_return(dttp_response)
 
           described_class.call(trainee: trainee)
-          expect(trainee.state).to eq("deferred")
         end
       end
 
@@ -40,7 +39,6 @@ module Dttp
           expect {
             described_class.call(trainee: trainee)
           }.to raise_error(Dttp::Defer::Error, error_body)
-          expect(trainee.state).to eq("trn_received")
         end
       end
     end

--- a/spec/services/dttp/register_for_trn_spec.rb
+++ b/spec/services/dttp/register_for_trn_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 module Dttp
   describe RegisterForTrn do
     describe "#call" do
-      let(:time_now) { Time.zone.now }
       let(:trainee) { create(:trainee, :with_programme_details) }
       let(:degree) { build(:degree, :uk_degree_with_details) }
 
@@ -44,7 +43,6 @@ module Dttp
       before do
         allow(AccessToken).to receive(:fetch).and_return("token")
         allow(BatchRequest).to receive(:new).and_return(batch_request)
-        allow(Time).to receive(:now).and_return(time_now)
         trainee.degrees << degree
       end
 
@@ -78,10 +76,6 @@ module Dttp
           contact_entity_id,
         ).and change(trainee, :placement_assignment_dttp_id).to(
           placement_assignment_entity_id,
-        ).and change(trainee, :submitted_for_trn_at).to(
-          time_now,
-        ).and change(degree, :dttp_id).to(
-          degree_qualification_entity_id,
         )
       end
     end


### PR DESCRIPTION
### Context

- https://trello.com/c/7OwDOpJw/923-m-make-state-transitions-when-jobs-are-queued

### Changes proposed in this pull request

- Set a few of the state transitions before their jobs are queued (bubble them up outside of the services)

### Guidance to review

This was mainly a refactor, no actual product changes were implemented.

