### PR TITLE
[1243] Improve handling of freetext responses to autocomplete fields

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: build
 
 on:
   push:
-   branches: 
+   branches:
     - master
   pull_request:
-    branches: 
+    branches:
     - master
 
 env:
@@ -50,6 +50,9 @@ jobs:
         docker-compose up --no-build -d
         docker-compose exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
         docker-compose exec -T web /bin/sh -c "yarn add jest"
+
+    - name: Install chromedriver
+      run: docker-compose exec -T web /bin/sh -c 'apk add chromium chromium-chromedriver'
 
     - name: Setup DB
       run: docker-compose exec -T web /bin/sh -c "bundle exec rails db:setup"

--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -20,21 +20,20 @@ const suggestionTemplate = (value) => {
 const setupAutoComplete = (component) => {
   const selectEl = component.querySelector('select')
 
+  // We add a name which we base off the name for the select element and add "raw" to it, eg
+  // if there is a select input called "course_details[subject]" we add a name to the text input
+  // as "course_details[subject_raw]"
+  const matches = /(\w+)\[(\w+)\]/.exec(selectEl.name)
+  const rawFieldName = `${matches[1]}[${matches[2]}_raw]`
+
   accessibleAutocomplete.enhanceSelectElement({
     defaultValue: defaultValueOption(component),
     selectElement: selectEl,
     showAllValues: showAllValuesOption(component),
     autoselect: !disableAutoselectOption(component),
     confirmOnBlur: !disableConfirmOnBlurOption(component),
-    templates: { suggestion: suggestionTemplate }
-  })
-
-  // Fixes a bug whereby if the user enters a search term with no results
-  // accesible-autocomplete defaults to the last valid input and there is no
-  // error to handle.
-  component.querySelector('input').addEventListener('keyup', () => {
-    const noResults = component.querySelector('.autocomplete__option--no-results')
-    if (noResults) selectEl.value = ''
+    templates: { suggestion: suggestionTemplate },
+    name: rawFieldName
   })
 }
 

--- a/app/components/form_components/autocomplete/view.rb
+++ b/app/components/form_components/autocomplete/view.rb
@@ -5,8 +5,11 @@ module FormComponents
     class View < GovukComponent::Base
       attr_accessor :form_field
 
-      def initialize(form_field:, classes: [], html_attributes: {})
+      def initialize(form, attribute_name:, form_field:, classes: [], html_attributes: {})
+        @raw_attribute_value = form.object.send("#{attribute_name}_raw")
+        @attribute_value = form.object.send(attribute_name)
         super(classes: classes, html_attributes: default_html_attributes.merge(html_attributes))
+
         @form_field = form_field
       end
 
@@ -19,6 +22,7 @@ module FormComponents
       def default_html_attributes
         {
           "data-module" => "app-autocomplete",
+          "data-default-value" => (@raw_attribute_value || @attribute_value).to_s,
         }
       end
     end

--- a/app/controllers/trainees/degrees_controller.rb
+++ b/app/controllers/trainees/degrees_controller.rb
@@ -10,7 +10,7 @@ module Trainees
     end
 
     def create
-      @degree_form = @degrees_form.build_degree(degree_params)
+      @degree_form = @degrees_form.build_degree(degree_params, autocomplete_params)
 
       if @degree_form.save_or_stash
         redirect_to trainee_degrees_confirm_path(trainee)
@@ -47,7 +47,11 @@ module Trainees
   private
 
     def degree_params
-      params.require(:degree).permit(DegreeForm::FIELDS.excluding(:slug))
+      params.require(:degree).permit(DegreeForm::FIELDS.excluding(:slug, *DegreeForm::AUTOCOMPLETE_FIELDS))
+    end
+
+    def autocomplete_params
+      params.require(:degree).permit(DegreeForm::AUTOCOMPLETE_FIELDS)
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -56,8 +56,11 @@ module Trainees
         *DOB_CONVERSION.keys,
         :other,
         :other_nationality1,
+        :other_nationality1_raw,
         :other_nationality2,
+        :other_nationality2_raw,
         :other_nationality3,
+        :other_nationality3_raw,
         nationality_ids: [],
       ).transform_keys do |key|
         DOB_CONVERSION.keys.include?(key) ? DOB_CONVERSION[key] : key

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -3,6 +3,7 @@
 class CourseDetailsForm < TraineeForm
   FIELDS = %i[
     subject
+    subject_raw
     start_day
     start_month
     start_year
@@ -11,13 +12,15 @@ class CourseDetailsForm < TraineeForm
     end_year
     main_age_range
     additional_age_range
+    additional_age_range_raw
   ].freeze
 
   attr_accessor(*FIELDS)
 
   before_validation :sanitise_course_dates
 
-  validates :subject, presence: true
+  validates :subject, autocomplete: true, presence: true
+  validates :additional_age_range, autocomplete: true, if: -> { main_age_range&.to_sym == :other }
   validate :age_range_valid
   validate :course_start_date_valid
   validate :course_end_date_valid

--- a/app/forms/degree_form.rb
+++ b/app/forms/degree_form.rb
@@ -18,23 +18,31 @@ class DegreeForm
     country
   ].freeze
 
-  attr_accessor(*FIELDS, :degrees_form, :degree)
+  AUTOCOMPLETE_FIELDS = %i[
+    uk_degree_raw
+    subject_raw
+    institution_raw
+  ].freeze
 
+  attr_accessor(*FIELDS, *AUTOCOMPLETE_FIELDS, :degrees_form, :degree)
+
+  validates :uk_degree, :subject, :institution, autocomplete: true, allow_nil: true
   validate :validate_with_degree_model
 
-  delegate :uk?, :non_uk?, :non_uk_degree_non_enic?,
+  delegate :uk?, :non_uk?, :non_uk_degree_non_enic?, :persisted?,
            to: :degree
 
-  def initialize(degrees_form:, degree:)
+  def initialize(degrees_form:, degree:, autocomplete_params: {})
     @degrees_form = degrees_form
     @degree = degree
     self.attributes = degree.attributes
       .symbolize_keys
       .slice(*FIELDS)
+    assign_attributes(autocomplete_params)
   end
 
-  def persisted?
-    slug.present?
+  def self.model_name
+    ActiveModel::Name.new(self, nil, "Degree")
   end
 
   def id

--- a/app/forms/degrees_form.rb
+++ b/app/forms/degrees_form.rb
@@ -17,8 +17,8 @@ class DegreesForm
     { degree_ids: trainee.degree_ids }
   end
 
-  def build_degree(params)
-    DegreeForm.new(degrees_form: self, degree: trainee.degrees.new(params))
+  def build_degree(degree_params, autocomplete_params = {})
+    DegreeForm.new(degrees_form: self, degree: trainee.degrees.new(degree_params), autocomplete_params: autocomplete_params)
   end
 
   def find_degree_from_param(slug)

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -9,7 +9,10 @@ class PersonalDetailsForm < TraineeForm
     nationality_ids
   ].freeze
 
-  attr_accessor(*FIELDS, :day, :month, :year, :other_nationality1, :other_nationality2, :other_nationality3, :other)
+  attr_accessor(*FIELDS, :day, :month, :year, :other_nationality1,
+                :other_nationality1_raw, :other_nationality2,
+                :other_nationality2_raw, :other_nationality3,
+                :other_nationality3_raw, :other)
 
   validates :first_names, presence: true
   validates :last_name, presence: true
@@ -17,6 +20,7 @@ class PersonalDetailsForm < TraineeForm
   validate :date_of_birth_valid
   validate :date_of_birth_not_in_future
   validates :gender, presence: true, inclusion: { in: Trainee.genders.keys }
+  validates :other_nationality1, :other_nationality2, :other_nationality3, autocomplete: true, allow_nil: true
   validate :nationalities_cannot_be_empty
 
   def date_of_birth

--- a/app/validators/autocomplete_validator.rb
+++ b/app/validators/autocomplete_validator.rb
@@ -9,6 +9,9 @@ class AutocompleteValidator < ActiveModel::EachValidator
 
     value = record.send(attribute)
     unless value == raw_value
+      # If the user hasn't selected something, we need to reset the value so that the autocomplete
+      # doesn't clobber the raw value when the page reloads
+      record.send("#{attribute}=", raw_value)
       record.errors.add(attribute, I18n.t("activemodel.errors.validators.autocomplete.#{attribute}"))
     end
   end

--- a/app/validators/autocomplete_validator.rb
+++ b/app/validators/autocomplete_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AutocompleteValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, _value)
+    raw_value = record.send("#{attribute}_raw")
+    # The form must have been submitted without the text field being on the page,
+    # likely through js being disabled
+    return if raw_value.nil?
+
+    value = record.send(attribute)
+    unless value == raw_value
+      record.errors.add(attribute, I18n.t("activemodel.errors.validators.autocomplete.#{attribute}"))
+    end
+  end
+end

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -14,6 +14,8 @@
       <h1 class="govuk-heading-l">Course details</h1>
 
       <%= render FormComponents::Autocomplete::View.new(
+        f,
+        attribute_name: :subject,
         form_field: f.govuk_collection_select(:subject, course_subjects_options,
                                               :name, :name, label: { text: "Subject", size: "s" },
                                                             hint: { text: "Search for the closest matching subject" }),
@@ -33,6 +35,8 @@
                                  :other,
                                  label: { text: "Other age range" }) do %>
           <%= render FormComponents::Autocomplete::View.new(
+            f,
+            attribute_name: :additional_age_range,
             form_field: f.govuk_collection_select(:additional_age_range, additional_age_ranges_options,
                                                   :name,
                                                   :name,

--- a/app/views/trainees/degrees/_non_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_non_uk_degree_form.html.erb
@@ -1,10 +1,12 @@
-<%= register_form_with model: [@trainee, @degree_form.degree], local: true do |f| %>
+<%= register_form_with model: [@trainee, @degree_form], local: true do |f| %>
   <%= f.hidden_field :locale_code, value: "non_uk" %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-l">Degree details</h1>
 
   <%= render FormComponents::Autocomplete::View.new(
+    f,
+    attribute_name: :subject,
     form_field: f.govuk_collection_select(:subject, subjects_options,
                                           :name, :name, label: { text: "Degree subject", size: "s" },
                                                         hint: { text: 'Search for the closest matching subject.

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -1,4 +1,4 @@
-<%= register_form_with model: [@trainee, @degree_form.degree], local: true do |f| %>
+<%= register_form_with model: [@trainee, @degree_form], local: true do |f| %>
   <%= f.hidden_field :locale_code, value: "uk" %>
 
   <%= f.govuk_error_summary %>
@@ -6,6 +6,8 @@
   <h1 class="govuk-heading-l">Degree details</h1>
 
   <%= render FormComponents::Autocomplete::View.new(
+    f,
+    attribute_name: :subject,
     form_field: f.govuk_collection_select(:subject, subjects_options,
                                           :name, :name, label: { text: "Degree subject", size: "s" },
                                                         hint: { text: 'Search for the closest matching subject.
@@ -17,6 +19,8 @@
   ) %>
 
   <%= render FormComponents::Autocomplete::View.new(
+    f,
+    attribute_name: :uk_degree,
     form_field: f.govuk_collection_select(:uk_degree, hesa_degree_types_options, :option_value, :option_name,
                                           label: { text: "Type of degree", size: "s" },
                                           hint: { text: "For example, BA, BSc or other (please specify)" }),
@@ -26,6 +30,8 @@
   ) %>
 
   <%= render FormComponents::Autocomplete::View.new(
+    f,
+    attribute_name: :institution,
     form_field: f.govuk_collection_select(:institution, institutions_options, :name,
                                           :name, label: { text: "Institution", size: "s" }),
     html_attributes: {

--- a/app/views/trainees/personal_details/_nationality_select_field.html.erb
+++ b/app/views/trainees/personal_details/_nationality_select_field.html.erb
@@ -1,4 +1,6 @@
 <%= render FormComponents::Autocomplete::View.new(
+  form,
+  attribute_name: field,
   form_field: form.govuk_collection_select(field, format_nationalities(nationalities, empty_option: true, description: false), :id, :name, label: { text: "Other nationality", size: "s", aria: { label: "#{(index + 1).ordinalize} additional nationality" } }),
   classes: "govuk-!-margin-bottom-6",
   html_attributes: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -451,11 +451,11 @@ en:
         email:
           invalid: "You must enter an email address in the correct format, like name@example.com"
         autocomplete:
-          subject: "Select a subject after typing"
-          additional_age_range: "Select an age range after typing"
-          uk_degree: "Select a nationality after typing"
-          institution: "Select an intitution after typing"
-          other_nationality1: &nationality "Select a nationality after typing"
+          subject: "Select a subject from the list - your entry is not recognised"
+          additional_age_range: "Select an age range from the list - your entry is not recognised"
+          uk_degree: "Select a type of degree from the list - your entry is not recognised"
+          institution: "Select an institution from the list - your entry is not recognised"
+          other_nationality1: &nationality "Select a nationality from the list - your entry is not recognised"
           other_nationality2: *nationality
           other_nationality3: *nationality
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,7 +215,7 @@ en:
   views:
     all_records: "All records"
     trainees:
-      index: 
+      index:
         no_records: Your trainee records will appear here. You do not have any records yet.
       edit:
         defer: Defer
@@ -450,6 +450,9 @@ en:
           invalid: "You must enter a valid postcode (for example, BN1 1AA)"
         email:
           invalid: "You must enter an email address in the correct format, like name@example.com"
+        autocomplete:
+          subject: "Select a subject after typing"
+          additional_age_range: "Select an age range after typing"
       models:
         contact_details_form:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -453,6 +453,11 @@ en:
         autocomplete:
           subject: "Select a subject after typing"
           additional_age_range: "Select an age range after typing"
+          uk_degree: "Select a nationality after typing"
+          institution: "Select an intitution after typing"
+          other_nationality1: &nationality "Select a nationality after typing"
+          other_nationality2: *nationality
+          other_nationality3: *nationality
       models:
         contact_details_form:
           attributes:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,8 +83,8 @@ ActiveRecord::Schema.define(version: 2021_04_14_150758) do
     t.integer "duration_in_years", null: false
     t.string "course_length", null: false
     t.integer "qualification", null: false
-    t.integer "route", null: false
     t.string "summary", null: false
+    t.integer "route", null: false
     t.integer "level", null: false
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
     t.index ["provider_id"], name: "index_courses_on_provider_id"
@@ -160,8 +160,8 @@ ActiveRecord::Schema.define(version: 2021_04_14_150758) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.boolean "apply_sync_enabled", default: false
     t.string "code"
+    t.boolean "apply_sync_enabled", default: false
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
 

--- a/spec/components/form_components/autocomplete/view_preview.rb
+++ b/spec/components/form_components/autocomplete/view_preview.rb
@@ -3,29 +3,38 @@
 module FormComponents
   module Autocomplete
     class ViewPreview < ViewComponent::Preview
+      include ActionView::Helpers::FormHelper
+
       def enhancing_select_list
-        render(FormComponents::Autocomplete::View.new(form_field: setup_form))
+        render(FormComponents::Autocomplete::View.new(form, attribute_name: :country, form_field: form_field))
       end
 
       def with_custom_class
-        render(FormComponents::Autocomplete::View.new(form_field: setup_form, classes: "app-testing-class"))
+        render(FormComponents::Autocomplete::View.new(form, attribute_name: :country, form_field: form_field, classes: "app-testing-class"))
       end
 
       def with_custom_html_attributes
-        render(FormComponents::Autocomplete::View.new(form_field: setup_form, html_attributes: { "test-html-attribute" => "testing" }))
+        render(FormComponents::Autocomplete::View.new(form, attribute_name: :country, form_field: form_field, html_attributes: { "test-html-attribute" => "testing" }))
       end
 
       def with_show_all_values
-        render(FormComponents::Autocomplete::View.new(form_field: setup_form, html_attributes: { "data-show-all-values" => true }))
+        render(FormComponents::Autocomplete::View.new(form, attribute_name: :country, form_field: form_field, html_attributes: { "data-show-all-values" => true }))
       end
 
       def with_default_value
-        render(FormComponents::Autocomplete::View.new(form_field: setup_form, html_attributes: { "data-default-value" => "France" }))
+        render(FormComponents::Autocomplete::View.new(form, attribute_name: :country, form_field: form_field, html_attributes: { "data-default-value" => "France" }))
       end
 
     private
 
-      def setup_form
+      attr_accessor :output_buffer
+
+      class ExampleModel
+        include ActiveModel::Model
+        attr_accessor :id, :country, :country_raw
+      end
+
+      def form_field
         '<div class="govuk-form-group">
           <label class="govuk-label" for="select-1">
             Select a country
@@ -37,6 +46,12 @@ module FormComponents
             <option value="gb">United Kingdom</option>
           </select>
         </div>'
+      end
+
+      def form
+        form_for ExampleModel.new, url: "example.com" do |f|
+          return f
+        end
       end
     end
   end

--- a/spec/components/form_components/autocomplete/view_spec.rb
+++ b/spec/components/form_components/autocomplete/view_spec.rb
@@ -5,21 +5,29 @@ require "rails_helper"
 module FormComponents
   module Autocomplete
     describe View do
+      include ActionView::Helpers::FormHelper
       alias_method :component, :page
 
       it "supports custom classes on the parent container" do
-        render_inline(View.new(form_field: setup_form, classes: "test-css-class"))
+        render_inline(View.new(form, attribute_name: :country, form_field: form_field, classes: "test-css-class"))
         expect(component).to have_selector(".test-css-class")
       end
 
       it "supports custom html attributes on the parent container" do
-        render_inline(View.new(form_field: setup_form, html_attributes: { "test-attribute" => "my-custom-attribute" }))
+        render_inline(View.new(form, attribute_name: :country, form_field: form_field, html_attributes: { "test-attribute" => "my-custom-attribute" }))
         expect(component).to have_selector('[test-attribute="my-custom-attribute"]')
       end
 
     private
 
-      def setup_form
+      attr_accessor :output_buffer
+
+      class ExampleModel
+        include ActiveModel::Model
+        attr_accessor :id, :country, :country_raw
+      end
+
+      def form_field
         '<div class="govuk-form-group">
           <label class="govuk-label" for="select-1">
             Select a country
@@ -31,6 +39,12 @@ module FormComponents
             <option value="gb">United Kingdom</option>
           </select>
         </div>'
+      end
+
+      def form
+        form_for ExampleModel.new, url: "example.com" do |f|
+          return f
+        end
       end
     end
   end

--- a/spec/features/trainees/degrees/adding_degree_spec.rb
+++ b/spec/features/trainees/degrees/adding_degree_spec.rb
@@ -78,6 +78,19 @@ RSpec.feature "Adding a degree" do
       and_i_click_the_continue_button_on_the_degree_details_page
       then_i_see_the_error_summary_for_degree_details_page
     end
+
+    scenario "the user submits partially entered autocompletes", js: true do
+      and_i_have_selected_uk_route
+      when_i_visit_the_degree_details_page
+      and_i_fill_in_subject_without_selecting_a_value(with: "moose")
+      and_i_fill_in_degree_without_selecting_a_value(with: "goose")
+      and_i_fill_in_institution_without_selecting_a_value(with: "obtuse")
+      and_i_click_continue
+      then_subject_is_populated(with: "moose")
+      then_degree_is_populated(with: "goose")
+      then_institution_is_populated(with: "obtuse")
+      # TODO: error message
+    end
   end
 
   describe "Non-UK Route" do
@@ -97,6 +110,15 @@ RSpec.feature "Adding a degree" do
       when_i_visit_the_degree_details_page
       and_i_click_the_continue_button_on_the_degree_details_page
       then_i_see_the_error_summary_for_degree_details_page
+    end
+
+    scenario "the user submits partially entered autocompletes", js: true do
+      and_i_have_selected_non_uk_route
+      when_i_visit_the_degree_details_page
+      and_i_fill_in_subject_without_selecting_a_value(with: "moose")
+      and_i_click_continue
+      then_subject_is_populated(with: "moose")
+      # TODO: error message
     end
   end
 
@@ -204,5 +226,29 @@ private
 
   def then_i_see_a_flash_message
     expect(confirm_details_page).to have_text("Trainee degree deleted")
+  end
+
+  def and_i_fill_in_subject_without_selecting_a_value(with:)
+    degree_details_page.subject_raw.fill_in with: with
+  end
+
+  def then_subject_is_populated(with:)
+    expect(degree_details_page.subject_raw.value).to eq(with)
+  end
+
+  def and_i_fill_in_degree_without_selecting_a_value(with:)
+    degree_details_page.uk_degree_raw.fill_in with: with
+  end
+
+  def then_degree_is_populated(with:)
+    expect(degree_details_page.uk_degree_raw.value).to eq(with)
+  end
+
+  def and_i_fill_in_institution_without_selecting_a_value(with:)
+    degree_details_page.institution_raw.fill_in with: with
+  end
+
+  def then_institution_is_populated(with:)
+    expect(degree_details_page.institution_raw.value).to eq(with)
   end
 end

--- a/spec/features/trainees/degrees/adding_degree_spec.rb
+++ b/spec/features/trainees/degrees/adding_degree_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature "Adding a degree" do
       then_subject_is_populated(with: "moose")
       then_degree_is_populated(with: "goose")
       then_institution_is_populated(with: "obtuse")
-      # TODO: error message
+      then_i_see_error_messages_for_partially_submitted_fields(:subject, :uk_degree, :institution)
     end
   end
 
@@ -118,7 +118,7 @@ RSpec.feature "Adding a degree" do
       and_i_fill_in_subject_without_selecting_a_value(with: "moose")
       and_i_click_continue
       then_subject_is_populated(with: "moose")
-      # TODO: error message
+      then_i_see_error_messages_for_partially_submitted_fields(:subject)
     end
   end
 
@@ -250,5 +250,14 @@ private
 
   def then_institution_is_populated(with:)
     expect(degree_details_page.institution_raw.value).to eq(with)
+  end
+
+  def then_i_see_error_messages_for_partially_submitted_fields(*fields)
+    fields.each do |f|
+      message = I18n.t(
+        "activemodel.errors.validators.autocomplete.#{f}",
+      )
+      expect(degree_details_page).to have_content(message)
+    end
   end
 end

--- a/spec/features/trainees/edit_course_details_spec.rb
+++ b/spec/features/trainees/edit_course_details_spec.rb
@@ -57,20 +57,14 @@ feature "course details", type: :feature do
       then_start_date_is_still_populated
     end
 
-    scenario "submitting with a partial subject", js: true do
+    scenario "submitting with a partial subject/age range", js: true do
       when_i_visit_the_course_details_page
       and_i_fill_in_subject_without_selecting_a_value(with: "moose")
+      and_i_fill_in_additional_age_range_without_selecting_a_value(with: "goose")
       and_i_submit_the_form
       then_subject_is_populated(with: "moose")
-      # TODO: error message assertion
-    end
-
-    scenario "submitting with a partial age range", js: true do
-      when_i_visit_the_course_details_page
-      and_i_fill_in_additional_age_range_without_selecting_a_value(with: "moose")
-      and_i_submit_the_form
-      then_additional_age_range_is_populated(with: "moose")
-      # TODO: error message assertion
+      then_additional_age_range_is_populated(with: "goose")
+      then_i_see_error_messages_for_partially_submitted_fields
     end
   end
 
@@ -163,6 +157,15 @@ private
     )
     expect(course_details_page).to have_content(
       I18n.t("#{translation_key_prefix}.course_start_date.blank"),
+    )
+  end
+
+  def then_i_see_error_messages_for_partially_submitted_fields
+    expect(course_details_page).to have_content(
+      I18n.t("activemodel.errors.validators.autocomplete.subject"),
+    )
+    expect(course_details_page).to have_content(
+      I18n.t("activemodel.errors.validators.autocomplete.additional_age_range"),
     )
   end
 

--- a/spec/features/trainees/edit_course_details_spec.rb
+++ b/spec/features/trainees/edit_course_details_spec.rb
@@ -56,6 +56,22 @@ feature "course details", type: :feature do
       and_i_submit_the_form
       then_start_date_is_still_populated
     end
+
+    scenario "submitting with a partial subject", js: true do
+      when_i_visit_the_course_details_page
+      and_i_fill_in_subject_without_selecting_a_value(with: "moose")
+      and_i_submit_the_form
+      then_subject_is_populated(with: "moose")
+      # TODO: error message assertion
+    end
+
+    scenario "submitting with a partial age range", js: true do
+      when_i_visit_the_course_details_page
+      and_i_fill_in_additional_age_range_without_selecting_a_value(with: "moose")
+      and_i_submit_the_form
+      then_additional_age_range_is_populated(with: "moose")
+      # TODO: error message assertion
+    end
   end
 
 private
@@ -113,6 +129,23 @@ private
 
   def and_i_fill_in_start_date_only
     course_details_page.set_date_fields("course_start_date", template.course_start_date.strftime("%d/%m/%Y"))
+  end
+
+  def and_i_fill_in_subject_without_selecting_a_value(with:)
+    course_details_page.subject_raw.fill_in with: with
+  end
+
+  def and_i_fill_in_additional_age_range_without_selecting_a_value(with:)
+    choose "Other age range", allow_label_click: true
+    course_details_page.additional_age_range.fill_in with: with
+  end
+
+  def then_additional_age_range_is_populated(with:)
+    expect(course_details_page.additional_age_range_raw.value).to eq(with)
+  end
+
+  def then_subject_is_populated(with:)
+    expect(course_details_page.subject_raw.value).to eq(with)
   end
 
   def then_start_date_is_still_populated

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -47,7 +47,7 @@ feature "edit personal details", type: :feature do
     and_i_fill_in_nationalities_without_selecting_a_value(with: ["moose", "on", "the loose"])
     and_i_submit_the_form
     then_nationalities_are_populated(with: ["moose", "on", "the loose"])
-    # TODO: error messages
+    then_i_see_error_messages_for_partially_completed_nationalities
   end
 
   context "as a non-draft trainee" do
@@ -175,5 +175,13 @@ private
     expect(personal_details_page.other_nationality1_raw.value).to eq nationality1
     expect(personal_details_page.other_nationality2_raw.value).to eq nationality2
     expect(personal_details_page.other_nationality3_raw.value).to eq nationality3
+  end
+
+  def then_i_see_error_messages_for_partially_completed_nationalities
+    expect(personal_details_page).to have_content(
+      I18n.t(
+        "activemodel.errors.validators.autocomplete.other_nationality1",
+      ),
+    )
   end
 end

--- a/spec/features/trainees/edit_personal_details_spec.rb
+++ b/spec/features/trainees/edit_personal_details_spec.rb
@@ -40,6 +40,16 @@ feature "edit personal details", type: :feature do
     then_i_see_error_messages
   end
 
+  scenario "partially entering nationality", js: true do
+    given_a_trainee_exists
+    and_nationalities_exist_in_the_system
+    when_i_visit_the_personal_details_page
+    and_i_fill_in_nationalities_without_selecting_a_value(with: ["moose", "on", "the loose"])
+    and_i_submit_the_form
+    then_nationalities_are_populated(with: ["moose", "on", "the loose"])
+    # TODO: error messages
+  end
+
   context "as a non-draft trainee" do
     before do
       given_a_trainee_exists(:submitted_for_trn)
@@ -148,5 +158,22 @@ private
 
   def then_i_see_a_flash_message
     expect(record_page).to have_text("Trainee personal details updated")
+  end
+
+  def and_i_fill_in_nationalities_without_selecting_a_value(with:)
+    nationality1, nationality2, nationality3 = *with
+    personal_details_page.nationality.check "Other", allow_label_click: true
+    personal_details_page.other_nationality1_raw.fill_in with: nationality1
+    personal_details_page.add_nationality.click
+    personal_details_page.other_nationality2_raw.fill_in with: nationality2
+    personal_details_page.add_nationality.click
+    personal_details_page.other_nationality3_raw.fill_in with: nationality3
+  end
+
+  def then_nationalities_are_populated(with:)
+    nationality1, nationality2, nationality3 = *with
+    expect(personal_details_page.other_nationality1_raw.value).to eq nationality1
+    expect(personal_details_page.other_nationality2_raw.value).to eq nationality2
+    expect(personal_details_page.other_nationality3_raw.value).to eq nationality3
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,8 @@ require "audited-rspec"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
+WebMock.disable_net_connect!(allow_localhost: true)
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,7 +6,7 @@ Capybara.register_driver :cuprite do |app|
   Capybara::Cuprite::Driver.new(
     app,
     window_size: [1200, 800],
-    browser_options: { "ignore-certificate-errors" => nil },
+    browser_options: { "ignore-certificate-errors" => nil, "no-sandbox" => nil },
     process_timeout: 10,
     inspector: true,
     headless: true,
@@ -17,8 +17,9 @@ Capybara.server = :puma, { Silent: true }
 Capybara.server_host = "0.0.0.0"
 Capybara.server_port = "4000"
 Capybara.app_host = "http://localhost:4000"
+Capybara.asset_host = "https://localhost:5000"
 
 # Enable once Github actions is properly configured
-# Capybara.default_driver = :cuprite
-# Capybara.javascript_driver = :cuprite
+Capybara.default_driver = :rack_test
+Capybara.javascript_driver = :cuprite
 Capybara.default_max_wait_time = 10

--- a/spec/support/page_objects/trainees/course_details.rb
+++ b/spec/support/page_objects/trainees/course_details.rb
@@ -7,6 +7,7 @@ module PageObjects
       set_url "/trainees/{id}/course-details/edit"
 
       element :subject, "#course-details-form-subject-field"
+      element :subject_raw, "input[data-nameoriginal='course_details_form[subject_raw]']"
 
       element :course_start_date_day, "#course_details_form_course_start_date_3i"
       element :course_start_date_month, "#course_details_form_course_start_date_2i"
@@ -23,6 +24,7 @@ module PageObjects
       element :main_age_range_other, "#course-details-form-main-age-range-other-field"
 
       element :additional_age_range, "#course-details-form-additional-age-range-field"
+      element :additional_age_range_raw, "input[data-nameoriginal='course_details_form[additional_age_range_raw]']"
 
       element :submit_button, "input[name='commit']"
     end

--- a/spec/support/page_objects/trainees/new_degree_details.rb
+++ b/spec/support/page_objects/trainees/new_degree_details.rb
@@ -6,6 +6,7 @@ module PageObjects
       set_url "/trainees/{trainee_id}/degrees/new?locale_code={locale_code}"
 
       element :uk_degree, "#degree-uk-degree-field"
+      element :uk_degree_raw, "input[data-nameoriginal='degree[uk_degree_raw]']"
 
       element :bachelor_degree, "#degree-non-uk-degree-bachelor-degree-field"
       element :ordinary_bachelor_degree, "#degree-non-uk-degree-ordinary-bachelor-degree-field"
@@ -15,7 +16,9 @@ module PageObjects
       element :non_enic, "#degree-non-uk-degree-non-enic-field"
 
       element :subject, "#degree-subject-field"
+      element :subject_raw, "input[data-nameoriginal='degree[subject_raw]']"
       element :institution, "#degree-institution-field"
+      element :institution_raw, "input[data-nameoriginal='degree[institution_raw]']"
       element :graduation_year, "#degree-graduation-year-field"
       element :grade, ".degree-grade"
       element :other_grade, "#degree-other-grade-field"

--- a/spec/support/page_objects/trainees/personal_details.rb
+++ b/spec/support/page_objects/trainees/personal_details.rb
@@ -14,6 +14,10 @@ module PageObjects
       element :gender, ".govuk-radios.gender"
       element :nationality, ".govuk-checkboxes.nationality"
       element :other_nationality, "#personal-details-form-other-nationality1-field"
+      element :other_nationality1_raw, "input[data-nameoriginal='personal_details_form[other_nationality1_raw]']"
+      element :other_nationality2_raw, "input[data-nameoriginal='personal_details_form[other_nationality2_raw]']"
+      element :other_nationality3_raw, "input[data-nameoriginal='personal_details_form[other_nationality3_raw]']"
+      element :add_nationality, "#add-nationality-button"
       element :continue_button, "input[name='commit'][value='Continue']"
     end
   end

--- a/spec/validators/autocomplete_validator_spec.rb
+++ b/spec/validators/autocomplete_validator_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe AutocompleteValidator do
+  class Validatable
+    include ActiveModel::Validations
+    attr_accessor :search, :search_raw
+
+    validates :search, autocomplete: true
+  end
+
+  subject do
+    Validatable.new.tap do |v|
+      v.search = search
+      v.search_raw = search_raw
+    end
+  end
+
+  context "when the field/raw value are the same" do
+    let(:search) { "Does ask jeeves still exist?" }
+    let(:search_raw) { "Does ask jeeves still exist?" }
+
+    it "does not add an error" do
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the field/raw value are different" do
+    let(:search) { "Does ask jeeves still exist?" }
+    let(:search_raw) { "Does jeeves" }
+
+    it "adds an error" do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:search]).not_to be_blank
+    end
+
+    # If the user hasn't selected something, we need to reset the value so that the autocomplete
+    # doesn't clobber the raw value when the page reloads
+    it "resets the field" do
+      expect { subject.valid? }.to change { subject.search }
+        .from("Does ask jeeves still exist?")
+        .to("Does jeeves")
+    end
+  end
+end


### PR DESCRIPTION
### Context
Ticket: https://trello.com/c/dEEa06yg/1243-m-improve-handling-of-freetext-responses-to-autocompletes-that-require-a-fixed-answer

### Changes proposed in this pull request
Adds a validation to all autocompletes (excluding country) so that the
User will get a specific message if they type something into the field
but fail to select a value.

This works by submitting a text and select input for the autocomplete
field and comparing the two in a form object validation.

To test this, it was easiest to do a feature test because there are 
parts in the views, controller and form objects that need to all slot
together to ensure the validation is correctly shown to the user. This
required setting up chrome web driver on CI, and enabling js for these
tests using `js: true`

The country autocomplete was left out because it uses an external js
library which would be hard to override, and it doesn’t suffer from the
same usability problem because it uses the “autoselect” option for the
Accessible-autocomplete library.

The copy for the error messages is not yet confirmed.

### Added bonus

Somehow the rspec tests seem to be running about a minute faster down from 4 minutes, I have no explanation for that.

### Guidance to review

 - Visit degree details form (uk and non-uk) and enter some text eg "sdfsdfsdfsdfsdf" into any autocomplete fields (degree, subject, institution), and don't select an answer from the dropdown. Submit the form and the fields should be populated with the text that had been filled in them previously and an error message specific to this scenario should be shown, instructing you to select a value from the dropdown.
 - Do the same for the personal details form (nationality fields)
 - Also for the course details from (subject  and additional age range)

Example:
![image](https://user-images.githubusercontent.com/823643/114889628-2f8fab80-9e02-11eb-9994-098e271590ce.png)
