### PR TITLE
[1051] Fix: duplicate ids on radio inputs after validation error

### DIFF
--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -8,9 +8,9 @@
   <%= render FormComponents::Autocomplete::View.new(
     form_field: f.govuk_collection_select(:subject, subjects_options,
                                           :name, :name, label: { text: 'Degree subject', size: 's' },
-                                          hint: { text: 'Search for the closest matching subject. 
+                                          hint: { text: 'Search for the closest matching subject.
                                                          You can start typing to narrow down your search.' }),
-                                                           
+
     html_attributes: {
       "data-show-all-values" => true,
     }
@@ -42,11 +42,11 @@
         legend: { text: "Degree grade", size: 's' },
         classes: "degree-grade" ) do %>
 
-    <% grades.map do |name| %>
+    <% grades.each_with_index do |name, index| %>
       <% if name != "Other" %>
-        <%= f.govuk_radio_button :grade, name, label: { text: name }, link_errors: true %>
+        <%= f.govuk_radio_button :grade, name, label: { text: name }, link_errors: index.zero? %>
       <% else %>
-        <%= f.govuk_radio_button :grade, name, label: { text: name }, link_errors: true do %>
+        <%= f.govuk_radio_button :grade, name, label: { text: name } do %>
           <%= f.govuk_text_field :other_grade, label: { text: "Enter the degree grade" }, width: "two-thirds" %>
         <% end %>
       <% end %>


### PR DESCRIPTION
### Context
https://trello.com/c/Vh9IQurw/1051-duplicate-ids-on-errors-degree-grade-field-error-no-label-on-options-invalid-size-on-links-validate-html-with-validation-errors

### Changes proposed in this pull request
Only apply `link_errors: true` to the first element. It's was only intended to be on the first.

### Guidance to review
- Load up the new UK degree page and submit empty form
- Open the HTML inspector and confirm that only the first radio input element under "Degree grade" has the ID `degree-grade-field-error`. All the others are unique.