### PR TITLE
[1309] Rename Provider-led to Provider-led (postgrad)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
   end
 
   def multiple_routes_enabled?
-    %w[routes_provider_led routes_early_years_undergrad].any? { |flag| FeatureService.enabled?(flag) }
+    %w[routes_provider_led_postgrad routes_early_years_undergrad].any? { |flag| FeatureService.enabled?(flag) }
   end
 
 private

--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -5,7 +5,7 @@ module Dttp
     module Routes
       MAPPING = {
         TRAINING_ROUTE_ENUMS[:assessment_only] => { entity_id: "99f435d5-a626-e711-80c8-0050568902d3" },
-        TRAINING_ROUTE_ENUMS[:provider_led] => { entity_id: "6189922e-acc2-e611-80be-00155d010316" },
+        TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => { entity_id: "6189922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:early_years_undergrad] => { entity_id: "6b89922e-acc2-e611-80be-00155d010316" },
       }.freeze
     end

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -6,13 +6,13 @@ class TrainingRouteManager
   end
 
   def requires_placement_details?
-    feature_enabled?(:routes_provider_led) && provider_led?
+    feature_enabled?(:routes_provider_led_postgrad) && provider_led_postgrad?
   end
 
 private
 
-  def provider_led?
-    training_route == TRAINING_ROUTE_ENUMS[:provider_led].to_sym
+  def provider_led_postgrad?
+    training_route == TRAINING_ROUTE_ENUMS[:provider_led_postgrad].to_sym
   end
 
   def assessment_only?

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -19,7 +19,7 @@ class Trainee < ApplicationRecord
 
   enum training_route: {
     TRAINING_ROUTE_ENUMS[:assessment_only] => 0,
-    TRAINING_ROUTE_ENUMS[:provider_led] => 1,
+    TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => 1,
     TRAINING_ROUTE_ENUMS[:early_years_undergrad] => 2,
   }
 

--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -2,12 +2,12 @@
 
   <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:assessment_only], label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
 
-  <% if FeatureService.enabled?("routes_early_years_undergrad") %>
+  <% if FeatureService.enabled?(:routes_early_years_undergrad) %>
     <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:early_years_undergrad], label: { text: t("activerecord.attributes.trainee.training_routes.early_years_undergrad") } %>
   <% end %>
 
-  <% if FeatureService.enabled?("routes_provider_led") %>
-    <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:provider_led], label: { text: t("activerecord.attributes.trainee.training_routes.provider_led") } %>
+  <% if FeatureService.enabled?(:routes_provider_led_postgrad) %>
+    <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:provider_led_postgrad], label: { text: t("activerecord.attributes.trainee.training_routes.provider_led_postgrad") } %>
   <% end %>
 
   <% if multiple_routes_enabled? %>

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -2,6 +2,6 @@
 
 TRAINING_ROUTE_ENUMS = {
   assessment_only: "assessment_only",
-  provider_led: "provider_led",
+  provider_led_postgrad: "provider_led_postgrad",
   early_years_undergrad: "early_years_undergrad",
 }.freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,7 +273,7 @@ en:
         trainee_id: "Trainee ID"
         training_routes:
           assessment_only: Assessment only
-          provider_led: Provider-led
+          provider_led_postgrad: Provider-led (postgrad)
           early_years_undergrad: Early years (undergrad)
         states:
           draft: Draft

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,7 +26,7 @@ features:
   enable_feedback_link: true
   basic_auth: true
   trainee_export: true
-  routes_provider_led: false
+  routes_provider_led_postgrad: false
   routes_early_years_undergrad: false
   import_courses_from_ttapi: false
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -9,7 +9,7 @@ features:
   use_dfe_sign_in: false
   basic_auth: false
   import_courses_from_ttapi: true
-  routes_provider_led: true
+  routes_provider_led_postgrad: true
   routes_early_years_undergrad: true
 
 pagination:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -12,7 +12,7 @@ dttp:
 features:
   home_text: true
   use_dfe_sign_in: false
-  routes_provider_led: true
+  routes_provider_led_postgrad: true
   routes_early_years_undergrad: true
 
 pagination:

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -5,7 +5,7 @@ features:
   home_text: true
   use_dfe_sign_in: false
   enable_feedback_link: true
-  routes_provider_led: true
+  routes_provider_led_postgrad: true
   routes_early_years_undergrad: true
 
 pagination:

--- a/spec/components/trainees/confirmation/placement_details/view_preview.rb
+++ b/spec/components/trainees/confirmation/placement_details/view_preview.rb
@@ -14,7 +14,7 @@ module Trainees
         def mock_trainee
           @mock_trainee ||= Trainee.new(
             id: 1,
-            training_route: TRAINING_ROUTE_ENUMS[:provider_led],
+            training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
           )
         end
       end

--- a/spec/components/trainees/confirmation/placement_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/placement_details/view_spec.rb
@@ -9,7 +9,7 @@ module Trainees
         alias_method :component, :page
 
         context "when data has not been provided" do
-          let(:trainee) { create(:trainee, :provider_led) }
+          let(:trainee) { create(:trainee, :provider_led_postgrad) }
 
           before do
             render_inline(View.new(trainee: trainee))

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -123,8 +123,8 @@ FactoryBot.define do
       outcome_date { Faker::Date.in_date_period }
     end
 
-    trait :provider_led do
-      training_route { "provider_led" }
+    trait :provider_led_postgrad do
+      training_route { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
     end
 
     trait :draft do

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -15,14 +15,14 @@ feature "Create trainee journey" do
     then_i_should_see_the_new_trainee_overview
   end
 
-  scenario "setting up an initial provider led record", feature_routes_provider_led: true do
-    and_i_select_provider_led_route
+  scenario "setting up an initial provider led record", feature_routes_provider_led_postgrad: true do
+    and_i_select_provider_led_postgrad_route
     and_i_save_the_form
     then_i_should_see_the_new_trainee_overview
   end
 
-  scenario "provider led radio button not shown when feature set to false", feature_routes_provider_led: false do
-    and_i_should_not_see_provider_led_route
+  scenario "provider led (postgrad) radio button not shown when feature set to false", feature_routes_provider_led_postgrad: false do
+    and_i_should_not_see_provider_led_postgrad_route
   end
 
   scenario "setting up an initial early years undergrad record", feature_routes_early_years_undergrad: true do
@@ -54,17 +54,17 @@ private
     new_trainee_page.assessment_only.click
   end
 
-  def and_i_select_provider_led_route
-    new_trainee_page.provider_led.click
+  def and_i_select_provider_led_postgrad_route
+    new_trainee_page.provider_led_postgrad.click
   end
 
   def and_i_select_early_years_undergrad_route
     new_trainee_page.early_years_undergrad.click
   end
 
-  def and_i_should_not_see_provider_led_route
+  def and_i_should_not_see_provider_led_postgrad_route
     expect(new_trainee_page).to be_displayed
-    expect(new_trainee_page).to_not have_provider_led
+    expect(new_trainee_page).to_not have_provider_led_postgrad
   end
 
   def and_i_should_not_see_early_years_undergrad_route

--- a/spec/features/trainees/edit_trainee_training_route_spec.rb
+++ b/spec/features/trainees/edit_trainee_training_route_spec.rb
@@ -16,11 +16,11 @@ feature "editing a trainee training route", type: :feature do
       and_current_training_route_should_be_selected
     end
 
-    scenario "editing a draft-trainee's current training route", feature_routes_provider_led: true do
-      then_i_select_provider_led
+    scenario "editing a draft-trainee's current training route", feature_routes_provider_led_postgrad: true do
+      then_i_select_provider_led_postgrad
       and_i_submit_the_new_route
       and_i_visit_the_edit_training_route_page
-      and_provider_led_should_be_selected
+      and_provider_led_postgrad_should_be_selected
     end
   end
 
@@ -45,15 +45,15 @@ private
     expect(trainee_edit_training_route_page.assessment_only).to be_checked
   end
 
-  def then_i_select_provider_led
-    trainee_edit_training_route_page.provider_led.click
+  def then_i_select_provider_led_postgrad
+    trainee_edit_training_route_page.provider_led_postgrad.click
   end
 
   def and_i_submit_the_new_route
     trainee_edit_training_route_page.continue_button.click
   end
 
-  def and_provider_led_should_be_selected
-    expect(trainee_edit_training_route_page.provider_led).to be_checked
+  def and_provider_led_postgrad_should_be_selected
+    expect(trainee_edit_training_route_page.provider_led_postgrad).to be_checked
   end
 end

--- a/spec/features/trainees/filtering_trainees_spec.rb
+++ b/spec/features/trainees/filtering_trainees_spec.rb
@@ -76,7 +76,7 @@ private
 
   def given_trainees_exist_in_the_system
     @assessment_only_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
-    @provider_led_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:provider_led])
+    @provider_led_postgrad_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
     @biology_trainee ||= create(:trainee, subject: "Biology")
     @history_trainee ||= create(:trainee, subject: "History")
     @searchable_trainee ||= create(:trainee, trn: "123")
@@ -133,12 +133,12 @@ private
 
   def then_only_assessment_only_trainees_are_visible
     expect(page).to have_text(full_name(@assessment_only_trainee))
-    expect(page).to_not have_text(full_name(@provider_led_trainee))
+    expect(page).to_not have_text(full_name(@provider_led_postgrad_trainee))
   end
 
-  def then_only_provider_led_trainees_are_visible
+  def then_only_provider_led_postgrad_trainees_are_visible
     expect(page).to_not have_text(full_name(@assessment_only_trainee))
-    expect(page).to have_text(full_name(@provider_led_trainee))
+    expect(page).to have_text(full_name(@provider_led_postgrad_trainee))
   end
 
   def then_only_biology_trainees_are_visible
@@ -150,7 +150,7 @@ private
     expect(page).to have_text(full_name(@biology_trainee))
     [
       @assessment_only_trainee,
-      @provider_led_trainee,
+      @provider_led_postgrad_trainee,
       @history_trainee,
       @searchable_trainee,
     ].each do |trainee|
@@ -162,7 +162,7 @@ private
     expect(page).to have_text(full_name(@searchable_trainee))
     [
       @assessment_only_trainee,
-      @provider_led_trainee,
+      @provider_led_postgrad_trainee,
       @history_trainee,
       @biology_trainee,
     ].each do |trainee|
@@ -186,7 +186,7 @@ private
 
   def then_i_see_my_trainee_search_results
     expect(csv_output).to include(@assessment_only_trainee.trainee_id)
-    expect(csv_output).to include(@provider_led_trainee.trainee_id)
+    expect(csv_output).to include(@provider_led_postgrad_trainee.trainee_id)
     expect(csv_output).to include(@biology_trainee.trainee_id)
     expect(csv_output).to include(@history_trainee.trainee_id)
   end
@@ -195,7 +195,7 @@ private
     expect(csv_output).to include(@biology_trainee.trainee_id)
 
     expect(csv_output).not_to include(@assessment_only_trainee.trainee_id)
-    expect(csv_output).not_to include(@provider_led_trainee.trainee_id)
+    expect(csv_output).not_to include(@provider_led_postgrad_trainee.trainee_id)
     expect(csv_output).not_to include(@searchable_trainee.trainee_id)
     expect(csv_output).not_to include(@history_trainee.trainee_id)
   end

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -6,13 +6,9 @@ describe TrainingRouteManager do
   subject { described_class.new(trainee) }
 
   describe "#requires_placement_details?" do
-    context "with the :routes_provider_led feature flag enabled" do
-      before do
-        allow(FeatureService).to receive(:enabled?).with(:routes_provider_led).and_return(true)
-      end
-
+    context "with the :routes_provider_led_postgrad feature flag enabled", feature_routes_provider_led_postgrad: true do
       context "with a provider-led trainee" do
-        let(:trainee) { build(:trainee, :provider_led) }
+        let(:trainee) { build(:trainee, :provider_led_postgrad) }
 
         it "returns true" do
           expect(subject.requires_placement_details?).to be true
@@ -28,12 +24,8 @@ describe TrainingRouteManager do
       end
     end
 
-    context "with the :routes_provider_led feature flag disabled" do
-      let(:trainee) { build(:trainee, :provider_led) }
-
-      before do
-        allow(FeatureService).to receive(:enabled?).with(:routes_provider_led).and_return(false)
-      end
+    context "with the :routes_provider_led_postgrad feature flag disabled", feature_routes_provider_led_postgrad: false do
+      let(:trainee) { build(:trainee, :provider_led_postgrad) }
 
       it "returns false" do
         expect(subject.requires_placement_details?).to be false

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -9,7 +9,7 @@ describe Trainee do
     it do
       is_expected.to define_enum_for(:training_route).with_values(
         TRAINING_ROUTE_ENUMS[:assessment_only] => 0,
-        TRAINING_ROUTE_ENUMS[:provider_led] => 1,
+        TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => 1,
         TRAINING_ROUTE_ENUMS[:early_years_undergrad] => 2,
       )
     end

--- a/spec/support/page_objects/trainees/edit_training_route.rb
+++ b/spec/support/page_objects/trainees/edit_training_route.rb
@@ -9,7 +9,7 @@ module PageObjects
 
       element :assessment_only, "#trainee-training-route-assessment-only-field"
 
-      element :provider_led, "#trainee-training-route-provider-led-field"
+      element :provider_led_postgrad, "#trainee-training-route-provider-led-postgrad-field"
 
       element :other, "#trainee-training-route-other-field"
 

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -21,7 +21,7 @@ module PageObjects
 
       element :text_search, "#text_search"
       element :assessment_only_checkbox, "#training_route-assessment_only"
-      element :provider_led_checkbox, "#training_route-provider_led"
+      element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"
       element :subject, "#subject"
 
       element :export_link, ".app-trainee-export"

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -8,7 +8,7 @@ module PageObjects
       element :page_heading, ".govuk-heading-xl"
 
       element :assessment_only, "#trainee-training-route-assessment-only-field"
-      element :provider_led, "#trainee-training-route-provider-led-field"
+      element :provider_led_postgrad, "#trainee-training-route-provider-led-postgrad-field"
       element :early_years_undergrad, "#trainee-training-route-early-years-undergrad-field"
       element :other, "#trainee-training-route-other-field"
 

--- a/spec/views/trainees/review_draft/show.html.erb_spec.rb
+++ b/spec/views/trainees/review_draft/show.html.erb_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe "trainees/review_draft/show.html.erb" do
   before do
-    allow(FeatureService).to receive(:enabled?).with(:routes_provider_led).and_return(true)
+    allow(FeatureService).to receive(:enabled?).with(:routes_provider_led_postgrad).and_return(true)
     assign(:trainee, trainee)
     render
   end
@@ -17,8 +17,8 @@ describe "trainees/review_draft/show.html.erb" do
     end
   end
 
-  context "with a Provider-led trainee" do
-    let(:trainee) { create(:trainee, :provider_led) }
+  context "with a Provider-led (postgrad) trainee" do
+    let(:trainee) { create(:trainee, :provider_led_postgrad) }
 
     it "renders the placement details component" do
       expect(rendered).to have_text("Placement details")

--- a/spec/views/trainees/show.html.erb_spec.rb
+++ b/spec/views/trainees/show.html.erb_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe "trainees/show.html.erb" do
   before do
-    allow(FeatureService).to receive(:enabled?).with(:routes_provider_led).and_return(true)
+    allow(FeatureService).to receive(:enabled?).with(:routes_provider_led_postgrad).and_return(true)
     assign(:trainee, trainee)
     render
   end
@@ -17,8 +17,8 @@ describe "trainees/show.html.erb" do
     end
   end
 
-  context "with a Provider-led trainee" do
-    let(:trainee) { create(:trainee, :provider_led) }
+  context "with a Provider-led (postgrad) trainee" do
+    let(:trainee) { create(:trainee, :provider_led_postgrad) }
 
     it "renders the placement details component" do
       expect(rendered).to have_text("Placement details")


### PR DESCRIPTION
### Context

https://trello.com/c/tLSW3ieX/1309-s-rename-providerled-to-providerledpostgrad

### Changes proposed in this pull request

Rename all instances of `provider_led` to `provider_led_postgrad` and all strings to "Provider-led (postgrad)" (via locales).

Since there will be other routes which start with `provider_led`, we've done a 'full' rename in the code rather than just changing the translation to fix things visually.

### Guidance to review

🚢 