### PR TITLE
[1369] Nest traits for factories

### DIFF
--- a/app/components/trainees/sections/view.rb
+++ b/app/components/trainees/sections/view.rb
@@ -3,12 +3,12 @@
 module Trainees
   module Sections
     class View < ViewComponent::Base
-      attr_accessor :trainee, :section, :trn_submission
+      attr_accessor :trainee, :section, :trn_submission_form
 
-      def initialize(trainee:, section:, trn_submission:)
+      def initialize(trainee:, section:, trn_submission_form:)
         @trainee = trainee
         @section = section
-        @trn_submission = trn_submission
+        @trn_submission_form = trn_submission_form
       end
 
       def component
@@ -77,11 +77,11 @@ module Trainees
       end
 
       def error
-        @error ||= trn_submission.errors.present?
+        @error ||= trn_submission_form.errors.present?
       end
 
       def status
-        @status ||= trn_submission.section_status(section)
+        @status ||= trn_submission_form.section_status(section)
       end
 
       def title

--- a/app/controllers/trainees/check_details_controller.rb
+++ b/app/controllers/trainees/check_details_controller.rb
@@ -7,7 +7,7 @@ module Trainees
     def show
       authorize trainee
       page_tracker.save_as_origin!
-      @trn_submission = TrnSubmissionForm.new(trainee: trainee)
+      @trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
     end
 
   private

--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -6,11 +6,11 @@ module Trainees
 
     def show
       page_tracker.save_as_origin!
-      deferral
+      deferral_form
     end
 
     def update
-      if deferral.save!
+      if deferral_form.save!
         trainee.defer!
 
         DeferJob.perform_later(trainee)
@@ -26,8 +26,8 @@ module Trainees
       @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
-    def deferral
-      @deferral ||= DeferralForm.new(trainee)
+    def deferral_form
+      @deferral_form ||= DeferralForm.new(trainee)
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -11,7 +11,7 @@ module Trainees
       page_tracker.save_as_origin!
 
       if trainee.draft?
-        @confirm_detail = ConfirmDetailForm.new(mark_as_completed: trainee.progress.public_send(trainee_section_key))
+        @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.public_send(trainee_section_key))
       end
 
       # Temporary conditional while we wait for all sections to support save-on-confirm

--- a/app/controllers/trainees/contact_details_controller.rb
+++ b/app/controllers/trainees/contact_details_controller.rb
@@ -5,14 +5,14 @@ module Trainees
     before_action :authorize_trainee
 
     def edit
-      @contact_details = ContactDetailsForm.new(trainee)
+      @contact_details_form = ContactDetailsForm.new(trainee)
     end
 
     def update
-      @contact_details = ContactDetailsForm.new(trainee, contact_details_params)
+      @contact_details_form = ContactDetailsForm.new(trainee, contact_details_params)
       save_strategy = trainee.draft? ? :save! : :stash
 
-      if @contact_details.public_send(save_strategy)
+      if @contact_details_form.public_send(save_strategy)
         redirect_to trainee_contact_details_confirm_path(trainee)
       else
         render :edit

--- a/app/controllers/trainees/course_details_controller.rb
+++ b/app/controllers/trainees/course_details_controller.rb
@@ -14,13 +14,13 @@ module Trainees
     }.freeze
 
     def edit
-      @course_details = CourseDetailsForm.new(trainee)
+      @course_details_form = CourseDetailsForm.new(trainee)
     end
 
     def update
-      @course_details = CourseDetailsForm.new(trainee, course_details_params.merge(course_date_params))
+      @course_details_form = CourseDetailsForm.new(trainee, course_details_params.merge(course_date_params))
       save_strategy = trainee.draft? ? :save! : :stash
-      if @course_details.public_send(save_strategy)
+      if @course_details_form.public_send(save_strategy)
         redirect_to trainee_course_details_confirm_path(trainee)
       else
         render :edit

--- a/app/controllers/trainees/deferrals_controller.rb
+++ b/app/controllers/trainees/deferrals_controller.rb
@@ -5,15 +5,15 @@ module Trainees
     before_action :authorize_trainee
 
     def show
-      @deferral = DeferralForm.new(trainee)
+      @deferral_form = DeferralForm.new(trainee)
     end
 
     def update
       authorize(trainee, :defer?)
 
-      @deferral = DeferralForm.new(trainee, trainee_params)
+      @deferral_form = DeferralForm.new(trainee, trainee_params)
 
-      if @deferral.stash
+      if @deferral_form.stash
         redirect_to trainee_confirm_deferral_path(trainee)
       else
         render :show

--- a/app/controllers/trainees/degrees_controller.rb
+++ b/app/controllers/trainees/degrees_controller.rb
@@ -11,6 +11,7 @@ module Trainees
 
     def create
       @degree_form = @degrees_form.build_degree(degree_params)
+
       if @degree_form.save_or_stash
         redirect_to trainee_degrees_confirm_path(trainee)
       else
@@ -25,6 +26,7 @@ module Trainees
     def update
       @degree_form = @degrees_form.find_degree_from_param(params[:id])
       @degree_form.attributes = degree_params
+
       if @degree_form.save_or_stash
         redirect_to trainee_degrees_confirm_path(trainee)
       else
@@ -34,8 +36,11 @@ module Trainees
 
     def destroy
       @degree_form = @degrees_form.find_degree_from_param(params[:id])
+
       @degree_form.destroy!
+
       flash[:success] = "Trainee degree deleted"
+
       redirect_to page_tracker.last_origin_page_path
     end
 

--- a/app/controllers/trainees/diversity/confirm_details_controller.rb
+++ b/app/controllers/trainees/diversity/confirm_details_controller.rb
@@ -7,7 +7,7 @@ module Trainees
         page_tracker.save_as_origin!
 
         if trainee.draft?
-          @confirm_detail = ConfirmDetailForm.new(mark_as_completed: trainee.progress.diversity)
+          @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.diversity)
         end
 
         data_model = trainee.draft? ? trainee : diversity_form

--- a/app/controllers/trainees/diversity/disability_details_controller.rb
+++ b/app/controllers/trainees/diversity/disability_details_controller.rb
@@ -7,14 +7,14 @@ module Trainees
       before_action :load_disabilities
 
       def edit
-        @disability_detail = Diversities::DisabilityDetailForm.new(trainee)
+        @disability_detail_form = Diversities::DisabilityDetailForm.new(trainee)
       end
 
       def update
-        @disability_detail = Diversities::DisabilityDetailForm.new(trainee, disability_detail_params)
+        @disability_detail_form = Diversities::DisabilityDetailForm.new(trainee, disability_detail_params)
         save_strategy = trainee.draft? ? :save! : :stash
 
-        if @disability_detail.public_send(save_strategy)
+        if @disability_detail_form.public_send(save_strategy)
           redirect_to trainee_diversity_confirm_path(trainee)
         else
           render :edit

--- a/app/controllers/trainees/diversity/disability_disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disability_disclosures_controller.rb
@@ -6,14 +6,14 @@ module Trainees
       before_action :authorize_trainee
 
       def edit
-        @disability_disclosure = Diversities::DisabilityDisclosureForm.new(trainee)
+        @disability_disclosure_form = Diversities::DisabilityDisclosureForm.new(trainee)
       end
 
       def update
-        @disability_disclosure = Diversities::DisabilityDisclosureForm.new(trainee, disability_disclosure_params)
+        @disability_disclosure_form = Diversities::DisabilityDisclosureForm.new(trainee, disability_disclosure_params)
         save_strategy = trainee.draft? ? :save! : :stash
 
-        if @disability_disclosure.public_send(save_strategy)
+        if @disability_disclosure_form.public_send(save_strategy)
           redirect_to_relevant_step
         else
           render :edit
@@ -33,7 +33,7 @@ module Trainees
       end
 
       def redirect_to_relevant_step
-        if @disability_disclosure.disability_not_provided? || @disability_disclosure.no_disability?
+        if @disability_disclosure_form.disability_not_provided? || @disability_disclosure_form.no_disability?
           redirect_to(trainee_diversity_confirm_path(trainee))
         else
           redirect_to(edit_trainee_diversity_disability_detail_path(trainee))

--- a/app/controllers/trainees/diversity/disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disclosures_controller.rb
@@ -6,14 +6,14 @@ module Trainees
       before_action :authorize_trainee
 
       def edit
-        @disclosure = Diversities::DisclosureForm.new(trainee)
+        @disclosure_form = Diversities::DisclosureForm.new(trainee)
       end
 
       def update
-        @disclosure = Diversities::DisclosureForm.new(trainee, disclosure_params)
+        @disclosure_form = Diversities::DisclosureForm.new(trainee, disclosure_params)
         save_strategy = trainee.draft? ? :save! : :stash
 
-        if @disclosure.public_send(save_strategy)
+        if @disclosure_form.public_send(save_strategy)
           redirect_to_relevant_step
         else
           render :edit
@@ -33,7 +33,7 @@ module Trainees
       end
 
       def redirect_to_relevant_step
-        if @disclosure.diversity_disclosed?
+        if @disclosure_form.diversity_disclosed?
           redirect_to(edit_trainee_diversity_ethnic_group_path(trainee))
         else
           redirect_to(trainee_diversity_confirm_path(trainee))

--- a/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
@@ -6,14 +6,14 @@ module Trainees
       before_action :authorize_trainee
 
       def edit
-        @ethnic_background = Diversities::EthnicBackgroundForm.new(trainee)
+        @ethnic_background_form = Diversities::EthnicBackgroundForm.new(trainee)
       end
 
       def update
-        @ethnic_background = Diversities::EthnicBackgroundForm.new(trainee, ethnic_background_params)
+        @ethnic_background_form = Diversities::EthnicBackgroundForm.new(trainee, ethnic_background_params)
         save_strategy = trainee.draft? ? :save! : :stash
 
-        if @ethnic_background.public_send(save_strategy)
+        if @ethnic_background_form.public_send(save_strategy)
           redirect_to(origin_page_or_next_step)
         else
           render :edit

--- a/app/controllers/trainees/diversity/ethnic_groups_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_groups_controller.rb
@@ -6,14 +6,14 @@ module Trainees
       before_action :authorize_trainee
 
       def edit
-        @ethnic_group = Diversities::EthnicGroupForm.new(trainee)
+        @ethnic_group_form = Diversities::EthnicGroupForm.new(trainee)
       end
 
       def update
-        @ethnic_group = Diversities::EthnicGroupForm.new(trainee, ethnic_group_param)
+        @ethnic_group_form = Diversities::EthnicGroupForm.new(trainee, ethnic_group_param)
         save_strategy = trainee.draft? ? :save! : :stash
 
-        if @ethnic_group.public_send(save_strategy)
+        if @ethnic_group_form.public_send(save_strategy)
           redirect_to_relevant_step
         else
           render :edit
@@ -33,7 +33,7 @@ module Trainees
       end
 
       def redirect_to_relevant_step
-        if @ethnic_group.not_provided_ethnic_group?
+        if @ethnic_group_form.not_provided_ethnic_group?
           if trainee.disability_disclosure.present?
             redirect_to(page_tracker.last_origin_page_path)
           else

--- a/app/controllers/trainees/outcome_dates_controller.rb
+++ b/app/controllers/trainees/outcome_dates_controller.rb
@@ -4,14 +4,14 @@ module Trainees
   class OutcomeDatesController < ApplicationController
     def edit
       authorize trainee
-      @outcome = OutcomeDateForm.new(trainee)
+      @outcome_form = OutcomeDateForm.new(trainee)
     end
 
     def update
       authorize trainee
-      @outcome = OutcomeDateForm.new(trainee, trainee_params)
+      @outcome_form = OutcomeDateForm.new(trainee, trainee_params)
 
-      if @outcome.stash
+      if @outcome_form.stash
         redirect_to confirm_trainee_outcome_details_path(trainee)
       else
         render :edit

--- a/app/controllers/trainees/outcome_details_controller.rb
+++ b/app/controllers/trainees/outcome_details_controller.rb
@@ -4,7 +4,7 @@ module Trainees
   class OutcomeDetailsController < ApplicationController
     def confirm
       authorize trainee
-      @outcome = OutcomeDateForm.new(trainee)
+      @outcome_form = OutcomeDateForm.new(trainee)
     end
 
     def recommended

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -24,7 +24,7 @@ module Trainees
     end
 
     def edit
-      @personal_detail = PersonalDetailsForm.new(trainee)
+      @personal_detail_form = PersonalDetailsForm.new(trainee)
     end
 
     def update
@@ -34,7 +34,7 @@ module Trainees
       if personal_detail.public_send(save_strategy)
         redirect_to trainee_personal_details_confirm_path(personal_detail.trainee)
       else
-        @personal_detail = personal_detail
+        @personal_detail_form = personal_detail
         render :edit
       end
     end

--- a/app/controllers/trainees/start_dates_controller.rb
+++ b/app/controllers/trainees/start_dates_controller.rb
@@ -11,15 +11,15 @@ module Trainees
     }.freeze
 
     def edit
-      @training_details = TraineeStartDateForm.new(trainee)
+      @trainee_start_date_form = TraineeStartDateForm.new(trainee)
     end
 
     def update
-      @training_details = TraineeStartDateForm.new(trainee, trainee_params)
+      @trainee_start_date_form = TraineeStartDateForm.new(trainee, trainee_params)
 
       save_strategy = trainee.draft? ? :save! : :stash
 
-      if @training_details.public_send(save_strategy)
+      if @trainee_start_date_form.public_send(save_strategy)
         redirect_to trainee_start_date_confirm_path(trainee)
       else
         render :edit

--- a/app/controllers/trainees/trainee_ids_controller.rb
+++ b/app/controllers/trainees/trainee_ids_controller.rb
@@ -5,15 +5,15 @@ module Trainees
     before_action :authorize_trainee
 
     def edit
-      @training_details = TraineeIdForm.new(trainee)
+      @trainee_id_form = TraineeIdForm.new(trainee)
     end
 
     def update
-      @training_details = TraineeIdForm.new(trainee, trainee_params)
+      @trainee_id_form = TraineeIdForm.new(trainee, trainee_params)
 
       save_strategy = trainee.draft? ? :save! : :stash
 
-      if @training_details.public_send(save_strategy)
+      if @trainee_id_form.public_send(save_strategy)
         redirect_to trainee_trainee_id_confirm_path(trainee)
       else
         render :edit

--- a/app/controllers/trainees/training_details_controller.rb
+++ b/app/controllers/trainees/training_details_controller.rb
@@ -11,14 +11,14 @@ module Trainees
     }.freeze
 
     def edit
-      @training_details = TrainingDetailsForm.new(trainee)
+      @training_details_form = TrainingDetailsForm.new(trainee)
     end
 
     def update
-      @training_details = TrainingDetailsForm.new(trainee)
-      @training_details.assign_attributes(trainee_params)
+      @training_details_form = TrainingDetailsForm.new(trainee)
+      @training_details_form.assign_attributes(trainee_params)
 
-      if @training_details.save
+      if @training_details_form.save
         redirect_to trainee_training_details_confirm_path(trainee)
       else
         render :edit

--- a/app/controllers/trn_submissions_controller.rb
+++ b/app/controllers/trn_submissions_controller.rb
@@ -4,8 +4,8 @@ class TrnSubmissionsController < ApplicationController
   before_action :authorize_trainee
 
   def create
-    @trn_submission = TrnSubmissionForm.new(trainee: trainee)
-    return render "trainees/check_details/show" unless @trn_submission.valid?
+    @trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
+    return render "trainees/check_details/show" unless @trn_submission_form.valid?
 
     trainee.submit_for_trn!
 

--- a/app/views/trainees/check_details/_error_summary.html.erb
+++ b/app/views/trainees/check_details/_error_summary.html.erb
@@ -4,7 +4,7 @@
   </h2>
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">
-      <% @trn_submission.errors.messages.map do |_, messages| %>
+      <% @trn_submission_form.errors.messages.map do |_, messages| %>
         <li><%= messages.first %></li>
       <% end %>
     </ul>

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -13,7 +13,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 
-    <% if @trn_submission.errors.any? %>
+    <% if @trn_submission_form.errors.any? %>
       <%= render "trainees/check_details/error_summary" %>
     <% end %>
 
@@ -26,7 +26,7 @@
           Review trainee record
         </h1>
 
-        <% unless @trn_submission.all_sections_complete? %>
+        <% unless @trn_submission_form.all_sections_complete? %>
           <div class="govuk-inset-text">
             <p class="govuk-body">
               This record is not complete and cannot be submitted for TRN. If you do not
@@ -45,23 +45,23 @@
       Personal details and education
     </h2>
 
-    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :personal_details) %>
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :personal_details) %>
 
-    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :contact_details) %>
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :contact_details) %>
 
-    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :diversity) %>
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :diversity) %>
 
-    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :degrees) %>
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :degrees) %>
 
     <h2 class="govuk-heading-m">
       About their teacher training
     </h2>
 
-    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :training_details) %>
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :training_details) %>
 
-    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission: @trn_submission, section: :course_details) %>
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :course_details) %>
 
-    <%= register_form_with(model: @trn_submission, url: trn_submissions_path, method: :post, local: true) do |f| %>
+    <%= register_form_with(model: @trn_submission_form, url: trn_submissions_path, method: :post, local: true) do |f| %>
       <%= hidden_field_tag :trainee_id, @trainee.slug %>
       <%= f.govuk_submit "Submit record and request TRN" %>
     <% end %>

--- a/app/views/trainees/confirm_deferrals/show.html.erb
+++ b/app/views/trainees/confirm_deferrals/show.html.erb
@@ -15,7 +15,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render Trainees::DeferralDetails::View.new(@deferral) %>
+    <%= render Trainees::DeferralDetails::View.new(@deferral_form) %>
 
     <%= register_form_with url: trainee_confirm_deferral_path(@trainee), method: :put, local: true do |f| %>
       <%= f.govuk_submit "Defer this trainee" %>

--- a/app/views/trainees/confirm_details/_form.html.erb
+++ b/app/views/trainees/confirm_details/_form.html.erb
@@ -4,13 +4,14 @@
 
     <%= render(component) %>
 
-    <%= register_form_with(model: @confirm_detail, url: resource_confirm_update_path, method: :put, local: true) do |f| %>
+    <%= register_form_with(model: confirm_detail_form, url: resource_confirm_update_path, method: :put, local: true) do |f| %>
       <% if @trainee.draft? %>
         <%= f.govuk_check_boxes_fieldset :mark_as_completed, multiple: false, legend: { text: "" } do %>
           <%= f.govuk_check_box :mark_as_completed, 1, 0, multiple: false, link_errors: true, label: { text: "I have completed this section " } %>
         <% end %>
       <% end %>
-      <%= f.govuk_submit @trainee.draft? ? t(:continue) : t(:update_record) %>
+      <%= f.govuk_submit trainee.draft? ? t(:continue) : t(:update_record) %>
     <% end %>
   </div>
 </div>
+

--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -8,13 +8,13 @@
   partial: "form",
   locals: {
     heading: t("components.confirmation.heading", section_title: confirm_section_title),
-    confirm_detail: @confirm_detail,
+    confirm_detail_form: @confirm_detail_form,
     trainee: @trainee,
     component: @confirmation_component,
     resource_confirm_update_path: trainee_section_update_path(trainee_section_key, @trainee),
   },
 ) %>
 
-<% if !@trainee.draft? %>
-  <p class="govuk-body"><%= govuk_link_to(t("components.confirmation.cancel_and_return"), view_trainee(@trainee)) %></p>
-<% end %>
+<% unless @trainee.draft? %>
+  <p class="govuk-body"><%=  govuk_link_to(t("components.confirmation.cancel_and_return"), view_trainee(@trainee)) %></p>
+<%  end %>

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.contact_details.edit", has_errors: @contact_details.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.contact_details.edit", has_errors: @contact_details_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @contact_details, url: trainee_contact_details_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @contact_details_form, url: trainee_contact_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset(:locale_code, legend: { text: "Where does the trainee live?", size: "s" }, classes: "locale") do %>

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.course_details.edit", has_errors: @course_details.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.course_details.edit", has_errors: @course_details_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
-    <%= register_form_with(model: @course_details, url: trainee_course_details_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @course_details_form, url: trainee_course_details_path(@trainee), method: :put, local: true) do |f| %>
 
       <%= f.govuk_error_summary %>
 

--- a/app/views/trainees/deferrals/show.html.erb
+++ b/app/views/trainees/deferrals/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.deferral.show", has_errors: @deferral.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.deferral.show", has_errors: @deferral_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @deferral, url: trainee_deferral_path(@trainee), local: true) do |f| %>
+    <%= register_form_with(model: @deferral_form, url: trainee_deferral_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">

--- a/app/views/trainees/diversity/confirm_details/show.html.erb
+++ b/app/views/trainees/diversity/confirm_details/show.html.erb
@@ -8,13 +8,13 @@
   partial: "trainees/confirm_details/form",
   locals: {
     heading: t("components.page_titles.trainees.diversity.confirm"),
-    confirm_detail: @confirm_detail,
+    confirm_detail_form: @confirm_detail_form,
     trainee: @trainee,
     component: @confirmation_component,
     resource_confirm_update_path: trainee_diversity_confirm_path(@trainee),
   },
 ) %>
 
-<% if !@trainee.draft? %>
-  <p class="govuk-body"><%= govuk_link_to(t("components.confirmation.cancel_and_return"), view_trainee(@trainee)) %></p>
-<% end %>
+<% unless @trainee.draft? %>
+  <p class="govuk-body"><%=  govuk_link_to(t("components.confirmation.cancel_and_return"), view_trainee(@trainee))  %></p>
+<%  end %>

--- a/app/views/trainees/diversity/disability_details/edit.html.erb
+++ b/app/views/trainees/diversity/disability_details/edit.html.erb
@@ -1,4 +1,5 @@
-<%= render PageTitle::View.new(title: "trainees.diversity.disabilities.edit", has_errors: @disability_detail.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.diversity.disabilities.edit",
+                               has_errors: @disability_detail_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
@@ -9,7 +10,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @disability_detail, url: trainee_diversity_disability_detail_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @disability_detail_form, url: trainee_diversity_disability_detail_path(@trainee),
+                           method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_check_boxes_fieldset :disability_ids,
@@ -19,9 +21,11 @@
 
         <% @disabilities.each_with_index do |disability, index| %>
           <% if disability.name != Diversities::OTHER %>
-            <%= f.govuk_check_box :disability_ids, disability.id, label: { text: disability.name, size: "s" }, hint: { text: disability.description }, link_errors: index.zero? %>
+            <%= f.govuk_check_box :disability_ids, disability.id, label: { text: disability.name, size: "s" },
+                                  hint: { text: disability.description }, link_errors: index.zero? %>
           <% else %>
-            <%= f.govuk_check_box :disability_ids, disability.id, label: { text: disability.name, size: "s" }, link_errors: index.zero? do %>
+            <%= f.govuk_check_box :disability_ids, disability.id, label: { text: disability.name, size: "s" },
+                                  link_errors: index.zero? do %>
               <%= f.govuk_text_field :additional_disability,
                                      label: { text: "Describe their disability (optional)" },
                                      width: "two-thirds",

--- a/app/views/trainees/diversity/disability_disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disability_disclosures/edit.html.erb
@@ -1,4 +1,5 @@
-<%= render PageTitle::View.new(title: "trainees.diversity.disability_disclosure.edit", has_errors: @disability_disclosure.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.diversity.disability_disclosure.edit",
+                               has_errors: @disability_disclosure_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -6,10 +7,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @disability_disclosure, url: trainee_diversity_disability_disclosure_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @disability_disclosure_form,
+                           url: trainee_diversity_disability_disclosure_path(@trainee),
+                           method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
-        <%= f.govuk_radio_buttons_fieldset(:disability_disclosure, legend: { text: t("components.page_titles.trainees.diversity.disability_disclosure.edit"), tag: "h1", size: "l" }) do %>
+        <%= f.govuk_radio_buttons_fieldset(:disability_disclosure,
+                                           legend: { text: t("components.page_titles.trainees.diversity.disability_disclosure.edit"),
+                                                     tag: "h1", size: "l" }) do %>
           <% format_disability_disclosure_options(Diversities::DISABILITY_DISCLOSURE_ENUMS.values).each_with_index do |disclosure_option, index| %>
             <%= f.govuk_radio_button(
               :disability_disclosure,
@@ -20,7 +25,8 @@
           <% end %>
 
           <%= f.govuk_radio_divider %>
-          <%= f.govuk_radio_button :disability_disclosure, Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided], label: { text: "They did not say" } %>
+          <%= f.govuk_radio_button :disability_disclosure, Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided],
+                                   label: { text: "They did not say" } %>
         <% end %>
 
       <%= f.govuk_submit %>

--- a/app/views/trainees/diversity/disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disclosures/edit.html.erb
@@ -1,4 +1,5 @@
-<%= render PageTitle::View.new(title: "trainees.diversity.disclosures.edit", has_errors: @disclosure.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.diversity.disclosures.edit",
+                               has_errors: @disclosure_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -6,7 +7,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @disclosure, url: trainee_diversity_disclosure_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @disclosure_form, url: trainee_diversity_disclosure_path(@trainee),
+                           method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
         <%= f.govuk_collection_radio_buttons(

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render PageTitle::View.new(
   title: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")),
-  has_errors: @ethnic_background.errors.present?,
+  has_errors: @ethnic_background_form.errors.present?,
 ) %>
 
 <%= content_for(:breadcrumbs) do %>
@@ -12,7 +12,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @ethnic_background, url: trainee_diversity_ethnic_background_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @ethnic_background_form, url: trainee_diversity_ethnic_background_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
         <%= f.govuk_radio_buttons_fieldset(
@@ -24,7 +24,7 @@
 },
         ) do %>
 
-          <% Diversities::BACKGROUNDS[@ethnic_background.ethnic_group].each_with_index do |ethnic_background, index| %>
+          <% Diversities::BACKGROUNDS[@ethnic_background_form.ethnic_group].each_with_index do |ethnic_background, index| %>
             <% if other_ethnic_background_option?(ethnic_background) %>
               <%= f.govuk_radio_button(:ethnic_background, ethnic_background, label: { text: ethnic_background }, link_errors: index.zero?) do %>
                 <%= f.govuk_text_field(

--- a/app/views/trainees/diversity/ethnic_groups/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_groups/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.diversity.ethnic_group.edit", has_errors: @ethnic_group.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.diversity.ethnic_group.edit", has_errors: @ethnic_group_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @ethnic_group, url: trainee_diversity_ethnic_group_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @ethnic_group_form, url: trainee_diversity_ethnic_group_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
         <%= f.govuk_radio_buttons_fieldset(:ethnic_group, legend: { text: t("components.page_titles.trainees.diversity.ethnic_group.edit"), tag: "h1", size: "l" }) do %>

--- a/app/views/trainees/outcome_dates/edit.html.erb
+++ b/app/views/trainees/outcome_dates/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.outcome_date.edit", has_errors: @outcome.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.outcome_date.edit", has_errors: @outcome_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @outcome, url: trainee_outcome_details_outcome_date_path(@trainee), local: true) do |f| %>
+    <%= register_form_with(model: @outcome_form, url: trainee_outcome_details_outcome_date_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-l">

--- a/app/views/trainees/outcome_details/confirm.html.erb
+++ b/app/views/trainees/outcome_details/confirm.html.erb
@@ -15,7 +15,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render Trainees::OutcomeDetails::View.new(@outcome) %>
+    <%= render Trainees::OutcomeDetails::View.new(@outcome_form) %>
 
     <%= register_form_with url: trainee_qts_recommendations_path, method: :post, local: true do |f| %>
       <%= hidden_field_tag :trainee_id, @trainee.slug %>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.personal_details.edit", has_errors: @personal_detail.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.personal_details.edit", has_errors: @personal_detail_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @personal_detail, url: trainee_personal_details_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @personal_detail_form, url: trainee_personal_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">Trainee personal details</h1>

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -4,7 +4,7 @@
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
-<%= register_form_with model: @training_details, url: trainee_start_date_path, local: true do |f| %>
+<%= register_form_with model: @trainee_start_date_form, url: trainee_start_date_path, local: true do |f| %>
   <%= f.govuk_date_field :commencement_date, legend: { text: t("views.forms.training_details.commencement_date.label"), size: "l", tag: "h1" } %>
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/trainees/trainee_ids/edit.html.erb
+++ b/app/views/trainees/trainee_ids/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with model: @training_details, url: trainee_trainee_id_path, local: true do |f| %>
+    <%= register_form_with model: @trainee_id_form, url: trainee_trainee_id_path, local: true do |f| %>
       <%= f.govuk_text_field :trainee_id,
                              label: { text: "Trainee ID", tag: "h1", size: "l" },
                              width: 20,

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_for(@training_details, url: trainee_training_details_path(@trainee), local: true) do |f| %>
+    <%= form_for(@training_details_form, url: trainee_training_details_path(@trainee), local: true) do |f| %>
       <h1 class="govuk-heading-l"><%= t("views.forms.training_details.title") %></h1>
 
       <%= f.govuk_date_field :commencement_date, legend: {

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -14,16 +14,16 @@ module Pages
           define_method sections do
             @trainee = trainee(sections)
 
-            @trn_submission = TrnSubmissionForm.new(trainee: @trainee)
-            render template: template, locals: { "@trainee": @trainee, "@trn_submission": @trn_submission }
+            @trn_submission_form = TrnSubmissionForm.new(trainee: @trainee)
+            render template: template, locals: { "@trainee": @trainee, "@trn_submission_form": @trn_submission_form }
           end
 
           define_method "#{sections}_validated" do
             @trainee = trainee(sections)
 
-            @trn_submission = TrnSubmissionForm.new(trainee: @trainee)
-            @trn_submission.validate
-            render template: template, locals: { "@trainee": @trainee, "@trn_submission": @trn_submission }
+            @trn_submission_form = TrnSubmissionForm.new(trainee: @trainee)
+            @trn_submission_form.validate
+            render template: template, locals: { "@trainee": @trainee, "@trn_submission_form": @trn_submission_form }
           end
         end
 

--- a/spec/components/trainees/sections/view_preview.rb
+++ b/spec/components/trainees/sections/view_preview.rb
@@ -13,28 +13,28 @@ module Trainees
          training_details].each do |section|
         define_method "continue_sections_#{section}" do
           trainee = continue_sections_trainee
-          trn_submission = TrnSubmissionForm.new(trainee: trainee)
-          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission: trn_submission))
+          trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
+          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission_form: trn_submission_form))
         end
 
         define_method "continue_sections_#{section}_validated" do
           trainee = continue_sections_trainee
-          trn_submission = TrnSubmissionForm.new(trainee: trainee)
-          trn_submission.validate
-          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission: trn_submission))
+          trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
+          trn_submission_form.validate
+          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission_form: trn_submission_form))
         end
 
         define_method "start_sections_#{section}" do
           trainee = start_sections_trainee
-          trn_submission = TrnSubmissionForm.new(trainee: trainee)
-          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission: trn_submission))
+          trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
+          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission_form: trn_submission_form))
         end
 
         define_method "start_sections_#{section}_validated" do
           trainee = start_sections_trainee
-          trn_submission = TrnSubmissionForm.new(trainee: trainee)
-          trn_submission.validate
-          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission: trn_submission))
+          trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
+          trn_submission_form.validate
+          render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission_form: trn_submission_form))
         end
       end
 

--- a/spec/components/trainees/sections/view_spec.rb
+++ b/spec/components/trainees/sections/view_spec.rb
@@ -8,8 +8,8 @@ module Trainees
       alias_method :component, :page
 
       let(:trainees_sections_component) do
-        trn_submission = TrnSubmissionForm.new(trainee: trainee)
-        described_class.new(trainee: trainee, section: section, trn_submission: trn_submission)
+        trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
+        described_class.new(trainee: trainee, section: section, trn_submission_form: trn_submission_form)
       end
 
       before do

--- a/spec/factories/nationalities.rb
+++ b/spec/factories/nationalities.rb
@@ -3,17 +3,17 @@
 FactoryBot.define do
   factory :nationality do
     sequence(:name) { |n| "nationality #{n}" }
-  end
 
-  trait :british do
-    name { Dttp::CodeSets::Nationalities::BRITISH }
-  end
+    trait :british do
+      name { Dttp::CodeSets::Nationalities::BRITISH }
+    end
 
-  trait :irish do
-    name { Dttp::CodeSets::Nationalities::IRISH }
-  end
+    trait :irish do
+      name { Dttp::CodeSets::Nationalities::IRISH }
+    end
 
-  trait :other do
-    name { Dttp::CodeSets::Nationalities::OTHER }
+    trait :other do
+      name { Dttp::CodeSets::Nationalities::OTHER }
+    end
   end
 end

--- a/spec/forms/diversities/form_validator_spec.rb
+++ b/spec/forms/diversities/form_validator_spec.rb
@@ -110,16 +110,16 @@ module Diversities
               it { is_expected.to be_valid }
 
               context "when trainee is disabled" do
-                let(:disability_detail) { instance_double(DisabilityDetailForm) }
+                let(:disability_detail_form) { instance_double(DisabilityDetailForm) }
 
                 before do
                   trainee.disability_disclosure = DISABILITY_DISCLOSURE_ENUMS[:disabled]
-                  expect(DisabilityDetailForm).to receive(:new).and_return(disability_detail)
+                  expect(DisabilityDetailForm).to receive(:new).and_return(disability_detail_form)
                 end
 
                 context "when DisabilityDetailForm is valid" do
                   before do
-                    allow(disability_detail).to receive(:valid?).and_return(true)
+                    allow(disability_detail_form).to receive(:valid?).and_return(true)
                   end
 
                   it { is_expected.to be_valid }
@@ -127,7 +127,7 @@ module Diversities
 
                 context "when DisabilityDetailForm is invalid" do
                   before do
-                    allow(disability_detail).to receive(:valid?).and_return(false)
+                    allow(disability_detail_form).to receive(:valid?).and_return(false)
                   end
 
                   it "returns an error for the disability_ids key" do


### PR DESCRIPTION
### Context
https://trello.com/c/UnUnk0cs/1369-nest-traits-for-factories

### Changes proposed in this pull request
- Move global FactoryBot traits into nested context

#### Took the opportunity to sort out another pet peeve of mine here:

- Add `_form` suffix to all variables that store form objects. It's idiomatic ruby to name variables the same as the class name. This is important so as to remove any doubt what the variable is storing. Sometimes it's hard to know whether instance variable references in ERB templates are form objects or active record objects. We need to be clear on this.

