### PR TITLE
[1430] Nest routes features

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,6 +24,6 @@ module ApplicationHelper
   end
 
   def multiple_routes_enabled?
-    %w[routes_provider_led_postgrad routes_early_years_undergrad].any? { |flag| FeatureService.enabled?(flag) }
+    %w[routes.provider_led_postgrad routes.early_years_undergrad].any? { |flag| FeatureService.enabled?(flag) }
   end
 end

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -6,7 +6,7 @@ class TrainingRouteManager
   end
 
   def requires_placement_details?
-    feature_enabled?(:routes_provider_led_postgrad) && provider_led_postgrad?
+    feature_enabled?("routes.provider_led_postgrad") && provider_led_postgrad?
   end
 
 private

--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -2,11 +2,11 @@
 
   <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:assessment_only], label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
 
-  <% if FeatureService.enabled?(:routes_early_years_undergrad) %>
+  <% if FeatureService.enabled?("routes.early_years_undergrad") %>
     <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:early_years_undergrad], label: { text: t("activerecord.attributes.trainee.training_routes.early_years_undergrad") } %>
   <% end %>
 
-  <% if FeatureService.enabled?(:routes_provider_led_postgrad) %>
+  <% if FeatureService.enabled?("routes.provider_led_postgrad") %>
     <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:provider_led_postgrad], label: { text: t("activerecord.attributes.trainee.training_routes.provider_led_postgrad") } %>
   <% end %>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,10 +25,11 @@ features:
   enable_feedback_link: true
   basic_auth: true
   trainee_export: true
-  routes_provider_led_postgrad: false
-  routes_early_years_undergrad: false
   import_applications_from_apply: false
   import_courses_from_ttapi: false
+  routes:
+    provider_led_postgrad: false
+    early_years_undergrad: false
 
 dfe_sign_in:
   # Our service name
@@ -69,5 +70,5 @@ teacher_training_api:
 environment:
   name: qa
 
-slack: 
+slack:
   publish_register_alerts_channel: "#twd_publish_register_tech"

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,9 +8,10 @@ features:
   use_dfe_sign_in: false
   basic_auth: false
   import_courses_from_ttapi: true
-  routes_provider_led_postgrad: true
-  routes_early_years_undergrad: true
   publish_course_details: true
+  routes:
+    provider_led_postgrad: true
+    early_years_undergrad: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -12,8 +12,9 @@ dttp:
 features:
   home_text: true
   use_dfe_sign_in: false
-  routes_provider_led_postgrad: true
-  routes_early_years_undergrad: true
+  routes:
+    provider_led_postgrad: true
+    early_years_undergrad: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -5,8 +5,9 @@ features:
   home_text: true
   use_dfe_sign_in: false
   enable_feedback_link: true
-  routes_provider_led_postgrad: true
-  routes_early_years_undergrad: true
+  routes:
+    provider_led_postgrad: true
+    early_years_undergrad: true
 
 pagination:
   records_per_page: 30

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -15,23 +15,23 @@ feature "Create trainee journey" do
     then_i_should_see_the_new_trainee_overview
   end
 
-  scenario "setting up an initial provider led record", feature_routes_provider_led_postgrad: true do
+  scenario "setting up an initial provider led record", 'feature_routes.provider_led_postgrad': true do
     and_i_select_provider_led_postgrad_route
     and_i_save_the_form
     then_i_should_see_the_new_trainee_overview
   end
 
-  scenario "provider led (postgrad) radio button not shown when feature set to false", feature_routes_provider_led_postgrad: false do
+  scenario "provider led (postgrad) radio button not shown when feature set to false", 'feature_routes.provider_led_postgrad': false do
     and_i_should_not_see_provider_led_postgrad_route
   end
 
-  scenario "setting up an initial early years undergrad record", feature_routes_early_years_undergrad: true do
+  scenario "setting up an initial early years undergrad record", 'feature_routes.early_years_undergrad': true do
     and_i_select_early_years_undergrad_route
     and_i_save_the_form
     then_i_should_see_the_new_trainee_overview
   end
 
-  scenario "early years undergrad radio button not shown when feature set to false", feature_routes_early_years_undergrad: false do
+  scenario "early years undergrad radio button not shown when feature set to false", 'feature_routes.early_years_undergrad': false do
     and_i_should_not_see_early_years_undergrad_route
   end
 

--- a/spec/features/trainees/edit_trainee_training_route_spec.rb
+++ b/spec/features/trainees/edit_trainee_training_route_spec.rb
@@ -17,7 +17,7 @@ feature "editing a trainee training route", type: :feature do
       and_current_training_route_should_be_selected
     end
 
-    scenario "editing a draft-trainee's current training route", feature_routes_provider_led_postgrad: true do
+    scenario "editing a draft-trainee's current training route", 'feature_routes.provider_led_postgrad': true do
       then_i_select_provider_led_postgrad
       and_i_submit_the_new_route
       and_i_visit_the_edit_training_route_page

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -6,7 +6,7 @@ describe TrainingRouteManager do
   subject { described_class.new(trainee) }
 
   describe "#requires_placement_details?" do
-    context "with the :routes_provider_led_postgrad feature flag enabled", feature_routes_provider_led_postgrad: true do
+    context "with the :routes_provider_led_postgrad feature flag enabled", 'feature_routes.provider_led_postgrad': true do
       context "with a provider-led trainee" do
         let(:trainee) { build(:trainee, :provider_led_postgrad) }
 
@@ -24,7 +24,7 @@ describe TrainingRouteManager do
       end
     end
 
-    context "with the :routes_provider_led_postgrad feature flag disabled", feature_routes_provider_led_postgrad: false do
+    context "with the :routes_provider_led_postgrad feature flag disabled", 'feature.routes_provider_led_postgrad': false do
       let(:trainee) { build(:trainee, :provider_led_postgrad) }
 
       it "returns false" do

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -10,11 +10,20 @@ require_relative "features/confirmation_steps"
 require_relative "dfe_sign_in_user_helper"
 
 RSpec.configure do |config|
-  # Store original feature flag values before the examples run
-  original_features = {}
-
   # Helper method to normalise the feature metadata key name, eg :feature_trainees -> :trainees
   normalise_feature_name = ->(feature) { feature.to_s.delete_prefix("feature_").to_sym }
+
+  settings_has_key = lambda do |feature_name|
+    segments = feature_name.to_s.split(".")
+    final_key = segments.last
+    segments[0..-2].reduce(Settings.features) { |settings, segment| settings[segment] }.key? final_key.to_sym
+  end
+
+  set_feature = lambda do |feature_name, value|
+    segments = feature_name.to_s.split(".")
+    final_key = segments.last
+    segments[0..-2].reduce(Settings.features) { |settings, segment| settings[segment] }[final_key.to_sym] = value
+  end
 
   config.include Features::AuthenticationSteps, type: :feature
   config.include Features::TraineeSteps, type: :feature
@@ -26,27 +35,23 @@ RSpec.configure do |config|
   config.include DfESignInUserHelper, type: :feature
 
   config.around :each do |example|
-    example.metadata.keys.grep(/^feature_.*/) do |metadata_key|
-      feature = normalise_feature_name.call(metadata_key)
-      if Settings.features.key?(feature)
-        original_features[feature] = Settings.features[feature]
-      end
-
-      Settings.features[feature] = example.metadata[metadata_key]
-    end
-
-    example.run
-  end
-
-  config.after :each do |example|
+    original_features = {}
     features = example.metadata.keys.grep(/^feature_.*/)
 
     features.each do |metadata_key|
       feature = normalise_feature_name.call(metadata_key)
-
-      if original_features.key?(feature)
-        Settings.features[feature] = original_features[feature]
+      if settings_has_key.call(feature)
+        original_features[feature] = FeatureService.enabled?(feature)
       end
+
+      set_feature.call(feature, example.metadata[metadata_key])
+    end
+
+    example.run
+
+    features.each do |metadata_key|
+      feature = normalise_feature_name.call(metadata_key)
+      set_feature.call(feature, original_features[feature])
     end
   end
 end

--- a/spec/views/trainees/review_draft/show.html.erb_spec.rb
+++ b/spec/views/trainees/review_draft/show.html.erb_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "trainees/review_draft/show.html.erb", feature_routes_provider_led_postgrad: true do
+describe "trainees/review_draft/show.html.erb", 'feature_routes.provider_led_postgrad': true do
   before do
     assign(:trainee, trainee)
     render

--- a/spec/views/trainees/show.html.erb_spec.rb
+++ b/spec/views/trainees/show.html.erb_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-describe "trainees/show.html.erb" do
+describe "trainees/show.html.erb", 'feature_routes.provider_led_postgrad': true do
   before do
-    allow(FeatureService).to receive(:enabled?).with(:routes_provider_led_postgrad).and_return(true)
     assign(:trainee, trainee)
     render
   end


### PR DESCRIPTION
Requires a small change to the test setup. This will now raise an error
when attempting to set a nested feature that hasn’t been defined.

### Context

https://trello.com/c/IWaiPEmK/1430-s-nest-route-features

### Changes proposed in this pull request

- Nests routes feature flags like this:
  ```
   routes:
      provider_led_postgrad: false
      early_years_undergrad: false
  ```
  And changes all places they are references in the codebase to reflect this.

- Updates the test helper to allow the setting and restoring of nested features.


### Guidance to review

