### PR TITLE
[1550] validation errors page added to system admin

### DIFF
--- a/app/controllers/system_admin/validation_errors_controller.rb
+++ b/app/controllers/system_admin/validation_errors_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class ValidationErrorsController < ApplicationController
+    def index
+      authorize ValidationError, :index?
+      @grouped_counts = ValidationError.group(:form_object).order("count_all DESC").count
+      @grouped_column_error_counts = ValidationError.list_of_distinct_errors_with_count
+    end
+  end
+end

--- a/app/policies/validation_error_policy.rb
+++ b/app/policies/validation_error_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidationErrorPolicy
+  attr_reader :user
+
+  def initialize(user, provider)
+    @user = user
+    @provider = provider
+  end
+
+  def index?
+    user.system_admin?
+  end
+end

--- a/app/views/system_admin/_menu.html.erb
+++ b/app/views/system_admin/_menu.html.erb
@@ -1,4 +1,5 @@
 <%= render TabNavigation::View.new(items: [
   { name: "Providers", url: providers_path, current: request.path.starts_with?(providers_path) },
-  { name: "Dttp Providers", url: dttp_providers_path },
+  { name: "Dttp providers", url: dttp_providers_path },
+  { name: "Validation errors", url: validation_errors_path },
 ]) %>

--- a/app/views/system_admin/validation_errors/index.html.erb
+++ b/app/views/system_admin/validation_errors/index.html.erb
@@ -1,0 +1,53 @@
+<%= render PageTitle::View.new(title: "validation_errors.index") %>
+
+<h1 class="govuk-heading-l">Validation errors</h1>
+
+<%= render "system_admin/menu" %>
+
+<table class="govuk-table" summary="Attribute error">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-three-quarters">Attribute error</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-width-one-quarter">Error count</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @grouped_column_error_counts.each do |(form_object, attribute, message), count| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
+          <span class="govuk-!-font-weight-regular"><%= form_object.demodulize.underscore.humanize %>:</span>
+          <%= attribute.humanize %>
+        </h2>
+        <p class="govuk-body govuk-!-margin-bottom-0"><%= message %></p>
+      </td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        <%= count %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
+<table class="govuk-table" summary="Form">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-three-quarters">Form</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-width-one-quarter">Error count</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @grouped_counts.each do |form_object, count| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
+          <%= form_object.demodulize.underscore.humanize %>
+        </h2>
+      </td>
+      <td class="govuk-table__cell govuk-table__cell--numeric">
+        <%= count %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/system_admin/validation_errors/index.html.erb
+++ b/app/views/system_admin/validation_errors/index.html.erb
@@ -1,14 +1,14 @@
-<%= render PageTitle::View.new(title: "validation_errors.index") %>
+<%= render PageTitle::View.new(title: "validation_errors.page_title") %>
 
-<h1 class="govuk-heading-l">Validation errors</h1>
+<h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
 <%= render "system_admin/menu" %>
 
-<table class="govuk-table" summary="Attribute error">
+<table class="govuk-table" summary="<%= t(".attribute_error") %>">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-three-quarters">Attribute error</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-width-one-quarter">Error count</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-three-quarters"><%= t(".attribute_error") %></th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-width-one-quarter"><%= t(".error_count") %></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -29,11 +29,11 @@
   </tbody>
 </table>
 
-<table class="govuk-table" summary="Form">
+<table class="govuk-table" summary="<%= t(".form") %>">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-three-quarters">Form</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-width-one-quarter">Error count</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-three-quarters"><%= t(".form") %></th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-width-one-quarter"><%= t(".error_count") %></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,7 +160,7 @@ en:
       users:
         new: Add a user
       validation_errors:
-        index: Validation errors
+        page_title: Validation errors
     filter:
       training_route: Training route
       state: Status
@@ -605,3 +605,10 @@ en:
               max_char_exceeded: Your entry must not exceed 100 characters
   page_headings:
     start_page: "Register trainee teachers"
+  system_admin:
+    validation_errors:
+      index:
+        heading: Validation errors
+        attribute_error: Attribute error
+        error_count: Error count
+        form: Form

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,8 @@ en:
         index: Dttp Providers
       users:
         new: Add a user
+      validation_errors:
+        index: Validation errors
     filter:
       training_route: Training route
       state: Status

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
       end
     end
     resources :dttp_providers, only: %i[index show create]
+    resources :validation_errors, only: %i[index]
   end
 
   resources :trainees, except: :edit do

--- a/spec/factories/validation_errors.rb
+++ b/spec/factories/validation_errors.rb
@@ -4,6 +4,17 @@ FactoryBot.define do
   factory :validation_error do
     user
     form_object { "PersonalDetailsForm" }
-    details { { "gender" => { "value" => nil, "messages" => ["You must select a gender", "is not included in the list"] }, "last_name" => { "value" => "", "messages" => ["You must enter a last name"] }, "first_names" => { "value" => "", "messages" => ["You must enter a first name"] }, "date_of_birth" => { "value" => { "table" => { "day" => "", "year" => "", "month" => "" } }, "messages" => ["You must enter a valid date"] }, "nationality_ids" => { "value" => [], "messages" => ["You must select at least one nationality"] } } }
+    details do
+      {
+        "gender" => { "value" => nil, "messages" => ["You must select a gender", "is not included in the list"] },
+        "last_name" => { "value" => "", "messages" => ["You must enter a last name"] },
+        "first_names" => { "value" => "", "messages" => ["You must enter a first name"] },
+        "date_of_birth" => {
+          "value" => { "table" => { "day" => "", "year" => "", "month" => "" } },
+          "messages" => ["You must enter a valid date"],
+        },
+        "nationality_ids" => { "value" => [], "messages" => ["You must select at least one nationality"] },
+      }
+    end
   end
 end

--- a/spec/factories/validation_errors.rb
+++ b/spec/factories/validation_errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :validation_error do
+    user
+    form_object { "PersonalDetailsForm" }
+    details { { "gender" => { "value" => nil, "messages" => ["You must select a gender", "is not included in the list"] }, "last_name" => { "value" => "", "messages" => ["You must enter a last name"] }, "first_names" => { "value" => "", "messages" => ["You must enter a first name"] }, "date_of_birth" => { "value" => { "table" => { "day" => "", "year" => "", "month" => "" } }, "messages" => ["You must enter a valid date"] }, "nationality_ids" => { "value" => [], "messages" => ["You must select at least one nationality"] } } }
+  end
+end

--- a/spec/features/validation_errors/list_validation_errors_spec.rb
+++ b/spec/features/validation_errors/list_validation_errors_spec.rb
@@ -4,17 +4,16 @@ require "rails_helper"
 
 feature "List validation errors" do
   context "as a system admin" do
-    let(:user) { create(:user, system_admin: true) }
-
-    before do
-      @validation_error = create(:validation_error)
-      given_i_am_authenticated(user: user)
-    end
-
     scenario "list validation_errors" do
+      given_i_am_authenticated_as_system_admin
+      and_a_validation_error_exists
       when_i_visit_the_validation_errors_index_page
       then_i_see_the_validation_errors
     end
+  end
+
+  def and_a_validation_error_exists
+    @validation_error = create(:validation_error)
   end
 
   def when_i_visit_the_validation_errors_index_page

--- a/spec/features/validation_errors/list_validation_errors_spec.rb
+++ b/spec/features/validation_errors/list_validation_errors_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "List validation errors" do
+  context "as a system admin" do
+    let(:user) { create(:user, system_admin: true) }
+
+    before do
+      @validation_error = create(:validation_error)
+      given_i_am_authenticated(user: user)
+    end
+
+    scenario "list validation_errors" do
+      when_i_visit_the_validation_errors_index_page
+      then_i_see_the_validation_errors
+    end
+  end
+
+  def when_i_visit_the_validation_errors_index_page
+    validation_errors_index_page.load
+  end
+
+  def then_i_see_the_validation_errors
+    expect(validation_errors_index_page).to have_text(@validation_error.form_object.underscore.humanize)
+  end
+end

--- a/spec/support/features/authentication_steps.rb
+++ b/spec/support/features/authentication_steps.rb
@@ -11,6 +11,10 @@ module Features
       visit_sign_in_page
     end
 
+    def given_i_am_authenticated_as_system_admin
+      given_i_am_authenticated(user: create(:user, :system_admin))
+    end
+
     def visit_sign_in_page
       sign_in_page = PageObjects::SignIn.new
       sign_in_page.load

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -70,6 +70,10 @@ module Features
       @provider_index_page ||= PageObjects::DttpProviders::Index.new
     end
 
+    def validation_errors_index_page
+      @validation_errors_index_page ||= PageObjects::ValidationErrors::Index.new
+    end
+
     def sign_in_page
       @sign_in_page ||= PageObjects::SignIn.new
     end

--- a/spec/support/page_objects/validation_errors/index.rb
+++ b/spec/support/page_objects/validation_errors/index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module ValidationErrors
+    class Index < PageObjects::Base
+      set_url "/system-admin/validation_errors"
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/wwobcHLC/1550-m-validation-errors-page-in-support-console

### Changes proposed in this pull request

* new page in system admin section showing validation errors, similar to apply

### Guidance to review

* login as admin and visit '/system-admin/validation_errors'
* If you don't see errors, try to add a new trainee and submit a form without any values to show error.

