### PR TITLE
[973] Add forbidden error page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   include Pundit
 
   rescue_from Pundit::NotAuthorizedError do
-    render :'errors/forbidden', status: :forbidden
+    render "errors/forbidden", status: :forbidden
   end
 
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,11 @@ class ApplicationController < ActionController::Base
   before_action :track_page
 
   include Pundit
+
+  rescue_from Pundit::NotAuthorizedError do
+    render :'errors/forbidden', status: :forbidden
+  end
+
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
 
   helper_method :current_user, :authenticated?

--- a/app/helpers/support_email_helper.rb
+++ b/app/helpers/support_email_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SupportEmailHelper
+  def support_email(name: nil, subject: nil, classes: nil)
+    govuk_mail_to(Settings.support_email, name, subject: subject, class: classes)
+  end
+end

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,11 @@
+<%= render PageTitle::View.new(title: "pages.forbidden") %>
+
+<main role="main" class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h1 class="govuk-heading-l">You do not have access to view details for this trainee</h1>
+      <p class="govuk-body">If you think you should have access, contact: <%= govuk_mail_to "becomingateacher@digital.education.gov.uk",
+                                                                                            "becomingateacher@digital.education.gov.uk", subject: "Register trainee teachers support" %>.</p>
+    </div>
+  </div>
+</main>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -4,8 +4,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h1 class="govuk-heading-l">You do not have access to view details for this trainee</h1>
-      <p class="govuk-body">If you think you should have access, contact: <%= govuk_mail_to "becomingateacher@digital.education.gov.uk",
-                                                                                            "becomingateacher@digital.education.gov.uk", subject: "Register trainee teachers support" %>.</p>
+      <p class="govuk-body">If you think you should have access, contact: <%= govuk_mail_to t("support_email"),
+                                                                                            t("support_email"), subject: "Register trainee teachers support" %>.</p>
     </div>
   </div>
 </main>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,11 +1,7 @@
 <%= render PageTitle::View.new(title: "pages.forbidden") %>
-
-<main role="main" class="govuk-main-wrapper" id="main-content">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <h1 class="govuk-heading-l">You do not have access to view details for this trainee</h1>
-      <p class="govuk-body">If you think you should have access, contact: <%= govuk_mail_to t("support_email"),
-                                                                                            t("support_email"), subject: "Register trainee teachers support" %>.</p>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">You do not have access to view details for this trainee</h1>
+    <p class="govuk-body">If you think you should have access, contact: <%= support_email(subject: "Register trainee teachers support") %>.</p>
   </div>
-</main>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
               Beta
             </strong>
             <span class="govuk-phase-banner__text">
-                This is a new service – <%= mail_to "becomingateacher@digital.education.gov.uk", "give feedback or report a problem", subject: "Register trainee teachers feedback", class: "govuk-link govuk-link--no-visited-state" %>
+                This is a new service – <%= mail_to t("support_email"), "give feedback or report a problem", subject: "Register trainee teachers feedback", class: "govuk-link govuk-link--no-visited-state" %>
             </span>
           </p>
         </div>
@@ -78,7 +78,7 @@
             <h2 class="govuk-heading-m">Get support</h2>
             <div class="govuk-footer__meta-custom">
               <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                <li>Email: <%= mail_to "becomingateacher@digital.education.gov.uk", "becomingateacher@digital.education.gov.uk", subject: "Register trainee teachers support", class: "govuk-link govuk-footer__link" %></li>
+                <li>Email: <%= mail_to t("support_email"), t("support_email"), subject: "Register trainee teachers support", class: "govuk-link govuk-footer__link" %></li>
                 <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
               </ul>
             </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
               Beta
             </strong>
             <span class="govuk-phase-banner__text">
-                This is a new service – <%= mail_to t("support_email"), "give feedback or report a problem", subject: "Register trainee teachers feedback", class: "govuk-link govuk-link--no-visited-state" %>
+                This is a new service – <%= support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback", classes: "govuk-link--no-visited-state") %>
             </span>
           </p>
         </div>
@@ -78,7 +78,7 @@
             <h2 class="govuk-heading-m">Get support</h2>
             <div class="govuk-footer__meta-custom">
               <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                <li>Email: <%= mail_to t("support_email"), t("support_email"), subject: "Register trainee teachers support", class: "govuk-link govuk-footer__link" %></li>
+                <li>Email: <%= support_email(subject: "Register trainee teachers support", classes: "govuk-footer__link") %></li>
                 <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
               </ul>
             </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,5 @@
+<%= render PageTitle::View.new(title: "pages.home") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
   <h1 class="govuk-heading-l">Register trainee teachers</h1>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -22,8 +22,7 @@
 
     <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to Register trainee teachers, email
 
-    <%= govuk_mail_to t("support_email"),
-                      t("support_email"), subject: "Get access to Register trainee teachers" %>.
+    <%= support_email(subject: "Get access to Register trainee teachers") %>.
     </p>
 
   </div>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -22,8 +22,8 @@
 
     <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to Register trainee teachers, email
 
-    <%= govuk_mail_to "becomingateacher@digital.education.gov.uk",
-                      "becomingateacher@digital.education.gov.uk", subject: "Get access to Register trainee teachers" %>.
+    <%= govuk_mail_to t("support_email"),
+                      t("support_email"), subject: "Get access to Register trainee teachers" %>.
     </p>
 
   </div>

--- a/app/views/sign_in/new.html.erb
+++ b/app/views/sign_in/new.html.erb
@@ -7,8 +7,7 @@
                              for this service.</p>
 
     <p class="govuk-body"> Contact us at
-    <%= govuk_mail_to t("support_email"),
-                      t("support_email") %> to ask for an account.
+    <%= support_email(subject: "Get access to Register trainee teachers") %> to ask for an account.
     </p>
 
     <%= govuk_button_link_to("Return home", root_path) %>

--- a/app/views/sign_in/new.html.erb
+++ b/app/views/sign_in/new.html.erb
@@ -6,11 +6,11 @@
     <p class="govuk-body"> Although you have a DfE Sign-in account, you also need an account
                              for this service.</p>
 
-    <p class="govuk-body"> Contact us at 
-    <%= govuk_mail_to "becomingateacher@digital.education.gov.uk", 
-                      "becomingateacher@digital.education.gov.uk" %> to ask for an account. 
+    <p class="govuk-body"> Contact us at
+    <%= govuk_mail_to t("support_email"),
+                      t("support_email") %> to ask for an account.
     </p>
-    
+
     <%= govuk_button_link_to("Return home", root_path) %>
 
   </div>

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -18,7 +18,7 @@
       </h1>
 
       <%= f.govuk_radio_buttons_fieldset(:record_type, legend: { size: "s", text: "What type of training are they doing?", tag: "span"} ) do %>
-        <%= f.govuk_radio_button :record_type, :assessment_only, label: { text: "Assessment only" }, link_errors: true %>
+        <%= f.govuk_radio_button :record_type, :assessment_only, label: { text: t("activerecord.attributes.trainee.record_types.assessment_only") }, link_errors: true %>
         <%= f.govuk_radio_button :record_type, :other, label: { text: "Other" } %>
       <% end %>
 

--- a/app/views/trainees/not_supported_route.html.erb
+++ b/app/views/trainees/not_supported_route.html.erb
@@ -14,7 +14,7 @@
     </h1>
 
     <p class="govuk-body">
-      Assessment Only is the only route currently supported by this service. More routes will be added soon.
+      <%= t("activerecord.attributes.trainee.record_types.assessment_only") %> is the only route currently supported by this service. More routes will be added soon.
     </p>
 
     <p class="govuk-body">You can:</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
   service_name: Register trainee teachers
   cancel: Cancel and return to record
   change: Change
+  support_email: becomingateacher@digital.education.gov.uk
   components:
     confirmation:
       diversity:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,6 @@ en:
   service_name: Register trainee teachers
   cancel: Cancel and return to record
   change: Change
-  support_email: becomingateacher@digital.education.gov.uk
   components:
     confirmation:
       diversity:
@@ -61,6 +60,7 @@ en:
         data_requirements: Data requirements
         privacy_policy: How we use your personal data when you use Register trainee teachers
         forbidden: You do not have access to view details for this trainee
+        home: Home
         not_found: Page not found
         internal_server_error: Sorry, something went wrong
         unprocessable_entity: Sorry, the change you wanted was rejected

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
         cookies: Cookies on Register trainee teachers
         data_requirements: Data requirements
         privacy_policy: How we use your personal data when you use Register trainee teachers
+        forbidden: You do not have access to view details for this trainee
         not_found: Page not found
         internal_server_error: Sorry, something went wrong
         unprocessable_entity: Sorry, the change you wanted was rejected

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,9 @@ base_url: https://localhost:5000
 # The url for the google doc feedback link (live version)
 feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSfhdvlUkg7oxPjl1C6FcJ2pnlc1OQ82r7o3ZMNKthhVAt_h5g/viewform?usp=sf_link"
 
+# The email address for support queries
+support_email: becomingateacher@digital.education.gov.uk
+
 dttp:
   back_office_url: https://dttp-dev.crm4.dynamics.com/
   client_id: "application-registration-client-id-from-env"

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -114,7 +114,7 @@ module ApplicationRecordCard
       end
 
       it "renders route if there is no route" do
-        expect(component.find(".app-application-card__route")).to have_text("Assessment only")
+        expect(component.find(".app-application-card__route")).to have_text(t("activerecord.attributes.trainee.record_types.assessment_only"))
       end
     end
   end

--- a/spec/features/trainees/viewing_an_existing_trainee_spec.rb
+++ b/spec/features/trainees/viewing_an_existing_trainee_spec.rb
@@ -5,12 +5,22 @@ require "rails_helper"
 feature "View trainees" do
   background { given_i_am_authenticated }
 
-  scenario "viewing the personal details of trainee" do
-    given_a_trainee_exists
-    when_i_view_the_trainee_index_page
-    then_i_see_the_draft_trainee_data
-    and_i_click_on_trainee_name
-    then_i_should_see_the_trainee_details
+  context "when trainee belongs to me" do
+    scenario "viewing the personal details of trainee" do
+      given_a_trainee_exists
+      when_i_view_the_trainee_index_page
+      then_i_see_the_draft_trainee_data
+      and_i_click_on_trainee_name
+      then_i_should_see_the_trainee_details
+    end
+  end
+
+  context "when trainee does not belong to me" do
+    let(:trainee) { create(:trainee) }
+    scenario "viewing the personal details of trainee" do
+      and_i_visit_the_trainee
+      then_i_should_see_no_access_text
+    end
   end
 
   def when_i_view_the_trainee_index_page
@@ -27,5 +37,13 @@ feature "View trainees" do
 
   def then_i_should_see_the_trainee_details
     expect(review_draft_page).to be_displayed(id: trainee.slug)
+  end
+
+  def then_i_should_see_no_access_text
+    expect(page).to have_text(t("components.page_titles.pages.forbidden"))
+  end
+
+  def and_i_visit_the_trainee
+    visit(trainee_path(trainee))
   end
 end

--- a/spec/helpers/support_email_helper_spec.rb
+++ b/spec/helpers/support_email_helper_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SupportEmailHelper do
+  include SupportEmailHelper
+
+  describe "#support_email" do
+    has_correct_formatting = "has the correct formatting"
+    context "without params" do
+      subject { helper.support_email }
+
+      it has_correct_formatting do
+        expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk\">becomingateacher@digital.education.gov.uk</a>"
+        expect(subject).to eq(expected_output)
+      end
+    end
+
+    context "with subject" do
+      subject { helper.support_email(subject: "Register trainee teachers support") }
+
+      it has_correct_formatting do
+        expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20support\">becomingateacher@digital.education.gov.uk</a>"
+        expect(subject).to eq(expected_output)
+      end
+
+      context "with name" do
+        subject { helper.support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback") }
+        it "has the correct formatting" do
+          expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
+          expect(subject).to eq(expected_output)
+        end
+        context "with class" do
+          subject { helper.support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback", classes: "govuk-link--no-visited-state") }
+          it has_correct_formatting do
+            expected_output = "<a class=\"govuk-link govuk-link--no-visited-state\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
+            expect(subject).to eq(expected_output)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

When a user tries to navigate to a trainee that does not 'belong' to them, they currently get a 500. They should get a forbidden page (403).

### Changes proposed in this pull request

- Forbidden page renders when a user attempts to access a trainee that does not belong to them.
- Refactor support email into locale
- Refactor 'Assessment only' text into locale
- Fix homepage tab title

### Guidance to review forbidden error page

- Pull down the code and boot up the server
- Sign in as `User A` and navigate to a trainee
- Copy the URL
- Sign out and sign in as `User B`
- Paste the URL into the address bar
- Watch the error message & check the email link

### Guidance to review refactor and fix

- Navigate to homepage and check that the title of the tab appears
- Check support links work everywhere
- Check the words `Assessment only` appears correctly where it should.

### Screenshot of error page

![image](https://user-images.githubusercontent.com/50492247/107074466-adbb4a80-67e0-11eb-8268-5d1f7d16655c.png)

### Screenshot of home tab

![image](https://user-images.githubusercontent.com/50492247/107085194-0219f680-67f0-11eb-9da4-0857870b8c43.png)
