### PR TITLE
[1368] Refactor job params to be consistent

### DIFF
--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -13,7 +13,7 @@ module Trainees
       if deferral.save!
         trainee.defer!
 
-        DeferJob.perform_later(trainee.id)
+        DeferJob.perform_later(trainee)
 
         flash[:success] = "Trainee deferred"
         redirect_to trainee_path(trainee)

--- a/app/controllers/trainees/confirm_reinstatements_controller.rb
+++ b/app/controllers/trainees/confirm_reinstatements_controller.rb
@@ -13,7 +13,7 @@ module Trainees
       if reinstatement.save!
         trainee.trn.present? ? trainee.trn_received! : trainee.submit_for_trn!
 
-        ReinstateJob.perform_later(trainee.id)
+        ReinstateJob.perform_later(trainee)
 
         flash[:success] = "Trainee reinstated"
         redirect_to trainee_path(trainee)

--- a/app/controllers/trainees/confirm_withdrawals_controller.rb
+++ b/app/controllers/trainees/confirm_withdrawals_controller.rb
@@ -12,7 +12,7 @@ module Trainees
     def update
       if withdrawal.save!
         trainee.withdraw!
-        WithdrawJob.perform_later(trainee.id)
+        WithdrawJob.perform_later(trainee)
 
         flash[:success] = "Trainee withdrawn"
         redirect_to trainee_path(trainee)

--- a/app/controllers/trainees/qts_recommendations_controller.rb
+++ b/app/controllers/trainees/qts_recommendations_controller.rb
@@ -8,8 +8,8 @@ module Trainees
       if OutcomeDateForm.new(trainee).save!
         trainee.recommend_for_qts!
 
-        RecommendForQtsJob.perform_later(trainee.id)
-        RetrieveQtsJob.set(wait: RetrieveQtsJob::POLL_DELAY).perform_later(trainee.id)
+        RecommendForQtsJob.perform_later(trainee)
+        RetrieveQtsJob.set(wait: RetrieveQtsJob::POLL_DELAY).perform_later(trainee)
 
         redirect_to recommended_trainee_outcome_details_path(trainee)
       end

--- a/app/controllers/trn_submissions_controller.rb
+++ b/app/controllers/trn_submissions_controller.rb
@@ -9,8 +9,8 @@ class TrnSubmissionsController < ApplicationController
 
     trainee.submit_for_trn!
 
-    RegisterForTrnJob.perform_later(trainee.id, current_user.dttp_id)
-    RetrieveTrnJob.set(wait: RetrieveTrnJob::POLL_DELAY).perform_later(trainee.id)
+    RegisterForTrnJob.perform_later(trainee, current_user.dttp_id)
+    RetrieveTrnJob.set(wait: RetrieveTrnJob::POLL_DELAY).perform_later(trainee)
 
     redirect_to trn_submission_path(trainee)
   end

--- a/app/jobs/defer_job.rb
+++ b/app/jobs/defer_job.rb
@@ -4,9 +4,7 @@ class DeferJob < ApplicationJob
   queue_as :default
   retry_on Dttp::UpdateTraineeStatus::Error
 
-  def perform(trainee_id)
-    trainee = Trainee.find(trainee_id)
-
+  def perform(trainee)
     Dttp::UpdateTraineeStatus.call(
       status: DttpStatuses::DEFERRED,
       entity_id: trainee.dttp_id,

--- a/app/jobs/recommend_for_qts_job.rb
+++ b/app/jobs/recommend_for_qts_job.rb
@@ -5,9 +5,7 @@ class RecommendForQtsJob < ApplicationJob
   retry_on Dttp::RecommendForQTS::Error
   retry_on Dttp::UpdateTraineeStatus::Error
 
-  def perform(trainee_id)
-    trainee = Trainee.find(trainee_id)
-
+  def perform(trainee)
     Dttp::RecommendForQTS.call(trainee: trainee)
 
     Dttp::UpdateTraineeStatus.call(

--- a/app/jobs/register_for_trn_job.rb
+++ b/app/jobs/register_for_trn_job.rb
@@ -4,33 +4,19 @@ class RegisterForTrnJob < ApplicationJob
   queue_as :default
   retry_on Dttp::BatchRequest::Error
 
-  def perform(trainee_id, trainee_creator_dttp_id)
-    @trainee = Trainee.find(trainee_id)
-
+  def perform(trainee, trainee_creator_dttp_id)
     Dttp::RegisterForTrn.call(trainee: trainee, trainee_creator_dttp_id: trainee_creator_dttp_id)
 
     ChangeTraineeStatusJob.perform_later(
-      contact_dttp_id,
+      trainee.dttp_id,
       DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED,
       Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
     )
 
     ChangeTraineeStatusJob.perform_later(
-      placement_assignment_dttp_id,
+      trainee.placement_assignment_dttp_id,
       DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED,
       Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
     )
-  end
-
-private
-
-  attr_reader :trainee
-
-  def contact_dttp_id
-    trainee.dttp_id
-  end
-
-  def placement_assignment_dttp_id
-    trainee.placement_assignment_dttp_id
   end
 end

--- a/app/jobs/reinstate_job.rb
+++ b/app/jobs/reinstate_job.rb
@@ -4,9 +4,7 @@ class ReinstateJob < ApplicationJob
   queue_as :default
   retry_on Dttp::UpdateTraineeStatus::Error
 
-  def perform(trainee_id)
-    trainee = Trainee.find(trainee_id)
-
+  def perform(trainee)
     status = trainee.trn.present? ? DttpStatuses::YET_TO_COMPLETE_COURSE : DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED
 
     Dttp::UpdateTraineeStatus.call(

--- a/app/jobs/retrieve_qts_job.rb
+++ b/app/jobs/retrieve_qts_job.rb
@@ -9,15 +9,13 @@ class RetrieveQtsJob < ApplicationJob
   POLL_DELAY = Settings.jobs.poll_delay_hours.hours
   MAX_POLL_DURATION = Settings.jobs.max_poll_duration_days.days
 
-  def perform(trainee_id)
-    trainee = Trainee.find(trainee_id)
-
+  def perform(trainee)
     qts_awarded = Dttp::RetrieveQts.call(trainee: trainee)
 
     if qts_awarded
       trainee.award_qts!
     elsif continue_polling?(trainee)
-      RetrieveQtsJob.set(wait: POLL_DELAY).perform_later(trainee.id)
+      RetrieveQtsJob.set(wait: POLL_DELAY).perform_later(trainee)
     end
   end
 

--- a/app/jobs/retrieve_trn_job.rb
+++ b/app/jobs/retrieve_trn_job.rb
@@ -9,15 +9,13 @@ class RetrieveTrnJob < ApplicationJob
   POLL_DELAY = Settings.jobs.poll_delay_hours.hours
   MAX_POLL_DURATION = Settings.jobs.max_poll_duration_days.days
 
-  def perform(trainee_id)
-    trainee = Trainee.find(trainee_id)
-
+  def perform(trainee)
     trn = Dttp::RetrieveTrn.call(trainee: trainee)
 
     if trn
       trainee.trn_received!(trn)
     elsif continue_polling?(trainee)
-      RetrieveTrnJob.set(wait: POLL_DELAY).perform_later(trainee.id)
+      RetrieveTrnJob.set(wait: POLL_DELAY).perform_later(trainee)
     end
   end
 

--- a/app/jobs/withdraw_job.rb
+++ b/app/jobs/withdraw_job.rb
@@ -4,9 +4,7 @@ class WithdrawJob < ApplicationJob
   queue_as :default
   retry_on Dttp::UpdateTraineeStatus::Error
 
-  def perform(trainee_id)
-    trainee = Trainee.find(trainee_id)
-
+  def perform(trainee)
     Dttp::UpdateTraineeStatus.call(
       status: DttpStatuses::REJECTED,
       entity_id: trainee.dttp_id,

--- a/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
@@ -17,7 +17,7 @@ describe Trainees::ConfirmDeferralsController do
     it "it updates the placement assignment in DTTP to mark it as deferred" do
       expect {
         post :update, params: { trainee_id: trainee }
-      }.to have_enqueued_job(DeferJob).with(trainee.id)
+      }.to have_enqueued_job(DeferJob).with(trainee)
     end
 
     context "trainee state" do

--- a/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
@@ -20,7 +20,7 @@ describe Trainees::ConfirmReinstatementsController do
       it "queues a background job to reinstate a trainee" do
         expect {
           post :update, params: { trainee_id: trainee }
-        }.to have_enqueued_job(ReinstateJob).with(trainee.id)
+        }.to have_enqueued_job(ReinstateJob).with(trainee)
       end
     end
 
@@ -39,7 +39,7 @@ describe Trainees::ConfirmReinstatementsController do
       it "queues a background job to reinstate a trainee" do
         expect {
           post :update, params: { trainee_id: trainee }
-        }.to have_enqueued_job(ReinstateJob).with(trainee.id)
+        }.to have_enqueued_job(ReinstateJob).with(trainee)
       end
     end
   end

--- a/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
@@ -17,7 +17,7 @@ describe Trainees::ConfirmWithdrawalsController do
     it "it updates the placement assignment in DTTP to mark it as withdrawn" do
       expect {
         post :update, params: { trainee_id: trainee }
-      }.to have_enqueued_job(WithdrawJob).with(trainee.id)
+      }.to have_enqueued_job(WithdrawJob).with(trainee)
     end
 
     context "trainee state" do

--- a/spec/controllers/trainees/qts_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/qts_recommendations_controller_spec.rb
@@ -17,14 +17,14 @@ describe Trainees::QtsRecommendationsController do
     it "it updates the placement assignment in DTTP to mark it ready for QTS" do
       expect {
         post :create, params: { trainee_id: trainee }
-      }.to have_enqueued_job(RecommendForQtsJob).with(trainee.id)
+      }.to have_enqueued_job(RecommendForQtsJob).with(trainee)
     end
 
     it "queues a background job to poll for the trainee's QTS" do
       Timecop.freeze(Time.zone.now) do
         expect {
           post :create, params: { trainee_id: trainee }
-        }.to have_enqueued_job(RetrieveQtsJob).at(RetrieveQtsJob::POLL_DELAY.from_now).with(trainee.id)
+        }.to have_enqueued_job(RetrieveQtsJob).at(RetrieveQtsJob::POLL_DELAY.from_now).with(trainee)
       end
     end
 

--- a/spec/controllers/trn_submissions_controller_spec.rb
+++ b/spec/controllers/trn_submissions_controller_spec.rb
@@ -21,14 +21,14 @@ describe TrnSubmissionsController do
       it "queues a background job to register trainee for TRN" do
         expect {
           post :create, params: { trainee_id: trainee }
-        }.to have_enqueued_job(RegisterForTrnJob).with(trainee.id, current_user.dttp_id)
+        }.to have_enqueued_job(RegisterForTrnJob).with(trainee, current_user.dttp_id)
       end
 
       it "queues a background job to poll for the trainee's TRN" do
         Timecop.freeze(Time.zone.now) do
           expect {
             post :create, params: { trainee_id: trainee }
-          }.to have_enqueued_job(RetrieveTrnJob).at(RetrieveTrnJob::POLL_DELAY.from_now).with(trainee.id)
+          }.to have_enqueued_job(RetrieveTrnJob).at(RetrieveTrnJob::POLL_DELAY.from_now).with(trainee)
         end
       end
 

--- a/spec/jobs/recommend_for_qts_job_spec.rb
+++ b/spec/jobs/recommend_for_qts_job_spec.rb
@@ -32,6 +32,6 @@ describe RecommendForQtsJob do
   it "updates the contact and placement assignment status in DTTP" do
     expect(Dttp::UpdateTraineeStatus).to receive(:call).with(expected_contact_params)
     expect(Dttp::UpdateTraineeStatus).to receive(:call).with(expected_placement_assignment_params)
-    described_class.perform_now(trainee.id)
+    described_class.perform_now(trainee)
   end
 end

--- a/spec/jobs/register_for_trn_job_spec.rb
+++ b/spec/jobs/register_for_trn_job_spec.rb
@@ -13,7 +13,7 @@ describe RegisterForTrnJob do
   end
 
   describe "#perform_now" do
-    subject { described_class.perform_now(trainee.id, creator_dttp_id) }
+    subject { described_class.perform_now(trainee, creator_dttp_id) }
 
     it "registers the trainee" do
       expect(Dttp::RegisterForTrn).to receive(:call).with(trainee: trainee, trainee_creator_dttp_id: creator_dttp_id)

--- a/spec/jobs/reinstate_job_spec.rb
+++ b/spec/jobs/reinstate_job_spec.rb
@@ -29,7 +29,7 @@ describe ReinstateJob do
   let(:placement_assignment_update_params_with_trn) { placement_assignment_update_params.merge(with_trn_param) }
   let(:placement_assignment_update_params_without_trn) { placement_assignment_update_params.merge(without_trn_param) }
 
-  subject { described_class.perform_now(trainee.id) }
+  subject { described_class.perform_now(trainee) }
 
   before do
     allow(Dttp::UpdateTraineeStatus).to receive(:call).with(contact_update_params_with_trn)

--- a/spec/jobs/retrieve_qts_job_spec.rb
+++ b/spec/jobs/retrieve_qts_job_spec.rb
@@ -17,13 +17,13 @@ describe RetrieveQtsJob do
 
     it "transitions the trainee to qts_awarded" do
       expect {
-        described_class.perform_now(trainee.id)
+        described_class.perform_now(trainee)
         trainee.reload
       }.to change(trainee, :state).to("qts_awarded")
     end
 
     it "doesn't queue another job" do
-      described_class.perform_now(trainee.id)
+      described_class.perform_now(trainee)
       expect(RetrieveQtsJob).to_not have_been_enqueued
     end
   end
@@ -33,8 +33,8 @@ describe RetrieveQtsJob do
 
     it "queues another job to fetch the QTS 6 hours from now" do
       Timecop.freeze(Time.zone.now) do
-        described_class.perform_now(trainee.id)
-        expect(RetrieveQtsJob).to have_been_enqueued.at(6.hours.from_now).with(trainee.id)
+        described_class.perform_now(trainee)
+        expect(RetrieveQtsJob).to have_been_enqueued.at(6.hours.from_now).with(trainee)
       end
     end
 
@@ -42,7 +42,7 @@ describe RetrieveQtsJob do
       let(:trainee) { create(:trainee, recommended_for_qts_at: 2.days.ago) }
 
       it "doesn't queue another job after 2 days have passed with no QTS" do
-        described_class.perform_now(trainee.id)
+        described_class.perform_now(trainee)
         expect(RetrieveQtsJob).to_not have_been_enqueued
       end
     end
@@ -54,7 +54,7 @@ describe RetrieveQtsJob do
 
     it "raises a TraineeAttributeError" do
       expect {
-        described_class.perform_now(trainee.id)
+        described_class.perform_now(trainee)
       }.to raise_error(RetrieveQtsJob::TraineeAttributeError, error_msg)
     end
   end

--- a/spec/jobs/retrieve_trn_job_spec.rb
+++ b/spec/jobs/retrieve_trn_job_spec.rb
@@ -17,13 +17,13 @@ describe RetrieveTrnJob do
 
     it "updates the trainee TRN attribute" do
       expect {
-        described_class.perform_now(trainee.id)
+        described_class.perform_now(trainee)
         trainee.reload
       }.to change(trainee, :trn).to(trn)
     end
 
     it "doesn't queue another job" do
-      described_class.perform_now(trainee.id)
+      described_class.perform_now(trainee)
       expect(RetrieveTrnJob).to_not have_been_enqueued
     end
   end
@@ -31,8 +31,8 @@ describe RetrieveTrnJob do
   context "TRN is not available" do
     it "queues another job to fetch the TRN 6 hours from now" do
       Timecop.freeze(Time.zone.now) do
-        described_class.perform_now(trainee.id)
-        expect(RetrieveTrnJob).to have_been_enqueued.at(6.hours.from_now).with(trainee.id)
+        described_class.perform_now(trainee)
+        expect(RetrieveTrnJob).to have_been_enqueued.at(6.hours.from_now).with(trainee)
       end
     end
 
@@ -40,7 +40,7 @@ describe RetrieveTrnJob do
       let(:trainee) { create(:trainee, submitted_for_trn_at: 2.days.ago) }
 
       it "doesn't queue another job after 2 days have passed without a TRN" do
-        described_class.perform_now(trainee.id)
+        described_class.perform_now(trainee)
         expect(RetrieveTrnJob).to_not have_been_enqueued
       end
     end
@@ -52,7 +52,7 @@ describe RetrieveTrnJob do
 
     it "raises a TraineeAttributeError" do
       expect {
-        described_class.perform_now(trainee.id)
+        described_class.perform_now(trainee)
       }.to raise_error(RetrieveTrnJob::TraineeAttributeError, error_msg)
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/vn4wSnvX/1368-pass-objects-to-jobs

### Changes proposed in this pull request

Based on this comment https://github.com/DFE-Digital/register-trainee-teachers/pull/638#discussion_r592265750 and the ticket above. We no longer need to be explicit with passing around ids for model instances since https://github.com/rails/globalid .

### Guidance to review

