### PR TITLE
[1047] Remove '?' from URL if all filters are removed

### DIFF
--- a/app/components/trainees/filters/view.rb
+++ b/app/components/trainees/filters/view.rb
@@ -11,10 +11,12 @@ module Trainees
         @filter_actions = filter_actions
       end
 
-    private
-
       def label_for(attribute, value)
         I18n.t("activerecord.attributes.trainee.#{attribute.pluralize}.#{value}")
+      end
+
+      def filter_label_for(filter)
+        I18n.t("components.filter.#{filter}")
       end
 
       def title_html(filter, value)
@@ -39,19 +41,17 @@ module Trainees
         end
       end
 
+    private
+
       def remove_checkbox_tag_link(filter, value)
         new_filters = filters.deep_dup
         new_filters[filter].reject! { |v| v == value }
-        "?" + new_filters.to_query
+        new_filters.to_query.blank? ? nil : "?" + new_filters.to_query
       end
 
       def remove_select_tag_link(filter)
         new_filters = filters.reject { |f| f == filter }
-        "?" + new_filters.to_query
-      end
-
-      def filter_label_for(filter)
-        I18n.t("components.filter.#{filter}")
+        new_filters.to_query.blank? ? nil : "?" + new_filters.to_query
       end
     end
   end

--- a/spec/components/trainees/filters/view_spec.rb
+++ b/spec/components/trainees/filters/view_spec.rb
@@ -3,8 +3,19 @@
 require "rails_helper"
 
 RSpec.describe Trainees::Filters::View do
+  let(:trainees_path) { "/trainees" }
   let(:selected_text) { "Selected filters" }
-  let(:result) { render_inline described_class.new(filters: filters) }
+  let(:result) { render_inline(described_class.new(filters: filters)) }
+
+  before do
+    # When link_to() is called with a nil path, it normally renders a href using the current URL path without
+    # the query params. However, link_to() blows up in this spec unless we mock the route so it behaves as if
+    # it's a real app rendering the template.
+    allow_any_instance_of(ActionDispatch::Journey::Route).to receive(:dispatcher?).and_return(true)
+
+    # Override the route /sidekiq, which seems to show up as the default route
+    allow_any_instance_of(ActionDispatch::Journey::Formatter::RouteWithParams).to receive(:path).and_return(trainees_path)
+  end
 
   context "when no filters are applied" do
     let(:filters) { nil }
@@ -41,6 +52,22 @@ RSpec.describe Trainees::Filters::View do
 
     it "shows a 'Selected filters' dialogue" do
       expect(result.text).to include(selected_text)
+    end
+  end
+
+  context "a single checkbox filter" do
+    let(:filters) { { state: %w[draft] }.with_indifferent_access }
+
+    it "has no query params in URL" do
+      expect(result.css("a.moj-filter__tag").attr("href").value).to eq(trainees_path)
+    end
+  end
+
+  context "a subject filter" do
+    let(:filters) { { subject: "English" }.with_indifferent_access }
+
+    it "has no query params in URL" do
+      expect(result.css("a.moj-filter__tag").attr("href").value).to eq(trainees_path)
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/zq26DBRe/1047-when-all-filters-are-removed-the-final-url-ends-in-can-this-be-removed

### Changes proposed in this pull request
- Gets rid of the `?` from the URL when all filters have been removed

### Guidance to review
- Visit the trainees index page and apply some filters then remove them.
