### PR TITLE
Fix bug with diversity confirmation routing

### DIFF
--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -61,9 +61,6 @@ module Trainees
         trainee_personal_details_path,
         trainee_contact_details_path,
         trainee_degrees_path,
-        trainee_diversity_disclosure_path,
-        trainee_diversity_disability_disclosure_path,
-        trainee_diversity_disability_detail_path,
         trainee_programme_details_path,
       ].map { |path| path.split("/").last }
     end

--- a/app/controllers/trainees/diversity/confirm_details_controller.rb
+++ b/app/controllers/trainees/diversity/confirm_details_controller.rb
@@ -14,6 +14,10 @@ module Trainees
 
     private
 
+      def flash_message_title
+        I18n.t("components.confirmation.flash.disclosure")
+      end
+
       def toggle_trainee_progress_field
         trainee.progress.diversity = mark_as_completed_params
       end

--- a/app/controllers/trainees/diversity/disability_details_controller.rb
+++ b/app/controllers/trainees/diversity/disability_details_controller.rb
@@ -16,7 +16,7 @@ module Trainees
         disability_detail = Diversities::DisabilityDetailForm.new(trainee: trainee, attributes: disability_detail_params)
 
         if disability_detail.save
-          redirect_to(trainee_diversity_disability_detail_confirm_path(trainee))
+          redirect_to(trainee_diversity_confirm_path(trainee))
         else
           @disability_detail = disability_detail
           render :edit

--- a/app/controllers/trainees/diversity/disability_disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disability_disclosures_controller.rb
@@ -37,7 +37,7 @@ module Trainees
 
       def redirect_to_relevant_step
         if trainee.disability_not_provided? || trainee.no_disability?
-          redirect_to(trainee_diversity_disability_disclosure_confirm_path(trainee))
+          redirect_to(trainee_diversity_confirm_path(trainee))
         else
           redirect_to(edit_trainee_diversity_disability_detail_path(trainee))
         end

--- a/app/controllers/trainees/diversity/disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disclosures_controller.rb
@@ -36,7 +36,7 @@ module Trainees
         if trainee.diversity_disclosed?
           redirect_to(edit_trainee_diversity_ethnic_group_path(trainee))
         else
-          redirect_to(trainee_diversity_disclosure_confirm_path(trainee))
+          redirect_to(trainee_diversity_confirm_path(trainee))
         end
       end
     end

--- a/app/helpers/confirm_details_helper.rb
+++ b/app/helpers/confirm_details_helper.rb
@@ -6,9 +6,6 @@ module ConfirmDetailsHelper
       "personal-details" => "trainee_personal_details_confirm_path",
       "contact-details" => "trainee_contact_details_confirm_path",
       "degrees" => "trainee_degrees_confirm_path",
-      "information-disclosed" => "trainee_diversity_disclosure_confirm_path",
-      "disability-disclosure" => "trainee_diversity_disability_disclosure_confirm_path",
-      "disabilities" => "trainee_diversity_disability_detail_confirm_path",
       "programme-details" => "trainee_programme_details_confirm_path",
     }
 

--- a/app/views/trainees/diversity/confirm_details/show.html.erb
+++ b/app/views/trainees/diversity/confirm_details/show.html.erb
@@ -11,6 +11,6 @@
     confirm_detail: @confirm_detail,
     trainee: @trainee,
     component: @confirmation_component,
-    resource_confirm_update_path: trainee_section_update_path(trainee_section_key, @trainee),
+    resource_confirm_update_path: trainee_diversity_confirm_path(@trainee),
   }
 ) %>

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -47,7 +47,7 @@
         :row,
         task_name: 'Diversity information',
         path: edit_trainee_diversity_disclosure_path(@trainee),
-        confirm_path: trainee_diversity_disclosure_confirm_path(@trainee),
+        confirm_path: trainee_diversity_confirm_path(@trainee),
         classes: "diversity-details",
         status: ProgressService.call(
           validator: Diversities::FormValidator.new(@trainee),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,8 +44,7 @@ en:
       not_provided: Not provided
       heading: Confirm %{section_title}
       flash:
-        disability_disclosure: disclosure
-        information_disclosed: disclosure
+        diversity: disclosure
     programme_detail:
       title: "%{record_type} programme details"
     degrees:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,11 +62,14 @@ Rails.application.routes.draw do
       resource :personal_details, concerns: :confirmable, only: %i[show edit update], path: "/personal-details"
 
       namespace :diversity do
-        resource :disclosure, concerns: :confirmable, only: %i[edit update], path: "/information-disclosed"
+        get "/confirm", to: "confirm_details#show"
+        post "/confirm", to: "confirm_details#update"
+        put "/confirm", to: "confirm_details#update"
+        resource :disclosure, only: %i[edit update], path: "/information-disclosed"
         resource :ethnic_group, only: %i[edit update], path: "/ethnic-group"
         resource :ethnic_background, only: %i[edit update], path: "/ethnic-background"
-        resource :disability_disclosure, concerns: :confirmable, only: %i[edit update], path: "/disability-disclosure"
-        resource :disability_detail, concerns: :confirmable, only: %i[edit update], path: "/disabilities"
+        resource :disability_disclosure, only: %i[edit update], path: "/disability-disclosure"
+        resource :disability_detail, only: %i[edit update], path: "/disabilities"
       end
 
       resource :outcome_details, only: [], path: "outcome-details" do

--- a/spec/features/trainees/diversities/edit_disabilities_spec.rb
+++ b/spec/features/trainees/diversities/edit_disabilities_spec.rb
@@ -42,7 +42,7 @@ feature "edit disability details", type: :feature do
 
   def and_confirm_my_details
     @confirm_page ||= PageObjects::Trainees::Diversities::ConfirmDetails.new
-    expect(@confirm_page).to be_displayed(id: trainee.slug, section: "disabilities")
+    expect(@confirm_page).to be_displayed(id: trainee.slug)
     @confirm_page.submit_button.click
   end
 

--- a/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
@@ -52,7 +52,7 @@ private
 
   def and_confirm_my_details
     @confirm_page ||= PageObjects::Trainees::Diversities::ConfirmDetails.new
-    expect(@confirm_page).to be_displayed(id: trainee.slug, section: "disability-disclosure")
+    expect(@confirm_page).to be_displayed(id: trainee.slug)
     @confirm_page.submit_button.click
   end
 

--- a/spec/features/trainees/diversities/edit_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disclosure_spec.rb
@@ -48,7 +48,7 @@ feature "edit diversity disclosure", type: :feature do
 
   def and_confirm_my_details
     @confirm_page ||= PageObjects::Trainees::Diversities::ConfirmDetails.new
-    expect(@confirm_page).to be_displayed(id: trainee.slug, section: "information-disclosed")
+    expect(@confirm_page).to be_displayed(id: trainee.slug)
     @confirm_page.submit_button.click
   end
 

--- a/spec/support/page_objects/trainees/diversities/confirm_details.rb
+++ b/spec/support/page_objects/trainees/diversities/confirm_details.rb
@@ -4,7 +4,7 @@ module PageObjects
   module Trainees
     module Diversities
       class ConfirmDetails < PageObjects::Trainees::ConfirmDetails
-        set_url "/trainees/{id}/diversity/{section}/confirm"
+        set_url "/trainees/{id}/diversity/confirm"
       end
     end
   end


### PR DESCRIPTION
### Context
For the diversity flow, we have three different rails paths, which use the same controller and render the same page.

This is an issue for backlinks if you start from one diversity confirm page and end up on another, e.g.:

```
1. visit review_draft_trainee, with a trainee with a completed diversity section
origin_pages = [review_draft_trainee]

2. click the Diversity details link and you're immediately take to a confirmation
origin_pages = [review_draft_trainee, trainee_diversity_disclosure_confirm]

3. click change, complete the flow and you end up on a different confirmation!
origin_pages = [trainee_diversity_disclosure_confirm, trainee_diversity_disability_disclosure_confirm] <- this is where it's going wrong!

4. click continue and you're stuck in a loop
origin_pages = [trainee_diversity_disability_disclosure_confirm, trainee_diversity_disclosure_confirm]
```

### Changes proposed in this pull request

The solution is to have just one confirm route for the diversity flow.

### Guidance to review

Repeat the above steps and check that you're redirected back to the original origin page e.g. `review_draft_trainee`
