### PR TITLE
[1365] Fix expected translated cancel link text

### DIFF
--- a/app/views/trainees/confirm_delete/show.html.erb
+++ b/app/views/trainees/confirm_delete/show.html.erb
@@ -15,4 +15,4 @@
 
 <%= govuk_button_to "Delete this draft", trainee_path(@trainee), method: :delete, class: "govuk-button govuk-button--warning" %>
 
-<p class="govuk-body"><%= govuk_link_to(I18n.t("cancel"), trainee_path(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee)) %></p>

--- a/app/views/trainees/confirm_reinstatements/show.html.erb
+++ b/app/views/trainees/confirm_reinstatements/show.html.erb
@@ -21,4 +21,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), trainee_path(@trainee), class: "qa-cancel-link") %></p>
+<p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee), class: "qa-cancel-link") %></p>

--- a/app/views/trainees/confirm_withdrawals/show.html.erb
+++ b/app/views/trainees/confirm_withdrawals/show.html.erb
@@ -21,4 +21,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), trainee_path(@trainee), class: "qa-cancel-link") %></p>
+<p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee), class: "qa-cancel-link") %></p>

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -49,4 +49,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), trainee_path(@trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee)) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
   back_to_record: Back to record
   back_to_draft: Back to draft record
   service_name: Register trainee teachers
-  cancel: Cancel and return to record
+  cancel: Cancel
   change: Change
   continue: Continue
   update_record: Update record


### PR DESCRIPTION
### Context

https://trello.com/c/8nO4xkX2/1365-fix-inconsistant-use-of-i18n
https://github.com/DFE-Digital/register-trainee-teachers/pull/710
Fix due to the above PR.

### Changes proposed in this pull request

* Change en.yml so "cancel" translates to "Cancel" and not "Cancel and return to record"
* Changed all pages that expected "Cancel and return to record" text to use key: "views.forms.common.cancel_and_return_to_record"

### Guidance to review

