### PR TITLE
[1125] Add routes feature flag

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -29,7 +29,7 @@ module ApplicationRecordCard
     def route
       return "No route provided" if record.training_route.blank?
 
-      record.training_route.humanize
+      t('activerecord.attributes.trainee.training_routes.' + record.training_route)
     end
 
     def updated_at

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -29,7 +29,7 @@ module ApplicationRecordCard
     def route
       return "No route provided" if record.training_route.blank?
 
-      t('activerecord.attributes.trainee.training_routes.' + record.training_route)
+      t("activerecord.attributes.trainee.training_routes." + record.training_route)
     end
 
     def updated_at

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -29,7 +29,7 @@ module ApplicationRecordCard
     def route
       return "No route provided" if record.training_route.blank?
 
-      t("activerecord.attributes.trainee.training_routes." + record.training_route)
+      t("activerecord.attributes.trainee.training_routes.#{record.training_route}")
     end
 
     def updated_at

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -27,9 +27,9 @@ module ApplicationRecordCard
     end
 
     def route
-      return "No route provided" if record.record_type.blank?
+      return "No route provided" if record.training_route.blank?
 
-      record.record_type.humanize
+      record.training_route.humanize
     end
 
     def updated_at

--- a/app/components/trainees/confirmation/programme_details/view.rb
+++ b/app/components/trainees/confirmation/programme_details/view.rb
@@ -30,9 +30,9 @@ module Trainees
         end
 
         def programme_type
-          return @not_provided_copy if trainee.record_type.blank?
+          return @not_provided_copy if trainee.training_route.blank?
 
-          trainee.record_type.humanize
+          trainee.training_route.humanize
         end
 
         def programme_start_date

--- a/app/components/trainees/confirmation/programme_details/view.rb
+++ b/app/components/trainees/confirmation/programme_details/view.rb
@@ -32,7 +32,7 @@ module Trainees
         def programme_type
           return @not_provided_copy if trainee.training_route.blank?
 
-          trainee.training_route.humanize
+          t("activerecord.attributes.trainee.training_routes.#{trainee.training_route}")
         end
 
         def programme_start_date

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -32,7 +32,7 @@ class TraineesController < ApplicationController
   end
 
   def create
-    if trainee_params[:record_type] == "other"
+    if trainee_params[:training_route] == "other"
       redirect_to trainees_not_supported_route_path
     else
       authorize @trainee = Trainee.new(trainee_params.merge(provider_id: current_user.provider_id))
@@ -81,11 +81,11 @@ private
   end
 
   def trainee_params
-    params.fetch(:trainee, {}).permit(:record_type)
+    params.fetch(:trainee, {}).permit(:training_route)
   end
 
   def filter_params
-    params.permit(:subject, :text_search, :sort_by, record_type: [], state: [])
+    params.permit(:subject, :text_search, :sort_by, training_route: [], state: [])
   end
 
   def data_export

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -13,9 +13,9 @@ class Trainee < ApplicationRecord
 
   attribute :progress, Progress.to_type
 
-  validates :record_type, presence: { message: I18n.t("activerecord.errors.models.trainee.attributes.record_type") }
+  validates :training_route, presence: { message: I18n.t("activerecord.errors.models.trainee.attributes.training_route") }
 
-  enum record_type: { assessment_only: 0, provider_led: 1 }
+  enum training_route: { assessment_only: 0, provider_led: 1 }
   enum locale_code: { uk: 0, non_uk: 1 }
   enum gender: {
     male: 0,

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -19,19 +19,19 @@ private
 
   def merged_filters
     @merged_filters ||= text_search.merge(
-      **record_type, **state, **subject, **text_search,
+      **training_route, **state, **subject, **text_search,
     ).with_indifferent_access
   end
 
-  def record_type
-    return {} unless record_type_options.any?
+  def training_route
+    return {} unless training_route_options.any?
 
-    { "record_type" => record_type_options }
+    { "training_route" => training_route_options }
   end
 
-  def record_type_options
-    Trainee.record_types.keys.each_with_object([]) do |option, arr|
-      arr << option if params[:record_type]&.include?(option)
+  def training_route_options
+    Trainee.training_routes.keys.each_with_object([]) do |option, arr|
+      arr << option if params[:training_route]&.include?(option)
     end
   end
 

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -34,7 +34,7 @@ module Exports
           "Trainee Id" => trainee.trainee_id,
           "TRN" => trainee.trn,
           "Status" => trainee.state,
-          "Route" => trainee.record_type,
+          "Route" => trainee.training_route,
           "Subject" => trainee.subject,
           "Programme start date" => trainee.programme_start_date,
           "Programme end date" => trainee.programme_end_date,

--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -8,5 +8,6 @@ module FeatureService
       segments = feature_name.to_s.split(".")
       segments.reduce(Settings.features) { |config, segment| config[segment] }
     end
+    
   end
 end

--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -8,6 +8,5 @@ module FeatureService
       segments = feature_name.to_s.split(".")
       segments.reduce(Settings.features) { |config, segment| config[segment] }
     end
-    
   end
 end

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -19,10 +19,10 @@ module Trainees
 
     attr_reader :trainees, :filters
 
-    def record_type(trainees, record_type)
-      return trainees if record_type.blank?
+    def training_route(trainees, training_route)
+      return trainees if training_route.blank?
 
-      trainees.where(record_type: record_type)
+      trainees.where(training_route: training_route)
     end
 
     def state(trainees, state)
@@ -47,7 +47,7 @@ module Trainees
       # Tech note: If you're adding a new filter to the top of this list, make
       # sure that it acts on `trainees` and all other filters then act on
       # `filtered_trainees`
-      filtered_trainees = record_type(trainees, filters[:record_type])
+      filtered_trainees = training_route(trainees, filters[:training_route])
       filtered_trainees = state(filtered_trainees, filters[:state])
       filtered_trainees = subject(filtered_trainees, filters[:subject])
       filtered_trainees = text_search(filtered_trainees, filters[:text_search])

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -17,9 +17,10 @@
         Add a trainee
       </h1>
 
-      <%= f.govuk_radio_buttons_fieldset(:record_type, legend: { size: "s", text: "What type of training are they doing?", tag: "span"} ) do %>
-        <%= f.govuk_radio_button :record_type, :assessment_only, label: { text: t("activerecord.attributes.trainee.record_types.assessment_only") }, link_errors: true %>
-        <%= f.govuk_radio_button :record_type, :other, label: { text: "Other" } %>
+      <%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "s", text: "What type of training are they doing?", tag: "span"} ) do %>
+        <%= f.govuk_radio_button :training_route, :assessment_only, label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
+        <%= f.govuk_radio_button :training_route, :provider_led, label: { text: t("activerecord.attributes.trainee.training_routes.provider_led") } %>
+        <%= f.govuk_radio_button :training_route, :other, label: { text: "Other" } %>
       <% end %>
 
       <%= f.govuk_submit %>

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -19,7 +19,7 @@
 
       <%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "s", text: "What type of training are they doing?", tag: "span"} ) do %>
         <%= f.govuk_radio_button :training_route, :assessment_only, label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
-        <%= f.govuk_radio_button :training_route, :provider_led, label: { text: t("activerecord.attributes.trainee.training_routes.provider_led") } %>
+        <%= f.govuk_radio_button :training_route, :provider_led, label: { text: t("activerecord.attributes.trainee.training_routes.provider_led") } if FeatureService.enabled?("routes_provider_led") %> 
         <%= f.govuk_radio_button :training_route, :other, label: { text: "Other" } %>
       <% end %>
 

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -19,7 +19,10 @@
 
       <%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "s", text: "What type of training are they doing?", tag: "span"} ) do %>
         <%= f.govuk_radio_button :training_route, :assessment_only, label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
-        <%= f.govuk_radio_button :training_route, :provider_led, label: { text: t("activerecord.attributes.trainee.training_routes.provider_led") } if FeatureService.enabled?("routes_provider_led") %> 
+        <% if FeatureService.enabled?("routes_provider_led") %>
+          <%= f.govuk_radio_button :training_route, :provider_led, label: { text: t("activerecord.attributes.trainee.training_routes.provider_led") } %> 
+          <%= f.govuk_radio_divider %>
+        <% end %>
         <%= f.govuk_radio_button :training_route, :other, label: { text: "Other" } %>
       <% end %>
 

--- a/app/views/trainees/not_supported_route.html.erb
+++ b/app/views/trainees/not_supported_route.html.erb
@@ -14,7 +14,7 @@
     </h1>
 
     <p class="govuk-body">
-      <%= t("activerecord.attributes.trainee.record_types.assessment_only") %> is the only route currently supported by this service. More routes will be added soon.
+      <%= t("activerecord.attributes.trainee.training_routes.assessment_only") %> is the only route currently supported by this service. More routes will be added soon.
     </p>
 
     <p class="govuk-body">You can:</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,7 +138,7 @@ en:
       users:
         new: Add a user
     filter:
-      record_type: Training route
+      training_route: Training route
       state: Status
       subject: Subject
       text_search: Text search
@@ -243,7 +243,7 @@ en:
     attributes:
       trainee:
         trainee_id: "Trainee ID"
-        record_types:
+        training_routes:
           assessment_only: Assessment only
           provider_led: Provider-led
         states:
@@ -258,7 +258,7 @@ en:
       models:
         trainee:
           attributes:
-            record_type: You must select a route
+            training_route: You must select a route
         degree:
           attributes:
             uk_degree:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,8 +26,7 @@ features:
   enable_feedback_link: true
   basic_auth: true
   trainee_export: true
-  routes:
-    provider_led: true
+  routes_provider_led: true
 
 dfe_sign_in:
   # Our service name

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,7 +26,7 @@ features:
   enable_feedback_link: true
   basic_auth: true
   trainee_export: true
-  routes_provider_led: true
+  routes_provider_led: false
 
 dfe_sign_in:
   # Our service name

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,8 @@ features:
   enable_feedback_link: true
   basic_auth: true
   trainee_export: true
+  routes:
+    provider_led: true
 
 dfe_sign_in:
   # Our service name

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,6 +8,7 @@ features:
   allow_user_creation: true
   use_dfe_sign_in: false
   basic_auth: false
+  routes_provider_led: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -12,6 +12,7 @@ dttp:
 features:
   home_text: true
   use_dfe_sign_in: false
+  routes_provider_led: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -5,6 +5,7 @@ features:
   home_text: true
   use_dfe_sign_in: false
   enable_feedback_link: false
+  routes_provider_led: true
 
 pagination:
   records_per_page: 30

--- a/db/migrate/20210226124052_change_record_type_to_training_route_for_trainees.rb
+++ b/db/migrate/20210226124052_change_record_type_to_training_route_for_trainees.rb
@@ -1,0 +1,5 @@
+class ChangeRecordTypeToTrainingRouteForTrainees < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :trainees, :record_type, :training_route
+  end
+end

--- a/db/migrate/20210226124052_change_record_type_to_training_route_for_trainees.rb
+++ b/db/migrate/20210226124052_change_record_type_to_training_route_for_trainees.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeRecordTypeToTrainingRouteForTrainees < ActiveRecord::Migration[6.1]
   def change
     rename_column :trainees, :record_type, :training_route

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_154323) do
+ActiveRecord::Schema.define(version: 2021_02_26_124052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,7 +122,7 @@ ActiveRecord::Schema.define(version: 2021_02_24_154323) do
     t.text "email"
     t.uuid "dttp_id"
     t.text "middle_names"
-    t.integer "record_type"
+    t.integer "training_route"
     t.text "international_address"
     t.integer "locale_code"
     t.integer "gender"
@@ -158,9 +158,9 @@ ActiveRecord::Schema.define(version: 2021_02_24_154323) do
     t.index ["locale_code"], name: "index_trainees_on_locale_code"
     t.index ["progress"], name: "index_trainees_on_progress", using: :gin
     t.index ["provider_id"], name: "index_trainees_on_provider_id"
-    t.index ["record_type"], name: "index_trainees_on_record_type"
     t.index ["slug"], name: "index_trainees_on_slug", unique: true
     t.index ["state"], name: "index_trainees_on_state"
+    t.index ["training_route"], name: "index_trainees_on_training_route"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/components/application_record_card/view_preview.rb
+++ b/spec/components/application_record_card/view_preview.rb
@@ -17,14 +17,14 @@ module ApplicationRecordCard
   private
 
     def mock_trainee
-      Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", record_type: "assessment_only", subject: "Primary")
+      Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: "assessment_only", subject: "Primary")
     end
 
     def mock_multiple_trainees
-      [Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", record_type: "assessment_only", subject: "Primary"),
-       Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Paddington", last_name: "Bear", record_type: "assessment_only", subject: "Science"),
+      [Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: "assessment_only", subject: "Primary"),
+       Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Paddington", last_name: "Bear", training_route: "assessment_only", subject: "Science"),
        Trainee.new(id: 1, created_at: Time.zone.now),
-       Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tim", last_name: "Knight", record_type: "assessment_only", subject: "Maths"),
+       Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tim", last_name: "Knight", training_route: "assessment_only", subject: "Maths"),
        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Toby", last_name: "Rocker")]
     end
   end

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -79,7 +79,7 @@ module ApplicationRecordCard
             first_names: "Teddy",
             last_name: "Smith",
             subject: "Designer",
-            record_type: "assessment_only",
+            training_route: "assessment_only",
             trainee_id: "132456",
             created_at: Time.zone.now,
             trn: "789456",
@@ -114,7 +114,7 @@ module ApplicationRecordCard
       end
 
       it "renders route if there is no route" do
-        expect(component.find(".app-application-card__route")).to have_text(t("activerecord.attributes.trainee.record_types.assessment_only"))
+        expect(component.find(".app-application-card__route")).to have_text(t("activerecord.attributes.trainee.training_routes.assessment_only"))
       end
     end
   end

--- a/spec/components/trainees/confirmation/programme_details/view_preview.rb
+++ b/spec/components/trainees/confirmation/programme_details/view_preview.rb
@@ -10,7 +10,7 @@ module Trainees
         end
 
         def with_no_data
-          render(Trainees::Confirmation::ProgrammeDetails::View.new(trainee: Trainee.new(id: 2, record_type: :assessment_only)))
+          render(Trainees::Confirmation::ProgrammeDetails::View.new(trainee: Trainee.new(id: 2, training_route: :assessment_only)))
         end
 
       private
@@ -21,7 +21,7 @@ module Trainees
             subject: "Primary",
             age_range: "3 to 11 programme",
             programme_start_date: Date.new(2020, 0o1, 28),
-            record_type: :assessment_only,
+            training_route: :assessment_only,
           )
         end
       end

--- a/spec/components/trainees/confirmation/programme_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/programme_details/view_spec.rb
@@ -9,7 +9,7 @@ module Trainees
         alias_method :component, :page
 
         context "when data has not been provided" do
-          let(:trainee) { build(:trainee, id: 1, record_type: nil, subject: nil, age_range: nil, programme_start_date: nil) }
+          let(:trainee) { build(:trainee, id: 1, training_route: nil, subject: nil, age_range: nil, programme_start_date: nil) }
           before do
             render_inline(View.new(trainee: trainee))
           end
@@ -34,7 +34,7 @@ module Trainees
 
           it "renders the programme type" do
             expect(component.find(".govuk-summary-list__row.type-of-course .govuk-summary-list__value"))
-              .to have_text(trainee.record_type.humanize)
+              .to have_text(trainee.training_route.humanize)
           end
 
           it "renders the subject" do

--- a/spec/components/trainees/confirmation/trainee_id/view_preview.rb
+++ b/spec/components/trainees/confirmation/trainee_id/view_preview.rb
@@ -18,7 +18,7 @@ module Trainees
         def mock_trainee
           @mock_trainee ||= Trainee.new(
             id: 1,
-            record_type: :assessment_only,
+            training_route: :assessment_only,
             trainee_id: "ABC-1234-XYZ",
           )
         end

--- a/spec/components/trainees/filters/view_preview.rb
+++ b/spec/components/trainees/filters/view_preview.rb
@@ -12,9 +12,9 @@ module Trainees
 
       def filter_mock
         ActionController::Parameters.new({
-          record_type: %w[assessment_only],
+          training_route: %w[assessment_only],
           subject: "Biology",
-        }).permit(:subject, :text_search, record_type: [], state: [])
+        }).permit(:subject, :text_search, training_route: [], state: [])
       end
     end
   end

--- a/spec/components/trainees/record_details/view_preview.rb
+++ b/spec/components/trainees/record_details/view_preview.rb
@@ -26,7 +26,7 @@ module Trainees
       def mock_trainee(trainee_id, state = :draft)
         @mock_trainee ||= Trainee.new(
           id: 1,
-          record_type: :assessment_only,
+          training_route: :assessment_only,
           trainee_id: trainee_id,
           created_at: Time.zone.today,
           updated_at: Time.zone.today,

--- a/spec/components/trainees/timeline/view_preview.rb
+++ b/spec/components/trainees/timeline/view_preview.rb
@@ -18,7 +18,7 @@ module Trainees
 
       def trainee
         @trainee ||= Trainee.create!(
-          record_type: "assessment_only",
+          training_route: "assessment_only",
           provider: user.provider,
         )
       end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     provider
 
-    record_type { "assessment_only" }
+    training_route { "assessment_only" }
 
     first_names { Faker::Name.first_name }
     middle_names { Faker::Name.middle_name }

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -15,10 +15,14 @@ feature "Create trainee journey" do
     then_i_should_see_the_new_trainee_overview
   end
 
-  scenario "setting up an initial provide led record" do
+  scenario "setting up an initial provider led record", "feature_routes_provider_led": true do
     and_i_select_provider_led_route
     and_i_save_the_form
     then_i_should_see_the_new_trainee_overview
+  end
+
+  scenario "provider led radio button not shown when feature set to false", "feature_routes_provider_led": false do
+    and_i_should_not_see_provider_led_route
   end
 
   scenario "submitting without choosing a route" do
@@ -42,6 +46,11 @@ private
 
   def and_i_select_provider_led_route
     new_trainee_page.provider_led.click
+  end
+
+  def and_i_should_not_see_provider_led_route
+    expect(new_trainee_page).to be_displayed
+    expect(new_trainee_page).to_not have_provider_led
   end
 
   def and_i_save_the_form

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -15,13 +15,13 @@ feature "Create trainee journey" do
     then_i_should_see_the_new_trainee_overview
   end
 
-  scenario "setting up an initial provider led record", "feature_routes_provider_led": true do
+  scenario "setting up an initial provider led record", feature_routes_provider_led: true do
     and_i_select_provider_led_route
     and_i_save_the_form
     then_i_should_see_the_new_trainee_overview
   end
 
-  scenario "provider led radio button not shown when feature set to false", "feature_routes_provider_led": false do
+  scenario "provider led radio button not shown when feature set to false", feature_routes_provider_led: false do
     and_i_should_not_see_provider_led_route
   end
 

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -15,6 +15,12 @@ feature "Create trainee journey" do
     then_i_should_see_the_new_trainee_overview
   end
 
+  scenario "setting up an initial provide led record" do
+    and_i_select_provider_led_route
+    and_i_save_the_form
+    then_i_should_see_the_new_trainee_overview
+  end
+
   scenario "submitting without choosing a route" do
     and_i_save_the_form
     then_i_should_see_a_validation_error
@@ -34,6 +40,10 @@ private
     new_trainee_page.assessment_only.click
   end
 
+  def and_i_select_provider_led_route
+    new_trainee_page.provider_led.click
+  end
+
   def and_i_save_the_form
     new_trainee_page.continue_button.click
   end
@@ -43,6 +53,6 @@ private
   end
 
   def then_i_should_see_a_validation_error
-    expect(new_trainee_page).to have_content(I18n.t("activerecord.errors.models.trainee.attributes.record_type"))
+    expect(new_trainee_page).to have_content(I18n.t("activerecord.errors.models.trainee.attributes.training_route"))
   end
 end

--- a/spec/features/trainees/filtering_trainees_spec.rb
+++ b/spec/features/trainees/filtering_trainees_spec.rb
@@ -75,8 +75,8 @@ RSpec.feature "Filtering trainees" do
 private
 
   def given_trainees_exist_in_the_system
-    @assessment_only_trainee ||= create(:trainee, record_type: "assessment_only")
-    @provider_led_trainee ||= create(:trainee, record_type: "provider_led")
+    @assessment_only_trainee ||= create(:trainee, training_route: "assessment_only")
+    @provider_led_trainee ||= create(:trainee, training_route: "provider_led")
     @biology_trainee ||= create(:trainee, subject: "Biology")
     @history_trainee ||= create(:trainee, subject: "History")
     @searchable_trainee ||= create(:trainee, trn: "123")

--- a/spec/models/trainee_filter_spec.rb
+++ b/spec/models/trainee_filter_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe TraineeFilter do
   let(:permitted_params) do
     ActionController::Parameters.new(params)
-    .permit(:subject, :text_search, record_type: [], state: [])
+    .permit(:subject, :text_search, training_route: [], state: [])
   end
 
   subject { TraineeFilter.new(params: permitted_params) }
@@ -23,7 +23,7 @@ describe TraineeFilter do
         {
           subject: "Biology",
           text_search: "search terms",
-          record_type: %w[assessment_only],
+          training_route: %w[assessment_only],
           state: %w[draft],
         }
       end
@@ -47,13 +47,13 @@ describe TraineeFilter do
       include_examples returns_nil
     end
 
-    context "with invalid record type" do
-      let(:params) { { record_type: %w[not_a_record_type] } }
+    context "with invalid training route" do
+      let(:params) { { training_route: %w[not_a_training_route] } }
       include_examples returns_nil
     end
 
     context "with invalid state" do
-      let(:params) { { record_type: %w[not_a_state] } }
+      let(:params) { { training_route: %w[not_a_state] } }
       include_examples returns_nil
     end
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -6,7 +6,7 @@ describe Trainee do
   context "fields" do
     subject { build(:trainee) }
 
-    it { is_expected.to define_enum_for(:record_type).with_values(assessment_only: 0, provider_led: 1) }
+    it { is_expected.to define_enum_for(:training_route).with_values(assessment_only: 0, provider_led: 1) }
     it { is_expected.to define_enum_for(:locale_code).with_values(uk: 0, non_uk: 1) }
     it { is_expected.to define_enum_for(:gender).with_values(male: 0, female: 1, other: 2, gender_not_provided: 3) }
 
@@ -89,7 +89,7 @@ describe Trainee do
 
       describe "validation" do
         context "when record type is present" do
-          subject { build(:trainee, record_type: "assessment_only") }
+          subject { build(:trainee, training_route: "assessment_only") }
 
           it "is valid" do
             expect(subject).to be_valid
@@ -99,7 +99,7 @@ describe Trainee do
         context "when record type is not present" do
           it "is not valid" do
             expect(subject).not_to be_valid
-            expect(subject.errors.attribute_names).to include(:record_type)
+            expect(subject.errors.attribute_names).to include(:training_route)
           end
         end
       end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -88,7 +88,7 @@ describe Trainee do
       end
 
       describe "validation" do
-        context "when record type is present" do
+        context "when training route is present" do
           subject { build(:trainee, training_route: "assessment_only") }
 
           it "is valid" do
@@ -96,7 +96,7 @@ describe Trainee do
           end
         end
 
-        context "when record type is not present" do
+        context "when training route is not present" do
           it "is not valid" do
             expect(subject).not_to be_valid
             expect(subject.errors.attribute_names).to include(:training_route)

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -18,7 +18,7 @@ module Exports
           "Trainee Id" => trainee.trainee_id,
           "TRN" => trainee.trn,
           "Status" => trainee.state,
-          "Route" => trainee.record_type,
+          "Route" => trainee.training_route,
           "Subject" => trainee.subject,
           "Programme start date" => trainee.programme_start_date,
           "Programme end date" => trainee.programme_end_date,

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -24,7 +24,6 @@ RSpec.configure do |config|
   config.around :each do |example|
     example.metadata.keys.grep(/^feature_.*/) do |metadata_key|
       feature = normalise_feature_name.call(metadata_key)
-
       if Settings.features.key?(feature)
         original_features[feature] = Settings.features[feature]
       end

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -20,8 +20,8 @@ module PageObjects
       element :apply_filters, "input[name='commit']"
 
       element :text_search, "#text_search"
-      element :assessment_only_checkbox, "#record_type-assessment_only"
-      element :provider_led_checkbox, "#record_type-provider_led"
+      element :assessment_only_checkbox, "#training_route-assessment_only"
+      element :provider_led_checkbox, "#training_route-provider_led"
       element :subject, "#subject"
 
       element :export_link, ".trainee-search-export"

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -7,8 +7,11 @@ module PageObjects
 
       element :page_heading, ".govuk-heading-xl"
 
-      element :assessment_only, "#trainee-record-type-assessment-only-field"
-      element :other, "#trainee-record-type-other-field"
+      element :assessment_only, "#trainee-training-route-assessment-only-field"
+
+      element :provider_led, "#trainee-training-route-provider-led-field"
+      
+      element :other, "#trainee-training-route-other-field"
 
       element :continue_button, 'input.govuk-button[type="submit"]'
     end

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -10,7 +10,7 @@ module PageObjects
       element :assessment_only, "#trainee-training-route-assessment-only-field"
 
       element :provider_led, "#trainee-training-route-provider-led-field"
-      
+
       element :other, "#trainee-training-route-other-field"
 
       element :continue_button, 'input.govuk-button[type="submit"]'


### PR DESCRIPTION
### Context

Added a new training route `Provider-led` and changed `record_type` column to `training_path`, supported by feature flag.

### Changes proposed in this pull request

- New migration to change record_type to training_path
- Added new `route_provider_led` feature to settings.yml
- Changed all references from `record_type` to `training_route`
- Added new Provider-led radio button on new trainee view

### Guidance to review

- On creation of a new trainee, you should see an option to choose the provider led route
- In settings.yml you can toggle this feature

### Screenshots
![Screenshot 2021-03-01 at 15 17 39](https://user-images.githubusercontent.com/53180713/109517609-5cca0980-7aa1-11eb-82d1-915b297c76a8.png)
![Screenshot 2021-03-01 at 15 17 22](https://user-images.githubusercontent.com/53180713/109517620-5d62a000-7aa1-11eb-8f7f-fb144631e120.png)
