### PR TITLE
Add blue\green deployment strategy to worker app

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -27,7 +27,7 @@ resource cloudfoundry_app web_app {
   instances                  = var.web_app_instances
   memory                     = var.web_app_memory
   space                      = data.cloudfoundry_space.space.id
-  strategy                   = var.web_app_deployment_strategy
+  strategy                   = var.deployment_strategy
   timeout                    = var.app_start_timeout
   environment                = local.app_environment
   docker_credentials         = var.docker_credentials
@@ -59,6 +59,7 @@ resource cloudfoundry_app worker_app {
   instances          = var.worker_app_instances
   memory             = var.worker_app_memory
   space              = data.cloudfoundry_space.space.id
+  strategy           = var.deployment_strategy
   timeout            = var.app_start_timeout
   environment        = local.app_environment
   docker_credentials = var.docker_credentials

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -10,7 +10,7 @@ variable redis_service_plan {}
 
 variable space_name {}
 
-variable web_app_deployment_strategy { default = "blue-green-v2" }
+variable deployment_strategy { default = "blue-green-v2" }
 
 variable web_app_instances { default = 1 }
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -38,7 +38,7 @@ module paas {
   postgres_service_plan       = var.paas_postgres_service_plan
   redis_service_plan          = var.paas_redis_service_plan
   space_name                  = var.paas_space_name
-  web_app_deployment_strategy = var.paas_web_app_deployment_strategy
+  deployment_strategy         = var.paas_deployment_strategy
   web_app_instances           = var.paas_web_app_instances
   web_app_memory              = var.paas_web_app_memory
   worker_app_instances        = var.paas_worker_app_instances

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,7 +16,7 @@ variable paas_postgres_service_plan {}
 
 variable paas_redis_service_plan {}
 
-variable paas_web_app_deployment_strategy { default = "blue-green-v2" }
+variable paas_deployment_strategy { default = "blue-green-v2" }
 
 variable paas_web_app_instances { default = 2 }
 


### PR DESCRIPTION
When the workerApp is deployed, it does not always refelect changes
such as enviroment variables etc; even if the underlying docker image
appears to be updated.

### Context

When the workerApp is deployed, it does not always refelect changes
such as enviroment variables etc; even if the underlying docker image

### Changes proposed in this pull request

add `strategy = var.web_app_deployment_strategy` to worker app terraform resource settings
### Guidance to review

