### PR TITLE
[1100] Add draft record caption

### DIFF
--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -10,6 +10,8 @@
 <h1 class="govuk-heading-l">
   <% if @trainee.first_names.present? && @trainee.last_name.present? %>
     <span class="govuk-caption-l">Draft record for <%= trainee_name(@trainee) %></span>
+  <% else %>
+    <span class="govuk-caption-l">Draft record</span>
   <% end %>
   Add a trainee
 </h1>


### PR DESCRIPTION
### Context
https://trello.com/c/9UZr8PFs/1100-bug-prod-doesnt-show-the-caption-draft-record-above-the-h1-on-the-trainee-record-overview-page

### Changes proposed in this pull request
Adds caption to h1 in trainee overview/review-draft page 

### Guidance to review
Navigate to /trainees/id/check-draft by adding trainee

