### PR TITLE
[1044] Programme Dates strip whitespace before validation

### DIFF
--- a/app/forms/programme_detail_form.rb
+++ b/app/forms/programme_detail_form.rb
@@ -11,6 +11,8 @@ class ProgrammeDetailForm
 
   delegate :id, :persisted?, to: :trainee
 
+  before_validation :sanitise_programme_dates
+
   validates :subject, presence: true
   validate :age_range_valid
   validate :programme_start_date_valid
@@ -66,6 +68,23 @@ class ProgrammeDetailForm
       Date.new(*date_args)
     else
       Struct.new(*date_hash.keys).new(*date_hash.values)
+    end
+  end
+
+  def sanitise_programme_dates
+    programme_dates = %w[start_day
+                         start_month
+                         start_year
+                         end_day
+                         end_month
+                         end_year]
+
+    return if programme_dates.any?(&:nil?)
+
+    programme_dates.each do |date_attribute|
+      date = "#{date_attribute}="
+      sanitised_date = public_send(date_attribute).to_s.gsub(/\s+/, "")
+      public_send(date, sanitised_date)
     end
   end
 

--- a/spec/forms/programme_detail_form_spec.rb
+++ b/spec/forms/programme_detail_form_spec.rb
@@ -7,6 +7,30 @@ describe ProgrammeDetailForm, type: :model do
 
   subject { described_class.new(trainee) }
 
+  describe "before validation" do
+    context "#sanitise_programme_dates" do
+      let(:attributes) do
+        { start_day: "1 2",
+          start_month: "1 1",
+          start_year: "2 0 2 0",
+          end_day: "1 2",
+          end_month: "1 1",
+          end_year: "2 0 2 1" }
+      end
+
+      before do
+        subject.assign_attributes(attributes)
+        subject.sanitise_programme_dates
+        subject.valid?
+      end
+
+      it "does not return programme date errors" do
+        expect(subject.errors[:programme_start_date]).to be_empty
+        expect(subject.errors[:programme_end_date]).to be_empty
+      end
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:subject) }
 


### PR DESCRIPTION
### Context
https://trello.com/c/lT3akjMG/1044-cant-type-numbers-with-voice-control-need-to-strip-whitespace
### Changes proposed in this pull request
Adds method on programme details form model that, before validation, strips the whitespace from all programme date fields. This allows voice control to add space between each number and pass validation. 

### Guidance to review
https://rtt-review-pr-513.herokuapp.com/

Some of the existing tests feed in integer values so I had to convert array elements to strings in order for .gsub method to work. Some also feed in nil values, so I had to return the method if any of the array elements were nil otherwise it would also error on .gsub. 


