### PR TITLE
[1095] Origin page is nil when confirmation page submitted

### DIFF
--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -26,7 +26,7 @@ module Trainees
 
       flash[:success] = "Trainee #{flash_message_title} updated"
 
-      redirect_to page_tracker.last_origin_page_path
+      redirect_to page_tracker.last_origin_page_path || trainee_path(trainee)
     end
 
   private


### PR DESCRIPTION
### Context

- https://trello.com/c/WuxOa5zn/1095-origin-page-is-nil-when-confirmation-page-submitted
- https://sentry.io/organizations/dfe-bat/issues/2206888502/events/727b4bc3dce34c5e9a8de85c6edb8ed2/?environment=production&project=5552118

### Changes proposed in this pull request

- Handle a possible `nil` value from the `page_tracker.last_origin_page_path` method and redirect to a sensible default path so the app doesn't blow up

### Guidance to review

Before:

![bug](https://user-images.githubusercontent.com/616080/108379234-a42cdc00-71fd-11eb-974a-063b92336295.gif)

After:

![fix](https://user-images.githubusercontent.com/616080/108379251-a858f980-71fd-11eb-92e2-04bc5e9346cb.gif)

