### PR TITLE
Target bat-prod space for Sandbox target in Make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ production:
 
 sandbox:
 	$(eval env=sandbox)
-	$(eval env_config=production)
-	$(eval space=sandbox)
+	$(eval env_config=sandbox)
+	$(eval space=bat-prod)
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-production)
 
 install-fetch-config:


### PR DESCRIPTION
### Context

Until now, Sandbox target in the make file has its `space` variable set to sandbox. However, the application `register-sandbox` is deployed to `bat-prod`. This makes it difficult to issue `make sandbox console`

### Changes proposed in this pull request

The  `space` variable under the Sandbox target in the make file needs to be changed to `space=bat-prod`

### Guidance to review

