### PR TITLE
[1254] (Bug) Undeferring trainees when trn is received after deferral 

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -145,7 +145,9 @@ class Trainee < ApplicationRecord
   def trn_received!(new_trn = nil)
     raise StateTransitionError, "Cannot transition to :trn_received without a trn" unless new_trn || trn
 
-    receive_trn! unless deferred?
+    # Skip deferred and withdrawn to avoid state change
+    # but to still register trn
+    receive_trn! unless deferred? || withdrawn?
     # A deferred trainee will probably already have a trn - don't overwrite that!
     update!(trn: new_trn) unless trn
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -145,7 +145,7 @@ class Trainee < ApplicationRecord
   def trn_received!(new_trn = nil)
     raise StateTransitionError, "Cannot transition to :trn_received without a trn" unless new_trn || trn
 
-    receive_trn!
+    receive_trn! unless deferred?
     # A deferred trainee will probably already have a trn - don't overwrite that!
     update!(trn: new_trn) unless trn
   end

--- a/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
@@ -16,15 +16,6 @@ describe Trainees::ConfirmReinstatementsController do
     context "with a trainee with a trn" do
       let(:trn) { "trn" }
 
-      it "transitions the trainee back to trn_received" do
-        expect {
-          post :update, params: { trainee_id: trainee }
-          trainee.reload
-        }.to change {
-          trainee.state
-        } .from("deferred") .to("trn_received")
-      end
-
       it "queues a background job to reinstate a trainee" do
         expect {
           post :update, params: { trainee_id: trainee }

--- a/spec/models/trainee/state_transitions_spec.rb
+++ b/spec/models/trainee/state_transitions_spec.rb
@@ -21,9 +21,9 @@ describe "Trainee state transitions" do
       context "with an existing trn" do
         let(:trainee) { create(:trainee, :deferred, trn: old_trn) }
 
-        it "transitions the trainee to :trn_received" do
+        it "doesnt transition the trainee to :trn_received" do
           trainee.trn_received!
-          expect(trainee.state).to eq("trn_received")
+          expect(trainee.state).to eq("deferred")
           expect(trainee.trn).to eq(old_trn)
         end
       end
@@ -36,9 +36,9 @@ describe "Trainee state transitions" do
           }.to raise_error(StateTransitionError)
         end
 
-        it "transitions the trainee to :trn_received and updates the trn" do
+        it "updates the trn but not the trainee state" do
           trainee.trn_received!(new_trn)
-          expect(trainee.state).to eq("trn_received")
+          expect(trainee.state).to eq("deferred")
           expect(trainee.trn).to eq(new_trn)
         end
       end
@@ -47,9 +47,9 @@ describe "Trainee state transitions" do
     context "with a :deferred trainee with an existing trn" do
       let(:trainee) { create(:trainee, :deferred, trn: old_trn) }
 
-      it "transitions the trainee to :trn_received" do
+      it "doesnt update state or trn" do
         trainee.trn_received!
-        expect(trainee.state).to eq("trn_received")
+        expect(trainee.state).to eq("deferred")
         expect(trainee.trn).to eq(old_trn)
       end
     end

--- a/spec/models/trainee/state_transitions_spec.rb
+++ b/spec/models/trainee/state_transitions_spec.rb
@@ -54,13 +54,35 @@ describe "Trainee state transitions" do
       end
     end
 
+    context "with a :withdrawn trainee" do
+      context "with an existing trn" do
+        let(:trainee) { create(:trainee, :withdrawn, trn: old_trn) }
+        
+        it "doesnt update state or trn" do
+          trainee.trn_received!
+          expect(trainee.state).to eq("withdrawn")
+          expect(trainee.trn).to eq(old_trn)
+        end
+      end
+
+      context "without an existing trn" do
+        let(:trainee) { create(:trainee, :withdrawn) }
+        
+        it "doesnt update state but updates trn" do
+          trainee.trn_received!(new_trn)
+          expect(trainee.state).to eq("withdrawn")
+          expect(trainee.trn).to eq(new_trn)
+        end
+      end
+    end
+
     (Trainee.states.keys - %w[submitted_for_trn deferred]).each do |state|
       context "with a :#{state} trainee" do
         let(:trainee) { create(:trainee, state) }
 
         it "raises an error" do
           expect {
-            trainee.trn_received!(new_trn)
+            trainee.receive_trn!
           }.to raise_error(RuntimeError, "Invalid transition")
         end
       end

--- a/spec/models/trainee/state_transitions_spec.rb
+++ b/spec/models/trainee/state_transitions_spec.rb
@@ -57,7 +57,7 @@ describe "Trainee state transitions" do
     context "with a :withdrawn trainee" do
       context "with an existing trn" do
         let(:trainee) { create(:trainee, :withdrawn, trn: old_trn) }
-        
+
         it "doesnt update state or trn" do
           trainee.trn_received!
           expect(trainee.state).to eq("withdrawn")
@@ -67,7 +67,7 @@ describe "Trainee state transitions" do
 
       context "without an existing trn" do
         let(:trainee) { create(:trainee, :withdrawn) }
-        
+
         it "doesnt update state but updates trn" do
           trainee.trn_received!(new_trn)
           expect(trainee.state).to eq("withdrawn")


### PR DESCRIPTION
### Context

- [Trello link](https://trello.com/c/CzfeE3tA/1254-bug-re-un-deferring-trainees-when-trn-is-received-after-deferral)
- If a trainee is submitted for TRN, a job is opened requesting a TRN for said trainee
- The trainee may be deferred when waiting for their TRN 
- The TRN is returned, and the bug is that the trainee is undeferred and put into `trn_received` state. 
- We want to keep the `deferred` state, but still register the TRN
- There is a similar problem with `withdrawn`, but instead of a state change, we get a state transition error (which is fine, but we also want to record the TRN)

### Changes proposed in this pull request

- Conditional statement before the `receive_trn!` state change is checking that the trainee is not in a `deferred` or `withdrawn` state, insuring that the state change or raised transition error is skipped, and that the TRN is still recorded
- Also changed a state_transition spec to test `receive_trn` event (as this event is what triggers state change) and not the `trn_received!` method

### Guidance to review

- Navigate to `trainee.rb` and `state_transitions_spec.rb`, specifically the `trn_received!` method.  

