### PR TITLE
[1020] missing details component

### DIFF
--- a/app/components/incomplete_section/script.js
+++ b/app/components/incomplete_section/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/incomplete_section/style.scss
+++ b/app/components/incomplete_section/style.scss
@@ -1,0 +1,26 @@
+@import "../base.scss";
+
+.app-inset-text--narrow-border {
+  border-left-width: $govuk-border-width-narrow;
+}
+
+.app-inset-text--important {
+  border-color: govuk-colour("blue");
+
+  .app-inset-text__title {
+    color: govuk-colour("blue");
+  }
+}
+
+.app-inset-text--error {
+  border-color: $govuk-error-colour;
+
+  .app-inset-text__title {
+    color: $govuk-error-colour;
+  }
+}
+
+.app-inset-text__title {
+  @include govuk-font($size: 19, $weight: "bold");
+  margin-bottom: govuk-spacing(2);
+}

--- a/app/components/incomplete_section/view.html.erb
+++ b/app/components/incomplete_section/view.html.erb
@@ -1,0 +1,4 @@
+<div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--<%= @error ? 'error' : 'important' %>">
+  <p class="app-inset-text__title"><%= title %></p>
+  <%= govuk_link_to link_text, url %>
+</div>

--- a/app/components/incomplete_section/view.rb
+++ b/app/components/incomplete_section/view.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class IncompleteSection::View < ViewComponent::Base
+  attr_accessor :title, :url, :link_text, :error
+
+  def initialize(title:, link_text:, url:, error: false)
+    @url = url
+    @link_text = link_text
+    @title = title
+    @error = error
+  end
+end

--- a/app/components/trainees/sections/view.html.erb
+++ b/app/components/trainees/sections/view.html.erb
@@ -1,0 +1,1 @@
+<%= render component %>

--- a/app/components/trainees/sections/view.rb
+++ b/app/components/trainees/sections/view.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Sections
+    class View < ViewComponent::Base
+      attr_accessor :trainee, :section, :trn_submission
+
+      def initialize(trainee:, section:, trn_submission:)
+        @trainee = trainee
+        @section = section
+        @trn_submission = trn_submission
+      end
+
+      def component
+        if status == :completed
+          confirmation_view_args = { trainee: trainee }
+
+          confirmation_view_args.merge!({ show_add_another_degree_button: false, show_delete_button: true }) if section == :degrees
+          confirmation_view.new(**confirmation_view_args)
+        else
+          IncompleteSection::View.new(title: title, link_text: link_text, url: url, error: error)
+        end
+      end
+
+    private
+
+      def confirmation_view
+        {
+          personal_details: Trainees::Confirmation::PersonalDetails::View,
+          contact_details: Trainees::Confirmation::ContactDetails::View,
+          diversity: Trainees::Confirmation::Diversity::View,
+          degrees: Trainees::Confirmation::Degrees::View,
+          programme_details: Trainees::Confirmation::ProgrammeDetails::View,
+          training_details: Trainees::Confirmation::TrainingDetails::View,
+        }[section]
+      end
+
+      def path
+        {
+          personal_details: {
+            not_started: "edit_trainee_personal_details_path",
+            in_progress: "trainee_personal_details_confirm_path",
+          },
+          contact_details: {
+            not_started: "edit_trainee_contact_details_path",
+            in_progress: "trainee_contact_details_confirm_path",
+          },
+          diversity: {
+            not_started: "edit_trainee_diversity_disclosure_path",
+            in_progress: "trainee_diversity_confirm_path",
+          },
+          degrees: {
+            not_started: "trainee_degrees_new_type_path",
+            in_progress: "trainee_degrees_confirm_path",
+          },
+          programme_details: {
+            not_started: "edit_trainee_programme_details_path",
+            in_progress: "trainee_programme_details_confirm_path",
+          },
+          training_details: {
+            not_started: "edit_trainee_training_details_path",
+            in_progress: "trainee_training_details_confirm_path",
+          },
+        }[section][status]
+      end
+
+      def error
+        @error ||= trn_submission.errors.present?
+      end
+
+      def status
+        @status ||= trn_submission.section_status(section)
+      end
+
+      def title
+        "#{section_title} #{section_status}"
+      end
+
+      def section_title
+        I18n.t("components.sections.titles.#{section}")
+      end
+
+      def section_status
+        I18n.t("components.sections.statuses.#{status}")
+      end
+
+      def url
+        Rails.application.routes.url_helpers.public_send(path, trainee)
+      end
+
+      def link_text
+        link_text = I18n.t("components.sections.link_texts.#{status}")
+        "#{link_text}<span class=\"govuk-visually-hidden\"> #{section_title.downcase}</span>".html_safe
+      end
+    end
+  end
+end

--- a/app/forms/trn_submission_form.rb
+++ b/app/forms/trn_submission_form.rb
@@ -5,24 +5,29 @@ class TrnSubmissionForm
 
   validate :submission_ready
 
-  VALIDATORS = [
-    { validator: PersonalDetailForm, progress_key: :personal_details },
-    { validator: ContactDetailForm, progress_key: :contact_details },
-    { validator: DegreeDetailForm, progress_key: :degrees },
-    { validator: Diversities::FormValidator, progress_key: :diversity },
-    { validator: TrainingDetailsForm, progress_key: :training_details },
-    { validator: ProgrammeDetailForm, progress_key: :programme_details },
-  ].freeze
+  FORM_VALIDATORS =
+    {
+      personal_details: PersonalDetailForm,
+      contact_details: ContactDetailForm,
+      diversity: Diversities::FormValidator,
+      degrees: DegreeDetailForm,
+      programme_details: ProgrammeDetailForm,
+      training_details: TrainingDetailsForm,
+    }.freeze
+
+  PROGRESS_KEYS = FORM_VALIDATORS.keys.freeze
 
   def initialize(trainee:)
     @trainee = trainee
   end
 
+  def section_status(progress_key)
+    progress_service(progress_key).status.parameterize(separator: "_").to_sym
+  end
+
   def all_sections_complete?
-    VALIDATORS.all? do |validator_hash|
-      validator = validator_hash[:validator].new(trainee)
-      progress_value = trainee.progress.public_send(validator_hash[:progress_key])
-      progress_is_completed?(validator, progress_value)
+    PROGRESS_KEYS.all? do |progress_key|
+      progress_is_completed?(progress_key)
     end
   end
 
@@ -30,11 +35,21 @@ private
 
   attr_reader :trainee
 
+  def validator(section)
+    FORM_VALIDATORS[section]
+  end
+
   def submission_ready
     errors.add(:trainee, :incomplete) unless all_sections_complete?
   end
 
-  def progress_is_completed?(validator, progress_value)
-    ProgressService.call(validator: validator, progress_value: progress_value).completed?
+  def progress_service(progress_key)
+    validator = validator(progress_key).new(trainee)
+    progress_value = trainee.progress.public_send(progress_key)
+    ProgressService.call(validator: validator, progress_value: progress_value)
+  end
+
+  def progress_is_completed?(progress_key)
+    progress_service(progress_key).completed?
   end
 end

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -21,7 +21,7 @@
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
           <span class="govuk-caption-l">
-            Draft record for <%= trainee_name(@trainee)  %>
+            Draft record <%= "for #{trainee_name(@trainee)}" if trainee_name(@trainee).present?  %>
           </span>
           Review trainee record
         </h1>
@@ -42,16 +42,21 @@
       Personal details and education
     </h2>
 
-    <%= render Trainees::Confirmation::PersonalDetails::View.new(trainee: @trainee) %>
-    <%= render Trainees::Confirmation::ContactDetails::View.new(trainee: @trainee) %>
-    <%= render Trainees::Confirmation::Diversity::View.new(trainee: @trainee) %>
-    <%= render Trainees::Confirmation::Degrees::View.new(trainee: @trainee, show_add_another_degree_button: false, show_delete_button: true) %>
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :personal_details) %>
+
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :contact_details) %>
+
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :diversity) %>
+
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :degrees) %>
 
     <h2 class="govuk-heading-m">
       About their training
     </h2>
-    <%= render Trainees::Confirmation::TrainingDetails::View.new(trainee: @trainee) %>
-    <%= render Trainees::Confirmation::ProgrammeDetails::View.new(trainee: @trainee) %>
+
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :training_details) %>
+
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :programme_details) %>
 
     <%= form_with(model: @trn_submission, url: trn_submissions_path, method: :post, local: true) do |f| %>
       <%= hidden_field_tag :trainee_id, @trainee.slug %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,20 @@ en:
         withdrawn: Trainee withdrawn
         deferred: Trainee deferred
         qts_awarded: Trainee awarded QTS
+    sections:
+      titles:
+        personal_details: Personal details
+        contact_details: Contact details
+        diversity: Diversity information
+        degrees: Degree details
+        programme_details: Programme details
+        training_details: Training details
+      statuses:
+        not_started: not started
+        in_progress: not marked as complete
+      link_texts:
+        not_started: Start section
+        in_progress: Continue section
   views:
     trainees:
       edit:

--- a/spec/components/incomplete_section/view_preview.rb
+++ b/spec/components/incomplete_section/view_preview.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module IncompleteSection
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render IncompleteSection::View.new(title: "title", link_text: "link_text", url: "url")
+    end
+
+    def error
+      render IncompleteSection::View.new(title: "title", link_text: "link_text", url: "url", error: true)
+    end
+  end
+end

--- a/spec/components/incomplete_section/view_spec.rb
+++ b/spec/components/incomplete_section/view_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module IncompleteSection
+  describe View do
+    alias_method :component, :page
+    let(:title) { "title" }
+    let(:link_text) { "link_text" }
+    let(:url) { "url" }
+
+    context "default" do
+      before do
+        render_inline(
+          described_class.new(title: title, link_text: link_text, url: url),
+        )
+      end
+
+      it "renders the title" do
+        expect(component).to have_css(".app-inset-text__title", text: title)
+      end
+
+      it "renders the link" do
+        expect(component).to have_link(link_text, href: url)
+      end
+
+      it "renders the correct css classes" do
+        expect(component).to have_css(".govuk-inset-text.app-inset-text--narrow-border.app-inset-text--important")
+      end
+    end
+
+    context "error" do
+      before do
+        render_inline(
+          described_class.new(title: title, link_text: link_text, url: url, error: true),
+        )
+      end
+
+      it "renders the title" do
+        expect(component).to have_css(".app-inset-text__title", text: title)
+      end
+
+      it "renders the link" do
+        expect(component).to have_link(link_text, href: url)
+      end
+
+      it "renders the correct css classes" do
+        expect(component).to have_css(".govuk-inset-text.app-inset-text--narrow-border.app-inset-text--error")
+      end
+    end
+  end
+end

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module Pages
+  module Trainees
+    module CheckDetails
+      class ViewPreview < ViewComponent::Preview
+        ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
+
+        %i[start_sections
+           continue_sections
+           confirmations_sections].each do |sections|
+          define_method sections do
+            @trainee = trainee(sections)
+
+            @trn_submission = TrnSubmissionForm.new(trainee: @trainee)
+            render template: template, locals: { "@trainee": @trainee, "@trn_submission": @trn_submission }
+          end
+
+          define_method "#{sections}_validated" do
+            @trainee = trainee(sections)
+
+            @trn_submission = TrnSubmissionForm.new(trainee: @trainee)
+            @trn_submission.validate
+            render template: template, locals: { "@trainee": @trainee, "@trn_submission": @trn_submission }
+          end
+        end
+
+      private
+
+        def trainee(section)
+          if section == :start_sections
+            trainee_with_all_sections_not_started
+          elsif section == :continue_sections
+            trainee_with_all_sections_in_progress
+          else
+            trainee_with_all_sections_completed
+          end
+        end
+
+        def trainee_with_all_sections_not_started
+          Trainee.new(id: 1000)
+        end
+
+        def trainee_with_all_sections_in_progress
+          Trainee.new(id: 1000, trainee_id: "trainee_id",
+                      first_names: "first_names",
+                      last_name: "last_name",
+                      address_line_one: "address_line_one",
+                      address_line_two: "address_line_two",
+                      town_city: "town_city",
+                      postcode: "postcode",
+                      email: "email",
+                      middle_names: "middle_names",
+                      international_address: "international_address",
+                      ethnic_background: "ethnic_background",
+                      additional_ethnic_background: "additional_ethnic_background",
+                      subject: "subject",
+                      degrees: [Degree.new(id: 1)])
+        end
+
+        def trainee_with_all_sections_completed
+          nationalities = [Nationality.first || Nationality.new(id: 1)]
+
+          Trainee.new(id: 1000, trainee_id: "trainee_id",
+                      first_names: "first_names",
+                      last_name: "last_name",
+                      address_line_one: "address_line_one",
+                      address_line_two: "address_line_two",
+                      town_city: "town_city",
+                      middle_names: "middle_names",
+                      international_address: "international_address",
+                      ethnic_background: "ethnic_background",
+                      additional_ethnic_background: "additional_ethnic_background",
+                      subject: "subject",
+                      gender: 1,
+                      date_of_birth: Time.zone.now,
+                      locale_code: 1,
+                      postcode: "BN1 1AA",
+                      email: "email@example.com",
+                      programme_start_date: 6.months.ago,
+                      programme_end_date: Time.zone.now,
+                      nationalities: nationalities,
+                      progress: Progress.new(
+                        personal_details: true,
+                        contact_details: true,
+                        degrees: true,
+                        diversity: true,
+                        programme_details: true,
+                        training_details: true,
+                      ),
+                      age_range: 1,
+                      diversity_disclosure: 1,
+                      degrees: [Degree.new(id: 1, locale_code: 1, subject: "subject")],
+                      commencement_date: Time.zone.now)
+        end
+
+        def template
+          "trainees/check_details/show"
+        end
+      end
+    end
+  end
+end

--- a/spec/components/trainees/sections/view_preview.rb
+++ b/spec/components/trainees/sections/view_preview.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module Trainees
+  module Sections
+    class ViewPreview < ViewComponent::Preview
+      %i[personal_details
+         contact_details
+         degrees
+         diversity
+         programme_details
+         training_details].each do |section|
+        define_method "continue_sections_#{section}" do
+          trainee = continue_sections_trainee
+          trn_submission = TrnSubmissionForm.new(trainee: trainee)
+          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission: trn_submission))
+        end
+
+        define_method "continue_sections_#{section}_validated" do
+          trainee = continue_sections_trainee
+          trn_submission = TrnSubmissionForm.new(trainee: trainee)
+          trn_submission.validate
+          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission: trn_submission))
+        end
+
+        define_method "start_sections_#{section}" do
+          trainee = start_sections_trainee
+          trn_submission = TrnSubmissionForm.new(trainee: trainee)
+          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission: trn_submission))
+        end
+
+        define_method "start_sections_#{section}_validated" do
+          trainee = start_sections_trainee
+          trn_submission = TrnSubmissionForm.new(trainee: trainee)
+          trn_submission.validate
+          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission: trn_submission))
+        end
+      end
+
+    private
+
+      def continue_sections_trainee
+        @continue_sections_trainee ||= Trainee.new(id: 1000, trainee_id: "trainee_id",
+                                                   first_names: "first_names",
+                                                   last_name: "last_name",
+                                                   address_line_one: "address_line_one",
+                                                   address_line_two: "address_line_two",
+                                                   town_city: "town_city",
+                                                   postcode: "postcode",
+                                                   email: "email",
+                                                   middle_names: "middle_names",
+                                                   international_address: "international_address",
+                                                   ethnic_background: "ethnic_background",
+                                                   additional_ethnic_background: "additional_ethnic_background",
+                                                   subject: "subject",
+                                                   degrees: [Degree.new(id: 1)])
+      end
+
+      def start_sections_trainee
+        @start_sections_trainee ||= Trainee.new(id: 1000)
+      end
+    end
+  end
+end

--- a/spec/components/trainees/sections/view_spec.rb
+++ b/spec/components/trainees/sections/view_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  module Sections
+    describe View do
+      alias_method :component, :page
+
+      let(:trainees_sections_component) do
+        trn_submission = TrnSubmissionForm.new(trainee: trainee)
+        described_class.new(trainee: trainee, section: section, trn_submission: trn_submission)
+      end
+
+      before do
+        render_inline(trainees_sections_component)
+      end
+
+      renders_confirmation = "renders confirmation"
+      shared_examples renders_confirmation do |trainee_section|
+        context trainee_section.to_s do
+          let(:section) { trainee_section }
+
+          it "return correct component to render" do
+            expect(trainees_sections_component.component).to_not be_a(IncompleteSection::View)
+            expect(trainees_sections_component.component).to be_a(expected_confirmation_view(section))
+          end
+        end
+      end
+
+      renders_incomplete_section = "renders IncompleteSection"
+      shared_examples renders_incomplete_section do |trainee_section, status|
+        context trainee_section.to_s do
+          let(:section) { trainee_section }
+
+          it "return correct component to render" do
+            expect(trainees_sections_component.component).to be_a(IncompleteSection::View)
+          end
+
+          it "has title" do
+            expect(component).to have_css(".app-inset-text__title", text: expected_title(section, status))
+          end
+
+          it "has link" do
+            expect(component).to have_link(expected_link_text(section, status), href: expected_href(section, status, trainee))
+          end
+        end
+      end
+
+      context "trainee not started" do
+        let(:trainee) { create(:trainee, :not_started) }
+
+        include_examples renders_incomplete_section, :personal_details, :not_started
+        include_examples renders_incomplete_section, :contact_details, :not_started
+        include_examples renders_incomplete_section, :diversity, :not_started
+        include_examples renders_incomplete_section, :degrees, :not_started
+        include_examples renders_incomplete_section, :programme_details, :not_started
+        include_examples renders_incomplete_section, :training_details, :not_started
+      end
+
+      context "trainee in progress" do
+        let(:trainee) { create(:trainee, :in_progress) }
+
+        include_examples renders_incomplete_section, :personal_details, :in_progress
+        include_examples renders_incomplete_section, :contact_details, :in_progress
+        include_examples renders_incomplete_section, :diversity, :in_progress
+        include_examples renders_incomplete_section, :degrees, :in_progress
+        include_examples renders_incomplete_section, :programme_details, :in_progress
+        include_examples renders_incomplete_section, :training_details, :in_progress
+      end
+
+      context "trainee completed" do
+        let(:trainee) do
+          create(:trainee, :completed)
+        end
+
+        include_examples renders_confirmation, :personal_details
+        include_examples renders_confirmation, :contact_details
+        include_examples renders_confirmation, :diversity
+        include_examples renders_confirmation, :degrees
+        include_examples renders_confirmation, :programme_details
+        include_examples renders_confirmation, :training_details
+      end
+
+      def expected_title(section, status)
+        I18n.t("components.sections.titles.#{section}") + " " + I18n.t("components.sections.statuses.#{status}")
+      end
+
+      def expected_link_text(_section, status)
+        I18n.t("components.sections.link_texts.#{status}")
+      end
+
+      def expected_href(section, status, trainee)
+        path = expected_path(section, status)
+        Rails.application.routes.url_helpers.public_send(path, trainee)
+      end
+
+      def expected_path(section, status)
+        {
+          personal_details: {
+            not_started: "edit_trainee_personal_details_path",
+            in_progress: "trainee_personal_details_confirm_path",
+          },
+          contact_details: {
+            not_started: "edit_trainee_contact_details_path",
+            in_progress: "trainee_contact_details_confirm_path",
+          },
+          diversity: {
+            not_started: "edit_trainee_diversity_disclosure_path",
+            in_progress: "trainee_diversity_confirm_path",
+          },
+          degrees: {
+            not_started: "trainee_degrees_new_type_path",
+            in_progress: "trainee_degrees_confirm_path",
+          },
+          programme_details: {
+            not_started: "edit_trainee_programme_details_path",
+            in_progress: "trainee_programme_details_confirm_path",
+          },
+          training_details: {
+            not_started: "edit_trainee_training_details_path",
+            in_progress: "trainee_training_details_confirm_path",
+          },
+        }[section][status]
+      end
+
+      def expected_confirmation_view(section)
+        {
+          personal_details: Trainees::Confirmation::PersonalDetails::View,
+          contact_details: Trainees::Confirmation::ContactDetails::View,
+          diversity: Trainees::Confirmation::Diversity::View,
+          degrees: Trainees::Confirmation::Degrees::View,
+          programme_details: Trainees::Confirmation::ProgrammeDetails::View,
+          training_details: Trainees::Confirmation::TrainingDetails::View,
+        }[section]
+      end
+    end
+  end
+end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -44,6 +44,51 @@ FactoryBot.define do
       add_attribute("date_of_birth(1i)") { form_dob.year.to_s }
     end
 
+    trait :not_started do
+      trainee_id { nil }
+      first_names { nil }
+      middle_names { nil }
+      last_name { nil }
+      gender { nil }
+      date_of_birth { nil }
+
+      diversity_disclosure { nil }
+      ethnic_group { nil }
+      ethnic_background { nil }
+      additional_ethnic_background { nil }
+      disability_disclosure { nil }
+
+      address_line_one { nil }
+      address_line_two { nil }
+      town_city { nil }
+      postcode { nil }
+      international_address { nil }
+      locale_code { nil }
+      email { nil }
+      commencement_date { nil }
+    end
+
+    trait :in_progress do
+      with_programme_details
+      with_start_date
+      degrees { [build(:degree, :uk_degree_with_details)] }
+    end
+
+    trait :completed do
+      in_progress
+      nationalities { [build(:nationality)] }
+      progress do
+        Progress.new(
+          personal_details: true,
+          contact_details: true,
+          diversity: true,
+          degrees: true,
+          programme_details: true,
+          training_details: true,
+        )
+      end
+    end
+
     trait :with_programme_details do
       subject { Dttp::CodeSets::ProgrammeSubjects::MAPPING.keys.sample }
       age_range { Dttp::CodeSets::AgeRanges::MAPPING.keys.sample }

--- a/spec/features/view_components_spec.rb
+++ b/spec/features/view_components_spec.rb
@@ -9,6 +9,12 @@ RSpec.feature "view components" do
     end
   end).flatten
 
+  let(:create_nationality) { create :nationality }
+
+  before do
+    create_nationality
+  end
+
   shared_examples "navigate to" do |link|
     scenario "navigate to #{link}" do
       visit link


### PR DESCRIPTION
### Context

Adding logic to the `check-details` page which renders a link and text to sections that haven't been started, or are uncompleted.

### Changes proposed in this pull request

- Add new missing details component
- Add custom CSS
- Create logic to make component dynamic
- Add missing details text to locale
- Create view preview
- Add styling for error messages

### Guidance to review
- Navigate to the check details page: https://rtt-review-pr-540.herokuapp.com/trainees/nXZr9qmsuEQ6BDPEm2qZjPpU/check-details
- Click the `Start section` link and complete the section without ticking the 'completed' checkbox at the end
- The text and link should have changed on the `/check-details` page
- Repeat for each section
- Check the view previews
- Check styling for error messages


#### Dumb components
`IncompleteSection::View`
- only get feed with values
- it a wrapper for `GovukComponent::InsetText`
- and displays as seen in the links below, there is a default and an error
https://rtt-review-pr-540.herokuapp.com/view_components/incomplete_section/view/default
https://rtt-review-pr-540.herokuapp.com/view_components/incomplete_section/view/error

#### Smart components
`Trainees::Sections::View`
- it decides which component to renders
- its a wrapper for any confirmation components as well as `IncompleteSection::View` over various states
- it deals with trainee progress
https://rtt-review-pr-540.herokuapp.com/view_components/trainees/sections/view


### Screenshots
![image](https://user-images.githubusercontent.com/50492247/108375977-624e6680-71fa-11eb-998b-7fdffc390ec3.png)
![image](https://user-images.githubusercontent.com/50492247/108376037-78f4bd80-71fa-11eb-86e8-1d0360910333.png)
![image](https://user-images.githubusercontent.com/50492247/108376459-eef92480-71fa-11eb-91a5-d769f0e09791.png)
![image](https://user-images.githubusercontent.com/50492247/108376592-0cc68980-71fb-11eb-8405-86b531906f25.png)
![image](https://user-images.githubusercontent.com/50492247/108376702-27006780-71fb-11eb-994f-306c217dda37.png)

