### PR TITLE
[1437] Change timeline times to match local time zone

### DIFF
--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -24,8 +24,7 @@
       <%= t(
           ".get_access_html",
           link: support_email(subject: "Get access to Register trainee teachers"),
-        )
-      %>
+        ) %>
     </p>
 
   </div>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -14,5 +14,5 @@ Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
              "%e %B %Y at %l:%M%P"
            end
 
-  time.strftime(format)
+  time.in_time_zone("London").strftime(format)
 end


### PR DESCRIPTION
### Context

Since we changed from GMT to BST the times on the timelines are incorrect. This PR changes the timeline times to match the local time zone.

### Guidance to review

- https://rtt-review-pr-765.herokuapp.com/
- Visit a trainee in a non draft state. E.g `Pending TRN`  
- Make a change, for example add a degree
- Go to the timeline and check that the time the change was made matches the current time