### PR TITLE
[1329] Retrieve and store publish subjects

### DIFF
--- a/app/jobs/teacher_training_api/import_courses_job.rb
+++ b/app/jobs/teacher_training_api/import_courses_job.rb
@@ -7,9 +7,9 @@ module TeacherTrainingApi
     def perform
       return unless FeatureService.enabled?("import_courses_from_ttapi")
 
-      Provider.all.each do |provider|
-        ImportProviderCoursesJob.perform_later(provider)
-      end
+      RetrieveSubjects.call.each { |s| ImportSubject.call(subject: s) }
+
+      Provider.all.each { |p| ImportProviderCoursesJob.perform_later(p) }
     end
   end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Subject < ApplicationRecord
+  validates :code, presence: true, uniqueness: true
+  validates :name, presence: true
+end

--- a/app/services/teacher_training_api/import_subject.rb
+++ b/app/services/teacher_training_api/import_subject.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module TeacherTrainingApi
+  class ImportSubject
+    include ServicePattern
+
+    def initialize(subject:)
+      @attrs = subject["attributes"]
+    end
+
+    def call
+      return unless code
+
+      subject.update!(name: attrs["name"])
+    end
+
+  private
+
+    attr_reader :attrs
+
+    def subject
+      @subject ||= Subject.find_or_initialize_by(code: code)
+    end
+
+    def code
+      @code ||= attrs["code"]
+    end
+  end
+end

--- a/app/services/teacher_training_api/retrieve_subjects.rb
+++ b/app/services/teacher_training_api/retrieve_subjects.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
 module TeacherTrainingApi
-  class RetrieveCourses
+  class RetrieveSubjects
     include ServicePattern
 
     class Error < StandardError; end
-
-    def initialize(provider:)
-      @provider = provider
-    end
 
     def call
       if response.code != 200
@@ -20,11 +16,8 @@ module TeacherTrainingApi
 
   private
 
-    attr_reader :provider
-
-    # TODO: Make the recruitment cycle dynamic once we have a concept of cycles.
     def response
-      @response ||= Client.get("/recruitment_cycles/2021/providers/#{provider.code}/courses")
+      @response ||= Client.get("/subjects")
     end
   end
 end

--- a/db/migrate/20210324095637_create_subjects.rb
+++ b/db/migrate/20210324095637_create_subjects.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateSubjects < ActiveRecord::Migration[6.1]
+  def change
+    create_table :subjects do |t|
+      t.string :code, null: false, index: { unique: true }
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_15_141417) do
+ActiveRecord::Schema.define(version: 2021_03_24_095637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,6 +109,14 @@ ActiveRecord::Schema.define(version: 2021_03_15_141417) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
+  create_table "subjects", force: :cascade do |t|
+    t.string "code", null: false
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["code"], name: "index_subjects_on_code", unique: true
   end
 
   create_table "trainee_disabilities", force: :cascade do |t|

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subject do
+    sequence(:name) { |c| "Subject #{c}" }
+    code { Faker::Alphanumeric.alphanumeric(number: 2).upcase }
+  end
+end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -162,6 +162,7 @@ FactoryBot.define do
 
     trait :reinstated do
       state { "trn_received" }
+      defer_date { Faker::Date.in_date_period }
       reinstate_date { Faker::Date.in_date_period }
     end
 

--- a/spec/jobs/teacher_training_api/import_courses_job_spec.rb
+++ b/spec/jobs/teacher_training_api/import_courses_job_spec.rb
@@ -6,12 +6,22 @@ module TeacherTrainingApi
   describe ImportCoursesJob do
     include ActiveJob::TestHelper
 
+    let(:subject) { double }
+
     before do
+      allow(ImportSubject).to receive(:call).with(subject: subject).and_return(true)
+      allow(RetrieveSubjects).to receive(:call).and_return([subject])
+
       create_list(:provider, 2)
       described_class.perform_now
     end
 
     context "when the feature flag is turned on", feature_import_courses_from_ttapi: true do
+      it "retrieves all the subjects" do
+        expect(RetrieveSubjects).to have_received(:call)
+        expect(ImportSubject).to have_received(:call).with(subject: subject)
+      end
+
       it "queues up a job to import courses for each provider" do
         Provider.all.each do |provider|
           expect(ImportProviderCoursesJob).to have_been_enqueued.with(provider)

--- a/spec/services/teacher_training_api/import_subject_spec.rb
+++ b/spec/services/teacher_training_api/import_subject_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module TeacherTrainingApi
+  describe ImportSubject do
+    describe "#call" do
+      let(:api_subject) { JSON(ApiStubs::TeacherTrainingApi.subject) }
+      let(:code) { api_subject["attributes"]["code"] }
+      let(:name) { api_subject["attributes"]["name"] }
+
+      subject { described_class.call(subject: api_subject) }
+
+      context "when the subject code does not exist in register" do
+        it "create a subject with the correct code and name" do
+          subject
+          expect(Subject.find_by(code: code, name: name)).to_not be_nil
+        end
+      end
+
+      context "when the subject code already exists" do
+        context "with the same name" do
+          before { create(:subject, code: code, name: name) }
+
+          it "does not create a duplicate subject" do
+            expect { subject }.not_to(change { Subject.count })
+          end
+        end
+
+        context "with a different name" do
+          before { create(:subject, code: code) }
+
+          it "updates the name" do
+            subject
+            expect(Subject.find_by(code: code).name).to eq name
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/teacher_training_api/retrieve_courses_spec.rb
+++ b/spec/services/teacher_training_api/retrieve_courses_spec.rb
@@ -26,10 +26,10 @@ module TeacherTrainingApi
         let(:headers) { { foo: "bar" } }
         let(:response) { double(code: status, body: body, headers: headers) }
 
-        it "raises a HttpError error with the response body as the message" do
+        it "raises a Error error with the response body as the message" do
           expect {
             described_class.call(provider: provider)
-          }.to raise_error(TeacherTrainingApi::RetrieveCourses::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
+          }.to raise_error(TeacherTrainingApi::RetrieveCourses::Error, "status: #{status}, body: #{body}, headers: #{headers}")
         end
       end
     end

--- a/spec/services/teacher_training_api/retrieve_subjects_spec.rb
+++ b/spec/services/teacher_training_api/retrieve_subjects_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module TeacherTrainingApi
+  describe RetrieveSubjects do
+    describe "#call" do
+      before do
+        allow(Client).to receive(:get).with("/subjects").and_return(response)
+      end
+
+      context "when the response is success" do
+        let(:response) { double(code: 200, body: ApiStubs::TeacherTrainingApi.subjects) }
+
+        it "returns the subjects in full" do
+          expect(described_class.call).to eq JSON(response.body)["data"]
+        end
+      end
+
+      context "when the response is error" do
+        let(:status) { 404 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:response) { double(code: status, body: body, headers: headers) }
+
+        it "raises an Error error with the response body as the message" do
+          expect {
+            described_class.call
+          }.to raise_error(TeacherTrainingApi::RetrieveSubjects::Error, "status: #{status}, body: #{body}, headers: #{headers}")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/api_stubs/teacher_training_api.rb
+++ b/spec/support/api_stubs/teacher_training_api.rb
@@ -2,6 +2,27 @@
 
 module ApiStubs
   module TeacherTrainingApi
+    def self.subjects
+      { "data": [subject] }.to_json
+    end
+
+    def self.subject(attrs = {})
+      s = {
+        "id": "3",
+        "type": "subjects",
+        "attributes": {
+          "name": "Primary with science",
+          "code": "07",
+          "bursary_amount": "9000",
+          "early_career_payments": "8388",
+          "scholarship": "3500",
+          "subject_knowledge_enhancement_course_available": true,
+        },
+      }
+      attrs.each { |k, v| s[:attributes][k] = v }
+      s.to_json
+    end
+
     def self.courses
       { "data": [course] }.to_json
     end


### PR DESCRIPTION
### Context

https://trello.com/c/nJHVsjt5/1329-s-store-a-local-list-of-publish-subjects

### Changes proposed in this pull request

This PR creates the following new services:

1. `TeacherTrainingApi::RetrieveSubjects` which gets all subjects from the API on `/subjects`
2. `TeacherTrainingApi::ImportSubject` which takes a subject as returned from `RetrieveSubjects` and stores a `Subject` locally (name and code). If we already have a subject with that code, we update the name.

This PR also includes the new model `Subject` and the associated migration. Attribute `code` is unique.

The new services are called from within `TeacherTrainingApi::ImportCoursesJob`, right before we fetch the courses. We need to ensure we have the most up to date list before calling the `ImportProviderCoursesJob`, since courses are soon to be joined up to subjects.

### Guidance to review

From rails console, run:

```
RetrieveSubjects.call.each { |s| ImportSubject.call(subject: s) }
```

- Run it a second time and check that subjects aren't duplicated
- Change the name of a subject locally, run it a third time, and check that the subject's name is updated