### PR TITLE
[xxx] Allow nil dttp_id for system_admin

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :email, presence: true
-  validates :dttp_id, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
+  validates :dttp_id, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }, unless: :system_admin?
 
   validate do |record|
     EmailFormatValidator.new(record).validate

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,14 @@ describe User do
       expect(subject).to validate_presence_of(:email)
       expect(subject).to validate_presence_of(:dttp_id).with_message("You must enter a DTTP ID in the correct format, like 6a61d94f-5060-4d57-8676-bdb265a5b949")
     end
+
+    context "system_admin" do
+      before { subject.system_admin = true }
+
+      it "allows empty dttp_id" do
+        expect(subject).not_to validate_presence_of(:dttp_id).with_message("You must enter a DTTP ID in the correct format, like 6a61d94f-5060-4d57-8676-bdb265a5b949")
+      end
+    end
   end
 
   describe "associations" do


### PR DESCRIPTION
### Context

System admins don't necessarily map to a user on DTTP.

### Changes proposed in this pull request

Allow system_admin users to be created without a DTTP ID.

### Guidance to review

