### PR TITLE
[1079] Restore partial dates to programme details form

### DIFF
--- a/app/forms/programme_detail_form.rb
+++ b/app/forms/programme_detail_form.rb
@@ -50,25 +50,11 @@ class ProgrammeDetailForm
   end
 
   def programme_start_date
-    date_hash = { start_year: start_year, start_month: start_month, start_day: start_day }
-    date_args = date_hash.values.map(&:to_i)
-
-    if Date.valid_date?(*date_args)
-      Date.new(*date_args)
-    else
-      Struct.new(*date_hash.keys).new(*date_hash.values)
-    end
+    new_date({ year: start_year, month: start_month, day: start_day })
   end
 
   def programme_end_date
-    date_hash = { end_year: end_year, end_month: end_month, end_day: end_day }
-    date_args = date_hash.values.map(&:to_i)
-
-    if Date.valid_date?(*date_args)
-      Date.new(*date_args)
-    else
-      Struct.new(*date_hash.keys).new(*date_hash.values)
-    end
+    new_date({ year: end_year, month: end_month, day: end_day })
   end
 
   def sanitise_programme_dates
@@ -101,12 +87,15 @@ private
     end
   end
 
+  def new_date(date_hash)
+    date_args = date_hash.values.map(&:to_i)
+    Date.valid_date?(*date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+  end
+
   def age_range
-    if main_age_range.to_sym == :other
-      additional_age_range
-    else
-      main_age_range
-    end
+    return additional_age_range if main_age_range.to_sym == :other
+
+    main_age_range
   end
 
   def age_range_valid

--- a/spec/features/trainees/edit_programme_details_spec.rb
+++ b/spec/features/trainees/edit_programme_details_spec.rb
@@ -49,6 +49,13 @@ feature "programme details", type: :feature do
       and_i_submit_the_form
       then_i_see_error_messages
     end
+
+    scenario "submitting with a partial date" do
+      when_i_visit_the_programme_details_page
+      and_i_fill_in_start_date_only
+      and_i_submit_the_form
+      then_start_date_is_still_populated
+    end
   end
 
   def when_i_visit_the_programme_details_page
@@ -100,6 +107,14 @@ feature "programme details", type: :feature do
 
   def and_the_section_should_be(status)
     expect(review_draft_page.programme_details.status.text).to eq(Progress::STATUSES[status])
+  end
+
+  def and_i_fill_in_start_date_only
+    programme_details_page.set_date_fields("programme_start_date", template.programme_start_date.strftime("%d/%m/%Y"))
+  end
+
+  def then_start_date_is_still_populated
+    expect(programme_details_page.programme_start_date_day.value).to eq(template.programme_start_date.day.to_s)
   end
 
   def then_i_see_error_messages


### PR DESCRIPTION
### Context

https://trello.com/c/BxNrRWzx/1079-partial-dates-not-restored-when-showing-validation-errors

### Changes proposed in this pull request

We have two methods `def programme_start_date` and `def programme_end_date` that rehydrated the programme details form after submission.

When the date not valid (yet) i.e. partially completed, these methods fell back to creating a `Struct`. This should have been in the 'shape' of a date, however we were passing in keys like `start_year`, `start_month`, `start_day` etc. Our form didn't know what these were referencing, so did not pre-fill the fields.

The structs now have the correct keys `year`, `month`, `day`.

### Guidance to review

- Head to a trainees `programme-details/edit` page
- Partially fill in a date
- Click continue
- Check that the form field still contains your partial date.