### PR TITLE
[1271] fixed example_data rake task, Provider needs code

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -21,6 +21,7 @@ namespace :example_data do
         provider = Provider.find_or_create_by!(
           name: persona_attributes[:provider],
           dttp_id: SecureRandom.uuid,
+          code: Faker::Alphanumeric.alphanumeric(number: 3).upcase,
         )
         persona.update!(provider: provider)
       end


### PR DESCRIPTION
### Context

https://trello.com/c/DIshqJdy/1271-exampledata-rake-task-not-creating-provider

### Changes proposed in this pull request

* used faker to add 3 characters alphanumerical code to Provider in example_data task

### Guidance to review

* When testing in review on heroku, persona login should work now