### PR TITLE
[1123] Reinstate trainee

### DIFF
--- a/app/components/trainees/confirmation/reinstatement_details/view.html.erb
+++ b/app/components/trainees/confirmation/reinstatement_details/view.html.erb
@@ -1,0 +1,11 @@
+<%= render SummaryCard::View.new(trainee: trainee,
+  title: t("components.confirmation.reinstatement_details.summary_title"),
+  heading_level: 2,
+  rows: [
+    {
+      key: t("components.confirmation.reinstatement_details.reinstate_date_label"),
+      value: reinstate_date,
+      action: govuk_link_to(t(:change), trainee_reinstatement_path(trainee)),
+    },
+  ])
+%>

--- a/app/components/trainees/confirmation/reinstatement_details/view.rb
+++ b/app/components/trainees/confirmation/reinstatement_details/view.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Confirmation
+    module ReinstatementDetails
+      class View < GovukComponent::Base
+        include SummaryHelper
+
+        attr_reader :trainee
+
+        def initialize(trainee:)
+          @trainee = trainee
+        end
+
+        def confirm_section_title
+          I18n.t("components.confirmation.reinstatement_details.heading")
+        end
+
+        def reinstate_date
+          date_for_summary_view(trainee.reinstate_date)
+        end
+      end
+    end
+  end
+end

--- a/app/components/trainees/record_actions/view.rb
+++ b/app/components/trainees/record_actions/view.rb
@@ -28,15 +28,15 @@ module Trainees
     private
 
       def defer_link
-        govuk_link_to t("views.trainees.edit.defer"), trainee_deferral_path(@trainee), class: "defer"
+        govuk_link_to t("views.trainees.edit.defer"), trainee_deferral_path(trainee), class: "defer"
       end
 
       def withdraw_link
-        govuk_link_to t("views.trainees.edit.withdraw"), trainee_withdrawal_path(@trainee), class: "withdraw"
+        govuk_link_to t("views.trainees.edit.withdraw"), trainee_withdrawal_path(trainee), class: "withdraw"
       end
 
       def reinstate_link
-        govuk_link_to t("view.trainees.edit.reinstate"), trainees_path, class: "reinstate"
+        govuk_link_to t("views.trainees.edit.reinstate"), trainee_reinstatement_path(trainee), class: "reinstate"
       end
     end
   end

--- a/app/components/trainees/timeline/view.rb
+++ b/app/components/trainees/timeline/view.rb
@@ -34,7 +34,7 @@ module Trainees
       def state_change_events
         state_change_audits.map do |audit|
           Event.new(
-            state_change_title(audit.audited_changes["state"][1]),
+            state_change_title(audit.audited_changes["state"]),
             username(audit),
             audit.created_at,
           )
@@ -51,8 +51,14 @@ module Trainees
         end
       end
 
-      def state_change_title(value)
-        I18n.t("components.timeline.titles.#{Trainee.states.key(value)}")
+      def state_change_title(changes)
+        from_state, to_state = changes.map { |state| Trainee.states.key(state) }
+
+        if from_state == "deferred" && to_state != "withdrawn"
+          I18n.t("components.timeline.titles.reinstated")
+        else
+          I18n.t("components.timeline.titles.#{to_state}")
+        end
       end
 
       # Fall back on the provider's name if there's no user for the audit, e.g.

--- a/app/controllers/trainees/confirm_reinstatements_controller.rb
+++ b/app/controllers/trainees/confirm_reinstatements_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Trainees
+  class ConfirmReinstatementsController < ApplicationController
+    before_action :authorize_trainee
+
+    def show
+      page_tracker.save_as_origin!
+    end
+
+    def update
+      trainee.trn.present? ? trainee.trn_received! : trainee.submit_for_trn!
+
+      ReinstateJob.perform_later(trainee.id)
+
+      flash[:success] = "Trainee reinstated"
+      redirect_to trainee_path(trainee)
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def authorize_trainee
+      authorize(trainee)
+    end
+  end
+end

--- a/app/controllers/trainees/reinstatements_controller.rb
+++ b/app/controllers/trainees/reinstatements_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Trainees
+  class ReinstatementsController < ApplicationController
+    before_action :authorize_trainee
+
+    def show
+      @reinstatement_form = ReinstatementForm.new(trainee)
+    end
+
+    def update
+      authorize(trainee, :reinstate?)
+
+      @reinstatement_form = ReinstatementForm.new(trainee)
+      @reinstatement_form.assign_attributes(trainee_params)
+
+      if @reinstatement_form.save
+        redirect_to trainee_confirm_reinstatement_path(@trainee)
+      else
+        render :show
+      end
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def authorize_trainee
+      authorize(trainee)
+    end
+
+    def trainee_params
+      params.require(:reinstatement_form)
+        .permit(:date_string, *MultiDateForm::PARAM_CONVERSION.keys)
+        .transform_keys do |key|
+          MultiDateForm::PARAM_CONVERSION.fetch(key, key)
+        end
+    end
+  end
+end

--- a/app/forms/reinstatement_form.rb
+++ b/app/forms/reinstatement_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ReinstatementForm < MultiDateForm
+private
+
+  def date_field
+    @date_field ||= :reinstate_date
+  end
+end

--- a/app/jobs/reinstate_job.rb
+++ b/app/jobs/reinstate_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ReinstateJob < ApplicationJob
+  queue_as :default
+  retry_on Dttp::UpdateTraineeStatus::Error
+
+  def perform(trainee_id)
+    trainee = Trainee.find(trainee_id)
+
+    status = trainee.trn.present? ? DttpStatuses::YET_TO_COMPLETE_COURSE : DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED
+
+    Dttp::UpdateTraineeStatus.call(status: status,
+                                   entity_id: trainee.dttp_id,
+                                   entity_type: Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE)
+
+    Dttp::UpdateTraineeStatus.call(status: status,
+                                   entity_id: trainee.placement_assignment_dttp_id,
+                                   entity_type: Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE)
+  end
+end

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -22,31 +22,32 @@ class TraineePolicy
   end
 
   def show?
-    user && (user.system_admin? || user.provider_id == trainee.provider_id)
-  end
-
-  def confirm?
-    user && (user.system_admin? || user.provider_id == trainee.provider_id)
-  end
-
-  def recommended?
-    user && (user.system_admin? || user.provider_id == trainee.provider_id)
+    allowed_user?
   end
 
   def withdraw?
-    defer? || trainee.deferred?
+    allowed_user? && (defer? || trainee.deferred?)
   end
 
   def defer?
-    trainee.submitted_for_trn? || trainee.trn_received?
+    allowed_user? && (trainee.submitted_for_trn? || trainee.trn_received?)
   end
 
-  def destroy?
-    user && (user.system_admin? || user.provider_id == trainee.provider_id)
+  def reinstate?
+    allowed_user? && trainee.deferred?
   end
 
   alias_method :create?, :show?
   alias_method :update?, :show?
   alias_method :edit?, :show?
   alias_method :new?, :show?
+  alias_method :destroy?, :show?
+  alias_method :confirm?, :show?
+  alias_method :recommended?, :show?
+
+private
+
+  def allowed_user?
+    user&.system_admin? || user&.provider == trainee.provider
+  end
 end

--- a/app/services/dttp/retrieve_qts.rb
+++ b/app/services/dttp/retrieve_qts.rb
@@ -14,6 +14,7 @@ module Dttp
 
     def call
       response = Client.get("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})?$select=dfe_qtsawardflag")
+
       if response.code != 200
         raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
       end

--- a/app/views/trainees/confirm_reinstatements/show.html.erb
+++ b/app/views/trainees/confirm_reinstatements/show.html.erb
@@ -1,0 +1,24 @@
+<%= render PageTitle::View.new(title: "trainees.confirm_reinstatement.show") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLink.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l">
+        <%= trainee_name(@trainee) %>
+      </span>
+      <%= t("views.confirm_reinstatement.heading") %>
+    </h1>
+
+    <%= render Trainees::Confirmation::ReinstatementDetails::View.new(trainee: @trainee) %>
+
+    <%= form_with url: trainee_confirm_reinstatement_path(@trainee), method: :patch, local: true do |f| %>
+      <%= f.govuk_submit  t("views.confirm_reinstatement.submit") %>
+    <%- end -%>
+  </div>
+</div>
+
+<p class="govuk-body"><%= govuk_link_to(t("cancel"), trainee_path(@trainee)) %></p>

--- a/app/views/trainees/reinstatements/show.html.erb
+++ b/app/views/trainees/reinstatements/show.html.erb
@@ -1,0 +1,29 @@
+<%= render PageTitle::View.new(title: "trainees.reinstatement.show", has_errors: @reinstatement_form.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with(model: @reinstatement_form, url: trainee_reinstatement_path(@trainee), local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l">
+        <%= trainee_name(@trainee) %>
+      </span>
+
+      <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: t("views.forms.reinstatement.heading"), tag: "h1", size: "l" }) do %>
+        <%= f.govuk_radio_button :date_string, :today, label: { text: t("views.forms.common.today") }, link_errors: true %>
+        <%= f.govuk_radio_button :date_string, :yesterday, label: { text: t("views.forms.common.yesterday") } %>
+        <%= f.govuk_radio_button :date_string, :other, label: { text: t("views.forms.common.specific_date") } do %>
+          <%= f.govuk_date_field :date, legend: { text: t("views.forms.common.on_what_date"), size: 's' }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>
+
+<p class="govuk-body"><%= govuk_link_to("Cancel and return to record", trainee_path(@trainee)) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,10 @@ en:
           female: Female
           other: Other
           gender_not_provided: Not provided
+      reinstatement_details:
+        header: Check reinstatement details
+        reinstate_date_label: Date of return
+        summary_title: Reinstatement details
       withdrawal_details:
         heading: Check withdrawal details
         summary_title: Withdrawal details
@@ -132,6 +136,10 @@ en:
           show: When did the trainee defer?
         deferral_details:
           confirm: Check deferral details
+        reinstatement:
+           show: When did the trainee return?
+        confirm_reinstatement:
+          show: Check reinstatement details
         sort_links:
           sort_switcher: Change record sort order
           sort_by: Sort by
@@ -157,6 +165,7 @@ en:
         withdrawn: Trainee withdrawn
         deferred: Trainee deferred
         qts_awarded: Trainee awarded QTS
+        reinstated: Trainee reinstated
     sections:
       titles:
         personal_details: Personal details
@@ -195,6 +204,9 @@ en:
     confirm_withdrawal:
       heading: Check withdrawal details
       submit: Withdraw this trainee
+    confirm_reinstatement:
+      heading: Check reinstatement details
+      submit: Reinstate this trainee
     forms:
       common:
         today: Today
@@ -227,6 +239,8 @@ en:
         labels:
           disabled: "Yes, they shared that they’re disabled"
           no_disability: "They shared that they’re not disabled"
+      reinstatement:
+        heading: When did the trainee return?
       withdrawal_reasons:
         headings:
           withdrawal_date: When did the trainee withdraw?
@@ -408,6 +422,13 @@ en:
               invalid: "You must enter a valid programme end date"
               too_old: "You must enter a valid programme end date"
               before_or_same_as_start_date: "The programme end date must be after the start date"
+        reinstatement_form:
+          attributes:
+            date_string:
+              blank: You must choose a date of return
+            date:
+              blank: You must enter a date of return
+              invalid: You must enter a valid date of return
         trn_submission_form:
           attributes:
             trainee:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,9 @@ Rails.application.routes.draw do
       resource :confirm_deferral, only: %i[show update], path: "/defer/confirm"
       resource :deferral, only: %i[show update], path: "/defer"
 
+      resource :confirm_reinstatement, only: %i[show update], path: "/reinstate/confirm"
+      resource :reinstatement, only: %i[show update], path: "/reinstate"
+
       resource :timeline, only: :show
     end
 

--- a/db/migrate/20210301131856_add_reinstate_date_to_trainees.rb
+++ b/db/migrate/20210301131856_add_reinstate_date_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReinstateDateToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :reinstate_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_26_124052) do
+ActiveRecord::Schema.define(version: 2021_03_01_131856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2021_02_26_124052) do
     t.datetime "recommended_for_qts_at"
     t.string "dttp_update_sha"
     t.date "commencement_date"
+    t.date "reinstate_date"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"
     t.index ["dttp_id"], name: "index_trainees_on_dttp_id"

--- a/spec/components/trainees/confirmation/reinstatement_details/view_preview.rb
+++ b/spec/components/trainees/confirmation/reinstatement_details/view_preview.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Confirmation
+    module ReinstatementDetails
+      class ViewPreview < ViewComponent::Preview
+        def default
+          render(Trainees::Confirmation::ReinstatementDetails::View.new(trainee: trainee))
+        end
+
+      private
+
+        def trainee
+          @trainee ||= OpenStruct.new({
+            reinstate_date: Faker::Date.in_date_period,
+          })
+        end
+      end
+    end
+  end
+end

--- a/spec/components/trainees/confirmation/reinstatement_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/reinstatement_details/view_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Trainees::Confirmation::ReinstatementDetails::View do
+  include SummaryHelper
+
+  alias_method :component, :page
+
+  let(:trainee) { build(:trainee, :reinstated, id: 1) }
+
+  before do
+    render_inline(described_class.new(trainee: trainee))
+  end
+
+  it "renders the date the trainee was reinstated" do
+    expect(component).to have_text(date_for_summary_view(trainee.reinstate_date))
+  end
+end

--- a/spec/components/trainees/timeline/view_spec.rb
+++ b/spec/components/trainees/timeline/view_spec.rb
@@ -85,6 +85,21 @@ module Trainees
           end
         end
 
+        context "reinstated" do
+          before do
+            methods = %i[submit_for_trn! receive_trn! defer! receive_trn!]
+            call_methods!(methods, trainee)
+            render_inline(described_class.new(trainee))
+          end
+          it "shows state changes until reinstated" do
+            expect(component).to have_text(expected_title(:created))
+            expect(component).to have_text(expected_title(:submitted_for_trn))
+            expect(component).to have_text(expected_title(:trn_received))
+            expect(component).to have_text(expected_title(:deferred))
+            expect(component).to have_text(expected_title(:reinstated))
+          end
+        end
+
         context "qts_awarded" do
           before do
             methods = %i[submit_for_trn! receive_trn! recommend_for_qts! award_qts!]

--- a/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
@@ -24,7 +24,7 @@ describe Trainees::ConfirmDeferralsController do
         post :update, params: { trainee_id: trainee }
       end
 
-      it "transitions the trainee state to defferred" do
+      it "transitions the trainee state to deferred" do
         expect(trainee.reload).to be_deferred
       end
     end

--- a/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Trainees::ConfirmReinstatementsController do
+  include ActiveJob::TestHelper
+
+  let(:current_user) { create(:user) }
+  let(:trainee) { create(:trainee, :deferred, trn: trn, provider: current_user.provider) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(current_user)
+  end
+
+  describe "#update" do
+    context "with a trainee with a trn" do
+      let(:trn) { "trn" }
+
+      it "transitions the trainee back to trn_received" do
+        expect {
+          post :update, params: { trainee_id: trainee }
+          trainee.reload
+        }.to change {
+          trainee.state
+        } .from("deferred") .to("trn_received")
+      end
+
+      it "queues a background job to reinstate a trainee" do
+        expect {
+          post :update, params: { trainee_id: trainee }
+        }.to have_enqueued_job(ReinstateJob).with(trainee.id)
+      end
+    end
+
+    context "with a trainee with no trn" do
+      let(:trn) { nil }
+
+      it "transitions the trainee back to submitted_for_trn" do
+        expect {
+          post :update, params: { trainee_id: trainee }
+          trainee.reload
+        }.to change {
+          trainee.state
+        } .from("deferred") .to("submitted_for_trn")
+      end
+
+      it "queues a background job to reinstate a trainee" do
+        expect {
+          post :update, params: { trainee_id: trainee }
+        }.to have_enqueued_job(ReinstateJob).with(trainee.id)
+      end
+    end
+  end
+end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -145,6 +145,11 @@ FactoryBot.define do
       state { "deferred" }
     end
 
+    trait :reinstated do
+      state { "trn_received" }
+      reinstate_date { Faker::Date.in_date_period }
+    end
+
     trait :qts_awarded do
       state { "qts_awarded" }
     end

--- a/spec/features/trainees/reinstating_a_trainee_spec.rb
+++ b/spec/features/trainees/reinstating_a_trainee_spec.rb
@@ -2,17 +2,17 @@
 
 require "rails_helper"
 
-feature "Deferring a trainee", type: :feature do
+feature "Reinstating a trainee", type: :feature do
   include SummaryHelper
 
   before do
     given_i_am_authenticated
-    given_a_trainee_exists_to_be_deferred
+    given_a_trainee_exists_to_be_reinstated
     and_i_am_on_the_trainee_record_page
-    and_i_click_on_defer
+    and_i_click_on_reinstate
   end
 
-  context "trainee deferral date" do
+  context "trainee reinstatement date" do
     scenario "submit empty form" do
       and_i_continue
       then_i_see_the_error_message_for_date_not_chosen
@@ -21,15 +21,15 @@ feature "Deferring a trainee", type: :feature do
     scenario "choosing today" do
       when_i_choose_today
       and_i_continue
-      then_i_am_redirected_to_deferral_confirmation_page
-      and_the_defer_date_is_updated
+      then_i_am_redirected_to_reinstatement_confirmation_page
+      and_the_reinstate_date_is_updated
     end
 
     scenario "choosing yesterday" do
       when_i_choose_yesterday
       and_i_continue
-      then_i_am_redirected_to_deferral_confirmation_page
-      and_the_defer_date_is_updated
+      then_i_am_redirected_to_reinstatement_confirmation_page
+      and_the_reinstate_date_is_updated
     end
 
     context "choosing another day" do
@@ -40,8 +40,8 @@ feature "Deferring a trainee", type: :feature do
       scenario "and filling out a valid date" do
         and_i_enter_a_valid_date
         and_i_continue
-        then_i_am_redirected_to_deferral_confirmation_page
-        and_the_defer_date_is_updated
+        then_i_am_redirected_to_reinstatement_confirmation_page
+        and_the_reinstate_date_is_updated
       end
 
       scenario "and not filling out the date displays the correct error" do
@@ -50,7 +50,7 @@ feature "Deferring a trainee", type: :feature do
       end
 
       scenario "and filling out an invalid date displays the correct error" do
-        deferral_page.set_date_fields("defer_date", "32/01/2020")
+        reinstatement_page.set_date_fields("reinstate_date", "32/01/2020")
         and_i_continue
         then_i_see_the_error_message_for_invalid_date
       end
@@ -66,8 +66,8 @@ feature "Deferring a trainee", type: :feature do
   end
 
   def and_i_enter_a_valid_date
-    Faker::Date.in_date_period.tap do |defer_date|
-      deferral_page.set_date_fields(:defer_date, defer_date.strftime("%d/%m/%Y"))
+    Faker::Date.in_date_period.tap do |reinstate_date|
+      reinstatement_page.set_date_fields(:reinstate_date, reinstate_date.strftime("%d/%m/%Y"))
     end
   end
 
@@ -75,12 +75,12 @@ feature "Deferring a trainee", type: :feature do
     record_page.load(id: trainee.slug)
   end
 
-  def and_i_click_on_defer
-    record_page.defer.click
+  def and_i_click_on_reinstate
+    record_page.reinstate.click
   end
 
   def when_i_choose(option)
-    deferral_page.choose(option)
+    reinstatement_page.choose(option)
   end
 
   def when_i_choose_another_day
@@ -88,37 +88,37 @@ feature "Deferring a trainee", type: :feature do
   end
 
   def and_i_continue
-    deferral_page.continue.click
+    reinstatement_page.continue.click
   end
 
   def then_i_see_the_error_message_for_invalid_date
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.deferral_form.attributes.date.invalid"),
+      I18n.t("activemodel.errors.models.reinstatement_form.attributes.date.invalid"),
     )
   end
 
   def then_i_see_the_error_message_for_blank_date
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.deferral_form.attributes.date.blank"),
+      I18n.t("activemodel.errors.models.reinstatement_form.attributes.date.blank"),
     )
   end
 
   def then_i_see_the_error_message_for_date_not_chosen
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.deferral_form.attributes.date_string.blank"),
+      I18n.t("activemodel.errors.models.reinstatement_form.attributes.date_string.blank"),
     )
   end
 
-  def then_i_am_redirected_to_deferral_confirmation_page
-    expect(deferral_confirmation_page).to be_displayed(id: trainee.slug)
+  def then_i_am_redirected_to_reinstatement_confirmation_page
+    expect(reinstatement_confirmation_page).to be_displayed(id: trainee.slug)
   end
 
-  def given_a_trainee_exists_to_be_deferred
-    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample)
+  def given_a_trainee_exists_to_be_reinstated
+    given_a_trainee_exists(:deferred)
   end
 
-  def and_the_defer_date_is_updated
+  def and_the_reinstate_date_is_updated
     trainee.reload
-    expect(page).to have_text(date_for_summary_view(trainee.defer_date))
+    expect(page).to have_text(date_for_summary_view(trainee.reinstate_date))
   end
 end

--- a/spec/jobs/reinstate_job_spec.rb
+++ b/spec/jobs/reinstate_job_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ReinstateJob do
+  include ActiveJob::TestHelper
+
+  let(:trainee) { create(:trainee, :deferred, trn: trn) }
+
+  let(:contact_update_params) do
+    {
+      entity_id: trainee.dttp_id,
+      entity_type: Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
+    }
+  end
+
+  let(:placement_assignment_update_params) do
+    {
+      entity_id: trainee.placement_assignment_dttp_id,
+      entity_type: Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
+    }
+  end
+
+  let(:with_trn_param) { { status: DttpStatuses::YET_TO_COMPLETE_COURSE } }
+  let(:without_trn_param) { { status: DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED } }
+
+  let(:contact_update_params_with_trn) { contact_update_params.merge(with_trn_param) }
+  let(:contact_update_params_without_trn) { contact_update_params.merge(without_trn_param) }
+  let(:placement_assignment_update_params_with_trn) { placement_assignment_update_params.merge(with_trn_param) }
+  let(:placement_assignment_update_params_without_trn) { placement_assignment_update_params.merge(without_trn_param) }
+
+  subject { described_class.perform_now(trainee.id) }
+
+  before do
+    allow(Dttp::UpdateTraineeStatus).to receive(:call).with(contact_update_params_with_trn)
+    allow(Dttp::UpdateTraineeStatus).to receive(:call).with(contact_update_params_without_trn)
+    allow(Dttp::UpdateTraineeStatus).to receive(:call).with(placement_assignment_update_params_with_trn)
+    allow(Dttp::UpdateTraineeStatus).to receive(:call).with(placement_assignment_update_params_without_trn)
+  end
+
+  context "with a trainee with a trn" do
+    let(:trn) { "trn" }
+
+    it "updates the contact status and the placement assignment status to 'Yet to complete course' in DTTP" do
+      expect(Dttp::UpdateTraineeStatus).to receive(:call).with(contact_update_params_with_trn)
+      expect(Dttp::UpdateTraineeStatus).to receive(:call).with(placement_assignment_update_params_with_trn)
+      subject
+    end
+  end
+
+  context "with a trainee without a trn" do
+    let(:trn) { nil }
+
+    it "updates the contact status and the placement assignment status to 'Prospective trainee - TREFNO requested' in DTTP" do
+      expect(Dttp::UpdateTraineeStatus).to receive(:call).with(contact_update_params_without_trn)
+      expect(Dttp::UpdateTraineeStatus).to receive(:call).with(placement_assignment_update_params_without_trn)
+      subject
+    end
+  end
+end

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -8,6 +8,7 @@ describe TraineePolicy do
   let(:provider_user) { build(:user, provider: provider) }
   let(:other_provider_user) { build(:user) }
   let(:trainee) { create(:trainee, provider: provider) }
+  let(:deferred_trainee) { create(:trainee, :deferred, provider: provider) }
 
   subject { described_class }
 
@@ -15,6 +16,14 @@ describe TraineePolicy do
     it { is_expected.to permit(provider_user, trainee) }
     it { is_expected.to permit(system_admin_user, trainee) }
     it { is_expected.not_to permit(other_provider_user, trainee) }
+  end
+
+  permissions :reinstate? do
+    it { is_expected.to permit(provider_user, deferred_trainee) }
+    it { is_expected.to permit(system_admin_user, deferred_trainee) }
+    it { is_expected.not_to permit(other_provider_user, deferred_trainee) }
+    it { is_expected.not_to permit(provider_user, trainee) }
+    it { is_expected.not_to permit(system_admin_user, trainee) }
   end
 
   describe TraineePolicy::Scope do

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -154,6 +154,14 @@ module Features
       @withdrawal_confirmation_page ||= PageObjects::Trainees::ConfirmWithdrawal.new
     end
 
+    def reinstatement_page
+      @reinstatement_page ||= PageObjects::Trainees::Reinstatement.new
+    end
+
+    def reinstatement_confirmation_page
+      @reinstatement_confirmation_page ||= PageObjects::Trainees::ConfirmReinstatement.new
+    end
+
     def start_page
       @start_page ||= PageObjects::Start.new
     end

--- a/spec/support/page_objects/trainees/confirm_reinstatement.rb
+++ b/spec/support/page_objects/trainees/confirm_reinstatement.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class ConfirmReinstatement < PageObjects::Base
+      set_url "/trainees/{id}/reinstate/confirm"
+      element :confirm, "input[name='commit']"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/record.rb
+++ b/spec/support/page_objects/trainees/record.rb
@@ -11,8 +11,8 @@ module PageObjects
       element :trn_status, ".govuk-tag.trainee-status", match: :first
 
       element :record_outcome, ".record-actions > .govuk-button"
+      element :reinstate, ".govuk-link.reinstate"
       element :withdraw, ".govuk-link.withdraw"
-
       element :defer, ".govuk-link.defer"
 
       section :record_detail, PageObjects::Sections::Summaries::RecordDetail, ".record-details"

--- a/spec/support/page_objects/trainees/reinstatement.rb
+++ b/spec/support/page_objects/trainees/reinstatement.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class Reinstatement < PageObjects::Base
+      include PageObjects::Helpers
+
+      set_url "/trainees/{id}/reinstate"
+
+      element :reinstate_date_day, "#reinstatement_form_date_3i"
+      element :reinstate_date_month, "#reinstatement_form_date_2i"
+      element :reinstate_date_year, "#reinstatement_form_date_1i"
+
+      element :continue, "input[name='commit']"
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/a0TK2ylu/1123-l-reinstate-trainee

### Changes proposed in this pull request

This PR encapsulates everything needed to reinstate a trainee:
- A form `/reinstate` where the user can select the date the trainee returned
- A new field on a trainee `reinstate_date` to record the date
- A form `/reinstate/confirm` where the user can view the return date, change if necessary, or confirm if correct
- A new component for this confirm page
- A new `ReinstateJob` that returns the trainee/contact to 'Yet to complete course' in DTTP if they have a TRN, or 'Prospective trainee - TREFNO requested' in DTTP if they don't
- An update to the trainee timeline that handles displaying reinstatement events (since there is no actual 'state' for reinstated)

### Guidance to review
**For a trainee with a TRN**
- Pick a deferred trainee with a TRN (or defer one if you don't have any)
- Head to the trainee show page `/trainees/:trainee_slug`
- Check that the link to 'reinstate' is present
- Click the link and submit a return date (checking for validation errors e.g. blank/invalid)
- Click 'Reinstate this trainee'
- Check that the trainee's timeline includes 'Trainee reinstated' on the correct date
- Check that the trainee is returned to 'TRN received'

**For a trainee with no TRN**
- Repeat the above steps for a trainee 'Pending TRN'
- For the final step, check that the trainee is returned to 'Pending TRN'