### PR TITLE
[1377] Track and store validation errors

### DIFF
--- a/app/controllers/trainees/contact_details_controller.rb
+++ b/app/controllers/trainees/contact_details_controller.rb
@@ -9,7 +9,8 @@ module Trainees
     end
 
     def update
-      @contact_details_form = ContactDetailsForm.new(trainee, contact_details_params)
+      @contact_details_form = ContactDetailsForm.new(trainee, params: contact_details_params, user: current_user)
+
       save_strategy = trainee.draft? ? :save! : :stash
 
       if @contact_details_form.public_send(save_strategy)

--- a/app/controllers/trainees/course_details_controller.rb
+++ b/app/controllers/trainees/course_details_controller.rb
@@ -18,8 +18,14 @@ module Trainees
     end
 
     def update
-      @course_details_form = CourseDetailsForm.new(trainee, course_details_params.merge(course_date_params))
+      @course_details_form = CourseDetailsForm.new(
+        trainee,
+        user: current_user,
+        params: course_details_params.merge(course_date_params),
+      )
+
       save_strategy = trainee.draft? ? :save! : :stash
+
       if @course_details_form.public_send(save_strategy)
         redirect_to trainee_course_details_confirm_path(trainee)
       else

--- a/app/controllers/trainees/deferrals_controller.rb
+++ b/app/controllers/trainees/deferrals_controller.rb
@@ -11,7 +11,7 @@ module Trainees
     def update
       authorize(trainee, :defer?)
 
-      @deferral_form = DeferralForm.new(trainee, trainee_params)
+      @deferral_form = DeferralForm.new(trainee, params: trainee_params, user: current_user)
 
       if @deferral_form.stash
         redirect_to trainee_confirm_deferral_path(trainee)

--- a/app/controllers/trainees/diversity/disability_details_controller.rb
+++ b/app/controllers/trainees/diversity/disability_details_controller.rb
@@ -11,7 +11,12 @@ module Trainees
       end
 
       def update
-        @disability_detail_form = Diversities::DisabilityDetailForm.new(trainee, disability_detail_params)
+        @disability_detail_form = Diversities::DisabilityDetailForm.new(
+          trainee,
+          params: disability_detail_params,
+          user: current_user,
+        )
+
         save_strategy = trainee.draft? ? :save! : :stash
 
         if @disability_detail_form.public_send(save_strategy)

--- a/app/controllers/trainees/diversity/disability_disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disability_disclosures_controller.rb
@@ -10,7 +10,12 @@ module Trainees
       end
 
       def update
-        @disability_disclosure_form = Diversities::DisabilityDisclosureForm.new(trainee, disability_disclosure_params)
+        @disability_disclosure_form = Diversities::DisabilityDisclosureForm.new(
+          trainee,
+          params: disability_disclosure_params,
+          user: current_user,
+        )
+
         save_strategy = trainee.draft? ? :save! : :stash
 
         if @disability_disclosure_form.public_send(save_strategy)

--- a/app/controllers/trainees/diversity/disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disclosures_controller.rb
@@ -10,7 +10,8 @@ module Trainees
       end
 
       def update
-        @disclosure_form = Diversities::DisclosureForm.new(trainee, disclosure_params)
+        @disclosure_form = Diversities::DisclosureForm.new(trainee, params: disclosure_params, user: current_user)
+
         save_strategy = trainee.draft? ? :save! : :stash
 
         if @disclosure_form.public_send(save_strategy)

--- a/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
@@ -10,7 +10,12 @@ module Trainees
       end
 
       def update
-        @ethnic_background_form = Diversities::EthnicBackgroundForm.new(trainee, ethnic_background_params)
+        @ethnic_background_form = Diversities::EthnicBackgroundForm.new(
+          trainee,
+          params: ethnic_background_params,
+          user: current_user,
+        )
+
         save_strategy = trainee.draft? ? :save! : :stash
 
         if @ethnic_background_form.public_send(save_strategy)

--- a/app/controllers/trainees/diversity/ethnic_groups_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_groups_controller.rb
@@ -10,7 +10,12 @@ module Trainees
       end
 
       def update
-        @ethnic_group_form = Diversities::EthnicGroupForm.new(trainee, ethnic_group_param)
+        @ethnic_group_form = Diversities::EthnicGroupForm.new(
+          trainee,
+          params: ethnic_group_param,
+          user: current_user,
+        )
+
         save_strategy = trainee.draft? ? :save! : :stash
 
         if @ethnic_group_form.public_send(save_strategy)

--- a/app/controllers/trainees/outcome_dates_controller.rb
+++ b/app/controllers/trainees/outcome_dates_controller.rb
@@ -9,7 +9,7 @@ module Trainees
     end
 
     def update
-      @outcome_form = OutcomeDateForm.new(trainee, trainee_params)
+      @outcome_form = OutcomeDateForm.new(trainee, params: trainee_params, user: current_user)
 
       if @outcome_form.stash
         redirect_to confirm_trainee_outcome_details_path(trainee)

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -28,7 +28,7 @@ module Trainees
     end
 
     def update
-      personal_detail = PersonalDetailsForm.new(trainee, personal_details_params)
+      personal_detail = PersonalDetailsForm.new(trainee, params: personal_details_params, user: current_user)
       save_strategy = trainee.draft? ? :save! : :stash
 
       if personal_detail.public_send(save_strategy)

--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -10,10 +10,9 @@ module Trainees
     end
 
     def update
-      @publish_course_details = PublishCourseDetailsForm.new(trainee, course_params)
+      @publish_course_details = PublishCourseDetailsForm.new(trainee, params: course_params, user: current_user)
 
-      result = @publish_course_details.stash
-      unless result
+      unless @publish_course_details.stash
         @courses = @trainee.available_courses
         render :edit
         return

--- a/app/controllers/trainees/reinstatements_controller.rb
+++ b/app/controllers/trainees/reinstatements_controller.rb
@@ -11,7 +11,7 @@ module Trainees
     def update
       authorize(trainee, :reinstate?)
 
-      @reinstatement_form = ReinstatementForm.new(trainee, trainee_params)
+      @reinstatement_form = ReinstatementForm.new(trainee, params: trainee_params, user: current_user)
 
       if @reinstatement_form.stash
         redirect_to trainee_confirm_reinstatement_path(@trainee)

--- a/app/controllers/trainees/start_dates_controller.rb
+++ b/app/controllers/trainees/start_dates_controller.rb
@@ -15,7 +15,7 @@ module Trainees
     end
 
     def update
-      @trainee_start_date_form = TraineeStartDateForm.new(trainee, trainee_params)
+      @trainee_start_date_form = TraineeStartDateForm.new(trainee, params: trainee_params, user: current_user)
 
       save_strategy = trainee.draft? ? :save! : :stash
 

--- a/app/controllers/trainees/trainee_ids_controller.rb
+++ b/app/controllers/trainees/trainee_ids_controller.rb
@@ -9,7 +9,7 @@ module Trainees
     end
 
     def update
-      @trainee_id_form = TraineeIdForm.new(trainee, trainee_params)
+      @trainee_id_form = TraineeIdForm.new(trainee, params: trainee_params, user: current_user)
 
       save_strategy = trainee.draft? ? :save! : :stash
 

--- a/app/controllers/trainees/training_details_controller.rb
+++ b/app/controllers/trainees/training_details_controller.rb
@@ -15,8 +15,7 @@ module Trainees
     end
 
     def update
-      @training_details_form = TrainingDetailsForm.new(trainee)
-      @training_details_form.assign_attributes(trainee_params)
+      @training_details_form = TrainingDetailsForm.new(trainee, params: trainee_params, user: current_user)
 
       if @training_details_form.save
         redirect_to trainee_training_details_confirm_path(trainee)

--- a/app/controllers/trainees/withdrawals_controller.rb
+++ b/app/controllers/trainees/withdrawals_controller.rb
@@ -11,7 +11,7 @@ module Trainees
     def update
       authorize(trainee, :withdraw?)
 
-      @withdrawal_form = WithdrawalForm.new(trainee, trainee_params)
+      @withdrawal_form = WithdrawalForm.new(trainee, params: trainee_params, user: current_user)
 
       if @withdrawal_form.stash
         redirect_to trainee_confirm_withdrawal_path(@trainee)

--- a/app/forms/diversities/disclosure_form.rb
+++ b/app/forms/diversities/disclosure_form.rb
@@ -1,42 +1,14 @@
 # frozen_string_literal: true
 
 module Diversities
-  class DisclosureForm
-    include ActiveModel::Model
-
+  class DisclosureForm < TraineeForm
     FIELDS = %i[
       diversity_disclosure
     ].freeze
 
     attr_accessor(*FIELDS)
 
-    attr_reader :trainee, :fields
-
     validates :diversity_disclosure, presence: true, inclusion: { in: Diversities::DIVERSITY_DISCLOSURE_ENUMS.values }
-
-    delegate :id, :persisted?, to: :trainee
-
-    def initialize(trainee, params = {}, store = FormStore)
-      @trainee = trainee
-      @store = store
-      new_attributes = fields_from_store.merge(params).symbolize_keys
-      @fields = trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
-      super(fields)
-    end
-
-    def save!
-      if valid?
-        trainee.assign_attributes(fields)
-        trainee.save!
-        store.set(id, :diversity_disclosure, nil)
-      else
-        false
-      end
-    end
-
-    def stash
-      valid? && store.set(id, :diversity_disclosure, fields)
-    end
 
     def diversity_disclosed?
       diversity_disclosure == Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed]
@@ -48,10 +20,12 @@ module Diversities
 
   private
 
-    attr_reader :store
+    def compute_fields
+      trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
 
-    def fields_from_store
-      store.get(id, :diversity_disclosure).presence || {}
+    def form_store_key
+      :diversity_disclosure
     end
   end
 end

--- a/app/forms/diversities/ethnic_background_form.rb
+++ b/app/forms/diversities/ethnic_background_form.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 module Diversities
-  class EthnicBackgroundForm
-    include ActiveModel::Model
-    include ActiveModel::AttributeAssignment
-    include ActiveModel::Validations::Callbacks
-
+  class EthnicBackgroundForm < TraineeForm
     FIELDS = %i[
       ethnic_background
       additional_ethnic_background
@@ -13,40 +9,23 @@ module Diversities
 
     attr_accessor(*FIELDS)
 
-    attr_reader :trainee, :fields
-
-    delegate :id, :persisted?, to: :trainee
     delegate :ethnic_group, to: :ethnic_group_form
 
     validates :ethnic_background, presence: true, if: -> { disclosure_form.diversity_disclosed? }
 
-    def initialize(trainee, params = {}, store = FormStore)
-      @trainee = trainee
-      @store = store
-      @params = params
+    def initialize(trainee, **kwargs)
       @disclosure_form = DisclosureForm.new(trainee)
       @ethnic_group_form = EthnicGroupForm.new(trainee)
-      @fields = trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
-      super(fields)
-    end
-
-    def save!
-      if valid?
-        trainee.assign_attributes(fields)
-        trainee.save!
-        store.set(trainee.id, :ethnic_background, nil)
-      else
-        false
-      end
-    end
-
-    def stash
-      valid? && store.set(trainee.id, :ethnic_background, fields)
+      super(trainee, **kwargs)
     end
 
   private
 
-    attr_reader :store, :params, :disclosure_form, :ethnic_group_form
+    attr_reader :disclosure_form, :ethnic_group_form
+
+    def compute_fields
+      trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
 
     def new_attributes
       if disclosure_form.diversity_disclosed?
@@ -54,10 +33,6 @@ module Diversities
       else
         { ethnic_background: nil, additional_ethnic_background: nil }
       end
-    end
-
-    def fields_from_store
-      store.get(id, :ethnic_background).presence || {}
     end
   end
 end

--- a/app/forms/diversities/ethnic_group_form.rb
+++ b/app/forms/diversities/ethnic_group_form.rb
@@ -1,45 +1,21 @@
 # frozen_string_literal: true
 
 module Diversities
-  class EthnicGroupForm
-    include ActiveModel::Model
-
+  class EthnicGroupForm < TraineeForm
     FIELDS = %i[
       ethnic_group
     ].freeze
 
     attr_accessor(*FIELDS)
 
-    attr_reader :trainee, :fields
-
     validates :ethnic_group,
               presence: true,
               inclusion: { in: Diversities::ETHNIC_GROUP_ENUMS.values },
               if: -> { disclosure_form.diversity_disclosed? }
 
-    delegate :id, :persisted?, to: :trainee
-
-    def initialize(trainee, params = {}, store = FormStore)
-      @trainee = trainee
-      @store = store
-      @params = params
+    def initialize(trainee, **kwargs)
       @disclosure_form = DisclosureForm.new(trainee)
-      @fields = trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
-      super(fields)
-    end
-
-    def save!
-      if valid?
-        trainee.assign_attributes(fields)
-        trainee.save!
-        store.set(trainee.id, :ethnic_group, nil)
-      else
-        false
-      end
-    end
-
-    def stash
-      valid? && store.set(trainee.id, :ethnic_group, fields)
+      super(trainee, **kwargs)
     end
 
     def not_provided_ethnic_group?
@@ -48,14 +24,14 @@ module Diversities
 
   private
 
-    attr_reader :store, :params, :disclosure_form
+    attr_reader :disclosure_form
+
+    def compute_fields
+      trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
 
     def new_attributes
       disclosure_form.diversity_disclosed? ? fields_from_store.merge(params).symbolize_keys : { ethnic_group: nil }
-    end
-
-    def fields_from_store
-      store.get(id, :ethnic_group).presence || {}
     end
   end
 end

--- a/app/forms/diversities/form_validator.rb
+++ b/app/forms/diversities/form_validator.rb
@@ -64,8 +64,8 @@ module Diversities
       add_error_for(:disability_ids)
     end
 
-    def validator_is_valid?(error_klass)
-      error_klass.new(trainee).valid?
+    def validator_is_valid?(form_klass)
+      form_klass.new(trainee).valid?
     end
 
     def add_error_for(key)

--- a/app/forms/outcome_date_form.rb
+++ b/app/forms/outcome_date_form.rb
@@ -6,8 +6,4 @@ private
   def date_field
     @date_field ||= :outcome_date
   end
-
-  def form_store_key
-    :outcome
-  end
 end

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -1,31 +1,15 @@
 # frozen_string_literal: true
 
-class PublishCourseDetailsForm
-  include ActiveModel::Model
-  include ActiveModel::AttributeAssignment
-
+class PublishCourseDetailsForm < TraineeForm
   NOT_LISTED = "not_listed"
 
   FIELDS = %i[
     code
   ].freeze
 
-  attr_accessor(*FIELDS, :trainee, :fields)
-
-  delegate :id, :persisted?, to: :trainee
+  attr_accessor(*FIELDS)
 
   validates :code, presence: true
-
-  def initialize(trainee, params = {}, store = FormStore)
-    @trainee = trainee
-    @store = store
-    @fields = fields_from_store.merge(params).symbolize_keys
-    super(fields)
-  end
-
-  def stash
-    valid? && store.set(trainee.id, :course_code, fields)
-  end
 
   def manual_entry_chosen?
     code == NOT_LISTED
@@ -33,9 +17,7 @@ class PublishCourseDetailsForm
 
 private
 
-  attr_reader :store
-
-  def fields_from_store
-    store.get(trainee.id, :course_code).presence || {}
+  def compute_fields
+    new_attributes
   end
 end

--- a/app/forms/reinstatement_form.rb
+++ b/app/forms/reinstatement_form.rb
@@ -6,8 +6,4 @@ private
   def date_field
     @date_field ||= :reinstate_date
   end
-
-  def form_store_key
-    :reinstatement
-  end
 end

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class TraineeForm
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations::Callbacks
+
+  attr_accessor :trainee, :user, :params, :store, :fields
+
+  delegate :id, :persisted?, to: :trainee
+
+  after_validation :track_validation_error, if: -> { user.present? && errors.any? }
+
+  def initialize(trainee, params: {}, user: nil, store: FormStore)
+    @user = user
+    @trainee = trainee
+    @params = params
+    @store = store
+    @fields = compute_fields
+    assign_attributes(fields)
+  end
+
+  def save!
+    if valid?
+      trainee.assign_attributes(fields)
+      trainee.save!
+      clear_stash
+    else
+      false
+    end
+  end
+
+  def stash
+    valid? && store.set(id, form_store_key, fields)
+  end
+
+private
+
+  def compute_fields
+    raise NotImplementedError
+  end
+
+  def new_attributes
+    fields_from_store.merge(params).symbolize_keys
+  end
+
+  def track_validation_error
+    ValidationError.create(form_object: self.class.name, user: user, details: validation_error_details.to_h)
+  end
+
+  def validation_error_details
+    errors.messages.map do |field, messages|
+      [field, { messages: messages, value: public_send(field) }]
+    end
+  end
+
+  def clear_stash
+    store.set(id, form_store_key, nil)
+  end
+
+  def fields_from_store
+    store.get(id, form_store_key).presence || {}
+  end
+
+  def form_store_key
+    self.class.name.underscore.chomp("_form").split("/").last.to_sym
+  end
+end

--- a/app/forms/trainee_id_form.rb
+++ b/app/forms/trainee_id_form.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-class TraineeIdForm
-  include ActiveModel::Model
-  include ActiveModel::AttributeAssignment
-  include ActiveModel::Validations::Callbacks
-
-  attr_accessor :trainee, :trainee_id
-
-  delegate :id, :persisted?, to: :trainee
+class TraineeIdForm < TraineeForm
+  attr_accessor :trainee_id
 
   validates :trainee_id, presence: true,
                          length: {
@@ -15,44 +9,26 @@ class TraineeIdForm
                            message: I18n.t("activemodel.errors.models.trainee_id_form.attributes.trainee_id.max_char_exceeded"),
                          }
 
-  def initialize(trainee, params = {}, store = FormStore)
-    @trainee = trainee
-    @store = store
-    @params = params
-    @new_attributes = fields_from_store.merge(params).symbolize_keys
-    super(fields)
+  def save!
+    if valid?
+      update_trainee_id
+      trainee.save!
+      clear_stash
+    else
+      false
+    end
   end
 
-  def fields
+private
+
+  def compute_fields
     trainee.attributes
            .symbolize_keys
            .slice(:trainee_id)
            .merge(new_attributes)
   end
 
-  def save!
-    if valid?
-      update_trainee_id
-      trainee.save!
-      store.set(trainee.id, :trainee_id, nil)
-    else
-      false
-    end
-  end
-
-  def stash
-    valid? && store.set(trainee.id, :trainee_id, fields)
-  end
-
-private
-
-  attr_reader :new_attributes, :store
-
   def update_trainee_id
     trainee.assign_attributes(trainee_id: trainee_id) if errors.empty?
-  end
-
-  def fields_from_store
-    store.get(trainee.id, :trainee_id).presence || {}
   end
 end

--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -1,44 +1,18 @@
 # frozen_string_literal: true
 
-class TraineeStartDateForm
-  include ActiveModel::Model
-  include ActiveModel::AttributeAssignment
-  include ActiveModel::Validations::Callbacks
-
-  attr_accessor :trainee, :day, :month, :year
-
-  delegate :id, :persisted?, to: :trainee
+class TraineeStartDateForm < TraineeForm
+  attr_accessor :day, :month, :year
 
   validate :commencement_date_valid
-
-  def initialize(trainee, params = {}, store = FormStore)
-    @trainee = trainee
-    @store = store
-    @params = params
-    @new_attributes = fields_from_store.merge(params).symbolize_keys
-    super(fields)
-  end
-
-  def fields
-    {
-      day: trainee.commencement_date&.day,
-      month: trainee.commencement_date&.month,
-      year: trainee.commencement_date&.year,
-    }.merge(new_attributes.slice(:day, :month, :year))
-  end
 
   def save!
     if valid?
       update_trainee_commencement_date
       trainee.save!
-      store.set(trainee.id, :trainee_start_date, nil)
+      clear_stash
     else
       false
     end
-  end
-
-  def stash
-    valid? && store.set(trainee.id, :trainee_start_date, fields)
   end
 
   def commencement_date
@@ -50,7 +24,13 @@ class TraineeStartDateForm
 
 private
 
-  attr_reader :new_attributes, :store
+  def compute_fields
+    {
+      day: trainee.commencement_date&.day,
+      month: trainee.commencement_date&.month,
+      year: trainee.commencement_date&.year,
+    }.merge(new_attributes.slice(:day, :month, :year))
+  end
 
   def update_trainee_commencement_date
     trainee.assign_attributes(commencement_date: commencement_date) if errors.empty?

--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-class TrainingDetailsForm
-  include ActiveModel::Model
-  include ActiveModel::AttributeAssignment
-  include ActiveModel::Validations::Callbacks
-
-  attr_accessor :trainee, :trainee_id, :day, :month, :year
-
-  delegate :id, :persisted?, to: :trainee
+class TrainingDetailsForm < TraineeForm
+  attr_accessor :trainee_id, :day, :month, :year
 
   validates :trainee_id, presence: true,
                          length: {
@@ -18,20 +12,6 @@ class TrainingDetailsForm
   validate :commencement_date_valid
 
   after_validation :update_trainee_attributes, if: -> { errors.empty? }
-
-  def initialize(trainee)
-    @trainee = trainee
-    super(fields)
-  end
-
-  def fields
-    {
-      trainee_id: trainee.trainee_id.presence,
-      day: trainee.commencement_date&.day,
-      month: trainee.commencement_date&.month,
-      year: trainee.commencement_date&.year,
-    }
-  end
 
   def save
     valid? && trainee.save
@@ -45,6 +25,15 @@ class TrainingDetailsForm
   end
 
 private
+
+  def compute_fields
+    {
+      trainee_id: trainee.trainee_id.presence,
+      day: trainee.commencement_date&.day,
+      month: trainee.commencement_date&.month,
+      year: trainee.commencement_date&.year,
+    }.merge(new_attributes.slice(:trainee_id, :day, :month, :year))
+  end
 
   def update_trainee_attributes
     trainee.assign_attributes(trainee_id: trainee_id, commencement_date: commencement_date)

--- a/app/forms/withdrawal_form.rb
+++ b/app/forms/withdrawal_form.rb
@@ -6,18 +6,14 @@ class WithdrawalForm < MultiDateForm
   validate :withdraw_reason_valid
   validate :additional_withdraw_reason_valid
 
-  def fields
+private
+
+  def compute_fields
     super.merge(new_attributes.slice(:withdraw_reason, :additional_withdraw_reason))
   end
 
-private
-
   def date_field
     @date_field ||= :withdraw_date
-  end
-
-  def form_store_key
-    :withdrawal
   end
 
   def additional_fields

--- a/app/models/validation_error.rb
+++ b/app/models/validation_error.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidationError < ApplicationRecord
+  validates :form_object, presence: true
+
+  belongs_to :user
+
+  def self.list_of_distinct_errors_with_count
+    distinct_errors = all.flat_map do |e|
+      e.details.flat_map do |attribute, details|
+        details["messages"].map do |message|
+          [e.form_object, attribute, message]
+        end
+      end
+    end
+
+    distinct_errors.tally.sort_by { |_a, b| b }.reverse
+  end
+end

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -5,14 +5,14 @@ class FormStore
 
   FORM_SECTION_KEYS = %i[
     contact_details
-    course_code
+    publish_course_details
     course_details
     personal_details
     trainee_id
     trainee_start_date
     deferral
     reinstatement
-    outcome
+    outcome_date
     withdrawal
     diversity_disclosure
     ethnic_group

--- a/db/migrate/20210407152050_create_validation_errors.rb
+++ b/db/migrate/20210407152050_create_validation_errors.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateValidationErrors < ActiveRecord::Migration[6.1]
+  def change
+    create_table :validation_errors do |t|
+      t.belongs_to :user
+      t.string :form_object
+      t.jsonb :details
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_01_153358) do
+ActiveRecord::Schema.define(version: 2021_04_07_152050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,9 +83,9 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
     t.integer "duration_in_years", null: false
     t.string "course_length", null: false
     t.integer "qualification", null: false
+    t.integer "route", null: false
     t.string "summary", null: false
     t.integer "level", null: false
-    t.integer "route", null: false
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
     t.index ["provider_id"], name: "index_courses_on_provider_id"
   end
@@ -140,8 +140,8 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.string "code"
     t.boolean "apply_sync_enabled", default: false
+    t.string "code"
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
 
@@ -244,6 +244,15 @@ ActiveRecord::Schema.define(version: 2021_04_01_153358) do
     t.index ["dttp_id"], name: "index_users_on_dttp_id", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["provider_id"], name: "index_users_on_provider_id"
+  end
+
+  create_table "validation_errors", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "form_object"
+    t.jsonb "details"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_validation_errors_on_user_id"
   end
 
   add_foreign_key "apply_applications", "providers"

--- a/spec/forms/contact_details_form_spec.rb
+++ b/spec/forms/contact_details_form_spec.rb
@@ -7,7 +7,7 @@ describe ContactDetailsForm, type: :model do
   let(:trainee) { build(:trainee, locale_code: nil) }
   let(:form_store) { class_double(FormStore) }
 
-  subject { described_class.new(trainee, params, form_store) }
+  subject { described_class.new(trainee, params: params, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)

--- a/spec/forms/course_detail_form_spec.rb
+++ b/spec/forms/course_detail_form_spec.rb
@@ -7,7 +7,7 @@ describe CourseDetailsForm, type: :model do
   let(:trainee) { build(:trainee) }
   let(:form_store) { class_double(FormStore) }
 
-  subject { described_class.new(trainee, params, form_store) }
+  subject { described_class.new(trainee, params: params, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)

--- a/spec/forms/deferral_form_spec.rb
+++ b/spec/forms/deferral_form_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe DeferralForm, type: :model do
+  let(:user) { create(:user) }
   let(:trainee) { create(:trainee, :deferred) }
   let(:form_store) { class_double(FormStore) }
 
@@ -15,7 +16,7 @@ describe DeferralForm, type: :model do
     }
   end
 
-  subject { described_class.new(trainee, params, form_store) }
+  subject { described_class.new(trainee, params: params, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)

--- a/spec/forms/diversities/disability_disclosure_form_spec.rb
+++ b/spec/forms/diversities/disability_disclosure_form_spec.rb
@@ -8,7 +8,7 @@ module Diversities
     let(:trainee) { create(:trainee, :diversity_disclosed) }
     let(:form_store) { class_double(FormStore) }
 
-    subject { described_class.new(trainee, params, form_store) }
+    subject { described_class.new(trainee, params: params, store: form_store) }
 
     before do
       allow(form_store).to receive(:get).and_return(nil)

--- a/spec/forms/diversities/disclosure_form_spec.rb
+++ b/spec/forms/diversities/disclosure_form_spec.rb
@@ -8,7 +8,7 @@ module Diversities
     let(:trainee) { create(:trainee, :diversity_disclosed) }
     let(:form_store) { class_double(FormStore) }
 
-    subject { described_class.new(trainee, params, form_store) }
+    subject { described_class.new(trainee, params: params, store: form_store) }
 
     before do
       allow(form_store).to receive(:get).and_return(nil)

--- a/spec/forms/diversities/ethnic_background_form_spec.rb
+++ b/spec/forms/diversities/ethnic_background_form_spec.rb
@@ -8,7 +8,7 @@ module Diversities
     let(:trainee) { create(:trainee, :diversity_disclosed, :with_ethnic_background) }
     let(:form_store) { class_double(FormStore) }
 
-    subject { described_class.new(trainee, params, form_store) }
+    subject { described_class.new(trainee, params: params, store: form_store) }
 
     before do
       allow(form_store).to receive(:get).and_return(nil)

--- a/spec/forms/diversities/ethnic_group_form_spec.rb
+++ b/spec/forms/diversities/ethnic_group_form_spec.rb
@@ -8,7 +8,7 @@ module Diversities
     let(:trainee) { create(:trainee, :diversity_disclosed, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:asian]) }
     let(:form_store) { class_double(FormStore) }
 
-    subject { described_class.new(trainee, params, form_store) }
+    subject { described_class.new(trainee, params: params, store: form_store) }
 
     before do
       allow(form_store).to receive(:get).and_return(nil)

--- a/spec/forms/outcome_date_form_spec.rb
+++ b/spec/forms/outcome_date_form_spec.rb
@@ -15,7 +15,7 @@ describe OutcomeDateForm, type: :model do
     }
   end
 
-  subject { described_class.new(trainee, params, form_store) }
+  subject { described_class.new(trainee, params: params, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)
@@ -68,7 +68,7 @@ describe OutcomeDateForm, type: :model do
 
   describe "#stash" do
     it "uses FormStore to temporarily save the fields under a key combination of trainee ID and deferral_details" do
-      expect(form_store).to receive(:set).with(trainee.id, :outcome, subject.fields)
+      expect(form_store).to receive(:set).with(trainee.id, :outcome_date, subject.fields)
 
       subject.stash
     end
@@ -76,7 +76,7 @@ describe OutcomeDateForm, type: :model do
 
   describe "#save!" do
     it "takes any data from the form store and saves it to the database and clears the store data" do
-      expect(form_store).to receive(:set).with(trainee.id, :outcome, nil)
+      expect(form_store).to receive(:set).with(trainee.id, :outcome_date, nil)
 
       date_params = params.except("date_string").values.map(&:to_i)
       expect { subject.save! }.to change(trainee, :outcome_date).to(Date.new(*date_params))

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -23,7 +23,7 @@ describe PersonalDetailsForm, type: :model do
     }
   end
 
-  subject { described_class.new(trainee, params, form_store) }
+  subject { described_class.new(trainee, params: params, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)
@@ -52,10 +52,8 @@ describe PersonalDetailsForm, type: :model do
     end
 
     context "date of birth" do
-      subject { described_class.new(trainee, attributes) }
-
       context "invalid date" do
-        let(:attributes) { { day: 323, month: 2, year: 1987 } }
+        let(:params) { { day: 323, month: 2, year: 1987 } }
 
         before do
           subject.validate
@@ -71,7 +69,7 @@ describe PersonalDetailsForm, type: :model do
       end
 
       context "future date" do
-        let(:attributes) { { day: 1, month: 2, year: 2021 } }
+        let(:params) { { day: 1, month: 2, year: 2021 } }
 
         before do
           subject.validate

--- a/spec/forms/publish_course_details_form_spec.rb
+++ b/spec/forms/publish_course_details_form_spec.rb
@@ -6,7 +6,7 @@ describe PublishCourseDetailsForm, type: :model do
   let(:params) { {} }
   let(:trainee) { build(:trainee) }
   let(:form_store) { class_double(FormStore) }
-  subject { described_class.new(trainee, params, form_store) }
+  subject { described_class.new(trainee, params: params, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)
@@ -22,7 +22,7 @@ describe PublishCourseDetailsForm, type: :model do
 
     describe "#stash" do
       it "uses FormStore to temporarily save the fields under a key combination of trainee ID and course_details" do
-        expect(form_store).to receive(:set).with(trainee.id, :course_code, params)
+        expect(form_store).to receive(:set).with(trainee.id, :publish_course_details, params)
 
         subject.stash
       end

--- a/spec/forms/reinstatement_form_spec.rb
+++ b/spec/forms/reinstatement_form_spec.rb
@@ -15,7 +15,7 @@ describe ReinstatementForm, type: :model do
     }
   end
 
-  subject { described_class.new(trainee, params, form_store) }
+  subject { described_class.new(trainee, params: params, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)

--- a/spec/forms/trainee_id_form_spec.rb
+++ b/spec/forms/trainee_id_form_spec.rb
@@ -7,7 +7,7 @@ describe TraineeIdForm, type: :model do
   let(:trainee) { build(:trainee, :not_started) }
   let(:form_store) { class_double(FormStore) }
 
-  subject { described_class.new(trainee, params, form_store) }
+  subject { described_class.new(trainee, params: params, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)

--- a/spec/forms/trainee_start_date_form_spec.rb
+++ b/spec/forms/trainee_start_date_form_spec.rb
@@ -8,15 +8,13 @@ describe TraineeStartDateForm, type: :model do
   let(:form_store) { class_double(FormStore) }
   let(:error_attr) { "activemodel.errors.models.training_details_form.attributes.commencement_date" }
 
-  subject { described_class.new(trainee, params, form_store) }
+  subject { described_class.new(trainee, params: params, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)
   end
 
   describe "validations" do
-    subject { described_class.new(trainee, params) }
-
     before { subject.validate }
 
     context "invalid date" do

--- a/spec/forms/training_details_form_spec.rb
+++ b/spec/forms/training_details_form_spec.rb
@@ -3,9 +3,10 @@
 require "rails_helper"
 
 describe TrainingDetailsForm, type: :model do
+  let(:params) { {} }
   let(:trainee) { build(:trainee) }
 
-  subject { described_class.new(trainee) }
+  subject { described_class.new(trainee, params: params) }
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:trainee_id) }
@@ -17,8 +18,6 @@ describe TrainingDetailsForm, type: :model do
     end
 
     context "trainee ID" do
-      subject { described_class.new(trainee) }
-
       context "not present" do
         let(:trainee) { build(:trainee, trainee_id: nil) }
 
@@ -50,15 +49,8 @@ describe TrainingDetailsForm, type: :model do
     end
 
     context "commencement date" do
-      subject { described_class.new(trainee) }
-
-      before do
-        subject.assign_attributes(date_attributes)
-        subject.validate
-      end
-
       context "not present" do
-        let(:date_attributes) { { day: "", month: "", year: "" } }
+        let(:params) { { day: "", month: "", year: "" } }
 
         it "returns a blank error message" do
           expect(subject.errors[:commencement_date]).to include(
@@ -68,7 +60,7 @@ describe TrainingDetailsForm, type: :model do
       end
 
       context "invalid date" do
-        let(:date_attributes) { { day: "2", month: "14", year: "" } }
+        let(:params) { { day: "2", month: "14", year: "" } }
 
         it "returns an invalid date error message" do
           expect(subject.errors[:commencement_date]).to include(

--- a/spec/forms/withdrawal_form_spec.rb
+++ b/spec/forms/withdrawal_form_spec.rb
@@ -7,7 +7,7 @@ describe WithdrawalForm, type: :model do
   let(:trainee) { create(:trainee, :withdrawn, :withdrawn_for_another_reason) }
   let(:form_store) { class_double(FormStore) }
 
-  subject { described_class.new(trainee, params, form_store) }
+  subject { described_class.new(trainee, params: params, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe EmailFormatValidator do
-  let(:trainee) { build :trainee }
+  let(:trainee) { build(:trainee) }
   subject { ContactDetailsForm.new(trainee) }
 
   before { subject.email = email }


### PR DESCRIPTION
### Context
https://trello.com/c/H7CfRbo1/1377-spike-1-2-day-store-validation-errors-in-the-db

There are no simple and well maintained gems out there to cover this, so the approach taken by Apply is the inspiration for this solution.

### Changes proposed in this pull request
- Create `ValidationError` model that stores a reference to the user that made the update and all the errors produced by the form object. Should we store a reference to the trainee?
- Create `FormBase` which all other form objects subclass from. This class will take on the responsibilty of storing the validation errors. It can also help reduce code duplication among the form objects.

### Guidance to review
- Run `db:migrate`
- Open rails console and run `ValidationError.list_of_distinct_errors_with_count` - it should return an empty array
- Visit the personal details form of a trainee
- Produce a validation error
- Go back to the rails console and run `ValidationError.list_of_distinct_errors_with_count`. It should produce something like this:

```rails
[[["PersonalDetailsForm", "date_of_birth", "You must enter a valid date"], 1]]
```

**This data structure allows us to easily replicate the following UI in Apply**

<img width="1117" alt="Screenshot 2021-04-08 at 11 01 05" src="https://user-images.githubusercontent.com/28728/114008040-c801bb00-9859-11eb-8689-06ed1e06a25e.png">

and

<img width="1117" alt="Screenshot 2021-04-08 at 11 02 02" src="https://user-images.githubusercontent.com/28728/114008146-dbad2180-9859-11eb-8c12-5ac4bf730282.png">