### PR TITLE
Set Audit worker app to stop

### DIFF
--- a/terraform/workspace-variables/audit.tfvars
+++ b/terraform/workspace-variables/audit.tfvars
@@ -9,7 +9,7 @@ paas_web_app_instances     = 1
 paas_web_app_memory        = 512
 paas_worker_app_instances  = 1
 paas_worker_app_memory     = 512
-paas_worker_app_stopped    = false
+paas_worker_app_stopped    = true
 statuscake_alerts          = {}
 #KeyVault
 key_vault_resource_group = "s121d01-shared-rg"


### PR DESCRIPTION
### Context

The `worker_app_stopped ` argument is currently set to `false` for Audit app's worker instance, but needs to be set to `true` i.e. the worker app should not be running.

### Changes proposed in this pull request

set paas_worker_app_stopped    = `true` in the audit.tfvars file

### Guidance to review

