### PR TITLE
Remove summary card bottom border on mobile

### DIFF
--- a/app/components/summary_card/style.scss
+++ b/app/components/summary_card/style.scss
@@ -64,6 +64,12 @@
     margin-bottom: 0;
   }
 
+  // Remove last item’s bottom border on mobile
+  .govuk-summary-list__row:last-child {
+    border-bottom: 0;
+  }
+
+  // Remove lsat item’s bottom border on tablet and larger
   .govuk-summary-list__row:last-child > * {
     border-bottom: 0;
   }


### PR DESCRIPTION
Summary lists have a border between each item. We don't need it on the last item as it's already in a summary-card which nicely contains it. There was already css to remove it, but it only worked on tablet breakpoints and higher as the border is done differently on mobile.

Before:
![Screenshot 2021-02-08 at 16 57 44](https://user-images.githubusercontent.com/2204224/107254213-0122d800-6a2f-11eb-8613-65dc3ee55d18.png)

After:
![Screenshot 2021-02-08 at 16 57 31](https://user-images.githubusercontent.com/2204224/107254220-03853200-6a2f-11eb-8540-48b60c4c0df1.png)
