### PR TITLE
[1448] Replace sentry-raven with sentry-rails and sentry-sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,8 @@ gem "foreman"
 gem "canonical-rails"
 
 # Sentry
-gem "sentry-raven"
+gem "sentry-rails"
+gem "sentry-sidekiq"
 
 # Logging
 gem "amazing_print", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,8 +403,14 @@ GEM
     semantic_logger (4.7.4)
       concurrent-ruby (~> 1.0)
     semantic_range (2.3.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (4.3.4)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-ruby-core (4.3.2)
+      concurrent-ruby
+      faraday
+    sentry-sidekiq (4.3.0)
+      sentry-ruby-core (~> 4.3.0)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     sidekiq (6.2.0)
@@ -530,7 +536,8 @@ DEPENDENCIES
   rspec-rails (~> 5.0.1)
   rubocop-govuk
   scss_lint-govuk
-  sentry-raven
+  sentry-rails
+  sentry-sidekiq
   shoulda-matchers (~> 4.5)
   sidekiq (~> 6.2)
   sidekiq-cron (~> 1.1)


### PR DESCRIPTION
### Context
[Ticket Link](https://trello.com/c/55JD7wHf/1448-actiondispatchhttpmimenegotiationinvalidtype)

`ActionDispatch::Http::MimeNegotiation::InvalidType` is ignored by `sentry-rails` by [default](https://github.com/getsentry/sentry-ruby/blob/ac722f0527360f05cfb83286a158addf162c3dea/sentry-rails/lib/sentry/rails/configuration.rb#L34).

This upgrade will help reduce noise caused by this exception.

### Changes proposed in this pull request
Replace `sentry-raven` gem with `sentry-rails` and `sentry-sidekiq`

### Guidance to review
1. Running `curl -I -H "Content-Type:INVALID MIME TYPE" <register-app-url>` returns `HTTP/1.1 406 Not Acceptable`, and captures an exception in sentry.
2. With this change the exception is triggered nonetheless, but sentry doesn't bother to deal with it.


