### PR TITLE
Make clear you don't need to explicitly save drafts

### DIFF
--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -31,7 +31,7 @@
             <p class="govuk-body">
               This record is not complete and cannot be submitted for TRN. If you do not
               have all the required information now, you can 
-              <%= govuk_link_to " save as a draft record", trainees_path %>.
+              <%= govuk_link_to " return to this draft record later", trainees_path %>.
             </p>
           </div>
         <% end %>


### PR DESCRIPTION
It was pointed out in show and tell that this link implied you needed to actively save drafts - which is incorrect. This updates the link to match the 'return later' link on the task list page.