### PR TITLE
[1439] Sync user list from DTTP

### DIFF
--- a/app/jobs/dttp/sync_users_job.rb
+++ b/app/jobs/dttp/sync_users_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Dttp
+  class SyncUsersJob < ApplicationJob
+    queue_as :dttp
+
+    def perform(path = nil)
+      @user_list = Dttp::RetrieveUsers.call(path: path)
+
+      Dttp::User.upsert_all(user_attributes, unique_by: :dttp_id)
+
+      Dttp::SyncUsersJob.perform_later(next_page_url) if next_page_url.present?
+    end
+
+  private
+
+    attr_reader :user_list
+
+    def user_attributes
+      Dttp::Parsers::Contact.to_user_attributes(contacts: user_list[:items])
+    end
+
+    def next_page_url
+      user_list[:meta][:next_page_url]
+    end
+  end
+end

--- a/app/lib/dttp/parsers/contact.rb
+++ b/app/lib/dttp/parsers/contact.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Dttp
+  module Parsers
+    class Contact
+      class << self
+        def to_user_attributes(contacts:)
+          contacts.map do |contact|
+            {
+              first_name: contact["firstname"],
+              last_name: contact["lastname"],
+              email: contact["emailaddress1"],
+              dttp_id: contact["contactid"],
+              provider_dttp_id: contact["_parentcustomerid_value"],
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/dttp/user.rb
+++ b/app/models/dttp/user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Dttp
+  class User < ApplicationRecord
+    self.table_name = "dttp_users"
+  end
+end

--- a/app/services/dttp/retrieve_users.rb
+++ b/app/services/dttp/retrieve_users.rb
@@ -19,12 +19,12 @@ module Dttp
         emailaddress1
         contactid
         _parentcustomerid_value
-      ].join(",")
+      ].join(","),
     }.freeze
 
     FILTER = {
       "$filter" => "dfe_portaluser eq true",
-     }.freeze
+    }.freeze
 
     QUERY = FILTER.merge(SELECT).to_query
     DEFAULT_PATH = "/contacts?#{QUERY}"

--- a/app/services/dttp/retrieve_users.rb
+++ b/app/services/dttp/retrieve_users.rb
@@ -6,12 +6,25 @@ module Dttp
 
     class Error < StandardError; end
 
-    DEFAULT_PATH = "/contacts?$filter=dfe_portaluser eq true"
-    MAX_PAGE_SIZE = 25
+    MAX_PAGE_SIZE = 5000
 
     HEADERS = {
       "Prefer" => "odata.maxpagesize=#{MAX_PAGE_SIZE}",
     }.freeze
+
+    FIELDS = %w[
+      firstname
+      lastname
+      emailaddress1
+      contactid
+      _parentcustomerid_value
+    ].freeze
+
+    FILTERS = [
+      "dfe_portaluser eq true",
+    ].freeze
+
+    DEFAULT_PATH = "/contacts?$filter=#{FILTERS.join('')}&$select=#{FIELDS.join(',')}"
 
     def initialize(path: nil)
       @path = path.presence || DEFAULT_PATH

--- a/app/services/dttp/retrieve_users.rb
+++ b/app/services/dttp/retrieve_users.rb
@@ -12,19 +12,22 @@ module Dttp
       "Prefer" => "odata.maxpagesize=#{MAX_PAGE_SIZE}",
     }.freeze
 
-    FIELDS = %w[
-      firstname
-      lastname
-      emailaddress1
-      contactid
-      _parentcustomerid_value
-    ].freeze
+    SELECT = {
+      "$select" => %w[
+        firstname
+        lastname
+        emailaddress1
+        contactid
+        _parentcustomerid_value
+      ].join(",")
+    }.freeze
 
-    FILTERS = [
-      "dfe_portaluser eq true",
-    ].freeze
+    FILTER = {
+      "$filter" => "dfe_portaluser eq true",
+     }.freeze
 
-    DEFAULT_PATH = "/contacts?$filter=#{FILTERS.join('')}&$select=#{FIELDS.join(',')}"
+    QUERY = FILTER.merge(SELECT).to_query
+    DEFAULT_PATH = "/contacts?#{QUERY}"
 
     def initialize(path: nil)
       @path = path.presence || DEFAULT_PATH

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -14,3 +14,7 @@ import_courses_from_ttapi:
   cron: "0 2 * * *"
   class: "TeacherTrainingApi::ImportCoursesJob"
   queue: default
+import_users_from_dttp:
+  cron: "0 4 * * *"
+  class: "Dttp::SyncUsersJob"
+  queue: dttp

--- a/db/migrate/20210408150651_create_dttp_users.rb
+++ b/db/migrate/20210408150651_create_dttp_users.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateDttpUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dttp_users do |t|
+      t.string :first_name
+      t.string :last_name
+      t.string :email
+      t.string :dttp_id, index: { unique: true }
+      t.string :provider_dttp_id
+      t.timestamps default: -> { "CURRENT_TIMESTAMP" }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -188,8 +188,8 @@ ActiveRecord::Schema.define(version: 2021_04_08_150651) do
     t.text "first_names"
     t.text "last_name"
     t.date "date_of_birth"
-    t.datetime "created_at", precision: 6
-    t.datetime "updated_at", precision: 6
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.text "address_line_one"
     t.text "address_line_two"
     t.text "town_city"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_07_152050) do
+ActiveRecord::Schema.define(version: 2021_04_08_150651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,17 @@ ActiveRecord::Schema.define(version: 2021_04_07_152050) do
     t.index ["name"], name: "index_disabilities_on_name", unique: true
   end
 
+  create_table "dttp_users", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email"
+    t.string "dttp_id"
+    t.string "provider_dttp_id"
+    t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.index ["dttp_id"], name: "index_dttp_users_on_dttp_id", unique: true
+  end
+
   create_table "nationalisations", force: :cascade do |t|
     t.bigint "trainee_id", null: false
     t.bigint "nationality_id", null: false
@@ -177,8 +188,8 @@ ActiveRecord::Schema.define(version: 2021_04_07_152050) do
     t.text "first_names"
     t.text "last_name"
     t.date "date_of_birth"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
     t.text "address_line_one"
     t.text "address_line_two"
     t.text "town_city"

--- a/spec/factories/dttp/users.rb
+++ b/spec/factories/dttp/users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dttp_user, class: Dttp::User do
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    email { Faker::Internet.email }
+    dttp_id { SecureRandom.uuid }
+    provider_dttp_id { SecureRandom.uuid }
+  end
+end

--- a/spec/jobs/sync_users_job_spec.rb
+++ b/spec/jobs/sync_users_job_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe SyncUsersJob do
+    include ActiveJob::TestHelper
+
+    let(:user_one_hash) { ApiStubs::Dttp::Contact.attributes }
+    let(:user_two_hash) { ApiStubs::Dttp::Contact.attributes }
+    let(:next_page_url) { "https://some-url.com" }
+
+    let(:user_list) do
+      {
+        items: [user_one_hash, user_two_hash],
+        meta: { next_page_url: next_page_url },
+      }
+    end
+
+    subject { described_class.perform_now }
+
+    before do
+      allow(Dttp::RetrieveUsers).to receive(:call) { user_list }
+    end
+
+    it "enqueues job with the next_page_url" do
+      expect {
+        subject
+      }.to have_enqueued_job(described_class).with("https://some-url.com")
+    end
+
+    context "when the Dttp:User is not in register" do
+      it "creates a Dttp::user record for each unique user" do
+        expect {
+          subject
+        }.to change(Dttp::User, :count).by(2)
+      end
+    end
+
+    context "when a Dttp::User exist" do
+      let(:dttp_user) { create(:dttp_user, dttp_id: user_one_hash["contactid"]) }
+
+      before do
+        dttp_user
+      end
+
+      it "updates the existing record" do
+        subject
+        expect(dttp_user.reload.first_name).to eq(user_one_hash["firstname"])
+      end
+    end
+
+    context "when next_page_url is not available" do
+      let(:next_page_url) { nil }
+
+      it "does not enqueue any further jobs" do
+        expect {
+          subject
+        }.not_to have_enqueued_job(described_class)
+      end
+    end
+  end
+end

--- a/spec/lib/dttp/parsers/contact_spec.rb
+++ b/spec/lib/dttp/parsers/contact_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  module Parsers
+    describe Contact do
+      describe ".to_user_attributes" do
+        let(:contact) { ApiStubs::Dttp::Contact.attributes }
+
+        let(:expected_attributes) do
+          {
+            first_name: contact["firstname"],
+            last_name: contact["lastname"],
+            email: contact["emailaddress1"],
+            dttp_id: contact["contactid"],
+            provider_dttp_id: contact["_parentcustomerid_value"],
+          }
+        end
+
+        subject { described_class.to_user_attributes(contacts: [contact]) }
+
+        it "returns an array of Dttp::User attributes" do
+          expect(subject).to eq([expected_attributes])
+        end
+      end
+    end
+  end
+end

--- a/spec/models/dttp/user_spec.rb
+++ b/spec/models/dttp/user_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe User do
+    subject { build(:dttp_user) }
+
+    it { is_expected.to be_valid }
+  end
+end

--- a/spec/services/dttp/retrieve_users_spec.rb
+++ b/spec/services/dttp/retrieve_users_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe RetrieveUsers do
+    describe "#call" do
+      let(:options) { { headers: RetrieveUsers::HEADERS } }
+      let(:path) { RetrieveUsers::DEFAULT_PATH }
+
+      before do
+        allow(AccessToken).to receive(:fetch).and_return("token")
+      end
+
+      context "when code 200" do
+        let(:status) { 200 }
+        let(:body) { { value: [{ "first_name" => "Jon" }], "@odata.nextLink" => "some_path" } }
+        let(:dttp_response) { double(code: status, body: body.to_json) }
+
+        before do
+          allow(Client).to receive(:get).with(path, options).and_return(dttp_response)
+        end
+
+        it "returns parsed json content" do
+          expected_hash = {
+            items: body[:value],
+            meta: {
+              next_page_url: body["@odata.nextLink"],
+            },
+          }
+
+          expect(described_class.call).to eq(expected_hash)
+        end
+      end
+
+      context "HTTP error" do
+        let(:status) { 400 }
+        let(:body) { "error" }
+        let(:headers) { { foo: "bar" } }
+        let(:dttp_response) { double(code: status, body: body, headers: headers) }
+
+        it "raises a HttpError error with the response body as the message" do
+          expect(Client).to receive(:get).with(path, options).and_return(dttp_response)
+          expect {
+            described_class.call
+          }.to raise_error(Dttp::RetrieveUsers::Error, "status: #{status}, body: #{body}, headers: #{headers}")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/api_stubs/dttp/contact.rb
+++ b/spec/support/api_stubs/dttp/contact.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ApiStubs
+  module Dttp
+    module Contact
+      def self.attributes
+        {
+          "firstname" => "John",
+          "lastname" => "Smith",
+          "emailaddress1" => "John@smith.com",
+          "contactid" => SecureRandom.uuid,
+          "_parentcustomerid_value" => SecureRandom.uuid,
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- In prep for [this](https://trello.com/c/OLvM8OAI/1416-l-provider-lookup) ticket, we are saving all Dttp users locally in register so we can reference to them when necessary and without making requests to Dttp. 
- To do this, we are importing (then syncing) all dttp users who are portal_users and saving them locally through a job which runs nightly 

### Changes proposed in this pull request

- A `Dttp::SyncUsersJob` scheduled nightly which in turn runs `Dttp::RetrieveUsers`, retrieving all users who are portal users.
- With each of these users, we run  `Dttp::ImportUser` which calls `find_or_initialize_by` using the dttp_id of the user. If the user exists, we update all the user attributes and sync the user with Dttp, or if they don't, we create a new dttp_user
- A new model called `Dttp::User` which saves the imported user. 

### Guidance to review

- Run your sidekiq server `bundle exec sidekiq -C config/sidekiq.yml`
- Run your rails server `bundle exec rails server` in a new terminal
- Navigate to `https://localhost::5000/sidekiq` in your browser
- Navigate to the `Cron` tab which is in the navigation bar. 
- You will see a list of jobs. Click on enqueue now for the `Import Users from Dttp` job
<img width="1186" alt="Screenshot 2021-04-09 at 15 52 08" src="https://user-images.githubusercontent.com/53180713/114198729-8c471e00-994b-11eb-8a58-0c2f7bd7325b.png">
- You should get a successful response after the job has finished processing (around 30secs) and the `dttp_users` table will be populated with dttp users