### PR TITLE
[1076] Correct ordering of personal details errors

### DIFF
--- a/app/forms/personal_detail_form.rb
+++ b/app/forms/personal_detail_form.rb
@@ -21,10 +21,9 @@ class PersonalDetailForm
   validates :first_names, presence: true
   validates :last_name, presence: true
   validates :date_of_birth, presence: true
-  validates :gender, presence: true, inclusion: { in: Trainee.genders.keys }
-
   validate :date_of_birth_valid
   validate :date_of_birth_not_in_future
+  validates :gender, presence: true, inclusion: { in: Trainee.genders.keys }
   validate :nationalities_cannot_be_empty
 
   after_validation :update_trainee_attributes


### PR DESCRIPTION
### Context

https://trello.com/c/ubdxzx3Y/1076-error-messages-out-of-order-on-personal-details-form

### Changes proposed in this pull request

Re-orders the validations in the personal details model so that the errors appear in the correct order in the form.

<img width="692" alt="Screenshot 2021-02-19 at 11 55 28" src="https://user-images.githubusercontent.com/18436946/108501555-61284280-72a9-11eb-89a5-245ca62c98e8.png">


### Guidance to review

- Create a new trainee
- Head to `/personal-details`
- Click continue without filling in any of the fields
- Check that the errors are rendered in the same order as the form fields

