### PR TITLE
[952] Add redirects for draft/non-draft trainees

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,4 +33,12 @@ private
   def authenticate
     redirect_to sign_in_path unless authenticated?
   end
+
+  def ensure_trainee_is_draft!
+    redirect_to trainee_path(trainee) unless trainee.draft?
+  end
+
+  def ensure_trainee_is_not_draft!
+    redirect_to review_draft_trainee_path(trainee) if trainee.draft?
+  end
 end

--- a/app/controllers/trainees/check_details_controller.rb
+++ b/app/controllers/trainees/check_details_controller.rb
@@ -4,9 +4,17 @@ module Trainees
   class CheckDetailsController < ApplicationController
     include Breadcrumbable
 
+    before_action :ensure_trainee_is_draft!
+
     def show
-      @trainee = Trainee.from_param(params[:id])
-      save_origin_page_for(@trainee)
+      authorize trainee
+      save_origin_page_for(trainee)
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.from_param(params[:id])
     end
   end
 end

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -4,6 +4,8 @@ module Trainees
   class PersonalDetailsController < ApplicationController
     include Breadcrumbable
 
+    before_action :ensure_trainee_is_not_draft!, only: :show
+
     DOB_CONVERSION = {
       "date_of_birth(3i)" => "day",
       "date_of_birth(2i)" => "month",

--- a/app/controllers/trainees/review_draft_controller.rb
+++ b/app/controllers/trainees/review_draft_controller.rb
@@ -4,6 +4,8 @@ module Trainees
   class ReviewDraftController < ApplicationController
     include Breadcrumbable
 
+    before_action :ensure_trainee_is_draft!
+
     def show
       authorize trainee
       save_origin_page_for(trainee)

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -3,6 +3,8 @@
 class TraineesController < ApplicationController
   include Breadcrumbable
 
+  before_action :ensure_trainee_is_not_draft!, only: :show
+
   def index
     @filters = TraineeFilter.new(params: filter_params).filters
 

--- a/spec/controllers/trainees/check_details_controller_spec.rb
+++ b/spec/controllers/trainees/check_details_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Trainees::CheckDetailsController do
+  let(:user) { build(:user) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#show" do
+    subject { get(:show, params: { id: trainee }) }
+
+    context "with a non-draft trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn) }
+
+      it "redirects to the trainee show page" do
+        expect(subject).to redirect_to(trainee_path(trainee))
+      end
+    end
+  end
+end

--- a/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
@@ -5,13 +5,11 @@ require "rails_helper"
 describe Trainees::ConfirmDeferralsController do
   include ActiveJob::TestHelper
 
-  let(:trainee) { create(:trainee, :trn_received) }
-  let(:current_user) { build(:user) }
-  let(:trainee_policy) { instance_double(TraineePolicy, update?: true) }
+  let(:current_user) { create(:user) }
+  let(:trainee) { create(:trainee, :trn_received, provider: current_user.provider) }
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
-    allow(TraineePolicy).to receive(:new).with(current_user, trainee).and_return(trainee_policy)
   end
 
   describe "#update" do

--- a/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
@@ -5,13 +5,11 @@ require "rails_helper"
 describe Trainees::ConfirmWithdrawalsController do
   include ActiveJob::TestHelper
 
-  let(:trainee) { create(:trainee, :trn_received) }
-  let(:current_user) { build(:user) }
-  let(:trainee_policy) { instance_double(TraineePolicy, update?: true) }
+  let(:current_user) { create(:user) }
+  let(:trainee) { create(:trainee, :trn_received, provider: current_user.provider) }
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
-    allow(TraineePolicy).to receive(:new).with(current_user, trainee).and_return(trainee_policy)
   end
 
   describe "#update" do

--- a/spec/controllers/trainees/personal_details_controller_spec.rb
+++ b/spec/controllers/trainees/personal_details_controller_spec.rb
@@ -3,20 +3,31 @@
 require "rails_helper"
 
 describe Trainees::PersonalDetailsController do
-  let(:trainee) { create(:trainee) }
-  let(:user) { build(:user) }
-  let(:trainee_policy) { instance_double(TraineePolicy, show?: true, edit?: true) }
+  let(:user) { create(:user) }
 
   before do
     allow(controller).to receive(:current_user).and_return(user)
-    allow(TraineePolicy).to receive(:new).with(user, trainee).and_return(trainee_policy)
   end
 
   describe "#show" do
-    before { get(:show, params: { trainee_id: trainee }) }
+    context "with a non-draft trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.provider) }
 
-    it "saves the origin page" do
-      expect(session["origin_pages_for_#{trainee.id}"]).to eq(%w[trainee_personal_details])
+      before do
+        get(:show, params: { trainee_id: trainee })
+      end
+
+      it "saves the origin page" do
+        expect(session["origin_pages_for_#{trainee.id}"]).to eq(%w[trainee_personal_details])
+      end
+    end
+
+    context "with a draft trainee" do
+      let(:trainee) { create(:trainee, :draft, provider: user.provider) }
+
+      it "redirects to /review-draft" do
+        expect(get(:show, params: { trainee_id: trainee })).to redirect_to(review_draft_trainee_path(trainee))
+      end
     end
   end
 end

--- a/spec/controllers/trainees/qts_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/qts_recommendations_controller_spec.rb
@@ -5,13 +5,11 @@ require "rails_helper"
 describe Trainees::QtsRecommendationsController do
   include ActiveJob::TestHelper
 
-  let(:trainee) { create(:trainee, :trn_received) }
-  let(:current_user) { build(:user) }
-  let(:trainee_policy) { instance_double(TraineePolicy, create?: true) }
+  let(:current_user) { create(:user) }
+  let(:trainee) { create(:trainee, :trn_received, provider: current_user.provider) }
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
-    allow(TraineePolicy).to receive(:new).with(current_user, trainee).and_return(trainee_policy)
   end
 
   describe "#create" do

--- a/spec/controllers/trainees/review_draft_controller_spec.rb
+++ b/spec/controllers/trainees/review_draft_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Trainees::ReviewDraftController do
+  let(:user) { build(:user) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#show" do
+    subject { get(:show, params: { id: trainee }) }
+
+    context "with a non-draft trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn) }
+
+      it "redirects to the trainee show page" do
+        expect(subject).to redirect_to(trainee_path(trainee))
+      end
+    end
+  end
+end

--- a/spec/controllers/trainees_controller_spec.rb
+++ b/spec/controllers/trainees_controller_spec.rb
@@ -3,20 +3,31 @@
 require "rails_helper"
 
 describe TraineesController do
-  let(:trainee) { create(:trainee) }
-  let(:user) { build(:user) }
-  let(:trainee_policy) { instance_double(TraineePolicy, show?: true) }
+  let(:user) { create(:user) }
 
   before do
     allow(controller).to receive(:current_user).and_return(user)
-    allow(TraineePolicy).to receive(:new).with(user, trainee).and_return(trainee_policy)
   end
 
   describe "#show" do
-    before { get(:show, params: { id: trainee }) }
+    context "with a non-draft trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.provider) }
 
-    it "saves the origin page" do
-      expect(session["origin_pages_for_#{trainee.id}"]).to eq(%w[trainee])
+      before do
+        get(:show, params: { id: trainee })
+      end
+
+      it "saves the origin page" do
+        expect(session["origin_pages_for_#{trainee.id}"]).to eq(%w[trainee])
+      end
+    end
+
+    context "with a draft trainee" do
+      let(:trainee) { create(:trainee, :draft) }
+
+      it "redirects to /review-draft" do
+        expect(get(:show, params: { id: trainee })).to redirect_to(review_draft_trainee_path(trainee))
+      end
     end
   end
 end

--- a/spec/controllers/trn_submissions_controller_spec.rb
+++ b/spec/controllers/trn_submissions_controller_spec.rb
@@ -6,13 +6,11 @@ describe TrnSubmissionsController do
   include ActiveJob::TestHelper
 
   describe "#create" do
-    let(:trainee) { create(:trainee) }
-    let(:current_user) { build(:user) }
-    let(:trainee_policy) { instance_double(TraineePolicy, create?: true) }
+    let(:current_user) { create(:user) }
+    let(:trainee) { create(:trainee, provider: current_user.provider) }
 
     before do
       allow(controller).to receive(:current_user).and_return(current_user)
-      allow(TraineePolicy).to receive(:new).with(current_user, trainee).and_return(trainee_policy)
     end
 
     it "queues a background job to register trainee for TRN" do

--- a/spec/features/trainees/edit_trainee_id_spec.rb
+++ b/spec/features/trainees/edit_trainee_id_spec.rb
@@ -7,7 +7,7 @@ feature "edit Trainee ID" do
 
   background do
     given_i_am_authenticated
-    given_a_trainee_exists
+    given_a_trainee_exists(:submitted_for_trn)
     when_i_visit_the_edit_trainee_id_page
     when_i_change_the_trainee_id
     when_i_click_continue

--- a/spec/features/trainees/edit_trainee_record_spec.rb
+++ b/spec/features/trainees/edit_trainee_record_spec.rb
@@ -37,7 +37,7 @@ feature "edit trainee record", type: :feature do
   end
 
   def given_a_trainee_exists_with_a_degree
-    given_a_trainee_exists(degrees: [create(:degree, :uk_degree_with_details)])
+    given_a_trainee_exists(:submitted_for_trn, degrees: [create(:degree, :uk_degree_with_details)])
   end
 
   def then_i_see_the_trainee_name
@@ -45,7 +45,8 @@ feature "edit trainee record", type: :feature do
   end
 
   def then_i_see_the_trn_status
-    expect(@record_page.trn_status.text).to eq(trainee.state)
+    state_text = "activerecord.attributes.trainee.states.#{trainee.state}"
+    expect(@record_page.trn_status.text).to eq(I18n.t(state_text).downcase)
   end
 
   def when_i_visit_the_trainee_record_page


### PR DESCRIPTION
### Context

https://trello.com/c/hw8lwrsd/952-add-redirects-for-draft-non-draft-trainees

### Changes proposed in this pull request

This PR:
1. Redirects non-draft trainees away from draft trainee origin pages (`/review-draft` and `/check-details`)
2. Redirects draft trainees away from the non-draft trainee origin pages (`trainee/:slug` and `/personal-details`)

### Guidance to review

- Choose a non-draft trainee and check that accessing `/review-draft` and `/check-details` redirects you to the trainee show page
- Choose a draft trainee and check that accessing `trainee/:slug` and `/personal-details` redirects you to the `/review-draft` page
