### PR TITLE
Reduce docker image size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
       run: |
         docker-compose up --no-build -d
         docker-compose exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
+        docker-compose exec -T web /bin/sh -c "yarn add jest"
 
     - name: Setup DB
       run: docker-compose exec -T web /bin/sh -c "bundle exec rails db:setup"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,25 @@
 FROM ruby:2.7.2-alpine3.12
 
-RUN apk add --update --no-cache tzdata && \
-  cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
-  echo "Europe/London" > /etc/timezone
-
-RUN apk add --update --no-cache --virtual runtime-dependances \
-  postgresql-dev \
-  yarn
-
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 
+RUN apk add --update --no-cache tzdata && \
+    cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
+    echo "Europe/London" > /etc/timezone
+
 COPY .tool-versions Gemfile Gemfile.lock ./
 
 RUN apk add --update --no-cache --virtual build-dependances \
-  build-base && \
-  bundle install --jobs=4 && \
-  apk del build-dependances
+    postgresql-dev build-base && \
+    apk add --update --no-cache libpq yarn && \
+    bundle install --jobs=4 && \
+    rm -rf /usr/local/bundle/cache && \
+    apk del build-dependances
 
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+RUN  yarn install --frozen-lockfile && \
+     yarn cache clean
 
 COPY . .
 
@@ -28,5 +27,8 @@ ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
 RUN echo export PATH=/usr/local/bin:\$PATH > /root/.ashrc
 ENV ENV="/root/.ashrc"
-RUN bundle exec rake assets:precompile
+
+RUN bundle exec rake assets:precompile && \
+    rm -rf node_modules tmp
+
 CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
### Context

Current docker image size is about ~`750MB`
This change brings it down to ~`390MB`

### Changes proposed in this pull request

Remove build time postgres dependencies, keep only `libpq`
Remove gem and yarn cache files.
