### PR TITLE
Move aria-labels to Navs

### DIFF
--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -20,8 +20,8 @@
     <% if user_signed_in? %>
       <div class="govuk-header__content app-header__content">
         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu" data-module="govuk-button">Menu</button>
-        <nav>
-          <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top level navigation">
+        <nav aria-label="Account menu">
+          <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end">
             <% if user_system_admin? %>
               <li class="govuk-header__navigation-item">
                 <%= govuk_link_to "System admin", providers_path, class: "govuk-header__link" %>

--- a/app/components/navigation_bar/view.html.erb
+++ b/app/components/navigation_bar/view.html.erb
@@ -2,8 +2,8 @@
   <div class="moj-primary-navigation">
     <div class="moj-primary-navigation__container">
       <div class="moj-primary-navigation__nav">
-        <nav class="moj-primary-navigation">
-          <ul class="moj-primary-navigation__list" aria-label="Primary navigation">
+        <nav class="moj-primary-navigation" aria-label="Primary navigation">
+          <ul class="moj-primary-navigation__list">
             <% items.each do |item| %>
             <li class="moj-primary-navigation__item">
               <%= item_link(item) %>


### PR DESCRIPTION
This reverts #491, and instead moves the `aria-label` from the ul to the nav.

This is a change already planned by the design system (flagged by a validator, like ours was), so we're getting ahead of the curve.

Also updated the label on the account menu to more accurately describe its purpose.