### PR TITLE
[1322] SPIKE - Add weighted synonym sort to degree autocomplete

### DIFF
--- a/app/components/form_components/synonym_autocomplete/script.js
+++ b/app/components/form_components/synonym_autocomplete/script.js
@@ -1,0 +1,114 @@
+import accessibleAutocomplete from 'accessible-autocomplete'
+import { nodeListForEach } from 'govuk-frontend/govuk/common'
+
+const $allAutocompleteElements = document.querySelectorAll('[data-module="app-synonym-autocomplete"]')
+const defaultValueOption = component => component.getAttribute('data-default-value') || ''
+
+const setupAutoComplete = (component) => {
+  const selectEl = component.querySelector('select')
+  const selectOptions = Array.apply(null, selectEl.options)
+
+  // Pull out rich data from the attributes on the select options.
+  const options = selectOptions.map(option => {
+    const boost = parseInt(option.getAttribute('data-boost'), 10) || 1
+    let synonyms = option.getAttribute('data-synonyms')
+    synonyms = synonyms ? synonyms.split('|') : []
+
+    return {
+      name: option.label,
+      synonyms: synonyms,
+      boost: boost
+    }
+  })
+
+  // Returns a weighting for an option based on it's 'closeness' to a query.
+  // The higher the weight, the better the match. Returns 0 if no match.
+  const calculateWeight = ({ name, synonyms }, query) => {
+    const queryRegexes = query.split(/\s+/).map(word => new RegExp('\\b' + word, 'i'))
+
+    const matchPositions = (str) => queryRegexes.map(regex => str.search(regex))
+    const nameMatchPositions = matchPositions(name).filter(i => i >= 0)
+    const synonymMatchPositions = synonyms.map(synonym => matchPositions(synonym)).flat().filter(i => i >= 0)
+
+    // Require all parts of the query to be matches:
+    if (nameMatchPositions.length !== queryRegexes.length && synonymMatchPositions.length !== queryRegexes.length) return 0
+
+    // Case insensitive exact matches:
+    const nameIsExactMatch = name.toLowerCase() === query.toLowerCase()
+    const synonymIsExactMatch = synonyms.some(s => s.toLowerCase() === query.toLowerCase())
+    // Case insensitive 'starts with':
+    const nameStartsWithQuery = nameMatchPositions.includes(0)
+    const synonymStartsWithQuery = synonymMatchPositions.includes(0)
+    const wordInNameStartsWithQuery = name.split(' ').map(w => matchPositions(w)).flat().includes(0)
+
+    if (nameIsExactMatch) {
+      return 100
+    } else if (synonymIsExactMatch) {
+      return 75
+    } else if (nameStartsWithQuery) {
+      return 60
+    } else if (synonymStartsWithQuery) {
+      return 50
+    } else if (wordInNameStartsWithQuery) {
+      return 25
+    } else {
+      return 0
+    }
+  }
+
+  // Sort options by their weights. If they are equally weighted, sort alphabetically.
+  const byWeightThenAlphabetically = (optionA, optionB) => {
+    if (optionA.weight > optionB.weight) {
+      return -1
+    } else if (optionA.weight < optionB.weight) {
+      return 1
+    } else if (optionA.name < optionB.name) {
+      return -1
+    } else if (optionA.name > optionB.name) {
+      return 1
+    } else {
+      return 0
+    }
+  }
+
+  const source = (q, populateResults) => {
+    // Tidy up the incoming query by trimming whitespace and removing punctuation.
+    const query = q.trim().replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, '')
+    // Calculate weights for all our options, boosted by any provided factor.
+    const matches = options.map(option => {
+      option.weight = calculateWeight(option, query) * option.boost
+      return option
+    })
+
+    // Remove anything that doesn't match.
+    const filteredMatches = matches.filter(option => option.weight !== 0)
+    // Sort those that do.
+    const sortedFilteredMatches = filteredMatches.sort((a, b) => byWeightThenAlphabetically(a, b))
+    // Show just the name.
+    const results = sortedFilteredMatches.map(option => option.name)
+    return populateResults(results)
+  }
+
+  const suggestionTemplate = (value) => {
+    const option = selectOptions.find(o => o.label === value)
+    const alt = option.getAttribute('data-alt')
+    return alt ? `<span>${value}</span> <strong>(${alt})</strong>` : `<span>${value}</span>`
+  }
+
+  accessibleAutocomplete.enhanceSelectElement({
+    defaultValue: defaultValueOption(component),
+    selectElement: selectEl,
+    showAllValues: true,
+    source: source,
+    templates: {
+      suggestion: suggestionTemplate
+    }
+  })
+
+  component.querySelector('input').addEventListener('keyup', () => {
+    const noResults = component.querySelector('.autocomplete__option--no-results')
+    if (noResults) selectEl.value = ''
+  })
+}
+
+nodeListForEach($allAutocompleteElements, setupAutoComplete)

--- a/app/components/form_components/synonym_autocomplete/view.html.erb
+++ b/app/components/form_components/synonym_autocomplete/view.html.erb
@@ -1,0 +1,5 @@
+<%= tag.div(class: classes, **html_attributes) do %>
+  <div class="govuk-form-group">
+    <%= form_group %>
+  </div>
+<% end %>

--- a/app/components/form_components/synonym_autocomplete/view.rb
+++ b/app/components/form_components/synonym_autocomplete/view.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module FormComponents
+  module SynonymAutocomplete
+    class View < GovukComponent::Base
+      with_content_areas :form_group
+
+      def initialize(classes: [], html_attributes: {})
+        super(classes: classes, html_attributes: default_html_attributes.merge(html_attributes))
+      end
+
+    private
+
+      def default_classes
+        %w[]
+      end
+
+      def default_html_attributes
+        {
+          "data-module" => "app-synonym-autocomplete",
+        }
+      end
+    end
+  end
+end

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -14,6 +14,22 @@ module DegreesHelper
     options
   end
 
+  def enhanced_degree_type_options
+    Dttp::CodeSets::DegreeTypes::MAPPING.map do |name, attributes|
+      data = {
+        # If you have multiple synonyms, you can provide them as a string, separated by |
+        # e.g. "PhD|Doctor of Philosophy".
+        "data-synonyms" => attributes[:abbreviation],
+        # Currently, this is a presentational attribute (the bit in brackets),
+        # but could also be searchable.
+        "data-alt" => attributes[:abbreviation],
+        "data-boost" => (common_degrees.include?(name) ? 1.5 : 1),
+        # Here we could have other attrs like 'data-hint', 'data-typos' etc
+      }
+      [name, name, data]
+    end
+  end
+
   def institutions_options
     to_options(institutions)
   end
@@ -31,6 +47,10 @@ module DegreesHelper
   end
 
 private
+
+  def common_degrees
+    ["Bachelor of Arts", "Bachelor of Science", "Master of Arts", "PhD"]
+  end
 
   def institutions
     Dttp::CodeSets::Institutions::MAPPING.keys

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -24,8 +24,7 @@
       <%= t(
           ".get_access_html",
           link: support_email(subject: "Get access to Register trainee teachers"),
-        )
-      %>
+        ) %>
     </p>
 
   </div>

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -20,7 +20,7 @@
     <% component.with(:form_group) do %>
       <%= f.label :uk_degree, "Type of degree", class: "govuk-label govuk-label--s" %>
       <span class="govuk-hint" id="degree-uk-degree-hint">For example, BA, BSc or other (please specify)</span>
-      <%= f.select :uk_degree, options_for_select(enhanced_degree_type_options,  @degree_form.degree.uk_degree), { include_blank: true }, { class: "govuk-select", id: "degree-uk-degree-field" } %>
+      <%= f.select :uk_degree, options_for_select(enhanced_degree_type_options, @degree_form.degree.uk_degree), { include_blank: true }, { class: "govuk-select", id: "degree-uk-degree-field" } %>
     <% end %>
   <% end %>
 

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -16,14 +16,13 @@
     },
   ) %>
 
-  <%= render FormComponents::Autocomplete::View.new(
-    form_field: f.govuk_collection_select(:uk_degree, hesa_degree_types_options, :option_value, :option_name,
-                                          label: { text: "Type of degree", size: "s" },
-                                          hint: { text: "For example, BA, BSc or other (please specify)" }),
-    html_attributes: {
-      "data-show-all-values" => true,
-    },
-  ) %>
+  <%= render FormComponents::SynonymAutocomplete::View.new do |component| %>
+    <% component.with(:form_group) do %>
+      <%= f.label :uk_degree, "Type of degree", class: "govuk-label govuk-label--s" %>
+      <span class="govuk-hint" id="degree-uk-degree-hint">For example, BA, BSc or other (please specify)</span>
+      <%= f.select :uk_degree, options_for_select(enhanced_degree_type_options,  @degree_form.degree.uk_degree), { include_blank: true }, { class: "govuk-select", id: "degree-uk-degree-field" } %>
+    <% end %>
+  <% end %>
 
   <%= render FormComponents::Autocomplete::View.new(
     form_field: f.govuk_collection_select(:institution, institutions_options, :name,

--- a/spec/features/trainees/degrees/adding_degree_spec.rb
+++ b/spec/features/trainees/degrees/adding_degree_spec.rb
@@ -154,9 +154,7 @@ private
 
   def and_i_fill_in_the_uk_form(other_grade)
     template = build(:degree, :uk_degree_with_details)
-    degree_abbreviation = Dttp::CodeSets::DegreeTypes::MAPPING[template.uk_degree][:abbreviation]
-    option_text = degree_abbreviation ? "#{template.uk_degree} (#{degree_abbreviation})" : template.uk_degree
-    degree_details_page.uk_degree.select(option_text)
+    degree_details_page.uk_degree.select(template.uk_degree)
     degree_details_page.subject.select(template.subject)
     degree_details_page.institution.select(template.institution)
 


### PR DESCRIPTION
### Context

https://trello.com/c/KQK4dPRs/1322-spike-1-day-add-sort-function-for-autocompletes
https://trello.com/c/7CGQRnN6/1326-spike-1-day-investigate-adding-synonyms-richer-data-to-autocomplete

This PR adds a weighted sort function to the degree autocomplete. The main aims were:
- Work natively with 'enhanceSelect' - e.g. work as better sort with no data changes
- Work with richer data
- Ability to boost specific entries

**Stretch:**
- Use synonyms specified in select options.
- Ability for it to be used in different autocompletes cross-teams

### Changes proposed in this pull request

There are two parts to this - changes to the native select input, and changes to the autocomplete JS.

**The select input**
- The options within the targeted select input now hold more information in a structured way (not just a string we can 'split' on). This makes the sorting code simpler.
- The options can still be supplier as simple string, but can now be enhanced with the following data attributes:

```html
<select id="degree-type">
    <option value="PhD" data-synonyms="Doctor of Philosophy"  data-alt="PhD" data-boost="2">PhD</option>
    <option value="Bachelor of Science" data-synonyms="BSc" data-alt="BSc">Bachelor of Science</option>
    <option value="Bachelor of Arts" data-synonyms="BA" data-alt="BA">"Bachelor of Arts"</option>
</select>
```

The supported attributes are:
- `data-synonyms` - pipe-separated string - the synonyms for the option
- `data-alt` - string - the string that will appear bracketed in the autocomplete results, not currently searched over (but could be)
- `data-boost` - integer - the amount by which the normal weighting should be boosted for that particular result. 2 = x 2

Issues: `f.govuk_collection_select` does not support setting data-attributes on options, so I had to revert to the basic rails helpers. Currently in discussion with @peteryates about getting support for this: https://github.com/DFE-Digital/govuk_design_system_formbuilder/pull/260

**The autocomplete**
We provide a custom function as the autocomplete's `source`. This function:
- Pulls out the extra data from the options' data attributes.
- Compares the inputted query to the results and calculates weights based on the list in the Trello ticket:
 
```
1. nameIsExactMatch
2. synonymIsExactMatch
3. nameStartsWithQuery
4. synonymStartsWithQuery
5. wordInNameStartsWithQuery
``` 
  - Applies any additional boost as per the `data-boost` attribute for options
  - Filters, sorts and returns the results.

### Guidance to review

Have a play!

I boosted a selected of degrees (see `def common_degrees`) by a factor of 2. You can see that these appear higher in search results:

<img width="688" alt="Screenshot 2021-04-09 at 11 07 09" src="https://user-images.githubusercontent.com/18436946/114171442-32832b80-992c-11eb-9e17-0024435fe9c3.png">


