### PR TITLE
[1198] Add hint text to translation file and make the year dynamic 

### DIFF
--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -29,7 +29,7 @@
       <%= f.govuk_date_field :date_of_birth,
                              date_of_birth: true,
                              legend: { text: 'Date of birth', size: 's' },
-                             hint: { text: 'For example, 31 3 1980' } %>
+                             hint: { text: I18n.t("activemodel.errors.models.personal_detail_form.attributes.date_of_birth.hint_html", year: 41.year.ago.year) } %>
 
       <%= f.govuk_radio_buttons_fieldset(:gender, legend: { text: "Gender", size: "s" }, classes: "gender") do %>
         <%= f.govuk_radio_button :gender, :female, label: { text: "Female" }, link_errors: true %>

--- a/app/views/trainees/programme_details/edit.html.erb
+++ b/app/views/trainees/programme_details/edit.html.erb
@@ -42,12 +42,12 @@
       <%= f.govuk_date_field(:programme_start_date,
                              date_of_birth: false,
                              legend: { text: 'Programme start date', size: 's' },
-                             hint: { text: 'For example, 2 11 2020' } ) %>
+                             hint: { text: I18n.t("activemodel.errors.models.programme_detail_form.attributes.programme_start_date.hint_html", year: 1.year.ago.year ) } ) %>
 
        <%= f.govuk_date_field(:programme_end_date,
                               date_of_birth: false,
                               legend: { text: 'Programme end date', size: 's' },
-                              hint: { text: 'For example, 15 6 2021' } ) %>
+                              hint: { text: I18n.t("activemodel.errors.models.programme_detail_form.attributes.programme_end_date.hint_html", year: Time.zone.now.year) } ) %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -397,6 +397,7 @@ en:
                 blank: "You must enter a date of birth"
                 invalid: "You must enter a valid date"
                 future: "You must enter a date of birth that is in the past, for example 31 3 1980"
+                hint_html: For example, 31 3 %{year}
               gender:
                 blank: "You must select a gender"
               nationality_ids:
@@ -416,6 +417,7 @@ en:
               future: "You must enter a programme start date that is not as far in the future"
               invalid: "You must enter a valid programme start date"
               too_old: "You must enter a valid programme start date"
+              hint_html: For example, 2 11 %{year}
             programme_end_date:
               blank: "You must enter a programme end date"
               future: "You must enter a programme end date that is not as far in the future"
@@ -429,6 +431,7 @@ en:
             date:
               blank: You must enter a date of return
               invalid: You must enter a valid date of return
+              hint_html: For example, 15 6 %{year}
         trn_submission_form:
           attributes:
             trainee:


### PR DESCRIPTION
### Context

Added the hint text html into the translation file and made the year dynamic. 

The hint text date was being underlined on a users machine in a UR session. We were unable to replicate this but there was one section that wasn't underlined on their machine (Date trainee started). This change _could_ address this issue.

### Changes proposed in this pull request

- Incorporated the hint text html into the translation file
- Made the year dynamic

### Guidance to review

https://rtt-review-pr-614.herokuapp.com/trainees/NnFmi4nUuxjKxXVJ4DBnFmvk/review-draft

- Unable to replicate the issue. Let me know if you are able to. There is a screenshot in the Trello ticket of the issue. The screenshots below are how they should look.

- Visit the sections in the screenshot below and check that the hint text is correct (programme details start and end date, and date of birth)

### Screenshots

![image](https://user-images.githubusercontent.com/50492247/110023287-e9d0c500-7d24-11eb-9e5c-396264928d57.png)

![image](https://user-images.githubusercontent.com/50492247/110023323-f8b77780-7d24-11eb-801b-6aebb77b9f7d.png)