### PR TITLE
[1248] Faker fakes dates for trainees deferred or withdrawn

### DIFF
--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -144,10 +144,12 @@ FactoryBot.define do
 
     trait :withdrawn do
       state { "withdrawn" }
+      withdraw_date { Faker::Date.in_date_period }
     end
 
     trait :deferred do
       state { "deferred" }
+      defer_date { Faker::Date.in_date_period }
     end
 
     trait :reinstated do


### PR DESCRIPTION
### Context

- At the moment, providers need to verify a date when withdrawing or deferring trainees. Faker does not match this when creating dummy data if trainees state is deferred or withdrawn, and thus no date is shown underneath the Withdrawn/Deferred status on dummy trainees.

### Changes proposed in this pull request

- Inside `trainees.rb` and inside the traits `:withdrawn` and `:deferred`, I have Faked a `withdraw_date` and `defer_date` respectively

### Guidance to review

- Navigate to the any trainee whos state is either `Deferred` or `Withdrawn` and whos details have been provided by Faker (not manually inputted, that is) and you should now see the date shown below. 

