### PR TITLE
Example Data Bug

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -14,12 +14,13 @@ namespace :example_data do
       persona = Persona.find_or_create_by!(first_name: persona_attributes[:first_name],
                                            last_name: persona_attributes[:last_name],
                                            email: persona_attributes[:email],
+                                           dttp_id: SecureRandom.uuid,
                                            system_admin: persona_attributes[:system_admin])
 
       if persona_attributes[:provider]
         provider = Provider.find_or_create_by!(
           name: persona_attributes[:provider],
-          dttp_id: "00000000-0000-0000-0000-000000000000",
+          dttp_id: SecureRandom.uuid,
         )
         persona.update!(provider: provider)
       end


### PR DESCRIPTION
### Context
Example data bug where a dttp_id validation on the user model was being triggered as the example data did not create a dttp_id for a persona. 
### Changes proposed in this pull request
Add dttp_id with correct format to pass validation

### Guidance to review
