### PR TITLE
[1040] Fix backlinks

### DIFF
--- a/app/components/dynamic_back_link/view.rb
+++ b/app/components/dynamic_back_link/view.rb
@@ -2,11 +2,12 @@
 
 module DynamicBackLink
   class View < GovukComponent::Base
-    attr_reader :trainee, :text
+    attr_reader :trainee, :text, :last_origin_page
 
-    def initialize(trainee, text: nil)
+    def initialize(trainee, text: nil, last_origin_page: false)
       @trainee = trainee
       @text = text
+      @last_origin_page = last_origin_page
     end
 
     def link_text
@@ -14,7 +15,8 @@ module DynamicBackLink
     end
 
     def path
-      PageTracker.new(trainee_slug: trainee.slug, session: session, request: request).previous_page_path
+      page_tracker = PageTracker.new(trainee_slug: trainee.slug, session: session, request: request)
+      page_tracker.public_send(last_origin_page ? :last_origin_page_path : :previous_page_path)
     end
   end
 end

--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -2,13 +2,13 @@
 
 module Trainees
   class ConfirmDeferralsController < ApplicationController
+    before_action :authorize_trainee
+
     def show
-      authorize trainee
+      page_tracker.save_as_origin!
     end
 
     def update
-      authorize trainee
-
       trainee.defer!
       DeferJob.perform_later(trainee.id)
 
@@ -20,6 +20,10 @@ module Trainees
 
     def trainee
       @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def authorize_trainee
+      authorize(trainee)
     end
   end
 end

--- a/app/controllers/trainees/confirm_withdrawals_controller.rb
+++ b/app/controllers/trainees/confirm_withdrawals_controller.rb
@@ -2,13 +2,13 @@
 
 module Trainees
   class ConfirmWithdrawalsController < ApplicationController
+    before_action :authorize_trainee
+
     def show
-      authorize trainee
+      page_tracker.save_as_origin!
     end
 
     def update
-      authorize trainee
-
       trainee.withdraw!
       WithdrawJob.perform_later(trainee.id)
 
@@ -20,6 +20,10 @@ module Trainees
 
     def trainee
       @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def authorize_trainee
+      authorize(trainee)
     end
   end
 end

--- a/app/views/trainees/confirm_deferrals/show.html.erb
+++ b/app/views/trainees/confirm_deferrals/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.deferral_details.confirm") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(text: t("back_to_record"), href:  trainee_deferral_path(@trainee)) %>
+  <%= render GovukComponent::BackLink.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/confirm_withdrawals/show.html.erb
+++ b/app/views/trainees/confirm_withdrawals/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.confirm_withdrawal.show") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(text: t("back_to_record"), href: trainee_withdrawal_path(@trainee)) %>
+  <%= render GovukComponent::BackLink.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.contact_details.edit", has_errors: @contact_details.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
 <h1 class="govuk-heading-l">Contact details</h1>

--- a/app/views/trainees/deferrals/show.html.erb
+++ b/app/views/trainees/deferrals/show.html.erb
@@ -1,8 +1,9 @@
 <%= render PageTitle::View.new(title: "trainees.deferral.show", has_errors: @deferral.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(text: t(:back), href: trainee_path(@trainee)) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>
 <% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with(model: @deferral, url: trainee_deferral_path(@trainee), local: true) do |f| %>

--- a/app/views/trainees/degrees/edit.html.erb
+++ b/app/views/trainees/degrees/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.degrees.edit", has_errors: @degree.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/degrees/type/new.html.erb
+++ b/app/views/trainees/degrees/type/new.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: (@trainee.degrees.size > 1 ? "Add another degree" : "Add undergraduate degree"), has_errors: @degree.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/diversity/disability_disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disability_disclosures/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.diversity.disability_disclosure.edit", has_errors: @disability_disclosure.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/diversity/disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disclosures/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.diversity.disclosures.edit", has_errors: @disclosure.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/diversity/ethnic_groups/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_groups/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.diversity.ethnic_group.edit", has_errors: @ethnic_group.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/outcome_details/confirm.html.erb
+++ b/app/views/trainees/outcome_details/confirm.html.erb
@@ -1,10 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.outcome_details.confirm") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(
-    text: t('back_to_record'),
-    href: edit_trainee_outcome_details_outcome_date_path(@trainee)
-  ) %>
+  <%= render GovukComponent::BackLink.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/outcome_details/recommended.html.erb
+++ b/app/views/trainees/outcome_details/recommended.html.erb
@@ -1,10 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.outcome_details.recommended") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(
-    text: 'Return to trainee',
-    href: trainee_path(@trainee)
-  ) %>
+  <%= render GovukComponent::BackLink.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.personal_details.edit", has_errors: @personal_detail.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/programme_details/edit.html.erb
+++ b/app/views/trainees/programme_details/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.programme_details.edit", has_errors: @programme_detail.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: "Back") %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.trainee_ids.edit") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: t(:back_to_record)) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
 <%= form_with model: @training_details, url: trainee_start_date_path, local: true do |f| %>

--- a/app/views/trainees/trainee_ids/edit.html.erb
+++ b/app/views/trainees/trainee_ids/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.trainee_ids.edit") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: t(:back_to_record)) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.withdrawal.show", has_errors: @withdrawal_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(text: t('back'), href: trainee_path(@trainee)) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
### Context
https://trello.com/b/BBEuhbHM/publish-register-sprint-board

### Changes proposed in this pull request
- Fix the backlinks on defer and withdraw pages. The URL of these pages, e.g. `/trainees/:trainee_id/withdraw` poses a problem for `PageTracker` because it if we visit say `/trainees/:trainee_id/withdraw/confirm` beforehand, the confirm page will get removed from history after entering the `/trainees/:trainee_id/withdraw`.
- Fix url for some hardcoded backlinks
- All backlinks in form pages use the word "Back" only
- Minor I18n changes

### Guidance to review
- Visit the defer and withdraw pages. Entering the form page the backlink should bring you back to either the trainee record page (if you came from there), or the confirm page (if you came from there).
- Check that all backlines on form pages use the word "Back"

