### PR TITLE
[1121] Delete draft trainee feature

### DIFF
--- a/app/controllers/trainees/confirm_delete_controller.rb
+++ b/app/controllers/trainees/confirm_delete_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Trainees
+  class ConfirmDeleteController < ApplicationController
+    before_action :ensure_trainee_is_draft!
+
+    def show
+      authorize trainee
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+  end
+end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -2,6 +2,7 @@
 
 class TraineesController < ApplicationController
   before_action :ensure_trainee_is_not_draft!, only: :show
+  before_action :ensure_trainee_is_draft!, only: :destroy
   helper_method :filter_params
 
   def index
@@ -48,6 +49,13 @@ class TraineesController < ApplicationController
     authorize trainee
     trainee.update!(trainee_params)
     redirect_to page_tracker.last_origin_page_path
+  end
+
+  def destroy
+    authorize trainee
+    trainee.destroy!
+    flash[:success] = "Draft deleted"
+    redirect_to trainees_path
   end
 
 private

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -41,6 +41,10 @@ class TraineePolicy
     trainee.submitted_for_trn? || trainee.trn_received?
   end
 
+  def destroy?
+    user && (user.system_admin? || user.provider_id == trainee.provider_id)
+  end
+
   alias_method :create?, :show?
   alias_method :update?, :show?
   alias_method :edit?, :show?

--- a/app/views/trainees/confirm_delete/show.html.erb
+++ b/app/views/trainees/confirm_delete/show.html.erb
@@ -1,0 +1,18 @@
+<%= render PageTitle::View.new(title: "trainees.delete") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLink.new(text: I18n.t("back_to_draft"), href: trainee_path(@trainee)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <span class="govuk-caption-l">
+      Draft record <%= "for #{trainee_name(@trainee)}" if trainee_name(@trainee).present?  %>
+    </span>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-8">Do you want to delete this draft?</h1>
+  </div>
+</div>
+
+<%= button_to "Delete this draft", trainee_path(@trainee), method: :delete, class: "govuk-button govuk-button--warning" %>
+
+<p class="govuk-body"><%= govuk_link_to(I18n.t("cancel"), trainee_path(@trainee)) %></p>

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -104,3 +104,7 @@
 <%= govuk_button_link_to "Review this record", check_details_trainee_path(@trainee), {id: "check-details"} %>
 
 <p class="govuk-body"><%= govuk_link_to("Return to this draft record later", trainees_path) %></p>
+
+<p class="govuk-body govuk-!-margin-top-8">
+  <%= govuk_link_to "Delete this draft", trainee_confirm_delete_path(@trainee), class: "app-link--warning" %>
+</p>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -76,3 +76,8 @@ a[href="#"] {
   color: $govuk-error-colour;
   font-weight: 700;
 }
+
+.app-link--warning {
+  @include govuk-link-common;
+  @include govuk-link-style-error;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
         show: Review trainee record
       trainees:
         new: Add a trainee
+        delete: Delete this draft record
         index: Trainee records (%{total_trainees_count_text})
         paginated_index: Trainee records (%{total_trainees_count_text}) - page %{current_page} of %{total_pages}
         not_supported_route: Other routes not supported
@@ -233,11 +234,11 @@ en:
         title: Trainee start date and ID
         commencement_date:
           label: Date trainee started
-          hint_html: When the trainee started the course. This may be different to your overall programme start date.<br><br> 
+          hint_html: When the trainee started the course. This may be different to your overall programme start date.<br><br>
                      For example, 9 2 %{year}
         trainee_id:
           label: Assign a trainee ID
-          hint: This will help you to identify them and search for them in your trainee records. 
+          hint: This will help you to identify them and search for them in your trainee records.
                 We may also use it if we need to get in touch with you about this trainee.
   activerecord:
     attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,13 +44,15 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :trainees, except: :destroy do
+  resources :trainees do
     scope module: :trainees do
       resource :training_details, concerns: :confirmable, only: %i[edit update], path: "/training-details"
       resource :programme_details, concerns: :confirmable, only: %i[edit update], path: "/programme-details"
       resource :contact_details, concerns: :confirmable, only: %i[edit update], path: "/contact-details"
       resource :trainee_id, concerns: :confirmable, only: %i[edit update], path: "/trainee-id"
       resource :start_date, concerns: :confirmable, only: %i[edit update], path: "/trainee-start-date"
+
+      get "/confirm-delete", to: "confirm_delete#show"
 
       namespace :degrees do
         get "/new/type", to: "type#new"

--- a/spec/controllers/trainees/confirm_delete_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_delete_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Trainees::ConfirmDeleteController do
+  let(:user) { create(:user) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#show" do
+    subject { get(:show, params: { trainee_id: trainee }) }
+
+    context "with a non-draft trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.provider) }
+
+      it "redirects to the trainee record page" do
+        expect(subject).to redirect_to(trainee_path(trainee))
+      end
+    end
+  end
+end

--- a/spec/controllers/trainees_controller_spec.rb
+++ b/spec/controllers/trainees_controller_spec.rb
@@ -30,4 +30,14 @@ describe TraineesController do
       end
     end
   end
+
+  describe "#destroy" do
+    context "with a non-draft trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.provider) }
+
+      it "redirects to the trainee record page" do
+        expect(get(:destroy, params: { id: trainee })).to redirect_to(trainee_path(trainee))
+      end
+    end
+  end
 end

--- a/spec/features/trainees/delete_trainee_spec.rb
+++ b/spec/features/trainees/delete_trainee_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Create a draft trainee" do
+  background do
+    given_i_am_authenticated
+    given_a_trainee_exists
+    given_i_visited_the_review_draft_page
+  end
+
+  scenario "deleting a draft trainee" do
+    and_i_click_the_delete_link
+    then_i_see_the_confirm_page
+    then_i_click_the_delete_button
+    i_am_redirected_to_the_trainee_records_list
+    and_i_see_a_flash_message
+    and_the_trainee_is_no_longer_listed
+  end
+
+private
+
+  def and_i_save_the_form
+    new_trainee_page.continue_button.click
+  end
+
+  def and_i_click_the_delete_link
+    review_draft_page.delete_this_draft_link.click
+  end
+
+  def then_i_see_the_confirm_page
+    expect(page.current_path).to eq("/trainees/#{trainee.slug}/confirm-delete")
+  end
+
+  def then_i_click_the_delete_button
+    confirm_draft_deletions_page.delete_this_draft.click
+  end
+
+  def i_am_redirected_to_the_trainee_records_list
+    expect(page.current_path).to eq("/trainees")
+  end
+
+  def and_i_see_a_flash_message
+    expect(page).to have_text("Draft deleted")
+  end
+
+  def and_the_trainee_is_no_longer_listed
+    expect(page).to_not have_text("Trainee ID: 1")
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -26,6 +26,10 @@ module Features
       @review_draft_page ||= PageObjects::Trainees::ReviewDraft.new
     end
 
+    def confirm_draft_deletions_page
+      @confirm_draft_deletions_page ||= PageObjects::Trainees::ConfirmDraftDeletions.new
+    end
+
     def confirm_details_page
       @confirm_page ||= PageObjects::Trainees::ConfirmDetails.new
     end

--- a/spec/support/page_objects/trainees/confirm_draft_deletions.rb
+++ b/spec/support/page_objects/trainees/confirm_draft_deletions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class ConfirmDraftDeletions < PageObjects::Base
+      set_url "/trainees/{id}/confirm-delete"
+
+      element :delete_this_draft, ".govuk-button--warning"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/review_draft.rb
+++ b/spec/support/page_objects/trainees/review_draft.rb
@@ -16,6 +16,7 @@ module PageObjects
       section :training_details, PageObjects::Sections::TrainingDetails, ".training-details"
 
       element :review_this_record_link, "#check-details"
+      element :delete_this_draft_link, ".app-link--warning"
     end
   end
 end


### PR DESCRIPTION
### Context

The ability to delete a draft trainee if the user is authorised. 

### Changes proposed in this pull request

- Add new controller
- Add destroy method to trainees controller
- Add destroy? method to trainee policy
- Add user interface for deleting a draft trainee
- Add logic for rendering a trainee with or without a name
- Add page title to `en.yml`file
- Add new route

### Guidance to review

- Navigate to a draft trainee and click on it: https://rtt-review-pr-592.herokuapp.com/trainees
- Scroll down and click `Delete this draft`
- Click the red button
- Check that the trainee has been deleted.
- Check that the `confirm-delete` page displays correctly whether the trainee has a name or not.
- Check that you cannot delete a non draft trainee by navigating there in the URL

### Screenshots

![image](https://user-images.githubusercontent.com/50492247/109344298-6ddb0680-7866-11eb-932a-41bf2f8bd3d0.png)

![image](https://user-images.githubusercontent.com/50492247/109344187-4e43de00-7866-11eb-8515-a2a8912eb7af.png)

![image](https://user-images.githubusercontent.com/50492247/109344219-5865dc80-7866-11eb-8723-6fc2402bc94a.png)