### PR TITLE
[1241] Import applications from Apply

### DIFF
--- a/app/jobs/apply_api/import_applications_job.rb
+++ b/app/jobs/apply_api/import_applications_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ApplyApi
+  class ImportApplicationsJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      return unless FeatureService.enabled?("import_applications_from_apply")
+
+      new_applications.each do |application|
+        ImportApplication.call(application: application)
+      end
+    end
+
+  private
+
+    def new_applications
+      RetrieveApplications.call(changed_since: last_successful_sync)
+    end
+
+    def last_successful_sync
+      ApplyApplicationSyncRequest.successful.pluck(:created_at).max
+    end
+  end
+end

--- a/app/jobs/apply_api/import_applications_job.rb
+++ b/app/jobs/apply_api/import_applications_job.rb
@@ -19,7 +19,7 @@ module ApplyApi
     end
 
     def last_successful_sync
-      ApplyApplicationSyncRequest.successful.pluck(:created_at).max
+      ApplyApplicationSyncRequest.successful.maximum(:created_at)
     end
   end
 end

--- a/app/lib/apply_api/client.rb
+++ b/app/lib/apply_api/client.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ApplyApi
+  class Client
+    include HTTParty
+    base_uri Settings.apply_api.base_url
+    headers "Accept" => "application/json",
+            "Content-Type" => "application/json",
+            "Authorization" => -> { "Bearer #{Settings.apply_api.auth_token}" },
+            "User-Agent" => "Register for teacher training (#{Settings.environment.name})"
+  end
+end

--- a/app/models/apply_application.rb
+++ b/app/models/apply_application.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ApplyApplication < ApplicationRecord
+  belongs_to :provider
+
+  validates :application, presence: true
+end

--- a/app/models/apply_application_sync_request.rb
+++ b/app/models/apply_application_sync_request.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplyApplicationSyncRequest < ApplicationRecord
+  scope :successful, -> { where(successful: true) }
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -3,6 +3,7 @@
 class Provider < ApplicationRecord
   has_many :users
   has_many :trainees
+  has_many :apply_applications
   has_many :courses
 
   validates :name, presence: true

--- a/app/services/apply_api/import_application.rb
+++ b/app/services/apply_api/import_application.rb
@@ -5,22 +5,38 @@ module ApplyApi
     include ServicePattern
 
     def initialize(application:)
-      @application = application
-      @provider_code = application["attributes"]["course"]["training_provider_code"]
+      @raw_application = application
     end
 
     def call
       return unless provider
 
-      provider.apply_applications.create!(application: application.to_json)
+      application.update!(
+        application: raw_application.to_json,
+        provider: provider,
+      )
     end
 
   private
 
-    attr_reader :application, :provider_code
+    attr_reader :raw_application
 
     def provider
       @provider ||= Provider.find_by(code: provider_code)
+    end
+
+    # This is `ApplyApplication.find` rather than `provider.apply_applications.find`
+    # to cover the possibility of an application's provider being updated.
+    def application
+      @application ||= ApplyApplication.find_or_initialize_by(apply_id: apply_id)
+    end
+
+    def provider_code
+      @provider_code ||= raw_application["attributes"]["course"]["training_provider_code"]
+    end
+
+    def apply_id
+      @apply_id ||= raw_application["id"]
     end
   end
 end

--- a/app/services/apply_api/import_application.rb
+++ b/app/services/apply_api/import_application.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ApplyApi
+  class ImportApplication
+    include ServicePattern
+
+    def initialize(application:)
+      @application = application
+      @provider_code = application["attributes"]["course"]["training_provider_code"]
+    end
+
+    def call
+      return unless provider
+
+      provider.apply_applications.create!(application: application.to_json)
+    end
+
+  private
+
+    attr_reader :application, :provider_code
+
+    def provider
+      @provider ||= Provider.find_by(code: provider_code)
+    end
+  end
+end

--- a/app/services/apply_api/retrieve_applications.rb
+++ b/app/services/apply_api/retrieve_applications.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module ApplyApi
+  class RetrieveApplications
+    include ServicePattern
+
+    SUCCESS = 200
+
+    RECRUITMENT_CYCLE_YEAR = 2021
+
+    class HttpError < StandardError; end
+
+    def initialize(changed_since:)
+      @changed_since = changed_since
+    end
+
+    def call
+      log_request!
+
+      if response.code != SUCCESS
+        raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
+
+      applications
+    end
+
+  private
+
+    attr_reader :changed_since
+
+    def applications
+      JSON(response.body)["data"]
+    end
+
+    def response
+      @response ||= Client.get("/applications?#{params}")
+    end
+
+    def params
+      params = "recruitment_cycle_year=#{RECRUITMENT_CYCLE_YEAR}"
+      params += "&changed_since=#{changed_since}" if changed_since.present?
+      params
+    end
+
+    def log_request!
+      ApplyApplicationSyncRequest.create!(
+        successful: response.code == SUCCESS,
+        response_code: response.code,
+      )
+    end
+  end
+end

--- a/app/services/apply_api/retrieve_applications.rb
+++ b/app/services/apply_api/retrieve_applications.rb
@@ -6,8 +6,6 @@ module ApplyApi
 
     SUCCESS = 200
 
-    RECRUITMENT_CYCLE_YEAR = 2021
-
     class HttpError < StandardError; end
 
     def initialize(changed_since:)
@@ -33,13 +31,14 @@ module ApplyApi
     end
 
     def response
-      @response ||= Client.get("/applications?#{params}")
+      @response ||= Client.get("/applications?#{query}")
     end
 
-    def params
-      params = "recruitment_cycle_year=#{RECRUITMENT_CYCLE_YEAR}"
-      params += "&changed_since=#{changed_since}" if changed_since.present?
-      params
+    def query
+      {
+        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        changed_since: changed_since,
+      }.compact.to_query
     end
 
     def log_request!

--- a/app/services/teacher_training_api/retrieve_courses.rb
+++ b/app/services/teacher_training_api/retrieve_courses.rb
@@ -22,9 +22,8 @@ module TeacherTrainingApi
 
     attr_reader :provider
 
-    # TODO: Make the recruitment cycle dynamic once we have a concept of cycles.
     def response
-      @response ||= Client.get("/recruitment_cycles/2021/providers/#{provider.code}/courses")
+      @response ||= Client.get("/recruitment_cycles/#{Settings.current_recruitment_cycle_year}/providers/#{provider.code}/courses")
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,6 +44,8 @@ apply_api:
   base_url: "base-url-from-env"
   auth_token: "auth-token-from-env"
 
+current_recruitment_cycle_year: 2021
+
 jobs:
   poll_delay_hours: 6
   max_poll_duration_days: 2

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,6 +27,7 @@ features:
   trainee_export: true
   routes_provider_led_postgrad: false
   routes_early_years_undergrad: false
+  import_applications_from_apply: false
   import_courses_from_ttapi: false
 
 dfe_sign_in:
@@ -38,6 +39,10 @@ dfe_sign_in:
   profile: https://test-profile.signin.education.gov.uk
   # This value must be set otherwise sign in will fail
   secret: secret required value
+
+apply_api:
+  base_url: "base-url-from-env"
+  auth_token: "auth-token-from-env"
 
 jobs:
   poll_delay_hours: 6

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -6,6 +6,10 @@ truncate_activerecord_session_store:
   cron: "0 0 * * *"
   class: "SessionStoreTruncateJob"
   queue: default
+import_applications_from_apply:
+  cron: "0 1 * * *"
+  class: "ApplyApi::ImportApplicationsJob"
+  queue: default
 import_courses_from_ttapi:
   cron: "0 2 * * *"
   class: "TeacherTrainingApi::ImportCoursesJob"

--- a/db/migrate/20210317131340_create_apply_applications.rb
+++ b/db/migrate/20210317131340_create_apply_applications.rb
@@ -3,6 +3,7 @@
 class CreateApplyApplications < ActiveRecord::Migration[6.1]
   def change
     create_table :apply_applications do |t|
+      t.integer :apply_id, index: { unique: true }, null: false
       t.jsonb :application
       t.references :provider, index: true, null: false, foreign_key: { to_table: :providers }
 

--- a/db/migrate/20210317131340_create_apply_applications.rb
+++ b/db/migrate/20210317131340_create_apply_applications.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateApplyApplications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :apply_applications do |t|
+      t.jsonb :application
+      t.references :provider, index: true, null: false, foreign_key: { to_table: :providers }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210317155738_create_apply_application_sync_requests.rb
+++ b/db/migrate/20210317155738_create_apply_application_sync_requests.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateApplyApplicationSyncRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :apply_application_sync_requests do |t|
+      t.integer :response_code
+      t.boolean :successful
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,21 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "apply_application_sync_requests", force: :cascade do |t|
+    t.integer "response_code"
+    t.boolean "successful"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "apply_applications", force: :cascade do |t|
+    t.jsonb "application"
+    t.bigint "provider_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider_id"], name: "index_apply_applications_on_provider_id"
+  end
+
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -220,6 +235,7 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
     t.index ["provider_id"], name: "index_users_on_provider_id"
   end
 
+  add_foreign_key "apply_applications", "providers"
   add_foreign_key "course_subjects", "courses"
   add_foreign_key "course_subjects", "subjects"
   add_foreign_key "courses", "providers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,10 +23,12 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
   end
 
   create_table "apply_applications", force: :cascade do |t|
+    t.integer "apply_id", null: false
     t.jsonb "application"
     t.bigint "provider_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["apply_id"], name: "index_apply_applications_on_apply_id", unique: true
     t.index ["provider_id"], name: "index_apply_applications_on_provider_id"
   end
 
@@ -129,8 +131,8 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.boolean "apply_sync_enabled", default: false
     t.string "code"
+    t.boolean "apply_sync_enabled", default: false
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
 

--- a/spec/factories/apply_application_sync_requests.rb
+++ b/spec/factories/apply_application_sync_requests.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :apply_application_sync_request do
+    trait :successful do
+      successful { true }
+      response_code { 200 }
+    end
+
+    trait :unsuccessful do
+      successful { false }
+      response_code { 500 }
+    end
+  end
+end

--- a/spec/factories/apply_applications.rb
+++ b/spec/factories/apply_applications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :apply_application do
+    sequence(:apply_id)
+    application { ApiStubs::ApplyApi.application }
+    provider
+  end
+end

--- a/spec/jobs/apply_api/import_applications_job_spec.rb
+++ b/spec/jobs/apply_api/import_applications_job_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ApplyApi
+  describe ImportApplicationsJob do
+    include ActiveJob::TestHelper
+
+    let(:application) { double("application") }
+
+    before do
+      allow(RetrieveApplications).to receive(:call).and_return([application])
+    end
+
+    context "when the feature flag is turned on", feature_import_applications_from_apply: true do
+      context "when there have been no previous syncs" do
+        it "imports all applications from Apply" do
+          expect(RetrieveApplications).to receive(:call).with(changed_since: nil)
+          expect(ImportApplication).to receive(:call).with(application: application)
+
+          described_class.perform_now
+        end
+      end
+
+      context "when the last sync was successful" do
+        let(:last_sync) { Time.zone.yesterday }
+        before { create(:apply_application_sync_request, :successful, created_at: last_sync) }
+
+        it "imports just the new applications from Apply" do
+          expect(RetrieveApplications).to receive(:call).with(changed_since: last_sync)
+          expect(ImportApplication).to receive(:call).with(application: application)
+
+          described_class.perform_now
+        end
+      end
+
+      context "when the last sync was unsuccessful" do
+        let(:last_successful_sync) { Time.zone.yesterday }
+        let(:last_sync) { Time.zone.today }
+        before do
+          create(:apply_application_sync_request, :successful, created_at: last_successful_sync)
+          create(:apply_application_sync_request, :unsuccessful, created_at: last_sync)
+        end
+
+        it "imports just the new applications from Apply" do
+          expect(RetrieveApplications).to receive(:call).with(changed_since: last_successful_sync)
+          expect(ImportApplication).to receive(:call).with(application: application)
+
+          described_class.perform_now
+        end
+      end
+    end
+
+    context "when the feature flag is turned off", feature_import_applications_from_apply: false do
+      it "does nothing" do
+        expect(RetrieveApplications).not_to receive(:call).with(changed_since: nil)
+        expect(ImportApplication).not_to receive(:call).with(application: application)
+
+        described_class.perform_now
+      end
+    end
+  end
+end

--- a/spec/models/apply_application_spec.rb
+++ b/spec/models/apply_application_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ApplyApplication do
+  describe "associations" do
+    it { is_expected.to belong_to(:provider) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:application) }
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -33,6 +33,7 @@ describe Provider do
 
   describe "associations" do
     it { is_expected.to have_many(:users) }
+    it { is_expected.to have_many(:apply_applications) }
     it { is_expected.to have_many(:courses) }
   end
 

--- a/spec/services/apply_api/import_application_spec.rb
+++ b/spec/services/apply_api/import_application_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ApplyApi
+  describe ImportApplication do
+    describe "#call" do
+      let(:application) { JSON.parse(ApiStubs::ApplyApi.application) }
+
+      subject { described_class.call(application: application) }
+
+      context "when the provider does not exist in register" do
+        let(:provider) { create(:provider) }
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+      end
+
+      context "when the provider does exist in register" do
+        let(:provider) { create(:provider, code: application["attributes"]["course"]["training_provider_code"]) }
+
+        it "creates the apply_application and associates it with that provider" do
+          expect { subject }.to change { provider.apply_applications.count }.by(1)
+          expect(provider.apply_applications.first.application).to eq application.to_json
+        end
+      end
+    end
+  end
+end

--- a/spec/services/apply_api/import_application_spec.rb
+++ b/spec/services/apply_api/import_application_spec.rb
@@ -17,12 +17,23 @@ module ApplyApi
         end
       end
 
-      context "when the provider does exist in register" do
-        let(:provider) { create(:provider, code: application["attributes"]["course"]["training_provider_code"]) }
+      context "when the provider exists in register" do
+        let(:provider_code) { application["attributes"]["course"]["training_provider_code"] }
+        let(:provider) { create(:provider, code: provider_code) }
 
         it "creates the apply_application and associates it with that provider" do
           expect { subject }.to change { provider.apply_applications.count }.by(1)
           expect(provider.apply_applications.first.application).to eq application.to_json
+        end
+
+        context "and the apply application also exists in register" do
+          before do
+            create(:apply_application, apply_id: application["id"])
+          end
+
+          it "does not create a duplicate" do
+            expect { subject }.not_to(change { ApplyApplication.count })
+          end
         end
       end
     end

--- a/spec/services/apply_api/retrieve_applications_spec.rb
+++ b/spec/services/apply_api/retrieve_applications_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ApplyApi
+  describe RetrieveApplications do
+    let(:changed_since) { nil }
+    let(:expected_url) { "/applications?recruitment_cycle_year=2021" }
+    let(:response) { double(code: code, body: ApiStubs::ApplyApi.applications) }
+
+    subject { described_class.call(changed_since: changed_since) }
+
+    before do
+      allow(Client).to receive(:get).with(expected_url).and_return(response)
+    end
+
+    describe "#call" do
+      context "when the response is success" do
+        let(:code) { 200 }
+
+        context "when no 'changed_since' is provided" do
+          before do
+            allow(Client).to receive(:get).with(expected_url).and_return(response)
+          end
+
+          it "logs the successful request" do
+            subject
+            request = ApplyApplicationSyncRequest.last
+            expect(request).to be_successful
+            expect(request.response_code).to eq code
+          end
+
+          it "returns all the Apply applications" do
+            expect(subject).to contain_exactly(ApiStubs::ApplyApi.application)
+          end
+
+          context "when there are no applications" do
+            let(:response) { double(code: code, body: { data: [] }.to_json) }
+
+            it "returns empty array" do
+              expect(subject).to eq []
+            end
+          end
+        end
+
+        context "when a 'changed_at' is provided" do
+          let(:changed_since) { Time.zone.now }
+          let(:expected_url) { "/applications?recruitment_cycle_year=2021&changed_since=#{changed_since}" }
+
+          it "includes the changed_at param in the request" do
+            expect(Client).to receive(:get).with(expected_url)
+            subject
+          end
+        end
+      end
+
+      context "when the response is error" do
+        let(:code) { 500 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:response) { double(code: code, body: body, headers: headers) }
+
+        it "raises a HttpError error and logs the unsuccessful response" do
+          expect {
+            subject
+          }.to raise_error(ApplyApi::RetrieveApplications::HttpError, "status: #{code}, body: #{body}, headers: #{headers}")
+
+          request = ApplyApplicationSyncRequest.last
+          expect(request).not_to be_successful
+          expect(request.response_code).to eq code
+        end
+      end
+    end
+  end
+end

--- a/spec/services/apply_api/retrieve_applications_spec.rb
+++ b/spec/services/apply_api/retrieve_applications_spec.rb
@@ -45,7 +45,8 @@ module ApplyApi
 
         context "when a 'changed_at' is provided" do
           let(:changed_since) { Time.zone.now }
-          let(:expected_url) { "/applications?recruitment_cycle_year=2021&changed_since=#{changed_since}" }
+          let(:expected_query) { { recruitment_cycle_year: 2021, changed_since: changed_since }.to_query }
+          let(:expected_url) { "/applications?#{expected_query}" }
 
           it "includes the changed_at param in the request" do
             expect(Client).to receive(:get).with(expected_url)

--- a/spec/support/api_stubs/apply_api.rb
+++ b/spec/support/api_stubs/apply_api.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module ApiStubs
+  module ApplyApi
+    def self.applications
+      { "data": [application] }.to_json
+    end
+
+    def self.application
+      {
+        "id": "3772",
+        "type": "application",
+        "attributes": {
+          "support_reference": "NV6357",
+          "status": "recruited",
+          "updated_at": "2020-06-17T09:05:53+01:00",
+          "submitted_at": "2020-06-11T15:54:15+01:00",
+          "recruited_at": "2020-06-17T09:05:53.165+01:00",
+          "candidate": {
+            "id": "C3134",
+            "first_name": "Martin",
+            "last_name": "Wells",
+            "date_of_birth": "1998-03-18",
+            "nationality": %w[GB],
+            "domicile": "XF",
+            "uk_residency_status": "UK Citizen",
+            "uk_residency_status_code": "A",
+            "fee_payer": "02",
+            "english_main_language": true,
+            "english_language_qualifications": "",
+            "other_languages": "I have a GCSE in French and have a Italian aunt - or should I say zia!",
+            "disability_disclosure": nil,
+            "gender": "",
+            "disabilities": [],
+            "ethnic_group": "",
+            "ethnic_background": "",
+          },
+          "contact_details": {
+            "phone_number": "07111999222",
+            "address_line1": "102 Keenan Drive",
+            "address_line2": "Bedworth",
+            "address_line3": "Coventry",
+            "address_line4": "Warwickshire",
+            "postcode": "CV12 0EJ",
+            "country": "GB",
+            "email": "martin.wells@mailinator.com",
+          },
+          "course": {
+            "recruitment_cycle_year": 2020,
+            "course_code": "V6X1",
+            "training_provider_code": "E84",
+            "site_code": "-",
+            "study_mode": "full_time",
+          },
+          "qualifications": {
+            "gcses": [
+              {
+                "id": 6244,
+                "qualification_type": "gcse",
+                "non_uk_qualification_type": nil,
+                "subject": "english",
+                "grade": "A",
+                "start_year": nil,
+                "award_year": "2013",
+                "institution_details": nil,
+                "equivalency_details": nil,
+                "comparable_uk_degree": nil,
+                "hesa_degtype": nil,
+                "hesa_degsbj": nil,
+                "hesa_degclss": nil,
+                "hesa_degest": nil,
+                "hesa_degctry": nil,
+                "hesa_degstdt": nil,
+                "hesa_degenddt": nil,
+              },
+            ],
+            "degrees": [
+              {
+                "id": 6242,
+                "qualification_type": "BA",
+                "non_uk_qualification_type": nil,
+                "subject": "Religious Studies",
+                "grade": "First class honours",
+                "start_year": nil,
+                "award_year": "2020",
+                "institution_details": "University of Warwick",
+                "equivalency_details": nil,
+                "comparable_uk_degree": nil,
+                "hesa_degtype": nil,
+                "hesa_degsbj": nil,
+                "hesa_degclss": "01",
+                "hesa_degest": nil,
+                "hesa_degctry": nil,
+                "hesa_degstdt": "-01-01",
+                "hesa_degenddt": "2020-01-01",
+              },
+            ],
+            "other_qualifications": [],
+            "missing_gcses_explanation": nil,
+          },
+          "hesa_itt_data": {},
+        },
+      }.to_json
+    end
+  end
+end

--- a/spec/support/api_stubs/apply_api.rb
+++ b/spec/support/api_stubs/apply_api.rb
@@ -46,7 +46,7 @@ module ApiStubs
             "email": "martin.wells@mailinator.com",
           },
           "course": {
-            "recruitment_cycle_year": 2020,
+            "recruitment_cycle_year": 2021,
             "course_code": "V6X1",
             "training_provider_code": "E84",
             "site_code": "-",


### PR DESCRIPTION
### Context

https://trello.com/c/xXqfjTsB/1241-l-retrieve-applications-from-apply

### Changes proposed in this pull request

#### New job - ApplyApi::ImportApplicationsJob
- This is a new job scheduled to run at 1am daily.
- It only runs if the `import_applications_from_apply` feature flag is turned on.
- If checks when the last successful sync with Apply happened, calls the `RetrieveApplications` to collect those applications, and iterates over them calling `ImportApplication` to create them.

#### New service - ApplyApi::RetrieveApplications
- This service takes a timestamp `accepted_since`, makes a request to retrieve all applications from Apply.
- It filters the returned json to include only those applications that have been accepted since the timestamp it was provided. It returns all applications if no timestamp is provided.
- It also logs the request (successful or not) by creating a `ApplyApplicationSyncRequest`.

#### New service - ApplyApi::ImportApplication
- This service takes a single application (probably returned from `RetrieveApplications`) and checks whether we have a matching provider.
- If no provider is found, it returns `nil`.
- If a provider is found, it saves the application by creating an `ApplyApplication`.

#### New model - ApplyApplication
- This is essentially a `jsonb` dump of the application as returned from the Apply endpoint, matched up to a provider.

#### New model - ApplyApplicationSyncRequest
- This is a log of every time we make a request to the Apply endpoint. We use this log to filter the applications we receive from the API to just the new applications i.e. everything since our last _successful_ request.

### Guidance to review
