### PR TITLE
[984] Change assessment only AO to assessment only

### DIFF
--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -17,8 +17,8 @@
         Add a trainee
       </h1>
 
-      <%= f.govuk_radio_buttons_fieldset(:record_type, legend: { size: "s", text: "What type of route is this?", tag: "span"} ) do %>
-        <%= f.govuk_radio_button :record_type, :assessment_only, label: { text: "Assessment Only" }, link_errors: true %>
+      <%= f.govuk_radio_buttons_fieldset(:record_type, legend: { size: "s", text: "What type of training are they doing?", tag: "span"} ) do %>
+        <%= f.govuk_radio_button :record_type, :assessment_only, label: { text: "Assessment only" }, link_errors: true %>
         <%= f.govuk_radio_button :record_type, :other, label: { text: "Other" } %>
       <% end %>
 

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -18,7 +18,7 @@
       </h1>
 
       <%= f.govuk_radio_buttons_fieldset(:record_type, legend: { size: "s", text: "What type of route is this?", tag: "span"} ) do %>
-        <%= f.govuk_radio_button :record_type, :assessment_only, label: { text: "Assessment Only (AO)" }, link_errors: true %>
+        <%= f.govuk_radio_button :record_type, :assessment_only, label: { text: "Assessment Only" }, link_errors: true %>
         <%= f.govuk_radio_button :record_type, :other, label: { text: "Other" } %>
       <% end %>
 


### PR DESCRIPTION
### Context

Content changes to the Add trainee page

### Before After

![image](https://user-images.githubusercontent.com/50492247/107024594-251cba00-67a0-11eb-9d13-818c504caf40.png)

### Guidance to review

- Add a trainee 
- Check that it only displays `Assessment only`
- Check that it displays `What type of training are they doing?`


