### PR TITLE
[1570] Remove hardcoded qualification aim to factor in others

### DIFF
--- a/app/components/status_tag/view.rb
+++ b/app/components/status_tag/view.rb
@@ -13,7 +13,8 @@ private
   def status
     {
       submitted_for_trn: "pending trn",
-      recommended_for_qts: "qts recommended",
+      recommended_for_award: "qts recommended",
+      awarded: "qts awarded",
     }[trainee.state.to_sym] || trainee.state.gsub("_", " ")
   end
 
@@ -22,8 +23,8 @@ private
       draft: "grey",
       submitted_for_trn: "turquoise",
       trn_received: "blue",
-      recommended_for_qts: "purple",
-      qts_awarded: "",
+      recommended_for_award: "purple",
+      awarded: "",
       deferred: "yellow",
       withdrawn: "red",
     }[trainee.state.to_sym]

--- a/app/components/summary_card/view.rb
+++ b/app/components/summary_card/view.rb
@@ -25,6 +25,6 @@ class SummaryCard::View < ViewComponent::Base
 private
 
   def prevent_action?
-    trainee.recommended_for_qts? || trainee.qts_awarded? || trainee.withdrawn?
+    trainee.recommended_for_award? || trainee.awarded? || trainee.withdrawn?
   end
 end

--- a/app/components/trainee_status_card/view.rb
+++ b/app/components/trainee_status_card/view.rb
@@ -8,8 +8,8 @@ module TraineeStatusCard
       draft: "grey",
       submitted_for_trn: "turquoise",
       trn_received: "blue",
-      recommended_for_qts: "purple",
-      qts_awarded: "",
+      recommended_for_award: "purple",
+      awarded: "",
       deferred: "yellow",
       withdrawn: "red",
     }.freeze

--- a/app/components/trainees/record_actions/view.html.erb
+++ b/app/components/trainees/record_actions/view.html.erb
@@ -1,8 +1,8 @@
 <% if display_actions? %>
   <div class="record-actions">
 
-    <% if can_recommend_for_qts? %>
-      <%= render GovukButtonLinkTo::View.new(body: t("views.trainees.edit.recommend_for_qts"), url: edit_trainee_outcome_details_outcome_date_path(trainee), class_option: "govuk-!-margin-bottom-0") %>
+    <% if can_recommend_for_award? %>
+      <%= render GovukButtonLinkTo::View.new(body: t("views.trainees.edit.recommend_for_award"), url: edit_trainee_outcome_details_outcome_date_path(trainee), class_option: "govuk-!-margin-bottom-0") %>
     <% else %>
       <div class="govuk-inset-text govuk-!-margin-0">
         <%= t("views.trainees.edit.status_summary.#{trainee.state}") %>

--- a/app/components/trainees/record_actions/view.rb
+++ b/app/components/trainees/record_actions/view.rb
@@ -15,7 +15,7 @@ module Trainees
         trainee.submitted_for_trn? || trainee.trn_received? || trainee.deferred?
       end
 
-      def can_recommend_for_qts?
+      def can_recommend_for_award?
         trainee.trn_received?
       end
 

--- a/app/controllers/trainees/award_recommendations_controller.rb
+++ b/app/controllers/trainees/award_recommendations_controller.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 module Trainees
-  class QtsRecommendationsController < ApplicationController
+  class AwardRecommendationsController < ApplicationController
     before_action :authorize_trainee
 
     def create
       if OutcomeDateForm.new(trainee).save!
-        trainee.recommend_for_qts!
+        trainee.recommend_for_award!
 
-        RecommendForQtsJob.perform_later(trainee)
-        RetrieveQtsJob.perform_with_default_delay(trainee)
+        RecommendForAwardJob.perform_later(trainee)
+        RetrieveAwardJob.perform_with_default_delay(trainee)
 
         redirect_to recommended_trainee_outcome_details_path(trainee)
       end
@@ -22,7 +22,7 @@ module Trainees
     end
 
     def authorize_trainee
-      authorize(trainee, :recommend_for_qts?)
+      authorize(trainee, :recommend_for_award?)
     end
   end
 end

--- a/app/controllers/trainees/outcome_dates_controller.rb
+++ b/app/controllers/trainees/outcome_dates_controller.rb
@@ -33,7 +33,7 @@ module Trainees
     end
 
     def authorize_trainee
-      authorize(trainee, :recommend_for_qts?)
+      authorize(trainee, :recommend_for_award?)
     end
   end
 end

--- a/app/jobs/queue_trainee_updates_job.rb
+++ b/app/jobs/queue_trainee_updates_job.rb
@@ -5,10 +5,10 @@ class QueueTraineeUpdatesJob < ApplicationJob
 
   INVALID_STATES = %w[
     draft
-    recommended_for_qts
+    recommended_for_award
     withdrawn
     deferred
-    qts_awarded
+    awarded
   ].freeze
 
   def perform

--- a/app/jobs/recommend_for_award_job.rb
+++ b/app/jobs/recommend_for_award_job.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-class RecommendForQtsJob < ApplicationJob
+class RecommendForAwardJob < ApplicationJob
   queue_as :default
-  retry_on Dttp::RecommendForQTS::Error
+  retry_on Dttp::RecommendForAward::Error
   retry_on Dttp::UpdateTraineeStatus::Error
 
   def perform(trainee)
-    Dttp::RecommendForQTS.call(trainee: trainee)
+    Dttp::RecommendForAward.call(trainee: trainee)
 
     Dttp::UpdateTraineeStatus.call(
       status: DttpStatuses::STANDARDS_MET,

--- a/app/lib/dttp/code_sets/qualification_aims.rb
+++ b/app/lib/dttp/code_sets/qualification_aims.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Dttp
+  module CodeSets
+    module QualificationAims
+      # Most of these are currently mapped to "Qualified Teacher Status (QTS)/registration with the DFE"
+      # The full DTTP list contains a number of qualification aims which our app isn't setup to collect.
+      # The DTTP qualification aim GUIDS will likely need to be updated once we collect more details about the trainee's qualification aim.
+      MAPPING = {
+        TRAINING_ROUTE_ENUMS[:assessment_only] => { entity_id: "68cbae32-7389-e711-80d8-005056ac45bb" },
+        TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => { entity_id: "68cbae32-7389-e711-80d8-005056ac45bb" },
+        TRAINING_ROUTE_ENUMS[:early_years_undergrad] => { entity_id: "d446cd4b-4d9c-e711-80d9-005056ac45bb" },
+        TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => { entity_id: "68cbae32-7389-e711-80d8-005056ac45bb" },
+        TRAINING_ROUTE_ENUMS[:school_direct_salaried] => { entity_id: "68cbae32-7389-e711-80d8-005056ac45bb" },
+      }.freeze
+    end
+  end
+end

--- a/app/lib/dttp/mappable.rb
+++ b/app/lib/dttp/mappable.rb
@@ -53,5 +53,9 @@ module Dttp
     def dttp_reason_for_leaving_id(reason)
       CodeSets::ReasonsForLeavingCourse::MAPPING.dig(reason, :entity_id)
     end
+
+    def dttp_qualification_aim_id(training_route)
+      CodeSets::QualificationAims::MAPPING.dig(training_route, :entity_id)
+    end
   end
 end

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -43,7 +43,7 @@ module Dttp
           "dfe_courselevel" => COURSE_LEVEL_PG, # TODO: this can be PG (12) or UG (20).  Postgrad or undergrad. Hardcoded for now.
           "dfe_sendforregistration" => true,
           "dfe_ProviderId@odata.bind" => "/accounts(#{trainee.provider.dttp_id})",
-          "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{ITT_QUALIFICATION_AIM_QTS})",
+          "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{dttp_qualification_aim_id(trainee.training_route)})",
           "dfe_programmeyear" => 1, # TODO: this will need to be derived for other routes. It's n of x year course e.g. 1 of 2
           "dfe_programmelength" => 1, # TODO: this will change for other routes as above. So these two are course_year of course_length
         }.merge(qualifying_degree.uk? ? uk_specific_params : non_uk_specific_params)

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -67,10 +67,10 @@ class Trainee < ApplicationRecord
     draft: 0,
     submitted_for_trn: 1,
     trn_received: 2,
-    recommended_for_qts: 3,
+    recommended_for_award: 3,
     withdrawn: 4,
     deferred: 5,
-    qts_awarded: 6,
+    awarded: 6,
   } do
     event :submit_for_trn do
       before do
@@ -84,12 +84,12 @@ class Trainee < ApplicationRecord
       transition %i[submitted_for_trn deferred] => :trn_received
     end
 
-    event :recommend_for_qts do
+    event :recommend_for_award do
       before do
-        self.recommended_for_qts_at = Time.zone.now
+        self.recommended_for_award_at = Time.zone.now
       end
 
-      transition %i[trn_received] => :recommended_for_qts
+      transition %i[trn_received] => :recommended_for_award
     end
 
     event :withdraw do
@@ -100,8 +100,8 @@ class Trainee < ApplicationRecord
       transition %i[submitted_for_trn trn_received] => :deferred
     end
 
-    event :award_qts do
-      transition %i[recommended_for_qts] => :qts_awarded
+    event :award do
+      transition %i[recommended_for_award] => :awarded
     end
   end
 

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -41,10 +41,10 @@ class TraineePolicy
   end
 
   def show_recommended?
-    allowed_user? && trainee.recommended_for_qts?
+    allowed_user? && trainee.recommended_for_award?
   end
 
-  def recommend_for_qts?
+  def recommend_for_award?
     allowed_user? && trainee.trn_received?
   end
 

--- a/app/services/dttp/recommend_for_award.rb
+++ b/app/services/dttp/recommend_for_award.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dttp
-  class RecommendForQTS
+  class RecommendForAward
     include ServicePattern
 
     class Error < StandardError; end

--- a/app/services/dttp/retrieve_award.rb
+++ b/app/services/dttp/retrieve_award.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dttp
-  class RetrieveQts
+  class RetrieveAward
     include ServicePattern
 
     class HttpError < StandardError; end

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -33,7 +33,7 @@ module Exports
           "Last name" => trainee.last_name,
           "Trainee Id" => trainee.trainee_id,
           "TRN" => trainee.trn,
-          "Status" => trainee.state,
+          "Status" => award_state(trainee),
           "Route" => trainee.training_route,
           "Subject" => trainee.subject,
           "Course start date" => trainee.course_start_date,
@@ -41,9 +41,16 @@ module Exports
           "Created date" => trainee.created_at,
           "Last updated date" => trainee.updated_at,
           "TRN Submitted date" => trainee.submitted_for_trn_at,
-          "QTS submitted date" => trainee.recommended_for_qts_at,
+          "Award submitted date" => trainee.recommended_for_award_at,
         }
       end
+    end
+
+    def award_state(trainee)
+      {
+        recommended_for_award: I18n.t("exports.trainees.award_recommended", award_type: trainee.award_type),
+        awarded: I18n.t("exports.trainees.award_given", award_type: trainee.award_type),
+      }[trainee.state.to_sym] || trainee.state
     end
   end
 end

--- a/app/views/pages/_badges.html.erb
+++ b/app/views/pages/_badges.html.erb
@@ -12,7 +12,7 @@
 </div>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-6">
-  <% %i[recommended_for_qts qts_awarded deferred withdrawn].map do |state| %>
+  <% %i[recommended_for_award awarded deferred withdrawn].map do |state| %>
     <div class=" govuk-grid-column-one-quarter ">
     <%= render TraineeStatusCard::View.new(state: state, target: trainees_path("state[]": state), trainees: @trainees) %>
   </div>

--- a/app/views/trainees/outcome_details/confirm.html.erb
+++ b/app/views/trainees/outcome_details/confirm.html.erb
@@ -17,7 +17,7 @@
   <div class="govuk-grid-column-full">
     <%= render Trainees::OutcomeDetails::View.new(@outcome_form) %>
 
-    <%= register_form_with url: trainee_qts_recommendations_path, method: :post, local: true do |f| %>
+    <%= register_form_with url: trainee_award_recommendations_path, method: :post, local: true do |f| %>
       <%= hidden_field_tag :trainee_id, @trainee.slug %>
       <%= f.govuk_submit "Recommend trainee for #{@trainee.award_type}" %>
     <%- end -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,7 +238,7 @@ en:
         withdraw: withdraw
         reinstate: Reinstate
         this_trainee: this trainee
-        recommend_for_qts: Recommend trainee for QTS
+        recommend_for_award: Recommend trainee for QTS
         status_summary:
           submitted_for_trn: This record is pending a TRN
           deferred: This record is deferred
@@ -415,10 +415,10 @@ en:
           draft: Draft
           submitted_for_trn: Pending TRN
           trn_received: TRN received
-          recommended_for_qts: QTS recommended
+          recommended_for_award: QTS recommended
           withdrawn: Withdrawn
           deferred: Deferred
-          qts_awarded: QTS awarded
+          awarded: QTS awarded
     errors:
       models:
         trainee:
@@ -648,3 +648,7 @@ en:
     schools:
       errors:
         bad_request: "The query param needs to be at least 3 characters"
+  exports:
+    trainees:
+      award_recommended: "Recommended for %{award_type}"
+      award_given: "Awarded %{award_type}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
         resource :outcome_date, only: %i[edit update], path: "/outcome-date"
       end
 
-      resource :qts_recommendations, only: %i[create]
+      resource :award_recommendations, only: %i[create]
 
       resource :confirm_withdrawal, only: %i[show update], path: "/withdraw/confirm"
       resource :withdrawal, only: %i[show update], path: "/withdraw"

--- a/db/migrate/20210426131345_rename_qts_recommended_date_from_trainees.rb
+++ b/db/migrate/20210426131345_rename_qts_recommended_date_from_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameQtsRecommendedDateFromTrainees < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :trainees, :recommended_for_qts_at, :recommended_for_award_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -245,7 +245,7 @@ ActiveRecord::Schema.define(version: 2021_04_26_162034) do
     t.string "additional_withdraw_reason"
     t.date "defer_date"
     t.string "slug", null: false
-    t.datetime "recommended_for_qts_at"
+    t.datetime "recommended_for_award_at"
     t.string "dttp_update_sha"
     t.date "commencement_date"
     t.date "reinstate_date"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -34,14 +34,14 @@ namespace :example_data do
         %i[with_start_date submitted_for_trn with_placement_assignment with_course_details diversity_not_disclosed],
         %i[with_start_date trn_received with_placement_assignment with_course_details diversity_disclosed],
         %i[with_start_date trn_received with_placement_assignment with_course_details diversity_not_disclosed],
-        %i[with_start_date recommended_for_qts with_placement_assignment with_outcome_date with_course_details diversity_disclosed],
-        %i[with_start_date recommended_for_qts with_placement_assignment with_outcome_date with_course_details diversity_not_disclosed],
+        %i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details diversity_disclosed],
+        %i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details diversity_not_disclosed],
         %i[with_start_date withdrawn with_placement_assignment with_course_details diversity_disclosed],
         %i[with_start_date withdrawn with_placement_assignment with_course_details diversity_not_disclosed],
         %i[with_start_date deferred with_placement_assignment with_course_details diversity_disclosed],
         %i[with_start_date deferred with_placement_assignment with_course_details diversity_not_disclosed],
-        %i[with_start_date qts_awarded with_placement_assignment with_outcome_date with_course_details diversity_disclosed],
-        %i[with_start_date qts_awarded with_placement_assignment with_outcome_date with_course_details diversity_not_disclosed],
+        %i[with_start_date awarded with_placement_assignment with_outcome_date with_course_details diversity_disclosed],
+        %i[with_start_date awarded with_placement_assignment with_outcome_date with_course_details diversity_not_disclosed],
       ]
 
       rand(50...100).times do

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -47,8 +47,8 @@ module ApplicationRecordCard
         { state: :draft, colour: "grey", text: "draft" },
         { state: :submitted_for_trn, colour: "turquoise", text: "pending trn" },
         { state: :trn_received, colour: "blue", text: "trn received" },
-        { state: :recommended_for_qts, colour: "purple", text: "qts recommended" },
-        { state: :qts_awarded, colour: "", text: "qts awarded" },
+        { state: :recommended_for_award, colour: "purple", text: "qts recommended" },
+        { state: :awarded, colour: "", text: "qts awarded" },
         { state: :deferred, colour: "yellow", text: "deferred" },
         { state: :withdrawn, colour: "red", text: "withdrawn" },
       ].each do |state_expectation|

--- a/spec/components/trainee_status_card/view_spec.rb
+++ b/spec/components/trainee_status_card/view_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TraineeStatusCard::View do
 
   describe "#state_name" do
     it "returns state name in correct format" do
-      %i[draft withdrawn deferred qts_awarded trn_received submitted_for_trn recommended_for_qts].each do |state|
+      %i[draft withdrawn deferred awarded trn_received submitted_for_trn recommended_for_award].each do |state|
         expect(described_class.new(state: state,
                                    target: target, trainees: trainees).state_name).to eql(I18n.t("activerecord.attributes.trainee.states.#{state}"))
       end

--- a/spec/components/trainees/record_actions/view_spec.rb
+++ b/spec/components/trainees/record_actions/view_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Trainees::RecordActions::View do
     end
 
     context "recommended for QTS" do
-      let(:trait) { :recommended_for_qts }
+      let(:trait) { :recommended_for_award }
       include_examples "no actions"
     end
 
@@ -51,7 +51,7 @@ RSpec.describe Trainees::RecordActions::View do
     end
 
     context "QTS awarded" do
-      let(:trait) { :qts_awarded }
+      let(:trait) { :awarded }
       include_examples "no actions"
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -27,13 +27,13 @@ describe SessionsController, type: :controller do
       end
 
       it "redirects to the original requested page if it exists in the session" do
-        session[:requested_path] = "/trainees/qts_awarded"
+        session[:requested_path] = "/trainees/awarded"
         request_callback
-        expect(response).to redirect_to("/trainees/qts_awarded")
+        expect(response).to redirect_to("/trainees/awarded")
       end
 
       it "clears the redirect_back_to key of the session after a redirect" do
-        session[:requested_path] = "/trainees/qts_awarded"
+        session[:requested_path] = "/trainees/awarded"
         request_callback
         expect(session[:requested_path]).to be_nil
       end
@@ -47,7 +47,7 @@ describe SessionsController, type: :controller do
       end
 
       it "deletes the requested_path session" do
-        session[:requested_path] = "/trainees/qts_awarded"
+        session[:requested_path] = "/trainees/awarded"
         request_callback
         expect(session[:requested_path]).to be_nil
       end

--- a/spec/controllers/trainees/award_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/award_recommendations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe Trainees::QtsRecommendationsController do
+describe Trainees::AwardRecommendationsController do
   include ActiveJob::TestHelper
 
   let(:current_user) { create(:user) }
@@ -17,11 +17,11 @@ describe Trainees::QtsRecommendationsController do
     it "it updates the placement assignment in DTTP to mark it ready for QTS" do
       expect {
         post :create, params: { trainee_id: trainee }
-      }.to have_enqueued_job(RecommendForQtsJob).with(trainee)
+      }.to have_enqueued_job(RecommendForAwardJob).with(trainee)
     end
 
     it "queues a background job to poll for the trainee's QTS" do
-      expect(RetrieveQtsJob).to receive(:perform_with_default_delay).with(trainee)
+      expect(RetrieveAwardJob).to receive(:perform_with_default_delay).with(trainee)
       post :create, params: { trainee_id: trainee }
     end
 
@@ -35,8 +35,8 @@ describe Trainees::QtsRecommendationsController do
         post :create, params: { trainee_id: trainee }
       end
 
-      it "transitions the trainee state to recommended_for_qts" do
-        expect(trainee.reload).to be_recommended_for_qts
+      it "transitions the trainee state to recommended_for_award" do
+        expect(trainee.reload).to be_recommended_for_award
       end
     end
   end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -154,9 +154,9 @@ FactoryBot.define do
       dttp_id { SecureRandom.uuid }
     end
 
-    trait :recommended_for_qts do
-      state { "recommended_for_qts" }
-      recommended_for_qts_at { Time.zone.now }
+    trait :recommended_for_award do
+      state { "recommended_for_award" }
+      recommended_for_award_at { Time.zone.now }
     end
 
     trait :withdrawn do
@@ -176,8 +176,8 @@ FactoryBot.define do
       reinstate_date { Faker::Date.in_date_period }
     end
 
-    trait :qts_awarded do
-      state { "qts_awarded" }
+    trait :awarded do
+      state { "awarded" }
     end
 
     trait :with_dttp_dormancy do

--- a/spec/jobs/recommend_for_award_job_spec.rb
+++ b/spec/jobs/recommend_for_award_job_spec.rb
@@ -2,10 +2,10 @@
 
 require "rails_helper"
 
-describe RecommendForQtsJob do
+describe RecommendForAwardJob do
   include ActiveJob::TestHelper
 
-  let(:trainee) { create(:trainee, :recommended_for_qts) }
+  let(:trainee) { create(:trainee, :recommended_for_award) }
 
   let(:expected_contact_params) do
     {
@@ -24,7 +24,7 @@ describe RecommendForQtsJob do
   end
 
   before do
-    allow(Dttp::RecommendForQTS).to receive(:call).with(trainee: trainee)
+    allow(Dttp::RecommendForAward).to receive(:call).with(trainee: trainee)
     allow(Dttp::UpdateTraineeStatus).to receive(:call).with(expected_contact_params)
     allow(Dttp::UpdateTraineeStatus).to receive(:call).with(expected_placement_assignment_params)
   end

--- a/spec/jobs/retrieve_award_job_spec.rb
+++ b/spec/jobs/retrieve_award_job_spec.rb
@@ -2,49 +2,49 @@
 
 require "rails_helper"
 
-describe RetrieveQtsJob do
+describe RetrieveAwardJob do
   include ActiveJob::TestHelper
 
-  let(:qts_flag) { nil }
-  let(:trainee) { create(:trainee, :recommended_for_qts) }
+  let(:award_flag) { nil }
+  let(:trainee) { create(:trainee, :recommended_for_award) }
 
   before do
-    allow(Dttp::RetrieveQts).to receive(:call).with(trainee: trainee).and_return(qts_flag)
+    allow(Dttp::RetrieveAward).to receive(:call).with(trainee: trainee).and_return(award_flag)
   end
 
-  context "QTS is awarded in DTTP" do
-    let(:qts_flag) { true }
+  context "Award is awarded in DTTP" do
+    let(:award_flag) { true }
 
-    it "transitions the trainee to qts_awarded" do
+    it "transitions the trainee to awarded" do
       expect {
         described_class.perform_now(trainee)
         trainee.reload
-      }.to change(trainee, :state).to("qts_awarded")
+      }.to change(trainee, :state).to("awarded")
     end
 
     it "doesn't queue another job" do
       described_class.perform_now(trainee)
-      expect(RetrieveQtsJob).to_not have_been_enqueued
+      expect(RetrieveAwardJob).to_not have_been_enqueued
     end
   end
 
-  context "QTS is not awarded in DTTP" do
-    let(:qts_flag) { false }
+  context "Award is not awarded in DTTP" do
+    let(:award_flag) { false }
     let(:configured_delay) { 6 }
 
     before do
       allow(Settings.jobs).to receive(:poll_delay_hours).and_return(configured_delay)
     end
 
-    it "queues another job to fetch the QTS the configured number of hours from now" do
+    it "queues another job to fetch the Award the configured number of hours from now" do
       Timecop.freeze(Time.zone.now) do
         described_class.perform_now(trainee)
-        expect(RetrieveQtsJob).to have_been_enqueued.at(configured_delay.hours.from_now).with(trainee)
+        expect(RetrieveAwardJob).to have_been_enqueued.at(configured_delay.hours.from_now).with(trainee)
       end
     end
 
     context "after the configured days of polling" do
-      let(:trainee) { create(:trainee, recommended_for_qts_at: configured_limit.days.ago) }
+      let(:trainee) { create(:trainee, recommended_for_award_at: configured_limit.days.ago) }
       let(:configured_limit) { 2 }
 
       before do
@@ -53,19 +53,19 @@ describe RetrieveQtsJob do
 
       it "doesn't queue another job after 2 days have passed with no QTS" do
         described_class.perform_now(trainee)
-        expect(RetrieveQtsJob).to_not have_been_enqueued
+        expect(RetrieveAwardJob).to_not have_been_enqueued
       end
     end
   end
 
-  context "the trainee attribute recommended_for_qts_at is nil" do
+  context "the trainee attribute recommended_for_award_at is nil" do
     let(:trainee) { create(:trainee) }
-    let(:error_msg) { "Trainee#recommended_for_qts_at is nil - it should be timestamped (id: #{trainee.id})" }
+    let(:error_msg) { "Trainee#recommended_for_award_at is nil - it should be timestamped (id: #{trainee.id})" }
 
     it "raises a TraineeAttributeError" do
       expect {
         described_class.perform_now(trainee)
-      }.to raise_error(RetrieveQtsJob::TraineeAttributeError, error_msg)
+      }.to raise_error(RetrieveAwardJob::TraineeAttributeError, error_msg)
     end
   end
 
@@ -79,7 +79,7 @@ describe RetrieveQtsJob do
     it "enqueues the job with the configured delay" do
       Timecop.freeze(Time.zone.now) do
         described_class.perform_now(trainee)
-        expect(RetrieveQtsJob).to have_been_enqueued.at(configured_delay.hours.from_now).with(trainee)
+        expect(RetrieveAwardJob).to have_been_enqueued.at(configured_delay.hours.from_now).with(trainee)
       end
     end
   end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -21,6 +21,7 @@ module Dttp
       let(:dttp_country_entity_id) { SecureRandom.uuid }
       let(:dttp_provider_id) { SecureRandom.uuid }
       let(:dttp_route_id) { Dttp::CodeSets::Routes::MAPPING[trainee.training_route][:entity_id] }
+      let(:dttp_qualification_aim_id) { Dttp::CodeSets::QualificationAims::MAPPING[trainee.training_route][:entity_id] }
 
       before do
         allow(Time).to receive(:now).and_return(time_now_in_zone)
@@ -63,7 +64,7 @@ module Dttp
               "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_PG,
               "dfe_sendforregistration" => true,
               "dfe_ProviderId@odata.bind" => "/accounts(#{dttp_provider_id})",
-              "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{Dttp::Params::PlacementAssignment::ITT_QUALIFICATION_AIM_QTS})",
+              "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{dttp_qualification_aim_id})",
               "dfe_programmeyear" => 1,
               "dfe_programmelength" => 1,
               "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id})",
@@ -89,7 +90,7 @@ module Dttp
               "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_PG,
               "dfe_sendforregistration" => true,
               "dfe_ProviderId@odata.bind" => "/accounts(#{dttp_provider_id})",
-              "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{Dttp::Params::PlacementAssignment::ITT_QUALIFICATION_AIM_QTS})",
+              "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{dttp_qualification_aim_id})",
               "dfe_programmeyear" => 1,
               "dfe_programmelength" => 1,
               "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id})",

--- a/spec/services/dttp/recommend_for_award_spec.rb
+++ b/spec/services/dttp/recommend_for_award_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 module Dttp
-  describe RecommendForQTS do
+  describe RecommendForAward do
     describe "#call" do
       let(:trainee) do
         create(:trainee, :trn_received, outcome_date: outcome_date, placement_assignment_dttp_id: placement_assignment_dttp_id)
@@ -24,7 +24,7 @@ module Dttp
 
       context "success" do
         let(:dttp_response) { double(code: 204) }
-        it_behaves_like "CreateOrUpdateConsistencyCheckJob", RecommendForQTS
+        it_behaves_like "CreateOrUpdateConsistencyCheckJob", RecommendForAward
 
         it "sends a PATCH request to set entity property 'dfe_datestandardsassessmentpassed'" do
           expect(Client).to receive(:patch).with(path, body: expected_params).and_return(dttp_response)
@@ -41,7 +41,7 @@ module Dttp
         it "raises an error exception" do
           expect {
             described_class.call(trainee: trainee)
-          }.to raise_error(Dttp::RecommendForQTS::Error, "status: #{status}, body: #{body}, headers: #{headers}")
+          }.to raise_error(Dttp::RecommendForAward::Error, "status: #{status}, body: #{body}, headers: #{headers}")
         end
       end
     end

--- a/spec/services/dttp/retrieve_award_spec.rb
+++ b/spec/services/dttp/retrieve_award_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 module Dttp
-  describe RetrieveQts do
+  describe RetrieveAward do
     describe "#call" do
       let(:placement_assignment_entity_id) { SecureRandom.uuid }
-      let(:trainee) { create(:trainee, :recommended_for_qts, placement_assignment_dttp_id: placement_assignment_entity_id) }
+      let(:trainee) { create(:trainee, :recommended_for_award, placement_assignment_dttp_id: placement_assignment_entity_id) }
       let(:path) { "/dfe_placementassignments(#{placement_assignment_entity_id})?$select=dfe_qtsawardflag" }
 
       subject { described_class.call(trainee: trainee) }
@@ -17,21 +17,21 @@ module Dttp
       end
 
       context "success response" do
-        let(:dttp_response) { double(code: 200, body: { dfe_qtsawardflag: qts_flag }.to_json) }
+        let(:dttp_response) { double(code: 200, body: { dfe_qtsawardflag: award_flag }.to_json) }
 
         context "QTS is awarded" do
-          let(:qts_flag) { true }
+          let(:award_flag) { true }
 
           it "returns the QTS flag" do
-            expect(subject).to eq(qts_flag)
+            expect(subject).to eq(award_flag)
           end
         end
 
         context "QTS is not awarded" do
-          let(:qts_flag) { false }
+          let(:award_flag) { false }
 
           it "returns the QTS flag" do
-            expect(subject).to eq(qts_flag)
+            expect(subject).to eq(award_flag)
           end
         end
       end
@@ -46,7 +46,7 @@ module Dttp
           expect(Client).to receive(:get).with(path).and_return(dttp_response)
           expect {
             subject
-          }.to raise_error(Dttp::RetrieveQts::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
+          }.to raise_error(Dttp::RetrieveAward::HttpError, "status: #{status}, body: #{body}, headers: #{headers}")
         end
       end
     end

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Exports
   describe TraineeSearchData do
     let(:trainee) do
-      create(:trainee, :with_course_details, :submitted_for_trn, :trn_received, :recommended_for_qts, :qts_awarded)
+      create(:trainee, :with_course_details, :submitted_for_trn, :trn_received, :recommended_for_award, :awarded)
     end
 
     subject { described_class.new([trainee]) }
@@ -17,7 +17,7 @@ module Exports
           "Last name" => trainee.last_name,
           "Trainee Id" => trainee.trainee_id,
           "TRN" => trainee.trn,
-          "Status" => trainee.state,
+          "Status" => t("exports.trainees.award_given", award_type: trainee.award_type),
           "Route" => trainee.training_route,
           "Subject" => trainee.subject,
           "Course start date" => trainee.course_start_date,
@@ -25,7 +25,7 @@ module Exports
           "Created date" => trainee.created_at,
           "Last updated date" => trainee.updated_at,
           "TRN Submitted date" => trainee.submitted_for_trn_at,
-          "QTS submitted date" => trainee.recommended_for_qts_at,
+          "Award submitted date" => trainee.recommended_for_award_at,
         }
       end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/CAtRXyah/1570-l-enable-award-of-eyts

### Changes proposed in this pull request

Shaun has confirmed that all trainees eventually get QTS. However, you can have different qualification aims. It's this field which needs to differentiate based on the route you're on and the qualification you're aiming for. 

At the moment, our app is not setup to collect all the details of the aiming qualification but this PR sets up the plumbing to be able to pull out the correct id for the qualification aim in DTTP. 

The full list of qualification aims contains quite a few entries and currently none of them map 1 to 1 with our training routes. EYTS for example has 4 different types of qualification aims.

The only thing which needs to change for now is the field in the screenshot and the route. A trainee is still awarded a QTS so there's no need to create a separate params class for the `PlacementOutcome` as it'll be exactly identical for EYTS, only the `PlacementAssignment` needs to be changed. There are a couple of fields in the exit information which are set by DQT depending on the profile outcome and qualification obtained on exit.

<img width="772" alt="Screenshot 2021-04-27 at 14 34 31" src="https://user-images.githubusercontent.com/616080/116251141-4ae5a980-a766-11eb-8a1d-fb86d7f306c3.png">


### Guidance to review

- Create an EYTS trainee locally and submit to DTTP.
- Use postman or DTTP dev to assert the correct EYTS values are set on the placement assignment
