### PR TITLE
[SPIKE] Persist record when the commit page is submitted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ gem "stateful_enum"
 
 # Pagination
 gem "kaminari"
+gem "kredis"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,9 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
+    kredis (0.2.3)
+      rails (>= 6.0.0)
+      redis (~> 4.2)
     launchy (2.5.0)
       addressable (~> 2.7)
     listen (3.4.1)
@@ -484,6 +487,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   httparty (~> 0.18)
   kaminari
+  kredis
   launchy
   listen (>= 3.0.5, < 3.5)
   omniauth

--- a/app/components/trainees/confirmation/personal_details/view.html.erb
+++ b/app/components/trainees/confirmation/personal_details/view.html.erb
@@ -1,29 +1,29 @@
-<%= render SummaryCard::View.new(trainee: trainee, title: 'Personal details',
+<%= render SummaryCard::View.new(trainee: form_model.trainee, title: 'Personal details',
     heading_level: 2,
     rows: [
       {
         key: "Full name",
         value: full_name,
         action: govuk_link_to('Change<span class="govuk-visually-hidden"> full name</span>'.html_safe,
-                              edit_trainee_personal_details_path(trainee))
+                              edit_trainee_personal_details_path(form_model.trainee))
       },
       {
         key: "Date of birth",
         value: date_of_birth,
         action: govuk_link_to('Change<span class="govuk-visually-hidden"> date of birth</span>'.html_safe,
-                              edit_trainee_personal_details_path(trainee))
+                              edit_trainee_personal_details_path(form_model.trainee))
       },
       {
         key: "Gender",
         value: gender,
         action: govuk_link_to('Change<span class="govuk-visually-hidden"> gender</span>'.html_safe,
-                              edit_trainee_personal_details_path(trainee))
+                              edit_trainee_personal_details_path(form_model.trainee))
       },
       {
         key: "Nationality",
         value: nationality,
         action: govuk_link_to('Change<span class="govuk-visually-hidden"> nationality</span>'.html_safe,
-                              edit_trainee_personal_details_path(trainee))
+                              edit_trainee_personal_details_path(form_model.trainee))
       },
     ]
   )

--- a/app/components/trainees/confirmation/personal_details/view.rb
+++ b/app/components/trainees/confirmation/personal_details/view.rb
@@ -6,44 +6,53 @@ module Trainees
       class View < GovukComponent::Base
         include SanitizeHelper
 
-        attr_accessor :trainee
+        attr_accessor :form_model
 
-        def initialize(trainee:)
-          @trainee = trainee
+        def initialize(form_model:)
+          @form_model = form_model
+          @nationalities = fetch_nationalities
           @not_provided_copy = I18n.t("components.confirmation.not_provided")
         end
 
         def full_name
-          return @not_provided_copy unless trainee.first_names && trainee.last_name
+          return @not_provided_copy unless form_model.first_names && form_model.last_name
 
-          "#{trainee.first_names} #{trainee.middle_names} #{trainee.last_name}"
+          "#{form_model.first_names} #{form_model.middle_names} #{form_model.last_name}"
         end
 
         def date_of_birth
-          return @not_provided_copy unless trainee.date_of_birth
+          return @not_provided_copy unless form_model.date_of_birth
 
-          trainee.date_of_birth.strftime("%-d %B %Y")
+          form_model.date_of_birth.strftime("%-d %B %Y")
         end
 
         def gender
-          return @not_provided_copy unless trainee.gender
+          return @not_provided_copy unless form_model.gender
 
-          I18n.t("components.confirmation.personal_detail.gender.#{trainee.gender}")
+          I18n.t("components.confirmation.personal_detail.gender.#{form_model.gender}")
         end
 
         def nationality
-          return @not_provided_copy if trainee.nationalities.blank?
+          return @not_provided_copy if nationalities.blank?
 
-          if trainee.nationalities.size == 1
-            trainee.nationalities.first.name.titleize
+          if nationalities.size == 1
+            nationalities.first.name.titleize
           else
-            nationalities = trainee.nationalities.map { |nationality| nationality.name.titleize }
+            nationality_names = nationalities.map { |nationality| nationality.name.titleize }
             sanitize(tag.ul(class: "govuk-list") do
-              nationalities.each do |nationality|
-                concat tag.li(nationality)
+              nationality_names.each do |nationality_name|
+                concat tag.li(nationality_name)
               end
             end)
           end
+        end
+
+      private
+
+        attr_reader :nationalities
+
+        def fetch_nationalities
+          Nationality.where(id: form_model.nationality_ids)
         end
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,4 +58,8 @@ private
       PageTracker.new(trainee_slug: trainee_slug, session: session, request: request)
     end
   end
+
+  def clear_form_stash
+    FormStore.clear_all
+  end
 end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -13,7 +13,9 @@ module Trainees
         @confirm_detail = ConfirmDetailForm.new(mark_as_completed: trainee.progress.public_send(trainee_section_key))
       end
 
-      @confirmation_component = component_klass(trainee_section_key).new(trainee: trainee)
+      @confirmation_component = component_klass(trainee_section_key).new(
+        form_model: PersonalDetailForm.new(trainee),
+      )
     end
 
     def update
@@ -21,8 +23,10 @@ module Trainees
 
       if trainee.draft?
         toggle_trainee_progress_field
-        trainee.save!
       end
+
+      personal_detail = PersonalDetailForm.new(trainee)
+      personal_detail.save!
 
       flash[:success] = "Trainee #{flash_message_title} updated"
 

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -3,6 +3,7 @@
 module Trainees
   class PersonalDetailsController < ApplicationController
     before_action :ensure_trainee_is_not_draft!, only: :show
+    before_action :clear_form_stash, only: :show
 
     DOB_CONVERSION = {
       "date_of_birth(3i)" => "day",
@@ -31,7 +32,7 @@ module Trainees
       other_nationalities
       personal_detail = PersonalDetailForm.new(trainee, personal_details_params)
 
-      if personal_detail.save
+      if personal_detail.save_to_store
         redirect_to trainee_personal_details_confirm_path(personal_detail.trainee)
       else
         @personal_detail = personal_detail

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -2,6 +2,7 @@
 
 class TraineesController < ApplicationController
   before_action :ensure_trainee_is_not_draft!, only: :show
+  before_action :clear_form_stash, only: :show
   helper_method :filter_params
 
   def index

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class FormStore
+  class InvalidKeyError < StandardError; end
+
+  FORM_SECTION_KEYS = [
+    :personal_details,
+  ].freeze
+
+  class << self
+    def get(key)
+      Kredis.json(key).value
+    end
+
+    def set(key, values)
+      raise InvalidKeyError unless FORM_SECTION_KEYS.include?(key)
+
+      slice = Kredis.json(key)
+      slice.value = values
+      true
+    end
+
+    def clear_all
+      FORM_SECTION_KEYS.each do |key|
+        set(key, nil)
+      end
+    end
+  end
+end

--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -14,3 +14,5 @@
     resource_confirm_update_path: trainee_section_update_path(trainee_section_key, @trainee),
   }
 ) %>
+
+<p class="govuk-body"><%= govuk_link_to("Cancel and return to record", view_trainee(@trainee)) %></p>

--- a/app/views/trainees/personal_details/show.html.erb
+++ b/app/views/trainees/personal_details/show.html.erb
@@ -1,5 +1,7 @@
 <div class="personal-details">
-  <%= render Trainees::Confirmation::PersonalDetails::View.new(trainee: @trainee) %>
+  <%= render Trainees::Confirmation::PersonalDetails::View.new(
+    form_model: PersonalDetailForm.new(@trainee)
+    ) %>
 </div>
 
 <div class="contact-details">

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,1 @@
+Redis.current = Redis.new(url: ENV["REDIS_URL"])

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,1 +1,0 @@
-Redis.current = Redis.new(url: ENV["REDIS_URL"])

--- a/config/redis/shared.yml
+++ b/config/redis/shared.yml
@@ -1,0 +1,12 @@
+production: &production
+  host: <%= ENV.fetch("REDIS_SHARED_HOST", "127.0.0.1") %>
+  port: <%= ENV.fetch("REDIS_SHARED_PORT", "6379") %>
+  timeout: 1
+
+development: &development
+  host: <%= ENV.fetch("REDIS_SHARED_HOST", "127.0.0.1") %>
+  port: <%= ENV.fetch("REDIS_SHARED_PORT", "6379") %>
+  timeout: 1
+
+test:
+  <<: *development


### PR DESCRIPTION
### Context

- https://trello.com/c/VI0mtlSP/1019-3-days-persist-record-when-the-commit-page-is-submitted

### Changes proposed in this pull request

Demo:

![spike-2](https://user-images.githubusercontent.com/616080/108089795-e5908080-7071-11eb-9a03-d4bb001655ac.gif)

## Notes

This PR demonstrates a proof of concept for enabling an "undo" functionality allowing providers to undo their form changes if they decide to cancel.

Two approaches were considered:

- Stashing form changes into Redis
- Using the audit gem to try and "rollback" changes

TLDR, the second approach was not feasible and became difficult to workout how to exactly rollback and to what revision. The audit keeps a full history of any change to a model so the table would grow quite quickly with trying to keep track of these form edits.

Using Redis seemed a lot more flexible and lighter. These changes are potentially "throw-away" until they are saved so using Redis as a lightweight store seemed appropriate.

To use Redis, the PR sets up a new gem authored under Rails directly called [Kredis](https://github.com/rails/kredis). Kredis (Keyed Redis) encapsulates higher-level types and data structures around a single key, so you can interact with them as coherent objects rather than isolated procedural commands. These higher-level structures can be configured as attributes within Active Models and Active Records using a declarative DSL.

### What needs to change

The high level approach behind this proof of concept would involve changing our form objects such that they receive an object, currently called a `FormStore` which is able to stash changes into Redis using the `Kredis` wrapper. 

The form objects would then be responsible for hydrating values from either a given set of attributes or from the Redis store (if it has values).

Each form object would be able to stash changes into a slice of the store, keyed by a name. It would then be able to retrieve those values using the same key, allowing it to re-hydrate itself.

Currently, all of our form objects implement a `field` method which returns relevant attributes/values for that form so we would simply store the value of this method into the `FormStore` which would serialize the values as json into Redis.

As you can see from the demo, this allows us to implement a flexible undo method which we could build upon.

### Caveats

#### Refactoring

This proof of concept also revealed some areas of the code we may need to change. Our form objects and many components are coupled to a data model as they require it to be given (ie `Trainee` in most cases). We would need to refactor the form objects and components so they're a bit more agnostic with what they're given to do their jobs, particularly being able to display stashed changes to the user as if they were saved.

I also implemented this proof of concept focusing on just one form section for simplicity (Personal Details). We would need to refactor the `ConfirmDetails` controller to make it dynamic for other form sections. Given that we already do this for components, this shouldn't be too difficult.

#### Dependency

While officially supported by Rails, the Kredis gem is still relatively new. We could also just use [redis gem](https://github.com/redis/redis-rb) itself to do the above.

#### UX issues

Question for @edwardhorsford, what happens if a user leaves the page when they're on the confirm page. If there are stashed changes, should we clear them or? Currently, this demo clears any stashed changes in the store when they return to the record page to create a clean slate.
