### PR TITLE
Improve trainee list header and title

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -7,6 +7,8 @@ class TraineesController < ApplicationController
   def index
     return redirect_to trainees_path(filter_params) if current_page_exceeds_total_pages?
 
+    @total_trainees_count = filtered_trainees.count
+
     # We can't use `#draft` to find @draft_trainees since that applies a `WHERE`
     # clause, removing Kaminari's pagination. Hence the use of `#select`.
     #

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -18,12 +18,18 @@ module TraineeHelper
 
   def trainees_page_title(trainees)
     total_pages = trainees.total_pages
-    return "trainees.index" if total_pages <= 1
+    trainees_count_text = (@paginated_trainees.count).to_s + " record".pluralize(@paginated_trainees.count)
+
+    if total_pages <= 1
+      return I18n.t("components.page_titles.trainees.index",
+                    trainees_count_text: trainees_count_text)
+    end
 
     I18n.t(
       "components.page_titles.trainees.paginated_index",
       current_page: trainees.current_page,
       total_pages: total_pages,
+      trainees_count_text: trainees_count_text
     )
   end
 end

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -16,20 +16,20 @@ module TraineeHelper
     end
   end
 
-  def trainees_page_title(trainees)
+  def trainees_page_title(trainees, total_trainees_count)
     total_pages = trainees.total_pages
-    trainees_count_text = @filtered_trainees.count.to_s + " record".pluralize(@filtered_trainees.count)
+    total_trainees_count_text = total_trainees_count.to_s + " record".pluralize(@filtered_trainees.count)
 
     if total_pages <= 1
       return I18n.t("components.page_titles.trainees.index",
-                    trainees_count_text: trainees_count_text)
+                    total_trainees_count_text: total_trainees_count_text)
     end
 
     I18n.t(
       "components.page_titles.trainees.paginated_index",
       current_page: trainees.current_page,
       total_pages: total_pages,
-      trainees_count_text: trainees_count_text,
+      total_trainees_count_text: total_trainees_count_text,
     )
   end
 end

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -18,7 +18,7 @@ module TraineeHelper
 
   def trainees_page_title(trainees)
     total_pages = trainees.total_pages
-    trainees_count_text = (@filtered_trainees.count).to_s + " record".pluralize(@filtered_trainees.count)
+    trainees_count_text = @filtered_trainees.count.to_s + " record".pluralize(@filtered_trainees.count)
 
     if total_pages <= 1
       return I18n.t("components.page_titles.trainees.index",
@@ -29,7 +29,7 @@ module TraineeHelper
       "components.page_titles.trainees.paginated_index",
       current_page: trainees.current_page,
       total_pages: total_pages,
-      trainees_count_text: trainees_count_text
+      trainees_count_text: trainees_count_text,
     )
   end
 end

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -21,8 +21,10 @@ module TraineeHelper
     total_trainees_count_text = total_trainees_count.to_s + " record".pluralize(total_trainees_count)
 
     if total_pages <= 1
-      return I18n.t("components.page_titles.trainees.index",
-                    total_trainees_count_text: total_trainees_count_text)
+      return I18n.t(
+        "components.page_titles.trainees.index",
+        total_trainees_count_text: total_trainees_count_text,
+      )
     end
 
     I18n.t(

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -18,7 +18,7 @@ module TraineeHelper
 
   def trainees_page_title(trainees, total_trainees_count)
     total_pages = trainees.total_pages
-    total_trainees_count_text = total_trainees_count.to_s + " record".pluralize(@filtered_trainees.count)
+    total_trainees_count_text = total_trainees_count.to_s + " record".pluralize(total_trainees_count)
 
     if total_pages <= 1
       return I18n.t("components.page_titles.trainees.index",

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -18,7 +18,7 @@ module TraineeHelper
 
   def trainees_page_title(trainees)
     total_pages = trainees.total_pages
-    trainees_count_text = (@paginated_trainees.count).to_s + " record".pluralize(@paginated_trainees.count)
+    trainees_count_text = (@filtered_trainees.count).to_s + " record".pluralize(@filtered_trainees.count)
 
     if total_pages <= 1
       return I18n.t("components.page_titles.trainees.index",

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -18,7 +18,7 @@ module TraineeHelper
 
   def trainees_page_title(trainees, total_trainees_count)
     total_pages = trainees.total_pages
-    total_trainees_count_text = total_trainees_count.to_s + " record".pluralize(total_trainees_count)
+    total_trainees_count_text = pluralize(total_trainees_count, "record")
 
     if total_pages <= 1
       return I18n.t(

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -1,9 +1,9 @@
-<%= render PageTitle::View.new(title: trainees_page_title(@paginated_trainees)) %>
+<%= render PageTitle::View.new(title: trainees_page_title(@paginated_trainees, @total_trainees_count)) %>
 
 <% if @paginated_trainees.current_page > 1 %>
   <span class="govuk-caption-xl">Page <%= @paginated_trainees.current_page %> of <%= @paginated_trainees.total_pages %></span>
 <% end %>
-<h1 class="govuk-heading-xl">Trainee records (<%= @filtered_trainees.count %><span class="govuk-visually-hidden"> <%= "record".pluralize(@filtered_trainees.count) %></span>)</h1>
+<h1 class="govuk-heading-xl">Trainee records (<%= @total_trainees_count %><span class="govuk-visually-hidden"> <%= "record".pluralize(@total_trainees_count) %></span>)</h1>
 
 <% unless current_user.system_admin? %>
   <p class="govuk-body">

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -1,6 +1,6 @@
 <%= render PageTitle::View.new(title: trainees_page_title(@paginated_trainees)) %>
 
-<h1 class="govuk-heading-xl">Trainee records</h1>
+<h1 class="govuk-heading-l">Trainee records (<%= @paginated_trainees.count %><span class="govuk-visually-hidden"> <%= "record".pluralize(@paginated_trainees.count) %></span>)</h1>
 
 <% unless current_user.system_admin? %>
   <p class="govuk-body">

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -1,6 +1,9 @@
 <%= render PageTitle::View.new(title: trainees_page_title(@paginated_trainees)) %>
 
-<h1 class="govuk-heading-l">Trainee records (<%= @paginated_trainees.count %><span class="govuk-visually-hidden"> <%= "record".pluralize(@paginated_trainees.count) %></span>)</h1>
+<% if @paginated_trainees.current_page > 1 %>
+  <span class="govuk-caption-xl">Page <%= @paginated_trainees.current_page %> of <%= @paginated_trainees.total_pages %></span>
+<% end %>
+<h1 class="govuk-heading-xl">Trainee records (<%= @filtered_trainees.count %><span class="govuk-visually-hidden"> <%= "record".pluralize(@filtered_trainees.count) %></span>)</h1>
 
 <% unless current_user.system_admin? %>
   <p class="govuk-body">
@@ -22,7 +25,7 @@
       <div class="govuk-!-margin-bottom-8 app-draft-records">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-half">
-            <h2 class="govuk-heading-m">Draft records (<%= @draft_trainees_count %><span class="govuk-visually-hidden"> draft <%= "record".pluralize(@draft_trainees_count) %></span>)</h2>
+            <h2 class="govuk-heading-m">Draft records</h2>
           </div>
         </div>
         <%= render ApplicationRecordCard::View.with_collection(@draft_trainees) %>
@@ -33,7 +36,7 @@
       <div class="govuk-!-margin-bottom-8 app-non-draft-records">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-half">
-            <h2 class="govuk-heading-m">Records (<%= @completed_trainees_count %><span class="govuk-visually-hidden"> <%= "record".pluralize(@completed_trainees_count) %></span>)</h2>
+            <h2 class="govuk-heading-m">Records</h2>
           </div>
         </div>
         <%= render ApplicationRecordCard::View.with_collection(@completed_trainees) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,8 +80,8 @@ en:
         show: Review trainee record
       trainees:
         new: Add a trainee
-        index: Trainee records
-        paginated_index: Trainee records (page %{current_page} of %{total_pages})
+        index: Trainee records (%{trainees_count_text})
+        paginated_index: Trainee records (%{trainees_count_text}) - page %{current_page} of %{total_pages}
         not_supported_route: Other routes not supported
         show: Trainee record overview
         diversity:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,8 +80,8 @@ en:
         show: Review trainee record
       trainees:
         new: Add a trainee
-        index: Trainee records (%{trainees_count_text})
-        paginated_index: Trainee records (%{trainees_count_text}) - page %{current_page} of %{total_pages}
+        index: Trainee records (%{total_trainees_count_text})
+        paginated_index: Trainee records (%{total_trainees_count_text}) - page %{current_page} of %{total_pages}
         not_supported_route: Other routes not supported
         show: Trainee record overview
         diversity:

--- a/spec/helpers/trainee_helper_spec.rb
+++ b/spec/helpers/trainee_helper_spec.rb
@@ -45,4 +45,46 @@ describe TraineeHelper do
       end
     end
   end
+
+  describe "#trainees_page_title" do
+    let(:page_size) { 25 }
+    # Using an `object_double` here to stub ActiveRecord::Relation passed into
+    # the component. We cannot use `instance_double(ActiveRecord::Relation...)`
+    # as it lacks the extra methods that Kaminari mixes in (e.g. `total_count`).
+    let(:trainees) do
+      object_double(
+        Trainee.all.page(1),
+        total_count: total_count,
+        limit_value: page_size,
+        current_page: 1,
+        total_pages: (total_count.to_f / page_size).ceil,
+      )
+    end
+
+    subject { trainees_page_title(trainees, total_count) }
+
+    context "when there is one page of trainees" do
+      let(:total_count) { page_size }
+
+      it "returns the title containing the total count" do
+        expect(subject).to eq "Trainee records (25 records)"
+      end
+    end
+
+    context "when there is more than one page of trainees" do
+      let(:total_count) { page_size + 1 }
+
+      it "returns the title containing the total count and which page you're on" do
+        expect(subject).to eq "Trainee records (26 records) - page 1 of 2"
+      end
+    end
+
+    context "when there are no trainees" do
+      let(:total_count) { 0 }
+
+      it "returns the title containing the 0 count" do
+        expect(subject).to eq "Trainee records (0 records)"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Changes:

* Include count of records in title and h1
* Show page number as caption if we have pagination and if we're on page 2 or greater
* Removed counts from sub sections draft and records

This makes it easier to see how many records are returned - which is more important for AT where you might need to advance past quite a bit of the page to get to the records.

The markup likely needs work - so please tell me what to fix!

I suspect the caption will want some tests - so perhaps a developer can help add these.

### After:
* Title without pagination: `Trainee records (15 records) - Register trainee teachers - GOV.UK`
* Title with pagination: `Trainee records (30 records) - page 1 of 3 - Register trainee teachers - GOV.UK`

<img width="804" alt="Screenshot 2021-02-17 at 12 54 08" src="https://user-images.githubusercontent.com/2204224/108207129-3dd18c00-711f-11eb-8813-74dbb2f98631.png">

When on page 2 or greater:
<img width="981" alt="Screenshot 2021-02-17 at 13 21 36" src="https://user-images.githubusercontent.com/2204224/108210165-1b417200-7123-11eb-9603-fe4884b4df93.png">


### Before:
* Title without pagination: `Trainee records - Register trainee teachers - GOV.UK`
* Title with pagination: `Trainee records (page 1 of 4) - Register trainee teachers - GOV.UK`

<img width="925" alt="Screenshot 2021-02-17 at 12 55 51" src="https://user-images.githubusercontent.com/2204224/108207300-796c5600-711f-11eb-9ec9-cc4365e75920.png">
