### PR TITLE
[1093] Add button back to site on all error pages

### DIFF
--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,5 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= yield %>
+    <%= govuk_button_link_to("Return home", root_path) %>
   </div>
 </div>


### PR DESCRIPTION
### Context

https://trello.com/c/H0t2FXqL/1093-sign-out-link-is-missing-on-all-static-and-error-pages

### Changes proposed in this pull request

Adds a button to all error pages, allowing the user to return back to the trainee list. If they're not signed in, then it will redirect back to sign in.

<img width="832" alt="Screenshot 2021-02-19 at 11 21 59" src="https://user-images.githubusercontent.com/18436946/108498383-b3b33000-72a4-11eb-9823-c241291df155.png">


### Guidance to review

- Visit the error pages `/404`, `/422`, `500`
- Check that they all have a button returning you to the correct page