### PR TITLE
Fix focus styles appearing on container

### DIFF
--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -1,3 +1,4 @@
+
 <div class='moj-filter-layout'>
   <div class="moj-filter-layout__filter app-filter">
     <div class="moj-filter">
@@ -5,6 +6,7 @@
         <div class="moj-filter__header-title">
           <h2 class="govuk-heading-m">Filters</h2>
         </div>
+
         <div class="moj-filter__header-action">
         </div>
       </div>
@@ -37,7 +39,8 @@
         </div>
       <% end %>
 
-        <div class="moj-filter__options">
+        <!-- Div made focusable to 'catch' focus from filters. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640 -->
+        <div class="moj-filter__options" tabindex="-1">
 
           <form method="get">
             <%= submit_tag "Apply filters", class: "govuk-button" %>


### PR DESCRIPTION
This fix mirrors a [similar fix I did on Manage](https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640), where the filter container would visually get focus when checkboxes where selected.

## How to test

Using the filters (typing in input, selecting and unselecting the checkboxes) should not cause visual focus to be shown on the container of the filters.

Filters should work normally on mobile when acting as a pop-over.