### PR TITLE
[1312] publish course details confirm page

### DIFF
--- a/app/components/trainees/confirmation/confirm_publish_course/view.html.erb
+++ b/app/components/trainees/confirmation/confirm_publish_course/view.html.erb
@@ -1,0 +1,28 @@
+<h1 class="govuk-heading-l"><%= heading %></h1>
+<p class="govuk-body">These are the course details as listed on Publish teacher training courses.</p>
+
+<%= render GovukComponent::Details.new(summary: "What if the details are incorrect?") do %>
+  <p class="govuk-body">If the details are incorrect for all trainees, you should <a class="govuk-link" href="https://www.publish-teacher-training-courses.service.gov.uk/">update the course on Publish</a>.</p>
+  <p class="govuk-body">If the details are wrong for this trainee only, you can edit them here.</p>
+<% end %>
+
+<section class="app-summary-card govuk-!-margin-bottom-6">
+  <header class="app-summary-card__header">
+    <h2 class="app-summary-card__title">
+      <%= summary_title %>
+    </h2>
+  </header>
+  <div class="app-summary-card__body">
+    <%= render GovukComponent::SummaryList.new do |component| %>
+      <% rows.each do |row| %>
+        <% component.slot(
+          :row,
+          key: row[:key],
+          value: row[:value],
+          action: row[:action],
+          classes: row[:key].to_s.downcase.gsub(/ /, "-"),
+        ) %>
+    <% end %>
+  <% end %>
+</div>
+  </section>

--- a/app/components/trainees/confirmation/confirm_publish_course/view.html.erb
+++ b/app/components/trainees/confirmation/confirm_publish_course/view.html.erb
@@ -1,9 +1,8 @@
 <h1 class="govuk-heading-l"><%= heading %></h1>
-<p class="govuk-body">These are the course details as listed on Publish teacher training courses.</p>
+<p class="govuk-body"><%= heading_text %></p>
 
-<%= render GovukComponent::Details.new(summary: "What if the details are incorrect?") do %>
-  <p class="govuk-body">If the details are incorrect for all trainees, you should <a class="govuk-link" href="https://www.publish-teacher-training-courses.service.gov.uk/">update the course on Publish</a>.</p>
-  <p class="govuk-body">If the details are wrong for this trainee only, you can edit them here.</p>
+<%= render GovukComponent::Details.new(summary: t(".incorrect_details_title")) do %>
+  <%= simple_format t(".incorrect_details_text"), class: "govuk-body" %>
 <% end %>
 
 <section class="app-summary-card govuk-!-margin-bottom-6">

--- a/app/components/trainees/confirmation/confirm_publish_course/view.rb
+++ b/app/components/trainees/confirmation/confirm_publish_course/view.rb
@@ -17,6 +17,10 @@ module Trainees
           t(".heading")
         end
 
+        def heading_text
+          t(".heading_text")
+        end
+
         def summary_title
           t(".summary_title")
         end

--- a/app/components/trainees/confirmation/confirm_publish_course/view.rb
+++ b/app/components/trainees/confirmation/confirm_publish_course/view.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Confirmation
+    module ConfirmPublishCourse
+      class View < GovukComponent::Base
+        include SummaryHelper
+
+        attr_accessor :trainee, :course
+
+        def initialize(trainee:, course:)
+          @trainee = trainee
+          @course = course
+        end
+
+        def heading
+          t(".heading")
+        end
+
+        def summary_title
+          t(".summary_title")
+        end
+
+        def rows
+          [
+            {
+              key: t(".summary_title"),
+              value: course_details,
+              action: govuk_link_to(t(".change_course"), edit_trainee_publish_course_details_path(@trainee)),
+            },
+            {
+              key: t(".subject"),
+              value: subject,
+            },
+            {
+              key: t(".level"),
+              value: level,
+            },
+            {
+              key: t(".age_range"),
+              value: age_range,
+            },
+            {
+              key: t(".start_date"),
+              value: start_date,
+            },
+            {
+              key: t(".duration"),
+              value: duration,
+            },
+          ]
+        end
+
+        def course_details
+          "#{course.name} (#{course.code})"
+        end
+
+        def subject
+          course.name
+        end
+
+        def level
+          course.level&.capitalize
+        end
+
+        delegate :age_range, to: :course
+
+        def start_date
+          date_for_summary_view(course.start_date)
+        end
+
+        def duration
+          pluralize(course.duration_in_years, "year")
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/trainees/confirm_publish_course_controller.rb
+++ b/app/controllers/trainees/confirm_publish_course_controller.rb
@@ -13,6 +13,7 @@ module Trainees
     def update
       @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee, course_params)
       if @confirm_publish_course_form.save
+        clear_form_stash(@trainee)
         redirect_to review_draft_trainee_path(@trainee)
       else
         render :edit
@@ -30,7 +31,7 @@ module Trainees
     end
 
     def set_course
-      @course = Course.find_by!(code: params[:id])
+      @course = @trainee.available_courses.find_by!(code: params[:id])
     end
 
     def course_params

--- a/app/controllers/trainees/confirm_publish_course_controller.rb
+++ b/app/controllers/trainees/confirm_publish_course_controller.rb
@@ -2,20 +2,39 @@
 
 module Trainees
   class ConfirmPublishCourseController < ApplicationController
+    before_action :set_trainee
     before_action :authorize_trainee
+    before_action :set_course
 
     def edit
-      render body: "ye olde confirm page"
+      @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee)
+    end
+
+    def update
+      @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee, course_params)
+      if @confirm_publish_course_form.save
+        redirect_to review_draft_trainee_path(@trainee)
+      else
+        render :edit
+      end
     end
 
   private
 
-    def trainee
-      @trainee ||= Trainee.from_param(params[:trainee_id])
+    def set_trainee
+      @trainee = Trainee.from_param(params[:trainee_id])
     end
 
     def authorize_trainee
-      authorize(trainee)
+      authorize(@trainee)
+    end
+
+    def set_course
+      @course = Course.find_by!(code: params[:id])
+    end
+
+    def course_params
+      params.fetch(:confirm_publish_course_form, {}).permit(:code)
     end
   end
 end

--- a/app/forms/confirm_publish_course_form.rb
+++ b/app/forms/confirm_publish_course_form.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class ConfirmPublishCourseForm
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations::Callbacks
+
+  FIELDS = %i[
+    code
+  ].freeze
+
+  attr_accessor(*FIELDS, :trainee, :fields)
+
+  delegate :id, :persisted?, to: :trainee
+
+  validates :code, :course, presence: true
+
+  def initialize(trainee, params = {})
+    @trainee = trainee
+    @params = params
+    super(params)
+  end
+
+  def course
+    @course ||= Course.find_by(code: code)
+  end
+
+  def save
+    return false unless valid?
+
+    update_trainee_attributes
+    trainee.save!
+  end
+
+  def subject
+    course&.name
+  end
+
+  def age_range
+    course&.age_range
+  end
+
+  def course_start_date
+    course&.start_date
+  end
+
+  def course_end_date
+    course&.end_date
+  end
+
+private
+
+  def update_trainee_attributes
+    trainee.progress.course_details = true
+    trainee.assign_attributes({
+      subject: subject,
+      age_range: age_range,
+      course_start_date: course_start_date,
+      course_end_date: course_end_date,
+    })
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -42,4 +42,11 @@ class Course < ApplicationRecord
 
   has_many :course_subjects
   has_many :subjects, through: :course_subjects
+
+  def end_date
+    return unless start_date
+    return if duration_in_years.to_i.zero?
+
+    (start_date + duration_in_years.years).prev_day
+  end
 end

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -3,6 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-9"><%= t(".heading") %></h1>
-    <%= t('.body_html', support_email: support_email) %>
+    <%= t(".body_html", support_email: support_email) %>
   </div>
 </div>

--- a/app/views/pages/data_requirements.html.erb
+++ b/app/views/pages/data_requirements.html.erb
@@ -2,14 +2,14 @@
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
-    text: t('back'),
+    text: t("back"),
     href: root_path,
   ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-9"><%= t('.heading') %></h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9"><%= t(".heading") %></h1>
 
     <%= t(".body_html") %>
   </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -30,17 +30,17 @@
   <% if FeatureService.enabled?("enable_feedback_link") %>
     <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-m">
-        <%= govuk_link_to t('.give_feedback_link'), Settings.feedback_link_url, { class: "govuk-link govuk-link--no-visited-state" } %>
+        <%= govuk_link_to t(".give_feedback_link"), Settings.feedback_link_url, { class: "govuk-link govuk-link--no-visited-state" } %>
       </h2>
-      <p class="govuk-body"><%= t('.give_feedback_link_desc') %></p>
+      <p class="govuk-body"><%= t(".give_feedback_link_desc") %></p>
     </div>
   <% end %>
 
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-m">
-      <%= govuk_link_to t('.data_requirements_link'), data_requirements_path, { class: "govuk-link govuk-link--no-visited-state" } %>
+      <%= govuk_link_to t(".data_requirements_link"), data_requirements_path, { class: "govuk-link govuk-link--no-visited-state" } %>
     </h2>
-    <p class="govuk-body"><%= t('.data_requirements_link_desc') %></p>
+    <p class="govuk-body"><%= t(".data_requirements_link_desc") %></p>
   </div>
 </div>
 

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -21,11 +21,10 @@
     <% end %>
 
     <p class="govuk-body-m">
-      <%=
-        t(
+t(
           ".get_access_html",
-          link: support_email(subject: "Get access to Register trainee teachers")
-         )
+          link: support_email(subject: "Get access to Register trainee teachers"),
+        )
       %>
     </p>
 

--- a/app/views/sign_in/new.html.erb
+++ b/app/views/sign_in/new.html.erb
@@ -7,12 +7,11 @@
 
     <% if FeatureService.enabled?("enable_feedback_link") %>
       <p class="govuk-body">
-        <%=
-          t(
+t(
             ".contact_us_html",
-            link: support_email(subject: "Get access to Register trainee teachers")
+            link: support_email(subject: "Get access to Register trainee teachers"),
           )
-         %>
+        %>
        </p>
     <% end %>
 

--- a/app/views/trainees/confirm_publish_course/edit.html.erb
+++ b/app/views/trainees/confirm_publish_course/edit.html.erb
@@ -1,0 +1,17 @@
+<%= render PageTitle::View.new(title: "trainees.confirm_publish_course.edit") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLink.new(text: t(:back), href: edit_trainee_publish_course_details_path(@trainee)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render Trainees::Confirmation::ConfirmPublishCourse::View.new(trainee: @trainee, course: @course) %>
+
+    <%= register_form_with(model: @confirm_publish_course_form, url: trainee_confirm_publish_course_path(@trainee, @course.code), method: :put, local: true) do |f| %>
+      <%= f.hidden_field :code, value: @course.code %>
+      <%= f.govuk_submit "Confirm course" %>
+    <% end %>
+    <p class="govuk-body"><%= govuk_link_to("Edit details for this trainee only", "#") %></p>
+  </div>
+</div>

--- a/app/views/trainees/confirm_publish_course/edit.html.erb
+++ b/app/views/trainees/confirm_publish_course/edit.html.erb
@@ -10,8 +10,8 @@
 
     <%= register_form_with(model: @confirm_publish_course_form, url: trainee_confirm_publish_course_path(@trainee, @course.code), method: :put, local: true) do |f| %>
       <%= f.hidden_field :code, value: @course.code %>
-      <%= f.govuk_submit "Confirm course" %>
+      <%= f.govuk_submit t(".confirm_course") %>
     <% end %>
-    <p class="govuk-body"><%= govuk_link_to("Edit details for this trainee only", "#") %></p>
+    <p class="govuk-body"><%= govuk_link_to(t(".edit_details"), "#") %></p>
   </div>
 </div>

--- a/app/views/trainees/not_supported_route.html.erb
+++ b/app/views/trainees/not_supported_route.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= t('.heading') %>
+      <%= t(".heading") %>
       Other routes not supported
     </h1>
 

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -12,9 +12,8 @@
       <% @courses.each do |course| %>
         <%= f.govuk_radio_button :code, course.code,
           label: { text: "#{course.name} (#{course.code})" },
-          hint:  { text: course.summary },
-          link_errors: true
-        %>
+          hint: { text: course.summary },
+          link_errors: true %>
       <% end %>
 
       <div class="govuk-radios__divider">
@@ -22,8 +21,7 @@
       </div>
 
       <%= f.govuk_radio_button :code, PublishCourseDetailsForm::NOT_LISTED,
-        label: { text: t(".course_not_listed") }
-      %>
+        label: { text: t(".course_not_listed") } %>
     <% end %>
   </div>
 

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -84,14 +84,14 @@
               confirm_path: lambda {
                 edit_trainee_confirm_publish_course_path(
                   id: form.code,
-                  trainee_id: @trainee.to_param
+                  trainee_id: @trainee.to_param,
                 )
               },
               classes: "course-details",
               status: ProgressService.call(
                 validator: form,
-                progress_value: @trainee.progress.course_details
-              ).status
+                progress_value: @trainee.progress.course_details,
+              ).status,
             )
           else
             component.slot(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,6 +210,22 @@ en:
       link_texts:
         not_started: Start section
         in_progress: Continue section
+  trainees:
+    confirmation:
+      confirm_publish_course:
+        view:
+          change_course: Change course
+          heading: Is this the course you want to add?
+          summary_title: Course details
+          subject: Subject
+          level: Level
+          age_range: Age range
+          start_date: Start date
+          duration: Duration
+    publish_course_details:
+      edit:
+        heading: What course are they doing?
+        course_not_listed: Another course not listed
   views:
     all_records: "All records"
     trainees:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,22 +210,6 @@ en:
       link_texts:
         not_started: Start section
         in_progress: Continue section
-  trainees:
-    confirmation:
-      confirm_publish_course:
-        view:
-          change_course: Change course
-          heading: Is this the course you want to add?
-          summary_title: Course details
-          subject: Subject
-          level: Level
-          age_range: Age range
-          start_date: Start date
-          duration: Duration
-    publish_course_details:
-      edit:
-        heading: What course are they doing?
-        course_not_listed: Another course not listed
   views:
     all_records: "All records"
     trainees:
@@ -371,6 +355,28 @@ en:
       edit:
         heading: What course are they doing?
         course_not_listed: Another course not listed
+    confirmation:
+      confirm_publish_course:
+        view:
+          change_course: Change course
+          heading: Is this the course you want to add?
+          heading_text: These are the course details as listed on Publish teacher training courses.
+          summary_title: Course details
+          subject: Subject
+          level: Level
+          age_range: Age range
+          start_date: Start date
+          duration: Duration
+          incorrect_details_title: What if the details are incorrect?
+          incorrect_details_text:
+            If the details are incorrect for all trainees, you should <a class="govuk-link" href="https://www.publish-teacher-training-courses.service.gov.uk/">update the course on Publish</a>.
+
+
+            If the details are wrong for this trainee only, you can edit them here.
+    confirm_publish_course:
+      edit:
+        confirm_course: Confirm course
+        edit_details: Edit details for this trainee only
 
   activerecord:
     attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
     scope module: :trainees do
       resource :training_details, concerns: :confirmable, only: %i[edit update], path: "/training-details"
       resource :publish_course_details, only: %i[edit update], path: "/publish-course-details"
-      resources :confirm_publish_course, only: %i[edit update]
+      resources :confirm_publish_course, only: %i[edit update], path: "confirm-publish-course"
 
       resource :course_details, concerns: :confirmable, only: %i[edit update], path: "/course-details"
       resource :contact_details, concerns: :confirmable, only: %i[edit update], path: "/contact-details"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,8 +67,8 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
     t.string "course_length", null: false
     t.integer "qualification", null: false
     t.string "summary", null: false
-    t.integer "route", null: false
     t.integer "level", null: false
+    t.integer "route", null: false
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
     t.index ["provider_id"], name: "index_courses_on_provider_id"
   end

--- a/spec/components/trainees/confirmation/confirm_publish_course/view_preview.rb
+++ b/spec/components/trainees/confirmation/confirm_publish_course/view_preview.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+module Trainees
+  module Confirmation
+    module ConfirmPublishCourse
+      class ViewPreview < ViewComponent::Preview
+        def default
+          render(Trainees::Confirmation::ConfirmPublishCourse::View.new(trainee: mock_trainee, course: mock_course))
+        end
+
+        def with_no_data
+          render(Trainees::Confirmation::ConfirmPublishCourse::View.new(trainee: Trainee.new(id: 2, training_route: TRAINING_ROUTE_ENUMS[:assessment_only]), course: mock_course))
+        end
+
+      private
+
+        def mock_trainee
+          @mock_trainee ||= Trainee.new(
+            id: 1,
+            subject: "Primary",
+            age_range: "3 to 11 course",
+            course_start_date: Date.new(2020, 0o1, 28),
+            training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+          )
+        end
+
+        def mock_course
+          @mock_course ||= FactoryBot.build(:course)
+        end
+      end
+    end
+  end
+end

--- a/spec/components/trainees/confirmation/confirm_publish_course/view_spec.rb
+++ b/spec/components/trainees/confirmation/confirm_publish_course/view_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  module Confirmation
+    module ConfirmPublishCourse
+      describe View do
+        alias_method :component, :page
+
+        let(:course) { build(:course, duration_in_years: 2) }
+        let(:trainee) { build(:trainee) }
+
+        before do
+          render_inline(View.new(trainee: trainee, course: course))
+        end
+
+        it "renders the course details" do
+          expect(component.find(".govuk-summary-list__row.course-details .govuk-summary-list__value"))
+            .to have_text("#{course.name} (#{course.code})")
+        end
+
+        it "renders the subject" do
+          expect(component.find(".govuk-summary-list__row.subject .govuk-summary-list__value"))
+            .to have_text(course.name)
+        end
+
+        it "renders the level" do
+          expect(component.find(".govuk-summary-list__row.level .govuk-summary-list__value"))
+            .to have_text(course.level.capitalize)
+        end
+
+        it "renders the age range" do
+          expect(component.find(".govuk-summary-list__row.age-range .govuk-summary-list__value"))
+            .to have_text(course.age_range)
+        end
+
+        it "renders the start date" do
+          expect(component.find(".govuk-summary-list__row.start-date .govuk-summary-list__value"))
+            .to have_text(course.start_date.strftime("%-d %B %Y"))
+        end
+
+        it "renders the duration" do
+          expect(component.find(".govuk-summary-list__row.duration .govuk-summary-list__value"))
+            .to have_text("#{course.duration_in_years} years")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/trainees/edit_confirm_publish_course_spec.rb
+++ b/spec/features/trainees/edit_confirm_publish_course_spec.rb
@@ -3,10 +3,14 @@
 require "rails_helper"
 
 feature "confirm publish course", type: :feature, feature_publish_course_details: true do
+  after do
+    FormStore.clear_all(trainee.id)
+  end
+
   background do
-    given_a_course_exists
     given_i_am_authenticated
     given_a_trainee_exists
+    given_a_course_exists
     given_i_visited_the_review_draft_page
   end
 
@@ -31,7 +35,6 @@ feature "confirm publish course", type: :feature, feature_publish_course_details
   end
 
   def given_a_course_exists
-    # TODO: make these match the route of the trainee
-    @course ||= FactoryBot.create(:course)
+    @course = create(:course, provider: trainee.provider, route: trainee.training_route)
   end
 end

--- a/spec/features/trainees/edit_confirm_publish_course_spec.rb
+++ b/spec/features/trainees/edit_confirm_publish_course_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "confirm publish course", type: :feature, feature_publish_course_details: true do
+  background do
+    given_a_course_exists
+    given_i_am_authenticated
+    given_a_trainee_exists
+    given_i_visited_the_review_draft_page
+  end
+
+  describe "selecting a course" do
+    scenario "confirm course" do
+      when_i_visit_the_confirm_publish_course_page
+      and_i_submit_the_form
+      then_i_am_redirected_to_the_review_draft_page
+    end
+  end
+
+  def then_i_am_redirected_to_the_review_draft_page
+    expect(review_draft_page).to be_displayed(id: trainee.slug)
+  end
+
+  def when_i_visit_the_confirm_publish_course_page
+    confirm_publish_course_page.load(trainee_id: trainee.slug, id: @course.code)
+  end
+
+  def and_i_submit_the_form
+    confirm_publish_course_page.confirm_course_button.click
+  end
+
+  def given_a_course_exists
+    # TODO: make these match the route of the trainee
+    @course ||= FactoryBot.create(:course)
+  end
+end

--- a/spec/features/trainees/edit_publish_course_details_spec.rb
+++ b/spec/features/trainees/edit_publish_course_details_spec.rb
@@ -62,7 +62,8 @@ feature "publish course details", type: :feature, feature_publish_course_details
       and_some_courses_for_other_providers_or_routes_exist
       then_i_only_see_the_courses_for_my_provider_and_route
       and_i_select_a_course
-      # TODO: confirm page when it is added
+      and_i_submit_the_form
+      then_i_see_the_confirm_publish_course_page
     end
 
     scenario "selecting 'Another course not listed'" do
@@ -143,5 +144,9 @@ feature "publish course details", type: :feature, feature_publish_course_details
       .sort
 
     expect(@matching_courses.map(&:code).sort).to eq(course_codes_on_page)
+  end
+
+  def then_i_see_the_confirm_publish_course_page
+    expect(confirm_publish_course_page).to be_displayed(trainee_id: trainee.slug, id: @matching_courses.first.code)
   end
 end

--- a/spec/features/trainees/edit_publish_course_details_spec.rb
+++ b/spec/features/trainees/edit_publish_course_details_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 feature "publish course details", type: :feature, feature_publish_course_details: true do
+  after do
+    FormStore.clear_all(trainee.id)
+  end
+
   background do
     given_i_am_authenticated
     given_a_trainee_exists

--- a/spec/forms/confirm_publish_course_form_spec.rb
+++ b/spec/forms/confirm_publish_course_form_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ConfirmPublishCourseForm, type: :model do
+  let(:params) { {} }
+  let(:trainee) { build(:trainee) }
+  subject { described_class.new(trainee, params) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:code) }
+  end
+
+  context "valid trainee" do
+    let(:course) { create(:course) }
+    let(:params) { { code: course.code } }
+    let(:trainee) { create(:trainee) }
+    subject { described_class.new(trainee, params) }
+
+    describe "#save" do
+      it "changed related trainee attributes" do
+        expect { subject.save }
+          .to change { trainee.subject }
+          .from(nil).to(course.name)
+          .and change { trainee.age_range }
+          .from(nil).to(course.age_range)
+          .and change { trainee.course_start_date }
+          .from(nil).to(course.start_date)
+          .and change { trainee.course_end_date }
+          .from(nil).to((course.start_date + course.duration_in_years.years).to_date.prev_day)
+      end
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -71,4 +71,26 @@ describe Course do
     it { is_expected.to belong_to(:provider) }
     it { is_expected.to have_many(:subjects) }
   end
+
+  describe ".end_date" do
+    it "returns nil if start_date not set" do
+      course = build(:course, start_date: nil)
+      expect(course.end_date).to be_nil
+    end
+
+    it "returns nil if duration_in_years not set" do
+      course = build(:course, start_date: Date.today, duration_in_years: nil)
+      expect(course.end_date).to be_nil
+    end
+
+    it "duration 1 year" do
+      course = build(:course, start_date: Date.today, duration_in_years: 1)
+      expect(course.end_date).to eql(1.year.from_now.to_date.prev_day)
+    end
+
+    it "duration 2 years" do
+      course = build(:course, start_date: Date.today, duration_in_years: 2)
+      expect(course.end_date).to eql(2.years.from_now.to_date.prev_day)
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -79,17 +79,17 @@ describe Course do
     end
 
     it "returns nil if duration_in_years not set" do
-      course = build(:course, start_date: Date.today, duration_in_years: nil)
+      course = build(:course, start_date: Time.zone.today, duration_in_years: nil)
       expect(course.end_date).to be_nil
     end
 
     it "duration 1 year" do
-      course = build(:course, start_date: Date.today, duration_in_years: 1)
+      course = build(:course, start_date: Time.zone.today, duration_in_years: 1)
       expect(course.end_date).to eql(1.year.from_now.to_date.prev_day)
     end
 
     it "duration 2 years" do
-      course = build(:course, start_date: Date.today, duration_in_years: 2)
+      course = build(:course, start_date: Time.zone.today, duration_in_years: 2)
       expect(course.end_date).to eql(2.years.from_now.to_date.prev_day)
     end
   end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -118,6 +118,10 @@ module Features
       @publish_course_details_page ||= PageObjects::Trainees::PublishCourseDetails.new
     end
 
+    def confirm_publish_course_page
+      @confirm_publish_course_page ||= PageObjects::Trainees::ConfirmPublishCourse.new
+    end
+
     def trainee_id_edit_page
       @trainee_id_edit_page ||= PageObjects::Trainees::EditTraineeId.new
     end

--- a/spec/support/page_objects/trainees/confirm_publish_course.rb
+++ b/spec/support/page_objects/trainees/confirm_publish_course.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class ConfirmPublishCourse < PageObjects::Base
+      include PageObjects::Helpers
+      set_url "/trainees/{trainee_id}/confirm-publish-course/{id}/edit"
+
+      element :confirm_course_button, "input[name='commit'][value='Confirm course']"
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/wFjZXhab/1312-m-publish-course-details-confirm-page

Should be merged after https://github.com/DFE-Digital/register-trainee-teachers/pull/731

### Changes proposed in this pull request

* View page for confirming publish course
* Component to show course info

### Guidance to review

* Add new trainee, choose "Provider led (postgrad)" path, add course details, choose one from list.