### PR TITLE
[1325] Create timeline events for all audits

### DIFF
--- a/app/components/trainees/timeline/view.rb
+++ b/app/components/trainees/timeline/view.rb
@@ -3,68 +3,10 @@
 module Trainees
   module Timeline
     class View < GovukComponent::Base
-      delegate :audits, :provider, to: :trainee
+      attr_reader :events
 
-      Event = Struct.new(:title, :username, :date)
-
-      def initialize(trainee)
-        @trainee = trainee
-      end
-
-    private
-
-      attr_reader :trainee
-
-      def events
-        state_change_events
-          .append(creation_event)
-          .compact.sort_by(&:date).reverse
-      end
-
-      def creation_event
-        return nil unless creation_audit
-
-        Event.new(
-          I18n.t("components.timeline.titles.created"),
-          username(creation_audit),
-          creation_audit.created_at,
-        )
-      end
-
-      def state_change_events
-        state_change_audits.map do |audit|
-          Event.new(
-            state_change_title(audit.audited_changes["state"]),
-            username(audit),
-            audit.created_at,
-          )
-        end
-      end
-
-      def creation_audit
-        @creation_audit ||= audits.find { |audit| audit.action == "create" }
-      end
-
-      def state_change_audits
-        @state_change_audits ||= audits.select do |audit|
-          audit.action == "update" && audit.audited_changes.key?("state")
-        end
-      end
-
-      def state_change_title(changes)
-        from_state, to_state = changes.map { |state| Trainee.states.key(state) }
-
-        if from_state == "deferred" && to_state != "withdrawn"
-          I18n.t("components.timeline.titles.reinstated")
-        else
-          I18n.t("components.timeline.titles.#{to_state}")
-        end
-      end
-
-      # Fall back on the provider's name if there's no user for the audit, e.g.
-      # it was created by a background job.
-      def username(audit)
-        audit.user&.name || provider.name
+      def initialize(events:)
+        @events = events
       end
     end
   end

--- a/app/controllers/trainees/timelines_controller.rb
+++ b/app/controllers/trainees/timelines_controller.rb
@@ -4,6 +4,7 @@ module Trainees
   class TimelinesController < ApplicationController
     def show
       authorize trainee
+      @timeline_events = Trainees::CreateTimelineEvents.call(audits: trainee.audits)
       render layout: "trainee_record"
     end
 

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class TimelineEvent
+  attr_reader :title, :date, :username
+
+  def initialize(title:, date:, username: "No user recorded")
+    @title = title
+    @date = date
+    @username = username
+  end
+end

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Trainees
+  class CreateTimelineEvents
+    include ServicePattern
+
+    IGNORED_EVENTS = %w[progress].freeze
+
+    def initialize(audits:)
+      @audits = audits
+    end
+
+    def call
+      events.flatten.compact.sort_by(&:date).reverse
+    end
+
+  private
+
+    attr_reader :audits
+
+    def events
+      audits.map do |audit|
+        # Create one 'master' event for the creation of a trainee
+        if is_trainee_creation?(audit)
+          TimelineEvent.new(
+            title: I18n.t("components.timeline.titles.created"),
+            date: audit.created_at,
+            username: audit.user&.name,
+          )
+
+        # Create one 'master' event when the trainee's state changes
+        elsif is_state_change?(audit)
+          TimelineEvent.new(
+            title: state_change_title(audit),
+            date: audit.created_at,
+            username: audit.user&.name,
+          )
+
+        # Create _multiple_ events for when the user submits a form with multiple fields
+        else
+          audit.audited_changes.map do |field, _|
+            next if IGNORED_EVENTS.include?(field)
+
+            TimelineEvent.new(
+              title: I18n.t(
+                "components.timeline.titles.#{field}",
+                default: "Trainee #{field.humanize(capitalize: false)} updated",
+              ),
+              date: audit.created_at,
+              username: audit.user&.name,
+            )
+          end
+        end
+      end
+    end
+
+    def is_trainee_creation?(audit)
+      audit.action == "create" && audit.auditable_type = "Trainee"
+    end
+
+    def is_state_change?(audit)
+      audit.audited_changes.keys.include?("state")
+    end
+
+    def state_change_title(audit)
+      change_from, change_to = audit.audited_changes["state"].map { |change| Trainee.states.key(change) }
+
+      if change_from == "deferred" && change_to != "withdrawn"
+        I18n.t("components.timeline.titles.reinstated")
+      else
+        I18n.t("components.timeline.titles.#{change_to}")
+      end
+    end
+  end
+end

--- a/app/views/trainees/timelines/show.html.erb
+++ b/app/views/trainees/timelines/show.html.erb
@@ -1,1 +1,1 @@
-<%= render Trainees::Timeline::View.new(@trainee) %>
+<%= render Trainees::Timeline::View.new(events: @timeline_events) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,6 +169,16 @@ en:
         deferred: Trainee deferred
         qts_awarded: Trainee awarded QTS
         reinstated: Trainee reinstated
+        age_range: Trainee course age range updated
+        subject: Trainee course subject updated
+        commencement_date: Trainee start date updated
+        trainee_id: Trainee ID updated
+        disability_disclosure: Trainee disability disclosures updated
+        trn: Trainee TRN updated
+        diversity_disclosure: Trainee diversity disclosures updated
+        locale_code: Trainee location updated
+        town_city: Trainee town/city updated
+
     sections:
       titles:
         personal_details: Personal details

--- a/spec/components/trainees/timeline/view_preview.rb
+++ b/spec/components/trainees/timeline/view_preview.rb
@@ -6,30 +6,16 @@ module Trainees
   module Timeline
     class ViewPreview < ViewComponent::Preview
       def created
-        render Trainees::Timeline::View.new(trainee)
-      end
-
-      def submitted_for_trn
-        trainee.submit_for_trn!
-        render Trainees::Timeline::View.new(trainee)
+        render Trainees::Timeline::View.new(events: [mock_event])
       end
 
     private
 
-      def trainee
-        @trainee ||= Trainee.create!(
-          training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
-          provider: user.provider,
-        )
-      end
-
-      def user
-        @user ||= User.create!(
-          first_name: "Tom",
-          last_name: "Jones",
-          email: "tom@example.com",
-          dttp_id: "1b5f121c-3e8b-4773-8560-5539fa93a5c8",
-          provider: Provider.create!(name: "Provider A", dttp_id: "b77c821a-c12a-4133-8036-6ef1db146f9e", code: "AB1"),
+      def mock_event
+        OpenStruct.new(
+          title: "Record created",
+          username: "Person A",
+          date: Time.zone.now,
         )
       end
     end

--- a/spec/components/trainees/timeline/view_spec.rb
+++ b/spec/components/trainees/timeline/view_spec.rb
@@ -7,126 +7,20 @@ module Trainees
     describe View do
       alias_method :component, :page
 
-      let(:trainee) { create(:trainee) }
+      let(:title) { "Title" }
+      let(:username) { "User" }
+      let(:date) { Time.zone.now }
 
-      describe "when the trainee state is" do
-        context "created" do
-          before do
-            render_inline(described_class.new(trainee))
-          end
-          it "shows when the record was created" do
-            expect(component).to have_text(expected_title(:created))
-          end
-        end
+      let(:event) { double(title: title, username: username, date: date) }
 
-        context "submitted for trn" do
-          before do
-            trainee.submit_for_trn!
-            render_inline(described_class.new(trainee))
-          end
-          it "shows state changes until submitted_for_trn" do
-            expect(component).to have_text(expected_title(:created))
-            expect(component).to have_text(expected_title(:submitted_for_trn))
-          end
-        end
-
-        context "trn_received" do
-          before do
-            methods = %i[submit_for_trn! receive_trn!]
-            call_methods!(methods, trainee)
-            render_inline(described_class.new(trainee))
-          end
-          it "shows state changes until trn_received" do
-            expect(component).to have_text(expected_title(:created))
-            expect(component).to have_text(expected_title(:submitted_for_trn))
-            expect(component).to have_text(expected_title(:trn_received))
-          end
-        end
-
-        context "recommended_for_qts" do
-          before do
-            methods = %i[submit_for_trn! receive_trn! recommend_for_qts!]
-            call_methods!(methods, trainee)
-            render_inline(described_class.new(trainee))
-          end
-          it "shows state changes until recommended_for_qts" do
-            expect(component).to have_text(expected_title(:created))
-            expect(component).to have_text(expected_title(:submitted_for_trn))
-            expect(component).to have_text(expected_title(:trn_received))
-            expect(component).to have_text(expected_title(:recommended_for_qts))
-          end
-        end
-
-        context "withdrawn" do
-          before do
-            methods = %i[submit_for_trn! receive_trn! withdraw!]
-            call_methods!(methods, trainee)
-            render_inline(described_class.new(trainee))
-          end
-          it "shows state changes until withdrawn" do
-            expect(component).to have_text(expected_title(:created))
-            expect(component).to have_text(expected_title(:submitted_for_trn))
-            expect(component).to have_text(expected_title(:trn_received))
-            expect(component).to have_text(expected_title(:withdrawn))
-          end
-        end
-
-        context "deferred" do
-          before do
-            methods = %i[submit_for_trn! receive_trn! defer!]
-            call_methods!(methods, trainee)
-            render_inline(described_class.new(trainee))
-          end
-          it "shows state changes until deferred" do
-            expect(component).to have_text(expected_title(:created))
-            expect(component).to have_text(expected_title(:submitted_for_trn))
-            expect(component).to have_text(expected_title(:trn_received))
-            expect(component).to have_text(expected_title(:deferred))
-          end
-        end
-
-        context "reinstated" do
-          before do
-            methods = %i[submit_for_trn! receive_trn! defer! receive_trn!]
-            call_methods!(methods, trainee)
-            render_inline(described_class.new(trainee))
-          end
-          it "shows state changes until reinstated" do
-            expect(component).to have_text(expected_title(:created))
-            expect(component).to have_text(expected_title(:submitted_for_trn))
-            expect(component).to have_text(expected_title(:trn_received))
-            expect(component).to have_text(expected_title(:deferred))
-            expect(component).to have_text(expected_title(:reinstated))
-          end
-        end
-
-        context "qts_awarded" do
-          before do
-            methods = %i[submit_for_trn! receive_trn! recommend_for_qts! award_qts!]
-            call_methods!(methods, trainee)
-            render_inline(described_class.new(trainee))
-          end
-
-          it "shows state changes until qts_awarded" do
-            expect(component).to have_text(expected_title(:created))
-            expect(component).to have_text(expected_title(:submitted_for_trn))
-            expect(component).to have_text(expected_title(:trn_received))
-            expect(component).to have_text(expected_title(:qts_awarded))
-          end
-        end
+      before do
+        render_inline(described_class.new(events: [event]))
       end
 
-      # Helper method to transfer the trainee through the various states in
-      # order.
-      def call_methods!(methods, trainee)
-        methods.each_with_object(trainee) do |method, t|
-          t.public_send(method)
-          t
-        end
-      end
-
-      def expected_title(value)
-        I18n.t("components.timeline.titles.#{value}")
+      it "displays the event title, username and date" do
+        expect(component).to have_text(title)
+        expect(component).to have_text(username)
+        expect(component).to have_text(date.to_s(:govuk_date_and_time))
       end
     end
   end

--- a/spec/services/trainees/create_timeline_events_spec.rb
+++ b/spec/services/trainees/create_timeline_events_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe CreateTimelineEvents do
+    let(:trainee) { create(:trainee) }
+
+    subject { described_class.call(audits: trainee.audits) }
+
+    describe "#call" do
+      shared_examples "created" do
+        it "returns a trainee created event" do
+          event = subject.last
+          expect(event.title).to eq(t("components.timeline.titles.created"))
+        end
+      end
+
+      shared_examples "updated" do
+        it "returns a timeline event the reflects the update" do
+          event = subject[-2]
+          expect(event.title).to eq("Trainee first names updated")
+        end
+      end
+
+      context "when a trainee is just created" do
+        include_examples "created"
+      end
+
+      context "when a trainee field is updated" do
+        before do
+          trainee.update!(first_names: "name")
+        end
+
+        include_examples "created"
+        include_examples "updated"
+      end
+
+      context "when a trainee field is updated and then the state is changed" do
+        before do
+          trainee.update!(first_names: "name")
+          trainee.submit_for_trn!
+        end
+
+        include_examples "created"
+        include_examples "updated"
+
+        it "returns a state change timeline event" do
+          expect(subject.first.title).to eq(t("components.timeline.titles.submitted_for_trn"))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/nCFp6241/1325-s-add-timeline-entries-for-each-discrete-user-action

### Changes proposed in this pull request

Instead of pulling out the audits for creating the trainee and the state changes for a trainee, map across _all_ audits and create timeline events for each one.

Some audits are treated differently to others:
- The trainee creation audit includes `audited_changes` for all trainee fields (setting most of them to `nil`). But we create just one `TimelineEvent` for this audit to mark the creation as a whole.
- The trainee state change audits include extra `audited_changes` for date fields (e.g. `defer_date`, `trn`). But we create just one `TimelineEvent` for this audit to mark the state the trainee transitioned to.
- All other audits are created from form submissions. They include multiple `audited_changes` for each field. We create a `TimelineEvent` for each `audited_change` to show which fields were updated.

### Guidance to review
- Head to `/trainees/:slug/timeline` for a couple of non-draft trainees and check that it all looks in order.
