### PR TITLE
[1008] Fix order of error messages on degree partials

### DIFF
--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -4,13 +4,13 @@ class Degree < ApplicationRecord
   include Sluggable
 
   validates :locale_code, presence: true
-  validates :uk_degree, presence: true, on: :uk
-  validates :country, presence: true, on: :non_uk
-  validates :non_uk_degree, presence: true, on: :non_uk
   validates :subject, presence: true, on: %i[uk non_uk]
+  validates :country, presence: true, on: :non_uk
+  validates :uk_degree, presence: true, on: :uk
   validates :institution, presence: true, on: :uk
   validates :graduation_year, presence: true, on: %i[uk non_uk]
   validate :graduation_year_valid, if: -> { graduation_year.present? }
+  validates :non_uk_degree, presence: true, on: :non_uk
   validates :grade, presence: true, on: :uk
 
   belongs_to :trainee


### PR DESCRIPTION
### Context
https://trello.com/c/Jjn20TdA/1008-error-messages-out-of-order-on-degrees-page
### Changes proposed in this pull request
Reorder validations on degree model to show error messages in correct order. The wrong order was found on both uk and non uk degree partials. 
### Guidance to review

<img width="1143" alt="Screenshot 2021-02-11 at 17 12 31" src="https://user-images.githubusercontent.com/58793682/107672610-02e9d700-6c8d-11eb-8928-b3e99a832001.png">
<img width="1173" alt="Screenshot 2021-02-11 at 17 13 08" src="https://user-images.githubusercontent.com/58793682/107672641-0aa97b80-6c8d-11eb-88e1-3fd600995808.png">
