### PR TITLE
[1150] removed caching on dttp access_token, added status and headers to dttp service errors

### DIFF
--- a/app/lib/dttp/access_token.rb
+++ b/app/lib/dttp/access_token.rb
@@ -7,9 +7,6 @@ module Dttp
       base_uri "https://login.microsoftonline.com"
     end
 
-    TOKEN_EXPIRY_TIME = 3599.seconds
-    CACHED_TOKEN_EXPIRY_TIME = TOKEN_EXPIRY_TIME - 5.seconds
-
     REQUEST_BODY = {
       grant_type: "client_credentials",
       client_id: Settings.dttp.client_id,
@@ -18,10 +15,8 @@ module Dttp
     }.freeze
 
     def self.fetch
-      Rails.cache.fetch("dttp-access-token", expires_in: CACHED_TOKEN_EXPIRY_TIME) do
-        response = Client.post("/#{Settings.dttp.tenant_id}/oauth2/v2.0/token", body: REQUEST_BODY)
-        JSON.parse(response.body)["access_token"]
-      end
+      response = Client.post("/#{Settings.dttp.tenant_id}/oauth2/v2.0/token", body: REQUEST_BODY)
+      JSON.parse(response.body)["access_token"]
     end
   end
 end

--- a/app/services/dttp/contact_update.rb
+++ b/app/services/dttp/contact_update.rb
@@ -27,7 +27,9 @@ module Dttp
 
     def dttp_update(path, body)
       response = Client.patch(path, body: body.to_json)
-      raise Error, response.body if response.code != 204
+      if response.code != 204
+        raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
     end
   end
 end

--- a/app/services/dttp/recommend_for_qts.rb
+++ b/app/services/dttp/recommend_for_qts.rb
@@ -22,7 +22,9 @@ module Dttp
         body: body,
       )
 
-      raise Error, response.body if response.code != 204
+      if response.code != 204
+        raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
 
       response
     end

--- a/app/services/dttp/retrieve_qts.rb
+++ b/app/services/dttp/retrieve_qts.rb
@@ -14,7 +14,9 @@ module Dttp
 
     def call
       response = Client.get("/contacts(#{trainee.dttp_id})?$select=dfe_qtsawardflag")
-      raise HttpError, response.body unless response.code == 200
+      if response.code != 200
+        raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
 
       JSON(response.body)["dfe_qtsawardflag"]
     end

--- a/app/services/dttp/retrieve_trn.rb
+++ b/app/services/dttp/retrieve_trn.rb
@@ -14,7 +14,9 @@ module Dttp
 
     def call
       response = Client.get("/contacts(#{trainee.dttp_id})?$select=dfe_trn")
-      raise HttpError, response.body unless response.code == 200
+      if response.code != 200
+        raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
 
       JSON(response.body)["dfe_trn"]
     end

--- a/app/services/dttp/update_trainee_status.rb
+++ b/app/services/dttp/update_trainee_status.rb
@@ -21,7 +21,9 @@ module Dttp
 
     def call
       response = Client.patch(path, body: params.to_json)
-      raise Error, response.body if response.code != 204
+      if response.code != 204
+        raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
     end
 
   private

--- a/spec/lib/dttp/access_token_spec.rb
+++ b/spec/lib/dttp/access_token_spec.rb
@@ -31,18 +31,6 @@ module Dttp
       it "returns the access token" do
         expect(described_class.fetch).to eq("token")
       end
-
-      context "with cache" do
-        before do
-          allow(Rails.cache).to receive(:fetch).and_return("token")
-        end
-
-        it "caches the access token after the initial request" do
-          expect(described_class::Client).to receive(:post).never
-
-          described_class.fetch
-        end
-      end
     end
   end
 end

--- a/spec/services/dttp/contact_update_spec.rb
+++ b/spec/services/dttp/contact_update_spec.rb
@@ -38,14 +38,16 @@ module Dttp
       end
 
       context "error" do
-        let(:error_body) { "error" }
-        let(:contact_response) { double(code: 405, body: error_body) }
+        let(:status) { 405 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:contact_response) { double(code: status, body: body, headers: headers) }
 
         it "raises an error exception" do
           expect(Client).to receive(:patch).and_return(contact_response)
           expect {
             described_class.call(trainee: trainee)
-          }.to raise_error(Dttp::ContactUpdate::Error, error_body)
+          }.to raise_error(Dttp::ContactUpdate::Error, "status: #{status}, body: #{body}, headers: #{headers}")
         end
       end
     end

--- a/spec/services/dttp/recommend_for_qts_spec.rb
+++ b/spec/services/dttp/recommend_for_qts_spec.rb
@@ -29,13 +29,15 @@ module Dttp
       end
 
       context "error" do
-        let(:error_body) { "error" }
-        let(:dttp_response) { double(code: 405, body: error_body) }
+        let(:status) { 405 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:dttp_response) { double(code: status, body: body, headers: headers) }
 
         it "raises an error exception" do
           expect {
             described_class.call(trainee: trainee)
-          }.to raise_error(Dttp::RecommendForQTS::Error, error_body)
+          }.to raise_error(Dttp::RecommendForQTS::Error, "status: #{status}, body: #{body}, headers: #{headers}")
         end
       end
     end

--- a/spec/services/dttp/retrieve_qts_spec.rb
+++ b/spec/services/dttp/retrieve_qts_spec.rb
@@ -37,13 +37,16 @@ module Dttp
       end
 
       context "HTTP error" do
-        let(:dttp_response) { double(code: 400, body: "error") }
+        let(:status) { 400 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:dttp_response) { double(code: status, body: body, headers: headers) }
 
         it "raises a HttpError error with the response body as the message" do
           expect(Client).to receive(:get).with(path).and_return(dttp_response)
           expect {
             subject
-          }.to raise_error(Dttp::RetrieveQts::HttpError, dttp_response.body)
+          }.to raise_error(Dttp::RetrieveQts::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
         end
       end
     end

--- a/spec/services/dttp/retrieve_trn_spec.rb
+++ b/spec/services/dttp/retrieve_trn_spec.rb
@@ -33,13 +33,16 @@ module Dttp
       end
 
       context "HTTP error" do
-        let(:dttp_response) { double(code: 400, body: "error") }
+        let(:status) { 400 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:dttp_response) { double(code: status, body: body, headers: headers) }
 
         it "raises a HttpError error with the response body as the message" do
           expect(Client).to receive(:get).with(path).and_return(dttp_response)
           expect {
             described_class.call(trainee: trainee)
-          }.to raise_error(Dttp::RetrieveTrn::HttpError, dttp_response.body)
+          }.to raise_error(Dttp::RetrieveTrn::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
         end
       end
     end

--- a/spec/services/dttp/update_trainee_status_spec.rb
+++ b/spec/services/dttp/update_trainee_status_spec.rb
@@ -26,15 +26,17 @@ module Dttp
       end
 
       context "error" do
-        let(:error_body) { "error" }
-        let(:dttp_response) { double(code: 405, body: error_body) }
+        let(:status) { 405 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:dttp_response) { double(code: status, body: body, headers: headers) }
 
         it "raises an error exception" do
           expect(Client).to receive(:patch).and_return(dttp_response)
 
           expect {
             described_class.call(status: status, entity_id: entity_id, entity_type: entity_type)
-          }.to raise_error(described_class::Error, error_body)
+          }.to raise_error(described_class::Error, "status: #{status}, body: #{body}, headers: #{headers}")
         end
       end
     end


### PR DESCRIPTION
### Context

https://trello.com/c/mtDnrOOg/1150-add-status-code-to-the-errors-in-the-dttp-workers-remove

### Changes proposed in this pull request

* Removed caching on `Dttp::AccessToken.fetch`
* DTTP service errors now include status and headers for easier debugging.

### Guidance to review

