### PR TITLE
[1247] Add british and irish into autocomplete list

### DIFF
--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -53,7 +53,7 @@ module Trainees
     end
 
     def other_nationalities
-      @other_nationalities ||= Nationality.where.not(name: NATIONALITIES)
+      @other_nationalities ||= Nationality.all
     end
 
     def personal_details_params


### PR DESCRIPTION
### Context

We have been excluding British and Irish from the autocomplete list as there are separate checkboxes for these nationalities. We want to show all nationalities in the autocomplete list so it works both ways.

### Changes proposed in this pull request

- Autocomplete list renders all nationalities

### Guidance to review

- Pull down the code (the review app is currently not working: https://trello.com/c/DIshqJdy/1271-exampledata-rake-task-not-creating-provider)

- Navigate to personal details and scroll down to nationalities 
- Click other
- Check that British and Irish appear in the list

