### PR TITLE
asdf implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,68 @@
 FROM ruby:2.7.2-alpine3.12
 
+RUN uname -r
+
 RUN apk add --update --no-cache tzdata && \
   cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
   echo "Europe/London" > /etc/timezone
 
 RUN apk add --update --no-cache --virtual runtime-dependances \
   postgresql-dev \
-  yarn
+  curl \
+  git \
+  bash \
+  vim
 
+ENV PATH "~/.asdf/bin:~/.asdf/shims:$PATH"
+
+RUN echo $PATH
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 
+RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch master
+
 COPY .tool-versions Gemfile Gemfile.lock ./
 
+SHELL ["/bin/bash", "-c"]
+RUN touch ~/.bashrc
+RUN echo ". ~/.asdf/asdf.sh" >> ~/.bashrc
+RUN echo ". ~/.asdf/completions/asdf.bash" >> ~/.bashrc
+
+RUN source  ~/.bashrc
+#RUN /app/.asdf/asdf.sh
+RUN asdf plugin-add yarn
+RUN asdf plugin-add nodejs
+RUN asdf plugin-add vim
+
+RUN apk add gnupg
+RUN /bin/bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-previous-release-team-keyring'
+RUN /bin/bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
+
+
+RUN asdf install
+RUN  ["/bin/bash", "-c", "/root/.asdf/installs/nodejs/13.14.0/bin/node --version"]
+
+RUN ls -lah ~/.asdf/shims
 RUN apk add --update --no-cache --virtual build-dependances \
   build-base && \
   bundle install --jobs=4 && \
   apk del build-dependances
 
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
 
+RUN /bin/sh node --version
+RUN asdf install 12.18.3 && yarn install --frozen-lockfile
+RUN cat  ~/.bashrc
 COPY . .
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
-RUN echo export PATH=/usr/local/bin:\$PATH > /root/.ashrc
+
+RUN cat  ~/.bashrc
+
+RUN echo export PATH=/usr/local/bin:\$PATH > ~/.ashrc
+RUN cat ~/.ashrc
 ENV ENV="/root/.ashrc"
 RUN bundle exec rake assets:precompile
 CMD bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
### Context
When building the app, we need to ensure we have the correct versions of tools like nodejs and yarn, etc, installed. This is normally handled with .tool-versions and asdf, but as we don't use asdf when building the Docker image, this doesn't happen.

Recently we had an issue where our base Docker image, rails:2.7.2-alpine, upgraded from Alpine 3.12 to 3.13, and upgraded nodejs from 12.20 to 14.15). This broke the build. The fix was to pin Alpine to 3.12 but this is a short-sighted fix, and means we won't get other essential updates.

### Changes proposed in this pull request

introduce `asdf`

### Guidance to review

