### PR TITLE
[1239] Retrieve placement assignment

### DIFF
--- a/app/services/dttp/placement_assignment.rb
+++ b/app/services/dttp/placement_assignment.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Dttp
+  class PlacementAssignment
+    include ServicePattern
+
+    class HttpError < StandardError; end
+
+    attr_reader :trainee
+
+    PLACEMENT_ASSIGNMENT_FIELDS = %w[
+      dfe_programmestartdate
+      dfe_programmeenddate
+      dfe_placementassignmentid
+      _dfe_providerid_value
+    ].freeze
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      response = Client.get("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})?$select=#{PLACEMENT_ASSIGNMENT_FIELDS.join(',')}")
+
+      if response.code != 200
+        raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
+
+      JSON(response.body).slice(*PLACEMENT_ASSIGNMENT_FIELDS)
+    end
+  end
+end

--- a/app/services/dttp/placement_assignment.rb
+++ b/app/services/dttp/placement_assignment.rb
@@ -2,31 +2,26 @@
 
 module Dttp
   class PlacementAssignment
-    include ServicePattern
+    attr_reader :placement_assignment_json
 
-    class HttpError < StandardError; end
-
-    attr_reader :trainee
-
-    PLACEMENT_ASSIGNMENT_FIELDS = %w[
-      dfe_programmestartdate
-      dfe_programmeenddate
-      dfe_placementassignmentid
-      _dfe_providerid_value
-    ].freeze
-
-    def initialize(trainee:)
-      @trainee = trainee
+    def initialize(placement_assignment_json:)
+      @placement_assignment_json = placement_assignment_json
     end
 
-    def call
-      response = Client.get("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})?$select=#{PLACEMENT_ASSIGNMENT_FIELDS.join(',')}")
+    def programme_start_date
+      placement_assignment_json[:dfe_programmestartdate]
+    end
 
-      if response.code != 200
-        raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
-      end
+    def programme_end_date
+      placement_assignment_json[:dfe_programmeenddate]
+    end
 
-      JSON(response.body).slice(*PLACEMENT_ASSIGNMENT_FIELDS)
+    def placement_assignment_id
+      placement_assignment_json[:dfe_placementassignmentid]
+    end
+
+    def provider_id_value
+      placement_assignment_json[:_dfe_providerid_value]
     end
   end
 end

--- a/app/services/dttp/placement_assignment.rb
+++ b/app/services/dttp/placement_assignment.rb
@@ -2,26 +2,28 @@
 
 module Dttp
   class PlacementAssignment
-    attr_reader :placement_assignment_json
-
-    def initialize(placement_assignment_json:)
-      @placement_assignment_json = placement_assignment_json
+    def initialize(placement_assignment_data:)
+      @placement_assignment_data = placement_assignment_data
     end
 
     def programme_start_date
-      placement_assignment_json[:dfe_programmestartdate]
+      placement_assignment_data["dfe_programmestartdate"]
     end
 
     def programme_end_date
-      placement_assignment_json[:dfe_programmeenddate]
+      placement_assignment_data["dfe_programmeenddate"]
     end
 
     def placement_assignment_id
-      placement_assignment_json[:dfe_placementassignmentid]
+      placement_assignment_data["dfe_placementassignmentid"]
     end
 
     def provider_id_value
-      placement_assignment_json[:_dfe_providerid_value]
+      placement_assignment_data["_dfe_providerid_value"]
     end
+
+  private
+
+    attr_reader :placement_assignment_data
   end
 end

--- a/app/services/dttp/placement_assignments/fetch.rb
+++ b/app/services/dttp/placement_assignments/fetch.rb
@@ -7,22 +7,22 @@ module Dttp
 
       class HttpError < StandardError; end
 
-      attr_reader :trainee
+      attr_reader :dttp_id
 
-      def initialize(trainee:)
-        @trainee = trainee
+      def initialize(dttp_id:)
+        @dttp_id = dttp_id
       end
 
       def call
-        response = Client.get("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})")
+        response = Client.get("/dfe_placementassignments(#{dttp_id})")
 
         if response.code != 200
           raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
         end
 
-        placement_assignment_json = JSON(response.body)
+        placement_assignment_data = JSON(response.body)
 
-        Dttp::PlacementAssignment.new(placement_assignment_json: placement_assignment_json)
+        Dttp::PlacementAssignment.new(placement_assignment_data: placement_assignment_data)
       end
     end
   end

--- a/app/services/dttp/placement_assignments/fetch.rb
+++ b/app/services/dttp/placement_assignments/fetch.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Dttp
+  module PlacementAssignments
+    class Fetch
+      include ServicePattern
+
+      class HttpError < StandardError; end
+
+      attr_reader :trainee
+
+      def initialize(trainee:)
+        @trainee = trainee
+      end
+
+      def call
+        response = Client.get("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})")
+
+        if response.code != 200
+          raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+        end
+
+        placement_assignment_json = JSON(response.body)
+
+        Dttp::PlacementAssignment.new(placement_assignment_json: placement_assignment_json)
+      end
+    end
+  end
+end

--- a/spec/services/dttp/placement_assignment_spec.rb
+++ b/spec/services/dttp/placement_assignment_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+
 module Dttp
   describe PlacementAssignment do
     let(:programme_start_date) { 1.year.ago }
@@ -8,18 +9,18 @@ module Dttp
     let(:placement_assignment_id) { SecureRandom.uuid }
     let(:provider_id_value) { SecureRandom.uuid }
 
-    let(:placement_assignment_json) do
+    let(:placement_assignment_data) do
       {
-        dfe_programmestartdate: programme_start_date,
-        dfe_programmeenddate: programme_end_date,
-        dfe_placementassignmentid: placement_assignment_id,
-        _dfe_providerid_value: provider_id_value,
+        "dfe_programmestartdate" => programme_start_date,
+        "dfe_programmeenddate" => programme_end_date,
+        "dfe_placementassignmentid" => placement_assignment_id,
+        "_dfe_providerid_value" => provider_id_value,
       }
     end
 
-    subject { described_class.new(placement_assignment_json: placement_assignment_json) }
+    subject { described_class.new(placement_assignment_data: placement_assignment_data) }
 
-    describe "instance methods" do
+    describe "methods" do
       it "#programme_start_dates" do
         expect(subject.programme_start_date).to eq(programme_start_date)
       end

--- a/spec/services/dttp/placement_assignment_spec.rb
+++ b/spec/services/dttp/placement_assignment_spec.rb
@@ -1,61 +1,39 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-
 module Dttp
   describe PlacementAssignment do
-    describe "#call" do
-      let(:trainee) { create(:trainee, dttp_id: :with_placement_assignment) }
-      let(:fields) { Dttp::PlacementAssignment::PLACEMENT_ASSIGNMENT_FIELDS }
-      let(:path) { "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})?$select=#{fields.join(',')}" }
-      let(:start_date) { 1.year.ago }
-      let(:end_date) { Time.zone.now }
-      let(:placement_assignment_id) { SecureRandom.uuid }
-      let(:provider_id_value) { SecureRandom.uuid }
+    let(:programme_start_date) { 1.year.ago }
+    let(:programme_end_date) { Time.zone.now }
+    let(:placement_assignment_id) { SecureRandom.uuid }
+    let(:provider_id_value) { SecureRandom.uuid }
 
-      before do
-        allow(AccessToken).to receive(:fetch).and_return("token")
-        allow(Client).to receive(:get).with(path).and_return(dttp_response)
+    let(:placement_assignment_json) do
+      {
+        dfe_programmestartdate: programme_start_date,
+        dfe_programmeenddate: programme_end_date,
+        dfe_placementassignmentid: placement_assignment_id,
+        _dfe_providerid_value: provider_id_value,
+      }
+    end
+
+    subject { described_class.new(placement_assignment_json: placement_assignment_json) }
+
+    describe "instance methods" do
+      it "#programme_start_dates" do
+        expect(subject.programme_start_date).to eq(programme_start_date)
       end
 
-      context "Placement Assignment sample fields are available" do
-        let(:dttp_response) do
-          double(code: 200, body: { dfe_programmestartdate: start_date,
-                                    dfe_programmeenddate: end_date,
-                                    dfe_placementassignmentid: placement_assignment_id,
-                                    _dfe_providerid_value: provider_id_value }.to_json)
-        end
-
-        it "returns placement assignment JSON ruby hash" do
-          expect(described_class.call(trainee: trainee)).to eq(JSON(dttp_response.body))
-        end
+      it "#programme_end_dates" do
+        expect(subject.programme_end_date).to eq(programme_end_date)
       end
 
-      context "Placement Assignment sample fields are unavailable" do
-        let(:dttp_response) do
-          double(code: 200, body: { dfe_programmestartdate: nil,
-                                    dfe_programmeenddate: nil,
-                                    dfe_placementassignmentid: nil,
-                                    _dfe_providerid_value: nil }.to_json)
-        end
-
-        it "returns placement assignment fields as nil" do
-          expect(described_class.call(trainee: trainee).values).to eq([nil, nil, nil, nil])
-        end
+      it "#placement_assignment_id" do
+        expect(subject.placement_assignment_id).to eq(placement_assignment_id)
       end
 
-      context "HTTP error" do
-        let(:status) { 400 }
-        let(:body) { "error" }
-        let(:headers) { { foo: "bar" } }
-        let(:dttp_response) { double(code: status, body: body, headers: headers) }
-
-        it "raises a HttpError error with the response body as the message" do
-          expect(Client).to receive(:get).with(path).and_return(dttp_response)
-          expect {
-            described_class.call(trainee: trainee)
-          }.to raise_error(Dttp::PlacementAssignment::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
-        end
+      it "#provider_id_value" do
+        expect(subject.provider_id_value).to eq(provider_id_value)
       end
     end
   end

--- a/spec/services/dttp/placement_assignment_spec.rb
+++ b/spec/services/dttp/placement_assignment_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe PlacementAssignment do
+    describe "#call" do
+      let(:trainee) { create(:trainee, dttp_id: :with_placement_assignment) }
+      let(:fields) { Dttp::PlacementAssignment::PLACEMENT_ASSIGNMENT_FIELDS }
+      let(:path) { "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})?$select=#{fields.join(',')}" }
+      let(:start_date) { 1.year.ago }
+      let(:end_date) { Time.zone.now }
+      let(:placement_assignment_id) { SecureRandom.uuid }
+      let(:provider_id_value) { SecureRandom.uuid }
+
+      before do
+        allow(AccessToken).to receive(:fetch).and_return("token")
+        allow(Client).to receive(:get).with(path).and_return(dttp_response)
+      end
+
+      context "Placement Assignment sample fields are available" do
+        let(:dttp_response) do
+          double(code: 200, body: { dfe_programmestartdate: start_date,
+                                    dfe_programmeenddate: end_date,
+                                    dfe_placementassignmentid: placement_assignment_id,
+                                    _dfe_providerid_value: provider_id_value }.to_json)
+        end
+
+        it "returns placement assignment JSON ruby hash" do
+          expect(described_class.call(trainee: trainee)).to eq(JSON(dttp_response.body))
+        end
+      end
+
+      context "Placement Assignment sample fields are unavailable" do
+        let(:dttp_response) do
+          double(code: 200, body: { dfe_programmestartdate: nil,
+                                    dfe_programmeenddate: nil,
+                                    dfe_placementassignmentid: nil,
+                                    _dfe_providerid_value: nil }.to_json)
+        end
+
+        it "returns placement assignment fields as nil" do
+          expect(described_class.call(trainee: trainee).values).to eq([nil, nil, nil, nil])
+        end
+      end
+
+      context "HTTP error" do
+        let(:status) { 400 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:dttp_response) { double(code: status, body: body, headers: headers) }
+
+        it "raises a HttpError error with the response body as the message" do
+          expect(Client).to receive(:get).with(path).and_return(dttp_response)
+          expect {
+            described_class.call(trainee: trainee)
+          }.to raise_error(Dttp::PlacementAssignment::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/dttp/placement_assignments/fetch_spec.rb
+++ b/spec/services/dttp/placement_assignments/fetch_spec.rb
@@ -6,8 +6,8 @@ module Dttp
   module PlacementAssignments
     describe Fetch do
       describe "#call" do
-        let(:trainee) { create(:trainee, dttp_id: :with_placement_assignment) }
-        let(:path) { "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})" }
+        let(:dttp_id) { SecureRandom.uuid }
+        let(:path) { "/dfe_placementassignments(#{dttp_id})" }
 
         before do
           allow(AccessToken).to receive(:fetch).and_return("token")
@@ -20,7 +20,7 @@ module Dttp
           end
 
           it "returns placement assignment JSON ruby hash" do
-            expect(described_class.call(trainee: trainee)).to be_a(Dttp::PlacementAssignment)
+            expect(described_class.call(dttp_id: dttp_id)).to be_a(Dttp::PlacementAssignment)
           end
         end
 
@@ -33,7 +33,7 @@ module Dttp
           it "raises a HttpError error with the response body as the message" do
             expect(Client).to receive(:get).with(path).and_return(dttp_response)
             expect {
-              described_class.call(trainee: trainee)
+              described_class.call(dttp_id: dttp_id)
             }.to raise_error(Dttp::PlacementAssignments::Fetch::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
           end
         end

--- a/spec/services/dttp/placement_assignments/fetch_spec.rb
+++ b/spec/services/dttp/placement_assignments/fetch_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  module PlacementAssignments
+    describe Fetch do
+      describe "#call" do
+        let(:trainee) { create(:trainee, dttp_id: :with_placement_assignment) }
+        let(:path) { "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})" }
+
+        before do
+          allow(AccessToken).to receive(:fetch).and_return("token")
+          allow(Client).to receive(:get).with(path).and_return(dttp_response)
+        end
+
+        context "Placement Assignment sample are available" do
+          let(:dttp_response) do
+            double(code: 200, body: nil)
+          end
+
+          it "returns placement assignment JSON ruby hash" do
+            expect(described_class.call(trainee: trainee)).to be_a(Dttp::PlacementAssignment)
+          end
+        end
+
+        context "HTTP error" do
+          let(:status) { 400 }
+          let(:body) { "error" }
+          let(:headers) { { foo: "bar" } }
+          let(:dttp_response) { double(code: status, body: body, headers: headers) }
+
+          it "raises a HttpError error with the response body as the message" do
+            expect(Client).to receive(:get).with(path).and_return(dttp_response)
+            expect {
+              described_class.call(trainee: trainee)
+            }.to raise_error(Dttp::PlacementAssignments::Fetch::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/Ky3W4nNo/1239-m-retrieve-placement-assignment
### Changes proposed in this pull request
* New Dttp::PlacementAssignments::Fetch service that makes request to the dfe_placementassignment entity in DTTP and retrieves all fields
* Response body is converted to JSON ruby hash and then fed into new Dttp::PlacementAssignment Ruby class
* Methods defined in new class access Dttp fields in JSON ruby hash
* Test of service with mock token, request and response. Unit test for Dttp::PlacementAssignment class. 

### Guidance to review
Use Postman to retrieve dttp_id from placement assignments field, e.g "dfe_placementassignmentid". In rails console Dttp::PlacementAssignments::Fetch.call(dttp_id: dttp_id) . As the method returns Dttp::PlacementAssignment object, you can then you can query the object returned using the methods defined in that class. 
