### PR TITLE
[1404] Rename NARIC to ENIC

### DIFF
--- a/app/components/trainees/confirmation/degrees/view.rb
+++ b/app/components/trainees/confirmation/degrees/view.rb
@@ -22,7 +22,7 @@ module Trainees
           if degree.uk?
             "#{degree.uk_degree}: #{degree.subject.downcase}"
           else
-            "Non-UK #{degree.non_uk_degree_non_naric? ? 'degree' : degree.non_uk_degree}: #{degree.subject.downcase}"
+            "Non-UK #{degree.non_uk_degree_non_enic? ? 'degree' : degree.non_uk_degree}: #{degree.subject.downcase}"
           end
         end
 
@@ -74,7 +74,7 @@ module Trainees
               },
               {
                 key: "Degree type",
-                value: degree.non_uk_degree == "non_naric" ? "NARIC not provided" : degree.non_uk_degree,
+                value: degree.non_uk_degree == NON_ENIC ? "UK ENIC not provided" : degree.non_uk_degree,
                 action: govuk_link_to('Change<span class="govuk-visually-hidden"> degree type</span>'.html_safe, edit_trainee_degree_path(trainee, degree)),
               },
             ]

--- a/app/forms/degree_form.rb
+++ b/app/forms/degree_form.rb
@@ -22,7 +22,7 @@ class DegreeForm
 
   validate :validate_with_degree_model
 
-  delegate :uk?, :non_uk?, :non_uk_degree_non_naric?,
+  delegate :uk?, :non_uk?, :non_uk_degree_non_enic?,
            to: :degree
 
   def initialize(degrees_form:, degree:)

--- a/app/lib/dttp/params/degree_qualification.rb
+++ b/app/lib/dttp/params/degree_qualification.rb
@@ -38,7 +38,7 @@ module Dttp
       end
 
       def non_uk_specific_params
-        degree_type = degree.non_uk_degree_non_naric? ? "Unknown" : "Degree equivalent"
+        degree_type = degree.non_uk_degree_non_enic? ? "Unknown" : "Degree equivalent"
 
         {
           "dfe_name" => degree.non_uk_degree,

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -26,8 +26,8 @@ class Degree < ApplicationRecord
     errors.add(:graduation_year, :invalid) unless graduation_year.between?(next_year - MAX_GRAD_YEARS, next_year)
   end
 
-  def non_uk_degree_non_naric?
-    non_uk_degree == NON_NARIC
+  def non_uk_degree_non_enic?
+    non_uk_degree == NON_ENIC
   end
 
   # other_grade should be nil if grade isn't 'Other'

--- a/app/views/trainees/degrees/_non_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_non_uk_degree_form.html.erb
@@ -26,13 +26,13 @@
                          autocomplete: :disabled %>
 
   <div class="govuk-form-group">
-    <%= f.govuk_radio_buttons_fieldset :non_uk_degree, legend: { text: "Select the NARIC comparable UK degree", size: "s" } do %>
-      <% NARIC_NON_UK.each do |name| %>
+    <%= f.govuk_radio_buttons_fieldset :non_uk_degree, legend: { text: "Select the UK ENIC comparable degree", size: "s" } do %>
+      <% ENIC_NON_UK.each do |name| %>
         <%= f.govuk_radio_button :non_uk_degree, name,
                                   label: { text: name }, link_errors: true %>
       <% end %>
       <%= f.govuk_radio_divider %>
-      <%= f.govuk_radio_button :non_uk_degree, :non_naric, label: { text: "NARIC not provided" } %>
+      <%= f.govuk_radio_button :non_uk_degree, :non_enic, label: { text: "UK ENIC not provided" } %>
     <% end %>
   </div>
 

--- a/config/initializers/enic_non_uk.rb
+++ b/config/initializers/enic_non_uk.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-NARIC_NON_UK = [
+ENIC_NON_UK = [
   "Bachelor degree",
   "Ordinary bachelor degree",
   "Bachelor degree with honours",
@@ -8,4 +8,4 @@ NARIC_NON_UK = [
   "Master’s degree or Integrated Master’s degree",
 ].freeze
 
-NON_NARIC = "non_naric"
+NON_ENIC = "non_enic"

--- a/config/locales/pages/data_requirements/en.yml
+++ b/config/locales/pages/data_requirements/en.yml
@@ -52,7 +52,7 @@ en:
         <h3 class='govuk-heading-s'>If it’s not a UK degree</h3>
 
         <ul class='govuk-list'>
-          <li>NARIC comparable UK degree (if provided)</li>
+          <li>UK ENIC comparable degree (if provided)</li>
           <li>Subject</li>
           <li>Country where the degree was obtained</li>
           <li>Graduation year</li>

--- a/db/migrate/20210414150758_change_non_uk_degree_non_naric_to_non_enic.rb
+++ b/db/migrate/20210414150758_change_non_uk_degree_non_naric_to_non_enic.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ChangeNonUkDegreeNonNaricToNonEnic < ActiveRecord::Migration[6.1]
+  NON_ENIC = "non_enic"
+  NON_NARIC = "non_naric"
+
+  def up
+    execute <<~SQL.squish
+      UPDATE degrees SET non_uk_degree = '#{NON_ENIC}' WHERE degrees.non_uk_degree = '#{NON_NARIC}'
+    SQL
+  end
+
+  def down
+    execute <<~SQL.squish
+      UPDATE degrees SET non_uk_degree = '#{NON_NARIC}' WHERE degrees.non_uk_degree = '#{NON_ENIC}'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_09_151447) do
+ActiveRecord::Schema.define(version: 2021_04_14_150758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
     trait :non_uk_degree_type do
       locale_code { :non_uk }
       uk_degree { nil }
-      non_uk_degree { NARIC_NON_UK.sample }
+      non_uk_degree { ENIC_NON_UK.sample }
     end
 
     trait :non_uk_degree_with_details do

--- a/spec/lib/dttp/params/degree_qualification_spec.rb
+++ b/spec/lib/dttp/params/degree_qualification_spec.rb
@@ -49,7 +49,7 @@ module Dttp
 
         context "Non-UK degree" do
           let(:degree) { build(:degree, :non_uk_degree_with_details) }
-          let(:degree_type) { degree.non_uk_degree_non_naric? ? "Unknown" : "Degree equivalent" }
+          let(:degree_type) { degree.non_uk_degree_non_enic? ? "Unknown" : "Degree equivalent" }
 
           it "returns a hash with all the Non-UK specific degree qualification fields" do
             expect(subject).to match({

--- a/spec/support/page_objects/trainees/new_degree_details.rb
+++ b/spec/support/page_objects/trainees/new_degree_details.rb
@@ -12,7 +12,7 @@ module PageObjects
       element :bachelor_degree_with_honours, "#degree-non-uk-degree-bachelor-degree-with-honours-field"
       element :postgraduate_certificate_or_postgraduate_diploma, "#degree-non-uk-degree-postgraduate-certificate-or-postgraduate-diploma-field"
       element :master_s_degree_or_integrated_master_s_degree, "#degree-non-uk-degree-master-s-degree-or-integrated-master-s-degree-field"
-      element :non_naric, "#degree-non-uk-degree-non-naric-field"
+      element :non_enic, "#degree-non-uk-degree-non-enic-field"
 
       element :subject, "#degree-subject-field"
       element :institution, "#degree-institution-field"


### PR DESCRIPTION
### Context

https://trello.com/c/Y68eiyWD/1404-s-rename-naric-to-enic

### Changes proposed in this pull request

- Renames all instances of `NARIC` to `ENIC`.
- Includes a migration to change all trainee degrees that have 'non_naric' recorded as their `non_uk_degree` to `non_enic`

### Guidance to review

- Check that saving non-enic degrees still works ok and the content is consistent.

