### PR TITLE
1463 non text colour contrast fix

### DIFF
--- a/app/components/status_card/style.scss
+++ b/app/components/status_card/style.scss
@@ -42,7 +42,7 @@
   display: block;
 }
 
-.status-card__status {
+.app-status-card__status {
   text-decoration: underline;
   overflow-wrap: break-word;
   word-wrap: break-word;

--- a/app/components/status_card/style.scss
+++ b/app/components/status_card/style.scss
@@ -42,6 +42,13 @@
   display: block;
 }
 
+.status-card__status {
+  text-decoration: underline;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
+}
+
 .app-status-card--grey {
   &, &:link, &:visited {
     color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);

--- a/app/components/status_card/style.scss
+++ b/app/components/status_card/style.scss
@@ -20,7 +20,6 @@
 
   color: govuk-colour("white");
   background-color: $govuk-brand-colour;
-  letter-spacing: 1px;
 
   &:hover {
     background-color: govuk-shade($govuk-brand-colour, 15%);

--- a/app/components/status_card/view.html.erb
+++ b/app/components/status_card/view.html.erb
@@ -1,5 +1,5 @@
 <a class="app-status-card app-status-card--<%= status_colour %> app-status-card__link" href="<%= target %>">
   <span class="app-status-card__count"><%= count %></span>
-  <%= state_name %>
-  <span class="govuk-visually-hidden"> records. View these records. </span>
+  <span class="app-status-card__status"><%= state_name %></span>
+  <span class="govuk-visually-hidden"> records. View these records.</span>
 </a>


### PR DESCRIPTION
### Context

The status cards were flagged as part of the accessibility review. DAC pointed out "that some users with colour deficiencies or low vision, may not realise that these elements are clickable."

### Changes proposed in this pull request

- Additional markup required for the proposed `text-decoration` added
- `text-decoration` style added plus a few extra CSS rules on the new element in anticipation of an upcoming refactor of the status cards.
- Removal of an unwanted `letter-spacing` rule 

### Guidance to review

View the home page and compare to the live service. You should see an underlined status name and a small reduction in letter spacing within each status card.

### Before 

![Screenshot 2021-04-19 at 07 40 05](https://user-images.githubusercontent.com/1108991/115192971-753ec380-a0e3-11eb-9815-70618d864927.png)

### After

![Screenshot 2021-04-19 at 07 40 15](https://user-images.githubusercontent.com/1108991/115192998-7cfe6800-a0e3-11eb-8b1c-d3875bd5a993.png)

