### PR TITLE
[1077] SPIKE: managing different routes

### DIFF
--- a/app/components/trainees/confirmation/trainee_start_date/view.rb
+++ b/app/components/trainees/confirmation/trainee_start_date/view.rb
@@ -11,7 +11,7 @@ module Trainees
         end
 
         def start_date
-          trainee.commencement_date.strftime("%d %B %Y")
+          trainee.commencement_date&.strftime("%d %B %Y")
         end
       end
     end

--- a/app/components/trainees/confirmation/training_details/view.html.erb
+++ b/app/components/trainees/confirmation/training_details/view.html.erb
@@ -1,18 +1,5 @@
 <%= render SummaryCard::View.new(trainee: trainee, title: t("components.confirmation.training_details.title"),
     heading_level: 2,
-    rows: [
-      {
-        key: t("components.confirmation.start_date.title"),
-        value: trainee_start_date,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> start date</span>'.html_safe,
-                              edit_trainee_training_details_path(trainee))
-      },
-      {
-        key: t("components.confirmation.trainee_id.title"),
-        value: trainee_id,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> trainee ID</span>'.html_safe,
-                              edit_trainee_training_details_path(trainee))
-      },
-    ]
+    rows: rows
   )
 %>

--- a/app/components/trainees/confirmation/training_details/view.rb
+++ b/app/components/trainees/confirmation/training_details/view.rb
@@ -13,6 +13,32 @@ module Trainees
           @not_provided_copy = I18n.t("components.confirmation.not_provided")
         end
 
+        def rows
+          items = []
+          items << start_date_row if trainee.requires_start_date?
+          items << trainee_id_row
+        end
+
+      private
+
+        def start_date_row
+          {
+            key: t("components.confirmation.start_date.title"),
+            value: trainee_start_date,
+            action: govuk_link_to('Change<span class="govuk-visually-hidden"> start date</span>'.html_safe,
+                                  edit_trainee_training_details_path(trainee)),
+          }
+        end
+
+        def trainee_id_row
+          {
+            key: t("components.confirmation.trainee_id.title"),
+            value: trainee_id,
+            action: govuk_link_to('Change<span class="govuk-visually-hidden"> trainee ID</span>'.html_safe,
+                                  edit_trainee_training_details_path(trainee)),
+          }
+        end
+
         def trainee_id
           trainee.trainee_id.presence || not_provided_copy
         end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -2,8 +2,7 @@
 
 module Trainees
   class ConfirmDetailsController < ApplicationController
-    helper_method :trainee_section_key
-    helper_method :confirm_section_title
+    helper_method :trainee_section_key, :confirm_section_title
 
     def show
       authorize trainee
@@ -40,7 +39,7 @@ module Trainees
     end
 
     def trainee_section_key
-      request.path.split("/").intersection(trainee_paths).first.underscore
+      request.path.split("/").intersection(trainee_paths).first&.underscore
     end
 
     def confirm_section_title

--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -16,10 +16,13 @@ class TrainingDetailsForm
                          },
                          if: -> { validate_trainee_id }
 
-  validate :commencement_date_valid, if: -> { validate_commencement_date }
+  validate :commencement_date_valid, if: -> { trainee.requires_start_date? && validate_commencement_date }
 
   after_validation :update_trainee_id, if: -> { validate_trainee_id && errors.empty? }
-  after_validation :update_trainee_commencement_date, if: -> { validate_commencement_date && errors.empty? }
+
+  after_validation :update_trainee_commencement_date, if: lambda {
+    trainee.requires_start_date? && validate_commencement_date && errors.empty?
+  }
 
   def initialize(trainee, validate_trainee_id: true, validate_commencement_date: true)
     @trainee = trainee

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -23,6 +23,10 @@ module Dttp
             "dfe_RouteId@odata.bind" => "/dfe_routes(#{ASSESSMENT_ONLY_DTTP_ID})",
           })
         end
+
+        if trainee.requires_start_date?
+          @params.merge!({ "dfe_commencementdate" => trainee.commencement_date.in_time_zone.iso8601 })
+        end
       end
 
       def to_json(*_args)
@@ -38,7 +42,6 @@ module Dttp
           "dfe_SubjectofUGDegreeId@odata.bind" => "/dfe_jacses(#{degree_subject_id(qualifying_degree.subject)})",
           "dfe_programmestartdate" => trainee.programme_start_date.in_time_zone.iso8601,
           "dfe_programmeenddate" => trainee.programme_end_date.in_time_zone.iso8601,
-          "dfe_commencementdate" => trainee.commencement_date.in_time_zone.iso8601,
           "dfe_traineeid" => trainee.trainee_id || "NOTPROVIDED",
           "dfe_AcademicYearId@odata.bind" => "/dfe_academicyears(#{ACADEMIC_YEAR_2020_2021})",
           "dfe_courselevel" => COURSE_LEVEL_PG, # TODO: this can be PG (12) or UG (20).  Postgrad or undergrad. Hardcoded for now.

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class TrainingRouteManager
+  def initialize(trainee)
+    @trainee = trainee
+  end
+
+  def requires_training_details?
+    feature_enabled?(:training_details) && assessment_only?
+  end
+
+  def requires_start_date?
+    feature_enabled?(:training_details) && false
+  end
+
+private
+
+  def provider_led?
+    training_route == :provider_led
+  end
+
+  def assessment_only?
+    training_route == :assessment_only
+  end
+
+  def training_route
+    @trainee.record_type.to_sym
+  end
+
+  def feature_enabled?(feature_name)
+    FeatureService.enabled?(feature_name)
+  end
+end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -131,6 +131,8 @@ class Trainee < ApplicationRecord
   # Returns draft trainees first, then all trainees in any other state.
   scope :ordered_by_drafts, -> { order(ordered_by_drafts_clause) }
 
+  delegate :requires_training_details?, :requires_start_date?, to: :training_route_manager
+
   def trn_requested!(dttp_id, placement_assignment_dttp_id)
     update!(dttp_id: dttp_id, placement_assignment_dttp_id: placement_assignment_dttp_id)
   end
@@ -174,5 +176,9 @@ class Trainee < ApplicationRecord
       ELSE 1
       END
     SQL
+  end
+
+  def training_route_manager
+    @training_route_manager ||= TrainingRouteManager.new(self)
   end
 end

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -19,6 +19,7 @@
 
       <%= f.govuk_radio_buttons_fieldset(:record_type, legend: { size: "s", text: "What type of training are they doing?", tag: "span"} ) do %>
         <%= f.govuk_radio_button :record_type, :assessment_only, label: { text: t("activerecord.attributes.trainee.record_types.assessment_only") }, link_errors: true %>
+        <%= f.govuk_radio_button :record_type, :provider_led, label: { text: t("activerecord.attributes.trainee.record_types.provider_led") }, link_errors: true %>
         <%= f.govuk_radio_button :record_type, :other, label: { text: "Other" } %>
       <% end %>
 

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -93,7 +93,7 @@
           validator: TrainingDetailsForm.new(@trainee),
           progress_value: @trainee.progress.training_details
         ).status
-      )
+      ) if @trainee.requires_training_details?
     end %>
   </div>
 </div>

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -9,9 +9,11 @@
     <%= form_for(@training_details, url: trainee_training_details_path(@trainee), local: true) do |f| %>
       <h1 class="govuk-heading-l"><%= t('views.forms.training_details.title') %></h1>
 
-      <%= f.govuk_date_field :commencement_date, legend: {
-        text: t("views.forms.training_details.commencement_date.label"), size: 's'
-      }, hint: { text: t("views.forms.training_details.commencement_date.hint", year: Time.zone.now.year) } %>
+      <% if @trainee.requires_start_date? %>
+        <%= f.govuk_date_field :commencement_date, legend: {
+          text: t("views.forms.training_details.commencement_date.label"), size: 's'
+        }, hint: { text: t("views.forms.training_details.commencement_date.hint", year: Time.zone.now.year) } %>
+      <% end %>
 
       <%= f.govuk_text_field :trainee_id, label: {
         text: t('views.forms.training_details.trainee_id.label'), size: 's'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,7 @@ features:
   enable_feedback_link: true
   basic_auth: true
   trainee_export: false
+  training_details: false
 
 dfe_sign_in:
   # Our service name


### PR DESCRIPTION
### Context
https://trello.com/c/pKlQORrL/1077-how-should-we-define-routes

### Changes proposed in this pull request
Proposing a new class `TrainingRouteManager` that defines methods that we can call via an instance of `Trainee` to control the behaviour of components, views, forms and DTTP param objects based on the training route selected.

**Note:** Protecting pages directly requested by the user but not supported by a training route has been left out as it's a bit more complicated and probably something to address later on if it's actually needed.

### Guidance to review
- Open a draft trainee record - it should not display the "Trainee start date and ID" section as it's under a feature flag
- Update `training_details` to `true`  in `settings.yml` and refresh page - the section should now appear
- Click on "Trainee start date and ID". It should only display the trainee ID
- Try entering a blank trainee ID - should only validate for that field
- Change `TrainingRouteManager#requires_start_date?` to return `true` and refreshing the "Trainee start date and ID" edit page. It should now display the start date and validate for both fields.




