### PR TITLE
[1549] Fix timeline bug for record details component

### DIFF
--- a/app/components/trainees/record_details/view.rb
+++ b/app/components/trainees/record_details/view.rb
@@ -6,10 +6,11 @@ module Trainees
       include SanitizeHelper
       include SummaryHelper
 
-      attr_reader :trainee, :not_provided_copy
+      attr_reader :trainee, :last_updated_event, :not_provided_copy
 
-      def initialize(trainee)
+      def initialize(trainee:, last_updated_event:)
         @trainee = trainee
+        @last_updated_event = last_updated_event
         @not_provided_copy = I18n.t("components.confirmation.not_provided")
       end
 
@@ -22,11 +23,11 @@ module Trainees
       end
 
       def submission_date
-        render_text_with_hint(Time.zone.yesterday)
+        render_text_with_hint(trainee.submitted_for_trn_at)
       end
 
       def last_updated_date
-        render_text_with_hint(trainee.updated_at)
+        render_text_with_hint(last_updated_event.date)
       end
 
       def trn_row

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -41,4 +41,8 @@ module TraineeHelper
 
     FeatureService.enabled?(:publish_course_details) && courses_available && !manual_entry_chosen
   end
+
+  def last_updated_event_for(trainee)
+    Trainees::CreateTimeline.call(audits: trainee.own_and_associated_audits).first
+  end
 end

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div class="record-details">
-  <%= render Trainees::RecordDetails::View.new(@trainee) %>
+  <%= render Trainees::RecordDetails::View.new(trainee: @trainee, last_updated_event: last_updated_event_for(@trainee)) %>
 </div>
 
 <div class="course-details">

--- a/spec/components/trainees/record_details/view_preview.rb
+++ b/spec/components/trainees/record_details/view_preview.rb
@@ -6,19 +6,19 @@ module Trainees
   module RecordDetails
     class ViewPreview < ViewComponent::Preview
       def default
-        render(Trainees::RecordDetails::View.new(mock_trainee("default")))
+        render(View.new(trainee: mock_trainee("default"), last_updated_event: last_updated_event))
       end
 
       def with_no_trainee_id
-        render(Trainees::RecordDetails::View.new(mock_trainee(nil)))
+        render(View.new(trainee: mock_trainee(nil), last_updated_event: last_updated_event))
       end
 
       def with_deferred_status
-        render(Trainees::RecordDetails::View.new(mock_trainee("deferred", :deferred)))
+        render(View.new(trainee: mock_trainee("deferred", :deferred), last_updated_event: last_updated_event))
       end
 
       def with_withdrawn_status
-        render(Trainees::RecordDetails::View.new(mock_trainee("withdrawn", :withdrawn)))
+        render(View.new(trainee: mock_trainee("withdrawn", :withdrawn), last_updated_event: last_updated_event))
       end
 
     private
@@ -29,11 +29,15 @@ module Trainees
           training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
           trainee_id: trainee_id,
           created_at: Time.zone.today,
-          updated_at: Time.zone.today,
           state: state,
+          submitted_for_trn_at: Time.zone.today,
           defer_date: state == :deferred ? Time.zone.today : nil,
           withdraw_date: state == :withdrawn ? Time.zone.today : nil,
         )
+      end
+
+      def last_updated_event
+        OpenStruct.new(date: Time.zone.today)
       end
     end
   end

--- a/spec/components/trainees/record_details/view_spec.rb
+++ b/spec/components/trainees/record_details/view_spec.rb
@@ -9,13 +9,15 @@ module Trainees
 
       alias_method :component, :page
 
-      let(:trainee) { create(:trainee, created_at: Time.zone.today, updated_at: Time.zone.today, state: "deferred", defer_date: Time.zone.today) }
+      let(:state) { :trn_received }
+      let(:trainee) { create(:trainee, state, trn: Faker::Number.number(digits: 10)) }
       let(:trainee_status) { "trainee-status" }
+      let(:timeline_event) { double(date: Time.zone.today) }
 
       context "when trainee_id data has not been provided" do
         before do
           trainee.trainee_id = nil
-          render_inline(View.new(trainee))
+          render_inline(View.new(trainee: trainee, last_updated_event: timeline_event))
         end
 
         it "tells the user that no data has been entered for trainee ID" do
@@ -25,38 +27,44 @@ module Trainees
 
       context "when trainee_id data has been provided" do
         before do
-          render_inline(View.new(trainee))
+          render_inline(View.new(trainee: trainee, last_updated_event: timeline_event))
         end
 
         it "renders the trainee ID" do
           expect(component.find(summary_card_row_for("trainee-id"))).to have_text(trainee.trainee_id)
         end
 
-        it "renders the trn submission date" do
-          expect(component.find(summary_card_row_for("submitted-for-trn"))).to have_text(date_for_summary_view(Time.zone.yesterday))
-        end
-
-        it "renders the trainee record last updated date" do
-          expect(component.find(summary_card_row_for("last-updated"))).to have_text(date_for_summary_view(trainee.updated_at))
+        it "renders the trainee's last timeline event date" do
+          expect(component.find(summary_card_row_for("last-updated"))).to have_text(date_for_summary_view(timeline_event.date))
         end
 
         it "renders the trainee record created date" do
           expect(component.find(summary_card_row_for("record-created"))).to have_text(date_for_summary_view(trainee.created_at))
         end
 
-        it "renders the trainee status tag" do
-          expect(component.find(summary_card_row_for(trainee_status))).to have_text("deferred")
+        context "when trainee state is submitted_for_trn" do
+          let(:trainee) { create(:trainee, :submitted_for_trn) }
+
+          it "renders the trn submission date" do
+            expect(component.find(summary_card_row_for("submitted-for-trn"))).to have_text(date_for_summary_view(trainee.submitted_for_trn_at))
+          end
         end
 
-        it "renders the trainee deferral date" do
-          expect(component.find(summary_card_row_for(trainee_status))).to have_text(date_for_summary_view(trainee.defer_date))
+        context "when trainee state is deferred" do
+          let(:state) { :deferred }
+
+          it "renders the trainee deferral date" do
+            expect(component.find(summary_card_row_for(trainee_status))).to have_text(date_for_summary_view(trainee.defer_date))
+          end
+
+          it "renders the trainee status tag" do
+            expect(component.find(summary_card_row_for(trainee_status))).to have_text("deferred")
+          end
         end
 
         context "when trainee state is withdrawn" do
-          before do
-            trainee.state = "withdrawn"
-            trainee.withdraw_date = Time.zone.today
-          end
+          let(:state) { :withdrawn }
+
           it "renders the trainee withdrawal date" do
             expect(component.find(summary_card_row_for(trainee_status))).to have_text(date_for_summary_view(trainee.withdraw_date))
           end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -141,6 +141,7 @@ FactoryBot.define do
     end
 
     trait :trn_received do
+      submitted_for_trn
       state { "trn_received" }
       dttp_id { SecureRandom.uuid }
     end
@@ -156,6 +157,7 @@ FactoryBot.define do
     end
 
     trait :deferred do
+      submitted_for_trn
       state { "deferred" }
       defer_date { Faker::Date.in_date_period }
     end

--- a/spec/features/trainees/recording_training_outcome_spec.rb
+++ b/spec/features/trainees/recording_training_outcome_spec.rb
@@ -7,7 +7,7 @@ feature "Recording a training outcome", type: :feature do
 
   before do
     given_i_am_authenticated
-    given_a_trainee_exists(state: :trn_received)
+    given_a_trainee_exists(:trn_received)
     and_i_am_on_the_trainee_record_page
     and_i_click_on_record_training_outcome
   end

--- a/spec/features/trainees/viewing_the_timeline_spec.rb
+++ b/spec/features/trainees/viewing_the_timeline_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "View the timeline" do
   background do
     given_i_am_authenticated
-    given_a_trainee_exists(state: :submitted_for_trn)
+    given_a_trainee_exists(:submitted_for_trn)
   end
 
   scenario "viewing the timeline of trainee" do

--- a/spec/views/trainees/show.html.erb_spec.rb
+++ b/spec/views/trainees/show.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe "trainees/show.html.erb", 'feature_routes.provider_led_postgrad': true 
   end
 
   context "with an Assessment only trainee" do
-    let(:trainee) { create(:trainee) }
+    let(:trainee) { create(:trainee, :submitted_for_trn) }
 
     it "does not render the placement details component" do
       expect(rendered).to_not have_text("Placement details")
@@ -17,7 +17,7 @@ describe "trainees/show.html.erb", 'feature_routes.provider_led_postgrad': true 
   end
 
   context "with a Provider-led (postgrad) trainee" do
-    let(:trainee) { create(:trainee, :provider_led_postgrad) }
+    let(:trainee) { create(:trainee, :submitted_for_trn, :provider_led_postgrad) }
 
     it "renders the placement details component" do
       expect(rendered).to have_text("Placement details")


### PR DESCRIPTION
### Context

- https://trello.com/c/qRN4iH4S/1549-m-created-submitted-updated-dates-and-their-timeline-equivalents-dont-match-up

### Changes proposed in this pull request

Update the `RecordDetails::View` component such that the `last_updated_date` property returns the most recent event from the list of timeline events (as Ed desired) to `sync` what has happened in the timeline view with what is displayed to the user through this component.

This PR also fixes another bug (likely a remnant from early stages of the app) where the TRN submission date was just set to `Time.zone.yesterday` to render the actual submission date. This broke a few tests since this date is required by the component. If you're viewing this component via the trainee record page, the trainee should have a trn submission date so have updated some of the trainee traits to reflect this.

### Guidance to review

- Create a trainee and do some things, assert the last updated date matches up with the most recent timeline event

