### PR TITLE
[1209] Implement save on confirm - outcome date / defer / withdraw / reinstate

### DIFF
--- a/app/components/trainees/confirmation/reinstatement_details/view.html.erb
+++ b/app/components/trainees/confirmation/reinstatement_details/view.html.erb
@@ -1,10 +1,12 @@
-<%= render SummaryCard::View.new(trainee: trainee,
-                                 title: t("components.confirmation.reinstatement_details.summary_title"),
-                                 heading_level: 2,
-                                 rows: [
+<%= render SummaryCard::View.new(
+  trainee: data_model.trainee,
+  title: t("components.confirmation.reinstatement_details.summary_title"),
+  heading_level: 2,
+  rows: [
     {
       key: t("components.confirmation.reinstatement_details.reinstate_date_label"),
       value: reinstate_date,
-      action: govuk_link_to(t(:change), trainee_reinstatement_path(trainee)),
+      action: govuk_link_to(t(:change), trainee_reinstatement_path(data_model.trainee)),
     },
-  ]) %>
+  ],
+) %>

--- a/app/components/trainees/confirmation/reinstatement_details/view.rb
+++ b/app/components/trainees/confirmation/reinstatement_details/view.rb
@@ -6,10 +6,10 @@ module Trainees
       class View < GovukComponent::Base
         include SummaryHelper
 
-        attr_reader :trainee
+        attr_reader :data_model
 
-        def initialize(trainee:)
-          @trainee = trainee
+        def initialize(data_model)
+          @data_model = data_model
         end
 
         def confirm_section_title
@@ -17,7 +17,7 @@ module Trainees
         end
 
         def reinstate_date
-          date_for_summary_view(trainee.reinstate_date)
+          date_for_summary_view(data_model.date)
         end
       end
     end

--- a/app/components/trainees/confirmation/withdrawal_details/view.html.erb
+++ b/app/components/trainees/confirmation/withdrawal_details/view.html.erb
@@ -1,15 +1,17 @@
-<%= render SummaryCard::View.new(trainee: trainee,
-                                 title: t("components.confirmation.withdrawal_details.summary_title"),
-                                 heading_level: 2,
-                                 rows: [
+<%= render SummaryCard::View.new(
+  trainee: data_model.trainee,
+  title: t("components.confirmation.withdrawal_details.summary_title"),
+  heading_level: 2,
+  rows: [
     {
       key: t("components.confirmation.withdrawal_details.withdraw_date_label"),
       value: withdraw_date,
-      action: govuk_link_to(t(:change), trainee_withdrawal_path(trainee)),
+      action: govuk_link_to(t(:change), trainee_withdrawal_path(data_model.trainee)),
     },
     {
       key: t("components.confirmation.withdrawal_details.withdraw_reason_label"),
       value: withdraw_reason,
-      action: govuk_link_to(t(:change), trainee_withdrawal_path(trainee)),
+      action: govuk_link_to(t(:change), trainee_withdrawal_path(data_model.trainee)),
     },
-  ]) %>
+  ],
+) %>

--- a/app/components/trainees/confirmation/withdrawal_details/view.rb
+++ b/app/components/trainees/confirmation/withdrawal_details/view.rb
@@ -6,10 +6,10 @@ module Trainees
       class View < GovukComponent::Base
         include SummaryHelper
 
-        attr_reader :trainee
+        attr_reader :data_model
 
-        def initialize(trainee:)
-          @trainee = trainee
+        def initialize(data_model)
+          @data_model = data_model
         end
 
         def confirm_section_title
@@ -17,13 +17,13 @@ module Trainees
         end
 
         def withdraw_date
-          date_for_summary_view(trainee.withdraw_date)
+          date_for_summary_view(data_model.date)
         end
 
         def withdraw_reason
-          return trainee.additional_withdraw_reason if trainee.withdraw_reason == WithdrawalReasons::FOR_ANOTHER_REASON
+          return data_model.additional_withdraw_reason if data_model.withdraw_reason == WithdrawalReasons::FOR_ANOTHER_REASON
 
-          I18n.t("components.confirmation.withdrawal_details.reasons.#{trainee.withdraw_reason}")
+          I18n.t("components.confirmation.withdrawal_details.reasons.#{data_model.withdraw_reason}")
         end
       end
     end

--- a/app/components/trainees/deferral_details/view.html.erb
+++ b/app/components/trainees/deferral_details/view.html.erb
@@ -1,10 +1,12 @@
-<%= render SummaryCard::View.new(trainee: trainee,
-                                 title: t("components.confirmation.deferral_details.summary_title"),
-                                 heading_level: 2,
-                                 rows: [
+<%= render SummaryCard::View.new(
+  trainee: data_model.trainee,
+  title: t("components.confirmation.deferral_details.summary_title"),
+  heading_level: 2,
+  rows: [
     {
       key: t("components.confirmation.deferral_details.defer_date_label"),
       value: defer_date,
-      action: govuk_link_to('Change<span class="govuk-visually-hidden"> date of deferral</span>'.html_safe, trainee_deferral_path(trainee)),
+      action: govuk_link_to('Change<span class="govuk-visually-hidden"> date of deferral</span>'.html_safe, trainee_deferral_path(data_model.trainee)),
     },
-  ]) %>
+  ],
+) %>

--- a/app/components/trainees/deferral_details/view.rb
+++ b/app/components/trainees/deferral_details/view.rb
@@ -5,14 +5,14 @@ module Trainees
     class View < GovukComponent::Base
       include SummaryHelper
 
-      attr_reader :trainee
+      attr_reader :data_model
 
-      def initialize(trainee)
-        @trainee = trainee
+      def initialize(data_model)
+        @data_model = data_model
       end
 
       def defer_date
-        date_for_summary_view(trainee.defer_date)
+        date_for_summary_view(data_model.date)
       end
     end
   end

--- a/app/components/trainees/outcome_details/view.html.erb
+++ b/app/components/trainees/outcome_details/view.html.erb
@@ -1,11 +1,15 @@
-<%= render SummaryCard::View.new(trainee: trainee,
-                                 title: "QTS details",
-                                 heading_level: 2,
-                                 rows: [
+<%= render SummaryCard::View.new(
+  trainee: data_model.trainee,
+  title: "QTS details",
+  heading_level: 2,
+  rows: [
     {
       key: "Date standards met",
       value: outcome_date,
-      action: govuk_link_to('Change<span class="govuk-visually-hidden"> outcome date</span>'.html_safe,
-                            edit_trainee_outcome_details_outcome_date_path(trainee)),
+      action: govuk_link_to(
+        'Change<span class="govuk-visually-hidden"> outcome date</span>'.html_safe,
+        edit_trainee_outcome_details_outcome_date_path(data_model.trainee),
+      ),
     },
-  ]) %>
+  ],
+) %>

--- a/app/components/trainees/outcome_details/view.rb
+++ b/app/components/trainees/outcome_details/view.rb
@@ -5,14 +5,14 @@ module Trainees
     class View < GovukComponent::Base
       include SummaryHelper
 
-      attr_reader :trainee
+      attr_reader :data_model
 
-      def initialize(trainee)
-        @trainee = trainee
+      def initialize(data_model)
+        @data_model = data_model
       end
 
       def outcome_date
-        date_for_summary_view(trainee.outcome_date)
+        date_for_summary_view(data_model.date)
       end
     end
   end

--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -6,20 +6,28 @@ module Trainees
 
     def show
       page_tracker.save_as_origin!
+      deferral
     end
 
     def update
-      trainee.defer!
-      DeferJob.perform_later(trainee.id)
+      if deferral.save!
+        trainee.defer!
 
-      flash[:success] = "Trainee deferred"
-      redirect_to trainee_path(trainee)
+        DeferJob.perform_later(trainee.id)
+
+        flash[:success] = "Trainee deferred"
+        redirect_to trainee_path(trainee)
+      end
     end
 
   private
 
     def trainee
       @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def deferral
+      @deferral ||= DeferralForm.new(trainee)
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/confirm_reinstatements_controller.rb
+++ b/app/controllers/trainees/confirm_reinstatements_controller.rb
@@ -6,21 +6,28 @@ module Trainees
 
     def show
       page_tracker.save_as_origin!
+      reinstatement
     end
 
     def update
-      trainee.trn.present? ? trainee.trn_received! : trainee.submit_for_trn!
+      if reinstatement.save!
+        trainee.trn.present? ? trainee.trn_received! : trainee.submit_for_trn!
 
-      ReinstateJob.perform_later(trainee.id)
+        ReinstateJob.perform_later(trainee.id)
 
-      flash[:success] = "Trainee reinstated"
-      redirect_to trainee_path(trainee)
+        flash[:success] = "Trainee reinstated"
+        redirect_to trainee_path(trainee)
+      end
     end
 
   private
 
     def trainee
       @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def reinstatement
+      @reinstatement ||= ReinstatementForm.new(trainee)
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/confirm_withdrawals_controller.rb
+++ b/app/controllers/trainees/confirm_withdrawals_controller.rb
@@ -6,20 +6,27 @@ module Trainees
 
     def show
       page_tracker.save_as_origin!
+      withdrawal
     end
 
     def update
-      trainee.withdraw!
-      WithdrawJob.perform_later(trainee.id)
+      if withdrawal.save!
+        trainee.withdraw!
+        WithdrawJob.perform_later(trainee.id)
 
-      flash[:success] = "Trainee withdrawn"
-      redirect_to trainee_path(trainee)
+        flash[:success] = "Trainee withdrawn"
+        redirect_to trainee_path(trainee)
+      end
     end
 
   private
 
     def trainee
       @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def withdrawal
+      @withdrawal ||= WithdrawalForm.new(trainee)
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/deferrals_controller.rb
+++ b/app/controllers/trainees/deferrals_controller.rb
@@ -11,10 +11,9 @@ module Trainees
     def update
       authorize(trainee, :defer?)
 
-      @deferral = DeferralForm.new(trainee)
-      @deferral.assign_attributes(trainee_params)
+      @deferral = DeferralForm.new(trainee, trainee_params)
 
-      if @deferral.save
+      if @deferral.stash
         redirect_to trainee_confirm_deferral_path(trainee)
       else
         render :show

--- a/app/controllers/trainees/outcome_dates_controller.rb
+++ b/app/controllers/trainees/outcome_dates_controller.rb
@@ -9,10 +9,9 @@ module Trainees
 
     def update
       authorize trainee
-      @outcome = OutcomeDateForm.new(trainee)
-      @outcome.assign_attributes(trainee_params)
+      @outcome = OutcomeDateForm.new(trainee, trainee_params)
 
-      if @outcome.save
+      if @outcome.stash
         redirect_to confirm_trainee_outcome_details_path(trainee)
       else
         render :edit

--- a/app/controllers/trainees/outcome_details_controller.rb
+++ b/app/controllers/trainees/outcome_details_controller.rb
@@ -4,6 +4,7 @@ module Trainees
   class OutcomeDetailsController < ApplicationController
     def confirm
       authorize trainee
+      @outcome = OutcomeDateForm.new(trainee)
     end
 
     def recommended

--- a/app/controllers/trainees/qts_recommendations_controller.rb
+++ b/app/controllers/trainees/qts_recommendations_controller.rb
@@ -4,12 +4,15 @@ module Trainees
   class QtsRecommendationsController < ApplicationController
     def create
       authorize trainee
-      trainee.recommend_for_qts!
 
-      RecommendForQtsJob.perform_later(trainee.id)
-      RetrieveQtsJob.set(wait: RetrieveQtsJob::POLL_DELAY).perform_later(trainee.id)
+      if OutcomeDateForm.new(trainee).save!
+        trainee.recommend_for_qts!
 
-      redirect_to recommended_trainee_outcome_details_path(trainee)
+        RecommendForQtsJob.perform_later(trainee.id)
+        RetrieveQtsJob.set(wait: RetrieveQtsJob::POLL_DELAY).perform_later(trainee.id)
+
+        redirect_to recommended_trainee_outcome_details_path(trainee)
+      end
     end
 
   private

--- a/app/controllers/trainees/reinstatements_controller.rb
+++ b/app/controllers/trainees/reinstatements_controller.rb
@@ -11,10 +11,9 @@ module Trainees
     def update
       authorize(trainee, :reinstate?)
 
-      @reinstatement_form = ReinstatementForm.new(trainee)
-      @reinstatement_form.assign_attributes(trainee_params)
+      @reinstatement_form = ReinstatementForm.new(trainee, trainee_params)
 
-      if @reinstatement_form.save
+      if @reinstatement_form.stash
         redirect_to trainee_confirm_reinstatement_path(@trainee)
       else
         render :show

--- a/app/controllers/trainees/withdrawals_controller.rb
+++ b/app/controllers/trainees/withdrawals_controller.rb
@@ -11,10 +11,9 @@ module Trainees
     def update
       authorize(trainee, :withdraw?)
 
-      @withdrawal_form = WithdrawalForm.new(trainee)
-      @withdrawal_form.assign_attributes(trainee_params)
+      @withdrawal_form = WithdrawalForm.new(trainee, trainee_params)
 
-      if @withdrawal_form.save
+      if @withdrawal_form.stash
         redirect_to trainee_confirm_withdrawal_path(@trainee)
       else
         render :show

--- a/app/forms/deferral_form.rb
+++ b/app/forms/deferral_form.rb
@@ -6,4 +6,8 @@ private
   def date_field
     @date_field ||= :defer_date
   end
+
+  def form_store_key
+    :deferral
+  end
 end

--- a/app/forms/outcome_date_form.rb
+++ b/app/forms/outcome_date_form.rb
@@ -6,4 +6,8 @@ private
   def date_field
     @date_field ||= :outcome_date
   end
+
+  def form_store_key
+    :outcome
+  end
 end

--- a/app/forms/reinstatement_form.rb
+++ b/app/forms/reinstatement_form.rb
@@ -6,4 +6,8 @@ private
   def date_field
     @date_field ||= :reinstate_date
   end
+
+  def form_store_key
+    :reinstatement
+  end
 end

--- a/app/forms/withdrawal_form.rb
+++ b/app/forms/withdrawal_form.rb
@@ -6,10 +6,18 @@ class WithdrawalForm < MultiDateForm
   validate :withdraw_reason_valid
   validate :additional_withdraw_reason_valid
 
+  def fields
+    super.merge(new_attributes.slice(:withdraw_reason, :additional_withdraw_reason))
+  end
+
 private
 
   def date_field
     @date_field ||= :withdraw_date
+  end
+
+  def form_store_key
+    :withdrawal
   end
 
   def additional_fields

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -8,6 +8,10 @@ class FormStore
     personal_details
     trainee_id
     trainee_start_date
+    deferral
+    reinstatement
+    outcome
+    withdrawal
   ].freeze
 
   class << self

--- a/app/views/trainees/confirm_deferrals/show.html.erb
+++ b/app/views/trainees/confirm_deferrals/show.html.erb
@@ -15,7 +15,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render Trainees::DeferralDetails::View.new(@trainee) %>
+    <%= render Trainees::DeferralDetails::View.new(@deferral) %>
 
     <%= register_form_with url: trainee_confirm_deferral_path(@trainee), method: :put, local: true do |f| %>
       <%= f.govuk_submit "Defer this trainee" %>
@@ -23,4 +23,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Cancel and return to record", trainee_path(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to("Cancel and return to record", trainee_path(@trainee), class: "qa-cancel-link") %></p>

--- a/app/views/trainees/confirm_reinstatements/show.html.erb
+++ b/app/views/trainees/confirm_reinstatements/show.html.erb
@@ -13,7 +13,7 @@
       <%= t("views.confirm_reinstatement.heading") %>
     </h1>
 
-    <%= render Trainees::Confirmation::ReinstatementDetails::View.new(trainee: @trainee) %>
+    <%= render Trainees::Confirmation::ReinstatementDetails::View.new(@reinstatement) %>
 
     <%= register_form_with url: trainee_confirm_reinstatement_path(@trainee), method: :patch, local: true do |f| %>
       <%= f.govuk_submit t("views.confirm_reinstatement.submit") %>
@@ -21,4 +21,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), trainee_path(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to(t("cancel"), trainee_path(@trainee), class: "qa-cancel-link") %></p>

--- a/app/views/trainees/confirm_withdrawals/show.html.erb
+++ b/app/views/trainees/confirm_withdrawals/show.html.erb
@@ -13,7 +13,7 @@
       <%= t("views.confirm_withdrawal.heading") %>
     </h1>
 
-    <%= render Trainees::Confirmation::WithdrawalDetails::View.new(trainee: @trainee) %>
+    <%= render Trainees::Confirmation::WithdrawalDetails::View.new(@withdrawal) %>
 
     <%= register_form_with url: trainee_confirm_withdrawal_path(@trainee), method: :patch, local: true do |f| %>
       <%= f.govuk_submit t("views.confirm_withdrawal.submit"), classes: "govuk-button--warning" %>
@@ -21,4 +21,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), trainee_path(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to(t("cancel"), trainee_path(@trainee), class: "qa-cancel-link") %></p>

--- a/app/views/trainees/outcome_details/confirm.html.erb
+++ b/app/views/trainees/outcome_details/confirm.html.erb
@@ -15,7 +15,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render Trainees::OutcomeDetails::View.new(@trainee) %>
+    <%= render Trainees::OutcomeDetails::View.new(@outcome) %>
 
     <%= register_form_with url: trainee_qts_recommendations_path, method: :post, local: true do |f| %>
       <%= hidden_field_tag :trainee_id, @trainee.slug %>
@@ -24,4 +24,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Cancel and return to record", trainee_path(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to("Cancel and return to record", trainee_path(@trainee), class: "qa-cancel-link") %></p>

--- a/spec/components/trainees/confirmation/reinstatement_details/view_preview.rb
+++ b/spec/components/trainees/confirmation/reinstatement_details/view_preview.rb
@@ -5,15 +5,14 @@ module Trainees
     module ReinstatementDetails
       class ViewPreview < ViewComponent::Preview
         def default
-          render(Trainees::Confirmation::ReinstatementDetails::View.new(trainee: trainee))
+          render(Trainees::Confirmation::ReinstatementDetails::View.new(data_model))
         end
 
       private
 
-        def trainee
-          @trainee ||= OpenStruct.new({
-            reinstate_date: Faker::Date.in_date_period,
-          })
+        def data_model
+          trainee = OpenStruct.new(id: 1, reinstate_date: Faker::Date.in_date_period)
+          OpenStruct.new(trainee: trainee, date: trainee.reinstate_date)
         end
       end
     end

--- a/spec/components/trainees/confirmation/reinstatement_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/reinstatement_details/view_spec.rb
@@ -8,12 +8,13 @@ RSpec.describe Trainees::Confirmation::ReinstatementDetails::View do
   alias_method :component, :page
 
   let(:trainee) { build(:trainee, :reinstated, id: 1) }
+  let(:data_model) { OpenStruct.new(trainee: trainee, date: trainee.defer_date) }
 
   before do
-    render_inline(described_class.new(trainee: trainee))
+    render_inline(described_class.new(data_model))
   end
 
   it "renders the date the trainee was reinstated" do
-    expect(component).to have_text(date_for_summary_view(trainee.reinstate_date))
+    expect(component).to have_text(date_for_summary_view(data_model.date))
   end
 end

--- a/spec/components/trainees/confirmation/withdrawal_details/view_preview.rb
+++ b/spec/components/trainees/confirmation/withdrawal_details/view_preview.rb
@@ -5,16 +5,17 @@ module Trainees
     module WithdrawalDetails
       class ViewPreview < ViewComponent::Preview
         def default
-          render(Trainees::Confirmation::WithdrawalDetails::View.new(trainee: trainee))
+          render(Trainees::Confirmation::WithdrawalDetails::View.new(data_model))
         end
 
       private
 
-        def trainee
-          @trainee ||= OpenStruct.new({
-            withdraw_date: Faker::Date.in_date_period,
+        def data_model
+          OpenStruct.new(
+            trainee: Trainee.new(id: 1),
+            date: Faker::Date.in_date_period,
             withdraw_reason: WithdrawalReasons::SPECIFIC.sample,
-          })
+          )
         end
       end
     end

--- a/spec/components/trainees/confirmation/withdrawal_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/withdrawal_details/view_spec.rb
@@ -7,31 +7,39 @@ RSpec.describe Trainees::Confirmation::WithdrawalDetails::View do
 
   alias_method :component, :page
 
+  let(:trainee) { build(:trainee, :withdrawn_on_another_day, id: 1) }
+  let(:withdraw_date) { trainee.withdraw_date }
+  let(:withdraw_reason) { nil }
+  let(:additional_withdraw_reason) { nil }
+
+  let(:data_model) do
+    OpenStruct.new(trainee: trainee, date: withdraw_date, withdraw_reason: withdraw_reason, additional_withdraw_reason: additional_withdraw_reason)
+  end
+
   before do
-    render_inline(described_class.new(trainee: trainee))
+    render_inline(described_class.new(data_model))
   end
 
   context "withdrawn on another day" do
-    let(:trainee) { build(:trainee, :withdrawn_on_another_day, id: 1) }
-
     it "renders the date of withdrawal" do
-      expect(component).to have_text(date_for_summary_view(trainee.withdraw_date))
+      expect(component).to have_text(date_for_summary_view(data_model.date))
     end
   end
 
   context "withdrawn for a specific reason" do
-    let(:trainee) { build(:trainee, :withdrawn_for_specific_reason, id: 1) }
+    let(:withdraw_reason) { WithdrawalReasons::SPECIFIC.sample }
 
     it "renders the reason for withdrawal " do
-      expect(component).to have_text(I18n.t("components.confirmation.withdrawal_details.reasons.#{trainee.withdraw_reason}"))
+      expect(component).to have_text(I18n.t("components.confirmation.withdrawal_details.reasons.#{data_model.withdraw_reason}"))
     end
   end
 
   context "for another reason" do
-    let(:trainee) { build(:trainee, :withdrawn_for_another_reason, id: 1) }
+    let(:withdraw_reason) { WithdrawalReasons::FOR_ANOTHER_REASON }
+    let(:additional_withdraw_reason) { "some other reason" }
 
     it "renders the reason for withdrawal " do
-      expect(component).to have_text(trainee.additional_withdraw_reason)
+      expect(component).to have_text(data_model.additional_withdraw_reason)
     end
   end
 end

--- a/spec/components/trainees/deferral_details/view_preview.rb
+++ b/spec/components/trainees/deferral_details/view_preview.rb
@@ -4,14 +4,14 @@ module Trainees
   module DeferralDetails
     class ViewPreview < ViewComponent::Preview
       def default
-        render(Trainees::DeferralDetails::View.new(trainee))
+        render(Trainees::DeferralDetails::View.new(data_model))
       end
 
     private
 
-      def trainee
-        @trainee ||= Trainee.new(id: 1,
-                                 defer_date: Time.zone.yesterday)
+      def data_model
+        trainee = Trainee.new(id: 1, defer_date: Time.zone.yesterday)
+        OpenStruct.new(trainee: trainee, date: trainee.defer_date)
       end
     end
   end

--- a/spec/components/trainees/deferral_details/view_spec.rb
+++ b/spec/components/trainees/deferral_details/view_spec.rb
@@ -9,14 +9,15 @@ module Trainees
 
       alias_method :component, :page
 
-      let(:trainee) { Trainee.new(defer_date: Time.zone.yesterday) }
+      let(:trainee_stub) { Trainee.new(defer_date: Time.zone.yesterday) }
+      let(:data_model) { OpenStruct.new(trainee: trainee_stub, date: trainee_stub.defer_date) }
 
       before do
-        render_inline(View.new(trainee))
+        render_inline(View.new(data_model))
       end
 
       it "renders the deferral end date" do
-        expect(component).to have_text(date_for_summary_view(trainee.defer_date))
+        expect(component).to have_text(date_for_summary_view(data_model.date))
       end
     end
   end

--- a/spec/components/trainees/outcome_details/view_preview.rb
+++ b/spec/components/trainees/outcome_details/view_preview.rb
@@ -6,13 +6,14 @@ module Trainees
   module OutcomeDetails
     class ViewPreview < ViewComponent::Preview
       def default
-        render(OutcomeDetails::View.new(mock_trainee))
+        render(OutcomeDetails::View.new(data_model))
       end
 
     private
 
-      def mock_trainee
-        OpenStruct.new(outcome_date: Time.zone.yesterday)
+      def data_model
+        trainee = OpenStruct.new(id: 1, outcome_date: Time.zone.yesterday)
+        OpenStruct.new(trainee: trainee, date: trainee.outcome_date)
       end
     end
   end

--- a/spec/components/trainees/outcome_details/view_spec.rb
+++ b/spec/components/trainees/outcome_details/view_spec.rb
@@ -9,14 +9,15 @@ module Trainees
 
       alias_method :component, :page
 
-      let(:trainee) { OpenStruct.new(outcome_date: Time.zone.yesterday) }
+      let(:trainee) { build(:trainee, :with_outcome_date) }
+      let(:data_model) { OpenStruct.new(trainee: trainee, date: trainee.outcome_date) }
 
       before do
-        render_inline(View.new(trainee))
+        render_inline(View.new(data_model))
       end
 
       it "renders the outcome end date" do
-        expect(component.find(summary_card_row_for("date-standards-met"))).to have_text(date_for_summary_view(trainee.outcome_date))
+        expect(component.find(summary_card_row_for("date-standards-met"))).to have_text(date_for_summary_view(data_model.date))
       end
     end
   end

--- a/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
@@ -10,6 +10,7 @@ describe Trainees::ConfirmDeferralsController do
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
+    allow(DeferralForm).to receive(:new).with(trainee).and_return(double(save!: true))
   end
 
   describe "#update" do

--- a/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
@@ -10,6 +10,7 @@ describe Trainees::ConfirmReinstatementsController do
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
+    allow(ReinstatementForm).to receive(:new).with(trainee).and_return(double(save!: true))
   end
 
   describe "#update" do

--- a/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
@@ -10,6 +10,7 @@ describe Trainees::ConfirmWithdrawalsController do
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
+    allow(WithdrawalForm).to receive(:new).with(trainee).and_return(double(save!: true))
   end
 
   describe "#update" do

--- a/spec/controllers/trainees/qts_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/qts_recommendations_controller_spec.rb
@@ -10,6 +10,7 @@ describe Trainees::QtsRecommendationsController do
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
+    allow(OutcomeDateForm).to receive(:new).with(trainee).and_return(double(save!: true))
   end
 
   describe "#create" do

--- a/spec/features/trainees/defer_trainee_spec.rb
+++ b/spec/features/trainees/defer_trainee_spec.rb
@@ -22,14 +22,18 @@ feature "Deferring a trainee", type: :feature do
       when_i_choose_today
       and_i_continue
       then_i_am_redirected_to_deferral_confirmation_page
-      and_the_defer_date_is_updated
+      and_i_see_my_date(Time.zone.today)
+      when_i_defer
+      then_the_defer_date_is_updated
     end
 
     scenario "choosing yesterday" do
       when_i_choose_yesterday
       and_i_continue
       then_i_am_redirected_to_deferral_confirmation_page
-      and_the_defer_date_is_updated
+      and_i_see_my_date(Time.zone.yesterday)
+      when_i_defer
+      then_the_defer_date_is_updated
     end
 
     context "choosing another day" do
@@ -41,7 +45,9 @@ feature "Deferring a trainee", type: :feature do
         and_i_enter_a_valid_date
         and_i_continue
         then_i_am_redirected_to_deferral_confirmation_page
-        and_the_defer_date_is_updated
+        and_i_see_my_date(@chosen_date)
+        when_i_defer
+        then_the_defer_date_is_updated
       end
 
       scenario "and not filling out the date displays the correct error" do
@@ -57,6 +63,16 @@ feature "Deferring a trainee", type: :feature do
     end
   end
 
+  scenario "cancelling changes" do
+    when_i_choose_today
+    and_i_continue
+    then_i_am_redirected_to_deferral_confirmation_page
+    and_i_see_my_date(Time.zone.today)
+    when_i_cancel_my_changes
+    then_i_am_redirected_to_the_record_page
+    and_the_defer_date_i_chose_is_cleared
+  end
+
   def when_i_choose_today
     when_i_choose("Today")
   end
@@ -65,8 +81,13 @@ feature "Deferring a trainee", type: :feature do
     when_i_choose("Yesterday")
   end
 
+  def when_i_defer
+    deferral_confirmation_page.defer.click
+  end
+
   def and_i_enter_a_valid_date
-    Faker::Date.in_date_period.tap do |defer_date|
+    @chosen_date = Faker::Date.in_date_period
+    @chosen_date.tap do |defer_date|
       deferral_page.set_date_fields(:defer_date, defer_date.strftime("%d/%m/%Y"))
     end
   end
@@ -117,8 +138,21 @@ feature "Deferring a trainee", type: :feature do
     given_a_trainee_exists(%i[submitted_for_trn trn_received].sample)
   end
 
-  def and_the_defer_date_is_updated
+  def then_the_defer_date_is_updated
     trainee.reload
     expect(page).to have_text(date_for_summary_view(trainee.defer_date))
+  end
+
+  def when_i_cancel_my_changes
+    deferral_confirmation_page.cancel.click
+  end
+
+  def then_i_am_redirected_to_the_record_page
+    expect(record_page).to be_displayed(id: trainee.slug)
+  end
+
+  def and_the_defer_date_i_chose_is_cleared
+    trainee.reload
+    expect(trainee.defer_date).to be_nil
   end
 end

--- a/spec/features/trainees/recommending_for_qts_spec.rb
+++ b/spec/features/trainees/recommending_for_qts_spec.rb
@@ -29,6 +29,6 @@ feature "Recommending for QTS", type: :feature do
   end
 
   def and_i_confirm_the_outcome_details
-    confirm_outcome_details_page.continue.click
+    confirm_outcome_details_page.record_outcome.click
   end
 end

--- a/spec/forms/deferral_form_spec.rb
+++ b/spec/forms/deferral_form_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DeferralForm, type: :model do
+  let(:trainee) { create(:trainee, :deferred) }
+  let(:form_store) { class_double(FormStore) }
+
+  let(:params) do
+    {
+      "year" => "1963",
+      "month" => "11",
+      "day" => "11",
+      "date_string" => "other",
+    }
+  end
+
+  subject { described_class.new(trainee, params, form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    context "date" do
+      context "empty date" do
+        before do
+          subject.date_string = nil
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date_string]).to include(
+            I18n.t(
+              "activemodel.errors.models.deferral_form.attributes.date_string.blank",
+            ),
+          )
+        end
+      end
+
+      context "invalid date" do
+        before do
+          subject.month = nil
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date]).to include(
+            I18n.t(
+              "activemodel.errors.models.deferral_form.attributes.date.invalid",
+            ),
+          )
+        end
+      end
+    end
+  end
+
+  describe "#fields" do
+    it "combines the data from params with the existing trainee data" do
+      expect(subject.fields).to match({
+        date_string: "other",
+        day: "11",
+        month: "11",
+        year: "1963",
+      })
+    end
+  end
+
+  describe "#stash" do
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and deferral_details" do
+      expect(form_store).to receive(:set).with(trainee.id, :deferral, subject.fields)
+
+      subject.stash
+    end
+  end
+
+  describe "#save!" do
+    it "takes any data from the form store and saves it to the database and clears the store data" do
+      expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
+
+      date_params = params.except("date_string").values.map(&:to_i)
+      expect { subject.save! }.to change(trainee, :defer_date).to(Date.new(*date_params))
+    end
+  end
+end

--- a/spec/forms/outcome_date_form_spec.rb
+++ b/spec/forms/outcome_date_form_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe OutcomeDateForm, type: :model do
+  let(:trainee) { create(:trainee, :deferred) }
+  let(:form_store) { class_double(FormStore) }
+
+  let(:params) do
+    {
+      "year" => "1963",
+      "month" => "11",
+      "day" => "11",
+      "date_string" => "other",
+    }
+  end
+
+  subject { described_class.new(trainee, params, form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    context "date" do
+      context "empty date" do
+        before do
+          subject.date_string = nil
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date_string]).to include(
+            I18n.t(
+              "activemodel.errors.models.outcome_date_form.attributes.date_string.blank",
+            ),
+          )
+        end
+      end
+
+      context "invalid date" do
+        before do
+          subject.month = nil
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date]).to include(
+            I18n.t(
+              "activemodel.errors.models.outcome_date_form.attributes.date.invalid",
+            ),
+          )
+        end
+      end
+    end
+  end
+
+  describe "#fields" do
+    it "combines the data from params with the existing trainee data" do
+      expect(subject.fields).to match({
+        date_string: "other",
+        day: "11",
+        month: "11",
+        year: "1963",
+      })
+    end
+  end
+
+  describe "#stash" do
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and deferral_details" do
+      expect(form_store).to receive(:set).with(trainee.id, :outcome, subject.fields)
+
+      subject.stash
+    end
+  end
+
+  describe "#save!" do
+    it "takes any data from the form store and saves it to the database and clears the store data" do
+      expect(form_store).to receive(:set).with(trainee.id, :outcome, nil)
+
+      date_params = params.except("date_string").values.map(&:to_i)
+      expect { subject.save! }.to change(trainee, :outcome_date).to(Date.new(*date_params))
+    end
+  end
+end

--- a/spec/forms/reinstatement_form_spec.rb
+++ b/spec/forms/reinstatement_form_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ReinstatementForm, type: :model do
+  let(:trainee) { create(:trainee, :reinstated) }
+  let(:form_store) { class_double(FormStore) }
+
+  let(:params) do
+    {
+      "year" => "1963",
+      "month" => "11",
+      "day" => "11",
+      "date_string" => "other",
+    }
+  end
+
+  subject { described_class.new(trainee, params, form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    context "date" do
+      context "empty date" do
+        before do
+          subject.date_string = nil
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date_string]).to include(
+            I18n.t(
+              "activemodel.errors.models.reinstatement_form.attributes.date_string.blank",
+            ),
+          )
+        end
+      end
+
+      context "invalid date" do
+        before do
+          subject.month = nil
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date]).to include(
+            I18n.t(
+              "activemodel.errors.models.reinstatement_form.attributes.date.invalid",
+            ),
+          )
+        end
+      end
+    end
+  end
+
+  describe "#fields" do
+    it "combines the data from params with the existing trainee data" do
+      expect(subject.fields).to match({
+        date_string: "other",
+        day: "11",
+        month: "11",
+        year: "1963",
+      })
+    end
+  end
+
+  describe "#stash" do
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and deferral_details" do
+      expect(form_store).to receive(:set).with(trainee.id, :reinstatement, subject.fields)
+
+      subject.stash
+    end
+  end
+
+  describe "#save!" do
+    it "takes any data from the form store and saves it to the database and clears the store data" do
+      expect(form_store).to receive(:set).with(trainee.id, :reinstatement, nil)
+
+      date_params = params.except("date_string").values.map(&:to_i)
+      expect { subject.save! }.to change(trainee, :reinstate_date).to(Date.new(*date_params))
+    end
+  end
+end

--- a/spec/forms/withdrawal_form_spec.rb
+++ b/spec/forms/withdrawal_form_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe WithdrawalForm, type: :model do
+  let(:params) { {} }
+  let(:trainee) { create(:trainee, :withdrawn, :withdrawn_for_another_reason) }
+  let(:form_store) { class_double(FormStore) }
+
+  subject { described_class.new(trainee, params, form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    context "date" do
+      context "empty date" do
+        before do
+          subject.date_string = nil
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date_string]).to include(
+            I18n.t(
+              "activemodel.errors.models.withdrawal_form.attributes.date_string.blank",
+            ),
+          )
+        end
+      end
+
+      context "invalid date" do
+        before do
+          subject.month = nil
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date]).to include(
+            I18n.t(
+              "activemodel.errors.models.withdrawal_form.attributes.date.invalid",
+            ),
+          )
+        end
+      end
+    end
+  end
+
+  describe "#fields" do
+    let(:params) do
+      {
+        "day" => "11",
+        "month" => "11",
+        "year" => "1963",
+        "date_string" => "other",
+        "withdraw_reason" => WithdrawalReasons::HEALTH_REASONS,
+        "additional_withdraw_reason" => "",
+      }
+    end
+
+    it "combines the data from params with the existing trainee data" do
+      expect(subject.fields).to match({
+        date_string: "other",
+        day: "11",
+        month: "11",
+        year: "1963",
+        withdraw_reason: WithdrawalReasons::HEALTH_REASONS,
+        additional_withdraw_reason: "",
+      })
+    end
+  end
+
+  describe "#stash" do
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and deferral_details" do
+      expect(form_store).to receive(:set).with(trainee.id, :withdrawal, subject.fields)
+
+      subject.stash
+    end
+  end
+
+  describe "#save!" do
+    before do
+      allow(form_store).to receive(:get).and_return({
+        "withdraw_reason" => WithdrawalReasons::FINANCIAL_REASONS,
+      })
+    end
+
+    it "takes any data from the form store and saves it to the database and clears the store data" do
+      expect(form_store).to receive(:set).with(trainee.id, :withdrawal, nil)
+
+      expect { subject.save! }.to change(trainee, :withdraw_reason).to(WithdrawalReasons::FINANCIAL_REASONS)
+    end
+  end
+end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -6,6 +6,7 @@ require_relative "features/dttp_steps"
 require_relative "features/common_steps"
 require_relative "features/page_helpers"
 require_relative "features/diversity_steps"
+require_relative "features/confirmation_steps"
 require_relative "dfe_sign_in_user_helper"
 
 RSpec.configure do |config|
@@ -21,6 +22,7 @@ RSpec.configure do |config|
   config.include Features::CommonSteps, type: :feature
   config.include Features::PageHelpers, type: :feature
   config.include Features::DiversitySteps, type: :feature
+  config.include Features::ConfirmationSteps, type: :feature
   config.include DfESignInUserHelper, type: :feature
 
   config.around :each do |example|

--- a/spec/support/features/confirmation_steps.rb
+++ b/spec/support/features/confirmation_steps.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Features
+  module ConfirmationSteps
+    def and_i_see_my_date(date)
+      expect(page).to have_text(date_for_summary_view(date))
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/confirm_deferral_details.rb
+++ b/spec/support/page_objects/trainees/confirm_deferral_details.rb
@@ -4,7 +4,9 @@ module PageObjects
   module Trainees
     class ConfirmDeferral < PageObjects::Base
       set_url "/trainees/{id}/defer/confirm"
-      element :continue, "input[name='commit']"
+
+      element :defer, "input[name='commit']"
+      element :cancel, ".govuk-link.qa-cancel-link"
     end
   end
 end

--- a/spec/support/page_objects/trainees/confirm_outcome_details.rb
+++ b/spec/support/page_objects/trainees/confirm_outcome_details.rb
@@ -5,7 +5,8 @@ module PageObjects
     class ConfirmOutcomeDetails < PageObjects::Base
       set_url "/trainees/{id}/outcome-details/confirm"
       element :confirm, "input[name='confirm_detail_form[mark_as_completed]']"
-      element :continue, "input[name='commit']"
+      element :record_outcome, "input[name='commit']"
+      element :cancel, ".govuk-link.qa-cancel-link"
     end
   end
 end

--- a/spec/support/page_objects/trainees/confirm_reinstatement.rb
+++ b/spec/support/page_objects/trainees/confirm_reinstatement.rb
@@ -4,7 +4,9 @@ module PageObjects
   module Trainees
     class ConfirmReinstatement < PageObjects::Base
       set_url "/trainees/{id}/reinstate/confirm"
-      element :confirm, "input[name='commit']"
+
+      element :reinstate, "input[name='commit']"
+      element :cancel, ".govuk-link.qa-cancel-link"
     end
   end
 end

--- a/spec/support/page_objects/trainees/confirm_withdrawal.rb
+++ b/spec/support/page_objects/trainees/confirm_withdrawal.rb
@@ -4,7 +4,9 @@ module PageObjects
   module Trainees
     class ConfirmWithdrawal < PageObjects::Base
       set_url "/trainees/{id}/withdraw/confirm"
-      element :continue, "input[name='commit']"
+
+      element :withdraw, "input[name='commit']"
+      element :cancel, ".govuk-link.qa-cancel-link"
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/Flwa2MGU/1209-l-implement-save-on-confirm-outcome-date-defer-withdraw-reinstate

### Changes proposed in this pull request

- Based on the agreed approach for stashing form changes from this spike https://github.com/DFE-Digital/register-trainee-teachers/pull/534.
- Implement stashing logic into the following forms `DeferralForm`, `OutcomeDateForm`, `ReinstatementForm` and `WithdrawalForm`
- Refactor complementary files and broken tests
- Add test coverage for the logic above

### Guidance to review

- Head to the review app, select a trainee that has a trn received status and go through any of the forms above. Make some changes and cancel, then assert the changes aren't persisted. Do it again and assert they are persisted.

