### PR TITLE
[1280] Ignore concurrent migration errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ ENV COMMIT_SHA=$COMMIT_SHA
 RUN echo export PATH=/usr/local/bin:\$PATH > /root/.ashrc
 ENV ENV="/root/.ashrc"
 RUN bundle exec rake assets:precompile
-CMD bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0
+CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails server -b 0.0.0.0

--- a/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
+++ b/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :migrate do
+    desc "Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors"
+    task ignore_concurrent_migration_exceptions: :environment do
+      Rake::Task["db:migrate"].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end


### PR DESCRIPTION
### Context

These happen a lot as we run the migrations on each instance that we
deploy too. 

### Changes proposed in this pull request

They're not useful. Ignore them.

### Guidance to review

We do this in TTAPI and Apply. 

