### PR TITLE
[1186] Add babel-polyfill to fix JavaScript exception in IE11

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import '../scripts/govuk_assets_import'
 import '../styles/application.scss'
 import '../scripts/components'

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@ministryofjustice/frontend": "^0.2.1",
     "@rails/webpacker": "^5.2.1",
     "accessible-autocomplete": "^2.0.3",
+    "babel-polyfill": "^6.26.0",
     "core-js": "^3.9.1",
     "govuk-country-and-territory-autocomplete": "^1.0.1",
     "govuk-frontend": "^3.11.0",
@@ -26,7 +27,9 @@
     "webpack-dev-server": "^3.11.2"
   },
   "standard": {
-    "env": [ "jest" ]
+    "env": [
+      "jest"
+    ]
   },
   "license": "MIT"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,6 +2129,15 @@ babel-plugin-macros@^2.8.0:
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
@@ -2154,6 +2163,14 @@ babel-preset-jest@^26.6.2:
   dependencies:
     babel-plugin-jest-hoist "^26.6.2"
     babel-preset-current-node-syntax "^1.0.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -2951,6 +2968,11 @@ core-js@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
   integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
+
+core-js@^2.4.0, core-js@^2.5.0:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.6.5, core-js@^3.9.1:
   version "3.9.1"
@@ -8307,6 +8329,16 @@ regenerate@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
   integrity sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.7"


### PR DESCRIPTION
### Context
https://trello.com/c/lofoBlCW/1186-bug-conditional-fields-not-opening-in-ie11

### Changes proposed in this pull request
- Add babel-polyfill to fix JavaScript exception in IE11

When babel converts ES6 to ES5, it creates a helper function called `_toConsumableArray()`. This blows up because IE11 doesn't have the necessary polyfills.

### Guidance to review
As you can see in the screen scapture shows JS behaviour is working now. Feel free to try it out in a real IE11 browser.

![1186-bug-conditional-fields-not-opening-in-ie11](https://user-images.githubusercontent.com/28728/111660438-fd405d80-8805-11eb-84e4-a7e86ad28b4a.gif)

