### PR TITLE
Move aria label to match design system

### DIFF
--- a/app/components/navigation_bar/view.html.erb
+++ b/app/components/navigation_bar/view.html.erb
@@ -2,8 +2,8 @@
   <div class="moj-primary-navigation">
     <div class="moj-primary-navigation__container">
       <div class="moj-primary-navigation__nav">
-        <nav class="moj-primary-navigation" aria-label="Primary navigation">
-          <ul class="moj-primary-navigation__list">
+        <nav class="moj-primary-navigation">
+          <ul class="moj-primary-navigation__list" aria-label="Primary navigation">
             <% items.each do |item| %>
             <li class="moj-primary-navigation__item">
               <%= item_link(item) %>


### PR DESCRIPTION
The primary nav in the header (from the design system) has the aria-label on the UL, not the nav. This makes the two consistent.
