### PR TITLE
[980] Don't send registration date

### DIFF
--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -20,7 +20,6 @@ module Dttp
         if contact_change_set_id
           @params.merge!({
             "dfe_ContactId@odata.bind" => "$#{contact_change_set_id}",
-            "dfe_sendforregistrationdate" => Time.zone.now.iso8601,
             "dfe_RouteId@odata.bind" => "/dfe_routes(#{ASSESSMENT_ONLY_DTTP_ID})",
           })
         end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -58,7 +58,6 @@ module Dttp
               "dfe_AcademicYearId@odata.bind" => "/dfe_academicyears(#{Dttp::Params::PlacementAssignment::ACADEMIC_YEAR_2020_2021})",
               "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_PG,
               "dfe_sendforregistration" => true,
-              "dfe_sendforregistrationdate" => time_now_in_zone.iso8601,
               "dfe_ProviderId@odata.bind" => "/accounts(#{dttp_provider_id})",
               "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{Dttp::Params::PlacementAssignment::ITT_QUALIFICATION_AIM_QTS})",
               "dfe_programmeyear" => 1,
@@ -84,7 +83,6 @@ module Dttp
               "dfe_AcademicYearId@odata.bind" => "/dfe_academicyears(#{Dttp::Params::PlacementAssignment::ACADEMIC_YEAR_2020_2021})",
               "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_PG,
               "dfe_sendforregistration" => true,
-              "dfe_sendforregistrationdate" => time_now_in_zone.iso8601,
               "dfe_ProviderId@odata.bind" => "/accounts(#{dttp_provider_id})",
               "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{Dttp::Params::PlacementAssignment::ITT_QUALIFICATION_AIM_QTS})",
               "dfe_programmeyear" => 1,
@@ -101,14 +99,6 @@ module Dttp
             expect(subject).not_to include(
               { "dfe_ContactId@odata.bind" => "$#{contact_change_set_id}" },
             )
-          end
-
-          it "doesn't include sendforregistrationdate" do
-            Timecop.freeze do
-              expect(subject).not_to include(
-                { "dfe_sendforregistrationdate" => Time.zone.now.iso8601 },
-              )
-            end
           end
         end
 


### PR DESCRIPTION
### Context

We send parameters to DTTP that trigger an export process to DQT. One of the fields that we were sending actually prevents the record from being picked up by the export 'scribe' process as it should be set by part of this process.

### Changes proposed in this pull request

* remove `dfe_sendforregistrationdate" from the placement assignment  params. This field is set internally in DTTP when the record is added to the TTR1 file for export to DQT.

### Guidance to review

I've run this locally against dev and it works without error and doesn't set the field. This will be run through a production test today so just needs a code review.

