### PR TITLE
[1389] [Bug] After diversity section is completed, the task list links to the wrong page

### DIFF
--- a/app/helpers/diversities_helper.rb
+++ b/app/helpers/diversities_helper.rb
@@ -24,7 +24,7 @@ module DiversitiesHelper
       edit_trainee_diversity_ethnic_background_path(trainee)
     elsif diversity_form.disability_disclosure.nil?
       edit_trainee_diversity_disability_disclosure_path(trainee)
-    elsif diversity_form.disabilities.empty?
+    elsif diversity_form.disabilities.empty? && diversity_form.disabled?
       edit_trainee_diversity_disability_detail_path(trainee)
     else
       trainee_diversity_confirm_path(trainee)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,14 +37,6 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
     t.index ["user_id", "user_type"], name: "user_index"
   end
 
-  create_table "consistency_checks", force: :cascade do |t|
-    t.integer "trainee_id"
-    t.datetime "contact_last_updated_at"
-    t.datetime "placement_assignment_last_updated_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "course_subjects", force: :cascade do |t|
     t.bigint "course_id", null: false
     t.bigint "subject_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,6 +37,14 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
     t.index ["user_id", "user_type"], name: "user_index"
   end
 
+  create_table "consistency_checks", force: :cascade do |t|
+    t.integer "trainee_id"
+    t.datetime "contact_last_updated_at"
+    t.datetime "placement_assignment_last_updated_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "course_subjects", force: :cascade do |t|
     t.bigint "course_id", null: false
     t.bigint "subject_id", null: false

--- a/spec/helpers/diversities_helper_spec.rb
+++ b/spec/helpers/diversities_helper_spec.rb
@@ -62,11 +62,28 @@ describe DiversitiesHelper do
                  ethnic_group_provided?: true,
                  ethnic_background: :not_provided,
                  disability_disclosure: :disabled,
+                 disabled?: true,
                  disabilities: [])
         end
 
         it "returns the path to the disability details page" do
           expect(subject).to eq(edit_trainee_diversity_disability_detail_path(trainee))
+        end
+      end
+
+      context "ethnic group, background and no disability are specified" do
+        let(:diversity_form) do
+          double(diversity_disclosed?: true,
+                 ethnic_group: :mixed,
+                 ethnic_group_provided?: true,
+                 ethnic_background: :not_provided,
+                 disability_disclosure: :no_disability,
+                 disabled?: false,
+                 disabilities: [])
+        end
+
+        it "returns the path to the confirm page" do
+          expect(subject).to eq(trainee_diversity_confirm_path(trainee))
         end
       end
 


### PR DESCRIPTION
### Context

- [Trello card](https://trello.com/c/kXKYVULk/1389-after-diversity-section-is-completed-the-task-list-links-to-the-wrong-page)
- If a provider currently creates a trainee, fills out the diversity form and says the trainee *doesnt* have a disability, on re-visiting the link to the form we are directed to the "which disability" page rather than the confirm details page.

### Changes proposed in this pull request

- The if else statement in `diversity_confirm_path` in `DiversitiesHelper` checks that if the trainee has no disability recorded, that they also are registered as disabled before linking them back to `edit_trainee_diversity_disability_detail_path`. 

### Guidance to review

- Create a new trainee and fill out the diversity information form. Ensure that when prompted if the trainee has a disability to select `They shared that they’re not disabled` or `They did not say`. Tick `I have completed this section` on the next page, and then click on the diversity information link again. This will direct you not to a disability selection page, but rather back to the confirm page. 

 