### PR TITLE
Tidy up other nationality remove link

### DIFF
--- a/app/webpacker/scripts/global/nationality_select.js
+++ b/app/webpacker/scripts/global/nationality_select.js
@@ -45,10 +45,12 @@ const prepareNationalitySelect = () => {
 
   const addRemoveLink = (labelEl, inputEl, selectEl, prevInputEl) => {
     const removeLink = document.createElement('a')
+    const parentEl = labelEl.parentElement
     removeLink.innerHTML = 'Remove'
     removeLink.classList.add('govuk-link', 'personal-detail-form-other-nationality__remove-link')
     removeLink.href = '#'
-    labelEl.appendChild(removeLink)
+
+    parentEl.insertBefore(removeLink, labelEl)
 
     if (labelEl === secondFormLabel) {
       addNthNationalityHiddenSpan(removeLink, 'second')

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -9,12 +9,6 @@
   }
 }
 
-// Styles links that do not have a path or a bookmark ID
-a[href="#"] {
-  color: govuk-colour("red") !important;
-  font-weight: bolder !important;
-}
-
 // Dashed list (used in Contents links list)
 .app-list--dash li {
   position: relative;
@@ -65,6 +59,7 @@ a[href="#"] {
 }
 
 .personal-detail-form-other-nationality__remove-link {
+  @include govuk-font($size: 19);
   float: right;
 }
 


### PR DESCRIPTION
The main change here is to move the remove link outside of the label - which more closely matches [Apply](https://github.com/DFE-Digital/apply-for-teacher-training/blob/d2eecada0de3058de630e964ec083cea8597f076/app/frontend/packs/nationalities-component.js#L32).

The link was also accidentally red and bold because we had global styles styling all `#` links like that to remind us to deal with them.

After:
<img width="624" alt="Screenshot 2021-02-26 at 17 30 20" src="https://user-images.githubusercontent.com/2204224/109334447-a4aa2000-7858-11eb-9eeb-8c719f5bac1c.png">

Before:
<img width="695" alt="Screenshot 2021-02-26 at 17 33 01" src="https://user-images.githubusercontent.com/2204224/109334478-b12e7880-7858-11eb-8b7d-85c1e2401198.png">
