### PR TITLE
[1252] Update header colours for different environments

### DIFF
--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -1,4 +1,4 @@
-<header class="govuk-header app-header--full-border" role="banner" data-module="govuk-header">
+<header class="govuk-header app-header--full-border app-header__env--<%= Settings.environment.name %>" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo app-header__logo">
       <%= link_to "/", class: "govuk-header__link govuk-header__link--homepage" do %>

--- a/app/components/start_page_banner/style.scss
+++ b/app/components/start_page_banner/style.scss
@@ -1,7 +1,50 @@
 @import "../base.scss";
 @import "../../webpacker/styles/inverted";
 
+.app-phase-banner__env--development .govuk-tag {
+  background: govuk-colour("dark-grey");
+}
+
+.app-phase-banner__env--qa .govuk-tag {
+  background-color: govuk-colour("orange");
+}
+
+.app-phase-banner__env--staging .govuk-tag {
+  background-color: govuk-colour("red");
+}
+
+.app-phase-banner__env--sandbox .govuk-tag,
+.app-phase-banner__env--review .govuk-tag {
+  background-color: govuk-colour("purple");
+}
+
+.app-header__env--development,
+.app-header__env--development .govuk-header__container {
+  border-color: govuk-colour("dark-grey");
+}
+
+.app-header__env--qa,
+.app-header__env--qa .govuk-header__container {
+  border-color: govuk-colour("orange");
+}
+
+.app-header__env--staging,
+.app-header__env--staging .govuk-header__container {
+  border-color: govuk-colour("red");
+}
+
+.app-header__env--sandbox,
+.app-header__env--review,
+.app-header__env--sandbox .govuk-header__container,
+.app-header__env--review .govuk-header__container {
+  border-color: govuk-colour("purple");
+}
+
 .app-start-page {
+  .govuk-header__container {
+    border-bottom-color: govuk-colour("blue");
+  }
+
   .app-phase-banner {
     background-color: $govuk-brand-colour;
     margin-top: -(govuk-spacing(2));

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,12 +62,12 @@
       current_user: @current_user
     ) %>
 
-    <div class="app-phase-banner">
+    <div class="app-phase-banner app-phase-banner__env--<%= Settings.environment.name %>">
       <div class="govuk-width-container">
         <div class="govuk-phase-banner">
           <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag">
-              Beta
+              <%= Settings.environment.name.titlecase %>
             </strong>
             <span class="govuk-phase-banner__text">
                 This is a new service - <% if FeatureService.enabled?("enable_feedback_link") %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,3 +50,6 @@ pagination:
 
 session_store:
   expire_after_days: 30
+
+environment:
+  name: qa

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -12,3 +12,6 @@ features:
 
 pagination:
   records_per_page: 30
+
+environment:
+  name: development

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -16,3 +16,5 @@ features:
   basic_auth: false
   enable_feedback_link: false
 
+environment:
+  name: beta

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -9,3 +9,6 @@ features:
 
 pagination:
   records_per_page: 30
+
+environment:
+  name: review

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -14,3 +14,6 @@ dfe_sign_in:
 
 features:
   basic_auth: false
+
+environment:
+  name: sandbox

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -17,3 +17,6 @@ dfe_sign_in:
 
 features:
   basic_auth: false
+
+environment:
+  name: staging

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -5,3 +5,6 @@ slack:
   webhook_url: "https://test-slack-webhook-url.com"
 features:
   basic_auth: false
+
+environment:
+  name: beta


### PR DESCRIPTION
### Context
Visually see different environments

### Changes proposed in this pull request
- Use a different colour for qa, staging, review and sandbox

### Guidance to review
You can change the value in `config/settings.yml`

<img width="1531" alt="Screenshot 2021-03-12 at 09 52 58" src="https://user-images.githubusercontent.com/3071606/110923406-c86d6b80-8318-11eb-9edd-d1511654b870.png">
<img width="1531" alt="Screenshot 2021-03-12 at 09 52 51" src="https://user-images.githubusercontent.com/3071606/110923430-cd321f80-8318-11eb-916d-276066fcaf77.png">
<img width="1531" alt="Screenshot 2021-03-12 at 09 52 39" src="https://user-images.githubusercontent.com/3071606/110923433-cdcab600-8318-11eb-8d10-6c1c89089e81.png">
<img width="1531" alt="Screenshot 2021-03-12 at 09 52 34" src="https://user-images.githubusercontent.com/3071606/110923436-cefbe300-8318-11eb-914b-f252d557a5d6.png">
<img width="1531" alt="Screenshot 2021-03-12 at 09 52 28" src="https://user-images.githubusercontent.com/3071606/110923438-cf947980-8318-11eb-93a4-d8c51b57fb4a.png">
