### PR TITLE
[1250] Validate uniqueness of dttpid on providers and users

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,10 +8,10 @@ class SessionsController < ApplicationController
 
     if FeatureService.enabled?("allow_user_creation") && current_user.nil?
       @current_user = User.new(
-        dttp_id: "00000000-0000-0000-0000-000000000000",
+        dttp_id: SecureRandom.uuid,
         provider: Provider.create_or_find_by(
           name: "DfE",
-          dttp_id: "00000000-0000-0000-0000-000000000000",
+          dttp_id: SecureRandom.uuid,
           code: "000",
         ),
       )

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,7 +5,7 @@ class Provider < ApplicationRecord
   has_many :trainees
 
   validates :name, presence: true
-  validates :dttp_id, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
+  validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
   validates :code, format: { with: /\A[A-Z0-9]+\z/i }
 
   def code=(cde)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :email, presence: true
-  validates :dttp_id, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }, unless: :system_admin?
+  validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }, unless: :system_admin?
 
   validate do |record|
     EmailFormatValidator.new(record).validate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -314,6 +314,7 @@ en:
               blank: You must enter a provider name
             dttp_id:
               invalid: You must enter a DTTP ID in the correct format, like b77c821a-c12a-4133-8036-6ef1db146f9e
+              taken: You must enter a unique DTTP ID
             code:
               invalid: You must enter a provider code in the correct format, like 12Y
         user:
@@ -326,6 +327,7 @@ en:
               blank: "You must enter the user's email address"
             dttp_id:
               invalid: "You must enter a DTTP ID in the correct format, like 6a61d94f-5060-4d57-8676-bdb265a5b949"
+              taken: You must enter a unique DTTP ID
   activemodel:
     errors:
       validators:

--- a/db/migrate/20210315141417_add_index_to_dttp_id.rb
+++ b/db/migrate/20210315141417_add_index_to_dttp_id.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIndexToDttpId < ActiveRecord::Migration[6.1]
+  def change
+    add_index :providers, :dttp_id, unique: true
+    add_index :users, :dttp_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_12_154826) do
+ActiveRecord::Schema.define(version: 2021_03_15_141417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,6 +89,7 @@ ActiveRecord::Schema.define(version: 2021_03_12_154826) do
     t.uuid "dttp_id"
     t.boolean "apply_sync_enabled", default: false
     t.string "code"
+    t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -179,6 +180,7 @@ ActiveRecord::Schema.define(version: 2021_03_12_154826) do
     t.uuid "dttp_id"
     t.boolean "system_admin", default: false
     t.index ["dfe_sign_in_uid"], name: "index_users_on_dfe_sign_in_uid", unique: true
+    t.index ["dttp_id"], name: "index_users_on_dttp_id", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["provider_id"], name: "index_users_on_provider_id"
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -19,6 +19,18 @@ describe Provider do
     end
   end
 
+  context "validates dttp_id" do
+    subject { create(:provider) }
+
+    it "validates uniqueness" do
+      expect(subject).to validate_uniqueness_of(:dttp_id).case_insensitive.with_message("You must enter a unique DTTP ID")
+    end
+  end
+
+  describe "indexes" do
+    it { should have_db_index(:dttp_id).unique(true) }
+  end
+
   describe "associations" do
     it { is_expected.to have_many(:users) }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,12 +20,21 @@ describe User do
     end
   end
 
+  context "validates dttp_id" do
+    subject { create(:user) }
+
+    it "validates uniqueness" do
+      expect(subject).to validate_uniqueness_of(:dttp_id).case_insensitive.with_message("You must enter a unique DTTP ID")
+    end
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:provider).optional }
   end
 
   describe "indexes" do
     it { should have_db_index(:dfe_sign_in_uid).unique(true) }
+    it { should have_db_index(:dttp_id).unique(true) }
   end
 
   describe "auditing" do


### PR DESCRIPTION
### Context
https://trello.com/c/ePAdh5Nn/1250-validate-uniqueness-of-dttpid-on-providers-and-users
### Changes proposed in this pull request
* Adds unique db constraint to provider and user model 
* Adds validations with custom error message
* Add model specs

### Guidance to review
Might need to reset db if you have duplicated dttp ids 

<img width="1001" alt="Screenshot 2021-03-15 at 14 41 10" src="https://user-images.githubusercontent.com/58793682/111185986-79d70000-85aa-11eb-824d-439e700c557d.png">
<img width="984" alt="Screenshot 2021-03-15 at 16 14 08" src="https://user-images.githubusercontent.com/58793682/111186045-88251c00-85aa-11eb-9028-49cad1a43f2f.png">

