### PR TITLE
[1417] Add create action from Dttp::Provider to Provider

### DIFF
--- a/app/controllers/system_admin/dttp_providers_controller.rb
+++ b/app/controllers/system_admin/dttp_providers_controller.rb
@@ -22,7 +22,7 @@ module SystemAdmin
     end
 
     def find_providers
-      authorize ::Dttp::Provider.order(:name)
+      authorize ::Dttp::Provider.left_outer_joins(:provider).order(:name)
     end
 
     def filter_params

--- a/app/controllers/system_admin/dttp_providers_controller.rb
+++ b/app/controllers/system_admin/dttp_providers_controller.rb
@@ -10,6 +10,11 @@ module SystemAdmin
       @provider = authorize Dttp::Provider.find(params[:id])
     end
 
+    def create
+      @provider = authorize Provider.create!(provider_params)
+      redirect_to provider_path(@provider)
+    end
+
   private
 
     def filtered_providers
@@ -22,6 +27,14 @@ module SystemAdmin
 
     def filter_params
       @filter_params ||= params.permit(:text_search).presence
+    end
+
+    def dttp_provider
+      @dttp_provider ||= ::Dttp::Provider.find(params[:dttp_provider_id])
+    end
+
+    def provider_params
+      dttp_provider.attributes.symbolize_keys.slice(:name, :dttp_id, :ukprn)
     end
   end
 end

--- a/app/models/dttp/provider.rb
+++ b/app/models/dttp/provider.rb
@@ -7,5 +7,7 @@ module Dttp
     include PgSearch::Model
 
     pg_search_scope :search_by_name, against: %i[name], using: { tsearch: { prefix: true } }
+
+    belongs_to :provider, class_name: "::Provider", primary_key: :dttp_id, foreign_key: :dttp_id, optional: true
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -10,6 +10,8 @@ class Provider < ApplicationRecord
   validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
   validates :code, format: { with: /\A[A-Z0-9]+\z/i }
 
+  alias_attribute :ukprn, :code
+
   def code=(cde)
     self[:code] = cde.to_s.upcase
   end

--- a/app/views/system_admin/dttp_providers/index.html.erb
+++ b/app/views/system_admin/dttp_providers/index.html.erb
@@ -11,6 +11,7 @@
         <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
         <th scope="col" class="govuk-table__header govuk-!-width-one-half">DTTP Id</th>
         <th scope="col" class="govuk-table__header govuk-!-width-one-half">UKPRN</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Actions</th>
       </tr>
     </thead>
 
@@ -33,6 +34,14 @@
             <span class="govuk-!-display-block govuk-!-margin-bottom-1">
               <%= provider.ukprn %>
             </span>
+          </td>
+          <td class="govuk-table__cell">
+            <%= govuk_button_to(
+                  "Create",
+                  dttp_providers_path,
+                  params: { dttp_provider_id: provider },
+                  class: "govuk-button--secondary",
+                ) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/system_admin/dttp_providers/index.html.erb
+++ b/app/views/system_admin/dttp_providers/index.html.erb
@@ -36,12 +36,16 @@
             </span>
           </td>
           <td class="govuk-table__cell">
-            <%= govuk_button_to(
-                  "Create",
-                  dttp_providers_path,
-                  params: { dttp_provider_id: provider },
-                  class: "govuk-button--secondary",
-                ) %>
+            <% if provider.provider.blank? %>
+              <%= govuk_button_to(
+                    "Create",
+                    dttp_providers_path,
+                    params: { dttp_provider_id: provider },
+                    class: "govuk-button--secondary",
+                  ) %>
+            <% else %>
+              <%= govuk_link_to 'View', provider_path(provider.provider) %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
     resources :providers, except: %i[edit update destroy] do
       resources :users, only: %i[new create]
     end
-    resources :dttp_providers, only: %i[index show]
+    resources :dttp_providers, only: %i[index show create]
   end
 
   resources :trainees, except: :edit do

--- a/db/migrate/20210419084629_change_dttp_providers_dttp_id_to_uuid.rb
+++ b/db/migrate/20210419084629_change_dttp_providers_dttp_id_to_uuid.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeDttpProvidersDttpIdToUuid < ActiveRecord::Migration[6.1]
+  def up
+    change_column :dttp_providers, :dttp_id, "uuid USING dttp_id::uuid"
+  end
+
+  def down
+    change_column :dttp_providers, :dttp_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_14_150758) do
+ActiveRecord::Schema.define(version: 2021_04_19_084629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 2021_04_14_150758) do
 
   create_table "dttp_providers", force: :cascade do |t|
     t.string "name"
-    t.string "dttp_id"
+    t.uuid "dttp_id"
     t.string "ukprn"
     t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false

--- a/spec/features/dttp_providers/list_providers_spec.rb
+++ b/spec/features/dttp_providers/list_providers_spec.rb
@@ -7,13 +7,19 @@ feature "List providers" do
     let(:user) { create(:user, system_admin: true) }
 
     before do
-      @provider = create(:dttp_provider, name: "Test 1")
+      @dttp_provider = create(:dttp_provider, name: "Test 1")
+      given_i_am_authenticated(user: user)
     end
 
     scenario "list providers" do
-      given_i_am_authenticated(user: user)
       when_i_visit_the_dttp_provider_index_page
       then_i_see_the_dttp_provider
+    end
+
+    scenario "creating a provider from dttp_provider" do
+      when_i_visit_the_dttp_provider_index_page
+      and_i_click_on_create_provider_button
+      then_i_am_redirected_to_the_provider_page
     end
   end
 
@@ -23,5 +29,21 @@ feature "List providers" do
 
   def then_i_see_the_dttp_provider
     expect(dttp_provider_index_page).to have_text("Test 1")
+  end
+
+  def and_i_click_on_create_provider_button
+    click_on "Create"
+  end
+
+  def then_i_am_redirected_to_the_provider_page
+    expect(page.current_path).to eq("/system-admin/providers/#{provider.id}")
+  end
+
+  def provider_show_page
+    @provider_show_page ||= PageObjects::Providers::Show.new
+  end
+
+  def provider
+    @provider ||= Provider.find_by(dttp_id: @dttp_provider.dttp_id)
   end
 end

--- a/spec/features/dttp_providers/list_providers_spec.rb
+++ b/spec/features/dttp_providers/list_providers_spec.rb
@@ -21,6 +21,13 @@ feature "List providers" do
       and_i_click_on_create_provider_button
       then_i_am_redirected_to_the_provider_page
     end
+
+    scenario "navigating from dttp_provider to provider" do
+      when_a_provider_is_imported
+      when_i_visit_the_dttp_provider_index_page
+      and_i_click_on_view_button
+      then_i_am_redirected_to_the_provider_page
+    end
   end
 
   def when_i_visit_the_dttp_provider_index_page
@@ -37,6 +44,14 @@ feature "List providers" do
 
   def then_i_am_redirected_to_the_provider_page
     expect(page.current_path).to eq("/system-admin/providers/#{provider.id}")
+  end
+
+  def when_a_provider_is_imported
+    create(:provider, dttp_id: @dttp_provider.dttp_id)
+  end
+
+  def and_i_click_on_view_button
+    click_on "View"
   end
 
   def provider_show_page

--- a/spec/models/dttp/provider_spec.rb
+++ b/spec/models/dttp/provider_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe Dttp::Provider, type: :model do
 
   it { is_expected.to have_db_index(:dttp_id) }
 
+  describe "associations" do
+    it {
+      is_expected.to belong_to(:provider)
+      .class_name("::Provider")
+      .with_primary_key(:dttp_id)
+      .with_primary_key(:dttp_id)
+      .optional
+    }
+  end
+
   describe "#search_by_name" do
     let!(:matching_provider) { create(:dttp_provider, name: "Test 1") }
 


### PR DESCRIPTION
### Context
On the list of provider results from the DTTP lookup add an 'Create' button that creates a provider record for the selected provider.

### Changes proposed in this pull request
- Change `Dttp::Provider#dttp_id` column to be a uuid instead of string.
- Add a relationship between `Dttp::Provider` and `Provider` based on `dttp_id` to easily check against existing records
- Add a create button that imports the `Dttp::Provider` record over to the `Provider` list.

### Guidance to review
Navigate to `system-admin/dttp_providers`, and from the list, choose a provider to import and click the "Create" button against that record.
On successful creation, the user is redirected to the providers page.
