### PR TITLE
[1088] Fix sort link snags

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -17,7 +17,7 @@ module ApplicationRecordCard
     def trainee_name
       return "Draft record" if record.blank? || record.first_names.blank? || record.last_name.blank?
 
-      [record.first_names, record.last_name].join(" ")
+      params[:sort_by] == "last_name" ? last_name_first : first_names_first
     end
 
     def subject
@@ -50,6 +50,16 @@ module ApplicationRecordCard
       return if record.trn.blank?
 
       tag.p("TRN: " + record.trn, class: "govuk-caption-m govuk-!-font-size-16 app-application-card__trn govuk-!-margin-bottom-0 govuk-!-margin-top-0")
+    end
+
+  private
+
+    def first_names_first
+      [record.first_names, record.last_name].join(" ")
+    end
+
+    def last_name_first
+      [record.last_name, record.first_names].join(", ")
     end
   end
 end

--- a/app/components/trainees/sort_links/view.rb
+++ b/app/components/trainees/sort_links/view.rb
@@ -4,7 +4,7 @@ module Trainees
   module SortLinks
     class View < GovukComponent::Base
       def sort_by_date_link
-        sort_link(t("components.page_titles.trainees.sort_links.date_updated"), :date_updated)
+        default_sort_link(t("components.page_titles.trainees.sort_links.date_updated"), :date_updated)
       end
 
       def sort_by_last_name_link
@@ -13,8 +13,14 @@ module Trainees
 
     private
 
+      def default_sort_link(name, sort_by)
+        return name if params[:sort_by].nil?
+
+        sort_link(name, sort_by)
+      end
+
       def sort_link(name, sort_by)
-        sorted_by?(sort_by) ? name : link_to(name, sort_path(sort_by), class: "govuk-link")
+        sorted_by?(sort_by) ? name : link_to(name, sort_path(sort_by), class: "govuk-link govuk-link--no-visited-state")
       end
 
       def sort_path(sort_by)

--- a/spec/components/trainees/sort_links/view_spec.rb
+++ b/spec/components/trainees/sort_links/view_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe Trainees::SortLinks::View do
   let(:last_name_link_text) { t("components.page_titles.trainees.sort_links.last_name") }
 
   context "no query params" do
-    it "has a link to sort by date updated" do
-      expect(component).to have_link(date_updated_link_text, href: "/?sort_by=date_updated")
+    it "has text date updated" do
+      expect(component).to_not have_link(date_updated_link_text, href: "/?sort_by=date_updated")
+      expect(component).to have_text(date_updated_link_text)
     end
 
     it "has a link to sort by last name" do


### PR DESCRIPTION
### Context

https://trello.com/c/iOUH2zu5/1088-s-snags-on-sort-links

### Changes proposed in this pull request

- Renders the default sort as text (not a link) when no sort is actively applied
- Removes visited link styles
- When sorting by last name, the changes the displayed name to "Lastname, Firstnames" rather than "Firstnames Lastname"

### Not included:
- Changes to markup (separate card being created)
 
### Guidance to review

- Visit `/trainees`
- Check that with no ordering actively applied, the 'Date updated' is not a link
- Click 'Last name'
- Check that the names are displayed as "Lastname, Firstnames"
- Click 'Date updated'
- Check that no visited link styles have been applied to 'Last name' i.e. purple font
