### PR TITLE
[1122] Refactor multi-date forms

### DIFF
--- a/app/controllers/trainees/deferrals_controller.rb
+++ b/app/controllers/trainees/deferrals_controller.rb
@@ -4,12 +4,6 @@ module Trainees
   class DeferralsController < ApplicationController
     before_action :authorize_trainee
 
-    PARAM_CONVERSION = {
-      "defer_date(3i)" => "day",
-      "defer_date(2i)" => "month",
-      "defer_date(1i)" => "year",
-    }.freeze
-
     def show
       @deferral = DeferralForm.new(trainee)
     end
@@ -38,10 +32,11 @@ module Trainees
     end
 
     def trainee_params
-      params.require(:deferral_form).permit(:defer_date_string, *PARAM_CONVERSION.keys)
-            .transform_keys do |key|
-        PARAM_CONVERSION.keys.include?(key) ? PARAM_CONVERSION[key] : key
-      end
+      params.require(:deferral_form)
+        .permit(:date_string, *MultiDateForm::PARAM_CONVERSION.keys)
+        .transform_keys do |key|
+          MultiDateForm::PARAM_CONVERSION.fetch(key, key)
+        end
     end
   end
 end

--- a/app/controllers/trainees/outcome_dates_controller.rb
+++ b/app/controllers/trainees/outcome_dates_controller.rb
@@ -2,12 +2,6 @@
 
 module Trainees
   class OutcomeDatesController < ApplicationController
-    PARAM_CONVERSION = {
-      "outcome_date(3i)" => "day",
-      "outcome_date(2i)" => "month",
-      "outcome_date(1i)" => "year",
-    }.freeze
-
     def edit
       authorize trainee
       @outcome = OutcomeDateForm.new(trainee)
@@ -32,9 +26,10 @@ module Trainees
     end
 
     def trainee_params
-      params.require(:outcome_date_form).permit(:outcome_date_string, *PARAM_CONVERSION.keys)
+      params.require(:outcome_date_form)
+        .permit(:date_string, *MultiDateForm::PARAM_CONVERSION.keys)
         .transform_keys do |key|
-          PARAM_CONVERSION.keys.include?(key) ? PARAM_CONVERSION[key] : key
+          MultiDateForm::PARAM_CONVERSION.fetch(key, key)
         end
     end
   end

--- a/app/controllers/trainees/withdrawals_controller.rb
+++ b/app/controllers/trainees/withdrawals_controller.rb
@@ -4,12 +4,6 @@ module Trainees
   class WithdrawalsController < ApplicationController
     before_action :authorize_trainee
 
-    PARAM_DATE_CONVERSION = {
-      "withdraw_date(3i)" => "day",
-      "withdraw_date(2i)" => "month",
-      "withdraw_date(1i)" => "year",
-    }.freeze
-
     def show
       @withdrawal_form = WithdrawalForm.new(trainee)
     end
@@ -38,12 +32,11 @@ module Trainees
     end
 
     def trainee_params
-      params.require(:withdrawal_form).permit(:withdraw_date_string,
-                                              :withdraw_reason,
-                                              :additional_withdraw_reason,
-                                              *PARAM_DATE_CONVERSION.keys).transform_keys do |key|
-        PARAM_DATE_CONVERSION.fetch(key, key)
-      end
+      params.require(:withdrawal_form)
+        .permit(:date_string, :withdraw_reason, :additional_withdraw_reason, *MultiDateForm::PARAM_CONVERSION.keys)
+        .transform_keys do |key|
+          MultiDateForm::PARAM_CONVERSION.fetch(key, key)
+        end
     end
   end
 end

--- a/app/forms/deferral_form.rb
+++ b/app/forms/deferral_form.rb
@@ -1,81 +1,9 @@
 # frozen_string_literal: true
 
-class DeferralForm
-  include ActiveModel::Model
-  include ActiveModel::AttributeAssignment
-  include ActiveModel::Validations::Callbacks
-
-  attr_accessor :trainee, :day, :month, :year, :defer_date_string
-
-  delegate :id, :persisted?, to: :trainee
-
-  validate :defer_date_valid
-
-  after_validation :update_trainee
-
-  def initialize(trainee)
-    @trainee = trainee
-    super(fields)
-  end
-
-  def fields
-    {
-      defer_date_string: rehydrate_defer_date_string,
-      day: trainee.defer_date&.day,
-      month: trainee.defer_date&.month,
-      year: trainee.defer_date&.year,
-    }
-  end
-
-  def save
-    valid? && trainee.save
-  end
-
-  def defer_date
-    date_conversion[defer_date_string]
-  end
-
+class DeferralForm < MultiDateForm
 private
 
-  def rehydrate_defer_date_string
-    return unless trainee.defer_date
-
-    case trainee.defer_date
-    when Time.zone.today
-      "today"
-    when Time.zone.yesterday
-      "yesterday"
-    else
-      "other"
-    end
-  end
-
-  def update_trainee
-    trainee.assign_attributes({ defer_date: defer_date }) if errors.empty?
-  end
-
-  def date_conversion
-    {
-      today: Time.zone.today,
-      yesterday: Time.zone.yesterday,
-      other: other_date,
-    }.with_indifferent_access
-  end
-
-  def other_date
-    date_hash = { year: year, month: month, day: day }
-    date_args = date_hash.values.map(&:to_i)
-
-    Date.valid_date?(*date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
-  end
-
-  def defer_date_valid
-    if defer_date_string.nil?
-      errors.add(:defer_date_string, :blank)
-    elsif defer_date_string == "other" && [day, month, year].all?(&:blank?)
-      errors.add(:defer_date, :blank)
-    elsif !defer_date.is_a?(Date)
-      errors.add(:defer_date, :invalid)
-    end
+  def date_field
+    @date_field ||= :defer_date
   end
 end

--- a/app/forms/multi_date_form.rb
+++ b/app/forms/multi_date_form.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+class MultiDateForm
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations::Callbacks
+
+  attr_accessor :trainee, :day, :month, :year, :date_string
+
+  delegate :id, :persisted?, to: :trainee
+
+  validate :date_valid
+
+  after_validation :update_trainee, if: -> { errors.empty? }
+
+  PARAM_CONVERSION = {
+    "date(3i)" => "day",
+    "date(2i)" => "month",
+    "date(1i)" => "year",
+  }.freeze
+
+  def initialize(trainee)
+    @trainee = trainee
+    super(fields)
+  end
+
+  def fields
+    {
+      date_string: rehydrate_date_string,
+      day: trainee_attribute&.day,
+      month: trainee_attribute&.month,
+      year: trainee_attribute&.year,
+    }.merge(additional_fields)
+  end
+
+  def save
+    valid? && trainee.save
+  end
+
+  def date
+    return unless date_string
+
+    {
+      today: Time.zone.today,
+      yesterday: Time.zone.yesterday,
+      other: other_date,
+    }[date_string.to_sym]
+  end
+
+private
+
+  def date_field
+    raise "Subclass of MultiDateForm must implement #date_field"
+  end
+
+  def trainee_attribute
+    trainee.public_send(date_field)
+  end
+
+  def additional_fields
+    {}
+  end
+
+  def rehydrate_date_string
+    return unless trainee_attribute
+
+    case trainee_attribute
+    when Time.zone.today
+      "today"
+    when Time.zone.yesterday
+      "yesterday"
+    else
+      "other"
+    end
+  end
+
+  def update_trainee
+    trainee[date_field] = date
+  end
+
+  def other_date
+    date_hash = { year: year, month: month, day: day }
+    date_args = date_hash.values.map(&:to_i)
+
+    Date.valid_date?(*date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+  end
+
+  def date_valid
+    if date_string.nil?
+      errors.add(:date_string, :blank)
+    elsif date_string == "other" && [day, month, year].all?(&:blank?)
+      errors.add(:date, :blank)
+    elsif !date.is_a?(Date)
+      errors.add(:date, :invalid)
+    end
+  end
+end

--- a/app/forms/outcome_date_form.rb
+++ b/app/forms/outcome_date_form.rb
@@ -1,81 +1,9 @@
 # frozen_string_literal: true
 
-class OutcomeDateForm
-  include ActiveModel::Model
-  include ActiveModel::AttributeAssignment
-  include ActiveModel::Validations::Callbacks
-
-  attr_accessor :trainee, :day, :month, :year, :outcome_date_string
-
-  delegate :id, :persisted?, to: :trainee
-
-  validate :outcome_date_valid
-
-  after_validation :update_trainee
-
-  def initialize(trainee)
-    @trainee = trainee
-    super(fields)
-  end
-
-  def fields
-    {
-      outcome_date_string: rehydrate_outcome_date_string,
-      day: trainee.outcome_date&.day,
-      month: trainee.outcome_date&.month,
-      year: trainee.outcome_date&.year,
-    }
-  end
-
-  def save
-    valid? && trainee.save
-  end
-
-  def outcome_date
-    date_conversion[outcome_date_string]
-  end
-
+class OutcomeDateForm < MultiDateForm
 private
 
-  def rehydrate_outcome_date_string
-    return unless trainee.outcome_date
-
-    case trainee.outcome_date
-    when Time.zone.today
-      "today"
-    when Time.zone.yesterday
-      "yesterday"
-    else
-      "other"
-    end
-  end
-
-  def update_trainee
-    trainee.assign_attributes({ outcome_date: outcome_date }) if errors.empty?
-  end
-
-  def date_conversion
-    {
-      today: Time.zone.today,
-      yesterday: Time.zone.yesterday,
-      other: other_date,
-    }.with_indifferent_access
-  end
-
-  def other_date
-    date_hash = { year: year, month: month, day: day }
-    date_args = date_hash.values.map(&:to_i)
-
-    Date.valid_date?(*date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
-  end
-
-  def outcome_date_valid
-    if outcome_date_string.nil?
-      errors.add(:outcome_date_string, :blank)
-    elsif outcome_date_string == "other" && [day, month, year].all?(&:blank?)
-      errors.add(:outcome_date, :blank)
-    elsif !outcome_date.is_a?(Date)
-      errors.add(:outcome_date, :invalid)
-    end
+  def date_field
+    @date_field ||= :outcome_date
   end
 end

--- a/app/forms/withdrawal_form.rb
+++ b/app/forms/withdrawal_form.rb
@@ -1,94 +1,34 @@
 # frozen_string_literal: true
 
-class WithdrawalForm
-  include ActiveModel::Model
-  include ActiveModel::AttributeAssignment
-  include ActiveModel::Validations::Callbacks
+class WithdrawalForm < MultiDateForm
+  attr_accessor :withdraw_reason, :additional_withdraw_reason
 
-  attr_accessor :trainee, :day, :month, :year, :withdraw_date_string, :withdraw_reason, :additional_withdraw_reason
-
-  delegate :id, :persisted?, to: :trainee
-
-  validate :withdraw_date_valid
   validate :withdraw_reason_valid
   validate :additional_withdraw_reason_valid
 
-  after_validation :update_trainee, if: -> { errors.empty? }
+private
 
-  def initialize(trainee)
-    @trainee = trainee
-    super(fields)
+  def date_field
+    @date_field ||= :withdraw_date
   end
 
-  def fields
+  def additional_fields
     {
-      withdraw_date_string: rehydrate_withdraw_date_string,
-      day: trainee.withdraw_date&.day,
-      month: trainee.withdraw_date&.month,
-      year: trainee.withdraw_date&.year,
       withdraw_reason: trainee.withdraw_reason,
       additional_withdraw_reason: trainee.additional_withdraw_reason,
     }
   end
 
-  def save
-    valid? && trainee.save
-  end
-
-  def withdraw_date
-    date_conversion[withdraw_date_string]
-  end
-
-private
-
   def for_another_reason?
     withdraw_reason == WithdrawalReasons::FOR_ANOTHER_REASON
   end
 
-  def rehydrate_withdraw_date_string
-    return unless trainee.withdraw_date
-
-    case trainee.withdraw_date
-    when Time.zone.today
-      "today"
-    when Time.zone.yesterday
-      "yesterday"
-    else
-      "other"
-    end
-  end
-
   def update_trainee
     trainee.assign_attributes({
-      withdraw_date: withdraw_date,
+      withdraw_date: date,
       withdraw_reason: withdraw_reason,
       additional_withdraw_reason: for_another_reason? ? additional_withdraw_reason : nil,
     })
-  end
-
-  def date_conversion
-    {
-      today: Time.zone.today,
-      yesterday: Time.zone.yesterday,
-      other: other_date,
-    }.with_indifferent_access
-  end
-
-  def other_date
-    date_hash = { year: year, month: month, day: day }
-    date_args = date_hash.values.map(&:to_i)
-
-    Date.valid_date?(*date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
-  end
-
-  def withdraw_date_valid
-    if withdraw_date_string.nil?
-      errors.add(:withdraw_date_string, :blank)
-    elsif withdraw_date_string == "other" && [day, month, year].all?(&:blank?)
-      errors.add(:withdraw_date, :blank)
-    elsif !withdraw_date.is_a?(Date)
-      errors.add(:withdraw_date, :invalid)
-    end
   end
 
   def withdraw_reason_valid

--- a/app/views/trainees/deferrals/show.html.erb
+++ b/app/views/trainees/deferrals/show.html.erb
@@ -13,11 +13,11 @@
         <%= trainee_name(@trainee) %>
       </span>
 
-      <%= f.govuk_radio_buttons_fieldset(:defer_date_string, legend: { text: "When did the trainee defer?", tag: "h1", size: "l" }, classes: "deferral-date") do %>
-        <%= f.govuk_radio_button :defer_date_string, :today, label: { text: t("views.forms.common.today") }, link_errors: true %>
-        <%= f.govuk_radio_button :defer_date_string, :yesterday, label: { text: t("views.forms.common.yesterday") } %>
-        <%= f.govuk_radio_button :defer_date_string, :other, label: { text: t("views.forms.common.specific_date") } do %>
-          <%= f.govuk_date_field :defer_date, legend: { text: t("views.forms.common.on_what_date"), size: 's' }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
+      <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: "When did the trainee defer?", tag: "h1", size: "l" }, classes: "deferral-date") do %>
+        <%= f.govuk_radio_button :date_string, :today, label: { text: t("views.forms.common.today") }, link_errors: true %>
+        <%= f.govuk_radio_button :date_string, :yesterday, label: { text: t("views.forms.common.yesterday") } %>
+        <%= f.govuk_radio_button :date_string, :other, label: { text: t("views.forms.common.specific_date") } do %>
+          <%= f.govuk_date_field :date, legend: { text: t("views.forms.common.on_what_date"), size: 's' }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
         <% end %>
       <% end %>
 

--- a/app/views/trainees/outcome_dates/edit.html.erb
+++ b/app/views/trainees/outcome_dates/edit.html.erb
@@ -16,11 +16,11 @@
         <%= trainee_name(@trainee) %>
       </span>
 
-      <%= f.govuk_radio_buttons_fieldset(:outcome_date_string, legend: { text: "When did they meet the standards?", tag: "h1", size: "l" }, classes: "outcome-date") do %>
-        <%= f.govuk_radio_button :outcome_date_string, :today, label: { text: "Today" }, link_errors: true %>
-        <%= f.govuk_radio_button :outcome_date_string, :yesterday, label: { text: "Yesterday" } %>
-        <%= f.govuk_radio_button :outcome_date_string, :other, label: { text: "On another day" } do %>
-          <%= f.govuk_date_field :outcome_date, legend: { text: t("views.forms.common.on_what_date"), size: 's' }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
+      <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: "When did they meet the standards?", tag: "h1", size: "l" }, classes: "outcome-date") do %>
+        <%= f.govuk_radio_button :date_string, :today, label: { text: "Today" }, link_errors: true %>
+        <%= f.govuk_radio_button :date_string, :yesterday, label: { text: "Yesterday" } %>
+        <%= f.govuk_radio_button :date_string, :other, label: { text: "On another day" } do %>
+          <%= f.govuk_date_field :date, legend: { text: t("views.forms.common.on_what_date"), size: 's' }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
         <% end %>
       <% end %>
 

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -16,11 +16,11 @@
         Withdraw trainee
       </h1>
 
-      <%= f.govuk_radio_buttons_fieldset(:withdraw_date_string, legend: { text: t("views.forms.withdrawal_reasons.headings.withdrawal_date"), size: "s" }, classes: "withdraw-date") do %>
-        <%= f.govuk_radio_button :withdraw_date_string, :today, label: { text: t("views.forms.common.today") }, link_errors: true %>
-        <%= f.govuk_radio_button :withdraw_date_string, :yesterday, label: { text: t("views.forms.common.yesterday") } %>
-        <%= f.govuk_radio_button :withdraw_date_string, :other, label: { text: t("views.forms.common.specific_date") } do %>
-          <%= f.govuk_date_field :withdraw_date, legend: { text: t("views.forms.common.on_what_date"), size: 's' }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
+      <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: t("views.forms.withdrawal_reasons.headings.withdrawal_date"), size: "s" }, classes: "withdraw-date") do %>
+        <%= f.govuk_radio_button :date_string, :today, label: { text: t("views.forms.common.today") }, link_errors: true %>
+        <%= f.govuk_radio_button :date_string, :yesterday, label: { text: t("views.forms.common.yesterday") } %>
+        <%= f.govuk_radio_button :date_string, :other, label: { text: t("views.forms.common.specific_date") } do %>
+          <%= f.govuk_date_field :date, legend: { text: t("views.forms.common.on_what_date"), size: 's' }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
         <% end %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,6 +318,13 @@ en:
             email:
               blank: "You must enter an email address"
               invalid: "You must enter an email address in the correct format, like name@example.com"
+        deferral_form:
+          attributes:
+            date_string:
+              blank: You must choose a deferral date
+            date:
+              blank: You must enter a deferral date
+              invalid: You must enter a valid deferral date
         degree_detail_form:
           attributes:
             degree_ids:
@@ -356,9 +363,9 @@ en:
               not_valid: Trainee has been disclosed as disabled but no disabilities exist
         outcome_date_form:
           attributes:
-            outcome_date_string:
+            date_string:
               blank: You must choose an outcome date
-            outcome_date:
+            date:
               blank: You must enter an outcome date
               invalid: You must enter a valid outcome date
         personal_detail_form:
@@ -402,22 +409,15 @@ en:
               incomplete: You must complete all sections before submitting for TRN
         withdrawal_form:
           attributes:
-            withdraw_date_string:
+            date_string:
               blank: You must choose a withdrawal date
-            withdraw_date:
+            date:
               blank: You must enter a withdrawal date
               invalid: You must enter a valid withdrawal date
             additional_withdraw_reason:
               blank: You must enter a reason
             withdraw_reason:
               invalid: You must choose a reason
-        deferral_form:
-          attributes:
-            defer_date_string:
-              blank: You must choose a deferral date
-            defer_date:
-              blank: You must enter a deferral date
-              invalid: You must enter a valid deferral date
         training_details_form:
           attributes:
             commencement_date:

--- a/spec/features/trainees/defer_trainee_spec.rb
+++ b/spec/features/trainees/defer_trainee_spec.rb
@@ -94,19 +94,19 @@ feature "Deferring a trainee", type: :feature do
 
   def then_i_see_the_error_message_for_invalid_date
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.deferral_form.attributes.defer_date.invalid"),
+      I18n.t("activemodel.errors.models.deferral_form.attributes.date.invalid"),
     )
   end
 
   def then_i_see_the_error_message_for_blank_date
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.deferral_form.attributes.defer_date.blank"),
+      I18n.t("activemodel.errors.models.deferral_form.attributes.date.blank"),
     )
   end
 
   def then_i_see_the_error_message_for_date_not_chosen
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.deferral_form.attributes.defer_date_string.blank"),
+      I18n.t("activemodel.errors.models.deferral_form.attributes.date_string.blank"),
     )
   end
 

--- a/spec/features/trainees/recording_training_outcome_spec.rb
+++ b/spec/features/trainees/recording_training_outcome_spec.rb
@@ -89,13 +89,13 @@ feature "Recording a training outcome", type: :feature do
 
   def then_i_see_the_error_message_for(type)
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.outcome_date_form.attributes.outcome_date.#{type}"),
+      I18n.t("activemodel.errors.models.outcome_date_form.attributes.date.#{type}"),
     )
   end
 
   def then_i_see_the_error_message_for_date_not_chosen
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.outcome_date_form.attributes.outcome_date_string.blank"),
+      I18n.t("activemodel.errors.models.outcome_date_form.attributes.date_string.blank"),
     )
   end
 

--- a/spec/features/trainees/withdraw_trainee_spec.rb
+++ b/spec/features/trainees/withdraw_trainee_spec.rb
@@ -134,19 +134,19 @@ feature "Withdrawing a trainee", type: :feature do
 
   def then_i_see_the_error_message_for_date_not_chosen
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.withdrawal_form.attributes.withdraw_date_string.blank"),
+      I18n.t("activemodel.errors.models.withdrawal_form.attributes.date_string.blank"),
     )
   end
 
   def then_i_see_the_error_message_for_invalid_date
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.withdrawal_form.attributes.withdraw_date.invalid"),
+      I18n.t("activemodel.errors.models.withdrawal_form.attributes.date.invalid"),
     )
   end
 
   def then_i_see_the_error_message_for_blank_date
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.withdrawal_form.attributes.withdraw_date.blank"),
+      I18n.t("activemodel.errors.models.withdrawal_form.attributes.date.blank"),
     )
   end
 

--- a/spec/support/page_objects/trainees/edit_deferral_date.rb
+++ b/spec/support/page_objects/trainees/edit_deferral_date.rb
@@ -8,9 +8,9 @@ module PageObjects
 
       element :defer_date_radios, ".govuk-radios.deferral-date"
 
-      element :defer_date_day, "#deferral_form_defer_date_3i"
-      element :defer_date_month, "#deferral_form_defer_date_2i"
-      element :defer_date_year, "#deferral_form_defer_date_1i"
+      element :defer_date_day, "#deferral_form_date_3i"
+      element :defer_date_month, "#deferral_form_date_2i"
+      element :defer_date_year, "#deferral_form_date_1i"
 
       element :continue, ".govuk-button"
     end

--- a/spec/support/page_objects/trainees/edit_outcome_date.rb
+++ b/spec/support/page_objects/trainees/edit_outcome_date.rb
@@ -8,9 +8,9 @@ module PageObjects
 
       element :outcome_date_radios, ".govuk-radios.outcome-date"
 
-      element :outcome_date_day, "#outcome_date_form_outcome_date_3i"
-      element :outcome_date_month, "#outcome_date_form_outcome_date_2i"
-      element :outcome_date_year, "#outcome_date_form_outcome_date_1i"
+      element :outcome_date_day, "#outcome_date_form_date_3i"
+      element :outcome_date_month, "#outcome_date_form_date_2i"
+      element :outcome_date_year, "#outcome_date_form_date_1i"
 
       element :continue, ".govuk-button"
     end

--- a/spec/support/page_objects/trainees/withdrawal.rb
+++ b/spec/support/page_objects/trainees/withdrawal.rb
@@ -7,9 +7,9 @@ module PageObjects
 
       set_url "/trainees/{id}/withdraw"
 
-      element :withdraw_date_day, "#withdrawal_form_withdraw_date_3i"
-      element :withdraw_date_month, "#withdrawal_form_withdraw_date_2i"
-      element :withdraw_date_year, "#withdrawal_form_withdraw_date_1i"
+      element :withdraw_date_day, "#withdrawal_form_date_3i"
+      element :withdraw_date_month, "#withdrawal_form_date_2i"
+      element :withdraw_date_year, "#withdrawal_form_date_1i"
 
       element :additional_withdraw_reason, "#withdrawal-form-additional-withdraw-reason-field"
 


### PR DESCRIPTION
### Context

https://trello.com/c/IU3JnBBB/1122-m-today-tomorrow-other-component

### Changes proposed in this pull request

We have three form models that we _basically_ doing all the same hydration / attribute saving / error handling for:
- withdrawal
- deferral
- outcome date.

We're about to add another one (reinstate), so this PR pulls all the code into one more generic form model that the other models now subclass.

### Guidance to review

Nothing should change.