### PR TITLE
[1311] Course details page with publish courses

### DIFF
--- a/app/components/task_list/view.rb
+++ b/app/components/task_list/view.rb
@@ -16,7 +16,7 @@ private
   end
 
   class Row < GovukComponent::Slot
-    attr_accessor :task_name, :status, :path, :confirm_path
+    attr_accessor :task_name, :status
 
     def initialize(task_name:, path:, confirm_path: nil, status:, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
@@ -28,7 +28,7 @@ private
     end
 
     def get_path
-      return path unless confirm_path
+      return path unless @confirm_path
 
       status == Progress::STATUSES[:not_started] ? path : confirm_path
     end
@@ -47,6 +47,14 @@ private
     end
 
   private
+
+    def path
+      @path.respond_to?(:call) ? @path.call : @path
+    end
+
+    def confirm_path
+      @confirm_path.respond_to?(:call) ? @confirm_path.call : @confirm_path
+    end
 
     def default_classes
       %w[app-task-list__item]

--- a/app/controllers/trainees/confirm_publish_course_controller.rb
+++ b/app/controllers/trainees/confirm_publish_course_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Trainees
+  class ConfirmPublishCourseController < ApplicationController
+    before_action :authorize_trainee
+
+    def edit
+      render body: "ye olde confirm page"
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def authorize_trainee
+      authorize(trainee)
+    end
+  end
+end

--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Trainees
+  class PublishCourseDetailsController < ApplicationController
+    before_action :authorize_trainee
+
+    def edit
+      @courses = Course.take(10)
+      @publish_course_details = PublishCourseDetailsForm.new(trainee)
+    end
+
+    def update
+      @publish_course_details = PublishCourseDetailsForm.new(trainee, course_params)
+
+      result = @publish_course_details.stash
+      unless result
+        @courses ||= Course.take(10)
+        render :edit
+        return
+      end
+
+      if course_params[:code] == PublishCourseDetailsForm::NOT_LISTED
+        redirect_to edit_trainee_course_details_path
+      else
+        redirect_to edit_trainee_confirm_publish_course_path(id: helpers.stashed_code(@trainee), trainee_id: @trainee.slug)
+      end
+    end
+
+  private
+
+    def course_params
+      params.fetch(:publish_course_details_form, {}).permit(:code)
+    end
+
+    def trainee
+      @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def authorize_trainee
+      authorize(trainee)
+    end
+  end
+end

--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -19,10 +19,10 @@ module Trainees
         return
       end
 
-      if course_params[:code] == PublishCourseDetailsForm::NOT_LISTED
+      if @publish_course_details.manual_entry_chosen?
         redirect_to edit_trainee_course_details_path
       else
-        redirect_to edit_trainee_confirm_publish_course_path(id: helpers.stashed_code(@trainee), trainee_id: @trainee.slug)
+        redirect_to edit_trainee_confirm_publish_course_path(id: @publish_course_details.code, trainee_id: @trainee.slug)
       end
     end
 

--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -5,7 +5,7 @@ module Trainees
     before_action :authorize_trainee
 
     def edit
-      @courses = Course.take(10)
+      @courses = @trainee.available_courses
       @publish_course_details = PublishCourseDetailsForm.new(trainee)
     end
 
@@ -14,7 +14,7 @@ module Trainees
 
       result = @publish_course_details.stash
       unless result
-        @courses ||= Course.take(10)
+        @courses = @trainee.available_courses
         render :edit
         return
       end

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class PublishCourseDetailsForm
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+
+  NOT_LISTED = "not_listed"
+
+  FIELDS = %i[
+    code
+  ].freeze
+
+  attr_accessor(*FIELDS, :trainee, :fields)
+
+  delegate :id, :persisted?, to: :trainee
+
+  validates :code, presence: true
+
+  def initialize(trainee, params = {}, store = FormStore)
+    @trainee = trainee
+    @store = store
+    @fields = fields_from_store.merge(params).symbolize_keys
+    super(fields)
+  end
+
+  def stash
+    valid? && store.set(trainee.id, :course_code, fields)
+  end
+
+  def manual_entry_chosen?
+    code == NOT_LISTED
+  end
+
+private
+
+  attr_reader :store
+
+  def fields_from_store
+    store.get(trainee.id, :course_code).presence || {}
+  end
+end

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -36,8 +36,7 @@ module TraineeHelper
   end
 
   def show_publish_courses?(trainee)
-    # TODO: do a look up of courses to see if there are any for this route
-    courses_available = true
+    courses_available = trainee.available_courses.present?
     manual_entry_chosen = PublishCourseDetailsForm.new(trainee).manual_entry_chosen?
 
     FeatureService.enabled?(:publish_course_details) && courses_available && !manual_entry_chosen

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -41,8 +41,4 @@ module TraineeHelper
 
     FeatureService.enabled?(:publish_course_details) && courses_available && !manual_entry_chosen
   end
-
-  def stashed_code(trainee)
-    PublishCourseDetailsForm.new(trainee).code || "not_used"
-  end
 end

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -34,4 +34,16 @@ module TraineeHelper
       total_trainees_count_text: total_trainees_count_text,
     )
   end
+
+  def show_publish_courses?(trainee)
+    # TODO: do a look up of courses to see if there are any for this route
+    courses_available = true
+    manual_entry_chosen = PublishCourseDetailsForm.new(trainee).manual_entry_chosen?
+
+    FeatureService.enabled?(:publish_course_details) && courses_available && !manual_entry_chosen
+  end
+
+  def stashed_code(trainee)
+    PublishCourseDetailsForm.new(trainee).code || "not_used"
+  end
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -177,4 +177,8 @@ class Trainee < ApplicationRecord
   def training_route_manager
     @training_route_manager ||= TrainingRouteManager.new(self)
   end
+
+  def available_courses
+    provider.courses.where(route: training_route)
+  end
 end

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -5,6 +5,7 @@ class FormStore
 
   FORM_SECTION_KEYS = %i[
     contact_details
+    course_code
     course_details
     personal_details
     trainee_id

--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -30,7 +30,8 @@ module TeacherTrainingApi
                      duration_in_years: duration_in_years,
                      course_length: attrs[:course_length],
                      subjects: subjects,
-                     route: route)
+                     route: route,
+                     summary: attrs[:summary])
     end
 
   private

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -1,0 +1,31 @@
+<%= render PageTitle::View.new(title: "trainees.publish_course_details.edit", has_errors: @publish_course_details.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+<% end %>
+
+<%= register_form_with(model: @publish_course_details, url: trainee_publish_course_details_path(@trainee), method: :put, local: true) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-form-group">
+    <%= f.govuk_radio_buttons_fieldset :code, legend: { text: "What course are they doing?", tag: "h1", size: "l" } do %>
+      <% @courses.each do |course| %>
+        <%= f.govuk_radio_button :code, course.code,
+          label: { text: "#{course.name} (#{course.code})" },
+          hint:  { text: "moose" },
+          link_errors: true
+        %>
+      <% end %>
+
+      <div class="govuk-radios__divider">
+        or
+      </div>
+
+      <%= f.govuk_radio_button :code, PublishCourseDetailsForm::NOT_LISTED,
+        label: { text: "Another course not listed"}
+      %>
+    <% end %>
+  </div>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.publish_course_details.edit", has_errors: @publish_course_details.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.course_details.edit", has_errors: @publish_course_details.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -8,11 +8,11 @@
   <%= f.govuk_error_summary %>
 
   <div class="govuk-form-group">
-    <%= f.govuk_radio_buttons_fieldset :code, legend: { text: "What course are they doing?", tag: "h1", size: "l" } do %>
+    <%= f.govuk_radio_buttons_fieldset :code, legend: { text: t(".heading"), tag: "h1", size: "l" } do %>
       <% @courses.each do |course| %>
         <%= f.govuk_radio_button :code, course.code,
           label: { text: "#{course.name} (#{course.code})" },
-          hint:  { text: "moose" },
+          hint:  { text: course.summary },
           link_errors: true
         %>
       <% end %>
@@ -22,7 +22,7 @@
       </div>
 
       <%= f.govuk_radio_button :code, PublishCourseDetailsForm::NOT_LISTED,
-        label: { text: "Another course not listed"}
+        label: { text: t(".course_not_listed") }
       %>
     <% end %>
   </div>

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -76,7 +76,6 @@
 
     <%= render TaskList::View.new(classes: "record-setup") do |component|
           if show_publish_courses?(@trainee)
-            require 'pry'; ::Kernel.binding.pry; hello=1
             component.slot(
               :row,
               task_name: "Course details",

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -76,14 +76,20 @@
 
     <%= render TaskList::View.new(classes: "record-setup") do |component|
           if show_publish_courses?(@trainee)
+            form = PublishCourseDetailsForm.new(@trainee)
             component.slot(
               :row,
               task_name: "Course details",
               path: edit_trainee_publish_course_details_path(@trainee),
-              confirm_path: edit_trainee_confirm_publish_course_path(id: stashed_code(@trainee), trainee_id: @trainee.to_param),
+              confirm_path: lambda {
+                edit_trainee_confirm_publish_course_path(
+                  id: form.code,
+                  trainee_id: @trainee.to_param
+                )
+              },
               classes: "course-details",
               status: ProgressService.call(
-                validator: PublishCourseDetailsForm.new(@trainee),
+                validator: form,
                 progress_value: @trainee.progress.course_details
               ).status
             )

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -75,17 +75,32 @@
     <h2 class="govuk-heading-m">About their teacher training</h2>
 
     <%= render TaskList::View.new(classes: "record-setup") do |component|
-          component.slot(
-            :row,
-            task_name: "Course details",
-            path: edit_trainee_course_details_path(@trainee),
-            confirm_path: trainee_course_details_confirm_path(@trainee),
-            classes: "course-details",
-            status: ProgressService.call(
-              validator: CourseDetailsForm.new(@trainee),
-              progress_value: @trainee.progress.course_details,
-            ).status,
-          )
+          if show_publish_courses?(@trainee)
+            require 'pry'; ::Kernel.binding.pry; hello=1
+            component.slot(
+              :row,
+              task_name: "Course details",
+              path: edit_trainee_publish_course_details_path(@trainee),
+              confirm_path: edit_trainee_confirm_publish_course_path(id: stashed_code(@trainee), trainee_id: @trainee.to_param),
+              classes: "course-details",
+              status: ProgressService.call(
+                validator: PublishCourseDetailsForm.new(@trainee),
+                progress_value: @trainee.progress.course_details
+              ).status
+            )
+          else
+            component.slot(
+              :row,
+              task_name: "Course details",
+              path: edit_trainee_course_details_path(@trainee),
+              confirm_path: trainee_course_details_confirm_path(@trainee),
+              classes: "course-details",
+              status: ProgressService.call(
+                validator: CourseDetailsForm.new(@trainee),
+                progress_value: @trainee.progress.course_details,
+              ).status,
+            )
+          end
 
           component.slot(
             :row,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,11 +210,6 @@ en:
       link_texts:
         not_started: Start section
         in_progress: Continue section
-  trainees:
-    publish_course_details:
-      edit:
-        heading: What course are they doing?
-        course_not_listed: Another course not listed
   views:
     all_records: "All records"
     trainees:
@@ -356,6 +351,10 @@ en:
       bullet_desc: "You can:"
       go_back: go back and change your answer
       use_dttp: use DTTP to register a different route
+    publish_course_details:
+      edit:
+        heading: What course are they doing?
+        course_not_listed: Another course not listed
 
   activerecord:
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,6 +210,11 @@ en:
       link_texts:
         not_started: Start section
         in_progress: Continue section
+  trainees:
+    publish_course_details:
+      edit:
+        heading: What course are they doing?
+        course_not_listed: Another course not listed
   views:
     all_records: "All records"
     trainees:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -524,6 +524,10 @@ en:
               too_old: "You must enter a valid course end date"
               before_or_same_as_start_date: "The course end date must be after the start date"
               hint_html: For example, 11 3 %{year}
+        publish_course_details_form:
+          attributes:
+            code:
+              blank: You must select a course
         reinstatement_form:
           attributes:
             date_string:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,9 @@ Rails.application.routes.draw do
   resources :trainees, except: :edit do
     scope module: :trainees do
       resource :training_details, concerns: :confirmable, only: %i[edit update], path: "/training-details"
+      resource :publish_course_details, only: %i[edit update], path: "/publish-course-details"
+      resources :confirm_publish_course, only: %i[edit update]
+
       resource :course_details, concerns: :confirmable, only: %i[edit update], path: "/course-details"
       resource :contact_details, concerns: :confirmable, only: %i[edit update], path: "/contact-details"
       resource :trainee_id, concerns: :confirmable, only: %i[edit update], path: "/trainee-id"
@@ -101,6 +104,7 @@ Rails.application.routes.draw do
 
     member do
       get "course-details", to: "trainees/course_details#edit"
+      get "publish-course-details", to: "trainees/publish_course_details#edit"
       get "check-details", to: "trainees/check_details#show"
       get "review-draft", to: "trainees/review_draft#show"
     end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -10,6 +10,7 @@ features:
   import_courses_from_ttapi: true
   routes_provider_led_postgrad: true
   routes_early_years_undergrad: true
+  publish_course_details: true
 
 pagination:
   records_per_page: 30

--- a/db/migrate/20210401142502_add_summary_to_courses.rb
+++ b/db/migrate/20210401142502_add_summary_to_courses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSummaryToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :summary, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
     t.integer "duration_in_years", null: false
     t.string "course_length", null: false
     t.integer "qualification", null: false
+    t.string "summary", null: false
     t.integer "route", null: false
     t.integer "level", null: false
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
@@ -122,8 +123,8 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.boolean "apply_sync_enabled", default: false
     t.string "code"
+    t.boolean "apply_sync_enabled", default: false
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
 

--- a/spec/components/task_list/view_spec.rb
+++ b/spec/components/task_list/view_spec.rb
@@ -81,4 +81,55 @@ RSpec.describe TaskList::View do
       expect(subject.status_id).to eq("some-key-status")
     end
   end
+
+  describe "#get_path" do
+    subject do
+      TaskList::View::Row.new(
+        task_name: "some key",
+        path: path,
+        confirm_path: confirm_path,
+        status: status,
+      )
+    end
+    let(:confirm_path) { -> { raise hell } }
+    let(:path) { "some_path" }
+
+    context "when the status is not started" do
+      let(:status) { "not started" }
+
+      context "when the path provided is a string" do
+        it "returns the path" do
+          expect(subject.get_path).to eq "some_path"
+        end
+      end
+
+      context "when the path provided is callable" do
+        let(:path) { -> { "some_path" } }
+
+        it "calls the callable and returns the result" do
+          expect(subject.get_path).to eq "some_path"
+        end
+      end
+    end
+
+    context "when the status is in progress" do
+      let(:status) { "in_progress" }
+
+      context "when the confirm_path provided is a string" do
+        let(:confirm_path) { "confirm_path" }
+
+        it "returns the confirm_path" do
+          expect(subject.get_path).to eq "confirm_path"
+        end
+      end
+
+      context "when the confirm_path provided is callable" do
+        let(:confirm_path) { -> { "confirm_path" } }
+
+        it "calls the callable and returns the result" do
+          expect(subject.get_path).to eq "confirm_path"
+        end
+      end
+    end
+  end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -12,6 +12,12 @@ FactoryBot.define do
     qualification { %i[qts pgce_with_qts pgde_with_qts pgce pgde].sample }
     course_length { %w[OneYear TwoYears].sample }
     route { TRAINING_ROUTES.keys.sample }
+
+    summary do |builder|
+      qualifications = builder.qualification.to_s.gsub("_", " ").upcase.gsub("WITH", "with")
+      time = ["full time", "part time"].sample
+      [qualifications, time].join(" ")
+    end
   end
 
   factory :course_with_a_subject do

--- a/spec/features/trainees/edit_publish_course_details_spec.rb
+++ b/spec/features/trainees/edit_publish_course_details_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "publish course details", type: :feature, feature_publish_course_details: true do
+  background do
+    some_courses_exist
+    given_i_am_authenticated
+    given_a_trainee_exists
+    given_i_visited_the_review_draft_page
+  end
+
+  describe "tracking the progress" do
+    scenario "renders a 'not started' status when no details provided" do
+      review_draft_page.load(id: trainee.slug)
+      then_the_section_should_be(not_started)
+    end
+
+    scenario "renders an 'in progress' status when details partially provided" do
+      when_i_visit_the_publish_course_details_page
+      and_i_select_a_course
+      and_i_submit_the_form
+      and_i_visit_the_review_draft_page
+      then_the_section_should_be(in_progress)
+    end
+  end
+
+  describe "selecting a course" do
+    scenario "not selecting anything" do
+      when_i_visit_the_publish_course_details_page
+      and_i_submit_the_form
+      then_i_see_an_error_message
+    end
+
+    scenario "selecting a course" do
+      when_i_visit_the_publish_course_details_page
+      and_i_select_a_course
+      # TODO: confirm page when it is added
+    end
+
+    scenario "selecting 'Another course not listed'" do
+      when_i_visit_the_publish_course_details_page
+      and_i_select_another_course_not_listed
+      and_i_submit_the_form
+      then_i_see_the_course_details_page
+      and_i_visit_the_review_draft_page
+      then_the_link_takes_me_back_to_the_course_details_edit_page
+    end
+  end
+
+  def then_the_section_should_be(status)
+    expect(review_draft_page.course_details.status.text).to eq(status)
+  end
+
+  def then_the_link_takes_me_back_to_the_course_details_edit_page
+    expect(review_draft_page.course_details.link[:href]).to eq edit_trainee_course_details_path(trainee)
+  end
+
+  def when_i_visit_the_publish_course_details_page
+    publish_course_details_page.load(id: trainee.slug)
+  end
+
+  def and_i_select_a_course
+    publish_course_details_page.course_options.first.choose
+  end
+
+  def and_i_submit_the_form
+    publish_course_details_page.submit_button.click
+  end
+
+  def and_i_select_another_course_not_listed
+    publish_course_details_page.course_options.last.choose
+  end
+
+  def and_i_visit_the_review_draft_page
+    review_draft_page.load(id: trainee.slug)
+  end
+
+  alias_method :when_i_visit_the_review_draft_page, :and_i_visit_the_review_draft_page
+
+  def then_i_see_an_error_message
+    translation_key_prefix = "activemodel.errors.models.publish_course_details_form.attributes"
+
+    expect(publish_course_details_page).to have_content(
+      I18n.t("#{translation_key_prefix}.code.blank"),
+    )
+  end
+
+  def then_i_see_the_course_details_page
+    expect(course_details_page).to be_displayed(id: trainee.slug)
+  end
+
+  def some_courses_exist
+    # TODO: make these match the route of the trainee
+    FactoryBot.create_list(:course, 10)
+  end
+end

--- a/spec/features/trainees/edit_publish_course_details_spec.rb
+++ b/spec/features/trainees/edit_publish_course_details_spec.rb
@@ -118,8 +118,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
   end
 
   def given_some_courses_exist
-    # TODO: make these match the route of the trainee
-    @matching_courses = FactoryBot.create_list(:course, 10, provider: trainee.provider, route: trainee.training_route)
+    @matching_courses = create_list(:course, 10, provider: trainee.provider, route: trainee.training_route)
   end
 
   def given_there_arent_any_courses
@@ -128,8 +127,8 @@ feature "publish course details", type: :feature, feature_publish_course_details
 
   def and_some_courses_for_other_providers_or_routes_exist
     other_route = TRAINING_ROUTES.keys.excluding(trainee.training_route).sample
-    FactoryBot.create(:course, provider: trainee.provider, route: other_route)
-    FactoryBot.create(:course, route: trainee.training_route)
+    create(:course, provider: trainee.provider, route: other_route)
+    create(:course, route: trainee.training_route)
   end
 
   def then_i_only_see_the_courses_for_my_provider_and_route

--- a/spec/forms/publish_course_details_form_spec.rb
+++ b/spec/forms/publish_course_details_form_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PublishCourseDetailsForm, type: :model do
+  let(:params) { {} }
+  let(:trainee) { build(:trainee) }
+  let(:form_store) { class_double(FormStore) }
+  subject { described_class.new(trainee, params, form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:code) }
+  end
+
+  context "valid code" do
+    let(:params) { { code: "c0de" } }
+    let(:trainee) { create(:trainee) }
+
+    describe "#stash" do
+      it "uses FormStore to temporarily save the fields under a key combination of trainee ID and course_details" do
+        expect(form_store).to receive(:set).with(trainee.id, :course_code, params)
+
+        subject.stash
+      end
+    end
+  end
+
+  context "missing code" do
+    describe "#stash" do
+      it "returns false and adds an error to the form" do
+        expect(subject.stash).to eq false
+        expect(subject.errors.messages).to eq({ code: ["You must select a course"] })
+      end
+    end
+  end
+
+  describe "manual entry chosen?" do
+    context "when code is NOT_LISTED" do
+      it { be_true }
+    end
+
+    context "when code is nil" do
+      let(:params) { { code: "not_listed" } }
+      it { be_false }
+    end
+
+    context "when code is something else" do
+      let(:params) { { code: "c0de" } }
+      it { be_false }
+    end
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -114,6 +114,10 @@ module Features
       @course_details_page ||= PageObjects::Trainees::CourseDetails.new
     end
 
+    def publish_course_details_page
+      @publish_course_details_page ||= PageObjects::Trainees::PublishCourseDetails.new
+    end
+
     def trainee_id_edit_page
       @trainee_id_edit_page ||= PageObjects::Trainees::EditTraineeId.new
     end

--- a/spec/support/page_objects/sections/course_details.rb
+++ b/spec/support/page_objects/sections/course_details.rb
@@ -5,6 +5,7 @@ require_relative "base"
 module PageObjects
   module Sections
     class CourseDetails < PageObjects::Sections::Base
+      element :link, ".govuk-link"
       element :status, ".govuk-tag"
     end
   end

--- a/spec/support/page_objects/trainees/publish_course_details.rb
+++ b/spec/support/page_objects/trainees/publish_course_details.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class CourseOptions < SitePrism::Section
+      element :input, "input"
+      element :label, "label"
+    end
+
+    class PublishCourseDetails < PageObjects::Base
+      include PageObjects::Helpers
+      set_url "/trainees/{id}/publish-course-details/edit"
+
+      sections :course_options, CourseOptions, ".govuk-radios__item"
+
+      element :submit_button, "input[name='commit']"
+    end
+  end
+end

--- a/spec/views/trainees/review_draft/show.html.erb_spec.rb
+++ b/spec/views/trainees/review_draft/show.html.erb_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-describe "trainees/review_draft/show.html.erb" do
+describe "trainees/review_draft/show.html.erb", feature_routes_provider_led_postgrad: true do
   before do
-    allow(FeatureService).to receive(:enabled?).with(:routes_provider_led_postgrad).and_return(true)
     assign(:trainee, trainee)
     render
   end


### PR DESCRIPTION
### Context
https://trello.com/c/p6yDzY9r/1311-l-course-details-page-with-publish-courses

### Changes proposed in this pull request
- Adds the summary field to courses (used for copy to help identify courses)
- Adds a feature flag, which will how a list of courses to pick from rather than the manual form for entering course information. List of courses is filtered by trainee provider and training route.
- When the course picker is submitted, it redirects to a confirmation page including the course code (dummy page in this PR, completed in https://github.com/DFE-Digital/register-trainee-teachers/pull/738)
<img width="1945" alt="Screenshot 2021-04-06 at 10 08 38" src="https://user-images.githubusercontent.com/823643/113687328-209d5080-96c0-11eb-95cd-c9f9b4771d19.png">

