### PR TITLE
[1119] Fix cookie overflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,8 @@ gem "stateful_enum"
 # Pagination
 gem "kaminari"
 
+gem "activerecord-session_store"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,12 @@ GEM
     activerecord (6.1.3)
       activemodel (= 6.1.3)
       activesupport (= 6.1.3)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (6.1.3)
       actionpack (= 6.1.3)
       activejob (= 6.1.3)
@@ -219,6 +225,7 @@ GEM
     mini_portile2 (2.5.0)
     minitest (5.14.3)
     msgpack (1.4.2)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.5)
@@ -468,6 +475,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   amazing_print (~> 1.2)
   audited (~> 4.9)
   bootsnap (>= 1.1.0)

--- a/app/jobs/session_store_truncate_job.rb
+++ b/app/jobs/session_store_truncate_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SessionStoreTruncateJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    # Copying from: rake db:sessions:trim
+    cutoff_period = (ENV["SESSION_DAYS_TRIM_THRESHOLD"] || 30).to_i.days.ago
+    ActiveRecord::SessionStore::Session.where("updated_at < ?", cutoff_period).delete_all
+  end
+end

--- a/app/jobs/session_store_truncate_job.rb
+++ b/app/jobs/session_store_truncate_job.rb
@@ -5,7 +5,7 @@ class SessionStoreTruncateJob < ApplicationJob
 
   def perform
     # Copying from: rake db:sessions:trim
-    cutoff_period = (ENV["SESSION_DAYS_TRIM_THRESHOLD"] || 30).to_i.days.ago
+    cutoff_period = Settings.session_store.expire_after_days.days.ago
     ActiveRecord::SessionStore::Session.where("updated_at < ?", cutoff_period).delete_all
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,6 @@ module RegisterTraineeTeachers
     config.middleware.use Rack::Deflater
     config.active_job.queue_adapter = :sidekiq
 
-    config.session_store :cookie_store, key: "_register_trainee_teachers_session", expire_after: 6.hours
+    config.session_store :active_record_store, key: "_register_trainee_teachers_session"
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -46,3 +46,6 @@ sidekiq:
 
 pagination:
   records_per_page: 100
+
+session_store:
+  expire_after_days: 30

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -2,3 +2,7 @@ update_trainees_to_dttp:
   cron: "0 0 * * *"
   class: "QueueTraineeUpdatesJob"
   queue: dttp
+truncate_activerecord_session_store:
+  cron: "0 0 * * *"
+  class: "SessionStoreTruncateJob"
+  queue: default

--- a/db/migrate/20210224104155_add_sessions_table.rb
+++ b/db/migrate/20210224104155_add_sessions_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddSessionsTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_09_141131) do
+ActiveRecord::Schema.define(version: 2021_02_24_104155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,15 @@ ActiveRecord::Schema.define(version: 2021_02_09_141131) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "trainee_disabilities", force: :cascade do |t|

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :session, class: ActiveRecord::SessionStore::Session do
+    session_id { SecureRandom.uuid }
+    data { Faker::Lorem.paragraph }
+
+    trait :recent_session do
+      created_at { 1.day.ago }
+      updated_at { 1.day.ago }
+    end
+
+    trait :old_session do
+      created_at { Settings.session_store.expire_after_days.days.ago }
+      updated_at { Settings.session_store.expire_after_days.days.ago }
+    end
+  end
+end

--- a/spec/jobs/session_store_truncate_job_spec.rb
+++ b/spec/jobs/session_store_truncate_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SessionStoreTruncateJob do
+  include ActiveJob::TestHelper
+
+  context "with sessions" do
+    let(:sessions) do
+      create(:session, :recent_session)
+      create(:session, :old_session)
+    end
+
+    before do
+      sessions
+    end
+
+    it "should enqueue job" do
+      expect {
+        described_class.perform_later
+      }.to have_enqueued_job
+    end
+
+    it "should delete only old session" do
+      expect(ActiveRecord::SessionStore::Session.count).to eq(2)
+      described_class.perform_now
+      expect(ActiveRecord::SessionStore::Session.count).to eq(1)
+    end
+  end
+end

--- a/spec/jobs/session_store_truncate_job_spec.rb
+++ b/spec/jobs/session_store_truncate_job_spec.rb
@@ -21,7 +21,7 @@ describe SessionStoreTruncateJob do
       }.to have_enqueued_job
     end
 
-    it "should delete only old session" do
+    it "deletes only old sessions" do
       expect(ActiveRecord::SessionStore::Session.count).to eq(2)
       described_class.perform_now
       expect(ActiveRecord::SessionStore::Session.count).to eq(1)

--- a/spec/jobs/session_store_truncate_job_spec.rb
+++ b/spec/jobs/session_store_truncate_job_spec.rb
@@ -15,7 +15,7 @@ describe SessionStoreTruncateJob do
       sessions
     end
 
-    it "should enqueue job" do
+    it "enqueues job" do
       expect {
         described_class.perform_later
       }.to have_enqueued_job


### PR DESCRIPTION
### Context

https://trello.com/c/jjZUDyqQ/1119-m-fix-cookie-overflow

### Changes proposed in this pull request

* Replace session store cookie_store with active_record_store, gem `activerecord-session_store`
* New ActiveJob that truncates the table of rows older than 30 days (by default, can be changed with ENV variable `SESSION_DAYS_TRIM_THRESHOLD`)
* ActiveJob runs nightly (midnight), added to sidekiq-cron.
* New migration to create "sessions" table.

### Guidance to review
* Gem URL: https://github.com/rails/activerecord-session_store
