### PR TITLE
[1126] - Check stored training route is being used

### DIFF
--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -4,8 +4,8 @@ module Dttp
   module CodeSets
     module Routes
       MAPPING = {
-        "assessment_only" => { entity_id: "99f435d5-a626-e711-80c8-0050568902d3" },
-        "provider_led" => { entity_id: "6189922e-acc2-e611-80be-00155d010316" },
+        TRAINING_ROUTE_ENUMS[:assessment_only] => { entity_id: "99f435d5-a626-e711-80c8-0050568902d3" },
+        TRAINING_ROUTE_ENUMS[:provider_led] => { entity_id: "6189922e-acc2-e611-80be-00155d010316" },
       }.freeze
     end
   end

--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Dttp
+  module CodeSets
+    module Routes
+      MAPPING = {
+        "assessment_only" => { entity_id: "99f435d5-a626-e711-80c8-0050568902d3" },
+        "provider_led" => { entity_id: "6189922e-acc2-e611-80be-00155d010316" },
+      }.freeze
+    end
+  end
+end

--- a/app/lib/dttp/mappable.rb
+++ b/app/lib/dttp/mappable.rb
@@ -34,6 +34,10 @@ module Dttp
       CodeSets::Nationalities::MAPPING.dig(nationality.downcase, :entity_id)
     end
 
+    def dttp_route_id(training_route)
+      CodeSets::Routes::MAPPING.dig(training_route, :entity_id)
+    end
+
     def dttp_disability_id(disability)
       CodeSets::Disabilities::MAPPING.dig(disability, :entity_id)
     end

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -5,7 +5,6 @@ module Dttp
     class PlacementAssignment
       include Mappable
 
-      ASSESSMENT_ONLY_DTTP_ID = "99f435d5-a626-e711-80c8-0050568902d3"
       ACADEMIC_YEAR_2020_2021 = "76bcaeca-2bd1-e711-80df-005056ac45bb"
       COURSE_LEVEL_PG = 12
       ITT_QUALIFICATION_AIM_QTS = "68cbae32-7389-e711-80d8-005056ac45bb"
@@ -20,7 +19,7 @@ module Dttp
         if contact_change_set_id
           @params.merge!({
             "dfe_ContactId@odata.bind" => "$#{contact_change_set_id}",
-            "dfe_RouteId@odata.bind" => "/dfe_routes(#{ASSESSMENT_ONLY_DTTP_ID})",
+            "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id(trainee.training_route)})",
           })
         end
       end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -15,7 +15,11 @@ class Trainee < ApplicationRecord
 
   validates :training_route, presence: { message: I18n.t("activerecord.errors.models.trainee.attributes.training_route") }
 
-  enum training_route: { assessment_only: 0, provider_led: 1 }
+  enum training_route: {
+    TRAINING_ROUTE_ENUMS[:assessment_only] => 0,
+    TRAINING_ROUTE_ENUMS[:provider_led] => 1,
+  }
+
   enum locale_code: { uk: 0, non_uk: 1 }
   enum gender: {
     male: 0,

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+TRAINING_ROUTE_ENUMS = {
+  assessment_only: "assessment_only",
+  provider_led: "provider_led",
+}.freeze

--- a/spec/components/application_record_card/view_preview.rb
+++ b/spec/components/application_record_card/view_preview.rb
@@ -17,15 +17,24 @@ module ApplicationRecordCard
   private
 
     def mock_trainee
-      Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: "assessment_only", subject: "Primary")
+      Trainee.new(
+        id: 1,
+        created_at: Time.zone.now,
+        first_names: "Tom",
+        last_name: "Jones",
+        training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+        subject: "Primary",
+      )
     end
 
     def mock_multiple_trainees
-      [Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: "assessment_only", subject: "Primary"),
-       Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Paddington", last_name: "Bear", training_route: "assessment_only", subject: "Science"),
-       Trainee.new(id: 1, created_at: Time.zone.now),
-       Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tim", last_name: "Knight", training_route: "assessment_only", subject: "Maths"),
-       Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Toby", last_name: "Rocker")]
+      [
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], subject: "Primary"),
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Paddington", last_name: "Bear", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], subject: "Science"),
+        Trainee.new(id: 1, created_at: Time.zone.now),
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tim", last_name: "Knight", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], subject: "Maths"),
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Toby", last_name: "Rocker"),
+      ]
     end
   end
 end

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -79,7 +79,7 @@ module ApplicationRecordCard
             first_names: "Teddy",
             last_name: "Smith",
             subject: "Designer",
-            training_route: "assessment_only",
+            training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
             trainee_id: "132456",
             created_at: Time.zone.now,
             trn: "789456",

--- a/spec/components/trainees/confirmation/programme_details/view_preview.rb
+++ b/spec/components/trainees/confirmation/programme_details/view_preview.rb
@@ -10,7 +10,7 @@ module Trainees
         end
 
         def with_no_data
-          render(Trainees::Confirmation::ProgrammeDetails::View.new(trainee: Trainee.new(id: 2, training_route: :assessment_only)))
+          render(Trainees::Confirmation::ProgrammeDetails::View.new(trainee: Trainee.new(id: 2, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])))
         end
 
       private
@@ -21,7 +21,7 @@ module Trainees
             subject: "Primary",
             age_range: "3 to 11 programme",
             programme_start_date: Date.new(2020, 0o1, 28),
-            training_route: :assessment_only,
+            training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
           )
         end
       end

--- a/spec/components/trainees/confirmation/trainee_id/view_preview.rb
+++ b/spec/components/trainees/confirmation/trainee_id/view_preview.rb
@@ -18,7 +18,7 @@ module Trainees
         def mock_trainee
           @mock_trainee ||= Trainee.new(
             id: 1,
-            training_route: :assessment_only,
+            training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
             trainee_id: "ABC-1234-XYZ",
           )
         end

--- a/spec/components/trainees/filters/view_preview.rb
+++ b/spec/components/trainees/filters/view_preview.rb
@@ -12,7 +12,7 @@ module Trainees
 
       def filter_mock
         ActionController::Parameters.new({
-          training_route: %w[assessment_only],
+          training_route: [TRAINING_ROUTE_ENUMS[:assessment_only]],
           subject: "Biology",
         }).permit(:subject, :text_search, training_route: [], state: [])
       end

--- a/spec/components/trainees/record_details/view_preview.rb
+++ b/spec/components/trainees/record_details/view_preview.rb
@@ -26,7 +26,7 @@ module Trainees
       def mock_trainee(trainee_id, state = :draft)
         @mock_trainee ||= Trainee.new(
           id: 1,
-          training_route: :assessment_only,
+          training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
           trainee_id: trainee_id,
           created_at: Time.zone.today,
           updated_at: Time.zone.today,

--- a/spec/components/trainees/timeline/view_preview.rb
+++ b/spec/components/trainees/timeline/view_preview.rb
@@ -18,7 +18,7 @@ module Trainees
 
       def trainee
         @trainee ||= Trainee.create!(
-          training_route: "assessment_only",
+          training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
           provider: user.provider,
         )
       end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     provider
 
-    training_route { "assessment_only" }
+    training_route { TRAINING_ROUTE_ENUMS[:assessment_only] }
 
     first_names { Faker::Name.first_name }
     middle_names { Faker::Name.middle_name }

--- a/spec/features/trainees/filtering_trainees_spec.rb
+++ b/spec/features/trainees/filtering_trainees_spec.rb
@@ -75,8 +75,8 @@ RSpec.feature "Filtering trainees" do
 private
 
   def given_trainees_exist_in_the_system
-    @assessment_only_trainee ||= create(:trainee, training_route: "assessment_only")
-    @provider_led_trainee ||= create(:trainee, training_route: "provider_led")
+    @assessment_only_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
+    @provider_led_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:provider_led])
     @biology_trainee ||= create(:trainee, subject: "Biology")
     @history_trainee ||= create(:trainee, subject: "History")
     @searchable_trainee ||= create(:trainee, trn: "123")

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -20,6 +20,7 @@ module Dttp
       let(:dttp_degree_grade_entity_id) { SecureRandom.uuid }
       let(:dttp_country_entity_id) { SecureRandom.uuid }
       let(:dttp_provider_id) { SecureRandom.uuid }
+      let(:dttp_route_id) { Dttp::CodeSets::Routes::MAPPING[trainee.training_route][:entity_id] }
 
       before do
         allow(Time).to receive(:now).and_return(time_now_in_zone)
@@ -65,7 +66,7 @@ module Dttp
               "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{Dttp::Params::PlacementAssignment::ITT_QUALIFICATION_AIM_QTS})",
               "dfe_programmeyear" => 1,
               "dfe_programmelength" => 1,
-              "dfe_RouteId@odata.bind" => "/dfe_routes(#{Dttp::Params::PlacementAssignment::ASSESSMENT_ONLY_DTTP_ID})",
+              "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id})",
             })
           end
         end
@@ -91,7 +92,7 @@ module Dttp
               "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{Dttp::Params::PlacementAssignment::ITT_QUALIFICATION_AIM_QTS})",
               "dfe_programmeyear" => 1,
               "dfe_programmelength" => 1,
-              "dfe_RouteId@odata.bind" => "/dfe_routes(#{Dttp::Params::PlacementAssignment::ASSESSMENT_ONLY_DTTP_ID})",
+              "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id})",
             })
           end
         end

--- a/spec/models/trainee_filter_spec.rb
+++ b/spec/models/trainee_filter_spec.rb
@@ -23,7 +23,7 @@ describe TraineeFilter do
         {
           subject: "Biology",
           text_search: "search terms",
-          training_route: %w[assessment_only],
+          training_route: [TRAINING_ROUTE_ENUMS[:assessment_only]],
           state: %w[draft],
         }
       end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -6,7 +6,13 @@ describe Trainee do
   context "fields" do
     subject { build(:trainee) }
 
-    it { is_expected.to define_enum_for(:training_route).with_values(assessment_only: 0, provider_led: 1) }
+    it do
+      is_expected.to define_enum_for(:training_route).with_values(
+        TRAINING_ROUTE_ENUMS[:assessment_only] => 0,
+        TRAINING_ROUTE_ENUMS[:provider_led] => 1,
+      )
+    end
+
     it { is_expected.to define_enum_for(:locale_code).with_values(uk: 0, non_uk: 1) }
     it { is_expected.to define_enum_for(:gender).with_values(male: 0, female: 1, other: 2, gender_not_provided: 3) }
 
@@ -89,7 +95,7 @@ describe Trainee do
 
       describe "validation" do
         context "when training route is present" do
-          subject { build(:trainee, training_route: "assessment_only") }
+          subject { build(:trainee, training_route: TRAINING_ROUTE_ENUMS[:assessment_only]) }
 
           it "is valid" do
             expect(subject).to be_valid


### PR DESCRIPTION
### Context

- https://trello.com/c/Wdnl7TdE/1126-s-check-stored-route-is-being-used

### Changes proposed in this pull request

- Remove hardcoded `assessment_only` dttp_id and make it dynamic based on the trainee training route
- Add codesets for `dfe_routes` to use correct entity id for that training route
- Move training route enum list into a constant in `config` so it's in one place

### Guidance to review

- You'll need to test this via postman. Fire a request to `https://{{dttp_host}}/api/data/v9.1/dfe_routes` to get a list of all training routes and their ids or `https://{{dttp_host}}/api/data/v9.1/dfe_routes(route_id)` for more details on a specific route.
