### PR TITLE
1556 add basic new route info

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,6 +24,6 @@ module ApplicationHelper
   end
 
   def multiple_routes_enabled?
-    %w[routes.provider_led_postgrad routes.early_years_undergrad].any? { |flag| FeatureService.enabled?(flag) }
+    TRAINING_ROUTE_FEATURE_FLAGS.any? { |flag| FeatureService.enabled?("routes.#{flag}") }
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -26,7 +26,7 @@ class Course < ApplicationRecord
     pgde: 4,
   }
 
-  enum route: TRAINING_ROUTES
+  enum route: TRAINING_ROUTES_FOR_COURSE
 
   enum age_range: {
     AgeRange::THREE_TO_SEVEN_COURSE => 0,

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -17,7 +17,7 @@ class Trainee < ApplicationRecord
 
   validates :training_route, presence: { message: I18n.t("activerecord.errors.models.trainee.attributes.training_route") }
 
-  enum training_route: TRAINING_ROUTES.select { |_routes, value| value < TRAINING_ROUTES[:school_direct_tuition_fee] }
+  enum training_route: TRAINING_ROUTES_FOR_TRAINEE
 
   enum locale_code: { uk: 0, non_uk: 1 }
   enum gender: {
@@ -179,7 +179,7 @@ class Trainee < ApplicationRecord
   end
 
   def available_courses
-    provider.courses.where(route: training_route)
+    provider.courses.where(route: training_route) if TRAINING_ROUTES_FOR_COURSE.keys.include?(training_route)
   end
 
   def clear_disabilities

--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -2,12 +2,10 @@
 
   <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:assessment_only], label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
 
-  <% if FeatureService.enabled?("routes.early_years_undergrad") %>
-    <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:early_years_undergrad], label: { text: t("activerecord.attributes.trainee.training_routes.early_years_undergrad") } %>
-  <% end %>
-
-  <% if FeatureService.enabled?("routes.provider_led_postgrad") %>
-    <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:provider_led_postgrad], label: { text: t("activerecord.attributes.trainee.training_routes.provider_led_postgrad") } %>
+  <% TRAINING_ROUTE_FEATURE_FLAGS.each do |training_route|%>
+    <% if FeatureService.enabled?("routes.#{training_route}") %>
+      <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[training_route], label: { text: t("activerecord.attributes.trainee.training_routes.#{training_route}") } %>
+    <% end %>
   <% end %>
 
   <% if multiple_routes_enabled? %>

--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -2,7 +2,7 @@
 
   <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:assessment_only], label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
 
-  <% TRAINING_ROUTE_FEATURE_FLAGS.each do |training_route|%>
+  <% TRAINING_ROUTE_FEATURE_FLAGS.each do |training_route| %>
     <% if FeatureService.enabled?("routes.#{training_route}") %>
       <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[training_route], label: { text: t("activerecord.attributes.trainee.training_routes.#{training_route}") } %>
     <% end %>

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -3,8 +3,8 @@
 TRAINING_ROUTE_ENUMS = {
   assessment_only: "assessment_only",
   early_years_assessment_only: "early_years_assessment_only",
+  early_years_graduate_employment_based: "early_years_graduate_employment_based",
   early_years_graduate_entry: "early_years_graduate_entry",
-  early_years_graduate_placement: "early_years_graduate_placement",
   early_years_undergrad: "early_years_undergrad",
   pg_teaching_apprenticeship: "pg_teaching_apprenticeship",
   provider_led_postgrad: "provider_led_postgrad",
@@ -20,8 +20,8 @@ TRAINING_ROUTES = {
   TRAINING_ROUTE_ENUMS[:school_direct_salaried] => 4,
   TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => 5,
   TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => 6,
-  TRAINING_ROUTE_ENUMS[:early_years_graduate_entry] => 7,
-  TRAINING_ROUTE_ENUMS[:early_years_graduate_placement] => 8,
+  TRAINING_ROUTE_ENUMS[:early_years_graduate_employment_based] => 7,
+  TRAINING_ROUTE_ENUMS[:early_years_graduate_entry] => 8,
 }.freeze
 
 TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -21,3 +21,7 @@ TRAINING_ROUTES = {
 TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|
   TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :early_years_undergrad).include? training_route
 } .freeze
+
+TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|
+  TRAINING_ROUTE_ENUMS.values_at(:provider_led_postgrad, :school_direct_tuition_fee, :school_direct_salaried, :pg_teaching_apprenticeship).include? training_route
+} .freeze

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -2,6 +2,9 @@
 
 TRAINING_ROUTE_ENUMS = {
   assessment_only: "assessment_only",
+  early_years_assessment_only: "early_years_assessment_only",
+  early_years_graduate_entry: "early_years_graduate_entry",
+  early_years_graduate_placement: "early_years_graduate_placement",
   early_years_undergrad: "early_years_undergrad",
   pg_teaching_apprenticeship: "pg_teaching_apprenticeship",
   provider_led_postgrad: "provider_led_postgrad",
@@ -16,6 +19,9 @@ TRAINING_ROUTES = {
   TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => 3,
   TRAINING_ROUTE_ENUMS[:school_direct_salaried] => 4,
   TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => 5,
+  TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => 6,
+  TRAINING_ROUTE_ENUMS[:early_years_graduate_entry] => 7,
+  TRAINING_ROUTE_ENUMS[:early_years_graduate_placement] => 8,
 }.freeze
 
 TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|
@@ -25,3 +31,7 @@ TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|
 TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|
   TRAINING_ROUTE_ENUMS.values_at(:provider_led_postgrad, :school_direct_tuition_fee, :school_direct_salaried, :pg_teaching_apprenticeship).include? training_route
 } .freeze
+
+TRAINING_ROUTE_FEATURE_FLAGS = TRAINING_ROUTE_ENUMS.keys.reject { |training_route|
+  %i[assessment_only pg_teaching_apprenticeship].include? training_route
+}.freeze

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -16,4 +16,8 @@ TRAINING_ROUTES = {
   TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => 3,
   TRAINING_ROUTE_ENUMS[:school_direct_salaried] => 4,
   TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => 5,
-}.with_indifferent_access.freeze
+}.freeze
+
+TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|
+  TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :early_years_undergrad).include? training_route
+} .freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -391,8 +391,8 @@ en:
         training_routes:
           assessment_only: Assessment only
           early_years_assessment_only: Early years (assessment only)
+          early_years_graduate_employment_based: Early years (graduate employment based)
           early_years_graduate_entry: Early years (graduate entry)
-          early_years_graduate_placement: Early years (graduate placement)
           early_years_undergrad: Early years (undergrad)
           provider_led_postgrad: Provider-led (postgrad)
           school_direct_salaried: School direct (salaried)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -390,8 +390,13 @@ en:
         trainee_id: "Trainee ID"
         training_routes:
           assessment_only: Assessment only
-          provider_led_postgrad: Provider-led (postgrad)
+          early_years_assessment_only: Early years (assessment only)
+          early_years_graduate_entry: Early years (graduate entry)
+          early_years_graduate_placement: Early years (graduate placement)
           early_years_undergrad: Early years (undergrad)
+          provider_led_postgrad: Provider-led (postgrad)
+          school_direct_salaried: School direct (salaried)
+          school_direct_tuition_fee: School direct (tuition fee)
         states:
           draft: Draft
           submitted_for_trn: Pending TRN

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,8 +29,8 @@ features:
   import_courses_from_ttapi: false
   routes:
     early_years_assessment_only: false 
+    early_years_graduate_employment_based: false 
     early_years_graduate_entry: false 
-    early_years_graduate_placement: false 
     early_years_undergrad: false 
     provider_led_postgrad: false 
     school_direct_salaried: false 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,8 +28,13 @@ features:
   import_applications_from_apply: false
   import_courses_from_ttapi: false
   routes:
-    provider_led_postgrad: false
-    early_years_undergrad: false
+    early_years_assessment_only: false 
+    early_years_graduate_entry: false 
+    early_years_graduate_placement: false 
+    early_years_undergrad: false 
+    provider_led_postgrad: false 
+    school_direct_salaried: false 
+    school_direct_tuition_fee: false
 
 dfe_sign_in:
   # Our service name

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     duration_in_years { 1 }
     qualification { %i[qts pgce_with_qts pgde_with_qts pgce pgde].sample }
     course_length { %w[OneYear TwoYears].sample }
-    route { TRAINING_ROUTES.keys.sample }
+    route { TRAINING_ROUTES_FOR_COURSE.keys.sample }
 
     summary do |builder|
       qualifications = builder.qualification.to_s.gsub("_", " ").upcase.gsub("WITH", "with")

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -189,5 +189,19 @@ FactoryBot.define do
       withdraw_reason { WithdrawalReasons::FOR_ANOTHER_REASON }
       additional_withdraw_reason { Faker::Lorem.paragraph }
     end
+
+    trait :with_related_courses do
+      training_route { (TRAINING_ROUTES_FOR_TRAINEE.keys & TRAINING_ROUTES_FOR_COURSE.keys).sample }
+
+      transient do
+        courses_count { 5 }
+      end
+
+      after(:create) do |trainee, evaluator|
+        create_list(:course, evaluator.courses_count, provider: trainee.provider, route: trainee.training_route)
+
+        trainee.reload
+      end
+    end
   end
 end

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -21,18 +21,38 @@ feature "Create trainee journey" do
     then_i_should_see_the_new_trainee_overview
   end
 
-  scenario "provider led (postgrad) radio button not shown when feature set to false", 'feature_routes.provider_led_postgrad': false do
-    and_i_should_not_see_provider_led_postgrad_route
-  end
-
   scenario "setting up an initial early years undergrad record", 'feature_routes.early_years_undergrad': true do
     and_i_select_early_years_undergrad_route
     and_i_save_the_form
     then_i_should_see_the_new_trainee_overview
   end
 
+  scenario "provider led postgrad radio button not shown when feature set to false", 'feature_routes.provider_led_postgrad': false do
+    and_i_should_not_see_provider_led_postgrad_route
+  end
+
   scenario "early years undergrad radio button not shown when feature set to false", 'feature_routes.early_years_undergrad': false do
     and_i_should_not_see_early_years_undergrad_route
+  end
+
+  scenario "early years assessment only radio button not shown when feature set to false", 'feature_routes.early_years_assessment_only': false do
+    and_i_should_not_see_early_years_assessment_only_route
+  end
+
+  scenario "early years graduate entry radio button not shown when feature set to false", 'feature_routes.early_years_graduate_entry': false do
+    and_i_should_not_see_early_years_graduate_entry_route
+  end
+
+  scenario "early years graduate placement radio button not shown when feature set to false", 'feature_routes.early_years_graduate_placement': false do
+    and_i_should_not_see_early_years_graduate_placement_route
+  end
+
+  scenario "school direct salaried radio button not shown when feature set to false", 'feature_routes.school_direct_salaried': false do
+    and_i_should_not_see_school_direct_salaried_route
+  end
+
+  scenario "school direct tuition fee radio button not shown when feature set to false", 'feature_routes.school_direct_tuition_fee': false do
+    and_i_should_not_see_school_direct_tuition_fee_route
   end
 
   scenario "submitting without choosing a route" do
@@ -70,6 +90,31 @@ private
   def and_i_should_not_see_early_years_undergrad_route
     expect(new_trainee_page).to be_displayed
     expect(new_trainee_page).to_not have_early_years_undergrad
+  end
+
+  def and_i_should_not_see_early_years_assessment_only_route
+    expect(new_trainee_page).to be_displayed
+    expect(new_trainee_page).to_not have_early_years_assessment_only
+  end
+
+  def and_i_should_not_see_early_years_graduate_entry_route
+    expect(new_trainee_page).to be_displayed
+    expect(new_trainee_page).to_not have_early_years_graduate_entry
+  end
+
+  def and_i_should_not_see_early_years_graduate_placement_route
+    expect(new_trainee_page).to be_displayed
+    expect(new_trainee_page).to_not have_early_years_graduate_placement
+  end
+
+  def and_i_should_not_see_school_direct_salaried_route
+    expect(new_trainee_page).to be_displayed
+    expect(new_trainee_page).to_not have_school_direct_salaried
+  end
+
+  def and_i_should_not_see_school_direct_tuition_fee_route
+    expect(new_trainee_page).to be_displayed
+    expect(new_trainee_page).to_not have_school_direct_tuition_fee
   end
 
   def and_i_save_the_form

--- a/spec/features/trainees/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainees/creating_a_new_trainee_spec.rb
@@ -39,12 +39,12 @@ feature "Create trainee journey" do
     and_i_should_not_see_early_years_assessment_only_route
   end
 
-  scenario "early years graduate entry radio button not shown when feature set to false", 'feature_routes.early_years_graduate_entry': false do
-    and_i_should_not_see_early_years_graduate_entry_route
+  scenario "early years graduate employment based radio button not shown when feature set to false", 'feature_routes.early_years_graduate_employment_based': false do
+    and_i_should_not_see_early_years_graduate_employment_based_route
   end
 
-  scenario "early years graduate placement radio button not shown when feature set to false", 'feature_routes.early_years_graduate_placement': false do
-    and_i_should_not_see_early_years_graduate_placement_route
+  scenario "early years graduate entry radio button not shown when feature set to false", 'feature_routes.early_years_graduate_entry': false do
+    and_i_should_not_see_early_years_graduate_entry_route
   end
 
   scenario "school direct salaried radio button not shown when feature set to false", 'feature_routes.school_direct_salaried': false do
@@ -102,9 +102,9 @@ private
     expect(new_trainee_page).to_not have_early_years_graduate_entry
   end
 
-  def and_i_should_not_see_early_years_graduate_placement_route
+  def and_i_should_not_see_early_years_graduate_employment_based_route
     expect(new_trainee_page).to be_displayed
-    expect(new_trainee_page).to_not have_early_years_graduate_placement
+    expect(new_trainee_page).to_not have_early_years_graduate_employment_based
   end
 
   def and_i_should_not_see_school_direct_salaried_route

--- a/spec/features/trainees/edit_confirm_publish_course_spec.rb
+++ b/spec/features/trainees/edit_confirm_publish_course_spec.rb
@@ -9,7 +9,7 @@ feature "confirm publish course", type: :feature, feature_publish_course_details
 
   background do
     given_i_am_authenticated
-    given_a_trainee_exists
+    given_a_trainee_exists(:with_related_courses)
     given_a_course_exists
     given_i_visited_the_review_draft_page
   end
@@ -35,6 +35,6 @@ feature "confirm publish course", type: :feature, feature_publish_course_details
   end
 
   def given_a_course_exists
-    @course = create(:course, provider: trainee.provider, route: trainee.training_route)
+    @course = trainee.provider.courses.where(route: trainee.training_route).first
   end
 end

--- a/spec/features/trainees/edit_publish_course_details_spec.rb
+++ b/spec/features/trainees/edit_publish_course_details_spec.rb
@@ -9,7 +9,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
 
   background do
     given_i_am_authenticated
-    given_a_trainee_exists
+    given_a_trainee_exists(:with_related_courses)
     given_some_courses_exist
     given_i_visited_the_review_draft_page
   end
@@ -123,7 +123,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
   end
 
   def given_some_courses_exist
-    @matching_courses = create_list(:course, 10, provider: trainee.provider, route: trainee.training_route)
+    @matching_courses = trainee.provider.courses.where(route: trainee.training_route)
   end
 
   def given_there_arent_any_courses
@@ -131,7 +131,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
   end
 
   def and_some_courses_for_other_providers_or_routes_exist
-    other_route = TRAINING_ROUTES.keys.excluding(trainee.training_route).sample
+    other_route = TRAINING_ROUTES_FOR_COURSE.keys.excluding(trainee.training_route).sample
     create(:course, provider: trainee.provider, route: other_route)
     create(:course, route: trainee.training_route)
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -43,9 +43,7 @@ describe Course do
     it do
       is_expected.to define_enum_for(:route)
         .with_values({
-          TRAINING_ROUTE_ENUMS[:assessment_only] => 0,
           TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => 1,
-          TRAINING_ROUTE_ENUMS[:early_years_undergrad] => 2,
           TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => 3,
           TRAINING_ROUTE_ENUMS[:school_direct_salaried] => 4,
           TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => 5,

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -12,8 +12,8 @@ module PageObjects
       element :early_years_undergrad, "#trainee-training-route-early-years-undergrad-field"
 
       element :early_years_assessment_only, "#trainee-training-route-early-years-assessment-only-field"
+      element :early_years_graduate_employment_based, "#trainee-training-route-early-years-graduate-placement-based-field"
       element :early_years_graduate_entry, "#trainee-training-route-early-years-graduate-entry-field"
-      element :early_years_graduate_placement, "#trainee-training-route-early-years-graduate-placement-field"
       element :school_direct_salaried, "#trainee-training-route-school-direct-salaried-field"
       element :school_direct_tuition_fee, "#trainee-training-route-school-direct-tuition-fee-field"
 

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -10,6 +10,13 @@ module PageObjects
       element :assessment_only, "#trainee-training-route-assessment-only-field"
       element :provider_led_postgrad, "#trainee-training-route-provider-led-postgrad-field"
       element :early_years_undergrad, "#trainee-training-route-early-years-undergrad-field"
+
+      element :early_years_assessment_only, "#trainee-training-route-early-years-assessment-only-field"
+      element :early_years_graduate_entry, "#trainee-training-route-early-years-graduate-entry-field"
+      element :early_years_graduate_placement, "#trainee-training-route-early-years-graduate-placement-field"
+      element :school_direct_salaried, "#trainee-training-route-school-direct-salaried-field"
+      element :school_direct_tuition_fee, "#trainee-training-route-school-direct-tuition-fee-field"
+
       element :other, "#trainee-training-route-other-field"
 
       element :continue_button, 'input.govuk-button[type="submit"]'


### PR DESCRIPTION
### Context
Training routes

### Changes proposed in this pull request

All of the following is toggable 
    Early years (assessment only)
    Early years (graduate entry)
    Early years (graduate employment based)
    Early years (undergrad)
    School direct (salaried)
    School direct (tuition fee)


### Guidance to review
Go to https://rtt-review-pr-782.herokuapp.com/trainees/new currently set to true for everything, 
![image](https://user-images.githubusercontent.com/470137/115740754-0bdedf00-a387-11eb-9050-9b2cc21de5e4.png)


There is a number of concept in play.

`TRAINING_ROUTE_ENUMS` and `TRAINING_ROUTES`
- The full list

`TRAINING_ROUTES_FOR_TRAINEE` 
- only applicable for trainee

`TRAINING_ROUTES_FOR_COURSE` 
- only applicable for course, fixed as it was making not constrained enough https://github.com/DFE-Digital/register-trainee-teachers/blob/724cd9cce80a7fca584269e41e0a9709f7845498/app/services/teacher_training_api/import_course.rb#L71-L81

`TRAINING_ROUTE_FEATURE_FLAGS` 
- toggle items

Only `TRAINING_ROUTES_FOR_TRAINEE` is actually used the rest of the routes are under development and can be exposed to user by toggling relative flag

