### PR TITLE
[721] Submit some trainees for QTS and confirm with DQT

### DIFF
--- a/app/lib/dttp/params/placement_assignment_outcome.rb
+++ b/app/lib/dttp/params/placement_assignment_outcome.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Dttp
+  module Params
+    class PlacementAssignmentOutcome
+      STANDARDS_PASSED = "bcdd9255-0fc2-e611-80be-00155d010316"
+      SUCCESSFUL_COMPLETION_OF_COURSE = "3f6a46ad-11c2-e611-80be-00155d010316"
+
+      delegate :to_json, to: :params
+
+      def initialize(trainee:)
+        @trainee = trainee
+      end
+
+      def params
+        @params ||= {
+          "dfe_dateleft" => date_left,
+          "dfe_datestandardsassessmentpassed" => date_left,
+          "dfe_StandardAssessedId@odata.bind" => "/dfe_standardassesseds(#{STANDARDS_PASSED})",
+          "dfe_ReasonforLeavingId@odata.bind" => "/dfe_reasonforleavings(#{SUCCESSFUL_COMPLETION_OF_COURSE})",
+          "dfe_recommendtraineetonctl" => true,
+        }
+      end
+
+    private
+
+      attr_reader :trainee
+
+      def date_left
+        # TODO: this will be different for non-assessment only routes
+        # we don't currently collect a leaving date for assessment only
+        date_standards_assessed
+      end
+
+      def date_standards_assessed
+        trainee.outcome_date ? trainee.outcome_date.in_time_zone.iso8601 : nil
+      end
+    end
+  end
+end

--- a/app/services/dttp/recommend_for_qts.rb
+++ b/app/services/dttp/recommend_for_qts.rb
@@ -13,18 +13,20 @@ module Dttp
     end
 
     def call
-      body = {
-        dfe_datestandardsassessmentpassed: trainee.outcome_date.in_time_zone.iso8601,
-      }.to_json
-
       response = Client.patch(
         "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})",
-        body: body,
+        body: params.to_json,
       )
 
       raise Error, response.body if response.code != 204
 
       response
+    end
+
+  private
+
+    def params
+      @params ||= Params::PlacementAssignmentOutcome.new(trainee: trainee)
     end
   end
 end

--- a/spec/lib/dttp/params/placement_assignment_outcome_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_outcome_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  module Params
+    describe PlacementAssignmentOutcome do
+      subject { described_class.new(trainee: trainee).params }
+
+      let(:trainee) { build(:trainee, outcome_date: "1/1/2021") }
+
+      describe "params" do
+        describe "date left" do
+          it "is set to outcome_date" do
+            # TODO: this will be different for non-assessment only routes
+            expect(subject["dfe_dateleft"]).to eq(trainee.outcome_date.in_time_zone.iso8601)
+          end
+        end
+
+        describe "dfe_datestandardsassessmentpassed" do
+          it "is set to outcome_date" do
+            expect(subject["dfe_datestandardsassessmentpassed"]).to eq(trainee.outcome_date.in_time_zone.iso8601)
+          end
+        end
+
+        describe "dfe_StandardAssessedId" do
+          it "is set as STANDARDS_PASSED" do
+            expect(subject["dfe_StandardAssessedId@odata.bind"]).to eq("/dfe_standardassesseds(#{described_class::STANDARDS_PASSED})")
+          end
+        end
+
+        describe "dfe_ReasonforLeavingId" do
+          it "is set as SUCCESSFUL_COMPLETION_OF_COURSE" do
+            expect(subject["dfe_ReasonforLeavingId@odata.bind"]).to eq("/dfe_reasonforleavings(#{described_class::SUCCESSFUL_COMPLETION_OF_COURSE})")
+          end
+        end
+
+        describe "dfe_recommendraineetonctl" do
+          it "is set to true" do
+            expect(subject["dfe_recommendtraineetonctl"]).to eq(true)
+          end
+        end
+      end
+
+      describe "to_json" do
+        subject { described_class.new(trainee: trainee) }
+
+        it "returns params to_json" do
+          expect(subject.to_json).to eq(subject.params.to_json)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/dttp/recommend_for_qts_spec.rb
+++ b/spec/services/dttp/recommend_for_qts_spec.rb
@@ -12,18 +12,21 @@ module Dttp
       let(:outcome_date) { Faker::Date.in_date_period }
       let(:placement_assignment_dttp_id) { SecureRandom.uuid }
       let(:path) { "/dfe_placementassignments(#{placement_assignment_dttp_id})" }
+      let(:expected_params) { { test: "value" }.to_json }
 
       before do
         allow(AccessToken).to receive(:fetch).and_return("token")
         allow(Client).to receive(:patch).and_return(dttp_response)
+        allow(Params::PlacementAssignmentOutcome)
+          .to receive(:new).with(trainee: trainee)
+          .and_return(double(to_json: expected_params))
       end
 
       context "success" do
         let(:dttp_response) { double(code: 204) }
 
         it "sends a PATCH request to set entity property 'dfe_datestandardsassessmentpassed'" do
-          body = { dfe_datestandardsassessmentpassed: outcome_date.in_time_zone.iso8601 }.to_json
-          expect(Client).to receive(:patch).with(path, body: body).and_return(dttp_response)
+          expect(Client).to receive(:patch).with(path, body: expected_params).and_return(dttp_response)
           described_class.call(trainee: trainee)
         end
       end


### PR DESCRIPTION
### Context

We currently send an incomplete payload when we recommend a register trainee for QTS to DTTP. This isn't sufficient to trigger the export to DQT.

### Changes proposed in this pull request

* Add `Params::PlacementAssignmentOutcome` to present the correct parameters. This should currently support 'Assessment Only' candidates but we'll need to revisit this for subsequent routes.

### Guidance to review

Example data sent to dev DTTP from localhost:

<img width="1363" alt="Screenshot 2021-02-22 at 22 42 07" src="https://user-images.githubusercontent.com/5216/108782153-f9048580-7562-11eb-9e95-cba72324061a.png">

To test:
* create a trainee
* submit for TRN
* set the TRN in DTTP back office
* manually run a `RetrieveTrnJob` in the console
* recommend the trainee for QTS
* state, params etc should be updated in DTTP

I'll run this in QA and confirm with the operations team. 
