### PR TITLE
[xxxx] Remove no longer required counts

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -11,14 +11,8 @@ class TraineesController < ApplicationController
 
     # We can't use `#draft` to find @draft_trainees since that applies a `WHERE`
     # clause, removing Kaminari's pagination. Hence the use of `#select`.
-    #
-    # Conversely, we need to call Kaminari's `#total_count` on the ActiveRecord
-    # Relations for the pre-pagination count. Hence the secondary call to `#draft`.
     @draft_trainees = paginated_trainees.select(&:draft?)
-    @draft_trainees_count = filtered_trainees.draft.count
-
     @completed_trainees = paginated_trainees.reject(&:draft?)
-    @completed_trainees_count = filtered_trainees.not_draft.count
 
     respond_to do |format|
       format.html


### PR DESCRIPTION
### Context

This PR https://github.com/DFE-Digital/register-trainee-teachers/pull/536 removed the individual counts for draft and non-draft records from the UI. This PR cleans up the controller - we don't need to count them anymore!

### Changes proposed in this pull request

Remove counts for draft and non-draft trainees from the trainees controller.

### Guidance to review

No front end changes.
