### PR TITLE
[1203] Implement 'save on confirm' for training details

### DIFF
--- a/app/components/trainees/confirmation/trainee_id/view.rb
+++ b/app/components/trainees/confirmation/trainee_id/view.rb
@@ -4,12 +4,16 @@ module Trainees
   module Confirmation
     module TraineeId
       class View < GovukComponent::Base
-        attr_accessor :trainee
+        attr_accessor :data_model
 
-        delegate :trainee_id, to: :trainee
+        delegate :trainee_id, to: :data_model
 
-        def initialize(trainee:)
-          @trainee = trainee
+        def initialize(data_model:)
+          @data_model = data_model
+        end
+
+        def trainee
+          data_model.is_a?(Trainee) ? data_model : data_model.trainee
         end
       end
     end

--- a/app/components/trainees/confirmation/trainee_start_date/view.rb
+++ b/app/components/trainees/confirmation/trainee_start_date/view.rb
@@ -4,14 +4,18 @@ module Trainees
   module Confirmation
     module TraineeStartDate
       class View < GovukComponent::Base
-        attr_accessor :trainee
+        attr_accessor :data_model
 
-        def initialize(trainee:)
-          @trainee = trainee
+        def initialize(data_model:)
+          @data_model = data_model
+        end
+
+        def trainee
+          data_model.is_a?(Trainee) ? data_model : data_model.trainee
         end
 
         def start_date
-          trainee.commencement_date.strftime("%d %B %Y")
+          data_model.commencement_date.strftime("%d %B %Y")
         end
       end
     end

--- a/app/controllers/trainees/start_dates_controller.rb
+++ b/app/controllers/trainees/start_dates_controller.rb
@@ -11,14 +11,15 @@ module Trainees
     }.freeze
 
     def edit
-      @training_details = TrainingDetailsForm.new(trainee)
+      @training_details = TraineeStartDateForm.new(trainee)
     end
 
     def update
-      @training_details = TrainingDetailsForm.new(trainee, validate_trainee_id: false)
-      @training_details.assign_attributes(trainee_params)
+      @training_details = TraineeStartDateForm.new(trainee, trainee_params)
 
-      if @training_details.save
+      save_strategy = trainee.draft? ? :save! : :stash
+
+      if @training_details.public_send(save_strategy)
         redirect_to trainee_start_date_confirm_path(trainee)
       else
         render :edit
@@ -36,7 +37,7 @@ module Trainees
     end
 
     def trainee_params
-      params.require(:training_details_form).permit(:commencement_date, *PARAM_CONVERSION.keys)
+      params.require(:trainee_start_date_form).permit(:commencement_date, *PARAM_CONVERSION.keys)
             .transform_keys do |key|
         PARAM_CONVERSION.keys.include?(key) ? PARAM_CONVERSION[key] : key
       end

--- a/app/controllers/trainees/trainee_ids_controller.rb
+++ b/app/controllers/trainees/trainee_ids_controller.rb
@@ -5,14 +5,15 @@ module Trainees
     before_action :authorize_trainee
 
     def edit
-      @training_details = TrainingDetailsForm.new(trainee)
+      @training_details = TraineeIdForm.new(trainee)
     end
 
     def update
-      @training_details = TrainingDetailsForm.new(trainee, validate_commencement_date: false)
-      @training_details.assign_attributes(trainee_params)
+      @training_details = TraineeIdForm.new(trainee, trainee_params)
 
-      if @training_details.save
+      save_strategy = trainee.draft? ? :save! : :stash
+
+      if @training_details.public_send(save_strategy)
         redirect_to trainee_trainee_id_confirm_path(trainee)
       else
         render :edit
@@ -30,7 +31,7 @@ module Trainees
     end
 
     def trainee_params
-      params.require(:training_details_form).permit(:trainee_id)
+      params.require(:trainee_id_form).permit(:trainee_id)
     end
 
     def authorize_trainee

--- a/app/forms/trainee_id_form.rb
+++ b/app/forms/trainee_id_form.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class TraineeIdForm
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations::Callbacks
+
+  attr_accessor :trainee, :trainee_id
+
+  delegate :id, :persisted?, to: :trainee
+
+  validates :trainee_id, presence: true,
+                         length: {
+                           maximum: 100,
+                           message: I18n.t("activemodel.errors.models.trainee_id_form.attributes.trainee_id.max_char_exceeded"),
+                         }
+
+  def initialize(trainee, params = {}, store = FormStore)
+    @trainee = trainee
+    @store = store
+    @params = params
+    @new_attributes = fields_from_store.merge(params).symbolize_keys
+    super(fields)
+  end
+
+  def fields
+    trainee.attributes
+           .symbolize_keys
+           .slice(:trainee_id)
+           .merge(new_attributes)
+  end
+
+  def save!
+    if valid?
+      update_trainee_id
+      trainee.save!
+      store.set(trainee.id, :trainee_id, nil)
+    else
+      false
+    end
+  end
+
+  def stash
+    valid? && store.set(trainee.id, :trainee_id, fields)
+  end
+
+private
+
+  attr_reader :new_attributes, :store
+
+  def update_trainee_id
+    trainee.assign_attributes(trainee_id: trainee_id) if errors.empty?
+  end
+
+  def fields_from_store
+    store.get(trainee.id, :trainee_id).presence || {}
+  end
+end

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -4,8 +4,10 @@ class FormStore
   class InvalidKeyError < StandardError; end
 
   FORM_SECTION_KEYS = %i[
-    personal_details
     contact_details
+    personal_details
+    trainee_id
+    trainee_start_date
   ].freeze
 
   class << self

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -460,6 +460,16 @@ en:
               blank: You must enter a reason
             withdraw_reason:
               invalid: You must choose a reason
+        trainee_id_form:
+          attributes:
+            trainee_id:
+                blank: You must enter a trainee ID
+                max_char_exceeded: Your entry must not exceed 100 characters
+        trainee_start_date_form:
+          attributes:
+            commencement_date:
+                blank: You must enter a start date
+                invalid: You must enter a valid start date
         training_details_form:
           attributes:
             commencement_date:

--- a/spec/components/trainees/confirmation/trainee_id/view_preview.rb
+++ b/spec/components/trainees/confirmation/trainee_id/view_preview.rb
@@ -6,11 +6,11 @@ module Trainees
     module TraineeId
       class ViewPreview < ViewComponent::Preview
         def default
-          render(Trainees::Confirmation::TraineeId::View.new(trainee: mock_trainee))
+          render(Trainees::Confirmation::TraineeId::View.new(data_model: mock_trainee))
         end
 
         def with_no_data
-          render(Trainees::Confirmation::TraineeId::View.new(trainee: Trainee.new(id: 2)))
+          render(Trainees::Confirmation::TraineeId::View.new(data_model: Trainee.new(id: 2)))
         end
 
       private

--- a/spec/components/trainees/confirmation/trainee_id/view_spec.rb
+++ b/spec/components/trainees/confirmation/trainee_id/view_spec.rb
@@ -12,7 +12,7 @@ module Trainees
           let(:trainee) { create(:trainee) }
 
           before do
-            render_inline(View.new(trainee: trainee))
+            render_inline(View.new(data_model: trainee))
           end
 
           it "renders the trainee ID" do

--- a/spec/components/trainees/confirmation/trainee_start_date/view_preview.rb
+++ b/spec/components/trainees/confirmation/trainee_start_date/view_preview.rb
@@ -7,7 +7,7 @@ module Trainees
     module TraineeStartDate
       class ViewPreview < ViewComponent::Preview
         def default
-          render(Trainees::Confirmation::TraineeStartDate::View.new(trainee: mock_trainee))
+          render(Trainees::Confirmation::TraineeStartDate::View.new(data_model: mock_trainee))
         end
 
       private

--- a/spec/components/trainees/confirmation/trainee_start_date/view_spec.rb
+++ b/spec/components/trainees/confirmation/trainee_start_date/view_spec.rb
@@ -16,7 +16,7 @@ module Trainees
           let(:trainee) { create(:trainee, commencement_date: commencement_date) }
 
           before do
-            render_inline(View.new(trainee: trainee))
+            render_inline(View.new(data_model: trainee))
           end
 
           it "renders the trainee start date" do

--- a/spec/forms/trainee_id_form_spec.rb
+++ b/spec/forms/trainee_id_form_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TraineeIdForm, type: :model do
+  let(:params) { {} }
+  let(:trainee) { build(:trainee, :not_started) }
+  let(:form_store) { class_double(FormStore) }
+
+  subject { described_class.new(trainee, params, form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:trainee_id) }
+
+    context "empty form data" do
+      let(:params) { { "trainee_id" => "" } }
+
+      before { subject.valid? }
+
+      it "returns an error" do
+        expect(subject.errors[:trainee_id]).to include(I18n.t("activemodel.errors.models.training_details_form.attributes.trainee_id.blank"))
+      end
+    end
+  end
+
+  describe "#stash" do
+    let(:trainee) { create(:trainee) }
+
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and trainee_id" do
+      expect(form_store).to receive(:set).with(trainee.id, :trainee_id, subject.fields)
+
+      subject.stash
+    end
+  end
+
+  describe "#save!" do
+    let(:params) { {} }
+    let(:trainee) { create(:trainee) }
+    let(:trainee_id) { "123" }
+
+    before do
+      allow(form_store).to receive(:get).and_return({ "trainee_id" => trainee_id })
+      allow(form_store).to receive(:set).with(trainee.id, :trainee_id, nil)
+    end
+
+    it "takes any data from the form store and saves it to the database" do
+      expect { subject.save! }.to change(trainee, :trainee_id).to(trainee_id)
+    end
+  end
+end

--- a/spec/forms/trainee_start_date_form_spec.rb
+++ b/spec/forms/trainee_start_date_form_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TraineeStartDateForm, type: :model do
+  let(:params) { { year: "2020", month: "12", day: "20" } }
+  let(:trainee) { build(:trainee, :not_started) }
+  let(:form_store) { class_double(FormStore) }
+  let(:error_attr) { "activemodel.errors.models.training_details_form.attributes.commencement_date" }
+
+  subject { described_class.new(trainee, params, form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    subject { described_class.new(trainee, params) }
+
+    before { subject.validate }
+
+    context "invalid date" do
+      let(:params) { { day: 20, month: 20, year: 2020 } }
+
+      it "is invalid" do
+        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.invalid"))
+      end
+    end
+
+    context "blank date" do
+      let(:params) { { day: "", month: "", year: "" } }
+
+      it "is invalid" do
+        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.blank"))
+      end
+    end
+  end
+
+  describe "#stash" do
+    let(:trainee) { create(:trainee) }
+
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and trainee_id" do
+      expect(form_store).to receive(:set).with(trainee.id, :trainee_start_date, subject.fields)
+
+      subject.stash
+    end
+  end
+
+  describe "#save!" do
+    let(:trainee) { create(:trainee) }
+
+    before do
+      allow(form_store).to receive(:set).with(trainee.id, :trainee_start_date, nil)
+    end
+
+    it "takes any data from the form store and saves it to the database" do
+      date_params = params.values.map(&:to_i)
+      expect { subject.save! }.to change(trainee, :commencement_date).to(Date.new(*date_params))
+    end
+  end
+end

--- a/spec/forms/training_details_form_spec.rb
+++ b/spec/forms/training_details_form_spec.rb
@@ -17,7 +17,7 @@ describe TrainingDetailsForm, type: :model do
     end
 
     context "trainee ID" do
-      subject { described_class.new(trainee, validate_commencement_date: false) }
+      subject { described_class.new(trainee) }
 
       context "not present" do
         let(:trainee) { build(:trainee, trainee_id: nil) }
@@ -30,7 +30,7 @@ describe TrainingDetailsForm, type: :model do
       end
 
       context "over 100 characters" do
-        let(:trainee) { build(:trainee, trainee_id: SecureRandom.alphanumeric(101)) }
+        let(:trainee) { build(:trainee, commencement_date: Time.zone.today, trainee_id: SecureRandom.alphanumeric(101)) }
 
         it "returns a max character exceeded message" do
           expect(subject).not_to be_valid
@@ -41,7 +41,7 @@ describe TrainingDetailsForm, type: :model do
       end
 
       context "under 100 characters" do
-        let(:trainee) { build(:trainee, trainee_id: SecureRandom.alphanumeric(99)) }
+        let(:trainee) { build(:trainee, commencement_date: Time.zone.today, trainee_id: SecureRandom.alphanumeric(99)) }
 
         it "is valid" do
           expect(subject).to be_valid
@@ -50,7 +50,7 @@ describe TrainingDetailsForm, type: :model do
     end
 
     context "commencement date" do
-      subject { described_class.new(trainee, validate_trainee_id: false) }
+      subject { described_class.new(trainee) }
 
       before do
         subject.assign_attributes(date_attributes)

--- a/spec/support/page_objects/trainees/edit_trainee_id.rb
+++ b/spec/support/page_objects/trainees/edit_trainee_id.rb
@@ -5,7 +5,7 @@ module PageObjects
     class EditTraineeId < PageObjects::Base
       set_url "/trainees/{trainee_id}/trainee-id/edit"
 
-      element :trainee_id_input, "#training-details-form-trainee-id-field"
+      element :trainee_id_input, "#trainee-id-form-trainee-id-field"
       element :continue, "input[name='commit']"
     end
   end

--- a/spec/support/page_objects/trainees/edit_trainee_start_date.rb
+++ b/spec/support/page_objects/trainees/edit_trainee_start_date.rb
@@ -7,9 +7,9 @@ module PageObjects
 
       set_url "/trainees/{trainee_id}/trainee-start-date/edit"
 
-      element :commencement_date_day, "#training_details_form_commencement_date_3i"
-      element :commencement_date_month, "#training_details_form_commencement_date_2i"
-      element :commencement_date_year, "#training_details_form_commencement_date_1i"
+      element :commencement_date_day, "#trainee_start_date_form_commencement_date_3i"
+      element :commencement_date_month, "#trainee_start_date_form_commencement_date_2i"
+      element :commencement_date_year, "#trainee_start_date_form_commencement_date_1i"
 
       element :continue, "input[name='commit']"
     end


### PR DESCRIPTION
### Context

https://trello.com/c/rPTLRvuZ/1203-s-implement-save-on-confirm-trainee-progress

### Changes proposed in this pull request

Implements save-on-confirm functionality for the Trainee progress section, i.e. the 'Trainee ID' and the 'Trainee start date' here:

<img width="1019" alt="Screenshot_2021-03-04_at_16 01 28" src="https://user-images.githubusercontent.com/18436946/111177192-e8fc2680-85a1-11eb-8522-f96aabc1e8b5.png">

- Similar to the changes made https://github.com/DFE-Digital/register-trainee-teachers/pull/648
- Split `TrainingDetailsForm` into `TraineeIdForm` and `TraineeStartDateForm` so that the booleans `validate_trainee_id` and `validate_commencement_date ` go away.
  - This makes the form compatible with the `ConfirmDetailsController` which calls `form_klass.new(trainee)` to create the forms.
- The combined 'Trainee start date and ID' form uses the old `TrainingDetailsForm`. This does not include any `FormStore` stashing since it's only used for draft trainees.

### Guidance to review

**Draft trainee**
- Visit a draft trainee 'Trainee start date and ID' form and make changes. It should work as before.

**Non-draft trainee, changing Trainee ID**
- Visit a non-draft trainee and click through to change 'Trainee ID'
- Check that validations are still working.
- Make a change, click continue.
- Click cancel and you'll see the original trainee ID, it won't have been saved.
- Repeat, but confirm your change.
- See that the new trainee ID is now saved.

**Non-draft trainee, changing Trainee start date**
- Repeat the steps for testing 'Non-draft trainee, changing Trainee ID', but replace 'Trainee ID' with 'Trainee start date'