### PR TITLE
[967] Fix mailto link on sign in page

### DIFF
--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -16,15 +16,15 @@
 
     <% if FeatureService.enabled?("use_dfe_sign_in")%>
       <%= govuk_button_to("Sign in using DfE Sign-in", "/auth/dfe") %>
-    <% else %>    
+    <% else %>
       <%= govuk_link_to "Sign in using Persona", "/personas", { class: "govuk-button" }  %>
     <% end %>
 
     <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to Register trainee teachers, email
 
-    <%= govuk_mail_to "becomingateacher@digital.education.gov.uk", 
-                      "becomingateacher@digital.education.gov.uk" %>. 
+    <%= govuk_mail_to "becomingateacher@digital.education.gov.uk",
+                      "becomingateacher@digital.education.gov.uk", subject: "Register trainee teachers support" %>.
     </p>
-    
+
   </div>
 </div>


### PR DESCRIPTION
### Context

Fix `mail_to` link on Sign in page
