### PR TITLE
[1251] Change trainee ids to be alphanumeric

### DIFF
--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/SymbolProc
 FactoryBot.define do
   factory :abstract_trainee, class: Trainee do
     sequence :trainee_id do |n|
-      n.to_s
+      year = (course_start_date || Faker::Date.between(from: 10.years.ago, to: Time.zone.today)).strftime("%y").to_i
+
+      "#{year}/#{year + 1}-#{n}"
     end
 
     provider
@@ -182,5 +183,3 @@ FactoryBot.define do
     end
   end
 end
-
-# rubocop:enable Style/SymbolProc


### PR DESCRIPTION
Format is the shortened year plus a sequenced int
eg: 20/21-123

### Context
https://trello.com/c/yy8pnlTa/1251-s-change-data-used-in-seeds-for-trainee-ids-to-be-alphanumeric

### Changes proposed in this pull request

### Guidance to review
For manually checking this: run `bundle exec rake example_data:generate`
