### PR TITLE
Upgrade Cloud Foundry plugin to v13

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.12.6"
+      version = "0.13.0"
     }
   }
 }
@@ -27,7 +27,7 @@ resource cloudfoundry_app web_app {
   instances                  = var.web_app_instances
   memory                     = var.web_app_memory
   space                      = data.cloudfoundry_space.space.id
-  strategy                   = var.deployment_strategy
+  strategy                   = "blue-green-v2"
   timeout                    = var.app_start_timeout
   environment                = local.app_environment
   docker_credentials         = var.docker_credentials
@@ -59,7 +59,7 @@ resource cloudfoundry_app worker_app {
   instances          = var.worker_app_instances
   memory             = var.worker_app_memory
   space              = data.cloudfoundry_space.space.id
-  strategy           = var.deployment_strategy
+  strategy           = "blue-green-v2"
   timeout            = var.app_start_timeout
   environment        = local.app_environment
   docker_credentials = var.docker_credentials

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.12.6"
+      version = "0.13.0"
     }
 
     statuscake = {

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -5,7 +5,6 @@ paas_space_name                  = "bat-prod"
 paas_postgres_service_plan       = "tiny-unencrypted-11"
 paas_redis_service_plan          = "tiny-ha-5_x"
 paas_app_start_timeout           = "180"
-paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances           = 2
 paas_web_app_memory              = 512
 paas_worker_app_instances        = 2

--- a/terraform/workspace-variables/qa.tfvars
+++ b/terraform/workspace-variables/qa.tfvars
@@ -5,7 +5,6 @@ paas_space_name                  = "bat-qa"
 paas_postgres_service_plan       = "tiny-unencrypted-11"
 paas_redis_service_plan          = "tiny-4_x"
 paas_app_start_timeout           = "180"
-paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances           = 1
 paas_web_app_memory              = 512
 paas_worker_app_instances        = 1

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -5,7 +5,6 @@ paas_space_name                  = "bat-qa"
 paas_postgres_service_plan       = "tiny-unencrypted-11"
 paas_redis_service_plan          = "tiny-4_x"
 paas_app_start_timeout           = "60"
-paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances           = 1
 paas_web_app_memory              = 512
 paas_worker_app_instances        = 1

--- a/terraform/workspace-variables/sandbox.tfvars
+++ b/terraform/workspace-variables/sandbox.tfvars
@@ -5,7 +5,6 @@ paas_space_name                  = "bat-prod"
 paas_postgres_service_plan       = "small-11"
 paas_redis_service_plan          = "micro-5_x"
 paas_app_start_timeout           = "180"
-paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances           = 2
 paas_web_app_memory              = 512
 paas_worker_app_instances        = 2


### PR DESCRIPTION
### Context

cloudfoundry plugin v13 fixes a long standing issues of not restarting the app services after deployment when only the app's environment changes.

### Changes proposed in this pull request
revert instances where worker app uses blue\green

 cloudfoundry = {
      source  = "cloudfoundry-community/cloudfoundry"
      version = "0.13.0"
    }

### Guidance to review

