### PR TITLE
[1378] User redirected to wrong link after sign in 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ private
   end
 
   def save_requested_path
-    session[:requested_path] = request.original_fullpath
+    session[:requested_path] = request.fullpath
   end
 
   def save_requested_path_and_redirect

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,7 @@ class PagesController < ApplicationController
   skip_before_action :authenticate
 
   def start
+    session[:requested_path] = root_path
     if authenticated?
       @trainees = policy_scope(Trainee.all)
       render :home

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,6 +11,7 @@ class SessionsController < ApplicationController
 
       redirect_to session.delete(:requested_path) || root_path
     else
+      session.delete(:requested_path)
       DfESignInUser.end_session!(session)
       redirect_to sign_in_user_not_found_path
     end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -14,6 +14,7 @@ describe PagesController, type: :controller do
     context "when not signed in and navigate to start page" do
       it "renders start page" do
         get :start
+        expect(session[:requested_path]).to eq "/"
         expect(response).to render_template("start")
       end
     end
@@ -28,6 +29,7 @@ describe PagesController, type: :controller do
 
     it "renders home page" do
       get :start
+      expect(session[:requested_path]).to eq "/"
       expect(response).to render_template("home")
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -46,6 +46,12 @@ describe SessionsController, type: :controller do
         expect(session[:dfe_sign_in_user]).to be_nil
       end
 
+      it "deletes the requested_path session" do
+        session[:requested_path] = "/trainees/qts_awarded"
+        request_callback
+        expect(session[:requested_path]).to be_nil
+      end
+
       it "redirects to the sign in user not found page" do
         request_callback
         expect(response).to redirect_to(sign_in_user_not_found_path)


### PR DESCRIPTION
### Context

- [Trello ticket](https://trello.com/c/zaxZTVl7/1378-redirected-to-wrong-page-after-signing-in)
- Users were being re-directed to a different link (possibly one from a previous visit) instead of to the home page.
- User journey to re-create the bug is unclear/unknown. 

### Changes proposed in this pull request

- Changed `original_fullpath` to `fullpath` for consistency around the app and with the logic in Apply, who share the redirect system. There is also [this answer](https://stackoverflow.com/questions/34033973/rails-4-what-is-the-difference-between-request-original-fullpath-and-request-f/34034054#answer-52605696:~:text=I'd%20like%20to%20add%20original_fullpath%20ignores,end) which mentions `fullpath` includes redirects.
- `session[:requested_path] = root_path` in pages controller. Fallback to if the user directs themselves to the home page, the `requested_path` from any previous session is definitely overwritten. 
- `session.delete(:requested_path)` in the else block of sessions_controller, so that if a user is authenticated but not authorised (they don't have an account on Register), the session will  be cleared

### Guidance to review

- Copy a direct link to a trainee, ie `https://localhost/trainees/{trainee_slug}`, then sign out, and revisit the page. You'll be prompted to login and then be redirected. 
