### PR TITLE
[1092] Fix diversity flash confirmation message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
       heading: Confirm %{section_title}
       flash:
         diversity: disclosure
+        disclosure: diversity information
         trainee_id: ID
         trainee_start_date: start date
     programme_detail:


### PR DESCRIPTION
### Context

- https://trello.com/c/Rqz3HQUF/1092-missing-translation-on-confirmation-page-flash

### Changes proposed in this pull request

Fix the diversity confirmation flash message

Before:

![image](https://user-images.githubusercontent.com/616080/108357269-1d6c0500-71e5-11eb-95be-b807e042e38a.png)

After:

<img width="1233" alt="Screenshot 2021-02-18 at 12 27 59" src="https://user-images.githubusercontent.com/616080/108357294-23fa7c80-71e5-11eb-9de8-8f295e05c9d5.png">

### Guidance to review

