### PR TITLE
[1264] Fix end date hint text

### DIFF
--- a/app/views/trainees/programme_details/edit.html.erb
+++ b/app/views/trainees/programme_details/edit.html.erb
@@ -42,12 +42,12 @@
       <%= f.govuk_date_field(:programme_start_date,
                              date_of_birth: false,
                              legend: { text: 'Programme start date', size: 's' },
-                             hint: { text: I18n.t("activemodel.errors.models.programme_detail_form.attributes.programme_start_date.hint_html", year: 1.year.ago.year ) } ) %>
+                             hint: { text: I18n.t("activemodel.errors.models.programme_detail_form.attributes.programme_start_date.hint_html", year: Time.zone.now.year ) } ) %>
 
        <%= f.govuk_date_field(:programme_end_date,
                               date_of_birth: false,
                               legend: { text: 'Programme end date', size: 's' },
-                              hint: { text: I18n.t("activemodel.errors.models.programme_detail_form.attributes.programme_end_date.hint_html", year: Time.zone.now.year) } ) %>
+                              hint: { text: I18n.t("activemodel.errors.models.programme_detail_form.attributes.programme_end_date.hint_html", year: Time.zone.now.next_year.year) } ) %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -422,13 +422,14 @@ en:
               future: "You must enter a programme start date that is not as far in the future"
               invalid: "You must enter a valid programme start date"
               too_old: "You must enter a valid programme start date"
-              hint_html: For example, 2 11 %{year}
+              hint_html: For example, 11 3 %{year}
             programme_end_date:
               blank: "You must enter a programme end date"
               future: "You must enter a programme end date that is not as far in the future"
               invalid: "You must enter a valid programme end date"
               too_old: "You must enter a valid programme end date"
               before_or_same_as_start_date: "The programme end date must be after the start date"
+              hint_html: For example, 11 3 %{year}
         reinstatement_form:
           attributes:
             date_string:


### PR DESCRIPTION
### Context

The programme end date hint text displays a string because it doesn't exist in the translation file. This is the fix.

### Changes proposed in this pull request

- Add end date hint text to translation file
- Change start date hint text to match prototype

### Guidance to review

- Navigate to the programme end date section 
- Check that the hint text is correct for both `start date` and `end date`

