### PR TITLE
[1418] - Add user from DTTP

### DIFF
--- a/app/components/tab_navigation/style.scss
+++ b/app/components/tab_navigation/style.scss
@@ -49,6 +49,8 @@
   padding-bottom: 17px;
   padding-left: govuk-spacing(3);
   position: relative;
+  font-weight: bold;
+  text-decoration: none;
 
   @include govuk-media-query($from: 375px) {
     padding-left: 0;

--- a/app/components/user_card/style.scss
+++ b/app/components/user_card/style.scss
@@ -1,24 +1,23 @@
 @import "../base.scss";
 
 .user-card {
+  border-bottom: 1px solid govuk-colour("mid-grey");
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &__name {
   display: flex;
   justify-content: space-between;
-  width: 75%;
-}
+  align-items: baseline;
 
-.user-card div {
-  display: inline-block;
-}
+    &__heading {
+      margin-bottom: 0;
+    }
 
-.user-card__created {
-  text-align: right;
-}
-
-.user-card__email {
-  border-bottom: 1px solid govuk-colour("mid-grey");
-  width: 75%
-}
-
-.user-card__name {
-  margin-top: 10px;
+    &__created {
+      text-align: right;
+    }
+  }
 }

--- a/app/components/user_card/view.html.erb
+++ b/app/components/user_card/view.html.erb
@@ -1,14 +1,28 @@
-<div class="user-card">
-  <h2 class="govuk-heading-m user-card__name">
-    <%= user.name %>
-  </h2>
-  <div class="govuk-caption-m govuk-!-font-size-16 user-card__created">
-    <%= updated_at %>
+<div class="user-card govuk-!-margin-bottom-5">
+  <div class="user-card__name">
+    <h2 class="govuk-heading-s user-card__name__heading">
+      <%= user.name %>
+    </h2>
+    <div class="govuk-caption-m govuk-!-font-size-16 user-card__name__created">
+      <%= updated_at %>
+    </div>
   </div>
-</div>
-<div class="govuk-caption-m govuk-!-font-size-16 user-card__dttp_id">
-  <%= dttp_id %>
-</div>
-<div class="govuk-caption-m govuk-!-font-size-16 user-card__email">
-  <%= email_address %>
+
+  <div class="govuk-caption-m govuk-!-font-size-16">
+    <%= dttp_id %>
+  </div>
+
+  <div class="govuk-caption-m govuk-!-font-size-16">
+    <%= email_address %>
+  </div>
+
+  <% if show_register_button %>
+    <%= govuk_button_to(
+      "Register user to provider",
+      registration_form_path,
+      params: { dttp_user_id: user },
+      id: "register-dttp-user",
+      class: "govuk-button--secondary",
+    ) %>
+  <% end %>
 </div>

--- a/app/components/user_card/view.rb
+++ b/app/components/user_card/view.rb
@@ -6,8 +6,10 @@ module UserCard
 
     attr_reader :user
 
-    def initialize(user:)
+    def initialize(user:, show_register_button: false, registration_form_path: nil)
       @user = user
+      @show_register_button = show_register_button
+      @registration_form_path = registration_form_path
     end
 
     def updated_at
@@ -23,5 +25,9 @@ module UserCard
 
       tag.p("DTTP ID: " + user.dttp_id)
     end
+
+  private
+
+    attr_reader :show_register_button, :registration_form_path
   end
 end

--- a/app/controllers/system_admin/imports/users_controller.rb
+++ b/app/controllers/system_admin/imports/users_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  module Imports
+    class UsersController < ApplicationController
+      def create
+        authorize provider.users.create!(user_params)
+        redirect_to provider_path(provider)
+      end
+
+    private
+
+      def provider
+        @provider ||= Provider.find(params[:provider_id])
+      end
+
+      def dttp_user
+        @dttp_user ||= ::Dttp::User.find(params[:dttp_user_id])
+      end
+
+      def user_params
+        dttp_user.attributes.symbolize_keys.slice(:first_name, :last_name, :email, :dttp_id)
+      end
+    end
+  end
+end

--- a/app/views/system_admin/dttp_providers/index.html.erb
+++ b/app/views/system_admin/dttp_providers/index.html.erb
@@ -44,7 +44,7 @@
                     class: "govuk-button--secondary",
                   ) %>
             <% else %>
-              <%= govuk_link_to 'View', provider_path(provider.provider) %>
+              <%= govuk_link_to "View", provider_path(provider.provider) %>
             <% end %>
           </td>
         </tr>

--- a/app/views/system_admin/providers/show.html.erb
+++ b/app/views/system_admin/providers/show.html.erb
@@ -1,9 +1,11 @@
 <%= render PageTitle::View.new(title: @provider.name, has_errors: @provider.errors.present?) %>
 
-<%= render GovukComponent::BackLink.new(
-  text: "Back",
-  href: providers_path,
-) %>
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLink.new(
+    text: t("back"),
+    href: providers_path,
+  ) %>
+<% end %>
 
 <h1 class="govuk-heading-l"><%= @provider.name %></h1>
 
@@ -18,24 +20,28 @@
 
 <h1 class="govuk-heading-m">Registered users</h1>
 
-<% if @provider.users.any? %>
-  <div class="govuk-!-margin-bottom-8">
-    <%= render UserCard::View.with_collection(@users_view.registered) %>
+<% if @users_view.registered.any? %>
+  <div class="govuk-!-margin-bottom-8 registered-users">
+    <%= render UserCard::View.with_collection(@users_view.registered, show_register_button: false) %>
   </div>
 <% else %>
-  <h2 class="govuk-heading-m">There are no users yet.</h2>
+  <p class="govuk-body">There are no users yet.</p>
 <% end %>
 
 <h1 class="govuk-heading-m">DTTP users</h1>
 
 <% if @users_view.not_registered.any? %>
-  <div class="govuk-!-margin-bottom-8" id="user-not-registered">
-    <div class="govuk-caption-m govuk-!-font-size-16 user-card__dttp_id">
+  <div class="govuk-!-margin-bottom-8 unregistered-users">
+    <div class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-3">
       These users are not registered with the provider on this service.
     </div>
-    
-    <%= render UserCard::View.with_collection(@users_view.not_registered) %>
+
+    <%= render UserCard::View.with_collection(
+      @users_view.not_registered,
+      show_register_button: true,
+      registration_form_path: provider_import_user_path(@provider.id),
+    ) %>
   </div>
 <% else %>
-  <h2 class="govuk-heading-m">All users with this provider are registered.</h2>
+  <p class="govuk-body">All users with this provider are registered.</p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,10 @@ Rails.application.routes.draw do
   scope module: :system_admin, path: "system-admin" do
     resources :providers, except: %i[edit update destroy] do
       resources :users, only: %i[new create]
+
+      scope module: :imports do
+        post "/users/import", to: "users#create", as: :import_user
+      end
     end
     resources :dttp_providers, only: %i[index show create]
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,8 +84,8 @@ ActiveRecord::Schema.define(version: 2021_04_19_084629) do
     t.string "course_length", null: false
     t.integer "qualification", null: false
     t.integer "route", null: false
-    t.integer "level", null: false
     t.string "summary", null: false
+    t.integer "level", null: false
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
     t.index ["provider_id"], name: "index_courses_on_provider_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,8 +84,8 @@ ActiveRecord::Schema.define(version: 2021_04_19_084629) do
     t.string "course_length", null: false
     t.integer "qualification", null: false
     t.integer "route", null: false
-    t.string "summary", null: false
     t.integer "level", null: false
+    t.string "summary", null: false
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
     t.index ["provider_id"], name: "index_courses_on_provider_id"
   end

--- a/spec/features/users/viewing_users_spec.rb
+++ b/spec/features/users/viewing_users_spec.rb
@@ -15,8 +15,13 @@ feature "View users" do
     end
 
     scenario "I can view the users" do
-      then_i_see_the_users
-      and_i_see_the_dttp_users_not_registered
+      then_i_see_the_registered_users
+      and_i_see_the_unregistered_users
+    end
+
+    scenario "I can register a dttp user to the provider" do
+      when_i_register_the_dttp_user
+      then_the_dttp_user_is_registered
     end
   end
 
@@ -36,12 +41,21 @@ feature "View users" do
     provider_show_page.load(id: user.provider.id)
   end
 
-  def then_i_see_the_users
-    expect(provider_show_page).to have_user_data
+  def then_i_see_the_registered_users
+    expect(provider_show_page.registered_users.size).to eq(1)
   end
 
-  def and_i_see_the_dttp_users_not_registered
-    expect(provider_show_page).to have_dttp_users_not_registered_data
+  def and_i_see_the_unregistered_users
+    expect(provider_show_page.unregistered_users.size).to eq(1)
+  end
+
+  def when_i_register_the_dttp_user
+    provider_show_page.register_user.click
+  end
+
+  def then_the_dttp_user_is_registered
+    expect(provider_show_page.registered_users.size).to eq(2)
+    expect(provider_show_page).not_to have_unregistered_user_data
   end
 
   def provider_show_page

--- a/spec/features/users/viewing_users_spec.rb
+++ b/spec/features/users/viewing_users_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "View users" do
   context "as a system admin" do
     let(:user) { create(:user, system_admin: true) }
-    let(:dttp_user) { create(:dttp_user, provider_id: user.provider.dttp_id) }
+    let(:dttp_user) { create(:dttp_user, provider_dttp_id: user.provider.dttp_id) }
 
     before do
       dttp_user

--- a/spec/features/users/viewing_users_spec.rb
+++ b/spec/features/users/viewing_users_spec.rb
@@ -5,10 +5,8 @@ require "rails_helper"
 feature "View users" do
   context "as a system admin" do
     let(:user) { create(:user, system_admin: true) }
-    let(:dttp_user) { create(:dttp_user, provider_dttp_id: user.provider.dttp_id) }
 
     before do
-      dttp_user
       given_i_am_authenticated(user: user)
       and_there_is_a_dttp_user
       when_i_visit_the_provider_index_page

--- a/spec/features/users/viewing_users_spec.rb
+++ b/spec/features/users/viewing_users_spec.rb
@@ -5,8 +5,10 @@ require "rails_helper"
 feature "View users" do
   context "as a system admin" do
     let(:user) { create(:user, system_admin: true) }
+    let(:dttp_user) { create(:dttp_user, provider_id: user.provider.dttp_id) }
 
     before do
+      dttp_user
       given_i_am_authenticated(user: user)
       and_there_is_a_dttp_user
       when_i_visit_the_provider_index_page

--- a/spec/support/page_objects/providers/show.rb
+++ b/spec/support/page_objects/providers/show.rb
@@ -6,10 +6,26 @@ module PageObjects
       set_url "system-admin/providers/{id}"
 
       element :add_a_user, "a", text: "Add a user"
+      element :register_user, "#register-dttp-user"
 
-      elements :user_data, ".user-card"
+      element :registered_user_data, ".registered-users"
+      element :unregistered_user_data, ".unregistered-users"
 
-      elements :dttp_users_not_registered_data, "#user-not-registered"
+      def registered_users
+        user_cards(registered_user_data)
+      end
+
+      def unregistered_users
+        user_cards(unregistered_user_data)
+      end
+
+    private
+
+      def user_cards(element_node)
+        within(element_node) do
+          find_all(".user-card")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Dependent on this PR: https://github.com/DFE-Digital/register-trainee-teachers/pull/759

- https://trello.com/b/BBEuhbHM/publish-register-sprint-board

### Changes proposed in this pull request

- Show a button in the list of unregistered users which will allow them to be registered to the provider

![Screen Recording (Google Chrome) 2](https://user-images.githubusercontent.com/616080/114718069-955e3380-9d2d-11eb-8ab5-c6dce022222c.gif)

### Guidance to review

- You can follow the steps from this PR https://github.com/DFE-Digital/register-trainee-teachers/pull/751 to get a local list of DTTP Users or you can create a couple manually in the console. You just need to set the `provider_dttp_user_id` on the `dttp_user` record to match the provider you want to test registering with
- Once above is done the dttp user should show on the provider's show page with a button to register
- Click register and the dttp user should re-appear as a registered User