### PR TITLE
[1255] Suppress flash messages on error pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -29,7 +29,7 @@ class ErrorsController < ApplicationController
     end
   end
 
-  private
+private
 
   def clear_flash_messages
     flash.clear

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,6 +2,7 @@
 
 class ErrorsController < ApplicationController
   skip_before_action :authenticate
+  before_action :clear_flash_messages
   layout "application"
 
   before_action :skip_authorization, only: %i[not_found internal_server_error unprocessable_entity]
@@ -26,5 +27,9 @@ class ErrorsController < ApplicationController
       format.html { render status: :unprocessable_entity }
       format.json { render json: { error: "Unprocessable entity" }, status: :unprocessable_entity }
     end
+  end
+
+  def clear_flash_messages
+    flash.clear
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -29,6 +29,8 @@ class ErrorsController < ApplicationController
     end
   end
 
+  private
+
   def clear_flash_messages
     flash.clear
   end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -23,4 +23,15 @@ RSpec.describe ErrorsController, type: :controller do
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
+
+  describe "removes flash messages" do
+    it "will remove any flash messages" do
+      get :not_found, flash: { success: "Success" }
+      expect(flash[:success]).to_not be_present
+      get :internal_server_error, flash: { success: "Success" }
+      expect(flash[:success]).to_not be_present
+      get :unprocessable_entity, flash: { success: "Success" }
+      expect(flash[:success]).to_not be_present
+    end
+  end
 end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -24,14 +24,12 @@ RSpec.describe ErrorsController, type: :controller do
     end
   end
 
-  describe "removes flash messages" do
+  describe "flash messages" do
     it "will remove any flash messages" do
-      get :not_found, flash: { success: "Success" }
-      expect(flash[:success]).to_not be_present
-      get :internal_server_error, flash: { success: "Success" }
-      expect(flash[:success]).to_not be_present
-      get :unprocessable_entity, flash: { success: "Success" }
-      expect(flash[:success]).to_not be_present
+      controller.action_methods.each do | action |
+        get action.to_sym, flash: { success: "Success" }
+        expect(flash[:success]).to_not be_present
+      end
     end
   end
 end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ErrorsController, type: :controller do
 
   describe "flash messages" do
     it "will remove any flash messages" do
-      controller.action_methods.each do | action |
+      controller.action_methods.each do |action|
         get action.to_sym, flash: { success: "Success" }
         expect(flash[:success]).to_not be_present
       end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/dzXQbcxr/1255-suppress-flash-messages-on-error-pages)

### Changes proposed in this pull request

- `before_action` created in the `ErrorsController` that will clear flash messages. This means that you will never see a flash message on an error page, success or not, as flash messages will conflict with messages on error pages. 

### Guidance to review

- Run the test suite (errors_controller_spec.rb). 
- If you want to simulate the problem, create a flash message in the `internal_server_error` method (for example, `flash[:success] = "This was a success!"` and navigate to `https://localhost:5000/500` to see the flash message. Any flash messages given to the controller will be cleared with the before action unless you hard code it. 

