### PR TITLE
Focussed links in start banner have poor contrast (A11Y issue)

### DIFF
--- a/app/components/start_page_banner/style.scss
+++ b/app/components/start_page_banner/style.scss
@@ -59,6 +59,10 @@
     color: govuk-colour("white");
   }
 
+  .govuk-phase-banner__text .govuk-link:focus {
+    color: govuk-colour('black');
+  }
+
   .govuk-tag {
     background: govuk-colour("white");
     color: $govuk-brand-colour;
@@ -74,6 +78,9 @@
     color: govuk-colour("white");
   }
 
+  .govuk-link:focus {
+    color: govuk-colour('black');
+  }
   @include govuk-media-query($from: tablet) {
     margin-top: -(govuk-spacing(7));
   }


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

### Guidance to review

#### Before

https://user-images.githubusercontent.com/3441519/111639957-9dd95200-87f3-11eb-87a1-d7427c2234c6.mp4


#### After

https://user-images.githubusercontent.com/3441519/111637958-cbbd9700-87f1-11eb-9ec8-99762d63b6db.mp4

