### PR TITLE
[1048] Disable browser auto-fill

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,5 @@
+> 0.5%
+last 2 versions
+Firefox ESR
+not dead
+ie 11

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
 
   def form_with(*args, &block)
     options = args.extract_options!
-    defaults = { html: { novalidate: true } }
+    defaults = { html: { novalidate: true, autocomplete: :off } }
     super(*args << defaults.deep_merge(options), &block)
   end
 

--- a/app/views/system_admin/providers/new.html.erb
+++ b/app/views/system_admin/providers/new.html.erb
@@ -10,8 +10,8 @@
         Add a provider
       </h1>
 
-      <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20 %>
-      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20 %>
+      <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20, autocomplete: :disabled %>
+      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :disabled %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/system_admin/users/new.html.erb
+++ b/app/views/system_admin/users/new.html.erb
@@ -15,10 +15,10 @@
         Add a user for <%= @provider.name %>
       </h1>
 
-      <%= f.govuk_text_field :first_name, label: { text: "First Name", size: "s" }, width: 20 %>
-      <%= f.govuk_text_field :last_name, label: { text: "Last Name", size: "s" }, width: 20 %>
-      <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: 20 %>
-      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20 %>
+      <%= f.govuk_text_field :first_name, label: { text: "First Name", size: "s" }, width: 20, autocomplete: :disabled %>
+      <%= f.govuk_text_field :last_name, label: { text: "Last Name", size: "s" }, width: 20, autocomplete: :disabled %>
+      <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: 20, autocomplete: :disabled %>
+      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :disabled %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -14,34 +14,37 @@
       <%= f.govuk_radio_buttons_fieldset(:locale_code, legend: { text: "Where does the trainee live?", size: "s" }, classes: "locale") do %>
         <%= f.govuk_radio_button :locale_code, :non_uk, label: { text: "Outside the UK" }, link_errors: true  do %>
           <%= f.govuk_text_area :international_address,
-            width: "one-quarter",
-            label: { text: "Home address" } %>
+                                width: "one-quarter",
+                                label: { text: "Home address" },
+                                autocomplete: :disabled %>
         <% end %>
 
         <%= f.govuk_radio_button :locale_code, :uk, label: { text: "In the UK" } do %>
           <%= f.govuk_fieldset legend: { text: "Home address", size: "s" } do %>
             <%= f.govuk_text_field :address_line_one,
-              width: "full",
-              label: { text: "Building and street" } %>
+                                   width: "full",
+                                   label: { text: "Building and street" },
+                                   autocomplete: :disabled %>
 
             <%= f.govuk_text_field :address_line_two,
-              width: "full",
-              label: { text: "Address line 2", hidden: true } %>
+                                   width: "full",
+                                   label: { text: "Address line 2", hidden: true },
+                                   autocomplete: :disabled %>
 
             <%= f.govuk_text_field :town_city,
-              width: "two-thirds",
-              label: { text: "Town or city" } %>
+                                   width: "two-thirds",
+                                   label: { text: "Town or city" },
+                                   autocomplete: :disabled %>
 
-            <%= f.govuk_text_field :postcode,
-              width: 10,
-              label: { text: "Postal code" } %>
+            <%= f.govuk_text_field :postcode, width: 10, label: { text: "Postal code" }, autocomplete: :disabled %>
           <% end %>
         <% end %>
       <% end %>
 
       <%= f.govuk_email_field :email,
-        width: "two-thirds",
-        label: { text: "Email address", size: "s" } %>
+                              width: "two-thirds",
+                              label: { text: "Email address", size: "s" },
+                              autocomplete: :disabled %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/trainees/degrees/_non_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_non_uk_degree_form.html.erb
@@ -20,7 +20,10 @@
     html_attributes: { "data-show-all-values" => false }
   ) %>
 
-  <%= f.govuk_text_field :graduation_year, label: { text: "Graduation year", size: 's' }, width: "one-quarter"  %>
+  <%= f.govuk_text_field :graduation_year,
+                         label: { text: "Graduation year", size: 's' },
+                         width: "one-quarter",
+                         autocomplete: :disabled  %>
 
   <div class="govuk-form-group">
     <%= f.govuk_radio_buttons_fieldset :non_uk_degree, legend: { text: "Select the NARIC comparable UK degree", size: 's'} do %>

--- a/app/views/trainees/diversity/disability_details/edit.html.erb
+++ b/app/views/trainees/diversity/disability_details/edit.html.erb
@@ -22,7 +22,10 @@
             <%= f.govuk_check_box :disability_ids, disability.id, label: { text: disability.name, size: "s" }, hint: { text: disability.description }, link_errors: index.zero? %>
           <% else %>
             <%= f.govuk_check_box :disability_ids, disability.id, label: { text: disability.name, size: "s" }, link_errors: index.zero? do %>
-              <%= f.govuk_text_field :additional_disability, label: { text: "Describe their disability (optional)" }, width: "two-thirds" %>
+              <%= f.govuk_text_field :additional_disability,
+                                     label: { text: "Describe their disability (optional)" },
+                                     width: "two-thirds",
+                                     autocomplete: :disabled %>
             <% end %>
           <% end %>
 

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -17,9 +17,9 @@
 
         <%= f.govuk_radio_buttons_fieldset(
           :ethnic_background,
-          legend: { 
-            text: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")), 
-            tag: "h1", 
+          legend: {
+            text: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")),
+            tag: "h1",
             size: "l" }
         ) do %>
 
@@ -29,6 +29,7 @@
                 <%= f.govuk_text_field(
                   :additional_ethnic_background,
                   width: "two-thirds",
+                  autocomplete: :disabled,
                   label: { text: I18n.t("views.forms.ethnic_backgrounds.another_ethnic_background_labels.#{@trainee.ethnic_group}") }
                 ) %>
               <% end %>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -11,13 +11,25 @@
 
       <h1 class="govuk-heading-l">Trainee personal details</h1>
 
-      <%= f.govuk_text_field :first_names, label: { text: 'First names', size: 's' }, width: 'three-quarters' %>
+      <%= f.govuk_text_field :first_names,
+                             label: { text: 'First names', size: 's' },
+                             width: 'three-quarters',
+                             autocomplete: :disabled %>
 
-      <%= f.govuk_text_field :middle_names, label: { text: 'Middle names', size: 's' }, width: 'three-quarters' %>
+      <%= f.govuk_text_field :middle_names,
+                             label: { text: 'Middle names', size: 's' },
+                             width: 'three-quarters',
+                             autocomplete: :disabled  %>
 
-      <%= f.govuk_text_field :last_name, label: { text: 'Last names', size: 's' }, width: 'three-quarters' %>
+      <%= f.govuk_text_field :last_name,
+                             label: { text: 'Last names', size: 's' },
+                             width: 'three-quarters',
+                             autocomplete: :disabled %>
 
-      <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: 'Date of birth', size: 's' }, hint: { text: 'For example, 31 3 1980' } %>
+      <%= f.govuk_date_field :date_of_birth,
+                             date_of_birth: true,
+                             legend: { text: 'Date of birth', size: 's' },
+                             hint: { text: 'For example, 31 3 1980' } %>
 
       <%= f.govuk_radio_buttons_fieldset(:gender, legend: { text: "Gender", size: "s" }, classes: "gender") do %>
         <%= f.govuk_radio_button :gender, :female, label: { text: "Female" }, link_errors: true %>
@@ -27,7 +39,10 @@
         <%= f.govuk_radio_button :gender, :gender_not_provided, label: { text: "Not provided" } %>
       <% end %>
 
-      <%= f.govuk_check_boxes_fieldset :nationality_ids, legend: { text: "Nationality", size: 's' }, hint: { text: "Select all that apply" }, classes: "nationality" do %>
+      <%= f.govuk_check_boxes_fieldset :nationality_ids,
+                                       legend: { text: "Nationality", size: 's' },
+                                       hint: { text: "Select all that apply" },
+                                       classes: "nationality" do %>
         <% format_nationalities(@nationalities).each do |nationality| %>
           <%= f.govuk_check_box(
               :nationality_ids,

--- a/app/views/trainees/trainee_ids/edit.html.erb
+++ b/app/views/trainees/trainee_ids/edit.html.erb
@@ -7,7 +7,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @training_details, url: trainee_trainee_id_path, local: true do |f| %>
-      <%= f.govuk_text_field :trainee_id, label: { text: 'Trainee ID', tag: 'h1', size: 'l' }, width: 20 %>
+      <%= f.govuk_text_field :trainee_id,
+                             label: { text: 'Trainee ID', tag: 'h1', size: 'l' },
+                             width: 20,
+                             autocomplete: :disabled %>
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -15,7 +15,7 @@
 
       <%= f.govuk_text_field :trainee_id, label: {
         text: t('views.forms.training_details.trainee_id.label'), size: 's'
-      }, hint: { text: t('views.forms.training_details.trainee_id.hint').html_safe }, width: 20 %>
+      }, hint: { text: t('views.forms.training_details.trainee_id.hint').html_safe }, width: 20, autocomplete: :disabled %>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -36,7 +36,8 @@
         <%= f.govuk_radio_button :withdraw_reason, WithdrawalReasons::FOR_ANOTHER_REASON,
                                  label: { text: t("views.forms.withdrawal_reasons.labels.for_another_reason") } do %>
           <%= f.govuk_text_field :additional_withdraw_reason,
-                                 label: { text: t("views.forms.withdrawal_reasons.labels.additional_reason") } %>
+                                 label: { text: t("views.forms.withdrawal_reasons.labels.additional_reason") },
+                                 autocomplete: :disabled%>
         <% end %>
 
         <%= f.govuk_radio_button :withdraw_reason, WithdrawalReasons::UNKNOWN,

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -2,6 +2,7 @@ import '../scripts/govuk_assets_import'
 import '../styles/application.scss'
 import '../scripts/components'
 import '../scripts/global/nationality_select'
+import '../scripts/global/disable-browser-autofill'
 import CookieBanner from '../scripts/cookie_banner'
 import { initAll } from 'govuk-frontend'
 

--- a/app/webpacker/scripts/global/disable-browser-autofill.js
+++ b/app/webpacker/scripts/global/disable-browser-autofill.js
@@ -2,6 +2,11 @@ function disableBrowserAutofill () {
   const dataAttributeName = 'data-nameoriginal'
   const inputTypes = ['text', 'tel', 'email', 'number']
 
+  // Missing forEach on NodeList for IE11
+  if (window.NodeList && !window.NodeList.prototype.forEach) {
+    window.NodeList.prototype.forEach = Array.prototype.forEach
+  }
+
   document.querySelectorAll('form').forEach(form => {
     if (form.getAttribute('autocomplete') === 'off') {
       const inputs = [...form.querySelectorAll('input[autocomplete]')].filter(input => inputTypes.includes(input.type))

--- a/app/webpacker/scripts/global/disable-browser-autofill.js
+++ b/app/webpacker/scripts/global/disable-browser-autofill.js
@@ -1,0 +1,23 @@
+function disableBrowserAutofill () {
+  const dataAttributeName = 'data-nameoriginal'
+  const inputTypes = ['text', 'tel', 'email', 'number']
+
+  document.querySelectorAll('form').forEach(form => {
+    if (form.getAttribute('autocomplete') === 'off') {
+      const inputs = [...form.querySelectorAll('input[autocomplete]')].filter(input => inputTypes.includes(input.type))
+
+      inputs.forEach(input => {
+        input.setAttribute(dataAttributeName, input.name)
+        input.name = Math.random().toString(36).substring(7) // NOSONAR
+      })
+
+      form.addEventListener('submit', () => {
+        inputs.forEach(input => {
+          input.name = input.getAttribute(dataAttributeName)
+        })
+      })
+    }
+  })
+}
+
+disableBrowserAutofill()


### PR DESCRIPTION
### Context
https://trello.com/c/xHwsbyBY/1048-spike-1day-disable-browser-autofill-autocomplete-throughout-service

### Changes proposed in this pull request
There are two parts to the solution:

Part 1: add `autocomplete="disabled"` to input field (can be any string except "off") to prevent Chrome from activating managed address auto-fill.

Part 2: A progressive enhancement solution that disables Chrome's auto suggestion based on past input values. We remove the name attribute on the given input. The script replaces the name attribute with a random string and saves it as a data attribute. When the form gets submitted all name attributes will be replaced with their previous value.



### Guidance to review
- Make sure have entered your name and address under Chrome => Preferences => Auto-fill => Addresses and more
- Visit an edit page
- Click on the field - no auto-fill option is presented (both managed addresses and past input suggestions)
