### PR TITLE
[1382] Ignore further education courses from Publish API

### DIFF
--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -20,6 +20,7 @@ module TeacherTrainingApi
 
     def call
       return unless IMPORTABLE_STATES.include?(attrs[:state])
+      return if further_education_level_course?
 
       course.update!(name: attrs[:name],
                      start_date: start_date,
@@ -34,6 +35,10 @@ module TeacherTrainingApi
   private
 
     attr_reader :provider, :attrs
+
+    def further_education_level_course?
+      attrs[:level] == "further_education"
+    end
 
     def subjects
       Subject.where(code: attrs[:subject_codes])

--- a/spec/services/teacher_training_api/import_course_spec.rb
+++ b/spec/services/teacher_training_api/import_course_spec.rb
@@ -57,6 +57,14 @@ module TeacherTrainingApi
           end
         end
 
+        context "course has a further_education level" do
+          let(:imported_course) { JSON(ApiStubs::TeacherTrainingApi.course(level: "further_education")) }
+
+          it "doesn't get imported" do
+            expect { subject }.to_not(change { Course.count })
+          end
+        end
+
         context "and it's draft" do
           let(:imported_course) { JSON(ApiStubs::TeacherTrainingApi.course(state: "draft")) }
 


### PR DESCRIPTION
### Context
https://trello.com/c/kNelYLke/1382-m-store-level-in-courses

### Changes proposed in this pull request
- Add another guard clause to `TeacherTrainingApi::ImportCourse#call` to prevent it from importing further education courses 

