### PR TITLE
[1002] Remove dfe_ClassofDegreeId (grade) from Non-UK degrees DTTP payload

### DIFF
--- a/app/lib/dttp/params/degree_qualification.rb
+++ b/app/lib/dttp/params/degree_qualification.rb
@@ -24,7 +24,6 @@ module Dttp
         {
           "dfe_ContactId@odata.bind" => "$#{contact_change_set_id}",
           "dfe_TrainingRecordId@odata.bind" => "$#{placement_assignment_change_set_id}",
-          "dfe_ClassofDegreeId@odata.bind" => "/dfe_classofdegrees(#{degree_class_id(degree.grade)})",
           "dfe_DegreeSubjectId@odata.bind" => "/dfe_jacses(#{degree_subject_id(degree.subject)})",
         }.merge(degree.uk? ? uk_specific_params : non_uk_specific_params)
       end
@@ -32,6 +31,7 @@ module Dttp
       def uk_specific_params
         {
           "dfe_name" => degree.uk_degree,
+          "dfe_ClassofDegreeId@odata.bind" => "/dfe_classofdegrees(#{degree_class_id(degree.grade)})",
           "dfe_DegreeTypeId@odata.bind" => "/dfe_degreetypes(#{degree_type_id(degree.uk_degree)})",
           "dfe_AwardingInstitutionId@odata.bind" => "/accounts(#{degree_institution_id(degree.institution)})",
         }

--- a/spec/lib/dttp/params/degree_qualification_spec.rb
+++ b/spec/lib/dttp/params/degree_qualification_spec.rb
@@ -35,7 +35,7 @@ module Dttp
           let(:degree_type) { degree.uk_degree }
 
           it "returns a hash with all the UK specific degree qualification fields " do
-            expect(subject).to include({
+            expect(subject).to match({
               "dfe_name" => degree.uk_degree,
               "dfe_ContactId@odata.bind" => "$#{contact_change_set_id}",
               "dfe_TrainingRecordId@odata.bind" => "$#{placement_assignment_change_set_id}",
@@ -52,11 +52,10 @@ module Dttp
           let(:degree_type) { degree.non_uk_degree_non_naric? ? "Unknown" : "Degree equivalent" }
 
           it "returns a hash with all the Non-UK specific degree qualification fields" do
-            expect(subject).to include({
+            expect(subject).to match({
               "dfe_name" => degree.non_uk_degree,
               "dfe_ContactId@odata.bind" => "$#{contact_change_set_id}",
               "dfe_TrainingRecordId@odata.bind" => "$#{placement_assignment_change_set_id}",
-              "dfe_ClassofDegreeId@odata.bind" => "/dfe_classofdegrees(#{dttp_degree_grade_entity_id})",
               "dfe_DegreeSubjectId@odata.bind" => "/dfe_jacses(#{dttp_degree_subject_entity_id})",
               "dfe_DegreeTypeId@odata.bind" => "/dfe_degreetypes(#{dttp_degree_type_id})",
               "dfe_DegreeCountryId@odata.bind" => "/dfe_countries(#{dttp_country_entity_id})",


### PR DESCRIPTION
### Context
https://trello.com/c/BtrW9NYu/1002-adr-for-cron-jobsnonuk-degree-not-sent-to-dttp

### Changes proposed in this pull request
- Update  `Dttp::Params::DegreeQualification` to include degree grade params for UK degrees only

