### PR TITLE
[1408] Sort links displayed only if matches are returned

### DIFF
--- a/app/components/paginated_filter/view.html.erb
+++ b/app/components/paginated_filter/view.html.erb
@@ -6,7 +6,7 @@
     <div class="moj-action-bar">
       <div class="moj-action-bar__filter"></div>
     </div>
-    <% if !@collection.empty? %>
+    <% unless @collection.empty? %>
       <%= render Trainees::SortLinks::View.new %>
     <% end %>
     <%= content %>

--- a/app/components/paginated_filter/view.html.erb
+++ b/app/components/paginated_filter/view.html.erb
@@ -6,8 +6,9 @@
     <div class="moj-action-bar">
       <div class="moj-action-bar__filter"></div>
     </div>
-
-    <%= render Trainees::SortLinks::View.new %>
+    <% if !@collection.empty? %>
+      <%= render Trainees::SortLinks::View.new %>
+    <% end %>
     <%= content %>
 
     <%= render Paginator::View.new(scope: collection) %>

--- a/spec/features/trainees/filtering_trainees_spec.rb
+++ b/spec/features/trainees/filtering_trainees_spec.rb
@@ -33,6 +33,12 @@ RSpec.feature "Filtering trainees" do
     then_all_trainees_are_visible
   end
 
+  scenario "no matches" do
+    when_i_filter_by_a_subject_which_returns_no_matches
+    then_i_see_a_no_records_found_message
+    then_i_cant_see_sort_links
+  end
+
   context "searching" do
     before { when_i_search_for(search_term) }
 
@@ -115,6 +121,18 @@ private
 
   def when_i_clear_filters
     trainee_index_page.clear_filters_link.click
+  end
+
+  def when_i_filter_by_a_subject_which_returns_no_matches
+    when_i_filter_by_subject("Chemistry")
+  end
+
+  def then_i_see_a_no_records_found_message
+    expect(trainee_index_page.no_records_found).to have_text("No records found")
+  end
+
+  def then_i_cant_see_sort_links
+    expect(trainee_index_page).to_not have_content("Sort by")
   end
 
   def then_the_checkbox_should_still_be_checked_for(value)

--- a/spec/features/trainees/filtering_trainees_spec.rb
+++ b/spec/features/trainees/filtering_trainees_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Filtering trainees" do
   scenario "no matches" do
     when_i_filter_by_a_subject_which_returns_no_matches
     then_i_see_a_no_records_found_message
-    then_i_cant_see_sort_links
+    then_i_should_not_see_sort_links
   end
 
   context "searching" do
@@ -131,7 +131,7 @@ private
     expect(trainee_index_page.no_records_found).to have_text("No records found")
   end
 
-  def then_i_cant_see_sort_links
+  def then_i_should_not_see_sort_links
     expect(trainee_index_page).to_not have_content("Sort by")
   end
 

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -25,6 +25,8 @@ module PageObjects
       element :subject, "#subject"
 
       element :export_link, ".app-trainee-export"
+
+      element :no_records_found, "h2", text: "No records found"
     end
   end
 end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/vClmil5T/1408-s-only-show-sort-options-if-there-are-results-to-sort)
- The sort links to sort by name or date updated were shown even if there were no results to sort

### Changes proposed in this pull request

- Only display the sort by links if there are sortable results

### Guidance to review

- Start your rails server, navigate to `https://localhost.com` and login using persona or DSI
- Use the search feature, but ensure that no trainees are returned. You may need to delete some in order to achieve this. 
- The sort by links will not be shown when there are no trainees returned in the filter. 

