### PR TITLE
[1403] Show banner when last degree deleted

### DIFF
--- a/app/components/trainees/confirmation/degrees/view.rb
+++ b/app/components/trainees/confirmation/degrees/view.rb
@@ -82,8 +82,6 @@ module Trainees
         end
 
         def degree_button_text
-          return t("components.degrees.add_a_degree") if degrees.empty?
-
           t("components.degrees.add_another_degree")
         end
 

--- a/app/controllers/trainees/degrees/confirm_details_controller.rb
+++ b/app/controllers/trainees/degrees/confirm_details_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Degrees
+    class ConfirmDetailsController < Trainees::ConfirmDetailsController
+      before_action :authorize_trainee
+
+      def show
+        page_tracker.save_as_origin!
+
+        if trainee.draft?
+          @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.degrees)
+        end
+
+        data_model = trainee.draft? ? trainee : degree_form
+
+        @confirmation_component = if trainee.degrees.empty?
+                                    IncompleteSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), error: false)
+                                  else
+                                    Trainees::Confirmation::Degrees::View.new(data_model: data_model)
+                                  end
+      end
+
+    private
+
+      def degree_form
+        @degree_form ||= DegreeForm.new(trainee)
+      end
+    end
+  end
+end

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -24,8 +24,7 @@
       <%= t(
           ".get_access_html",
           link: support_email(subject: "Get access to Register trainee teachers"),
-        )
-      %>
+        ) %>
     </p>
 
   </div>

--- a/app/views/trainees/personal_details/show.html.erb
+++ b/app/views/trainees/personal_details/show.html.erb
@@ -10,6 +10,10 @@
   <%= render Trainees::Confirmation::Diversity::View.new(data_model: @trainee) %>
 </div>
 
-<div class="degree-details">
-  <%= render Trainees::Confirmation::Degrees::View.new(data_model: @trainee, show_delete_button: true) %>
-</div>
+<% if @trainee.degrees.any? %>
+  <div class="degree-details">
+    <%= render Trainees::Confirmation::Degrees::View.new(data_model: @trainee, show_delete_button: true) %>
+  </div>
+<% else %>
+  <%= render IncompleteSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), error: false) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,8 +72,10 @@ en:
     placement_detail:
       title: Placement details
     degrees:
-      add_a_degree: Add a degree
       add_another_degree: Add another degree
+    incomplete_section:
+      degree_details_not_provided: Degree details not provided
+      add_degree_details: Add degree details
     page_titles:
       personas: Personas
       pages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,11 +61,12 @@ Rails.application.routes.draw do
       namespace :degrees do
         get "/new/type", to: "type#new"
         post "/new/type", to: "type#create"
+        get "/confirm", to: "confirm_details#show"
       end
 
       resources :degrees do
         collection do
-          resource :confirm_details, as: :degrees_confirm, only: %i[show update], path: "/confirm"
+          resource :confirm_details, as: :degrees_confirm, only: :update, path: "/confirm"
         end
       end
 

--- a/spec/components/trainees/confirmation/degrees/view_spec.rb
+++ b/spec/components/trainees/confirmation/degrees/view_spec.rb
@@ -86,14 +86,6 @@ RSpec.describe Trainees::Confirmation::Degrees::View do
   end
 
   describe "Degree button text" do
-    context "when there are no degrees" do
-      let(:trainee) { create(:trainee) }
-
-      it "renders 'Add a degree' button" do
-        expect(component.find(degree_button_selector)).to have_text(t("components.degrees.add_a_degree"))
-      end
-    end
-
     context "when there are degrees" do
       it "renders 'Add another degree' button" do
         expect(component.find(degree_button_selector)).to have_text(t("components.degrees.add_another_degree"))

--- a/spec/features/trainees/degrees/delete_degree_spec.rb
+++ b/spec/features/trainees/degrees/delete_degree_spec.rb
@@ -10,6 +10,7 @@ feature "deleting a degree" do
     when_i_visit_the_degrees_confirm_page
     and_i_click_the_delete_button
     then_i_should_not_see_any_degree
+    and_i_should_see_incomplete_degree_inset_text
   end
 
   scenario "with not UK degree" do
@@ -17,6 +18,7 @@ feature "deleting a degree" do
     when_i_visit_the_degrees_confirm_page
     and_i_click_the_delete_button
     then_i_should_not_see_any_degree
+    and_i_should_see_incomplete_degree_inset_text
   end
 
 private
@@ -41,6 +43,10 @@ private
   def when_i_visit_the_degrees_confirm_page
     degrees_confirm_page.load(trainee_id: trainee.slug)
     expect(degrees_confirm_page).to be_displayed(trainee_id: trainee.slug)
+  end
+
+  def and_i_should_see_incomplete_degree_inset_text
+    expect(degrees_confirm_page.inset_text.text).to include("Degree details not provided")
   end
 
   def trainee

--- a/spec/support/page_objects/trainees/degrees_confirm.rb
+++ b/spec/support/page_objects/trainees/degrees_confirm.rb
@@ -8,6 +8,7 @@ module PageObjects
       element :page_heading, "h1.govuk-heading-l"
       element :main_content, "#main-content"
       element :delete_degree, "input[value='Delete degree']"
+      element :inset_text, ".govuk-inset-text"
     end
   end
 end

--- a/spec/views/trainees/personal_details/show.html.erb_spec.rb
+++ b/spec/views/trainees/personal_details/show.html.erb_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "trainees/personal_details/show.html.erb" do
+  before do
+    assign(:trainee, trainee)
+    render
+  end
+
+  context "with a trainee with no degree" do
+    let(:trainee) { create(:trainee) }
+
+    it "renders the incomplete section component" do
+      expect(rendered).to have_text("Add degree details")
+    end
+  end
+
+  context "with a trainee with a degree" do
+    let(:trainee) { create(:trainee, :in_progress) }
+
+    it "renders the confirmation component" do
+      expect(rendered).to have_text("Add another degree")
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/izwer1EG/1403-show-banner-when-last-degree-deleted
### Changes proposed in this pull request
* Creates new degrees confirm details controller which decides whether to render confirmation component or incomplete section component depending whether the trainee has a degree. 
* Add a degree text to button no longer exists, as now dealt with by incomplete section component
* Edit feature test to test that incomplete component renders in user journey
* Add view spec for personal details show page 
### Guidance to review
Delete a trainee's degree so that component renders like below 

<img width="1102" alt="Screenshot 2021-04-12 at 17 57 24" src="https://user-images.githubusercontent.com/58793682/114432540-b81b0b80-9bb8-11eb-97bf-f633146e9fed.png">
<img width="1162" alt="Screenshot 2021-04-12 at 17 58 25" src="https://user-images.githubusercontent.com/58793682/114432553-bb15fc00-9bb8-11eb-9301-0f19ec8426d4.png">

