### PR TITLE
[954] Add trainee form redirect

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -33,7 +33,7 @@ class TraineesController < ApplicationController
     else
       authorize @trainee = Trainee.new(trainee_params.merge(provider_id: current_user.provider_id))
       if trainee.save
-        redirect_to trainee_path(trainee)
+        redirect_to review_draft_trainee_path(trainee)
       else
         render :new
       end

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -34,12 +34,12 @@ private
   end
 
   def and_i_save_the_form
-    @record_page ||= PageObjects::Trainees::Record.new
+    @review_draft_page ||= PageObjects::Trainees::ReviewDraft.new
     @not_supported_route_page ||= PageObjects::Trainees::NotSupportedRoute.new
     @new_page.continue_button.click
   end
 
   def then_i_should_see_the_new_trainee_overview
-    expect(@record_page).to be_displayed
+    expect(@review_draft_page).to be_displayed
   end
 end


### PR DESCRIPTION
### Context

When adding a new trainee the form redirects to `Trainees#show`. It should redirect to review draft.

### Changes proposed in this pull request

Update the path to redirect to the correct place.

### Guidance to review

Add a trainee. The first submit goes to review draft.

