### PR TITLE
[926] Prevent re-syncs if a trainee has already been updated to DTTP

### DIFF
--- a/app/jobs/queue_trainee_updates_job.rb
+++ b/app/jobs/queue_trainee_updates_job.rb
@@ -17,6 +17,8 @@ class QueueTraineeUpdatesJob < ApplicationJob
     return if trainees.blank?
 
     trainees.each do |trainee|
+      next if trainee_already_synced?(trainee)
+
       UpdateTraineeToDttpJob.perform_later(trainee)
     end
   end
@@ -25,5 +27,9 @@ private
 
   def fetch_trainees
     Trainee.where.not(state: INVALID_STATES)
+  end
+
+  def trainee_already_synced?(trainee)
+    trainee.sha == trainee.dttp_update_sha.presence
   end
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -153,4 +153,14 @@ class Trainee < ApplicationRecord
       assign_attributes(params.merge(address_line_one: nil, address_line_two: nil, town_city: nil, postcode: nil))
     end
   end
+
+  def sha
+    Digest::SHA1.hexdigest(digest)
+  end
+
+  def digest
+    exclude_list = %w[created_at updated_at dttp_update_sha]
+
+    [as_json.except(*exclude_list), degrees, nationalities, disabilities].map(&:to_json).join(",")
+  end
 end

--- a/app/services/dttp/contact_update.rb
+++ b/app/services/dttp/contact_update.rb
@@ -19,6 +19,8 @@ module Dttp
 
       dttp_update("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})",
                   @placement_assignment_payload)
+
+      trainee.update!(dttp_update_sha: trainee.sha)
     end
 
   private

--- a/db/migrate/20210201230107_add_dttp_update_sha_to_trainees.rb
+++ b/db/migrate/20210201230107_add_dttp_update_sha_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDttpUpdateShaToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :dttp_update_sha, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_27_104805) do
+ActiveRecord::Schema.define(version: 2021_02_01_230107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,7 @@ ActiveRecord::Schema.define(version: 2021_01_27_104805) do
     t.date "defer_date"
     t.string "slug", null: false
     t.datetime "recommended_for_qts_at"
+    t.string "dttp_update_sha"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"
     t.index ["dttp_id"], name: "index_trainees_on_dttp_id"

--- a/spec/jobs/queue_trainee_updates_job_spec.rb
+++ b/spec/jobs/queue_trainee_updates_job_spec.rb
@@ -15,7 +15,6 @@ describe QueueTraineeUpdatesJob do
       trainees
     end
 
-
     it "enqueues the UpdateTraineeToDttpJob" do
       described_class.perform_now
 

--- a/spec/jobs/queue_trainee_updates_job_spec.rb
+++ b/spec/jobs/queue_trainee_updates_job_spec.rb
@@ -5,15 +5,16 @@ require "rails_helper"
 describe QueueTraineeUpdatesJob do
   include ActiveJob::TestHelper
 
-  before do
-    trainees
-  end
-
   context "with valid trainees" do
     let(:trainees) do
       create(:trainee, :submitted_for_trn)
       create(:trainee, :trn_received)
     end
+
+    before do
+      trainees
+    end
+
 
     it "enqueues the UpdateTraineeToDttpJob" do
       described_class.perform_now
@@ -29,6 +30,28 @@ describe QueueTraineeUpdatesJob do
       QueueTraineeUpdatesJob::INVALID_STATES.each do |state|
         create(:trainee, state.to_sym)
       end
+    end
+
+    before do
+      trainees
+    end
+
+    it "does not enqueue the UpdateTraineeToDttpJob" do
+      described_class.perform_now
+
+      Trainee.all.each do |trainee|
+        expect(UpdateTraineeToDttpJob).to_not have_been_enqueued.with(trainee)
+      end
+    end
+  end
+
+  context "with trainees which have already been synced" do
+    let(:trainee1) { create(:trainee, :trn_received) }
+    let(:trainee2) { create(:trainee, :trn_received) }
+
+    before do
+      trainee1.update!(dttp_update_sha: trainee1.sha)
+      trainee2.update!(dttp_update_sha: trainee2.sha)
     end
 
     it "does not enqueue the UpdateTraineeToDttpJob" do

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -123,6 +123,32 @@ describe Trainee do
     end
   end
 
+  context "instance methods" do
+    describe "#sha" do
+      subject { create(:trainee) }
+
+      let(:expected_sha) { Digest::SHA1.hexdigest(subject.digest) }
+
+      it "returns a SHA of the trainee's current state" do
+        expect(subject.sha).to eq(expected_sha)
+      end
+    end
+
+    describe "#digest" do
+      subject { create(:trainee) }
+
+      let(:expected_digest) do
+        subject.as_json.except(
+          "created_at", "updated_at", "dttp_update_sha"
+        ).to_json
+      end
+
+      it "returns a string representation of the trainee's current state" do
+        expect(subject.digest).to include(expected_digest)
+      end
+    end
+  end
+
   describe "#with_name_trainee_id_or_trn_like" do
     let(:other_trainee) { create(:trainee) }
     let(:matching_trainee) do


### PR DESCRIPTION
### Context

- https://trello.com/c/yRo0UWI2/926-m-queue-updates-to-dttp

### Changes proposed in this pull request

This PR builds upon https://github.com/DFE-Digital/register-trainee-teachers/pull/459, to implement a way to prevent re-syncs if a trainee has already been updated with dttp.

It introduces a way to create a digest (json string representation) of the trainee's state and hash it using `Digest::SHA1.hexdigest`. We then save this sha into a new field `dttp_update_sha` when the trainee has been successfully updated. 

The next time the job runs, if the trainee hasn't been updated the `trainee.sha` method will always return the same sha and match up to the what was saved via `dttp_update_sha` so the trainee is skipped. If the trainee has been updated, `trainee.sha` will return a new sha and trigger an update job.

### Guidance to review

