### PR TITLE
[1442] Pass trainee to Dttp::UpdateTraineeStatus service

### DIFF
--- a/app/jobs/change_trainee_status_job.rb
+++ b/app/jobs/change_trainee_status_job.rb
@@ -4,7 +4,7 @@ class ChangeTraineeStatusJob < ApplicationJob
   queue_as :default
   retry_on Dttp::UpdateTraineeStatus::Error
 
-  def perform(entity_id, status, entity_type)
-    Dttp::UpdateTraineeStatus.call(status: status, entity_id: entity_id, entity_type: entity_type)
+  def perform(trainee, status, entity_type)
+    Dttp::UpdateTraineeStatus.call(status: status, trainee: trainee, entity_type: entity_type)
   end
 end

--- a/app/jobs/create_or_update_consistency_check_job.rb
+++ b/app/jobs/create_or_update_consistency_check_job.rb
@@ -4,8 +4,8 @@ class CreateOrUpdateConsistencyCheckJob < ApplicationJob
   queue_as :default
 
   def perform(trainee)
-    contact = Dttp::Contacts::Fetch.call(contact_entity_id: trainee.dttp_id)
-    placement_assignment = Dttp::PlacementAssignments::Fetch.call(placement_assignment_dttp_id: trainee.placement_assignment_dttp_id)
+    contact = Dttp::Contacts::Fetch.call(dttp_id: trainee.dttp_id)
+    placement_assignment = Dttp::PlacementAssignments::Fetch.call(dttp_id: trainee.placement_assignment_dttp_id)
 
     consistency_check = ConsistencyCheck.find_or_create_by!(trainee_id: trainee.id)
     consistency_check.contact_last_updated_at = contact.updated_at

--- a/app/jobs/create_or_update_consistency_check_job.rb
+++ b/app/jobs/create_or_update_consistency_check_job.rb
@@ -5,7 +5,7 @@ class CreateOrUpdateConsistencyCheckJob < ApplicationJob
 
   def perform(trainee)
     contact = Dttp::Contacts::Fetch.call(trainee: trainee)
-    placement_assignment = Dttp::PlacementAssignments::Fetch.call(dttp_id: trainee.dttp_id)
+    placement_assignment = Dttp::PlacementAssignments::Fetch.call(placement_assignment_dttp_id: trainee.placement_assignment_dttp_id)
 
     consistency_check = ConsistencyCheck.find_or_create_by!(trainee_id: trainee.id)
     consistency_check.contact_last_updated_at = contact.updated_at

--- a/app/jobs/create_or_update_consistency_check_job.rb
+++ b/app/jobs/create_or_update_consistency_check_job.rb
@@ -4,7 +4,7 @@ class CreateOrUpdateConsistencyCheckJob < ApplicationJob
   queue_as :default
 
   def perform(trainee)
-    contact = Dttp::Contacts::Fetch.call(trainee: trainee)
+    contact = Dttp::Contacts::Fetch.call(contact_entity_id: trainee.dttp_id)
     placement_assignment = Dttp::PlacementAssignments::Fetch.call(placement_assignment_dttp_id: trainee.placement_assignment_dttp_id)
 
     consistency_check = ConsistencyCheck.find_or_create_by!(trainee_id: trainee.id)

--- a/app/jobs/defer_job.rb
+++ b/app/jobs/defer_job.rb
@@ -7,13 +7,13 @@ class DeferJob < ApplicationJob
   def perform(trainee)
     Dttp::UpdateTraineeStatus.call(
       status: DttpStatuses::DEFERRED,
-      entity_id: trainee.dttp_id,
+      trainee: trainee,
       entity_type: Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
     )
 
     Dttp::UpdateTraineeStatus.call(
       status: DttpStatuses::DEFERRED,
-      entity_id: trainee.placement_assignment_dttp_id,
+      trainee: trainee,
       entity_type: Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
     )
 

--- a/app/jobs/dttp/check_consistency_job.rb
+++ b/app/jobs/dttp/check_consistency_job.rb
@@ -6,8 +6,8 @@ module Dttp
 
     def perform(consistency_check_id)
       @consistency_check = ConsistencyCheck.find(consistency_check_id)
-      @dttp_contact_updated_date = Dttp::Contacts::Fetch.call(contact_entity_id: trainee.dttp_id).updated_at
-      @dttp_placement_assignment_updated_date = Dttp::PlacementAssignments::Fetch.call(placement_assignment_dttp_id: trainee.placement_assignment_dttp_id).updated_at
+      @dttp_contact_updated_date = Dttp::Contacts::Fetch.call(dttp_id: trainee.dttp_id).updated_at
+      @dttp_placement_assignment_updated_date = Dttp::PlacementAssignments::Fetch.call(dttp_id: trainee.placement_assignment_dttp_id).updated_at
 
       if contact_conflict || placement_assignment_conflict
         SlackNotifierService.call(channel: Settings.slack.publish_register_alerts_channel, message: "<#{Rails.application.routes.url_helpers.trainees_url(trainee, host: Settings.base_url)}|Trainee #{trainee.id} has been updated in DTTP>", username: "DTTP Conflict Error")

--- a/app/jobs/dttp/check_consistency_job.rb
+++ b/app/jobs/dttp/check_consistency_job.rb
@@ -6,7 +6,7 @@ module Dttp
 
     def perform(consistency_check_id)
       @consistency_check = ConsistencyCheck.find(consistency_check_id)
-      @dttp_contact_updated_date = Dttp::Contacts::Fetch.call(trainee: trainee).updated_at
+      @dttp_contact_updated_date = Dttp::Contacts::Fetch.call(contact_entity_id: trainee.dttp_id).updated_at
       @dttp_placement_assignment_updated_date = Dttp::PlacementAssignments::Fetch.call(placement_assignment_dttp_id: trainee.placement_assignment_dttp_id).updated_at
 
       if contact_conflict || placement_assignment_conflict

--- a/app/jobs/recommend_for_qts_job.rb
+++ b/app/jobs/recommend_for_qts_job.rb
@@ -10,13 +10,13 @@ class RecommendForQtsJob < ApplicationJob
 
     Dttp::UpdateTraineeStatus.call(
       status: DttpStatuses::STANDARDS_MET,
-      entity_id: trainee.dttp_id,
+      trainee: trainee,
       entity_type: ::Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
     )
 
     Dttp::UpdateTraineeStatus.call(
       status: DttpStatuses::STANDARDS_MET,
-      entity_id: trainee.placement_assignment_dttp_id,
+      trainee: trainee,
       entity_type: ::Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
     )
   end

--- a/app/jobs/register_for_trn_job.rb
+++ b/app/jobs/register_for_trn_job.rb
@@ -8,13 +8,13 @@ class RegisterForTrnJob < ApplicationJob
     Dttp::RegisterForTrn.call(trainee: trainee, trainee_creator_dttp_id: trainee_creator_dttp_id)
 
     ChangeTraineeStatusJob.perform_later(
-      trainee.dttp_id,
+      trainee,
       DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED,
       Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
     )
 
     ChangeTraineeStatusJob.perform_later(
-      trainee.placement_assignment_dttp_id,
+      trainee,
       DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED,
       Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
     )

--- a/app/jobs/reinstate_job.rb
+++ b/app/jobs/reinstate_job.rb
@@ -9,13 +9,13 @@ class ReinstateJob < ApplicationJob
 
     Dttp::UpdateTraineeStatus.call(
       status: status,
-      entity_id: trainee.dttp_id,
+      trainee: trainee,
       entity_type: Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
     )
 
     Dttp::UpdateTraineeStatus.call(
       status: status,
-      entity_id: trainee.placement_assignment_dttp_id,
+      trainee: trainee,
       entity_type: Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
     )
 

--- a/app/jobs/withdraw_job.rb
+++ b/app/jobs/withdraw_job.rb
@@ -7,13 +7,13 @@ class WithdrawJob < ApplicationJob
   def perform(trainee)
     Dttp::UpdateTraineeStatus.call(
       status: DttpStatuses::REJECTED,
-      entity_id: trainee.dttp_id,
+      trainee: trainee,
       entity_type: Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
     )
 
     Dttp::UpdateTraineeStatus.call(
       status: DttpStatuses::REJECTED,
-      entity_id: trainee.placement_assignment_dttp_id,
+      trainee: trainee,
       entity_type: Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
     )
 

--- a/app/services/dttp/contacts/fetch.rb
+++ b/app/services/dttp/contacts/fetch.rb
@@ -7,12 +7,12 @@ module Dttp
 
       class HttpError < StandardError; end
 
-      def initialize(contact_entity_id:)
-        @contact_entity_id = contact_entity_id
+      def initialize(dttp_id:)
+        @dttp_id = dttp_id
       end
 
       def call
-        response = Client.get("/contacts(#{contact_entity_id})?")
+        response = Client.get("/contacts(#{dttp_id})?")
 
         if response.code != 200
           raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
@@ -23,7 +23,7 @@ module Dttp
 
     private
 
-      attr_reader :contact_entity_id
+      attr_reader :dttp_id
     end
   end
 end

--- a/app/services/dttp/contacts/fetch.rb
+++ b/app/services/dttp/contacts/fetch.rb
@@ -7,14 +7,12 @@ module Dttp
 
       class HttpError < StandardError; end
 
-      attr_reader :trainee
-
-      def initialize(trainee:)
-        @trainee = trainee
+      def initialize(contact_entity_id:)
+        @contact_entity_id = contact_entity_id
       end
 
       def call
-        response = Client.get("/contacts(#{trainee.dttp_id})?")
+        response = Client.get("/contacts(#{contact_entity_id})?")
 
         if response.code != 200
           raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
@@ -22,6 +20,10 @@ module Dttp
 
         Dttp::Contact.new(contact_data: JSON(response.body))
       end
+
+    private
+
+      attr_reader :contact_entity_id
     end
   end
 end

--- a/app/services/dttp/placement_assignments/fetch.rb
+++ b/app/services/dttp/placement_assignments/fetch.rb
@@ -7,14 +7,12 @@ module Dttp
 
       class HttpError < StandardError; end
 
-      attr_reader :placement_assignment_dttp_id
-
-      def initialize(placement_assignment_dttp_id:)
-        @placement_assignment_dttp_id = placement_assignment_dttp_id
+      def initialize(dttp_id:)
+        @dttp_id = dttp_id
       end
 
       def call
-        response = Client.get("/dfe_placementassignments(#{placement_assignment_dttp_id})")
+        response = Client.get("/dfe_placementassignments(#{dttp_id})")
 
         if response.code != 200
           raise HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
@@ -24,6 +22,10 @@ module Dttp
 
         Dttp::PlacementAssignment.new(placement_assignment_data: placement_assignment_data)
       end
+
+    private
+
+      attr_reader :dttp_id
     end
   end
 end

--- a/app/services/dttp/update_trainee_status.rb
+++ b/app/services/dttp/update_trainee_status.rb
@@ -14,10 +14,11 @@ module Dttp
 
     class Error < StandardError; end
 
-    def initialize(status:, entity_id:, entity_type:)
+    def initialize(status:, entity_type:, trainee:)
+      @trainee = trainee
+      @entity_type = entity_type
       @path = ENDPOINTS[entity_type] + "(#{entity_id})"
       @params = Dttp::Params::Status.new(status: status)
-      @entity_id = entity_id
     end
 
     def call
@@ -31,10 +32,12 @@ module Dttp
 
   private
 
-    attr_reader :path, :params, :entity_id
+    attr_reader :path, :params, :trainee, :entity_type
 
-    def trainee
-      Trainee.find_by(dttp_id: entity_id)
+    def entity_id
+      return trainee.dttp_id if entity_type == CONTACT_ENTITY_TYPE
+
+      trainee.placement_assignment_dttp_id
     end
   end
 end

--- a/spec/jobs/check_consistency_job_spec.rb
+++ b/spec/jobs/check_consistency_job_spec.rb
@@ -10,8 +10,8 @@ module Dttp
     subject { described_class.perform_now(consistency_check.id) }
 
     before do
-      allow(Dttp::Contacts::Fetch).to receive(:call).with(contact_dttp_id: trainee.dttp_id) { contact }
-      allow(Dttp::PlacementAssignments::Fetch).to receive(:call).with({ placement_assignment_dttp_id: trainee.placement_assignment_dttp_id }) { placement_assignment }
+      allow(Dttp::Contacts::Fetch).to receive(:call).with(dttp_id: trainee.dttp_id) { contact }
+      allow(Dttp::PlacementAssignments::Fetch).to receive(:call).with(dttp_id: trainee.placement_assignment_dttp_id) { placement_assignment }
       allow(SlackNotifierService).to receive(:call) { "foobar" }
       allow(Trainee).to receive(:find).with(trainee.id) { trainee }
     end

--- a/spec/jobs/check_consistency_job_spec.rb
+++ b/spec/jobs/check_consistency_job_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 module Dttp
   describe CheckConsistencyJob do
-    let(:trainee) { create(:trainee, id: 1) }
+    let(:trainee) { create(:trainee, dttp_id: SecureRandom.uuid) }
     let(:contact) { double({ updated_at: Faker::Date.backward(days: 2) }) }
     let(:placement_assignment) { double({ updated_at: Faker::Date.backward(days: 2) }) }
     subject { described_class.perform_now(consistency_check.id) }
 
     before do
-      allow(Dttp::Contacts::Fetch).to receive(:call).with({ trainee: trainee }) { contact }
+      allow(Dttp::Contacts::Fetch).to receive(:call).with(contact_dttp_id: trainee.dttp_id) { contact }
       allow(Dttp::PlacementAssignments::Fetch).to receive(:call).with({ placement_assignment_dttp_id: trainee.placement_assignment_dttp_id }) { placement_assignment }
       allow(SlackNotifierService).to receive(:call) { "foobar" }
       allow(Trainee).to receive(:find).with(trainee.id) { trainee }

--- a/spec/jobs/recommend_for_qts_job_spec.rb
+++ b/spec/jobs/recommend_for_qts_job_spec.rb
@@ -10,7 +10,7 @@ describe RecommendForQtsJob do
   let(:expected_contact_params) do
     {
       status: DttpStatuses::STANDARDS_MET,
-      entity_id: trainee.dttp_id,
+      trainee: trainee,
       entity_type: :contact,
     }
   end
@@ -18,7 +18,7 @@ describe RecommendForQtsJob do
   let(:expected_placement_assignment_params) do
     {
       status: DttpStatuses::STANDARDS_MET,
-      entity_id: trainee.placement_assignment_dttp_id,
+      trainee: trainee,
       entity_type: :placement_assignment,
     }
   end

--- a/spec/jobs/register_for_trn_job_spec.rb
+++ b/spec/jobs/register_for_trn_job_spec.rb
@@ -22,7 +22,7 @@ describe RegisterForTrnJob do
 
     it "queues a job to update the contact status" do
       expect { subject }.to have_enqueued_job(ChangeTraineeStatusJob).with(
-        dttp_id,
+        trainee,
         DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED,
         Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
       )
@@ -30,7 +30,7 @@ describe RegisterForTrnJob do
 
     it "queues a job to update the contact status" do
       expect { subject }.to have_enqueued_job(ChangeTraineeStatusJob).with(
-        placement_assignment_dttp_id,
+        trainee,
         DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED,
         Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
       )

--- a/spec/jobs/reinstate_job_spec.rb
+++ b/spec/jobs/reinstate_job_spec.rb
@@ -9,14 +9,14 @@ describe ReinstateJob do
 
   let(:contact_update_params) do
     {
-      entity_id: trainee.dttp_id,
+      trainee: trainee,
       entity_type: Dttp::UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
     }
   end
 
   let(:placement_assignment_update_params) do
     {
-      entity_id: trainee.placement_assignment_dttp_id,
+      trainee: trainee,
       entity_type: Dttp::UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
     }
   end

--- a/spec/services/dttp/contact_fetch_spec.rb
+++ b/spec/services/dttp/contact_fetch_spec.rb
@@ -7,8 +7,7 @@ module Dttp
     describe Fetch do
       describe "#call" do
         let(:contact_entity_id) { SecureRandom.uuid }
-        let(:trainee) { create(:trainee, dttp_id: contact_entity_id) }
-        let(:path) { "/contacts(#{trainee.dttp_id})?" }
+        let(:path) { "/contacts(#{contact_entity_id})?" }
 
         before do
           allow(AccessToken).to receive(:fetch).and_return("token")
@@ -27,7 +26,7 @@ module Dttp
           let(:dttp_response) { double(code: 200, body: parsed_response.to_json) }
 
           it "returns an instance of contact" do
-            expect(described_class.call(trainee: trainee)).to be_a Contact
+            expect(described_class.call(contact_entity_id: contact_entity_id)).to be_a Contact
           end
         end
 
@@ -40,7 +39,7 @@ module Dttp
           it "raises a HttpError error with the response body as the message" do
             expect(Client).to receive(:get).with(path).and_return(dttp_response)
             expect {
-              described_class.call(trainee: trainee)
+              described_class.call(contact_entity_id: contact_entity_id)
             }.to raise_error(Contacts::Fetch::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
           end
         end

--- a/spec/services/dttp/contact_fetch_spec.rb
+++ b/spec/services/dttp/contact_fetch_spec.rb
@@ -6,8 +6,8 @@ module Dttp
   module Contacts
     describe Fetch do
       describe "#call" do
-        let(:contact_entity_id) { SecureRandom.uuid }
-        let(:path) { "/contacts(#{contact_entity_id})?" }
+        let(:dttp_id) { SecureRandom.uuid }
+        let(:path) { "/contacts(#{dttp_id})?" }
 
         before do
           allow(AccessToken).to receive(:fetch).and_return("token")
@@ -26,7 +26,7 @@ module Dttp
           let(:dttp_response) { double(code: 200, body: parsed_response.to_json) }
 
           it "returns an instance of contact" do
-            expect(described_class.call(contact_entity_id: contact_entity_id)).to be_a Contact
+            expect(described_class.call(dttp_id: dttp_id)).to be_a Contact
           end
         end
 
@@ -39,7 +39,7 @@ module Dttp
           it "raises a HttpError error with the response body as the message" do
             expect(Client).to receive(:get).with(path).and_return(dttp_response)
             expect {
-              described_class.call(contact_entity_id: contact_entity_id)
+              described_class.call(dttp_id: dttp_id)
             }.to raise_error(Contacts::Fetch::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
           end
         end

--- a/spec/services/dttp/placement_assignments/fetch_spec.rb
+++ b/spec/services/dttp/placement_assignments/fetch_spec.rb
@@ -20,7 +20,7 @@ module Dttp
           end
 
           it "returns placement assignment JSON ruby hash" do
-            expect(described_class.call(placement_assignment_dttp_id: placement_assignment_dttp_id)).to be_a(Dttp::PlacementAssignment)
+            expect(described_class.call(dttp_id: placement_assignment_dttp_id)).to be_a(Dttp::PlacementAssignment)
           end
         end
 
@@ -33,7 +33,7 @@ module Dttp
           it "raises a HttpError error with the response body as the message" do
             expect(Client).to receive(:get).with(path).and_return(dttp_response)
             expect {
-              described_class.call(placement_assignment_dttp_id: placement_assignment_dttp_id)
+              described_class.call(dttp_id: placement_assignment_dttp_id)
             }.to raise_error(Dttp::PlacementAssignments::Fetch::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
           end
         end

--- a/spec/services/dttp/update_trainee_status_spec.rb
+++ b/spec/services/dttp/update_trainee_status_spec.rb
@@ -7,30 +7,39 @@ module Dttp
     describe "#call" do
       let(:status) {  DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED }
       let(:entity_id) { SecureRandom.uuid }
-      let(:entity_type) { described_class::ENDPOINTS.keys.sample }
+      let(:entity_type) { described_class::CONTACT_ENTITY_TYPE }
+      let(:trainee) { create(:trainee, dttp_id: entity_id) }
+      let(:dttp_response) { double(code: 204) }
+      let(:expected_body) { Params::Status.new(status: status).to_json }
+      let(:expected_path) { "/contacts(#{entity_id})" }
 
       before do
         allow(AccessToken).to receive(:fetch).and_return("token")
       end
 
-      context "when successful" do
-        let(:dttp_response) { double(code: 204) }
-        let(:expected_body) { Params::Status.new(status: status).to_json }
-        let(:expected_path) { described_class::ENDPOINTS[entity_type] + "(#{entity_id})" }
-        let(:trainee) { create(:trainee, dttp_id: entity_id) }
+      it "sends a PATCH request with status params" do
+        allow(CreateOrUpdateConsistencyCheckJob).to receive(:perform_later).and_return(true)
+        expect(Client).to receive(:patch).with(expected_path, body: expected_body).and_return(dttp_response)
+        described_class.call(status: status, trainee: trainee, entity_type: entity_type)
+      end
+
+      it "enqueues the CreateOrUpdateConsistencyJob" do
+        allow(Client).to receive(:patch).with(expected_path, body: expected_body).and_return(dttp_response)
+        expect {
+          described_class.call(status: status, trainee: trainee, entity_type: entity_type)
+        }.to have_enqueued_job(CreateOrUpdateConsistencyCheckJob).with(trainee)
+      end
+
+      context "when the entity_type is placement_assignment" do
+        let(:expected_path) { "/dfe_placementassignments(#{entity_id})" }
+        let(:entity_type) { described_class::PLACEMENT_ASSIGNMENT_ENTITY_TYPE }
+        let(:trainee) { create(:trainee, placement_assignment_dttp_id: entity_id) }
 
         it "sends a PATCH request with status params" do
           allow(CreateOrUpdateConsistencyCheckJob).to receive(:perform_later).and_return(true)
           expect(Client).to receive(:patch).with(expected_path, body: expected_body).and_return(dttp_response)
 
-          described_class.call(status: status, entity_id: entity_id, entity_type: entity_type)
-        end
-
-        it "enqueues the CreateOrUpdateConsistencyJob" do
-          allow(Client).to receive(:patch).with(expected_path, body: expected_body).and_return(dttp_response)
-          expect {
-            described_class.call(status: status, entity_id: entity_id, entity_type: entity_type)
-          }.to have_enqueued_job(CreateOrUpdateConsistencyCheckJob).with(trainee)
+          described_class.call(status: status, trainee: trainee, entity_type: entity_type)
         end
       end
 
@@ -44,7 +53,7 @@ module Dttp
           expect(Client).to receive(:patch).and_return(dttp_response)
 
           expect {
-            described_class.call(status: status, entity_id: entity_id, entity_type: entity_type)
+            described_class.call(status: status, trainee: trainee, entity_type: entity_type)
           }.to raise_error(described_class::Error, "status: #{status}, body: #{body}, headers: #{headers}")
         end
       end


### PR DESCRIPTION
### Context
The `CreateOrUpdateConsistencyCheckJob` requires a `trainee` object, but in [certain conditions](https://github.com/DFE-Digital/register-trainee-teachers/blob/6573d640e497f9c3dc93385c9b16a53f46c26ef0/app/services/dttp/update_trainee_status.rb#L36-L38), it could be receiving a `nil` value.
[Ticket](https://trello.com/c/5pyNNLo2/1442-nomethoderror-sidekiq-createorupdateconsistencycheckjob)


### Changes proposed in this pull request
Ensure that we pass `trainee` to the job, by making sure the calling service, i.e: `Dttp::UpdateTraineeStatus` does not have to deduce it based on if it is a contact/placement_assignment entity type.

### Guidance to review
I've relied solely on the test suite, but perhaps someone with more context might have a better way of validating this.
