### PR TITLE
Revert "Make captialisation consistent"

### DIFF
--- a/app/lib/dttp/code_sets/grades.rb
+++ b/app/lib/dttp/code_sets/grades.rb
@@ -3,8 +3,9 @@
 module Dttp
   module CodeSets
     module Grades
+      # Do not make any changes to the keys. If necessary, change Degree#grade to enum type first
       MAPPING = {
-        "First-class honours" => { entity_id: "fe2fca5f-766d-e711-80d2-005056ac45bb" },
+        "First-class Honours" => { entity_id: "fe2fca5f-766d-e711-80d2-005056ac45bb" },
         "Upper second-class honours (2:1)" => { entity_id: "0030ca5f-766d-e711-80d2-005056ac45bb" },
         "Lower second-class honours (2:2)" => { entity_id: "0230ca5f-766d-e711-80d2-005056ac45bb" },
         "Third-class honours" => { entity_id: "0630ca5f-766d-e711-80d2-005056ac45bb" },


### PR DESCRIPTION
### Context
https://trello.com/c/5bEQdwax/1207-the-supplied-reference-link-dfeclassofdegrees-is-invalid

### Changes proposed in this pull request
This reverts #615 because we're getting `The supplied reference link -- /dfe_classofdegrees() -- is invalid` from `UpdateTraineeToDttpJob`.

We can't make any changes to the keys now that there are degree records already in prod with matching `grade` values. If we change them, then `CodeSets::Grades::MAPPING.dig(grade, :entity_id)` will not be able to find the matching value. This coupling is not ideal, so we may migrate Degree#grade to enum type later on.



