### PR TITLE
[1069] Prevent TRN displaying as a phone number in IOS safari

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, property: 'og:image', content: asset_pack_path('media/images/govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
+    <%= tag :meta, name: 'format-detection', content: 'telephone=no' %>
     <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>


### PR DESCRIPTION
### Context

 Prevent TRN number displaying as a phone number in IOS Safari

### Guidance to review

- Using Safari on an iphone
- Navigate to https://rtt-review-pr-570.herokuapp.com/trainees?page=2 and find `Shoshana McKenzie`
- Check that their TRN number does not display as a phone number 
- Click into `Shoshana McKenzie` and check that the TRN number does not display like a phone number on that page too
- You can check another review app or the trello ticket to see how the TRN number used to display
- 🚢 