### PR TITLE
[1367] Remove user creation feature in the sessions controller

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,17 +6,6 @@ class SessionsController < ApplicationController
   def callback
     DfESignInUser.begin_session!(session, request.env["omniauth.auth"])
 
-    if FeatureService.enabled?("allow_user_creation") && current_user.nil?
-      @current_user = User.new(
-        dttp_id: SecureRandom.uuid,
-        provider: Provider.create_or_find_by(
-          name: "DfE",
-          dttp_id: SecureRandom.uuid,
-          code: "000",
-        ),
-      )
-    end
-
     if current_user
       DfESignInUsers::Update.call(user: current_user, dfe_sign_in_user: dfe_sign_in_user)
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,7 +22,6 @@ features:
   home_text: false
   use_ssl: true
   use_dfe_sign_in: true
-  allow_user_creation: false
   enable_feedback_link: true
   basic_auth: true
   trainee_export: true
@@ -59,6 +58,6 @@ session_store:
 
 teacher_training_api:
   base_url: "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1"
-  
+
 environment:
   name: qa

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -5,7 +5,6 @@ dttp:
   api_base_url: "https://dttp-dev.api.crm4.dynamics.com"
 
 features:
-  allow_user_creation: true
   use_dfe_sign_in: false
   basic_auth: false
   import_courses_from_ttapi: true

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -27,7 +27,6 @@ describe "Settings" do
     include_examples expected_value_test, :use_ssl, features, true
     include_examples expected_value_test, :use_dfe_sign_in, features, true
     include_examples expected_value_test, :home_text, features, false
-    include_examples expected_value_test, :allow_user_creation, features, false
   end
 
   describe ".dfe_sign_in" do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -50,35 +50,6 @@ describe SessionsController, type: :controller do
         request_callback
         expect(response).to redirect_to(sign_in_user_not_found_path)
       end
-
-      describe "save the new user", "feature_allow_user_creation": true do
-        it "creates a session for the new user" do
-          request_callback
-          expect(session[:dfe_sign_in_user]["dfe_sign_in_uid"]).to eq(user.dfe_sign_in_uid)
-          expect(session[:dfe_sign_in_user]["email"]).to eq(user.email)
-
-          expect(session[:dfe_sign_in_user]["first_name"]).to eq(user.first_name)
-          expect(session[:dfe_sign_in_user]["last_name"]).to eq(user.last_name)
-        end
-
-        it "redirects to the trainees index page" do
-          request_callback
-          expect(response).to redirect_to(root_path)
-        end
-
-        it "saved non existing user to database" do
-          expect { request_callback }.to change { User.count }
-          .from(0).to(1)
-        end
-
-        it "created provider if needed" do
-          expect { request_callback }.to change { Provider.count }
-          .from(0).to(1)
-
-          expect { request_callback }.to_not change { Provider.count }
-          .from(1)
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/Oq7hCz8U/1367-remove-the-user-creation-in-the-sessions-controller

### Changes proposed in this pull request
Deleting the code around creating a user, which has only been used in development, and seems to work pretty well without, since we use personas, which can be populated by using the [seed rake task](https://github.com/DFE-Digital/register-trainee-teachers#setting-up-seed-records)

