### PR TITLE
[1013] Remove feedback and support links from production env

### DIFF
--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -2,6 +2,8 @@
   <%= render PageTitle::View.new(title: "pages.forbidden") %>
 
   <h1 class="govuk-heading-l">You do not have access to view details for this trainee</h1>
-  
-  <p class="govuk-body">If you think you should have access, contact: <%= support_email(subject: "Register trainee teachers support") %>.</p>
+
+  <% if FeatureService.enabled?("enable_support_link") %>
+    <p class="govuk-body">If you think you should have access, contact: <%= support_email(subject: "Register trainee teachers support") %>.</p>
+  <% end %>
 <% end %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -4,6 +4,8 @@
   <h1 class="govuk-heading-l">Sorry, something went wrong</h1>
 
   <p class="govuk-body">Try again later.</p>
-  
-  <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
+
+  <% if FeatureService.enabled?("enable_support_link") %>
+    <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
+  <% end %>
 <% end %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,10 +1,11 @@
-
 <%= extends_layout :error do %>
   <%= render PageTitle::View.new(title: "pages.not_found") %>
 
   <h1 class="govuk-heading-l">Page not found</h1>
 
   <p class="govuk-body">Check the web address and try again.</p>
-  
-  <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
+
+  <% if FeatureService.enabled?("enable_support_link") %>
+    <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
+  <% end %>
 <% end %>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -2,6 +2,11 @@
   <%= render PageTitle::View.new(title: "pages.unprocessable_entity") %>
 
   <h1 class="govuk-heading-l">Sorry, the change you wanted was rejected</h1>
+
   <p class="govuk-body">Try again later.</p>
-  <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
+
+  <% if FeatureService.enabled?("enable_support_link") %>
+    <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
+  <% end %>
 <% end %>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
               Beta
             </strong>
             <span class="govuk-phase-banner__text">
-                This is a new service – <%= support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback", classes: "govuk-link--no-visited-state") %>
+                This is a new service <% if FeatureService.enabled?("enable_support_link") %> – <%= support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback", classes: "govuk-link--no-visited-state") %> <% end %>
             </span>
           </p>
         </div>
@@ -75,13 +75,15 @@
       <div class="govuk-width-container">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-            <h2 class="govuk-heading-m">Get support</h2>
-            <div class="govuk-footer__meta-custom">
-              <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                <li>Email: <%= support_email(subject: "Register trainee teachers support", classes: "govuk-footer__link") %></li>
-                <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
-              </ul>
-            </div>
+            <% if FeatureService.enabled?("enable_support_link") %>
+              <h2 class="govuk-heading-m">Get support</h2>
+              <div class="govuk-footer__meta-custom">
+                <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
+                  <li>Email: <%= support_email(subject: "Register trainee teachers support", classes: "govuk-footer__link") %></li>
+                  <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
+                </ul>
+              </div>
+            <% end %>
             <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
               <li class="govuk-footer__inline-list-item">
                 <%= link_to "Accessibility", accessibility_path, class: "govuk-footer__link" %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -27,12 +27,14 @@
     <p class="govuk-body">Review and manage your trainee records.</p>
   </div>
 
-  <div class ="govuk-grid-column-one-third">
-    <h2 class="govuk-heading-m">
-      <%= govuk_link_to "Give feedback", Settings.feedback_link_url, { class: "govuk-link govuk-link--no-visited-state" } %>
-    </h2>
-    <p class="govuk-body">This is a new service. Your views will help us improve it.</p>
-  </div>
+  <% if FeatureService.enabled?("enable_feedback_link") %>
+    <div class ="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-m">
+        <%= govuk_link_to "Give feedback", Settings.feedback_link_url, { class: "govuk-link govuk-link--no-visited-state" } %>
+      </h2>
+      <p class="govuk-body">This is a new service. Your views will help us improve it.</p>
+    </div>
+  <% end %>
 
   <div class ="govuk-grid-column-one-third">
     <h2 class="govuk-heading-m">

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -20,10 +20,12 @@
       <%= govuk_link_to "Sign in using Persona", "/personas", { class: "govuk-button" }  %>
     <% end %>
 
-    <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to Register trainee teachers, email
+    <% if FeatureService.enabled?("enable_support_link") %>
+      <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to Register trainee teachers, email
 
-    <%= support_email(subject: "Get access to Register trainee teachers") %>.
-    </p>
+      <%= support_email(subject: "Get access to Register trainee teachers") %>.
+      </p>
+    <% end %>
 
   </div>
 </div>

--- a/app/views/sign_in/new.html.erb
+++ b/app/views/sign_in/new.html.erb
@@ -6,9 +6,11 @@
     <p class="govuk-body"> Although you have a DfE Sign-in account, you also need an account
                              for this service.</p>
 
-    <p class="govuk-body"> Contact us at
-    <%= support_email(subject: "Get access to Register trainee teachers") %> to ask for an account.
-    </p>
+    <% if FeatureService.enabled?("enable_support_link") %>
+      <p class="govuk-body"> Contact us at
+      <%= support_email(subject: "Get access to Register trainee teachers") %> to ask for an account.
+      </p>
+    <% end %>
 
     <%= govuk_button_link_to("Return home", root_path) %>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,6 +25,7 @@ features:
   allow_user_creation: false
   enable_feedback_link: true
   basic_auth: true
+  enable_support_link: true
 
 dfe_sign_in:
   # Our service name

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -14,3 +14,5 @@ dfe_sign_in:
 
 features:
   basic_auth: false
+  enable_feedback_link: false
+  enable_support_link: false

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -4,3 +4,5 @@ feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSdYg4IA2tMiSfqIjM9C
 features:
   home_text: true
   use_dfe_sign_in: false
+  enable_feedback_link: false
+  enable_support_link: false


### PR DESCRIPTION
### Context

Hide feedback links and feedback forms behind a feature flag in production for the trial.

### Changes proposed in this pull request

- Add homepage feedback form into component
- Add feature flag for homepage feedback form
- Add feature flag for support link
- Disable feedback form and support link in production env

### Guidance to review

Check that the support links and feedback forms do not appear on the review app. (https://rtt-review-pr-502.herokuapp.com)
Check that the support links and feedback forms do appear on localhost.

