### PR TITLE
[1178] AccessToken gets loaded once on ruby load, and therefore not r…

### DIFF
--- a/app/lib/dttp/client.rb
+++ b/app/lib/dttp/client.rb
@@ -6,6 +6,6 @@ module Dttp
     base_uri Settings.dttp.api_base_url
     headers "Accept" => "application/json",
             "Content-Type" => "application/json;odata.metadata=minimal",
-            "Authorization" => "Bearer #{AccessToken.fetch}"
+            "Authorization" => -> { "Bearer #{AccessToken.fetch}" }
   end
 end

--- a/spec/lib/dttp/batch_request_spec.rb
+++ b/spec/lib/dttp/batch_request_spec.rb
@@ -9,7 +9,7 @@ module Dttp
     let(:content_id) { SecureRandom.uuid }
     let(:payload) { "payload" }
     let(:expected_url) { "#{Dttp::Client.base_uri}/$batch" }
-    let(:expected_headers) { Client.headers.merge("Content-Type" => "multipart/mixed;boundary=batch_#{batch_id}") }
+    let(:expected_headers) { Client.headers.merge("Content-Type" => "multipart/mixed;boundary=batch_#{batch_id}", "Authorization" => "Bearer token") }
 
     subject { described_class.new(batch_id: batch_id, change_set_id: change_set_id) }
 


### PR DESCRIPTION
### Context

https://trello.com/c/JCAC3KJM/1178-investigate-401-issue-for-dttp

### Changes proposed in this pull request

* Previously AccessToken is fetched on ruby load, and not re-fetched unless the process restarts. Making lambda means we should fetch at the point of making a new HTTP request. This explains why restarting workers works!

### Guidance to review
