### PR TITLE
[1054] Add aria-describedby to row status

### DIFF
--- a/app/components/status_tag/view.html.erb
+++ b/app/components/status_tag/view.html.erb
@@ -1,1 +1,1 @@
-<%= render GovukComponent::Tag.new(text: "<span class='govuk-visually-hidden'>Trainee status </span>".html_safe + status, colour: status_colour, classes: classes) %>
+<%= render GovukComponent::Tag.new(text: "<span class='govuk-visually-hidden'>Status </span>".html_safe + status, colour: status_colour, classes: classes) %>

--- a/app/components/task_list/view.html.erb
+++ b/app/components/task_list/view.html.erb
@@ -1,11 +1,15 @@
 <%= tag.ol(class: classes, **html_attributes) do %>
   <% rows.each do |row| %>
     <%= tag.li(class: row.classes, **row.html_attributes) do %>
-      <a href="<%= row.get_path  %>" class="govuk-link app-task-list__key">
+      <a href="<%= row.get_path  %>" class="govuk-link app-task-list__key" aria-describedby="<%= row.status_id  %>" >
         <%= row.task_name %>
       </a>
       <% if any_row_has_status? %>
-        <%= render GovukComponent::Tag.new(text: row.status, colour: row.get_status_colour) %>
+        <%= render GovukComponent::Tag.new(
+          text: "<span class='govuk-visually-hidden'>Status </span>".html_safe + row.status, 
+          colour: row.get_status_colour, 
+          html_attributes: { id: row.status_id }
+        ) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/task_list/view.rb
+++ b/app/components/task_list/view.rb
@@ -42,6 +42,10 @@ private
       }.fetch(status, "grey")
     end
 
+    def status_id
+      "#{task_name.downcase.parameterize}-status"
+    end
+
   private
 
     def default_classes

--- a/spec/components/task_list/view_spec.rb
+++ b/spec/components/task_list/view_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe TaskList::View do
         let(:status) { "completed" }
 
         it "renders the correct tag status" do
-          expect(component.find(".govuk-tag").text).to eq(status)
+          expect(component.find(".govuk-tag").text).to include(status)
         end
 
         it "renders the correct tag colour" do
@@ -46,7 +46,7 @@ RSpec.describe TaskList::View do
         let(:status) { "in progress" }
 
         it "renders the correct tag status" do
-          expect(component.find(".govuk-tag").text).to eq(status)
+          expect(component.find(".govuk-tag").text).to include(status)
         end
 
         it "renders the correct tag colour" do
@@ -58,13 +58,27 @@ RSpec.describe TaskList::View do
         let(:status) { "not started" }
 
         it "renders the correct tag status" do
-          expect(component.find(".govuk-tag").text).to eq(status)
+          expect(component.find(".govuk-tag").text).to include(status)
         end
 
         it "renders the correct tag colour" do
           expect(component).to have_selector(".govuk-tag--grey")
         end
       end
+    end
+  end
+
+  describe "#status_id" do
+    subject do
+      TaskList::View::Row.new(
+        task_name: "some key",
+        path: "some_path",
+        status: "completed",
+      )
+    end
+
+    it "returns a string id of the row status" do
+      expect(subject.status_id).to eq("some-key-status")
     end
   end
 end

--- a/spec/features/trainees/degrees/adding_degree_spec.rb
+++ b/spec/features/trainees/degrees/adding_degree_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Adding a degree" do
   describe "summary page" do
     scenario "no degrees entered" do
       and_i_visit_the_review_draft_page
-      then_the_degree_status_should_be(:not_started)
+      then_the_degree_status_should_be(not_started)
     end
   end
 
@@ -40,19 +40,19 @@ RSpec.feature "Adding a degree" do
         confirm_details_page.delete_button.click
         then_i_see_a_flash_message
         and_i_visit_the_review_draft_page
-        then_the_degree_status_should_be(:not_started)
+        then_the_degree_status_should_be(not_started)
       end
 
       scenario "the user confirms degree details" do
         and_confirm_my_details
         then_i_am_redirected_to_the_review_draft_page
-        then_the_degree_status_should_be(:completed)
+        then_the_degree_status_should_be(completed)
       end
 
       scenario "the user does not confirm degree details" do
         and_i_click_continue
         then_i_am_redirected_to_the_review_draft_page
-        then_the_degree_status_should_be(:in_progress)
+        then_the_degree_status_should_be(in_progress)
       end
     end
 
@@ -198,7 +198,7 @@ private
   end
 
   def then_the_degree_status_should_be(status)
-    expect(review_draft_page.degree_details.status.text).to eq(Progress::STATUSES[status])
+    expect(review_draft_page.degree_details.status.text).to eq(status)
   end
 
   def then_i_see_a_flash_message

--- a/spec/features/trainees/diversities/diversity_progress_spec.rb
+++ b/spec/features/trainees/diversities/diversity_progress_spec.rb
@@ -10,7 +10,7 @@ feature "completing the diversity section", type: :feature do
 
   scenario "renders a 'not started' status when diversity details are not provided" do
     and_i_visit_the_review_draft_page
-    then_the_diversity_section_should_be(:not_started)
+    then_the_diversity_section_should_be(not_started)
   end
 
   scenario "renders an 'in progress' status when diversity information partially provided" do
@@ -20,13 +20,13 @@ feature "completing the diversity section", type: :feature do
     and_unconfirm_my_details
     and_i_visit_the_record_page
     and_i_visit_the_review_draft_page
-    then_the_diversity_section_should_be(:in_progress)
+    then_the_diversity_section_should_be(in_progress)
   end
 
   scenario "renders a completed status when valid diversity information provided" do
     given_valid_diversity_information
     and_i_visit_the_review_draft_page
-    then_the_diversity_section_should_be(:completed)
+    then_the_diversity_section_should_be(completed)
   end
 
 private
@@ -52,7 +52,7 @@ private
   end
 
   def then_the_diversity_section_should_be(status)
-    expect(review_draft_page.diversity_section.status.text).to eq(Progress::STATUSES[status])
+    expect(review_draft_page.diversity_section.status.text).to eq(status)
   end
 
   def when_i_visit_the_diversity_confirmation_page

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -139,12 +139,12 @@ private
 
   def then_the_personal_details_section_should_be_completed
     review_draft_page.load(id: trainee.slug)
-    expect(review_draft_page.personal_details.status.text).to eq(Progress::STATUSES[:completed])
+    expect(review_draft_page.personal_details.status.text).to eq(completed)
   end
 
   def then_the_personal_details_section_should_be_in_progress
     review_draft_page.load(id: trainee.slug)
-    expect(review_draft_page.personal_details.status.text).to eq(Progress::STATUSES[:in_progress])
+    expect(review_draft_page.personal_details.status.text).to eq(in_progress)
   end
 
   def then_i_see_a_flash_message

--- a/spec/features/trainees/edit_programme_details_spec.rb
+++ b/spec/features/trainees/edit_programme_details_spec.rb
@@ -12,7 +12,7 @@ feature "programme details", type: :feature do
   describe "tracking the progress" do
     scenario "renders a 'not started' status when no details provided" do
       review_draft_page.load(id: trainee.slug)
-      and_the_section_should_be(:not_started)
+      and_the_section_should_be(not_started)
     end
 
     scenario "renders an 'in progress' status when details partially provided" do
@@ -21,7 +21,7 @@ feature "programme details", type: :feature do
       and_i_submit_the_form
       and_i_confirm_my_details(checked: false, section: programme_details_section)
       then_i_am_redirected_to_the_review_draft_page
-      and_the_section_should_be(:in_progress)
+      and_the_section_should_be(in_progress)
     end
 
     scenario "renders a completed status when valid details provided" do
@@ -30,7 +30,7 @@ feature "programme details", type: :feature do
       and_i_submit_the_form
       and_i_confirm_my_details(section: programme_details_section)
       then_i_am_redirected_to_the_review_draft_page
-      and_the_section_should_be(:completed)
+      and_the_section_should_be(completed)
     end
   end
 
@@ -106,7 +106,7 @@ feature "programme details", type: :feature do
   end
 
   def and_the_section_should_be(status)
-    expect(review_draft_page.programme_details.status.text).to eq(Progress::STATUSES[status])
+    expect(review_draft_page.programme_details.status.text).to eq(status)
   end
 
   def and_i_fill_in_start_date_only

--- a/spec/features/trainees/edit_trainee_record_spec.rb
+++ b/spec/features/trainees/edit_trainee_record_spec.rb
@@ -46,7 +46,7 @@ feature "edit trainee record", type: :feature do
 
   def then_i_see_the_trn_status
     state_text = "activerecord.attributes.trainee.states.#{trainee.state}"
-    expect(record_page.trn_status.text).to eq("Trainee status " + I18n.t(state_text).downcase)
+    expect(record_page.trn_status.text).to eq("Status " + I18n.t(state_text).downcase)
   end
 
   def when_i_visit_the_trainee_record_page

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -161,5 +161,23 @@ module Features
     def privacy_policy_page
       @privacy_policy_page ||= PageObjects::PrivacyPolicy.new
     end
+
+    def not_started
+      progress_with_prefix(Progress::STATUSES[:not_started])
+    end
+
+    def in_progress
+      progress_with_prefix(Progress::STATUSES[:in_progress])
+    end
+
+    def completed
+      progress_with_prefix(Progress::STATUSES[:completed])
+    end
+
+  private
+
+    def progress_with_prefix(status)
+      "Status #{status}"
+    end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/wJ9hiLdU/1054-accessibility-fix-implement-aria-describedby-relationship-to-the-task-list-links-and-tags

### Changes proposed in this pull request

- Adding `aria describedby` in the link and an `id` on the corresponding status tag helps create the relationship from an accessibility point of view.
  
### Guidance to review

<img width="1192" alt="Screenshot 2021-02-23 at 15 49 14" src="https://user-images.githubusercontent.com/616080/108870652-32cf9d80-75f0-11eb-8e65-d1f0d70033ff.png">


