### PR TITLE
[1011] Refactor error pages to remove duplicated markup

### DIFF
--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,7 +1,7 @@
-<%= render PageTitle::View.new(title: "pages.forbidden") %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l">You do not have access to view details for this trainee</h1>
-    <p class="govuk-body">If you think you should have access, contact: <%= support_email(subject: "Register trainee teachers support") %>.</p>
-  </div>
-</div>
+<%= extends_layout :error do %>
+  <%= render PageTitle::View.new(title: "pages.forbidden") %>
+
+  <h1 class="govuk-heading-l">You do not have access to view details for this trainee</h1>
+  
+  <p class="govuk-body">If you think you should have access, contact: <%= support_email(subject: "Register trainee teachers support") %>.</p>
+<% end %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,11 +1,9 @@
-<%= render PageTitle::View.new(title: "pages.internal_server_error") %>
+<%= extends_layout :error do %>
+  <%= render PageTitle::View.new(title: "pages.internal_server_error") %>
 
-<main role="main" class="govuk-main-wrapper" id="main-content">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <h1 class="govuk-heading-l">Sorry, something went wrong</h1>
-      <p class="govuk-body">Try again later.</p>
-      <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
-    </div>
-  </div>
-</main>
+  <h1 class="govuk-heading-l">Sorry, something went wrong</h1>
+
+  <p class="govuk-body">Try again later.</p>
+  
+  <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
+<% end %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,11 +1,10 @@
-<%= render PageTitle::View.new(title: "pages.not_found") %>
 
-<main role="main" class="govuk-main-wrapper" id="main-content">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <h1 class="govuk-heading-l">Page not found</h1>
-      <p class="govuk-body">Check the web address and try again.</p>
-      <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
-    </div>
-  </div>
-</main>
+<%= extends_layout :error do %>
+  <%= render PageTitle::View.new(title: "pages.not_found") %>
+
+  <h1 class="govuk-heading-l">Page not found</h1>
+
+  <p class="govuk-body">Check the web address and try again.</p>
+  
+  <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
+<% end %>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,11 +1,7 @@
-<%= render PageTitle::View.new(title: "pages.unprocessable_entity") %>
+<%= extends_layout :error do %>
+  <%= render PageTitle::View.new(title: "pages.unprocessable_entity") %>
 
-<main role="main" class="govuk-main-wrapper" id="main-content">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <h1 class="govuk-heading-l">Sorry, the change you wanted was rejected</h1>
-      <p class="govuk-body">Try again later.</p>
-      <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
-    </div>
-  </div>
-</main>
+  <h1 class="govuk-heading-l">Sorry, the change you wanted was rejected</h1>
+  <p class="govuk-body">Try again later.</p>
+  <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= govuk_mail_to 'registerateacher@digital.education.gov.uk', 'registerateacher@digital.education.gov.uk' %>.</p>
+<% end %>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= yield %>
+  </div>
+</div>


### PR DESCRIPTION
### Context

- https://trello.com/c/d6ITjwBW/1011-error-pages-has-2-main-elements

### Changes proposed in this pull request

- Create a base error layout which error views can extend. The base itself inherits from `application.html.erb`
- Remove previously generated duplicated markup

### Guidance to review

<img width="570" alt="Screenshot 2021-02-09 at 15 26 32" src="https://user-images.githubusercontent.com/616080/107386819-24f82380-6aec-11eb-8f50-6d039ad370f0.png">


