### PR TITLE
[1285] Fix Date of Birth Hint Text translation

### DIFF
--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -29,7 +29,7 @@
       <%= f.govuk_date_field :date_of_birth,
                              date_of_birth: true,
                              legend: { text: "Date of birth", size: "s" },
-                             hint: { text: I18n.t("activemodel.errors.models.personal_detail_form.attributes.date_of_birth.hint_html", year: 41.years.ago.year) } %>
+                             hint: { text: I18n.t("activemodel.errors.models.personal_details_form.attributes.date_of_birth.hint_html", year: 41.years.ago.year) } %>
 
       <%= f.govuk_radio_buttons_fieldset(:gender, legend: { text: "Gender", size: "s" }, classes: "gender") do %>
         <%= f.govuk_radio_button :gender, :female, label: { text: "Female" }, link_errors: true %>


### PR DESCRIPTION
### Context

There is a typo in the date of birth hint text translation and it isn't displaying correctly. This addresses the problem

### Changes proposed in this pull request

- Fix typo 

### Guidance to review

- Visit `Date of Birth` within `personal details` and check that the hint text is correct. 

### Screenshot

![image](https://user-images.githubusercontent.com/50492247/111443583-6d18f000-8701-11eb-856c-a09554fcb066.png)


