### PR TITLE
[1234] Add basic early years (undergrad) route

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,6 +37,10 @@ module ApplicationHelper
     items
   end
 
+  def multiple_routes_enabled?
+    %w[routes_provider_led routes_early_years_undergrad].any? { |flag| FeatureService.enabled?(flag) }
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -6,6 +6,7 @@ module Dttp
       MAPPING = {
         TRAINING_ROUTE_ENUMS[:assessment_only] => { entity_id: "99f435d5-a626-e711-80c8-0050568902d3" },
         TRAINING_ROUTE_ENUMS[:provider_led] => { entity_id: "6189922e-acc2-e611-80be-00155d010316" },
+        TRAINING_ROUTE_ENUMS[:early_years_undergrad] => { entity_id: "6b89922e-acc2-e611-80be-00155d010316" },
       }.freeze
     end
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -20,6 +20,7 @@ class Trainee < ApplicationRecord
   enum training_route: {
     TRAINING_ROUTE_ENUMS[:assessment_only] => 0,
     TRAINING_ROUTE_ENUMS[:provider_led] => 1,
+    TRAINING_ROUTE_ENUMS[:early_years_undergrad] => 2,
   }
 
   enum locale_code: { uk: 0, non_uk: 1 }

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.new", has_errors: @trainee.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.training_routes.edit", has_errors: @trainee.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
@@ -10,18 +10,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @trainee, local: true do |f| %>
-
       <%= f.govuk_error_summary %>
-
-      <%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "l", text: t("components.page_titles.trainees.new"), tag: "h1"} ) do %>
-        <%= f.govuk_radio_button :training_route, :assessment_only, label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
-        <% if FeatureService.enabled?("routes_provider_led") %>
-          <%= f.govuk_radio_button :training_route, :provider_led, label: { text: t("activerecord.attributes.trainee.training_routes.provider_led") } %> 
-          <%= f.govuk_radio_divider %>
-        <% end %>
-        <%= f.govuk_radio_button :training_route, :other, label: { text: "Other" } %>
-      <% end %>
-
+      <%= render "trainees/training_routes/form_fields", f: f %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -1,0 +1,18 @@
+<%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "l", text: t("components.page_titles.trainees.training_routes.edit"), tag: "h1"} ) do %>
+
+  <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:assessment_only], label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
+
+  <% if FeatureService.enabled?("routes_early_years_undergrad") %>
+    <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:early_years_undergrad], label: { text: t("activerecord.attributes.trainee.training_routes.early_years_undergrad") } %> 
+  <% end %>
+
+  <% if FeatureService.enabled?("routes_provider_led") %>
+    <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:provider_led], label: { text: t("activerecord.attributes.trainee.training_routes.provider_led") } %> 
+  <% end %>
+
+  <% if multiple_routes_enabled? %>
+    <%= f.govuk_radio_divider %>
+  <% end %>
+
+  <%= f.govuk_radio_button :training_route, :other, label: { text: "Other" } %>
+<% end %>

--- a/app/views/trainees/training_routes/edit.html.erb
+++ b/app/views/trainees/training_routes/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.edit", has_errors: @trainee.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.training_routes.edit", has_errors: @trainee.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -7,18 +7,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: @trainee, url: trainee_training_route_path(@trainee), local: true do |f| %>
-
       <%= f.govuk_error_summary %>
-
-      <%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "l", text: t("components.page_titles.trainees.edit"), tag: "h1"} ) do %>
-        <%= f.govuk_radio_button :training_route, :assessment_only, label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
-        <% if FeatureService.enabled?("routes_provider_led") %>
-          <%= f.govuk_radio_button :training_route, :provider_led, label: { text: t("activerecord.attributes.trainee.training_routes.provider_led") } %> 
-          <%= f.govuk_radio_divider %>
-        <% end %>
-        <%= f.govuk_radio_button :training_route, :other, label: { text: "Other" } %>
-      <% end %>
-
+      <%= render "form_fields", f: f %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -3,4 +3,5 @@
 TRAINING_ROUTE_ENUMS = {
   assessment_only: "assessment_only",
   provider_led: "provider_led",
+  early_years_undergrad: "early_years_undergrad",
 }.freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,8 +90,6 @@ en:
       check_details:
         show: Review trainee record
       trainees:
-        new: What type of training are they doing?
-        edit: What type of training are they doing?
         delete: Delete this draft record
         index: Trainee records (%{total_trainees_count_text})
         paginated_index: Trainee records (%{total_trainees_count_text}) - page %{current_page} of %{total_pages}
@@ -128,6 +126,8 @@ en:
           edit: Date trainee started
         training_details:
           edit: Edit training details
+        training_routes:
+          edit: What type of training are they doing?
         programme_details:
           edit: Programme details
         withdrawal:
@@ -268,6 +268,7 @@ en:
         training_routes:
           assessment_only: Assessment only
           provider_led: Provider-led
+          early_years_undergrad: Early years (undergrad)
         states:
           draft: Draft
           submitted_for_trn: Pending TRN

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,6 +27,7 @@ features:
   basic_auth: true
   trainee_export: true
   routes_provider_led: false
+  routes_early_years_undergrad: false
 
 dfe_sign_in:
   # Our service name

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -9,6 +9,7 @@ features:
   use_dfe_sign_in: false
   basic_auth: false
   routes_provider_led: true
+  routes_early_years_undergrad: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -13,6 +13,7 @@ features:
   home_text: true
   use_dfe_sign_in: false
   routes_provider_led: true
+  routes_early_years_undergrad: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -6,6 +6,7 @@ features:
   use_dfe_sign_in: false
   enable_feedback_link: true
   routes_provider_led: true
+  routes_early_years_undergrad: true
 
 pagination:
   records_per_page: 30

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -25,6 +25,16 @@ feature "Create trainee journey" do
     and_i_should_not_see_provider_led_route
   end
 
+  scenario "setting up an initial early years undergrad record", feature_routes_early_years_undergrad: true do
+    and_i_select_early_years_undergrad_route
+    and_i_save_the_form
+    then_i_should_see_the_new_trainee_overview
+  end
+
+  scenario "early years undergrad radio button not shown when feature set to false", feature_routes_early_years_undergrad: false do
+    and_i_should_not_see_early_years_undergrad_route
+  end
+
   scenario "submitting without choosing a route" do
     and_i_save_the_form
     then_i_should_see_a_validation_error
@@ -48,9 +58,18 @@ private
     new_trainee_page.provider_led.click
   end
 
+  def and_i_select_early_years_undergrad_route
+    new_trainee_page.early_years_undergrad.click
+  end
+
   def and_i_should_not_see_provider_led_route
     expect(new_trainee_page).to be_displayed
     expect(new_trainee_page).to_not have_provider_led
+  end
+
+  def and_i_should_not_see_early_years_undergrad_route
+    expect(new_trainee_page).to be_displayed
+    expect(new_trainee_page).to_not have_early_years_undergrad
   end
 
   def and_i_save_the_form

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -10,6 +10,7 @@ describe Trainee do
       is_expected.to define_enum_for(:training_route).with_values(
         TRAINING_ROUTE_ENUMS[:assessment_only] => 0,
         TRAINING_ROUTE_ENUMS[:provider_led] => 1,
+        TRAINING_ROUTE_ENUMS[:early_years_undergrad] => 2,
       )
     end
 

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -8,9 +8,8 @@ module PageObjects
       element :page_heading, ".govuk-heading-xl"
 
       element :assessment_only, "#trainee-training-route-assessment-only-field"
-
       element :provider_led, "#trainee-training-route-provider-led-field"
-
+      element :early_years_undergrad, "#trainee-training-route-early-years-undergrad-field"
       element :other, "#trainee-training-route-other-field"
 
       element :continue_button, 'input.govuk-button[type="submit"]'


### PR DESCRIPTION
### Context

https://trello.com/c/gXEJ2d5X/1234-madd-early-years-undergraduate-basic-route

### Changes proposed in this pull request

- Add `early_years_undergrad` to the trainee `training_route` enum
- Add 'Early years (undergrad)' option as a training route to the new trainee form and the edit training routes form
- Refactor the shared code in the new trainee form and the edit training routes form into a shared partial, and use the TRAINING_ROUTES_ENUM constant for consistency & maintainability
- Add mapping to send the correct route ID to DTTP

### Guidance to review
- Head to `trainees/new`
- Check that the option to create an 'Early years (undergrad)' trainee is there
- Select this option and check that the correct route is displayed on the page:
<img width="455" alt="Screenshot 2021-03-09 at 17 39 54" src="https://user-images.githubusercontent.com/18436946/110513742-79e48500-80fe-11eb-83b3-10192cd53d8b.png">

- Click the link to change the route and check that you are taken to the `trainee/:trainee_slug/training_routes/edit` page
- Check that you can still update the training route
