### PR TITLE
[1323] Add cop for register_form_with

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ require:
   - ./lib/rubocop/cop/govuk/govuk_button_to.rb
   - ./lib/rubocop/cop/govuk/govuk_link_to.rb
   - ./lib/rubocop/cop/govuk/govuk_submit.rb
+  - ./lib/rubocop/cop/register/register_form_with.rb
 
 Govuk:
   Include:
@@ -15,6 +16,11 @@ Govuk:
   Exclude:
     - "app/components/trainees/confirmation/degrees/view.html.erb"
     - "app/components/personas/view.html.erb"
+
+Register/RegisterFormWith:
+   Include:
+    - "app/views/**/*"
+    - "app/components/**/*"
 
 Naming/MemoizedInstanceVariableName:
   Exclude:

--- a/lib/rubocop/cop/register/register_form_with.rb
+++ b/lib/rubocop/cop/register/register_form_with.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Register
+      class RegisterFormWith < Base
+        def on_send(node)
+          return unless node.method_name == :form_with
+
+          add_offense(node, message: "Use the register_form_with helper method instead of inbuilt Rails form_with method")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/Un8guBBc/1323-new-cop-for-our-registerformwith-helper

### Changes proposed in this pull request
Adds a new check that catches any use of 'form_with' in views or components with the linter. Uses new Register module as different to Govuk, register_form_with method is defined in application helper

### Guidance to review
Check if form_with is caught in views or components when `bundle exec rake lint:erb` is run

