### PR TITLE
[1232] Create courses from TTAPI

### DIFF
--- a/app/jobs/teacher_training_api/import_courses_job.rb
+++ b/app/jobs/teacher_training_api/import_courses_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TeacherTrainingApi
+  class ImportCoursesJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      return unless FeatureService.enabled?("import_courses_from_ttapi")
+
+      Provider.all.each do |provider|
+        ImportProviderCoursesJob.perform_later(provider)
+      end
+    end
+  end
+end

--- a/app/jobs/teacher_training_api/import_provider_courses_job.rb
+++ b/app/jobs/teacher_training_api/import_provider_courses_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TeacherTrainingApi
+  class ImportProviderCoursesJob < ApplicationJob
+    queue_as :default
+
+    def perform(provider)
+      return unless FeatureService.enabled?("import_courses_from_ttapi")
+
+      RetrieveCourses.call(provider: provider).each do |course|
+        ImportCourse.call(provider: provider, course: course)
+      end
+    end
+  end
+end

--- a/app/lib/teacher_training_api/client.rb
+++ b/app/lib/teacher_training_api/client.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module TeacherTrainingApi
+  class Client
+    include HTTParty
+    base_uri Settings.teacher_training_api.base_url
+    headers "User-Agent" => "Register for teacher training"
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Course < ApplicationRecord
+  belongs_to :provider
+
+  validates :code, presence: true, uniqueness: { scope: :provider_id }
+  validates :name, presence: true
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -3,6 +3,7 @@
 class Provider < ApplicationRecord
   has_many :users
   has_many :trainees
+  has_many :courses
 
   validates :name, presence: true
   validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }

--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module TeacherTrainingApi
+  class ImportCourse
+    include ServicePattern
+
+    # For full list, see https://api.publish-teacher-training-courses.service.gov.uk/api-reference.html#schema-courseattributes
+    IMPORTABLE_STATES = %w[
+      empty
+      rolled_over
+      published
+      published_with_unpublished_changes
+      withdrawn
+    ].freeze
+
+    def initialize(provider:, course:)
+      @provider = provider
+      @attrs = course["attributes"]
+    end
+
+    def call
+      return unless IMPORTABLE_STATES.include?(attrs["state"])
+
+      course.update!(name: attrs["name"])
+    end
+
+  private
+
+    attr_reader :provider, :attrs
+
+    def course
+      @course ||= provider.courses.find_or_initialize_by(code: attrs["code"])
+    end
+  end
+end

--- a/app/services/teacher_training_api/retrieve_courses.rb
+++ b/app/services/teacher_training_api/retrieve_courses.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module TeacherTrainingApi
+  class RetrieveCourses
+    include ServicePattern
+
+    class HttpError < StandardError; end
+
+    def initialize(provider:)
+      @provider = provider
+    end
+
+    def call
+      if response.code != 200
+        raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
+
+      JSON(response.body)["data"]
+    end
+
+  private
+
+    attr_reader :provider
+
+    # TODO: Make the recruitment cycle dynamic once we have a concept of cycles.
+    def response
+      @response ||= Client.get("/recruitment_cycles/2021/providers/#{provider.code}/courses")
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,7 @@ features:
   trainee_export: true
   routes_provider_led: false
   routes_early_years_undergrad: false
+  import_courses_from_ttapi: false
 
 dfe_sign_in:
   # Our service name
@@ -52,5 +53,8 @@ pagination:
 session_store:
   expire_after_days: 30
 
+teacher_training_api:
+  base_url: "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1"
+  
 environment:
   name: qa

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,6 +8,7 @@ features:
   allow_user_creation: true
   use_dfe_sign_in: false
   basic_auth: false
+  import_courses_from_ttapi: true
   routes_provider_led: true
   routes_early_years_undergrad: true
 

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -6,3 +6,7 @@ truncate_activerecord_session_store:
   cron: "0 0 * * *"
   class: "SessionStoreTruncateJob"
   queue: default
+import_courses_from_ttapi:
+  cron: "0 2 * * *"
+  class: "TeacherTrainingApi::ImportCoursesJob"
+  queue: default

--- a/db/migrate/20210310134947_create_courses.rb
+++ b/db/migrate/20210310134947_create_courses.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateCourses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :courses do |t|
+      t.string :name, null: false
+      t.string :code, null: false
+      t.references :provider, index: true, null: false, foreign_key: { to_table: :providers }
+      t.index %i[provider_id code], unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,6 +37,16 @@ ActiveRecord::Schema.define(version: 2021_03_15_141417) do
     t.index ["user_id", "user_type"], name: "user_index"
   end
 
+  create_table "courses", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "code", null: false
+    t.bigint "provider_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
+    t.index ["provider_id"], name: "index_courses_on_provider_id"
+  end
+
   create_table "degrees", force: :cascade do |t|
     t.integer "locale_code", null: false
     t.string "uk_degree"
@@ -185,6 +195,7 @@ ActiveRecord::Schema.define(version: 2021_03_15_141417) do
     t.index ["provider_id"], name: "index_users_on_provider_id"
   end
 
+  add_foreign_key "courses", "providers"
   add_foreign_key "degrees", "trainees"
   add_foreign_key "nationalisations", "nationalities"
   add_foreign_key "nationalisations", "trainees"

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :course do
+    provider
+    sequence(:name) { |c| "Course #{c}" }
+    code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
+  end
+end

--- a/spec/jobs/teacher_training_api/import_courses_job_spec.rb
+++ b/spec/jobs/teacher_training_api/import_courses_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module TeacherTrainingApi
+  describe ImportCoursesJob do
+    include ActiveJob::TestHelper
+
+    before do
+      create_list(:provider, 2)
+      described_class.perform_now
+    end
+
+    context "when the feature flag is turned on", feature_import_courses_from_ttapi: true do
+      it "queues up a job to import courses for each provider" do
+        Provider.all.each do |provider|
+          expect(ImportProviderCoursesJob).to have_been_enqueued.with(provider)
+        end
+      end
+    end
+
+    context "when the feature flag is turned off", feature_import_courses_from_ttapi: false do
+      it "doesn't queue up anything" do
+        Provider.all.each do |provider|
+          expect(ImportProviderCoursesJob).not_to have_been_enqueued.with(provider)
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/teacher_training_api/import_provider_courses_job_spec.rb
+++ b/spec/jobs/teacher_training_api/import_provider_courses_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module TeacherTrainingApi
+  describe ImportProviderCoursesJob do
+    include ActiveJob::TestHelper
+
+    let(:provider) { create(:provider) }
+    let(:courses) { JSON(ApiStubs::TeacherTrainingApi.courses)["data"] }
+
+    before do
+      allow(RetrieveCourses).to receive(:call).with(provider: provider).and_return(courses)
+      allow(ImportCourse).to receive(:call).with(provider: provider, course: courses.first).and_return(nil)
+    end
+
+    context "when the feature flag is turned on", feature_import_courses_from_ttapi: true do
+      it "fetches the courses from the TTAPI and calls the creator service" do
+        expect(RetrieveCourses).to receive(:call).with(provider: provider)
+        expect(ImportCourse).to receive(:call).with(provider: provider, course: courses.first)
+        described_class.perform_now(provider)
+      end
+    end
+
+    context "when the feature flag is turned off", feature_import_courses_from_ttapi: false do
+      it "does not do anything" do
+        expect(RetrieveCourses).not_to receive(:call).with(provider: provider)
+        expect(ImportCourse).not_to receive(:call).with(provider: provider, course: courses.first)
+        described_class.perform_now(provider)
+      end
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Course do
+  context "fields" do
+    subject { create(:course) }
+
+    it "validates presence" do
+      expect(subject).to validate_presence_of(:code)
+      expect(subject).to validate_presence_of(:name)
+    end
+
+    it { is_expected.to validate_uniqueness_of(:code).scoped_to(:provider_id) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:provider) }
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -33,6 +33,7 @@ describe Provider do
 
   describe "associations" do
     it { is_expected.to have_many(:users) }
+    it { is_expected.to have_many(:courses) }
   end
 
   describe "auditing" do

--- a/spec/services/teacher_training_api/import_course_spec.rb
+++ b/spec/services/teacher_training_api/import_course_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module TeacherTrainingApi
+  describe ImportCourse do
+    describe "#call" do
+      let(:provider) { create(:provider) }
+      let(:course) { JSON(ApiStubs::TeacherTrainingApi.course) }
+      let(:code) { course["attributes"]["code"] }
+      let(:name) { course["attributes"]["name"] }
+
+      subject { described_class.call(provider: provider, course: course) }
+
+      context "when the course code does not exist in register" do
+        context "and it's non-draft" do
+          it "creates the course for the provider with the correct code and name" do
+            expect { subject }.to change { provider.courses.count }.by(1)
+          end
+
+          it "create a course with the correct code and name" do
+            subject
+            expect(provider.courses.find_by(code: code, name: name)).to_not be_nil
+          end
+        end
+
+        context "and it's draft" do
+          let(:course) { JSON(ApiStubs::TeacherTrainingApi.course(state: "draft")) }
+
+          it "does not create the course" do
+            expect { subject }.not_to(change { Course.count })
+          end
+        end
+      end
+
+      context "when the course code already exists for that provider" do
+        context "with the same name" do
+          before { create(:course, code: code, name: name, provider: provider) }
+
+          it "does not creates a duplicate course" do
+            expect { subject }.not_to(change { Course.count })
+          end
+        end
+
+        context "with a different name" do
+          before { create(:course, code: code, provider: provider) }
+
+          it "updates the name" do
+            subject
+            expect(provider.courses.find_by(code: code).name).to eq name
+          end
+        end
+      end
+
+      context "when the course code already exists in register, but for a different provider" do
+        before { create(:course, code: code) }
+
+        it "creates the course for the new provider" do
+          expect { subject }.to change { provider.courses.count }.by(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/teacher_training_api/retrieve_courses_spec.rb
+++ b/spec/services/teacher_training_api/retrieve_courses_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module TeacherTrainingApi
+  describe RetrieveCourses do
+    describe "#call" do
+      let(:provider) { create(:provider) }
+      let(:path) { "/recruitment_cycles/2021/providers/#{provider.code}/courses" }
+
+      before do
+        allow(Client).to receive(:get).with(path).and_return(response)
+      end
+
+      context "when the response is success" do
+        let(:response) { double(code: 200, body: ApiStubs::TeacherTrainingApi.courses) }
+
+        it "returns the courses in full" do
+          expect(described_class.call(provider: provider)).to eq JSON(response.body)["data"]
+        end
+      end
+
+      context "when the response is error" do
+        let(:status) { 404 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:response) { double(code: status, body: body, headers: headers) }
+
+        it "raises a HttpError error with the response body as the message" do
+          expect {
+            described_class.call(provider: provider)
+          }.to raise_error(TeacherTrainingApi::RetrieveCourses::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/api_stubs/teacher_training_api.rb
+++ b/spec/support/api_stubs/teacher_training_api.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module ApiStubs
+  module TeacherTrainingApi
+    def self.courses
+      { "data": [course] }.to_json
+    end
+
+    def self.course(attrs = {})
+      course = {
+        "id": "12944685",
+        "type": "courses",
+        "attributes": {
+          "about_accredited_body": "UCL Institute of Education is the world’s leading centre for research and teaching in education and related social sciences.",
+          "about_course": "The Secondary PGCE consists of three core modules: two Master's-level modules, which are assessed through written assignments, and the Professional Practice module, which is assessed by the observation of practical teaching in placement schools.",
+          "accredited_body_code": "2FR",
+          "age_minimum": 11,
+          "age_maximum": 14,
+          "applications_open_from": "2019-10-08",
+          "bursary_amount": 9000,
+          "bursary_requirements": [{}],
+          "changed_at": "2019-06-13T10:44:31Z",
+          "code": "3GTY",
+          "course_length": "OneYear",
+          "created_at": "2019-06-13T10:44:31Z",
+          "fee_details": "For those wishing to top up their qualification to the full PGCE, a further £1800 will be payable.",
+          "fee_international": 13_000,
+          "fee_domestic": 9200,
+          "financial_support": "You'll get a bursary of £9,000 if you have a degree of 2:2 or above in any subject. You may also be eligible for a loan while you study.",
+          "findable": true,
+          "funding_type": "apprenticeship",
+          "gcse_subjects_required": [{}],
+          "has_bursary": true,
+          "has_early_career_payments": true,
+          "has_scholarship": true,
+          "has_vacancies": true,
+          "how_school_placements_work": "You will spend two-thirds of your time (120 days) in schools, working with art and design mentors who support you through your two school placements.",
+          "interview_process": "At your interview day you will take part in a combination of group and individual interviews with members of the programme team, and you may also be asked to undertake written or presentation tasks, depending on your subject.",
+          "is_send": true,
+          "last_published_at": "2019-06-13T10:44:31Z",
+          "level": "secondary",
+          "name": "Art and Design",
+          "open_for_applications": true,
+          "other_requirements": "You'll need to provide confirmation you have the health and physical capacity to commence training, and a Disclosure and Barring Service (DBS) certificate.",
+          "personal_qualities": "We are looking for applicants who have the potential to become outstanding teachers, and who are able to work independently on their studies while training in a school context.",
+          "program_type": "scitt_programme",
+          "qualifications": [{}],
+          "required_qualifications": "A first or second-class UK Bachelor's degree in an appropriate subject, or an overseas qualification of an equivalent standard from a recognised higher education institution.",
+          "required_qualifications_english": "equivalence_test",
+          "required_qualifications_maths": "equivalence_test",
+          "required_qualifications_science": "equivalence_test",
+          "running": true,
+          "salary_details": "Successful applicants will be employed as unqualified teachers on at least Point 1 of the Unqualified Teachers' Pay Scale for the duration of the programme.",
+          "scholarship_amount": 17_000,
+          "start_date": "2020-09-01",
+          "state": "published",
+          "study_mode": "both",
+          "summary": "PGCE with QTS full time",
+          "subject_codes": [{}],
+        },
+        "relationships": {
+          "recruitment_cycle": {
+            "meta": {
+              "included": false,
+            },
+          },
+          "accredited_body": {
+            "meta": {
+              "included": false,
+            },
+          },
+          "provider": {
+            "meta": {
+              "included": false,
+            },
+          },
+        },
+      }
+
+      attrs.each { |k, v| course[:attributes][k] = v }
+      course.to_json
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/nPORPb0g/1232-m-retrieve-courses-from-ttapi

### Changes proposed in this pull request

This PR:
- Adds a scheduled job `TeacherTrainingApi::CreateCoursesJob` which is currently set to run every day 2am.
  - Unless the feature flag is on, this does nothing.
  - If the feature flag is on, the job fans out to one job per provider (currently all providers):
-  Adds a job `TeacherTrainingApi::CreateProviderCoursesJob` which takes a provider, and retrieves all of their courses from TTAPI via new service `TeacherTrainingApi::RetrieveCourses`
  - It then iterates over these returned course objects and find-or-creates a course for the provider via new service `TeacherTrainingApi::CreateCourse`.
- Adds this new model `Course`, which currently only has a `name` and a `provider_id`

### Guidance to review
- You can test each of the services manually by running them from the command line. You'll need to ensure that your providers have their actual codes attached.
