### PR TITLE
[1208] Add ga to cookies page

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -3,23 +3,71 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-9">Cookies on <%= t('service_name') %></h1>
-    
+
     <p class="govuk-body">This service puts small files (known as ‘cookies’) onto your computer, phone or tablet to collect information about how you use the service.</p>
-    
-    <h2 class="govuk-heading-m">What cookies we use</h2>
-    
-    <p class="govuk-body">We only use essential cookies.</p>
-    
-    <h3 class="govuk-heading-s">A cookie to give you access to your account</h3>
-    
-    <p class="govuk-body">"Register_trainee_teachers_session" is a cookie that reminds the service who you are when you’re signed in.</p>
-    
-    <p class="govuk-body">It enables you to access the information in your account, such as your trainee records.</p>
-    
-    <p class="govuk-body">It expires when you sign out, or after 6 hours on the service.</p>
 
-    <h3 class="govuk-heading-s">A cookie to store that you have seen the cookies banner.</h3>
+    <h2 class="govuk-heading-m">Essential cookies</h3>
+    <p class="govuk-body" id="essential_cookies_desc">Register trainee teachers uses the following essential cookies:</p>
 
-<p class="govuk-body">"viewed_cookie_message" is a cookie which tells the service that you have seen the cookies banner so we do not show it to you again.</p>
+    <table class="govuk-table" aria-describedby="essential_cookies_desc">
+      <thead class="govuk-table__header">
+        <tr>
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr scope="row" class="govuk-table__row">
+          <td class="govuk-table__cell">_register_trainee_teachers_session</td>
+          <td class="govuk-table__cell">Stores encrypted information about your time on the website</td>
+          <td class="govuk-table__cell">6 hours</td>
+        </tr>
+        <tr scope="row" class="govuk-table__row">
+          <td class="govuk-table__cell">viewed_cookie_message</td>
+          <td class="govuk-table__cell">Saves your cookie consent settings</td>
+          <td class="govuk-table__cell">6 months</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 class="govuk-heading-m">Measuring website usage (Google Analytics)</h3>
+    <p class="govuk-body">We use Google Analytics software to collect information about how you use Register trainee teachers. We do this to make sure the site is meeting the needs of our users and to help us make improvements based on those needs.</p>
+    <p class="govuk-body">Google Analytics stores information about:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the pages you visit on Register trainee teachers</li>
+      <li>how long you spend on each page</li>
+      <li>how you got to the site</li>
+      <li>what you click on while you're visiting the site</li>
+    </ul>
+    <p class="govuk-body">We don't allow Google to use or share our analytics data. We anonymise any personally identifiable data, like your IP address or your postcode before we share it with Google.</p>
+    <p class="govuk-body" id="google_analytics_cookies_desc">Google Analytics sets the following cookies:</p>
+
+    <table class="govuk-table" aria-describedby="google_analytics_cookies_desc">
+      <thead class="govuk-table__header">
+        <tr>
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Purpose</th>
+          <th scope="col" class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr scope="row" class="govuk-table__row">
+          <td class="govuk-table__cell">_ga</td>
+          <td class="govuk-table__cell">Used to distinguish anonymous users</td>
+          <td class="govuk-table__cell">2 years</td>
+        </tr>
+        <tr scope="row" class="govuk-table__row">
+          <td class="govuk-table__cell">_gid</td>
+          <td class="govuk-table__cell">Used to distinguish anonymous users</td>
+          <td class="govuk-table__cell">24 hours</td>
+        </tr>
+        <tr scope="row" class="govuk-table__row">
+          <td class="govuk-table__cell">_ga_RHM2PGFN72</td>
+          <td class="govuk-table__cell">Throttle requests</td>
+          <td class="govuk-table__cell">10 minutes</td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>


### PR DESCRIPTION
### Context
Google Analytics cookies

### Changes proposed in this pull request
Add GA cookies to cookies page

### Guidance to review
Visit `/cookies`
<img width="495" alt="Screenshot 2021-03-08 at 17 38 06" src="https://user-images.githubusercontent.com/3071606/110359169-12aece00-8035-11eb-81b2-0be1ff42131b.png">

