### PR TITLE
[1246] Include ApplicationHelper in view components and rename form_with

### DIFF
--- a/app/components/personas/view.html.erb
+++ b/app/components/personas/view.html.erb
@@ -12,7 +12,7 @@
     </p>
   </div>
 
-<%= form_with url: "/auth/developer/callback" do |f| %>
+<%= register_form_with url: "/auth/developer/callback" do |f| %>
   <%= hidden_field_tag "email", persona.email %>
   <%= hidden_field_tag "first_name", persona.first_name %>
   <%= hidden_field_tag "last_name", persona.last_name %>

--- a/app/components/personas/view.rb
+++ b/app/components/personas/view.rb
@@ -2,8 +2,8 @@
 
 module Personas
   class View < GovukComponent::Base
+    include ApplicationHelper
     with_collection_parameter :persona
-
     attr_reader :persona
 
     def initialize(persona:)

--- a/app/components/trainees/confirmation/degrees/view.html.erb
+++ b/app/components/trainees/confirmation/degrees/view.html.erb
@@ -3,7 +3,7 @@
     <%= render SummaryCard::View.new(trainee: trainee, title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree)) do |component| %>
       <% if show_delete_button %>
         <% component.with(:header_actions) do %>
-          <%= form_with model: [trainee, degree], method: :delete, local: true do |f| %>
+          <%= register_form_with model: [trainee, degree], method: :delete, local: true do |f| %>
             <%= f.submit "Delete degree", class: "govuk-link app-button--link govuk-body", role: "link" %>
           <% end %>
         <% end %>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,10 +23,10 @@ module ApplicationHelper
     link_to(body, url, html_options)
   end
 
-  def form_with(*args, &block)
+  def register_form_with(*args, &block)
     options = args.extract_options!
     defaults = { html: { novalidate: true, autocomplete: :off } }
-    super(*args << defaults.deep_merge(options), &block)
+    form_with(*args << defaults.deep_merge(options), &block)
   end
 
   def header_items(current_user)

--- a/app/views/system_admin/providers/new.html.erb
+++ b/app/views/system_admin/providers/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @provider, local: true do |f| %>
+    <%= register_form_with model: @provider, local: true do |f| %>
 
       <%= f.govuk_error_summary %>
 

--- a/app/views/system_admin/users/new.html.erb
+++ b/app/views/system_admin/users/new.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: [@provider, @user], local: true do |f| %>
+    <%= register_form_with model: [@provider, @user], local: true do |f| %>
 
       <%= f.govuk_error_summary %>
 

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -61,7 +61,7 @@
 
     <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :course_details) %>
 
-    <%= form_with(model: @trn_submission, url: trn_submissions_path, method: :post, local: true) do |f| %>
+    <%= register_form_with(model: @trn_submission, url: trn_submissions_path, method: :post, local: true) do |f| %>
       <%= hidden_field_tag :trainee_id, @trainee.slug %>
       <%= f.govuk_submit "Submit record and request TRN" %>
     <% end %>

--- a/app/views/trainees/confirm_deferrals/show.html.erb
+++ b/app/views/trainees/confirm_deferrals/show.html.erb
@@ -17,7 +17,7 @@
   <div class="govuk-grid-column-full">
     <%= render Trainees::DeferralDetails::View.new(@trainee) %>
 
-    <%= form_with url: trainee_confirm_deferral_path(@trainee), method: :put, local: true do |f| %>
+    <%= register_form_with url: trainee_confirm_deferral_path(@trainee), method: :put, local: true do |f| %>
       <%= f.govuk_submit "Defer this trainee" %>
     <%- end -%>
   </div>

--- a/app/views/trainees/confirm_details/_form.html.erb
+++ b/app/views/trainees/confirm_details/_form.html.erb
@@ -4,7 +4,7 @@
 
     <%= render(component) %>
 
-    <%= form_with(model: @confirm_detail, url: resource_confirm_update_path, method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @confirm_detail, url: resource_confirm_update_path, method: :put, local: true) do |f| %>
       <% if @trainee.draft? %>
         <%= f.govuk_check_boxes_fieldset :mark_as_completed, multiple: false, legend: { text: "" } do %>
           <%= f.govuk_check_box :mark_as_completed, 1, 0, multiple: false, link_errors: true, label: { text: "I have completed this section " } %>

--- a/app/views/trainees/confirm_reinstatements/show.html.erb
+++ b/app/views/trainees/confirm_reinstatements/show.html.erb
@@ -15,7 +15,7 @@
 
     <%= render Trainees::Confirmation::ReinstatementDetails::View.new(trainee: @trainee) %>
 
-    <%= form_with url: trainee_confirm_reinstatement_path(@trainee), method: :patch, local: true do |f| %>
+    <%= register_form_with url: trainee_confirm_reinstatement_path(@trainee), method: :patch, local: true do |f| %>
       <%= f.govuk_submit t("views.confirm_reinstatement.submit") %>
     <%- end -%>
   </div>

--- a/app/views/trainees/confirm_withdrawals/show.html.erb
+++ b/app/views/trainees/confirm_withdrawals/show.html.erb
@@ -15,7 +15,7 @@
 
     <%= render Trainees::Confirmation::WithdrawalDetails::View.new(trainee: @trainee) %>
 
-    <%= form_with url: trainee_confirm_withdrawal_path(@trainee), method: :patch, local: true do |f| %>
+    <%= register_form_with url: trainee_confirm_withdrawal_path(@trainee), method: :patch, local: true do |f| %>
       <%= f.govuk_submit t("views.confirm_withdrawal.submit"), classes: "govuk-button--warning" %>
     <%- end -%>
   </div>

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @contact_details, url: trainee_contact_details_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @contact_details, url: trainee_contact_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset(:locale_code, legend: { text: "Where does the trainee live?", size: "s" }, classes: "locale") do %>

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @course_detail, url: trainee_course_details_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @course_detail, url: trainee_course_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">Course details</h1>

--- a/app/views/trainees/deferrals/show.html.erb
+++ b/app/views/trainees/deferrals/show.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @deferral, url: trainee_deferral_path(@trainee), local: true) do |f| %>
+    <%= register_form_with(model: @deferral, url: trainee_deferral_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">

--- a/app/views/trainees/degrees/_non_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_non_uk_degree_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [@trainee, @degree], local: true do |f| %>
+<%= register_form_with model: [@trainee, @degree], local: true do |f| %>
   <%= f.hidden_field :locale_code, value: "non_uk" %>
   <%= f.govuk_error_summary %>
 

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [@trainee, @degree], local: true do |f| %>
+<%= register_form_with model: [@trainee, @degree], local: true do |f| %>
   <%= f.hidden_field :locale_code, value: "uk" %>
 
   <%= f.govuk_error_summary %>

--- a/app/views/trainees/degrees/type/new.html.erb
+++ b/app/views/trainees/degrees/type/new.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @degree, url: trainee_degrees_new_type_path, local: true) do |f| %>
+    <%= register_form_with(model: @degree, url: trainee_degrees_new_type_path, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <% if @trainee.degrees.size > 1 %>

--- a/app/views/trainees/diversity/disability_details/edit.html.erb
+++ b/app/views/trainees/diversity/disability_details/edit.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @disability_detail, url: trainee_diversity_disability_detail_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @disability_detail, url: trainee_diversity_disability_detail_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_check_boxes_fieldset :disability_ids,

--- a/app/views/trainees/diversity/disability_disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disability_disclosures/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @disability_disclosure, url: trainee_diversity_disability_disclosure_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @disability_disclosure, url: trainee_diversity_disability_disclosure_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
         <%= f.govuk_radio_buttons_fieldset(:disability_disclosure, legend: { text: t("components.page_titles.trainees.diversity.disability_disclosure.edit"), tag: "h1", size: "l" }) do %>

--- a/app/views/trainees/diversity/disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disclosures/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @disclosure, url: trainee_diversity_disclosure_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @disclosure, url: trainee_diversity_disclosure_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
         <%= f.govuk_collection_radio_buttons(

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -12,7 +12,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @ethnic_background, url: trainee_diversity_ethnic_background_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @ethnic_background, url: trainee_diversity_ethnic_background_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
         <%= f.govuk_radio_buttons_fieldset(

--- a/app/views/trainees/diversity/ethnic_groups/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_groups/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @ethnic_group, url: trainee_diversity_ethnic_group_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @ethnic_group, url: trainee_diversity_ethnic_group_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
         <%= f.govuk_radio_buttons_fieldset(:ethnic_group, legend: { text: t("components.page_titles.trainees.diversity.ethnic_group.edit"), tag: "h1", size: "l" }) do %>

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @trainee, local: true do |f| %>
+    <%= register_form_with model: @trainee, local: true do |f| %>
       <%= f.govuk_error_summary %>
       <%= render "trainees/training_routes/form_fields", f: f %>
       <%= f.govuk_submit %>

--- a/app/views/trainees/outcome_dates/edit.html.erb
+++ b/app/views/trainees/outcome_dates/edit.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @outcome, url: trainee_outcome_details_outcome_date_path(@trainee), local: true) do |f| %>
+    <%= register_form_with(model: @outcome, url: trainee_outcome_details_outcome_date_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">

--- a/app/views/trainees/outcome_details/confirm.html.erb
+++ b/app/views/trainees/outcome_details/confirm.html.erb
@@ -17,7 +17,7 @@
   <div class="govuk-grid-column-full">
     <%= render Trainees::OutcomeDetails::View.new(@trainee) %>
 
-    <%= form_with url: trainee_qts_recommendations_path, method: :post, local: true do |f| %>
+    <%= register_form_with url: trainee_qts_recommendations_path, method: :post, local: true do |f| %>
       <%= hidden_field_tag :trainee_id, @trainee.slug %>
       <%= f.govuk_submit "Recommend trainee for QTS" %>
     <%- end -%>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @personal_detail, url: trainee_personal_details_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @personal_detail, url: trainee_personal_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">Trainee personal details</h1>

--- a/app/views/trainees/reinstatements/show.html.erb
+++ b/app/views/trainees/reinstatements/show.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @reinstatement_form, url: trainee_reinstatement_path(@trainee), local: true) do |f| %>
+    <%= register_form_with(model: @reinstatement_form, url: trainee_reinstatement_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -4,7 +4,7 @@
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
-<%= form_with model: @training_details, url: trainee_start_date_path, local: true do |f| %>
+<%= register_form_with model: @training_details, url: trainee_start_date_path, local: true do |f| %>
   <%= f.govuk_date_field :commencement_date, legend: { text: t("views.forms.training_details.commencement_date.label"), size: "l", tag: "h1" } %>
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/trainees/trainee_ids/edit.html.erb
+++ b/app/views/trainees/trainee_ids/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @training_details, url: trainee_trainee_id_path, local: true do |f| %>
+    <%= register_form_with model: @training_details, url: trainee_trainee_id_path, local: true do |f| %>
       <%= f.govuk_text_field :trainee_id,
                              label: { text: "Trainee ID", tag: "h1", size: "l" },
                              width: 20,

--- a/app/views/trainees/training_routes/edit.html.erb
+++ b/app/views/trainees/training_routes/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: @trainee, url: trainee_training_route_path(@trainee), local: true do |f| %>
+    <%= register_form_with model: @trainee, url: trainee_training_route_path(@trainee), local: true do |f| %>
       <%= f.govuk_error_summary %>
       <%= render "form_fields", f: f %>
       <%= f.govuk_submit %>

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with(model: @withdrawal_form, url: trainee_withdrawal_path(@trainee), local: true) do |f| %>
+    <%= register_form_with(model: @withdrawal_form, url: trainee_withdrawal_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">


### PR DESCRIPTION
### Context

We have a helper function `form_with`, which overrides the rails `form_with`, adding `{ novalidate: true }`.

However, `ApplicationHelper` isn't automatically included in `ViewComponents` so it's not applying to those forms in components. This PR includes the `ApplicationHelper` in those files.

`form_with` is also renamed to `register_form_with` for greater clarity.

### Changes proposed in this pull request

- Include ApplicationHelper in the components that use form_with in order to use the register version and not the rails version
- Rename form_with to register_form_with for clarity

### Guidance to review

🚢 