### PR TITLE
Add trainee ID and training route to timeline

### DIFF
--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -7,6 +7,7 @@ module Trainees
     STATE_CHANGE = "state_change"
 
     FIELDS = %w[
+      trainee_id
       first_names
       last_name
       date_of_birth
@@ -16,6 +17,7 @@ module Trainees
       postcode
       email
       middle_names
+      training_route
       international_address
       locale_code
       gender


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

A couple of trainee fields (`trainee_id`, `training_route`) were missing from the 'allowed' list for the timeline, meaning that they didn't show up as entries.

This PR adds them.

### Guidance to review

🚢 