### PR TITLE
[1018] Implement exporting for trainee search results

### DIFF
--- a/app/components/trainees/filters/style.scss
+++ b/app/components/trainees/filters/style.scss
@@ -58,6 +58,8 @@
 }
 
 .app-filter {
+  box-shadow: none;
+
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(3);
   }

--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -71,6 +71,10 @@
         </div>
       </div>
     </div>
+
+    <% if filter_actions %>
+      <%= filter_actions %>
+    <% end %>
   </div>
 
   <div class='moj-filter-layout__content'>

--- a/app/components/trainees/filters/view.rb
+++ b/app/components/trainees/filters/view.rb
@@ -6,6 +6,8 @@ module Trainees
       include ProgrammeDetailsHelper
       attr_accessor :filters
 
+      with_content_areas :filter_actions
+
       def initialize(filters)
         @filters = filters
       end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -2,6 +2,7 @@
 
 class TraineesController < ApplicationController
   before_action :ensure_trainee_is_not_draft!, only: :show
+  helper_method :filter_params
 
   def index
     @filters = TraineeFilter.new(params: filter_params).filters
@@ -14,6 +15,11 @@ class TraineesController < ApplicationController
       trainees: policy_scope(Trainee.not_draft.ordered_by_date),
       filters: @filters,
     )
+
+    respond_to do |format|
+      format.html
+      format.csv { send_data data_export.data, filename: data_export.filename, disposition: :attachment }
+    end
   end
 
   def show
@@ -58,5 +64,9 @@ private
 
   def filter_params
     params.permit(:subject, :text_search, record_type: [], state: [])
+  end
+
+  def data_export
+    @data_export ||= Exports::TraineeSearchData.new(@draft_trainees + @trainees)
   end
 end

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -2,6 +2,6 @@
 
 module SummaryHelper
   def date_for_summary_view(date)
-    date.strftime("%-d %B %Y")
+    date&.strftime("%-d %B %Y")
   end
 end

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Exports
+  class TraineeSearchData
+    def initialize(trainees)
+      @data_for_export = format_trainees(trainees)
+    end
+
+    def data
+      header_row ||= data_for_export.first&.keys
+
+      CSV.generate(headers: true) do |rows|
+        rows << header_row
+
+        data_for_export.map(&:values).each do |value|
+          rows << value
+        end
+      end
+    end
+
+    def filename
+      "#{Time.zone.now.strftime('%Y-%m-%d_%H-%M_%S')}_Register-trainee-teachers_exported_records.csv"
+    end
+
+  private
+
+    attr_reader :data_for_export
+
+    def format_trainees(trainees)
+      trainees.map do |trainee|
+        {
+          "First name" => trainee.first_names,
+          "Last name" => trainee.last_name,
+          "Trainee Id" => trainee.trainee_id,
+          "TRN" => trainee.trn,
+          "Status" => trainee.state,
+          "Route" => trainee.record_type,
+          "Subject" => trainee.subject,
+          "Programme start date" => trainee.programme_start_date,
+          "Programme end date" => trainee.programme_end_date,
+          "Created date" => trainee.created_at,
+          "Last updated date" => trainee.updated_at,
+          "TRN Submitted date" => trainee.submitted_for_trn_at,
+          "QTS submitted date" => trainee.recommended_for_qts_at,
+        }
+      end
+    end
+  end
+end

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -10,7 +10,13 @@
   </p>
 <% end %>
 
-<%= render Trainees::Filters::View.new(@filters) do %>
+<%= render Trainees::Filters::View.new(@filters) do |component| %>
+  <% if FeatureService.enabled?(:trainee_export) && (@draft_trainees + @trainees).any?(&:present?) %>
+    <% component.with(:filter_actions) do %>
+      <p class="govuk-body govuk-!-margin-top-3"><%= govuk_link_to("Export these records", trainees_path(filter_params.merge(format: "csv")), class: "trainee-search-export") %></p>
+    <% end %>
+  <% end %>
+
   <% if @draft_trainees.any? || @trainees.any? %>
     <% if @draft_trainees.any? %>
       <div class="govuk-!-margin-bottom-8 app-draft-records">

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -39,7 +39,7 @@ a[href="#"] {
   }
 }
 
-.app-summary-card__actions .govuk-button--link {
+.govuk-button--link {
   @include govuk-link-common;
   @include govuk-link-style-default;
   @include govuk-link-print-friendly;

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,7 @@ features:
   enable_feedback_link: true
   basic_auth: true
   enable_support_link: true
+  trainee_export: false
 
 dfe_sign_in:
   # Our service name

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -12,3 +12,4 @@ dttp:
 features:
   home_text: true
   use_dfe_sign_in: false
+  trainee_export: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -6,3 +6,4 @@ features:
   use_dfe_sign_in: false
   enable_feedback_link: false
   enable_support_link: false
+  trainee_export: true

--- a/spec/features/trainees/filtering_trainees_spec.rb
+++ b/spec/features/trainees/filtering_trainees_spec.rb
@@ -59,6 +59,19 @@ RSpec.feature "Filtering trainees" do
     end
   end
 
+  context "exporting", feature_trainee_export: true do
+    scenario "exporting with no filter" do
+      and_i_export_the_results
+      then_i_see_my_trainee_search_results
+    end
+
+    scenario "exporting with a filter" do
+      when_i_filter_by_subject("Biology")
+      and_i_export_the_results
+      then_i_see_my_filtered_trainee_search_results
+    end
+  end
+
 private
 
   def given_trainees_exist_in_the_system
@@ -165,5 +178,29 @@ private
 
   def full_name(trainee)
     [trainee.first_names, trainee.last_name].join(" ")
+  end
+
+  def and_i_export_the_results
+    trainee_index_page.export_link.click
+  end
+
+  def then_i_see_my_trainee_search_results
+    expect(csv_output).to include(@assessment_only_trainee.trainee_id)
+    expect(csv_output).to include(@provider_led_trainee.trainee_id)
+    expect(csv_output).to include(@biology_trainee.trainee_id)
+    expect(csv_output).to include(@history_trainee.trainee_id)
+  end
+
+  def then_i_see_my_filtered_trainee_search_results
+    expect(csv_output).to include(@biology_trainee.trainee_id)
+
+    expect(csv_output).not_to include(@assessment_only_trainee.trainee_id)
+    expect(csv_output).not_to include(@provider_led_trainee.trainee_id)
+    expect(csv_output).not_to include(@searchable_trainee.trainee_id)
+    expect(csv_output).not_to include(@history_trainee.trainee_id)
+  end
+
+  def csv_output
+    @csv_output ||= CSV.parse(page.text).flatten.compact.map(&:strip)
   end
 end

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Exports
+  describe TraineeSearchData do
+    let(:trainee) do
+      create(:trainee, :with_programme_details, :submitted_for_trn, :trn_received, :recommended_for_qts, :qts_awarded)
+    end
+
+    subject { described_class.new([trainee]) }
+
+    describe "#data" do
+      let(:expected_output) do
+        {
+          "First name" => trainee.first_names,
+          "Last name" => trainee.last_name,
+          "Trainee Id" => trainee.trainee_id,
+          "TRN" => trainee.trn,
+          "Status" => trainee.state,
+          "Route" => trainee.record_type,
+          "Subject" => trainee.subject,
+          "Programme start date" => trainee.programme_start_date,
+          "Programme end date" => trainee.programme_end_date,
+          "Created date" => trainee.created_at,
+          "Last updated date" => trainee.updated_at,
+          "TRN Submitted date" => trainee.submitted_for_trn_at,
+          "QTS submitted date" => trainee.recommended_for_qts_at,
+        }
+      end
+
+      it "sets the correct headers" do
+        expect(subject.data).to include(expected_output.keys.join(","))
+      end
+
+      it "sets the correct row values" do
+        expect(subject.data).to include(expected_output.values.join(","))
+      end
+    end
+
+    describe "#time" do
+      let(:time_now_in_zone) { Time.zone.now }
+
+      let(:expected_filename) do
+        "#{time_now_in_zone.strftime('%Y-%m-%d_%H-%M_%S')}_Register-trainee-teachers_exported_records.csv"
+      end
+
+      before do
+        allow(Time).to receive(:now).and_return(time_now_in_zone)
+      end
+
+      it "sets the correct filename" do
+        expect(subject.filename).to eq(expected_filename)
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -23,6 +23,8 @@ module PageObjects
       element :assessment_only_checkbox, "#record_type-assessment_only"
       element :provider_led_checkbox, "#record_type-provider_led"
       element :subject, "#subject"
+
+      element :export_link, ".trainee-search-export"
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/X8OvI4HG/1018-s-export-trainee-list

### Changes proposed in this pull request

- Adds an export function to the trainee index page to allow users to export their search/filter results
- Add the feature behind a feature flag (enabled only on QA/Review environment)

### Guidance to review

- Head to https://rtt-review-pr-516.herokuapp.com/trainees and export the result set, assert csv attachment contains the same results on the page
- Apply a filter and export again, assert results in the csv match the results on the page

