### PR TITLE
1258 if redirected to sign in after sign in users should be returned to the page they requested

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,12 +36,12 @@ private
     current_user.present?
   end
 
-  def save_original_path
-    session[:original_path] = request.original_fullpath
+  def save_redirect_path
+    session[:redirect_back_to] = request.original_fullpath
   end
 
   def authenticate
-    (save_original_path && (redirect_to sign_in_path)) unless authenticated?
+    (save_redirect_path && (redirect_to sign_in_path)) unless authenticated?
   end
 
   def ensure_trainee_is_draft!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,12 +36,17 @@ private
     current_user.present?
   end
 
-  def save_redirect_path
-    session[:redirect_back_to] = request.original_fullpath
+  def save_requested_path
+    session[:requested_path] = request.original_fullpath
+  end
+
+  def save_requested_path_and_redirect
+    save_requested_path
+    redirect_to sign_in_path
   end
 
   def authenticate
-    (save_redirect_path && (redirect_to sign_in_path)) unless authenticated?
+    save_requested_path_and_redirect unless authenticated?
   end
 
   def ensure_trainee_is_draft!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,8 +36,12 @@ private
     current_user.present?
   end
 
+  def save_original_path
+    session[:original_path] = request.original_fullpath
+  end
+
   def authenticate
-    redirect_to sign_in_path unless authenticated?
+    (save_original_path && (redirect_to sign_in_path)) unless authenticated?
   end
 
   def ensure_trainee_is_draft!

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,7 @@ class SessionsController < ApplicationController
     if current_user
       DfESignInUsers::Update.call(user: current_user, dfe_sign_in_user: dfe_sign_in_user)
 
-      redirect_to (session[:redirect_back_to] ? session.delete(:redirect_back_to) : root_path)
+      redirect_to(session[:redirect_back_to] ? session.delete(:redirect_back_to) : root_path)
     else
       DfESignInUser.end_session!(session)
       redirect_to sign_in_user_not_found_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,11 @@ class SessionsController < ApplicationController
     if current_user
       DfESignInUsers::Update.call(user: current_user, dfe_sign_in_user: dfe_sign_in_user)
 
-      redirect_to root_path
+      if session[:original_path]
+        redirect_to session[:original_path] && session.delete(:original_path)
+      else
+        redirect_to root_path
+      end
     else
       DfESignInUser.end_session!(session)
       redirect_to sign_in_user_not_found_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,8 +20,8 @@ class SessionsController < ApplicationController
     if current_user
       DfESignInUsers::Update.call(user: current_user, dfe_sign_in_user: dfe_sign_in_user)
 
-      if session[:original_path]
-        redirect_to session[:original_path] && session.delete(:original_path)
+      if session[:redirect_back_to]
+        redirect_to session[:redirect_back_to] && session.delete(:redirect_back_to)
       else
         redirect_to root_path
       end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,7 @@ class SessionsController < ApplicationController
     if current_user
       DfESignInUsers::Update.call(user: current_user, dfe_sign_in_user: dfe_sign_in_user)
 
-      redirect_to(session[:redirect_back_to] ? session.delete(:redirect_back_to) : root_path)
+      redirect_to session.delete(:requested_path) || root_path
     else
       DfESignInUser.end_session!(session)
       redirect_to sign_in_user_not_found_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,11 +20,7 @@ class SessionsController < ApplicationController
     if current_user
       DfESignInUsers::Update.call(user: current_user, dfe_sign_in_user: dfe_sign_in_user)
 
-      if session[:redirect_back_to]
-        redirect_to session[:redirect_back_to] && session.delete(:redirect_back_to)
-      else
-        redirect_to root_path
-      end
+      redirect_to (session[:redirect_back_to] ? session.delete(:redirect_back_to) : root_path)
     else
       DfESignInUser.end_session!(session)
       redirect_to sign_in_user_not_found_path

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -27,15 +27,15 @@ describe SessionsController, type: :controller do
       end
 
       it "redirects to the original requested page if it exists in the session" do
-        session[:original_path] = "/trainees/qts_awarded"
+        session[:redirect_back_to] = "/trainees/qts_awarded"
         request_callback
         expect(response).to redirect_to("/trainees/qts_awarded")
       end
 
-      it "clears the original_path key of the session after a redirect" do
-        session[:original_path] = "/trainees/qts_awarded"
+      it "clears the redirect_back_to key of the session after a redirect" do
+        session[:redirect_back_to] = "/trainees/qts_awarded"
         request_callback
-        expect(session[:original_path]).to be_nil
+        expect(session[:redirect_back_to]).to be_nil
       end
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -27,15 +27,15 @@ describe SessionsController, type: :controller do
       end
 
       it "redirects to the original requested page if it exists in the session" do
-        session[:redirect_back_to] = "/trainees/qts_awarded"
+        session[:requested_path] = "/trainees/qts_awarded"
         request_callback
         expect(response).to redirect_to("/trainees/qts_awarded")
       end
 
       it "clears the redirect_back_to key of the session after a redirect" do
-        session[:redirect_back_to] = "/trainees/qts_awarded"
+        session[:requested_path] = "/trainees/qts_awarded"
         request_callback
-        expect(session[:redirect_back_to]).to be_nil
+        expect(session[:requested_path]).to be_nil
       end
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -21,9 +21,21 @@ describe SessionsController, type: :controller do
         expect(session[:dfe_sign_in_user]["last_name"]).to eq(user.last_name)
       end
 
-      it "redirects to the trainees index page" do
+      it "redirects to the trainees index page if no original path stored in the session" do
         request_callback
         expect(response).to redirect_to(root_path)
+      end
+
+      it "redirects to the original requested page if it exists in the session" do
+        session[:original_path] = "/trainees/qts_awarded"
+        request_callback
+        expect(response).to redirect_to("/trainees/qts_awarded")
+      end
+
+      it "clears the original_path key of the session after a redirect" do
+        session[:original_path] = "/trainees/qts_awarded"
+        request_callback
+        expect(session[:original_path]).to be_nil
       end
     end
 

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -7,11 +7,22 @@ describe "A user authenticates via DfE Sign-in" do
     given_i_am_registered_as_a_user
     and_i_have_a_dfe_sign_in_account
 
+    and_i_sign_in_via_dfe_sign_in
+
+    then_i_am_redirected_to_the_root_path
+    and_i_should_see_the_link_to_sign_out
+    and_my_details_are_refreshed
+  end
+
+  scenario "visiting an authenticated path, redirect and signing in successfully, and being redirected to original path" do
+    given_i_am_registered_as_a_user
+    and_i_have_a_dfe_sign_in_account
+
     when_i_visit_the_trainee_page
     then_i_am_redirected_to_the_sign_in_path
     and_i_sign_in_via_dfe_sign_in
 
-    then_i_am_redirected_to_the_root_path
+    then_i_am_redirected_back_to_the_trainee_page
     and_i_should_see_the_link_to_sign_out
     and_my_details_are_refreshed
 
@@ -51,6 +62,10 @@ private
     visit_sign_in_page
   end
 
+  def then_i_am_redirected_back_to_the_trainee_page
+    expect(page.current_path).to eq("/trainees")
+  end
+
   def then_i_am_redirected_to_the_root_path
     expect(page.current_path).to eq("/")
   end
@@ -70,7 +85,7 @@ private
 
   def when_i_signed_in_more_than_2_hours_ago
     Timecop.travel(Time.zone.now + 2.hours + 1.second) do
-      expect(page.current_path).to eq("/")
+      expect(page.current_path).to eq("/trainees")
 
       trainee_page = PageObjects::Trainees::Index.new
       trainee_page.load


### PR DESCRIPTION
### Context

- [Trello ticket](https://trello.com/c/ARJr6uyX/1258-m-if-redirected-to-sign-in-after-sign-in-users-should-be-returned-to-the-page-they-requested)
- Currently, if users direct themselves to a path via a hyperlink or manually putting it in the search bar and they are not logged in, they will be redirected to sign in, and then redirected back to home/root page ("/"). 
- We want the original search query to be saved in the session and then loaded on redirect after the sign in, and then deleted off the session. 

### Changes proposed in this pull request

- New `save_redirect_path` method in application controller
- `save_redirect_path` will be called on unsuccessful authentication, along with a `redirect to sign_in_path`
- `save_redirect_path` will save the path in `session[:redirect_back_to]` for further use
- On successful `current_user` (final step of DSI journey) in `SessionsController` in `callback`, a conditional will check for the `session[:redirect_back_to]` link and use it once before deleting it. Fallback is `root_path`

### Guidance to review

- Log in and take an endpoint that you are sure is protected by authentication (perhaps "/trainees" or "/trainees/{trainee_slug}"). 
- Ensure you are logged out, and try and navigate to that endpoint. On redirect to sign in, sign in and you will find yourself redirected back to the original path from step 1. 

### Caveats

- If a page is visited directly that is inside of a journey that has Dynamic Banklinks in it, the backlinks will not work (they wont break, but rather refresh the current page). Perhaps this should be separated into a different ticket as it will involve registering pages in page tracker, discussed with @jhenderson. 

