### PR TITLE
[1256] Disable spell check by default

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
 
   def register_form_with(*args, &block)
     options = args.extract_options!
-    defaults = { html: { novalidate: true, autocomplete: :off } }
+    defaults = { html: { novalidate: true, autocomplete: :off, spellcheck: false } }
     form_with(*args << defaults.deep_merge(options), &block)
   end
 


### PR DESCRIPTION
### Context

Unless a text field is collecting paragraph like English word responses, we should disable spellcheck.

### Changes proposed in this pull request

- Add an extra argument on the `form_with` method to disable spell check by default

### Guidance to review

- Navigate to a few text fields and check that spell check is not active.

