### PR TITLE
[1560] Non-JS lead schools results page

### DIFF
--- a/app/controllers/trainees/lead_schools_controller.rb
+++ b/app/controllers/trainees/lead_schools_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Trainees
+  class LeadSchoolsController < ApplicationController
+    before_action :authorize_trainee
+    before_action :load_schools
+
+    def index
+      @trainee_lead_school_form = TraineeLeadSchoolForm.new(trainee)
+    end
+
+    def update
+      @trainee_lead_school_form = TraineeLeadSchoolForm.new(trainee, params: trainee_params, user: current_user)
+      save_strategy = trainee.draft? ? :save! : :stash
+
+      if @trainee_lead_school_form.public_send(save_strategy)
+        redirect_to trainee_training_details_confirm_path(@trainee_lead_school_form.trainee)
+      else
+        render :index
+      end
+    end
+
+  private
+
+    def load_schools
+      @schools = SchoolSearch.call(query: params[:query], lead_schools_only: true)
+    end
+
+    def trainee
+      @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def trainee_params
+      params.fetch(:trainee_lead_school_form, {}).permit(:lead_school_id)
+    end
+
+    def authorize_trainee
+      authorize(trainee, :requires_schools?)
+    end
+  end
+end

--- a/app/forms/trainee_lead_school_form.rb
+++ b/app/forms/trainee_lead_school_form.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TraineeLeadSchoolForm < TraineeForm
+  attr_accessor :lead_school_id
+
+  validates :lead_school_id, presence: true
+
+private
+
+  def compute_fields
+    trainee.attributes.symbolize_keys.slice(:lead_school_id).merge(new_attributes)
+  end
+end

--- a/app/helpers/school_helper.rb
+++ b/app/helpers/school_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SchoolHelper
+  def school_urn_and_location(school)
+    [school.urn, school.town, school.postcode].join(", ")
+  end
+end

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -14,11 +14,14 @@ class TraineePolicy
     end
   end
 
-  attr_reader :user, :trainee
+  attr_reader :user, :trainee, :training_router_manager
+
+  delegate :requires_schools?, to: :training_router_manager
 
   def initialize(user, trainee)
     @user = user
     @trainee = trainee
+    @training_router_manager = TrainingRouteManager.new(trainee)
   end
 
   def show?
@@ -45,6 +48,7 @@ class TraineePolicy
     allowed_user? && trainee.trn_received?
   end
 
+  alias_method :index?, :show?
   alias_method :create?, :show?
   alias_method :update?, :show?
   alias_method :edit?, :show?

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -21,6 +21,7 @@ class FormStore
     disability_detail
     diversity
     degrees
+    trainee_lead_school
   ].freeze
 
   class << self

--- a/app/services/school_search.rb
+++ b/app/services/school_search.rb
@@ -5,7 +5,9 @@ class SchoolSearch
 
   attr_reader :query, :limit, :lead_schools_only
 
-  def initialize(query: nil, limit: nil, lead_schools_only: false)
+  DEFAULT_LIMIT = 15
+
+  def initialize(query: nil, limit: DEFAULT_LIMIT, lead_schools_only: false)
     @query = query
     @limit = limit
     @lead_schools_only = lead_schools_only

--- a/app/views/trainees/lead_schools/index.html.erb
+++ b/app/views/trainees/lead_schools/index.html.erb
@@ -1,0 +1,43 @@
+<%= render PageTitle::View.new(title: "search_schools.page_title_results") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <% if @schools.empty? %>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
+        <%= t("components.page_titles.search_schools.page_title_no_results") %>
+      </h1>
+      <div class="govuk-inset-text">
+        <p class="govuk-body"><%= t("components.page_titles.search_schools.sub_text_no_results") %>
+          <span class="govuk-!-font-weight-bold"><%= params[:query] %></span>.
+        </p>
+      </div>
+    <% else %>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
+        <%= t("components.page_titles.search_schools.page_title_results") %>
+      </h1>
+
+      <div class="govuk-hint"><%= t("components.page_titles.search_schools.sub_text_results") %>
+        ‘<%= params[:query] %>’
+      </div>
+
+      <%= register_form_with(model: @trainee_lead_school_form,
+                             url: trainee_lead_schools_path(@trainee),
+                             method: :put,
+                             local: true) do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <div class="govuk-!-margin-bottom-6">
+          <% @schools.each do |school| %>
+            <%= f.govuk_radio_button :lead_school_id, school.id,
+                                     label: { text: school.name },
+                                     hint: { text: school_urn_and_location(school) } %>
+          <% end %>
+        </div>
+
+        <%= f.govuk_submit %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<p class="govuk-body"><%= govuk_link_to(t("cancel"), view_trainee(@trainee)) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,6 +163,11 @@ en:
         new: Add a user
       validation_errors:
         page_title: Validation errors
+      search_schools:
+        page_title_results: Select the lead school
+        page_title_no_results: No results
+        sub_text_results: Results for
+        sub_text_no_results: No results for
     filter:
       training_route: Training route
       state: Status
@@ -204,7 +209,6 @@ en:
           create: Nationality updated
         traineedisability:
           create: Disability details updated
-
     sections:
       titles:
         personal_details: Personal details
@@ -223,7 +227,7 @@ en:
   views:
     all_records: "All records"
     trainees:
-      index: 
+      index:
         no_records: Your trainee records will appear here. You do not have any records yet.
       edit:
         defer: Defer
@@ -612,6 +616,10 @@ en:
             trainee_id:
               blank: You must enter a trainee ID
               max_char_exceeded: Your entry must not exceed 100 characters
+        trainee_lead_school_form:
+          attributes:
+            lead_school_id:
+              blank: You must choose a school
   page_headings:
     start_page: "Register trainee teachers"
   system_admin:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,9 @@ Rails.application.routes.draw do
       resource :confirm_reinstatement, only: %i[show update], path: "/reinstate/confirm"
       resource :reinstatement, only: %i[show update], path: "/reinstate"
 
+      resources :lead_schools, only: %i[index], path: "/lead-schools"
+      resource :lead_schools, only: %i[update], path: "/lead-schools"
+
       resource :timeline, only: :show
     end
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -5,6 +5,8 @@ slack:
   webhook_url: "https://test-slack-webhook-url.com"
 features:
   basic_auth: false
+  routes:
+    school_direct_salaried: true
 
 environment:
   name: beta

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :school do
     sequence(:urn) { |n| "urn_#{n}" }
-    sequence(:name) { |n| "School #{n}" }
+    name { Faker::University.name }
     town { Faker::Address.city }
     postcode { Faker::Address.postcode }
     lead_school { false }

--- a/spec/features/trainees/non_js_lead_school_search_spec.rb
+++ b/spec/features/trainees/non_js_lead_school_search_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Non-JS lead schools search" do
+  before do
+    given_i_am_authenticated
+    given_a_school_direct_salaried_trainee_exists
+    and_a_number_of_lead_school_exists
+    and_i_am_on_the_lead_schools_page_filtered_by_my_query
+  end
+
+  scenario "choosing a lead school" do
+    and_i_choose_my_lead_school
+    and_i_continue
+    then_i_am_redirected_to_the_confirm_training_details_page
+  end
+
+private
+
+  def given_a_school_direct_salaried_trainee_exists
+    given_a_trainee_exists(:school_direct_salaried)
+  end
+
+  def and_i_choose_my_lead_school
+    lead_schools_search_page.choose_school(id: my_lead_school.id)
+  end
+
+  def and_i_continue
+    lead_schools_search_page.continue.click
+  end
+
+  def and_a_number_of_lead_school_exists
+    @lead_schools = create_list(:school, 5, lead_school: true)
+  end
+
+  def and_i_am_on_the_lead_schools_page_filtered_by_my_query
+    lead_schools_search_page.load(trainee_id: trainee.slug, query: query)
+  end
+
+  def query
+    my_lead_school.name.split(" ").first
+  end
+
+  def my_lead_school
+    @my_lead_school ||= @lead_schools.sample
+  end
+
+  def then_i_am_redirected_to_the_confirm_training_details_page
+    expect(confirm_training_details_page).to be_displayed(id: trainee.slug)
+  end
+end

--- a/spec/forms/trainee_lead_school_form_spec.rb
+++ b/spec/forms/trainee_lead_school_form_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TraineeLeadSchoolForm, type: :model do
+  let(:trainee) { create(:trainee) }
+  let(:form_store) { class_double(FormStore) }
+  let(:lead_school_id) { create(:school, lead_school: true).id }
+  let(:params) { { "lead_school_id" => lead_school_id } }
+
+  subject { described_class.new(trainee, params: params, store: form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:lead_school_id) }
+
+    context "empty form data" do
+      let(:params) { { "lead_school_id" => "" } }
+
+      before { subject.valid? }
+
+      it "returns an error" do
+        expect(subject.errors[:lead_school_id]).to include(I18n.t("activemodel.errors.models.trainee_lead_school_form.attributes.lead_school_id.blank"))
+      end
+    end
+  end
+
+  describe "#stash" do
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and trainee_lead_school" do
+      expect(form_store).to receive(:set).with(trainee.id, :trainee_lead_school, subject.fields)
+
+      subject.stash
+    end
+  end
+
+  describe "#save!" do
+    before do
+      allow(form_store).to receive(:get).and_return({ "lead_school_id" => lead_school_id })
+      allow(form_store).to receive(:set).with(trainee.id, :trainee_lead_school, nil)
+    end
+
+    it "takes any data from the form store and saves it to the database" do
+      expect { subject.save! }.to change(trainee, :lead_school_id).to(lead_school_id)
+    end
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -182,6 +182,10 @@ module Features
       @start_page ||= PageObjects::Start.new
     end
 
+    def lead_schools_search_page
+      @lead_schools_search_page ||= PageObjects::Trainees::LeadSchoolsSearchPage.new
+    end
+
     def accessibility_page
       @accessibility_page ||= PageObjects::Accessibility.new
     end

--- a/spec/support/page_objects/trainees/lead_schools_search_page.rb
+++ b/spec/support/page_objects/trainees/lead_schools_search_page.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class LeadSchoolsSearchPage < PageObjects::Base
+      set_url "/trainees/{trainee_id}/lead-schools?query={query}"
+
+      element :continue, "input[name='commit']"
+
+      def choose_school(id:)
+        find("#trainee-lead-school-form-lead-school-id-#{id}-field").choose
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/wDKw1P00/1560-m-no-js-lead-schools-results-page

### Changes proposed in this pull request
- New `Trainees::LeadSchoolsController` to drive the search/results page
- `TraineeLeadSchoolForm` to validate and save/stash school selection

### Guidance to review
Run the following code to seed the schools table:

```ruby
require_relative "config/environment"
require "factory_bot_rails"
require "faker"
FactoryBot.find_definitions rescue nil
FactoryBot.create_list(:school, 20, lead_school: true)
```

Add the rollowing settings to your `development.local.yml`:

```yaml
features:
  routes:
    school_direct_salaried: true
```

- Create a new “School direct (salaried)” trainee
- Visit `/trainee/<trainee_id>/lead-schools`
- Click "Continue" without choosing a school - it should display a validation error
- Select a school and click "Continue" - it will save the choice and redirect you back to the training details confirm page