### PR TITLE
[1304] Fix diversities confirmation bug

### DIFF
--- a/app/components/task_list/view.rb
+++ b/app/components/task_list/view.rb
@@ -16,7 +16,7 @@ private
   end
 
   class Row < GovukComponent::Slot
-    attr_accessor :task_name, :status
+    attr_accessor :task_name, :status, :path, :confirm_path
 
     def initialize(task_name:, path:, confirm_path: nil, status:, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
@@ -28,9 +28,9 @@ private
     end
 
     def get_path
-      return @path unless @confirm_path
+      return path unless confirm_path
 
-      status == Progress::STATUSES[:not_started] ? @path : @confirm_path
+      status == Progress::STATUSES[:not_started] ? path : confirm_path
     end
 
     def get_status_colour

--- a/app/forms/diversities/disclosure_form.rb
+++ b/app/forms/diversities/disclosure_form.rb
@@ -42,6 +42,10 @@ module Diversities
       diversity_disclosure == Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed]
     end
 
+    def diversity_not_disclosed?
+      diversity_disclosure == Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed]
+    end
+
   private
 
     attr_reader :store

--- a/app/forms/diversity_form.rb
+++ b/app/forms/diversity_form.rb
@@ -53,6 +53,10 @@ class DiversityForm
     @ethnic_group_form.ethnic_group
   end
 
+  def ethnic_group_provided?
+    !@ethnic_group_form.not_provided_ethnic_group?
+  end
+
   def ethnic_background
     @ethnic_background_form.ethnic_background
   end

--- a/app/forms/diversity_form.rb
+++ b/app/forms/diversity_form.rb
@@ -21,6 +21,22 @@ class DiversityForm
     ]
   end
 
+  def diversity_disclosure
+    @disclosure_form.diversity_disclosure
+  end
+
+  def diversity_disclosed?
+    @disclosure_form.diversity_disclosed?
+  end
+
+  def diversity_not_disclosed?
+    @disclosure_form.diversity_not_disclosed?
+  end
+
+  def disability_disclosure
+    @disability_disclosure_form.disability_disclosure
+  end
+
   def disabled?
     @disability_disclosure_form.disabled?
   end
@@ -31,14 +47,6 @@ class DiversityForm
 
   def disabilities
     @disability_detail_form.disabilities
-  end
-
-  def diversity_disclosure
-    @disclosure_form.diversity_disclosure
-  end
-
-  def diversity_disclosed?
-    @disclosure_form.diversity_disclosed?
   end
 
   def ethnic_group

--- a/app/helpers/diversities_helper.rb
+++ b/app/helpers/diversities_helper.rb
@@ -13,11 +13,21 @@ module DiversitiesHelper
     options.reject { |option| option == Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] }
   end
 
-  def back_link(trainee)
-    if trainee.ethnic_group.blank? || trainee.ethnic_background.blank?
+  def diversity_confirm_path(trainee)
+    diversity_form = DiversityForm.new(trainee)
+
+    return trainee_diversity_confirm_path(trainee) unless diversity_form.diversity_disclosed?
+
+    if diversity_form.ethnic_group.nil?
       edit_trainee_diversity_ethnic_group_path(trainee)
-    else
+    elsif diversity_form.ethnic_group_provided? && diversity_form.ethnic_background.nil?
       edit_trainee_diversity_ethnic_background_path(trainee)
+    elsif diversity_form.disability_disclosure.nil?
+      edit_trainee_diversity_disability_disclosure_path(trainee)
+    elsif diversity_form.disabilities.empty?
+      edit_trainee_diversity_disability_detail_path(trainee)
+    else
+      trainee_diversity_confirm_path(trainee)
     end
   end
 end

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -51,7 +51,7 @@
             :row,
             task_name: "Diversity information",
             path: edit_trainee_diversity_disclosure_path(@trainee),
-            confirm_path: trainee_diversity_confirm_path(@trainee),
+            confirm_path: diversity_confirm_path(@trainee),
             classes: "diversity-details",
             status: ProgressService.call(
               validator: Diversities::FormValidator.new(@trainee),

--- a/spec/components/trainees/confirmation/reinstatement_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/reinstatement_details/view_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Trainees::Confirmation::ReinstatementDetails::View do
   alias_method :component, :page
 
   let(:trainee) { build(:trainee, :reinstated, id: 1) }
-  let(:data_model) { OpenStruct.new(trainee: trainee, date: trainee.defer_date) }
+  let(:data_model) { OpenStruct.new(trainee: trainee, date: trainee.reinstate_date) }
 
   before do
     render_inline(described_class.new(data_model))

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     ethnic_group { Diversities::ETHNIC_GROUP_ENUMS.values.sample }
     ethnic_background { nil }
     additional_ethnic_background { nil }
-    disability_disclosure { (Diversities::DISABILITY_DISCLOSURE_ENUMS.values - %w[disabled]) .sample }
+    disability_disclosure { (Diversities::DISABILITY_DISCLOSURE_ENUMS.values - %w[disabled]).sample }
 
     address_line_one { Faker::Address.street_address }
     address_line_two { Faker::Address.street_name }
@@ -104,11 +104,14 @@ FactoryBot.define do
 
     trait :diversity_disclosed do
       diversity_disclosure { Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed] }
-      ethnic_background { Dttp::CodeSets::Ethnicities::MAPPING.keys.sample }
     end
 
     trait :diversity_not_disclosed do
       diversity_disclosure { Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed] }
+    end
+
+    trait :with_ethnic_background do
+      ethnic_background { Dttp::CodeSets::Ethnicities::MAPPING.keys.sample }
     end
 
     trait :disabled do

--- a/spec/features/trainees/diversities/edit_disabilities_spec.rb
+++ b/spec/features/trainees/diversities/edit_disabilities_spec.rb
@@ -25,7 +25,7 @@ feature "edit disability details", type: :feature do
   end
 
   def given_a_disabled_trainee_exists
-    given_a_trainee_exists(:disabled)
+    given_a_trainee_exists(:diversity_disclosed, :disabled)
   end
 
   def and_disabilities_exist_in_the_system

--- a/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
@@ -5,24 +5,8 @@ require "rails_helper"
 feature "edit disability disclosure", type: :feature do
   background do
     given_i_am_authenticated
-    given_a_trainee_exists(disability_disclosure: nil)
-    given_i_visited_the_review_draft_page
+    given_a_trainee_exists_with_no_disability_disclosure
     and_i_am_on_the_disability_disclosure_page
-  end
-
-  scenario "choosing to disclose a disability" do
-    and_i_choose_to_disclose
-    and_i_submit_the_form
-    then_i_am_redirected_to_the_disabilities_page
-    and_the_disability_disclosure_is_updated
-  end
-
-  scenario "choosing not to disclose a disability" do
-    and_i_choose_not_to_disclose
-    and_i_submit_the_form
-    and_confirm_my_details
-    then_i_am_redirected_to_the_review_draft_page
-    and_the_disability_disclosure_is_updated
   end
 
   scenario "submitting with no option selected" do
@@ -30,7 +14,24 @@ feature "edit disability disclosure", type: :feature do
     then_i_see_error_messages
   end
 
+  scenario "choosing to disclose a disability" do
+    and_i_choose_to_disclose
+    and_i_submit_the_form
+    then_i_am_redirected_to_the_disabilities_page
+  end
+
+  scenario "choosing not to disclose a disability" do
+    and_i_choose_not_to_disclose
+    and_i_submit_the_form
+    and_confirm_my_details
+    then_i_am_redirected_to_the_review_draft_page
+  end
+
 private
+
+  def given_a_trainee_exists_with_no_disability_disclosure
+    given_a_trainee_exists(:diversity_disclosed, disability_disclosure: nil)
+  end
 
   def and_i_am_on_the_disability_disclosure_page
     disability_disclosure_page.load(id: trainee.slug)
@@ -49,16 +50,11 @@ private
   end
 
   def and_confirm_my_details
-    expect(diversities_confirm_page).to be_displayed(id: trainee.slug)
     diversities_confirm_page.submit_button.click
   end
 
   def then_i_am_redirected_to_the_disabilities_page
     expect(disabilities_page).to be_displayed(id: trainee.slug)
-  end
-
-  def and_the_disability_disclosure_is_updated
-    expect(trainee.reload.disability_disclosure).to be_truthy
   end
 
   def then_i_see_error_messages

--- a/spec/features/trainees/diversities/edit_ethnic_background_spec.rb
+++ b/spec/features/trainees/diversities/edit_ethnic_background_spec.rb
@@ -39,12 +39,11 @@ feature "edit ethnic background", type: :feature do
   end
 
   def given_a_trainee_exists(group = Diversities::ETHNIC_GROUP_ENUMS[:asian])
-    @trainee = create(:trainee, ethnic_group: group, provider: current_user.provider)
+    @trainee = create(:trainee, :diversity_disclosed, ethnic_group: group, provider: current_user.provider)
   end
 
   def with_an_additional_background_provided
-    @trainee.ethnic_background = Diversities::NOT_PROVIDED
-    @trainee.additional_ethnic_background = "some background"
+    @trainee.update(ethnic_background: Diversities::NOT_PROVIDED, additional_ethnic_background: "some background")
   end
 
   def when_i_visit_the_diversity_ethnic_background_page

--- a/spec/features/trainees/diversities/edit_ethnic_group_spec.rb
+++ b/spec/features/trainees/diversities/edit_ethnic_group_spec.rb
@@ -63,12 +63,13 @@ feature "edit ethnic group", type: :feature do
   end
 
   def given_a_trainee_exists
-    @trainee = create(:trainee, ethnic_group: nil, provider: current_user.provider)
+    @trainee = create(:trainee, :diversity_disclosed, ethnic_group: nil, provider: current_user.provider)
   end
 
   def given_a_trainee_with_a_background_exists
     @trainee = create(
       :trainee,
+      :diversity_disclosed,
       ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:mixed],
       ethnic_background: Diversities::BACKGROUNDS[Diversities::ETHNIC_GROUP_ENUMS[:mixed]].sample,
       provider: current_user.provider,

--- a/spec/features/trainees/diversities/edit_ethnic_group_spec.rb
+++ b/spec/features/trainees/diversities/edit_ethnic_group_spec.rb
@@ -41,17 +41,6 @@ feature "edit ethnic group", type: :feature do
     end
   end
 
-  scenario "updating the ethnic group clears the previous ethnic background" do
-    given_a_trainee_with_a_background_exists
-    and_i_am_on_the_diversity_ethnic_group_page
-    and_i_choose_the_asian_option
-    and_i_submit_the_form
-    then_i_am_redirected_to_the_ethnic_background_page
-    and_the_diversity_ethnic_group_is_updated_with_asian
-    and_the_previous_ethnic_background_is_cleared
-    and_i_see_ethnic_background_options_for_the_selected_group
-  end
-
   scenario "choosing not to provide ethnic group" do
     given_a_trainee_exists
     given_i_visited_the_diversities_confirm_page_page

--- a/spec/forms/diversities/disability_detail_form_spec.rb
+++ b/spec/forms/diversities/disability_detail_form_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Diversities
   describe DisabilityDetailForm, type: :model do
-    let(:trainee) { build(:trainee, :disabled) }
+    let(:trainee) { build(:trainee, :disabled, :diversity_disclosed) }
 
     subject { described_class.new(trainee) }
 

--- a/spec/forms/diversities/disability_disclosure_form_spec.rb
+++ b/spec/forms/diversities/disability_disclosure_form_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Diversities
   describe DisabilityDisclosureForm, type: :model do
     let(:params) { {} }
-    let(:trainee) { create(:trainee) }
+    let(:trainee) { create(:trainee, :diversity_disclosed) }
     let(:form_store) { class_double(FormStore) }
 
     subject { described_class.new(trainee, params, form_store) }
@@ -33,7 +33,7 @@ module Diversities
     end
 
     describe "#save!" do
-      let(:trainee) { create(:trainee, :not_started) }
+      let(:trainee) { create(:trainee, :not_started, :diversity_disclosed) }
       let(:disability_not_provided) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] }
 
       before do

--- a/spec/forms/diversities/ethnic_background_form_spec.rb
+++ b/spec/forms/diversities/ethnic_background_form_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Diversities
   describe EthnicBackgroundForm, type: :model do
     let(:params) { {} }
-    let(:trainee) { create(:trainee, :diversity_disclosed) }
+    let(:trainee) { create(:trainee, :diversity_disclosed, :with_ethnic_background) }
     let(:form_store) { class_double(FormStore) }
 
     subject { described_class.new(trainee, params, form_store) }

--- a/spec/forms/diversities/ethnic_group_form_spec.rb
+++ b/spec/forms/diversities/ethnic_group_form_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Diversities
   describe EthnicGroupForm, type: :model do
     let(:params) { {} }
-    let(:trainee) { create(:trainee) }
+    let(:trainee) { create(:trainee, :diversity_disclosed, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:asian]) }
     let(:form_store) { class_double(FormStore) }
 
     subject { described_class.new(trainee, params, form_store) }

--- a/spec/forms/diversity_form_spec.rb
+++ b/spec/forms/diversity_form_spec.rb
@@ -7,6 +7,21 @@ describe DiversityForm, type: :model do
 
   subject { described_class.new(trainee) }
 
+  describe "#diversity_disclosure" do
+    before do
+      allow(Diversities::EthnicBackgroundForm).to receive(:new) # form also calls diversity_disclosure() on initialisation
+      allow(Diversities::DisabilityDisclosureForm).to receive(:new) # form also calls diversity_disclosure() on initialisation
+      allow(Diversities::DisabilityDetailForm).to receive(:new) # form also calls diversity_disclosure() on initialisation
+      allow(Diversities::EthnicGroupForm).to receive(:new) # form also calls diversity_disclosure() on initialisation
+    end
+
+    it "delegates to Diversities::DisclosureForm#diversity_disclosure" do
+      expect_any_instance_of(Diversities::DisclosureForm).to receive(:diversity_disclosure)
+
+      subject.diversity_disclosure
+    end
+  end
+
   describe "#disabled?" do
     before do
       allow(Diversities::DisabilityDetailForm).to receive(:new) # form also calls disabled?() on initialisation
@@ -32,14 +47,6 @@ describe DiversityForm, type: :model do
       expect_any_instance_of(Diversities::DisabilityDetailForm).to receive(:disabilities)
 
       subject.disabilities
-    end
-  end
-
-  describe "#diversity_disclosure" do
-    it "delegates to Diversities::DisclosureForm#diversity_disclosure" do
-      expect_any_instance_of(Diversities::DisclosureForm).to receive(:diversity_disclosure)
-
-      subject.diversity_disclosure
     end
   end
 

--- a/spec/helpers/diversities_helper_spec.rb
+++ b/spec/helpers/diversities_helper_spec.rb
@@ -5,28 +5,83 @@ require "rails_helper"
 describe DiversitiesHelper do
   include DiversitiesHelper
 
-  describe "#back_link" do
-    context "trainee with ethic group" do
-      subject do
-        helper.back_link(trainee)
-      end
-      let(:trainee) do
-        create(:trainee,
-               ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:not_provided])
-      end
-      it "return correct path" do
-        expect(subject).to eq edit_trainee_diversity_ethnic_group_path(trainee)
-      end
-      context "with ethic background" do
-        let(:trainee) do
-          asian = Diversities::ETHNIC_GROUP_ENUMS[:asian]
+  let(:trainee) { build(:trainee) }
 
-          create(:trainee,
-                 ethnic_group: asian,
-                 ethnic_background: Diversities::BACKGROUNDS[asian].sample)
+  subject { helper.diversity_confirm_path(trainee) }
+
+  before do
+    allow(DiversityForm).to receive(:new).and_return(diversity_form)
+  end
+
+  describe "#diversity_confirm_path" do
+    context "diversity is not disclosed" do
+      let(:diversity_form) { double(diversity_disclosed?: false) }
+
+      it "returns the path to diversity confirm page" do
+        expect(subject).to eq(trainee_diversity_confirm_path(trainee))
+      end
+    end
+
+    context "diversity is disclosed" do
+      context "ethnic group not specified" do
+        let(:diversity_form) { double(diversity_disclosed?: true, ethnic_group: nil) }
+
+        it "returns the path to the ethnic group page" do
+          expect(subject).to eq(edit_trainee_diversity_ethnic_group_path(trainee))
         end
-        it "return correct path" do
-          expect(subject).to eq edit_trainee_diversity_ethnic_background_path(trainee)
+      end
+
+      context "ethnic group specified but ethnic background is not" do
+        let(:diversity_form) do
+          double(diversity_disclosed?: true, ethnic_group: :mixed, ethnic_group_provided?: true, ethnic_background: nil)
+        end
+
+        it "returns the path to the ethnic background page" do
+          expect(subject).to eq(edit_trainee_diversity_ethnic_background_path(trainee))
+        end
+      end
+
+      context "ethnic group and background are specified" do
+        let(:diversity_form) do
+          double(diversity_disclosed?: true,
+                 ethnic_group: :mixed,
+                 ethnic_group_provided?: true,
+                 ethnic_background: :not_provided,
+                 disability_disclosure: nil)
+        end
+
+        it "returns the path to the disability disclosure page" do
+          expect(subject).to eq(edit_trainee_diversity_disability_disclosure_path(trainee))
+        end
+      end
+
+      context "ethnic group and background are specified" do
+        let(:diversity_form) do
+          double(diversity_disclosed?: true,
+                 ethnic_group: :mixed,
+                 ethnic_group_provided?: true,
+                 ethnic_background: :not_provided,
+                 disability_disclosure: :disabled,
+                 disabilities: [])
+        end
+
+        it "returns the path to the disability details page" do
+          expect(subject).to eq(edit_trainee_diversity_disability_detail_path(trainee))
+        end
+      end
+
+      context "all diversity information has been entered" do
+        let(:diversity_form) do
+          double(diversity_disclosed?: true,
+                 ethnic_group: :mixed,
+                 ethnic_group_provided?: true,
+                 ethnic_background: :not_provided,
+                 disability_disclosure: :disabled,
+                 disabilities: [Disability.new])
+        end
+
+        it "returns the path to the diversity confirm page" do
+          expect(subject).to eq(trainee_diversity_confirm_path(trainee))
         end
       end
     end


### PR DESCRIPTION
### Context
https://trello.com/c/2JyE3W7F/1304-fix-diversities-bug

### Changes proposed in this pull request
- A new helper method to compute the correct path for the "Diversity information" link on the review draft page. It ensures the user finishes what they started
- Updated the diversity forms so that they know how to wipe all the data from the DB if the user decides to change their mind and not disclose diversity information later on
- Fix an unrelated Capybara warning

### Guidance to review
#### Diversities Bug
- Create a new trainee
- Click the diversity information link
- Choose "Yes" to share diversity information
- Go back to the revew draft page
- Click the diversity information link
- You should now be directly taken to the last page you didn't enter and submit any information
- Try this out on a number of diversity form pages

####  Diversities form validation
- Click the diversity information link and enter all the ethnicity and disability information
- Go back and change diversity disclosure to not share
- All the previous data should be wiped from the DB. To confirm, enter ethnicity and disability information again and notice that forms have no preselected values anymore.