### PR TITLE
[952] Set standards met in DTTP

### DIFF
--- a/app/jobs/recommend_for_qts_job.rb
+++ b/app/jobs/recommend_for_qts_job.rb
@@ -3,8 +3,23 @@
 class RecommendForQtsJob < ApplicationJob
   queue_as :default
   retry_on Dttp::RecommendForQTS::Error
+  retry_on Dttp::UpdateTraineeStatus::Error
 
   def perform(trainee_id)
-    Dttp::RecommendForQTS.call(trainee: Trainee.find(trainee_id))
+    trainee = Trainee.find(trainee_id)
+
+    Dttp::RecommendForQTS.call(trainee: trainee)
+
+    Dttp::UpdateTraineeStatus.call(
+      status: DttpStatuses::STANDARDS_MET,
+      entity_id: trainee.dttp_id,
+      entity_type: ::Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
+    )
+
+    Dttp::UpdateTraineeStatus.call(
+      status: DttpStatuses::STANDARDS_MET,
+      entity_id: trainee.placement_assignment_dttp_id,
+      entity_type: ::Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
+    )
   end
 end

--- a/app/services/dttp/recommend_for_qts.rb
+++ b/app/services/dttp/recommend_for_qts.rb
@@ -13,8 +13,15 @@ module Dttp
     end
 
     def call
-      body = { dfe_datestandardsassessmentpassed: trainee.outcome_date.in_time_zone.iso8601 }.to_json
-      response = Client.patch("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})", body: body)
+      body = {
+        dfe_datestandardsassessmentpassed: trainee.outcome_date.in_time_zone.iso8601,
+      }.to_json
+
+      response = Client.patch(
+        "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})",
+        body: body,
+      )
+
       raise Error, response.body if response.code != 204
 
       response

--- a/spec/jobs/recommend_for_qts_job_spec.rb
+++ b/spec/jobs/recommend_for_qts_job_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe RecommendForQtsJob do
+  include ActiveJob::TestHelper
+
+  let(:trainee) { create(:trainee, :recommended_for_qts) }
+
+  let(:expected_contact_params) do
+    {
+      status: DttpStatuses::STANDARDS_MET,
+      entity_id: trainee.dttp_id,
+      entity_type: :contact,
+    }
+  end
+
+  let(:expected_placement_assignment_params) do
+    {
+      status: DttpStatuses::STANDARDS_MET,
+      entity_id: trainee.placement_assignment_dttp_id,
+      entity_type: :placement_assignment,
+    }
+  end
+
+  before do
+    allow(Dttp::RecommendForQTS).to receive(:call).with(trainee: trainee)
+    allow(Dttp::UpdateTraineeStatus).to receive(:call).with(expected_contact_params)
+    allow(Dttp::UpdateTraineeStatus).to receive(:call).with(expected_placement_assignment_params)
+  end
+
+  it "updates the contact and placement assignment status in DTTP" do
+    expect(Dttp::UpdateTraineeStatus).to receive(:call).with(expected_contact_params)
+    expect(Dttp::UpdateTraineeStatus).to receive(:call).with(expected_placement_assignment_params)
+    described_class.perform_now(trainee.id)
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/fzP32oka/925-s-set-dttp-state-when-we-submit-for-qts

### Changes proposed in this pull request

Makes two separate calls to update the trainee status (contact and placement assignment) in DTTP.

This follows the pattern as suggested in https://github.com/DFE-Digital/register-trainee-teachers/pull/466 (see `DeferJob` and `Withdraw Job`.

### Guidance to review
