### PR TITLE
[1227] Redirect to origin page when editing ethnic group/background

### DIFF
--- a/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
@@ -15,7 +15,7 @@ module Trainees
         @ethnic_background.assign_attributes(ethnic_background_params)
 
         if @ethnic_background.save
-          redirect_to(edit_trainee_diversity_disability_disclosure_path(trainee))
+          redirect_to(origin_page_or_next_step)
         else
           render :edit
         end
@@ -40,6 +40,12 @@ module Trainees
 
       def background_is_different?(required_params)
         trainee.ethnic_background.present? && trainee.ethnic_background != required_params[:ethnic_background]
+      end
+
+      def origin_page_or_next_step
+        return page_tracker.last_origin_page_path if page_tracker.last_origin_page_path&.include?("diversity/confirm")
+
+        edit_trainee_diversity_disability_disclosure_path(trainee)
       end
     end
   end

--- a/spec/features/trainees/diversities/diversity_progress_spec.rb
+++ b/spec/features/trainees/diversities/diversity_progress_spec.rb
@@ -8,38 +8,39 @@ feature "completing the diversity section", type: :feature do
     given_a_trainee_exists(diversity_disclosure: nil, ethnic_group: nil, disability_disclosure: nil)
   end
 
-  scenario "renders a 'not started' status when diversity details are not provided" do
-    and_i_visit_the_review_draft_page
-    then_the_diversity_section_should_be(not_started)
+  context "progress tracking" do
+    scenario "renders a 'not started' status when diversity details are not provided" do
+      and_i_visit_the_review_draft_page
+      then_the_diversity_section_should_be(not_started)
+    end
+
+    scenario "renders an 'in progress' status when diversity information partially provided" do
+      given_valid_diversity_information
+      given_i_visited_the_review_draft_page
+      when_i_visit_the_diversity_confirmation_page
+      and_unconfirm_my_details
+      and_i_visit_the_record_page
+      and_i_visit_the_review_draft_page
+      then_the_diversity_section_should_be(in_progress)
+    end
+
+    scenario "renders a completed status when valid diversity information provided" do
+      given_valid_diversity_information
+      and_i_visit_the_review_draft_page
+      then_the_diversity_section_should_be(completed)
+    end
   end
 
-  scenario "renders an 'in progress' status when diversity information partially provided" do
-    given_valid_diversity_information
-    given_i_visited_the_review_draft_page
-    when_i_visit_the_diversity_confirmation_page
-    and_unconfirm_my_details
-    and_i_visit_the_record_page
-    and_i_visit_the_review_draft_page
-    then_the_diversity_section_should_be(in_progress)
-  end
-
-  scenario "renders a completed status when valid diversity information provided" do
-    given_valid_diversity_information
-    and_i_visit_the_review_draft_page
-    then_the_diversity_section_should_be(completed)
+  context "updating a section" do
+    scenario "returns back to confirm page after successfully updating" do
+      given_valid_diversity_information
+      when_i_visit_the_diversity_confirmation_page
+      and_i_edit_my_ethnic_group_details
+      then_i_am_redirected_to_the_confirm_page
+    end
   end
 
 private
-
-  def given_valid_diversity_information
-    @trainee.diversity_disclosure = Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed]
-    @trainee.ethnic_group = Diversities::ETHNIC_GROUP_ENUMS[:asian]
-    @trainee.ethnic_background = "some background"
-    @trainee.disability_disclosure = Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled]
-    @trainee.disabilities = [create(:disability, name: "deaf")]
-    @trainee.progress.diversity = true
-    @trainee.save!
-  end
 
   def and_i_visit_the_review_draft_page
     review_draft_page.load(id: @trainee.slug)
@@ -56,11 +57,19 @@ private
   end
 
   def when_i_visit_the_diversity_confirmation_page
-    diversities_confirm_page.load(id: @trainee.slug, section: "information-disclosed")
+    diversities_confirm_page.load(id: @trainee.slug)
+  end
+
+  def and_i_edit_my_ethnic_group_details
+    diversities_confirm_page.edit_link_for(:ethnicity).click
+    and_i_choose(Diversities::ETHNIC_GROUP_ENUMS[:asian])
+    ethnic_group_page.submit_button.click
+    and_i_choose_a_background(Diversities::BANGLADESHI.downcase)
+    ethnic_background_page.submit_button.click
   end
 
   def then_i_am_redirected_to_the_confirm_page
-    expect(diversities_confirm_page).to be_displayed(id: @trainee.slug, section: "information-disclosed")
+    expect(diversities_confirm_page).to be_displayed(id: @trainee.slug)
   end
 
   def and_unconfirm_my_details

--- a/spec/features/trainees/diversities/edit_ethnic_group_spec.rb
+++ b/spec/features/trainees/diversities/edit_ethnic_group_spec.rb
@@ -79,12 +79,6 @@ feature "edit ethnic group", type: :feature do
     ethnic_group_page.load(id: trainee.slug)
   end
 
-  def and_i_choose(option)
-    ethnic_group_page.find(
-      "#diversities-ethnic-group-form-ethnic-group-#{option.dasherize}-field",
-    ).choose
-  end
-
   def and_i_submit_the_form
     ethnic_group_page.submit_button.click
   end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -5,6 +5,7 @@ require_relative "features/trainee_steps"
 require_relative "features/dttp_steps"
 require_relative "features/common_steps"
 require_relative "features/page_helpers"
+require_relative "features/diversity_steps"
 require_relative "dfe_sign_in_user_helper"
 
 RSpec.configure do |config|
@@ -19,6 +20,7 @@ RSpec.configure do |config|
   config.include Features::DttpSteps, type: :feature
   config.include Features::CommonSteps, type: :feature
   config.include Features::PageHelpers, type: :feature
+  config.include Features::DiversitySteps, type: :feature
   config.include DfESignInUserHelper, type: :feature
 
   config.around :each do |example|

--- a/spec/support/features/diversity_steps.rb
+++ b/spec/support/features/diversity_steps.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Features
+  module DiversitySteps
+    def given_valid_diversity_information
+      @trainee.diversity_disclosure = Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed]
+      @trainee.ethnic_group = Diversities::ETHNIC_GROUP_ENUMS[:asian]
+      @trainee.ethnic_background = "some background"
+      @trainee.disability_disclosure = Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled]
+      @trainee.disabilities = [create(:disability, name: "deaf")]
+      @trainee.progress.diversity = true
+      @trainee.save!
+    end
+
+    def and_i_choose(option)
+      ethnic_group_page.find(
+        "#diversities-ethnic-group-form-ethnic-group-#{option.dasherize}-field",
+      ).choose
+    end
+
+    def and_i_choose_a_background(background)
+      ethnic_background_page.public_send(background).choose
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/diversities/confirm_details.rb
+++ b/spec/support/page_objects/trainees/diversities/confirm_details.rb
@@ -5,6 +5,12 @@ module PageObjects
     module Diversities
       class ConfirmDetails < PageObjects::Trainees::ConfirmDetails
         set_url "/trainees/{id}/diversity/confirm"
+
+        def edit_link_for(section)
+          within(".govuk-summary-list__row.#{section}") do
+            find(".govuk-link")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/2Q0wgbQg/1227-change-ethnicity-also-takes-the-user-through-the-disability-forms

### Changes proposed in this pull request

- Return to last origin page if they have come from the diversity confirm otherwise resume normal flow

![fix](https://user-images.githubusercontent.com/616080/110487471-86101880-80e5-11eb-8d8b-844e1fb22cf7.gif)


### Guidance to review

- Fill out a trainee's diversity details. Go back into the section to change ethnic group/background and submit. Assert you're taken back to the confirm page

