### PR TITLE
[967] Fix mailto feedback links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
               Beta
             </strong>
             <span class="govuk-phase-banner__text">
-                This is a new service – <%= mail_to "becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Register%20trainee%20teachers", "give feedback or report a problem", class: "govuk-link govuk-link--no-visited-state" %>
+                This is a new service – <%= mail_to "becomingateacher@digital.education.gov.uk", "give feedback or report a problem", subject: "Register trainee teachers feedback", class: "govuk-link govuk-link--no-visited-state" %>
             </span>
           </p>
         </div>
@@ -78,7 +78,7 @@
             <h2 class="govuk-heading-m">Get support</h2>
             <div class="govuk-footer__meta-custom">
               <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                <li>Email: <%= mail_to "mailto:becomingateacher@digital.education.gov.uk", "becomingateacher@digital.education.gov.uk", class: "govuk-link govuk-footer__link" %></li>
+                <li>Email: <%= mail_to "becomingateacher@digital.education.gov.uk", "becomingateacher@digital.education.gov.uk", subject: "Register trainee teachers support", class: "govuk-link govuk-footer__link" %></li>
                 <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
               </ul>
             </div>


### PR DESCRIPTION
### Context

The mailto links on the phase banner do not work. This is the fix. 

### Changes proposed in this pull request

- Fix link in phase banner using helper method
- Fix link in footer using helper method
- Add subject to both

### Guidance to review

- Pull down the code
- Check the link feedback link in the phase banner works and the subject is what it should be.
- Do the same for the support link in the footer.  

