### PR TITLE
Improve focus styling

### DIFF
--- a/app/components/navigation_bar/script.js
+++ b/app/components/navigation_bar/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/navigation_bar/style.scss
+++ b/app/components/navigation_bar/style.scss
@@ -1,0 +1,3 @@
+.moj-primary-navigation__link[aria-current]:focus:before {
+  height: 7px; // Make bar thicker so we don’t rely on colour alone to indicate focus
+}

--- a/app/components/tab_navigation/style.scss
+++ b/app/components/tab_navigation/style.scss
@@ -85,6 +85,10 @@
   position: relative;
   text-decoration: none;
 
+  &:focus:before {
+    height: 7px; // Bar needs to change thickness so that we don’t rely on colour alone.
+  }
+
   &:before {
     background-color: $govuk-link-colour;
     content: "";

--- a/app/components/trainees/filters/style.scss
+++ b/app/components/trainees/filters/style.scss
@@ -7,6 +7,19 @@
 @import "~@ministryofjustice/frontend/moj/objects/scrollable-pane";
 @import "~@ministryofjustice/frontend/moj/components/filter/filter";
 
+.app-filter {
+  box-shadow: none;
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(3);
+  }
+}
+
+// Apply GOV.UK focus styles - only needed with js.
+.js-enabled .app-filter:focus {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+}
+
 .moj-filter-layout__content {
   overflow-x: hidden;
 }
@@ -57,22 +70,13 @@
   box-shadow: none;
 }
 
-.app-filter {
-  box-shadow: none;
-
-  @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(3);
-  }
-}
-
-// Apply GOV.UK focus styles - only needed with js.
-.js-enabled .app-filter:focus {
-  outline: $govuk-focus-width solid $govuk-focus-colour;
+.moj-filter__tag:focus, .moj-filterfe__tag:focus:hover {
+  outline: none;
+  box-shadow: 0 4px #0b0c0c;
 }
 
 // Fix for focus issue - see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640
-
 // We're catching the focus on a second element rather than having the filter component itself flash with focus when checkbox labels are clicked.
-.moj-filter__options:focus {
+.moj-filter__content:focus {
   outline: none;
 }

--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -8,7 +8,8 @@
       </div>
     </div>
 
-    <div class="moj-filter__content">
+    <!-- Div made focusable to 'catch' focus from filters. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640 -->
+    <div class="moj-filter__content" tabindex="-1">
 
       <% if filters %>
         <div class="moj-filter__selected">
@@ -36,8 +37,7 @@
         </div>
       <% end %>
 
-      <!-- Div made focusable to 'catch' focus from filters. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640 -->
-      <div class="moj-filter__options"  tabindex="-1">
+      <div class="moj-filter__options">
 
         <form method="get">
           <%= submit_tag "Apply filters", class: "govuk-button" %>


### PR DESCRIPTION
This pr addresses some of the focus styling issues identified in our internal accessibility bash

## Selected filters tags unclear

The tags aren't fully compliant with GDS focus styles - they accidentally leave on the default focus outline. If that's removed, they then rely on colour alone to distinguish focus. I've used a box shadow similar to GDS' link focus styles to solve this.

After:
<img width="390" alt="Screenshot 2021-02-18 at 12 48 26" src="https://user-images.githubusercontent.com/2204224/108359472-f3681200-71e7-11eb-8abc-92eebaed16ce.png">

Before:
<img width="373" alt="Screenshot 2021-02-18 at 12 51 18" src="https://user-images.githubusercontent.com/2204224/108359519-01b62e00-71e8-11eb-9210-f86defd5ec01.png">

## Focus on active tabs

Active tabs rely on colour alone to indicate focus. Now the 'active' bar gets a bit bigger. This is a bit different than how the design system does it, but their markup is rather different and I was trying for a simple fix.

After:
![header-focus](https://user-images.githubusercontent.com/2204224/108505462-5cff2380-72af-11eb-8eea-1bc595b4657e.gif)

Before:
<img width="672" alt="Screenshot 2021-02-18 at 12 52 50" src="https://user-images.githubusercontent.com/2204224/108359694-3924da80-71e8-11eb-928b-60da14204dff.png">

Design system:
![Screenshot 2021-02-18 at 12 52 10](https://user-images.githubusercontent.com/2204224/108359667-31653600-71e8-11eb-8604-c9ffb87022d5.png)

## How to test

Focus the following items in turn - each item should be distinguishable as focused without relying on a change in colour alone - eg it gets a border or something gets thicker.

Items to check:
* Header navigation
* Tab navigation on records
* Selected filters