### PR TITLE
[1431] [Bug] Fixing persisting disabilities when disability state changed

### DIFF
--- a/app/controllers/trainees/diversity/disability_disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disability_disclosures_controller.rb
@@ -39,6 +39,7 @@ module Trainees
 
       def redirect_to_relevant_step
         if @disability_disclosure_form.disability_not_provided? || @disability_disclosure_form.no_disability?
+          trainee.clear_disabilities
           redirect_to(trainee_diversity_confirm_path(trainee))
         else
           redirect_to(edit_trainee_diversity_disability_detail_path(trainee))

--- a/app/controllers/trainees/diversity/disability_disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disability_disclosures_controller.rb
@@ -39,7 +39,6 @@ module Trainees
 
       def redirect_to_relevant_step
         if @disability_disclosure_form.disability_not_provided? || @disability_disclosure_form.no_disability?
-          trainee.clear_disabilities
           redirect_to(trainee_diversity_confirm_path(trainee))
         else
           redirect_to(edit_trainee_diversity_disability_detail_path(trainee))

--- a/app/forms/diversities/disability_disclosure_form.rb
+++ b/app/forms/diversities/disability_disclosure_form.rb
@@ -19,8 +19,10 @@ module Diversities
     end
 
     def save!
-      trainee.clear_disabilities if disability_not_provided? || no_disability?
-      super
+      ActiveRecord::Base.transaction do
+        trainee.clear_disabilities if disability_not_provided? || no_disability?
+        super
+      end
     end
 
     def disabled?

--- a/app/forms/diversities/disability_disclosure_form.rb
+++ b/app/forms/diversities/disability_disclosure_form.rb
@@ -18,6 +18,11 @@ module Diversities
       super(trainee, **kwargs)
     end
 
+    def save!
+      trainee.clear_disabilities if disability_not_provided? || no_disability?
+      super
+    end
+
     def disabled?
       fields[:disability_disclosure] == Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled]
     end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -181,4 +181,8 @@ class Trainee < ApplicationRecord
   def available_courses
     provider.courses.where(route: training_route)
   end
+
+  def clear_disabilities
+    disabilities.clear
+  end
 end

--- a/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
+++ b/spec/features/trainees/diversities/edit_disability_disclosure_spec.rb
@@ -3,34 +3,54 @@
 require "rails_helper"
 
 feature "edit disability disclosure", type: :feature do
-  background do
-    given_i_am_authenticated
-    given_a_trainee_exists_with_no_disability_disclosure
-    and_i_am_on_the_disability_disclosure_page
+  background { given_i_am_authenticated }
+
+  context "when a trainee has not disclosed a disability" do
+    background do
+      given_a_trainee_exists_with_no_disability_disclosure
+      and_i_am_on_the_disability_disclosure_page
+    end
+
+    scenario "submitting with no option selected" do
+      and_i_submit_the_form
+      then_i_see_error_messages
+    end
+
+    scenario "choosing to disclose a disability" do
+      and_i_choose_to_disclose
+      and_i_submit_the_form
+      then_i_am_redirected_to_the_disabilities_page
+    end
+
+    scenario "choosing not to disclose a disability" do
+      and_i_choose_not_to_disclose
+      and_i_submit_the_form
+      and_confirm_my_details
+      then_i_am_redirected_to_the_review_draft_page
+    end
   end
 
-  scenario "submitting with no option selected" do
-    and_i_submit_the_form
-    then_i_see_error_messages
-  end
+  context "when a trainee has already disclosed a disability" do
+    background do
+      given_a_trainee_exists_with_a_disability
+      and_i_am_on_the_disability_disclosure_page
+    end
 
-  scenario "choosing to disclose a disability" do
-    and_i_choose_to_disclose
-    and_i_submit_the_form
-    then_i_am_redirected_to_the_disabilities_page
-  end
-
-  scenario "choosing not to disclose a disability" do
-    and_i_choose_not_to_disclose
-    and_i_submit_the_form
-    and_confirm_my_details
-    then_i_am_redirected_to_the_review_draft_page
+    scenario "choosing not to disclose a disability" do
+      and_i_choose_not_to_disclose
+      and_i_submit_the_form
+      and_i_should_not_see_any_disabilities_listed
+    end
   end
 
 private
 
   def given_a_trainee_exists_with_no_disability_disclosure
     given_a_trainee_exists(:diversity_disclosed, disability_disclosure: nil)
+  end
+
+  def given_a_trainee_exists_with_a_disability
+    given_a_trainee_exists(:diversity_disclosed, disability_disclosure: :disabled, disabilities: [create(:disability)])
   end
 
   def and_i_am_on_the_disability_disclosure_page
@@ -55,6 +75,10 @@ private
 
   def then_i_am_redirected_to_the_disabilities_page
     expect(disabilities_page).to be_displayed(id: trainee.slug)
+  end
+
+  def and_i_should_not_see_any_disabilities_listed
+    expect(disabilities_page).to_not have_content("Disabilities shared:")
   end
 
   def then_i_see_error_messages


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/CrSrVFaO/1431-changing-disability-states-doesnt-get-rid-of-previous-disability)

### Changes proposed in this pull request

- Added a new method in trainees that clears their disabilities, called `clear_disabilities` 
- This method is called on the `trainee` inside the `DisabilityDisclosuresController` if the trainees disability_disclosure is set to either `disability_not_provided` or `no_disability`. 

### Guidance to review

- Fire up your `rails server`
- View a draft trainee you have previously made
- Click on Diversity Information
- Click on the `Change` link next to Disabilities
- Ensure you have selected `Yes, they shared that they're disabled`
- Select some disabilities and press continue
- Repeat the process by changing it again, but this time select `They shared that they're not disabled`
- The previously stated disabilities will no longer be shown or connected with the trainee (this process before would have shown conflicting no disabilities with disabilities shared.)

