### PR TITLE
[1021] Copy change to Trainee ID forms

### DIFF
--- a/app/views/trainees/trainee_ids/edit.html.erb
+++ b/app/views/trainees/trainee_ids/edit.html.erb
@@ -4,9 +4,18 @@
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
-<%= form_with model: @trainee, url: trainee_trainee_id_path, local: true do |f| %>
-    <%= f.govuk_text_field :trainee_id, label: { text: 'Trainee ID (optional)', tag: 'h1', size: 'l' }, hint: { text: 'Your internal identifier for this trainee or candidate'}, width: 20 %>
-  <%= f.govuk_submit "Continue" %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop"> 
+    <%= form_with model: @trainee, url: trainee_trainee_id_path, local: true do |f| %>
+      <%= f.govuk_text_field :trainee_id, label: { text: 'Trainee ID (optional)', tag: 'h1', size: 'l' }, width: 20 do %>  
+          <p class="govuk-body govuk-hint">
+            You can assign your own ID for this trainee. This can help you identify them
+            or search for them in your trainee records later.
+          </p> 
+        <% end %>
+      <%= f.govuk_submit "Continue" %>  
+    <% end %>
+  </div>
+</div>
 
 <p class="govuk-body"><%= govuk_link_to("Cancel and return to record", trainee_path(@trainee)) %></p>

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -4,8 +4,16 @@
   <%= render DynamicBackLink::View.new(@trainee) %>
 <% end %>
 
-<%= form_with model: @trainee, local: true do |f| %>
-  <%= f.govuk_text_field :trainee_id, label: { text: 'Trainee ID (optional)', tag: 'h1', size: 'l' }, hint: { text: 'Your internal identifier for this trainee or candidate'}, width: 20 %>
-
-  <%= f.govuk_submit "Continue" %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop"> 
+    <%= form_with model: @trainee, local: true do |f| %>
+      <%= f.govuk_text_field :trainee_id, label: { text: 'Trainee ID (optional)', tag: 'h1', size: 'l' }, width: 20 do %>  
+          <p class="govuk-body govuk-hint">
+            You can assign your own ID for this trainee. This can help you identify them
+            or search for them in your trainee records later.
+          </p> 
+        <% end %>
+      <%= f.govuk_submit "Continue" %>  
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
### Context
https://trello.com/c/Ymsov7au/1021-dev-add-content-to-trainee-id-optional-page

### Changes proposed in this pull request
Copy change to hint text in trainee id form, found on two views. Added HTML to avoid having a really long line and to make it resize correctly for different browsers/displays.


### Guidance to review
<img width="1159" alt="Screenshot 2021-02-09 at 19 51 01" src="https://user-images.githubusercontent.com/58793682/107419851-29cece80-6b10-11eb-8809-43ef01f06d07.png">
<img width="427" alt="Screenshot 2021-02-09 at 21 01 24" src="https://user-images.githubusercontent.com/58793682/107428037-00b33b80-6b1a-11eb-816c-ccaf644f539a.png">
