### PR TITLE
[1602] sentry is not receiving exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "canonical-rails"
 
 # Sentry
 gem "sentry-rails"
+gem "sentry-ruby"
 gem "sentry-sidekiq"
 
 # Logging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,6 +406,10 @@ GEM
     sentry-rails (4.3.4)
       railties (>= 5.0)
       sentry-ruby-core (~> 4.3.0)
+    sentry-ruby (4.3.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      faraday (>= 1.0)
+      sentry-ruby-core (= 4.3.2)
     sentry-ruby-core (4.3.2)
       concurrent-ruby
       faraday
@@ -537,6 +541,7 @@ DEPENDENCIES
   rubocop-govuk
   scss_lint-govuk
   sentry-rails
+  sentry-ruby
   sentry-sidekiq
   shoulda-matchers (~> 4.5)
   sidekiq (~> 6.2)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sentry.init do |config|
+  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+  config.before_send = lambda do |event, _hint|
+    filter.filter(event.to_hash)
+  end
+
+  config.release = ENV["COMMIT_SHA"]
+end


### PR DESCRIPTION
### Context
Sentry is not capturing exceptions since the upgrade from raven to sentry https://github.com/DFE-Digital/register-trainee-teachers/pull/748

### Changes proposed in this pull request
Add `sentry-ruby` gem.
Add initializer with minimal config (including commit hash mapping)

### Guidance to review

