### PR TITLE
[1414] Poll DTTP once per hour

### DIFF
--- a/app/controllers/trainees/qts_recommendations_controller.rb
+++ b/app/controllers/trainees/qts_recommendations_controller.rb
@@ -9,7 +9,7 @@ module Trainees
         trainee.recommend_for_qts!
 
         RecommendForQtsJob.perform_later(trainee)
-        RetrieveQtsJob.set(wait: RetrieveQtsJob::POLL_DELAY).perform_later(trainee)
+        RetrieveQtsJob.perform_with_default_delay(trainee)
 
         redirect_to recommended_trainee_outcome_details_path(trainee)
       end

--- a/app/controllers/trn_submissions_controller.rb
+++ b/app/controllers/trn_submissions_controller.rb
@@ -10,7 +10,7 @@ class TrnSubmissionsController < ApplicationController
     trainee.submit_for_trn!
 
     RegisterForTrnJob.perform_later(trainee, current_user.dttp_id)
-    RetrieveTrnJob.set(wait: RetrieveTrnJob::POLL_DELAY).perform_later(trainee)
+    RetrieveTrnJob.perform_with_default_delay(trainee)
 
     redirect_to trn_submission_path(trainee)
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,8 +40,8 @@ dfe_sign_in:
   secret: secret required value
 
 jobs:
-  poll_delay_hours: 6
-  max_poll_duration_days: 2
+  poll_delay_hours: 1
+  max_poll_duration_days: 4
 
 sidekiq:
   schedule_file: "config/sidekiq_cron_schedule.yml"

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -41,7 +41,7 @@ describe "Settings" do
   describe ".jobs" do
     jobs = settings[:jobs]
 
-    include_examples expected_value_test, :poll_delay_hours, jobs, 6
-    include_examples expected_value_test, :max_poll_duration_days, jobs, 2
+    include_examples expected_value_test, :poll_delay_hours, jobs, 1
+    include_examples expected_value_test, :max_poll_duration_days, jobs, 4
   end
 end

--- a/spec/controllers/trainees/qts_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/qts_recommendations_controller_spec.rb
@@ -21,11 +21,8 @@ describe Trainees::QtsRecommendationsController do
     end
 
     it "queues a background job to poll for the trainee's QTS" do
-      Timecop.freeze(Time.zone.now) do
-        expect {
-          post :create, params: { trainee_id: trainee }
-        }.to have_enqueued_job(RetrieveQtsJob).at(RetrieveQtsJob::POLL_DELAY.from_now).with(trainee)
-      end
+      expect(RetrieveQtsJob).to receive(:perform_with_default_delay).with(trainee)
+      post :create, params: { trainee_id: trainee }
     end
 
     it "redirects user to the recommended page" do

--- a/spec/controllers/trn_submissions_controller_spec.rb
+++ b/spec/controllers/trn_submissions_controller_spec.rb
@@ -25,11 +25,8 @@ describe TrnSubmissionsController do
       end
 
       it "queues a background job to poll for the trainee's TRN" do
-        Timecop.freeze(Time.zone.now) do
-          expect {
-            post :create, params: { trainee_id: trainee }
-          }.to have_enqueued_job(RetrieveTrnJob).at(RetrieveTrnJob::POLL_DELAY.from_now).with(trainee)
-        end
+        expect(RetrieveTrnJob).to receive(:perform_with_default_delay).with(trainee)
+        post :create, params: { trainee_id: trainee }
       end
 
       context "trainee state" do


### PR DESCRIPTION
### Context

We poll DTTP for TRN and QTS status. The interval we are polling is a bit too long and has left users waiting in register for information that has been available to them in DTTP for quite a while.

### Changes proposed in this pull request

Update settings to poll for TRN and QTS hourly rather than six hourly.

Continue to poll for four days rather than two as there can be delays
and weekends.

### Guidance to review

