### PR TITLE
[1276] Fix visual styling for default sort

### DIFF
--- a/app/components/trainees/sort_links/view.rb
+++ b/app/components/trainees/sort_links/view.rb
@@ -14,7 +14,7 @@ module Trainees
     private
 
       def default_sort_link(name, sort_by)
-        return tag.span(name, class: "app-sort-links__item") if params[:sort_by].nil?
+        return tag.span(name, class: "app-sort-links__item") if params[:sort_by].blank?
 
         sort_link(name, sort_by)
       end


### PR DESCRIPTION
### Context

- https://trello.com/b/BBEuhbHM/publish-register-sprint-board

### Changes proposed in this pull request

We implicitely default to sorting the trainee records by the date updated and on first visit, the sort link for this is shown as active. When you filter, it loses this styling even though the scope is still sorted by date updated.

This PR fixes the above. The component previously checked for `nil` which always built the default sort (`Date updated`) as a link. Changed to check with `blank?` as the query string IS in the url but it's empty.

<img width="1087" alt="Screenshot 2021-03-19 at 12 38 40" src="https://user-images.githubusercontent.com/616080/111780985-0be34f00-88b0-11eb-8f1b-14fa74c2f3eb.png">


### Guidance to review

Head to the trainee records, filter the results and assert the "Date updated" sort label is still shown as active.

