### PR TITLE
[1265] - Add extra params for Defer

### DIFF
--- a/app/jobs/defer_job.rb
+++ b/app/jobs/defer_job.rb
@@ -7,12 +7,18 @@ class DeferJob < ApplicationJob
   def perform(trainee_id)
     trainee = Trainee.find(trainee_id)
 
-    Dttp::UpdateTraineeStatus.call(status: DttpStatuses::DEFERRED,
-                                   entity_id: trainee.dttp_id,
-                                   entity_type: Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE)
+    Dttp::UpdateTraineeStatus.call(
+      status: DttpStatuses::DEFERRED,
+      entity_id: trainee.dttp_id,
+      entity_type: Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
+    )
 
-    Dttp::UpdateTraineeStatus.call(status: DttpStatuses::DEFERRED,
-                                   entity_id: trainee.placement_assignment_dttp_id,
-                                   entity_type: Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE)
+    Dttp::UpdateTraineeStatus.call(
+      status: DttpStatuses::DEFERRED,
+      entity_id: trainee.placement_assignment_dttp_id,
+      entity_type: Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
+    )
+
+    Dttp::CreateDormancy.call(trainee: trainee)
   end
 end

--- a/app/jobs/reinstate_job.rb
+++ b/app/jobs/reinstate_job.rb
@@ -9,12 +9,18 @@ class ReinstateJob < ApplicationJob
 
     status = trainee.trn.present? ? DttpStatuses::YET_TO_COMPLETE_COURSE : DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED
 
-    Dttp::UpdateTraineeStatus.call(status: status,
-                                   entity_id: trainee.dttp_id,
-                                   entity_type: Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE)
+    Dttp::UpdateTraineeStatus.call(
+      status: status,
+      entity_id: trainee.dttp_id,
+      entity_type: Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
+    )
 
-    Dttp::UpdateTraineeStatus.call(status: status,
-                                   entity_id: trainee.placement_assignment_dttp_id,
-                                   entity_type: Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE)
+    Dttp::UpdateTraineeStatus.call(
+      status: status,
+      entity_id: trainee.placement_assignment_dttp_id,
+      entity_type: Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
+    )
+
+    Dttp::UpdateDormancy.call(trainee: trainee)
   end
 end

--- a/app/lib/dttp/params/dormancy.rb
+++ b/app/lib/dttp/params/dormancy.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Dttp
+  module Params
+    class Dormancy
+      delegate :to_json, to: :params
+
+      def initialize(trainee:)
+        @trainee = trainee
+      end
+
+      def params
+        @params ||= {
+          "dfe_dateleftcourse" => date_left,
+          "dfe_datereturnedtocourse" => date_returned,
+          "dfe_TrainingRecordId@odata.bind" => "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})",
+        }
+      end
+
+    private
+
+      attr_reader :trainee
+
+      def date_left
+        trainee.defer_date.in_time_zone.iso8601
+      end
+
+      def date_returned
+        trainee.reinstate_date ? trainee.reinstate_date.in_time_zone.iso8601 : nil
+      end
+    end
+  end
+end

--- a/app/services/dttp/create_dormancy.rb
+++ b/app/services/dttp/create_dormancy.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Dttp
+  class CreateDormancy
+    include ServicePattern
+
+    class Error < StandardError; end
+
+    attr_reader :trainee
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      response = Client.post("/dfe_dormantperiods", body: params.to_json)
+
+      if response.code != 204
+        raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
+
+      trainee.update!(dormancy_dttp_id: Dttp::OdataParser.entity_id(trainee.id, response))
+    end
+
+  private
+
+    def params
+      @params ||= Params::Dormancy.new(trainee: trainee)
+    end
+  end
+end

--- a/app/services/dttp/update_dormancy.rb
+++ b/app/services/dttp/update_dormancy.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Dttp
+  class UpdateDormancy
+    include ServicePattern
+
+    class Error < StandardError; end
+
+    attr_reader :trainee
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      response = Client.patch(
+        "/dfe_dormantperiods(#{trainee.dormancy_dttp_id})",
+        body: params.to_json,
+      )
+
+      if response.code != 204
+        raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
+
+      response
+    end
+
+  private
+
+    def params
+      @params ||= Params::Dormancy.new(trainee: trainee)
+    end
+  end
+end

--- a/db/migrate/20210312135246_add_dormancy_dttp_id_to_trainees.rb
+++ b/db/migrate/20210312135246_add_dormancy_dttp_id_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDormancyDttpIdToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :dormancy_dttp_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -87,8 +87,8 @@ ActiveRecord::Schema.define(version: 2021_03_12_154826) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.string "code"
     t.boolean "apply_sync_enabled", default: false
+    t.string "code"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -153,6 +153,7 @@ ActiveRecord::Schema.define(version: 2021_03_12_154826) do
     t.string "dttp_update_sha"
     t.date "commencement_date"
     t.date "reinstate_date"
+    t.uuid "dormancy_dttp_id"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"
     t.index ["dttp_id"], name: "index_trainees_on_dttp_id"

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -161,6 +161,11 @@ FactoryBot.define do
       state { "qts_awarded" }
     end
 
+    trait :with_dttp_dormancy do
+      deferred
+      dormancy_dttp_id { SecureRandom.uuid }
+    end
+
     trait :withdrawn_on_another_day do
       withdraw_date { Faker::Date.in_date_period }
     end

--- a/spec/jobs/reinstate_job_spec.rb
+++ b/spec/jobs/reinstate_job_spec.rb
@@ -36,6 +36,7 @@ describe ReinstateJob do
     allow(Dttp::UpdateTraineeStatus).to receive(:call).with(contact_update_params_without_trn)
     allow(Dttp::UpdateTraineeStatus).to receive(:call).with(placement_assignment_update_params_with_trn)
     allow(Dttp::UpdateTraineeStatus).to receive(:call).with(placement_assignment_update_params_without_trn)
+    allow(Dttp::UpdateDormancy).to receive(:call).with(trainee: trainee)
   end
 
   context "with a trainee with a trn" do

--- a/spec/lib/dttp/params/dormancy_spec.rb
+++ b/spec/lib/dttp/params/dormancy_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  module Params
+    describe Dormancy do
+      subject { described_class.new(trainee: trainee).params }
+
+      let(:trainee) { build(:trainee, :with_placement_assignment, :deferred) }
+
+      describe "params" do
+        describe "dfe_dateleftcourse" do
+          it "is set to the deferral date" do
+            expect(subject["dfe_dateleftcourse"]).to eq(trainee.defer_date.in_time_zone.iso8601)
+          end
+        end
+
+        describe "dfe_datereturnedtocourse" do
+          let(:trainee) { build(:trainee, :with_placement_assignment, :deferred, :reinstated) }
+
+          it "is set to reinstated date" do
+            expect(subject["dfe_datereturnedtocourse"]).to eq(trainee.reinstate_date.in_time_zone.iso8601)
+          end
+        end
+
+        describe "dfe_TrainingRecordId" do
+          it "is set to the trainee's placement_assignment_dttp_id" do
+            expect(subject["dfe_TrainingRecordId@odata.bind"]).to eq("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})")
+          end
+        end
+      end
+
+      describe "to_json" do
+        subject { described_class.new(trainee: trainee) }
+
+        it "returns params to_json" do
+          expect(subject.to_json).to eq(subject.params.to_json)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/dttp/create_dormancy_spec.rb
+++ b/spec/services/dttp/create_dormancy_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe CreateDormancy do
+    describe "#call" do
+      let(:trainee) do
+        create(:trainee, :trn_received, :with_placement_assignment)
+      end
+
+      let(:path) { "/dfe_dormantperiods" }
+      let(:expected_params) { { test: "value" }.to_json }
+      let(:expected_dormant_id) { SecureRandom.uuid }
+
+      before do
+        allow(AccessToken).to receive(:fetch).and_return("token")
+        allow(Client).to receive(:post).and_return(dttp_response)
+        allow(Dttp::OdataParser).to receive(:entity_id).with(trainee.id, dttp_response).and_return(expected_dormant_id)
+        allow(Params::Dormancy).to receive(:new).with(trainee: trainee)
+          .and_return(double(to_json: expected_params))
+      end
+
+      context "success" do
+        let(:dttp_response) { double(code: 204) }
+
+        it "sends a POST request to create entity property 'dfe_dormantperiods'" do
+          expect(Client).to receive(:post).with(path, body: expected_params).and_return(dttp_response)
+          described_class.call(trainee: trainee)
+        end
+
+        it "sets the trainee's dormancy_dttp_id" do
+          expect {
+            described_class.call(trainee: trainee)
+            trainee.reload
+          }.to change {
+            trainee.dormancy_dttp_id
+          }.from(nil) .to(expected_dormant_id)
+        end
+      end
+
+      context "error" do
+        let(:status) { 405 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:dttp_response) { double(code: status, body: body, headers: headers) }
+
+        it "raises an error exception" do
+          expect {
+            described_class.call(trainee: trainee)
+          }.to raise_error(Dttp::CreateDormancy::Error, "status: #{status}, body: #{body}, headers: #{headers}")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/dttp/update_dormancy_spec.rb
+++ b/spec/services/dttp/update_dormancy_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe UpdateDormancy do
+    describe "#call" do
+      let(:trainee) do
+        create(:trainee, :trn_received, :with_dttp_dormancy)
+      end
+
+      let(:path) { "/dfe_dormantperiods(#{trainee.dormancy_dttp_id})" }
+      let(:expected_params) { { test: "value" }.to_json }
+
+      before do
+        allow(AccessToken).to receive(:fetch).and_return("token")
+        allow(Client).to receive(:patch).and_return(dttp_response)
+        allow(Params::Dormancy).to receive(:new).with(trainee: trainee)
+          .and_return(double(to_json: expected_params))
+      end
+
+      context "success" do
+        let(:dttp_response) { double(code: 204) }
+
+        it "sends a PATCH request to set entity property 'dfe_dormantperiods'" do
+          expect(Client).to receive(:patch).with(path, body: expected_params).and_return(dttp_response)
+          described_class.call(trainee: trainee)
+        end
+      end
+
+      context "error" do
+        let(:status) { 405 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:dttp_response) { double(code: status, body: body, headers: headers) }
+
+        it "raises an error exception" do
+          expect {
+            described_class.call(trainee: trainee)
+          }.to raise_error(Dttp::UpdateDormancy::Error, "status: #{status}, body: #{body}, headers: #{headers}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/QThGgrUa/1265-m-add-extra-params-for-defer

### Changes proposed in this pull request

- Create a new `Dttp::Params::Dormancy` params class
- Create two new services to create and update a trainee's dormancy when deferring/reinstating

### Guidance to review

You'll have to test this with local DTTP access.

- Prepare a trainee locally and in DTTP such that they have a TRN and are ready for a deferral
- Run `Dttp::CreateDormancy.call(trainee: trainee)` in the console passing in the trainee to create a dormancy
- Query that trainee's `dfe_dormantperiods(dormancy_dttp_id)` in postman and assert the correct deferral DTTP properties (found in Dttp::Params::Dormancy are set in the response
- Reinstate the trainee using `Dttp::UpdateDormancy.call(trainee: trainee)` and assert the `dfe_datereturnedtocourse` dttp property is set.

You can also check in the DTTP CRM directly instead of postman under the training instance, dormancy information tab.