### PR TITLE
[1165] Fix styling on export link

### DIFF
--- a/app/components/trainees/filters/style.scss
+++ b/app/components/trainees/filters/style.scss
@@ -45,6 +45,7 @@
 @media (min-width: 48.0625em) {
   .moj-filter-layout__filter {
     max-width: 300px;
+    margin-bottom: 10px;
   }
 }
 
@@ -89,3 +90,14 @@
 .moj-filter__content:focus {
   outline: none;
 }
+
+.moj-filter-layout__filter-wrapper {
+  max-width: 300px;
+  margin-right: 40px;
+  min-width: 260px;
+  width: 100%;
+  @include govuk-media-query($from: desktop) {
+    float: left;
+  }
+}
+

--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -1,79 +1,80 @@
-<div class="moj-filter-layout__filter app-filter">
-  <div class="moj-filter">
-    <div class="moj-filter__header">
-      <div class="moj-filter__header-title">
-        <h2 class="govuk-heading-m">Filters</h2>
-      </div>
-      <div class="moj-filter__header-action">
-      </div>
-    </div>
-
-    <!-- Div made focusable to 'catch' focus from filters. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640 -->
-    <div class="moj-filter__content" tabindex="-1">
-
-      <% if filters %>
-        <div class="moj-filter__selected">
-          <div class="moj-filter__selected-heading">
-            <div class="moj-filter__heading-title">
-              <h2 class="govuk-heading-m">Selected filters</h2>
-            </div>
-            <div class="moj-filter__heading-action">
-              <p class="govuk-body">
-              <%= govuk_link_to 'Clear<span class="govuk-visually-hidden"> all filters</span>'.html_safe, trainees_path, class: 'govuk-link--no-visited-state' %>
-              </p>
-            </div>
-          </div>
-
-          <% filters.each do |filter, value| %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= filter_label_for(filter) %></h3>
-            <ul class="moj-filter-tags">
-              <% tags_for_filter(filter, value).each do |tag| %>
-                <li>
-                  <%= link_to(tag[:title], tag[:remove_link], class: "moj-filter__tag", draggable: "false") %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
+<div class="moj-filter-layout__filter-wrapper app-filter">
+  <div class="moj-filter-layout__filter">
+    <div class="moj-filter">
+      <div class="moj-filter__header">
+        <div class="moj-filter__header-title">
+          <h2 class="govuk-heading-m">Filters</h2>
         </div>
-      <% end %>
+        <div class="moj-filter__header-action">
+        </div>
+      </div>
 
-      <div class="moj-filter__options">
+      <!-- Div made focusable to 'catch' focus from filters. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640 -->
+      <div class="moj-filter__content" tabindex="-1">
 
-        <form method="get">
-          <%= submit_tag "Apply filters", class: "govuk-button" %>
-          <%= hidden_field_tag :sort_by, params[:sort_by] %>
-
-          <div class="govuk-form-group">
-            <%= label_tag "text_search", "Search records", class: "govuk-label govuk-label--s" %>
-            <%= text_field_tag "text_search", (filters[:text_search] if filters), spellcheck: false, class: "govuk-input" %>
-          </div>
-
-          <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset">
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                Status
-              </legend>
-              <div class="govuk-checkboxes govuk-checkboxes--small">
-                <% Trainee.states.map do |state, _| %>
-                  <div class="govuk-checkboxes__item">
-                    <%= check_box_tag 'state[]', state, checked?(:state, state), id: "state-#{state}", class: "govuk-checkboxes__input"%>
-                    <%= label_tag "state-#{state}", label_for('state', state), class: "govuk-label govuk-checkboxes__label" %>
-                  </div>
-                <% end %>
+        <% if filters %>
+          <div class="moj-filter__selected">
+            <div class="moj-filter__selected-heading">
+              <div class="moj-filter__heading-title">
+                <h2 class="govuk-heading-m">Selected filters</h2>
               </div>
-            </fieldset>
-          </div>
+              <div class="moj-filter__heading-action">
+                <p class="govuk-body">
+                <%= govuk_link_to 'Clear<span class="govuk-visually-hidden"> all filters</span>'.html_safe, trainees_path, class: 'govuk-link--no-visited-state' %>
+                </p>
+              </div>
+            </div>
 
-          <div class="govuk-form-group">
-            <%= label_tag "subject", "Subject", class: "govuk-label govuk-label--s" %>
-            <%= select_tag :subject, options_from_collection_for_select(filter_programme_subjects_options, :name, :name, (filters[:subject] if filters)), class: "govuk-select" %>
+            <% filters.each do |filter, value| %>
+              <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= filter_label_for(filter) %></h3>
+              <ul class="moj-filter-tags">
+                <% tags_for_filter(filter, value).each do |tag| %>
+                  <li>
+                    <%= link_to(tag[:title], tag[:remove_link], class: "moj-filter__tag", draggable: "false") %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
           </div>
-        </form>
+        <% end %>
+
+        <div class="moj-filter__options">
+
+          <form method="get">
+            <%= submit_tag "Apply filters", class: "govuk-button" %>
+            <%= hidden_field_tag :sort_by, params[:sort_by] %>
+
+            <div class="govuk-form-group">
+              <%= label_tag "text_search", "Search records", class: "govuk-label govuk-label--s" %>
+              <%= text_field_tag "text_search", (filters[:text_search] if filters), spellcheck: false, class: "govuk-input" %>
+            </div>
+
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                  Status
+                </legend>
+                <div class="govuk-checkboxes govuk-checkboxes--small">
+                  <% Trainee.states.map do |state, _| %>
+                    <div class="govuk-checkboxes__item">
+                      <%= check_box_tag 'state[]', state, checked?(:state, state), id: "state-#{state}", class: "govuk-checkboxes__input"%>
+                      <%= label_tag "state-#{state}", label_for('state', state), class: "govuk-label govuk-checkboxes__label" %>
+                    </div>
+                  <% end %>
+                </div>
+              </fieldset>
+            </div>
+
+            <div class="govuk-form-group">
+              <%= label_tag "subject", "Subject", class: "govuk-label govuk-label--s" %>
+              <%= select_tag :subject, options_from_collection_for_select(filter_programme_subjects_options, :name, :name, (filters[:subject] if filters)), class: "govuk-select" %>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
-
-    <% if filter_actions %>
-      <%= filter_actions %>
-    <% end %>
   </div>
+  <% if filter_actions %>
+    <%= filter_actions %>
+  <% end %>
 </div>

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -16,7 +16,7 @@
 <%= render PaginatedFilter::View.new(filters: @filters, collection: @paginated_trainees) do |component| %>
   <% if FeatureService.enabled?(:trainee_export) && (@paginated_trainees).any?(&:present?) %>
     <% component.with(:filter_actions) do %>
-      <p class="govuk-body govuk-!-margin-top-3"><%= govuk_link_to("Export these records", trainees_path(filter_params.merge(format: "csv")), class: "trainee-search-export") %></p>
+      <p class="govuk-body govuk-!-margin-top-3"><%= govuk_link_to("Export these records", trainees_path(filter_params.merge(format: "csv")), class: "app-trainee-export") %></p>
     <% end %>
   <% end %>
 

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -80,3 +80,4 @@
   @include govuk-link-common;
   @include govuk-link-style-error;
 }
+

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -24,7 +24,7 @@ module PageObjects
       element :provider_led_checkbox, "#training_route-provider_led"
       element :subject, "#subject"
 
-      element :export_link, ".trainee-search-export"
+      element :export_link, ".app-trainee-export"
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/Rqn8bmoP/1165-fix-export-link-styling
Export link needs to be outside filters div.  And needs move up above the sort links on mobile. 

### Changes proposed in this pull request
Move the export link outside the filter div. Add css which moves html within filter wrapper (including link) to the left on desktop. Otherwise, export link appears at top on mobile. 

### Guidance to review
Load /trainees page and check that export link is now in correct place

<img width="578" alt="Screenshot 2021-03-04 at 16 09 14" src="https://user-images.githubusercontent.com/58793682/109993243-001a5900-7d04-11eb-90a4-3731d435948f.png">
<img width="549" alt="Screenshot 2021-03-04 at 16 09 39" src="https://user-images.githubusercontent.com/58793682/109993297-0c9eb180-7d04-11eb-8769-21aabb3342ea.png">
