### PR TITLE
[994] Personal details form validation bug

### DIFF
--- a/app/forms/personal_detail_form.rb
+++ b/app/forms/personal_detail_form.rb
@@ -18,8 +18,9 @@ class PersonalDetailForm
   attr_accessor(*FIELDS, :trainee, :day, :month, :year, :other_nationality1,
                 :other_nationality2, :other_nationality3, :other)
 
-  validates :first_names, presence: true
-  validates :last_name, presence: true
+  validates :first_names, presence: true, name: true
+  validates :middle_names, name: true
+  validates :last_name, presence: true, name: true
   validates :date_of_birth, presence: true
   validates :gender, presence: true, inclusion: { in: Trainee.genders.keys }
 

--- a/app/validators/name_validator.rb
+++ b/app/validators/name_validator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class NameValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    unless value =~ /\A([A-Za-z]+[\d]+[\w]*|[\d]+[A-Za-z]+[\w]*)|[A-Za-zÀ-ÖØ-öø-ÿ, '-]+\z/
+      record.errors.add(attribute, :invalid)
+    end
+  end
+end
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,8 +260,12 @@ en:
           attributes:
             first_names:
               blank: "You must enter a first name"
+              invalid: "You must enter valid first names"
+            middle_names:
+              invalid: "You must enter valid middle names"
             last_name:
               blank: "You must enter a last name"
+              invalid: "You must enter a valid last name"
             date_of_birth:
               blank: "You must enter a date of birth"
               invalid: "You must enter a valid date"

--- a/spec/validators/name_validator_spec.rb
+++ b/spec/validators/name_validator_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+class TestSubject
+  include ActiveModel::Model
+
+  attr_accessor :name
+
+  validates :name, name: true
+end
+
+describe NameValidator do
+  subject { TestSubject.new(name: name) }
+
+  describe "#validates_each" do
+    context "valid details" do
+      let(:name) { "Fred" }
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "invalid details" do
+      let(:name) { "21" }
+
+      it "is invalid" do
+        expect(subject).to be_invalid
+        expect(subject.errors.keys).to include(:name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/ob4qJ14N/994-personal-details-no-error-shown-for-inputting-numbers-into-first-name-middle-name-last-name
### Changes proposed in this pull request
* Add custom validator with regex pattern and use for name fields on personal details form
* Unit test for validator
* Add middle name validation but allow it to pass if left empty 
### Guidance to review
Create new record or edit existing one and see if validation is triggered if invalid details (e.g a number) entered on first name, middle name and last name fields on personal details form. 
https://rtt-review-pr-496.herokuapp.com/
