### PR TITLE
[943] Fix origin page bug when returning to same origin page

### DIFF
--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -23,6 +23,7 @@ module Trainees
       end
 
       flash[:success] = "Trainee #{flash_message_title} updated"
+
       redirect_to OriginPage.new(trainee, session, request).path
     end
 

--- a/app/lib/origin_page.rb
+++ b/app/lib/origin_page.rb
@@ -15,7 +15,7 @@ class OriginPage
 
   def save
     # Don't save it the same origin page on page refresh, for example.
-    origin_pages << current_page unless origin_pages.include?(current_page)
+    origin_pages << current_page unless origin_pages.last == current_page
 
     origin_pages.shift if origin_pages.length > MAX_PAGES
   end

--- a/spec/lib/origin_page_spec.rb
+++ b/spec/lib/origin_page_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe OriginPage do
+  let(:trainee_path) { "/trainees/#{trainee.slug}" }
   let(:review_draft_trainee_path) { "/trainees/#{trainee.slug}/review-draft" }
   let(:trainee_personal_details_confirm_path) { "/trainees/#{trainee.slug}/personal-details/confirm" }
   let(:session) { { "origin_pages_for_#{trainee.id}" => origin_pages } }
@@ -10,6 +11,23 @@ describe OriginPage do
   subject { described_class.new(trainee, session, request) }
 
   describe "#path" do
+    context "trainee not in draft" do
+      let(:trainee) { create(:trainee, :submitted_for_trn) }
+
+      context "GET request" do
+        let(:request) { double(path_info: request_path, head?: false, get?: true, patch?: false, put?: false) }
+
+        context "no origin pages saved" do
+          let(:request_path) { review_draft_trainee_path }
+          let(:origin_pages) { [] }
+
+          it "returns the path to trainee review draft page" do
+            expect(subject.path).to eq(trainee_path)
+          end
+        end
+      end
+    end
+
     context "trainee is in draft state" do
       let(:trainee) { create(:trainee, :draft) }
 
@@ -57,6 +75,61 @@ describe OriginPage do
             end
           end
         end
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:trainee) { create(:trainee) }
+    let(:request_path) { review_draft_trainee_path }
+    let(:request) { double(path_info: request_path, head?: false, get?: true, patch?: false, put?: false) }
+
+    before do
+      subject.save
+    end
+
+    context "origin pages is empty" do
+      let(:origin_pages) { [] }
+
+      it "stores the request path" do
+        expect(session["origin_pages_for_#{trainee.id}"]).to eq(%w[review_draft_trainee])
+      end
+    end
+
+    context "origin pages contains only the request path" do
+      let(:origin_pages) { %w[review_draft_trainee] }
+
+      it "is a noop" do
+        expect(session["origin_pages_for_#{trainee.id}"]).to eq(origin_pages)
+      end
+    end
+
+    context "origin pages contains one different path" do
+      let(:request_path) { trainee_personal_details_confirm_path }
+      let(:origin_pages) { %w[review_draft_trainee] }
+
+      it "appends the request path" do
+        expect(session["origin_pages_for_#{trainee.id}"]).to eq(%w[review_draft_trainee trainee_personal_details_confirm])
+      end
+    end
+
+    context "origin pages includes the request path last" do
+      let(:request_path) { review_draft_trainee_path }
+      let(:origin_pages) { %w[trainee_personal_details_confirm review_draft_trainee] }
+
+      it "is a noop" do
+        expect(session["origin_pages_for_#{trainee.id}"]).to eq(origin_pages)
+      end
+    end
+
+    # i.e. you're returning to an origin page, after having been on another - we
+    # still need to save it!
+    context "origin pages includes the request path, but not last" do
+      let(:request_path) { review_draft_trainee_path }
+      let(:origin_pages) { %w[review_draft_trainee trainee_personal_details_confirm] }
+
+      it "appends the request path" do
+        expect(session["origin_pages_for_#{trainee.id}"]).to eq(%w[trainee_personal_details_confirm review_draft_trainee])
       end
     end
   end


### PR DESCRIPTION
### Context

This should fix:
https://trello.com/c/f0961xZm/943-draft-records-return-to-the-review-draft-page
https://trello.com/c/yXhZznPL/945-confirm-pages-are-sometimes-submitting-and-redirecting-to-themselves
https://trello.com/c/lk0HGw8q/948-edits-from-the-check-details-page-are-redirected-to-review-draft
https://trello.com/c/nPcqvdkl/949-recently-submitted-records-sometimes-return-to-the-review-draft-page

### Changes proposed in this pull request

As discovered in https://github.com/DFE-Digital/register-trainee-teachers/pull/443 , this is how the `origin_pages` array is currently being built:

```
1. visit review_draft_trainee
origin_pages = [review_draft_trainee]

2. click the Personal details link and end up at the confirmation
origin_pages = [review_draft_trainee, confirm_personal_details]

3. submit and return to review
origin_pages = [review_draft_trainee, confirm_personal_details] <- this is where it's going wrong!

4. click the Contact details link and end up at the confirmation
origin_pages = [confirm_contact_details, confirm_personal_details]

5. submit confirm contact details and we're stuck on the confirm pages
```

The bug is in step 3. When we return to an origin page we should be saving it still! 

The only reason for _not_ saving an origin page is when it's the _last_ one we visited i.e. we refreshed the page, or we've come back to a confirm page from within the edit route.

 `origin_pages << current_page unless origin_pages.last == current_page`

### Guidance to review

As per https://github.com/DFE-Digital/register-trainee-teachers/pull/443