### PR TITLE
[1193] Query the correct dttp entity path for the qts awarded flag

### DIFF
--- a/app/services/dttp/retrieve_qts.rb
+++ b/app/services/dttp/retrieve_qts.rb
@@ -13,7 +13,7 @@ module Dttp
     end
 
     def call
-      response = Client.get("/contacts(#{trainee.dttp_id})?$select=dfe_qtsawardflag")
+      response = Client.get("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})?$select=dfe_qtsawardflag")
       if response.code != 200
         raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
       end

--- a/spec/services/dttp/retrieve_qts_spec.rb
+++ b/spec/services/dttp/retrieve_qts_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 module Dttp
   describe RetrieveQts do
     describe "#call" do
-      let(:contact_entity_id) { SecureRandom.uuid }
-      let(:trainee) { create(:trainee, :recommended_for_qts, dttp_id: contact_entity_id) }
-      let(:path) { "/contacts(#{contact_entity_id})?$select=dfe_qtsawardflag" }
+      let(:placement_assignment_entity_id) { SecureRandom.uuid }
+      let(:trainee) { create(:trainee, :recommended_for_qts, placement_assignment_dttp_id: placement_assignment_entity_id) }
+      let(:path) { "/dfe_placementassignments(#{placement_assignment_entity_id})?$select=dfe_qtsawardflag" }
 
       subject { described_class.call(trainee: trainee) }
 


### PR DESCRIPTION
### Context

- https://sentry.io/organizations/dfe-bat/issues/2239722865/?environment=qa&project=5552118&referrer=alert_email

### Changes proposed in this pull request

- Update the DTTP path to fetch the qts awarded property

### Guidance to review

You can test this out in postman by quering the following path:

`https://{{dttp_host}}/api/data/v9.1/dfe_placementassignments(1037728a-7928-e911-a82a-000d3ab0d281)?$select=dfe_qtsawardflag` which should return the correct json the class expects to parse.

