### PR TITLE
[1041] Remove status tag from heading

### DIFF
--- a/app/components/status_tag/view.html.erb
+++ b/app/components/status_tag/view.html.erb
@@ -1,1 +1,1 @@
-<%= render GovukComponent::Tag.new(text: status, colour: status_colour, classes: classes) %>
+<%= render GovukComponent::Tag.new(text: "<span class='govuk-visually-hidden'>Trainee status </span>".html_safe + status, colour: status_colour, classes: classes) %>

--- a/app/components/trainees/record_header/view.html.erb
+++ b/app/components/trainees/record_header/view.html.erb
@@ -1,14 +1,15 @@
 <div class="trainee-record-header">
-  <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
-    <%= trainee_name(trainee)%>
+  <div class="trainee-record-header-name-trn">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
+      <%= trainee_name(trainee)%>
+    </h1>
 
-    <%= render StatusTag::View.new(trainee: trainee) %>
+    <% if show_trn? %>
+      <span class="govuk-caption-l">
+        <%= "TRN: #{trn}" %>
+      </span>
+    <% end %>
+  </div>
 
-  </h1>
-
-  <% if show_trn? %>
-    <span class="govuk-caption-l">
-      <%= "TRN: #{trn}" %>
-    </span>
-  <% end %>
+  <%= render StatusTag::View.new(trainee: trainee) %>
 </div>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -33,10 +33,18 @@ a[href="#"] {
 }
 
 .trainee-record-header .govuk-tag {
+  left: 5px;
+  position: relative;
+  top: 6px;
+
   @include govuk-media-query($from: tablet) {
-    position: relative;
-    top: -5px;
+    top: 16px;
   }
+}
+
+.trainee-record-header-name-trn {
+  display: inline-block;
+  vertical-align: top;
 }
 
 .govuk-button--link {

--- a/spec/features/trainees/edit_trainee_record_spec.rb
+++ b/spec/features/trainees/edit_trainee_record_spec.rb
@@ -46,7 +46,7 @@ feature "edit trainee record", type: :feature do
 
   def then_i_see_the_trn_status
     state_text = "activerecord.attributes.trainee.states.#{trainee.state}"
-    expect(record_page.trn_status.text).to eq(I18n.t(state_text).downcase)
+    expect(record_page.trn_status.text).to eq("Trainee status " + I18n.t(state_text).downcase)
   end
 
   def when_i_visit_the_trainee_record_page


### PR DESCRIPTION
### Context
The trainee status shouldn't be nested within the H!

### Changes proposed in this pull request
Move trainee status out of H1

### Guidance to review
### After
<img width="1559" alt="Screenshot 2021-02-15 at 12 48 22" src="https://user-images.githubusercontent.com/3071606/107948698-1dbd9380-6f8c-11eb-8be6-f9e1e015990d.png">

