### PR TITLE
[1105-1107] Copy and format changes to trainee views

### DIFF
--- a/app/views/trainees/trainee_ids/edit.html.erb
+++ b/app/views/trainees/trainee_ids/edit.html.erb
@@ -7,9 +7,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @training_details, url: trainee_trainee_id_path, local: true do |f| %>
-      <%= f.govuk_text_field :trainee_id, label: { text: 'Trainee ID', tag: 'h1', size: 'l' }, width: 20 do %>
-          <p class="govuk-body govuk-hint"><%= t('views.forms.training_details.trainee_id.hint') %></p>
-        <% end %>
+      <%= f.govuk_text_field :trainee_id, label: { text: 'Trainee ID', tag: 'h1', size: 'l' }, width: 20 %>
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -11,7 +11,7 @@
 
       <%= f.govuk_date_field :commencement_date, legend: {
         text: t("views.forms.training_details.commencement_date.label"), size: 's'
-      }, hint: { text: t("views.forms.training_details.commencement_date.hint", year: Time.zone.now.year) } %>
+      }, hint: { text: t("views.forms.training_details.commencement_date.hint_html", year: Time.zone.now.year) } %>
 
       <%= f.govuk_text_field :trainee_id, label: {
         text: t('views.forms.training_details.trainee_id.label'), size: 's'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,14 +212,15 @@ en:
           additional_reason: Enter the reason for withdrawal
           <<: *withdrawal_reasons
       training_details:
-        title: Confirm trainee start date and ID
+        title: Trainee start date and ID
         commencement_date:
           label: Date trainee started
-          hint: When this trainee started, rather than the programme start date. For example, 9 2 %{year}
+          hint_html: When the trainee started the course. This may be different to your overall programme start date.<br><br> 
+                     For example, 9 2 %{year}
         trainee_id:
-          label: Trainee ID
-          hint: You can assign your own ID for this trainee. <br>This can help you identify them
-            or search for them in your trainee records later.
+          label: Assign a trainee ID
+          hint: This will help you to identify them and search for them in your trainee records. 
+                We may also use it if we need to get in touch with you about this trainee.
   activerecord:
     attributes:
       trainee:


### PR DESCRIPTION
### Context
https://trello.com/c/2vaarvWY/1107-prod-update-this-hint-text
https://trello.com/c/2PkxWXUM/1106-prod-remove-this-hint-text
https://trello.com/c/BY6xP0lb/1105-prod-change-hint-text-content-and-formatting-to-match-prototype-on-the-trainee-start-date-and-id-page-also-make-h1s-consistent

### Changes proposed in this pull request
Brings app in line with prototype. Changes hint texts and h1s on training-details/edit. And removes hint text from trainee-id/edit. 

### Guidance to review
<img width="855" alt="Screenshot 2021-02-22 at 17 09 03" src="https://user-images.githubusercontent.com/58793682/108743458-b32ec980-7530-11eb-856e-2455c679e644.png">
<img width="664" alt="Screenshot 2021-02-22 at 17 10 00" src="https://user-images.githubusercontent.com/58793682/108743602-dbb6c380-7530-11eb-9339-d25ace6c85fb.png">


