### PR TITLE
[1432] Ignore concurrent migration errors

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -26,7 +26,6 @@ resource cloudfoundry_service_instance redis_instance {
 
 resource cloudfoundry_app web_app {
   name                       = local.web_app_name
-  command                    = local.web_app_start_command
   docker_image               = var.app_docker_image
   health_check_type          = "http"
   health_check_http_endpoint = "/ping"

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -33,7 +33,6 @@ locals {
   postgres_service_name    = "register-postgres-${var.app_environment}"
   redis_service_name       = "register-redis-${var.app_environment}"
   web_app_name             = "register-${var.app_environment}"
-  web_app_start_command    = "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
   app_environment          = merge(var.app_config_variable, var.app_secrets_variable)
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "register-worker-${var.app_environment}"


### PR DESCRIPTION
To ensure that we ignore concurrent migration errors as implemented in
https://github.com/DFE-Digital/register-trainee-teachers/pull/659
by running (rails db:migrate:ignore_concurrent_migration_exceptions)

### Context
https://trello.com/c/vyNuP9k5/1432-ignore-concurrent-migration-errors

These errors appear as the default Dockerfile command, which incorporate the `ignore_concurrent_migration_exceptions` rake task, seem to be overridden by manually specifying the boot command.

### Changes proposed in this pull request
Fallback to the [default command in Dockerfile](https://github.com/DFE-Digital/register-trainee-teachers/blob/1f7d0b914be4b8c471ee6b77d650ae5ed56b7fb3/Dockerfile#L34)

### Guidance to review
Similar to https://github.com/DFE-Digital/register-trainee-teachers/pull/659, We do this in TTAPI and Apply.
