### PR TITLE
[1035] Fix filter display bug for smaller viewports

### DIFF
--- a/app/components/trainees/filters/style.scss
+++ b/app/components/trainees/filters/style.scss
@@ -48,7 +48,7 @@
   }
 }
 
-.js-enabled .moj-filter-layout__filter {
+.moj-filter-layout__filter {
   @include govuk-media-query($until: tablet) {
     // only display a scrollbar if it there is overflow to scroll
     overflow: auto;

--- a/app/components/trainees/filters/style.scss
+++ b/app/components/trainees/filters/style.scss
@@ -48,6 +48,15 @@
   }
 }
 
+.js-enabled .moj-filter-layout__filter {
+  @include govuk-media-query($until: tablet) {
+    // only display a scrollbar if it there is overflow to scroll
+    overflow: auto;
+    // At this width the filter has `position: fixed`. We should set a max width that will safely include the filter and a scrollbar if present 
+    max-width: calc(100vw - calc(100vw - 100%));
+  }
+}
+
 .moj-filter__header {
   background: govuk-colour("white");
   box-shadow: none;

--- a/app/components/trainees/filters/style.scss
+++ b/app/components/trainees/filters/style.scss
@@ -48,7 +48,7 @@
   }
 }
 
-.moj-filter-layout__filter {
+.js-enabled .moj-filter-layout__filter {
   @include govuk-media-query($until: tablet) {
     // only display a scrollbar if it there is overflow to scroll
     overflow: auto;


### PR DESCRIPTION
### Context

This PR adds an override to the MoJ filter to ensure it the filter remains visible at smaller viewports on desktop and also only shows the scroll bar when needed. We noticed in the bug in the accessibility audit.

### Changes proposed in this pull request

#### Before

![127 0 0 1_5000_trainees (5)](https://user-images.githubusercontent.com/1108991/109663084-9f541a80-7b63-11eb-993a-f85f67deb59d.png)
Obscured filter, additional scrollbar. 😢

#### After

![127 0 0 1_5000_trainees (4)](https://user-images.githubusercontent.com/1108991/109663205-c14d9d00-7b63-11eb-81e8-6770ad9a94a0.png)
Filter visible, scrollbar only visible when actually has overflow 🎉

### Guidance to review

Ensure scroll bars are set to always display, resize a desktop browser to 320px, see if the filter is not obscured by viewport edge. 