### PR TITLE
Restore support links by default and only hide feedback requests

### DIFF
--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -3,7 +3,6 @@
 
   <h1 class="govuk-heading-l">You do not have access to view details for this trainee</h1>
 
-  <% if FeatureService.enabled?("enable_support_link") %>
-    <p class="govuk-body">If you think you should have access, contact: <%= support_email(subject: "Register trainee teachers support") %>.</p>
-  <% end %>
+  <p class="govuk-body">If you think you should have access, contact: <%= support_email(subject: "Register trainee teachers support") %>.</p>
+
 <% end %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -5,7 +5,6 @@
 
   <p class="govuk-body">Try again later.</p>
 
-  <% if FeatureService.enabled?("enable_support_link") %>
-    <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= support_email %>.</p>
-  <% end %>
+  <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= support_email %>.</p>
+
 <% end %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -5,7 +5,6 @@
 
   <p class="govuk-body">Check the web address and try again.</p>
 
-  <% if FeatureService.enabled?("enable_support_link") %>
-    <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= support_email %>.</p>
-  <% end %>
+  <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= support_email %>.</p>
+
 <% end %>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -5,8 +5,7 @@
 
   <p class="govuk-body">Try again later.</p>
 
-  <% if FeatureService.enabled?("enable_support_link") %>
-    <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= support_email %>.</p>
-  <% end %>
+  <p class="govuk-body">If you continue to get this message, email the Register trainee teachers team at <%= support_email %>.</p>
+
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,11 @@
               Beta
             </strong>
             <span class="govuk-phase-banner__text">
-                This is a new service <% if FeatureService.enabled?("enable_support_link") %> – <%= support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback", classes: "govuk-link--no-visited-state") %> <% end %>
+                This is a new service - <% if FeatureService.enabled?("enable_feedback_link") %>
+                  <%= support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback", classes: "govuk-link--no-visited-state") %>
+                <% else %>
+                  <%= support_email(name: "report a problem", subject: "Register trainee teachers support", classes: "govuk-link--no-visited-state") %>
+                <% end %>
             </span>
           </p>
         </div>
@@ -75,15 +79,13 @@
       <div class="govuk-width-container">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-            <% if FeatureService.enabled?("enable_support_link") %>
-              <h2 class="govuk-heading-m">Get support</h2>
-              <div class="govuk-footer__meta-custom">
-                <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                  <li>Email: <%= support_email(subject: "Register trainee teachers support", classes: "govuk-footer__link") %></li>
-                  <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
-                </ul>
-              </div>
-            <% end %>
+            <h2 class="govuk-heading-m">Get support</h2>
+            <div class="govuk-footer__meta-custom">
+              <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
+                <li>Email: <%= support_email(subject: "Register trainee teachers support", classes: "govuk-footer__link") %></li>
+                <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
+              </ul>
+            </div>
             <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
               <li class="govuk-footer__inline-list-item">
                 <%= link_to "Accessibility", accessibility_path, class: "govuk-footer__link" %>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -20,12 +20,10 @@
       <%= govuk_link_to "Sign in using Persona", "/personas", { class: "govuk-button" }  %>
     <% end %>
 
-    <% if FeatureService.enabled?("enable_support_link") %>
-      <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to Register trainee teachers, email
+    <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to Register trainee teachers, email
 
-      <%= support_email(subject: "Get access to Register trainee teachers") %>.
-      </p>
-    <% end %>
+    <%= support_email(subject: "Get access to Register trainee teachers") %>.
+    </p>
 
   </div>
 </div>

--- a/app/views/sign_in/new.html.erb
+++ b/app/views/sign_in/new.html.erb
@@ -6,7 +6,7 @@
     <p class="govuk-body"> Although you have a DfE Sign-in account, you also need an account
                              for this service.</p>
 
-    <% if FeatureService.enabled?("enable_support_link") %>
+    <% if FeatureService.enabled?("enable_feedback_link") %>
       <p class="govuk-body"> Contact us at
       <%= support_email(subject: "Get access to Register trainee teachers") %> to ask for an account.
       </p>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,9 +23,8 @@ features:
   use_ssl: true
   use_dfe_sign_in: true
   allow_user_creation: false
-  enable_feedback_link: true
+  enable_feedback_link: false
   basic_auth: true
-  enable_support_link: true
   trainee_export: false
 
 dfe_sign_in:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,7 +23,7 @@ features:
   use_ssl: true
   use_dfe_sign_in: true
   allow_user_creation: false
-  enable_feedback_link: false
+  enable_feedback_link: true
   basic_auth: true
   trainee_export: false
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -15,4 +15,4 @@ dfe_sign_in:
 features:
   basic_auth: false
   enable_feedback_link: false
-  enable_support_link: false
+  enable_feedback_link: false

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -15,4 +15,4 @@ dfe_sign_in:
 features:
   basic_auth: false
   enable_feedback_link: false
-  enable_feedback_link: false
+

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -5,7 +5,6 @@ features:
   home_text: true
   use_dfe_sign_in: false
   enable_feedback_link: false
-  enable_feedback_link: false
   trainee_export: true
 
 pagination:

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -5,7 +5,7 @@ features:
   home_text: true
   use_dfe_sign_in: false
   enable_feedback_link: false
-  enable_support_link: false
+  enable_feedback_link: false
   trainee_export: true
 
 pagination:


### PR DESCRIPTION
This restores the support links to the service. The intention was to not solicit feedback in the service as our trial will collect feedback offline - but we should still provide links to the support email in case something goes wrong.

Please check I've updated everything appropriately.