### PR TITLE
[SPIKE / Audit Version] - Persist record when the commit page is submitted

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,4 +58,26 @@ private
       PageTracker.new(trainee_slug: trainee_slug, session: session, request: request)
     end
   end
+
+  def session_form_stash_key
+    "#{trainee.slug}_form_changes"
+  end
+
+  def stash_form_changes
+    session[session_form_stash_key] = { action: trainee.own_and_associated_audits.first.action, changes: trainee.own_and_associated_audits.first.audited_changes }
+  end
+
+  def clear_stash
+    session[session_form_stash_key] = nil
+  end
+
+  def cancel_form_changes
+    return if params[:cancel].blank? || session[session_form_stash_key].blank?
+
+    stash = trainee.own_and_associated_audits.where(action: session[session_form_stash_key]["action"], audited_changes: session[session_form_stash_key]["changes"])
+    return if stash.empty?
+
+    stash.first.undo
+    clear_stash
+  end
 end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -6,6 +6,7 @@ module Trainees
     helper_method :confirm_section_title
 
     def show
+      stash_form_changes
       authorize trainee
       page_tracker.save_as_origin!
 

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -3,6 +3,7 @@
 module Trainees
   class PersonalDetailsController < ApplicationController
     before_action :ensure_trainee_is_not_draft!, only: :show
+    before_action :cancel_form_changes, only: :show
 
     DOB_CONVERSION = {
       "date_of_birth(3i)" => "day",

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -2,6 +2,7 @@
 
 class TraineesController < ApplicationController
   before_action :ensure_trainee_is_not_draft!, only: :show
+  before_action :cancel_form_changes, only: :show
   helper_method :filter_params
 
   def index

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -8,11 +8,11 @@ module TraineeHelper
       .join(" ")
   end
 
-  def view_trainee(trainee)
+  def view_trainee(trainee, cancel_changes: false)
     if trainee.draft?
       review_draft_trainee_path(trainee)
     else
-      trainee_path(trainee)
+      trainee_path(trainee, cancel: cancel_changes)
     end
   end
 

--- a/app/models/nationalisation.rb
+++ b/app/models/nationalisation.rb
@@ -3,7 +3,7 @@
 class Nationalisation < ApplicationRecord
   belongs_to :nationality
   belongs_to :trainee
-  
+
   audited associated_with: :trainee
   has_associated_audits
 end

--- a/app/models/nationalisation.rb
+++ b/app/models/nationalisation.rb
@@ -3,4 +3,7 @@
 class Nationalisation < ApplicationRecord
   belongs_to :nationality
   belongs_to :trainee
+  
+  audited associated_with: :trainee
+  has_associated_audits
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -26,6 +26,7 @@ class Trainee < ApplicationRecord
   }
 
   audited associated_with: :provider
+  has_associated_audits
 
   enum diversity_disclosure: {
     Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed] => 0,

--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -14,3 +14,5 @@
     resource_confirm_update_path: trainee_section_update_path(trainee_section_key, @trainee),
   }
 ) %>
+
+<p class="govuk-body"><%= govuk_link_to("Cancel and return to record", view_trainee(@trainee, cancel_changes: true)) %></p>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -49,4 +49,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Cancel", view_trainee(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to("Cancel", view_trainee(@trainee, cancel_changes: true)) %></p>


### PR DESCRIPTION
### Context

https://trello.com/c/VI0mtlSP/1019-3-days-persist-record-when-the-commit-page-is-submitted

### Changes proposed in this pull request

Same proof of concept done here https://github.com/DFE-Digital/register-trainee-teachers/pull/534 (with some caveats).

## Notes

This PR demonstrates a proof of concept for enabling an "undo" functionality allowing providers to undo their form changes if they decide to cancel.

Two approaches were considered:

- Stashing form changes into Redis - https://github.com/DFE-Digital/register-trainee-teachers/pull/534
- Using the audit gem to try and "rollback" changes (this PR)

### Review

- Head to a trainee's personal details page. They should have a state which allows their information to still be changed.
- Attempt to change anything, confirm the new changes are shown on the confirm page. Click cancel and assert your original changes are shown on the record page
- Do the above but commit the changes and assert the changes are now saved

### What needs to change

Compared to the Redis approach in the PR above, we don't need to change as much but there are more UX cases to deal with using the audited gem.

Since we track any change to a model, we have to keep track of what the last set of audited changes where when a trainee is edited via one of the forms (along with the action).

If the trainee edits are cancelled then we need to search through the trainee's audits and find the last stashed changes in order to "undo" them, a functionality provided by the audit gem. This effectively "rolls back" the object to its previous revision.

### Caveats

#### Where to stash the changes?

As we need to keep track of the last set of audited changes, we need to put these somewhere. At the moment, they're stored in the session. This quickly blows up with a cookie size limit since some audited changes (particularly the first initial record) would track all the properties of the model. We would need to move sessions to the db to combat this.

#### Associated data

There's a situation where if you try to add an associated data (like a nationality), and undo it - it works fine the first time around and also saves fine if you commit the changes.

If you remove that nationality (after saving it) but then try to undo the deletion, it won't work. This could be because the audits aren't configured properly but it seems that at this point there's no audit of the deletion of that record in the audit trail so we can't undo it. 


