### PR TITLE
[1322] SPIKE - Add basic regex sort function to degree autocomplete

### DIFF
--- a/app/components/form_components/synonym_autocomplete/script.js
+++ b/app/components/form_components/synonym_autocomplete/script.js
@@ -1,0 +1,93 @@
+import accessibleAutocomplete from 'accessible-autocomplete'
+import { nodeListForEach } from 'govuk-frontend/govuk/common'
+
+const $allAutocompleteElements = document.querySelectorAll('[data-module="app-synonym-autocomplete"]')
+const defaultValueOption = component => component.getAttribute('data-default-value') || ''
+
+const setupAutoComplete = (component) => {
+  const selectEl = component.querySelector('select')
+  const selectOptions = Array.apply(null, selectEl.options)
+
+  const options = selectOptions.map(option => {
+    let synonyms = option.getAttribute('data-synonyms')
+    synonyms = synonyms ? synonyms.split('|') : []
+    return {
+      name: option.label,
+      synonyms: synonyms
+    }
+  })
+
+  const regexes = (query) => {
+    return query.trim().split(/\s+/).map(word => {
+      const pattern = '\\b' + word.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')
+      return new RegExp(pattern, 'i')
+    })
+  }
+
+  const source = (query, populateResults) => {
+    const optionsWithPositions = options.map(option => {
+      const allTerms = [option.name].concat(option.synonyms)
+
+      option.resultPosition = null
+
+      allTerms.forEach(term => {
+        const matches = regexes(query).reduce((acc, regex) => {
+          const matchPosition = term.search(regex)
+
+          if (matchPosition > -1) {
+            acc.count += 1
+
+            // Is this match earlier on in the result?
+            if (acc.earliestPosition === -1 || matchPosition < acc.earliestPosition) {
+              acc.earliestPosition = matchPosition
+            }
+          }
+          return acc
+        }, { count: 0, earliestPosition: -1 })
+
+        // Save the earliest matched postiion, but require all search terms present.
+        if (matches.count === regexes(query).length && (option.resultPosition == null || matches.earliestPosition < option.resultPosition)) {
+          option.resultPosition = matches.earliestPosition
+        }
+      })
+
+      return option
+    })
+
+    const filteredMatches = optionsWithPositions.filter(option => option.resultPosition != null)
+
+    const sortedFilteredMatches = filteredMatches.sort((optionA, optionB) => {
+      // Favour 'earlier' matches
+      if (optionA.resultPosition < optionB.resultPosition) return -1
+      if (optionA.resultPosition > optionB.resultPosition) return 1
+      return 0
+    })
+
+    const results = sortedFilteredMatches.map(option => option.name)
+
+    return populateResults(results)
+  }
+
+  const suggestion = (value) => {
+    const option = selectOptions.find(o => o.label === value)
+    const alt = option.getAttribute('data-alt')
+    return alt ? `<span>${value}</span> <strong>(${alt})</strong>` : `<span>${value}</span>`
+  }
+
+  accessibleAutocomplete.enhanceSelectElement({
+    defaultValue: defaultValueOption(component),
+    selectElement: selectEl,
+    showAllValues: true,
+    source: source,
+    templates: {
+      suggestion
+    }
+  })
+
+  component.querySelector('input').addEventListener('keyup', () => {
+    const noResults = component.querySelector('.autocomplete__option--no-results')
+    if (noResults) selectEl.value = ''
+  })
+}
+
+nodeListForEach($allAutocompleteElements, setupAutoComplete)

--- a/app/components/form_components/synonym_autocomplete/view.html.erb
+++ b/app/components/form_components/synonym_autocomplete/view.html.erb
@@ -1,0 +1,5 @@
+<%= tag.div(class: classes, **html_attributes) do %>
+  <div class="govuk-form-group">
+    <%= form_group %>
+  </div>
+<% end %>

--- a/app/components/form_components/synonym_autocomplete/view.rb
+++ b/app/components/form_components/synonym_autocomplete/view.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module FormComponents
+  module SynonymAutocomplete
+    class View < GovukComponent::Base
+      with_content_areas :form_group
+
+      def initialize(classes: [], html_attributes: {})
+        super(classes: classes, html_attributes: default_html_attributes.merge(html_attributes))
+      end
+
+    private
+
+      def default_classes
+        %w[]
+      end
+
+      def default_html_attributes
+        {
+          "data-module" => "app-synonym-autocomplete",
+        }
+      end
+    end
+  end
+end

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -14,6 +14,21 @@ module DegreesHelper
     options
   end
 
+  def enhanced_degree_type_options
+    Dttp::CodeSets::DegreeTypes::MAPPING.map do |name, attributes|
+      data = {
+        # If you have multiple synonyms, you can provide them as a string, separated by |
+        # e.g. "PhD|Doctor of Philosophy".
+        "data-synonyms" => attributes[:abbreviation],
+        # Currently, this is a presentational attribute (the bit in brackets),
+        # but could also be searchable.
+        "data-alt" => attributes[:abbreviation],
+        # Here we could have other attrs like 'data-hint', 'data-typos' etc
+      }
+      [name, name, data]
+    end
+  end
+
   def institutions_options
     to_options(institutions)
   end

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -16,14 +16,13 @@
     },
   ) %>
 
-  <%= render FormComponents::Autocomplete::View.new(
-    form_field: f.govuk_collection_select(:uk_degree, hesa_degree_types_options, :option_value, :option_name,
-                                          label: { text: "Type of degree", size: "s" },
-                                          hint: { text: "For example, BA, BSc or other (please specify)" }),
-    html_attributes: {
-      "data-show-all-values" => true,
-    },
-  ) %>
+  <%= render FormComponents::SynonymAutocomplete::View.new do |component| %>
+    <% component.with(:form_group) do %>
+      <%= f.label :uk_degree, "Type of degree", class: "govuk-label govuk-label--s" %>
+      <span class="govuk-hint" id="degree-uk-degree-hint">For example, BA, BSc or other (please specify)</span>
+      <%= f.select :uk_degree, options_for_select(enhanced_degree_type_options, @degree_form.degree.uk_degree), { include_blank: true }, { class: "govuk-select", id: "degree-uk-degree-field" } %>
+    <% end %>
+  <% end %>
 
   <%= render FormComponents::Autocomplete::View.new(
     form_field: f.govuk_collection_select(:institution, institutions_options, :name,

--- a/spec/features/trainees/degrees/adding_degree_spec.rb
+++ b/spec/features/trainees/degrees/adding_degree_spec.rb
@@ -154,9 +154,7 @@ private
 
   def and_i_fill_in_the_uk_form(other_grade)
     template = build(:degree, :uk_degree_with_details)
-    degree_abbreviation = Dttp::CodeSets::DegreeTypes::MAPPING[template.uk_degree][:abbreviation]
-    option_text = degree_abbreviation ? "#{template.uk_degree} (#{degree_abbreviation})" : template.uk_degree
-    degree_details_page.uk_degree.select(option_text)
+    degree_details_page.uk_degree.select(template.uk_degree)
     degree_details_page.subject.select(template.subject)
     degree_details_page.institution.select(template.institution)
 


### PR DESCRIPTION
### Context

See write up in PR https://github.com/DFE-Digital/register-trainee-teachers/pull/749

### Changes proposed in this pull request

This PR implements all the changes to the select input as per https://github.com/DFE-Digital/register-trainee-teachers/pull/749, however approaches the new `source` function in the autocomplete in a different way.

As opposed to applying weightings based on a set of rules, this uses regex matching, and the _position_ of the regex match to order the results.

Currently there is no ability to 'boost' results, but this could be added in a very similar fashion to https://github.com/DFE-Digital/register-trainee-teachers/pull/749

### Guidance to review

As per https://github.com/DFE-Digital/register-trainee-teachers/pull/749
