### PR TITLE
Remove custom duration format

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -3,9 +3,7 @@
 class CustomLogFormatter < SemanticLogger::Formatters::Raw
   def call(log, logger)
     super(log, logger)
-    format_add_type
     format_job_data
-    format_duration
     format_exception
     format_json_message_context
     format_backtrace
@@ -14,18 +12,9 @@ class CustomLogFormatter < SemanticLogger::Formatters::Raw
 
 private
 
-  def format_add_type
-    hash[:type] = "rails"
-  end
-
   def format_job_data
     hash[:job_id] = RequestStore.store[:job_id] if RequestStore.store[:job_id].present?
     hash[:job_queue] = RequestStore.store[:job_queue] if RequestStore.store[:job_queue].present?
-  end
-
-  def format_duration
-    hash[:duration] = hash[:duration_ms]
-    hash[:duration_ms] = nil
   end
 
   def format_exception


### PR DESCRIPTION
### Context
Logit filters are configured for the default rails duration and duration_ms format and other apps.

It is not required to swap `duration` and `duration_ms` filter.
Also now that register is logging to the same logit stack as other PaaS apps, it is required to follow the same pattern as the other apps.
Find and Publish follow the default rails format for the duration fields.

And application logs have `type: application` configured in logit filters.

### Changes proposed in this pull request
Use default rails formation for `duration` and `duration_ms` fields.
