### PR TITLE
[1046] Disable HTML5 validations on all forms

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,6 +23,12 @@ module ApplicationHelper
     link_to(body, url, html_options)
   end
 
+  def form_with(*args, &block)
+    options = args.extract_options!
+    defaults = { html: { novalidate: true } }
+    super(*args << defaults.deep_merge(options), &block)
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_for(@contact_details, url: trainee_contact_details_path(@trainee), method: :put, local: true) do |f| %>
+    <%= form_with(model: @contact_details, url: trainee_contact_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset(:locale_code, legend: { text: "Where does the trainee live?", size: "s" }, classes: "locale") do %>

--- a/app/views/trainees/deferrals/show.html.erb
+++ b/app/views/trainees/deferrals/show.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_for(@deferral, url: trainee_deferral_path(@trainee), local: true) do |f| %>
+    <%= form_with(model: @deferral, url: trainee_deferral_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">

--- a/app/views/trainees/outcome_dates/edit.html.erb
+++ b/app/views/trainees/outcome_dates/edit.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_for(@outcome, url: trainee_outcome_details_outcome_date_path(@trainee), local: true) do |f| %>
+    <%= form_with(model: @outcome, url: trainee_outcome_details_outcome_date_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">
@@ -30,4 +30,3 @@
 </div>
 
 <p class="govuk-body"><%= govuk_link_to("Cancel and return to record", trainee_path(@trainee)) %></p>
-

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_for(@personal_detail, url: trainee_personal_details_path(@trainee), method: :put, local: true) do |f| %>
+    <%= form_with(model: @personal_detail, url: trainee_personal_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">Trainee personal details</h1>

--- a/app/views/trainees/programme_details/edit.html.erb
+++ b/app/views/trainees/programme_details/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_for(@programme_detail, url: trainee_programme_details_path(@trainee), method: :put, local: true) do |f| %>
+    <%= form_with(model: @programme_detail, url: trainee_programme_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">Programme details</h1>

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_for(@withdrawal_form, url: trainee_withdrawal_path(@trainee), local: true) do |f| %>
+    <%= form_with(model: @withdrawal_form, url: trainee_withdrawal_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">


### PR DESCRIPTION
### Context
- Clientside validation on forms

> Code borrowed from [schools experience](https://github.com/DFE-Digital/schools-experience/blob/master/app/helpers/form_for_helper.rb)

### Changes proposed in this pull request
- Disable HTML5 validation on all forms
- Replace `form_for` with `form_with`

### Guidance to review
No visual changes to see
