### PR TITLE
Remove paas_web_app_deployment_strategy from staging.tfvars

### DIFF
--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -5,7 +5,6 @@ paas_space_name                  = "bat-staging"
 paas_postgres_service_plan       = "tiny-unencrypted-11"
 paas_redis_service_plan          = "tiny-ha-5_x"
 paas_app_start_timeout           = "180"
-paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances           = 1
 paas_web_app_memory              = 512
 paas_worker_app_instances        = 1


### PR DESCRIPTION
value is now hardcoded at the resource level

### Context

Remove paas_web_app_deployment_strategy from staging.tfvars

### Changes proposed in this pull request
Remove paas_web_app_deployment_strategy from staging.tfvars

### Guidance to review

