### PR TITLE
[1356] Fix ethnic background bug

### DIFF
--- a/app/lib/dttp/params/contact.rb
+++ b/app/lib/dttp/params/contact.rb
@@ -62,7 +62,7 @@ module Dttp
       end
 
       def contact_dttp_ethnicity_id
-        dttp_ethnicity_id(diversity_disclosed? ? trainee.ethnic_background : Diversities::NOT_PROVIDED)
+        dttp_ethnicity_id(diversity_disclosed? ? resolve_ethnicity_value : Diversities::NOT_PROVIDED)
       end
 
       def contact_dttp_disability_id
@@ -94,6 +94,12 @@ module Dttp
         british_or_irish = ->(nationality) { nationality == CodeSets::Nationalities::BRITISH || CodeSets::Nationalities::IRISH }
 
         (nationalities.select(&british_or_irish).presence || nationalities).first
+      end
+
+      def resolve_ethnicity_value
+        return Diversities::NOT_PROVIDED if trainee.not_provided_ethnic_group?
+
+        trainee.ethnic_background
       end
     end
   end

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -19,7 +19,7 @@
   <%= render FormComponents::Autocomplete::View.new(
     form_field: f.govuk_collection_select(:uk_degree, hesa_degree_types_options, :option_value, :option_name,
                                           label: { text: "Type of degree", size: "s" },
-                                          hint: { text: "For example, BA, BSc or other (please specify)"}),
+                                          hint: { text: "For example, BA, BSc or other (please specify)" }),
     html_attributes: {
       "data-show-all-values" => true,
     },

--- a/spec/lib/dttp/params/contact_spec.rb
+++ b/spec/lib/dttp/params/contact_spec.rb
@@ -98,7 +98,11 @@ module Dttp
             context "ethnicity information" do
               let(:trainee) { create(:trainee, :completed, :diversity_disclosed, ethnic_background: ethnic_background) }
 
-              context "provided" do
+              context "ethnic background provided" do
+                before do
+                  trainee.ethnic_group = Diversities::ETHNIC_GROUP_ENUMS[:white]
+                end
+
                 let(:ethnic_background) { Diversities::IRISH }
 
                 it "returns a hash with a foreign key of DTTP's 'Irish' ethnicity entity" do
@@ -106,8 +110,21 @@ module Dttp
                 end
               end
 
-              context "not provided" do
+              context "ethnic background not provided" do
                 let(:ethnic_background) { Diversities::NOT_PROVIDED }
+
+                it "returns a hash with a foreign of DTTP's 'Not known' ethnicity entity" do
+                  expect(subject).to include(ethnicity_param)
+                end
+              end
+
+              context "ethnic group not provided" do
+                let(:dttp_ethnicity_entity_id) { Dttp::CodeSets::Ethnicities::MAPPING[Diversities::NOT_PROVIDED][:entity_id] }
+                let(:ethnic_background) { nil }
+
+                before do
+                  trainee.ethnic_group = Diversities::ETHNIC_GROUP_ENUMS[:not_provided]
+                end
 
                 it "returns a hash with a foreign of DTTP's 'Not known' ethnicity entity" do
                   expect(subject).to include(ethnicity_param)


### PR DESCRIPTION
### Context

- https://trello.com/c/tSK65Pzc/1356-ethnic-background-bug

### Changes proposed in this pull request

Fixes this sentry error https://sentry.io/organizations/dfe-bat/issues/2198667894/?project=5552118&referrer=slack

### Guidance to review

- You can just test the service that calls DTTP for this PR as the issue was that a `nil` value was being sent
- Prepare a trainee to be submitted but choose not provided for the ethnic group.
- Fire the service manually `Dttp::RegisterForTrn.call(trainee: trainee, trainee_creator_dttp_id: trainee_creator_dttp_id)` in your console and assert this method https://github.com/DFE-Digital/register-trainee-teachers/blob/master/app/lib/dttp/params/contact.rb#L64 returns an entity id and not `nil`
