### PR TITLE
[1565] No JS employing schools search results page

### DIFF
--- a/app/controllers/trainees/employing_schools_controller.rb
+++ b/app/controllers/trainees/employing_schools_controller.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 module Trainees
-  class LeadSchoolsController < ApplicationController
+  class EmployingSchoolsController < ApplicationController
     before_action :authorize_trainee
     before_action :load_schools
 
     def index
-      @lead_school_form = LeadSchoolForm.new(trainee)
+      @employing_school_form = EmployingSchoolForm.new(trainee)
     end
 
     def update
-      @lead_school_form = LeadSchoolForm.new(trainee, params: trainee_params, user: current_user)
+      @employing_school_form = EmployingSchoolForm.new(trainee, params: trainee_params, user: current_user)
       save_strategy = trainee.draft? ? :save! : :stash
 
-      if @lead_school_form.public_send(save_strategy)
+      if @employing_school_form.public_send(save_strategy)
         redirect_to trainee_training_details_confirm_path(trainee)
       else
         render :index
@@ -23,7 +23,7 @@ module Trainees
   private
 
     def load_schools
-      @schools = SchoolSearch.call(query: params[:query], lead_schools_only: true)
+      @schools = SchoolSearch.call(query: params[:query])
     end
 
     def trainee
@@ -31,11 +31,11 @@ module Trainees
     end
 
     def trainee_params
-      params.fetch(:lead_school_form, {}).permit(:lead_school_id)
+      params.fetch(:employing_school_form, {}).permit(:employing_school_id)
     end
 
     def authorize_trainee
-      authorize(trainee, :requires_schools?)
+      authorize(trainee, :requires_employing_school?)
     end
   end
 end

--- a/app/forms/employing_school_form.rb
+++ b/app/forms/employing_school_form.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class EmployingSchoolForm < TraineeForm
+  attr_accessor :employing_school_id
+
+  validates :employing_school_id, presence: true
+
+private
+
+  def compute_fields
+    trainee.attributes.symbolize_keys.slice(:employing_school_id).merge(new_attributes)
+  end
+end

--- a/app/forms/lead_school_form.rb
+++ b/app/forms/lead_school_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TraineeLeadSchoolForm < TraineeForm
+class LeadSchoolForm < TraineeForm
   attr_accessor :lead_school_id
 
   validates :lead_school_id, presence: true

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -13,6 +13,10 @@ class TrainingRouteManager
     %w[routes.school_direct_salaried routes.school_direct_tuition_fee].any? { |flag| feature_enabled?(flag) } && schools_direct?
   end
 
+  def requires_employing_school?
+    feature_enabled?("routes.school_direct_salaried") && schools_direct_salaried?
+  end
+
   def award_type
     TRAINING_ROUTE_AWARD_TYPE[training_route]
   end
@@ -31,6 +35,10 @@ private
 
   def schools_direct?
     TRAINING_ROUTE_ENUMS.values_at(:school_direct_tuition_fee, :school_direct_salaried).include? training_route.to_s
+  end
+
+  def schools_direct_salaried?
+    training_route == TRAINING_ROUTE_ENUMS[:school_direct_salaried].to_sym
   end
 
   def training_route

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -11,6 +11,7 @@ class Trainee < ApplicationRecord
   has_many :trainee_disabilities, dependent: :destroy, inverse_of: :trainee
   has_many :disabilities, through: :trainee_disabilities
   belongs_to :lead_school, optional: true, class_name: "School"
+  belongs_to :employing_school, optional: true, class_name: "School"
 
   attribute :progress, Progress.to_type
 

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -16,7 +16,7 @@ class TraineePolicy
 
   attr_reader :user, :trainee, :training_router_manager
 
-  delegate :requires_schools?, to: :training_router_manager
+  delegate :requires_schools?, :requires_employing_school?, to: :training_router_manager
 
   def initialize(user, trainee)
     @user = user

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -21,7 +21,8 @@ class FormStore
     disability_detail
     diversity
     degrees
-    trainee_lead_school
+    lead_school
+    employing_school
   ].freeze
 
   class << self

--- a/app/views/trainees/employing_schools/index.html.erb
+++ b/app/views/trainees/employing_schools/index.html.erb
@@ -1,27 +1,27 @@
-<%= render PageTitle::View.new(title: "search_schools.page_title_results") %>
+<%= render PageTitle::View.new(title: "search_employing_schools.page_title_results") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <% if @schools.empty? %>
-      <%= render "no_results" %>
+      <%= render "trainees/lead_schools/no_results" %>
     <% else %>
       <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
-        <%= t("components.page_titles.search_schools.page_title_results") %>
+        <%= t("components.page_titles.search_employing_schools.page_title_results") %>
       </h1>
 
       <div class="govuk-hint"><%= t("components.page_titles.search_schools.sub_text_results") %>
         ‘<%= params[:query] %>’
       </div>
 
-      <%= register_form_with(model: @lead_school_form,
-                             url: trainee_lead_schools_path(@trainee),
+      <%= register_form_with(model: @employing_school_form,
+                             url: trainee_employing_schools_path(@trainee),
                              method: :put,
                              local: true) do |f| %>
         <%= f.govuk_error_summary %>
 
         <div class="govuk-!-margin-bottom-6">
           <% @schools.each do |school| %>
-            <%= f.govuk_radio_button :lead_school_id, school.id,
+            <%= f.govuk_radio_button :employing_school_id, school.id,
                                      label: { text: school.name },
                                      hint: { text: school_urn_and_location(school) } %>
           <% end %>

--- a/app/views/trainees/lead_schools/_no_results.html.erb
+++ b/app/views/trainees/lead_schools/_no_results.html.erb
@@ -1,0 +1,8 @@
+<h1 class="govuk-heading-l govuk-!-margin-bottom-1">
+  <%= t("components.page_titles.search_schools.page_title_no_results") %>
+</h1>
+<div class="govuk-inset-text">
+  <p class="govuk-body"><%= t("components.page_titles.search_schools.sub_text_no_results") %>
+    <span class="govuk-!-font-weight-bold"><%= params[:query] %></span>.
+  </p>
+</div>

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -75,76 +75,75 @@
     <h2 class="govuk-heading-m">About their teacher training</h2>
 
     <%= render TaskList::View.new(classes: "record-setup") do |component|
-          if show_publish_courses?(@trainee)
-            form = PublishCourseDetailsForm.new(@trainee)
-            component.slot(
-              :row,
-              task_name: "Course details",
-              path: edit_trainee_publish_course_details_path(@trainee),
-              confirm_path: lambda {
-                edit_trainee_confirm_publish_course_path(
-                  id: form.code,
-                  trainee_id: @trainee.to_param,
-                )
-              },
-              classes: "course-details",
-              status: ProgressService.call(
-                validator: form,
-                progress_value: @trainee.progress.course_details,
-              ).status,
+      if show_publish_courses?(@trainee)
+        form = PublishCourseDetailsForm.new(@trainee)
+        component.slot(
+          :row,
+          task_name: "Course details",
+          path: edit_trainee_publish_course_details_path(@trainee),
+          confirm_path: lambda {
+            edit_trainee_confirm_publish_course_path(
+              id: form.code,
+              trainee_id: @trainee.to_param,
             )
-          else
-            component.slot(
-              :row,
-              task_name: "Course details",
-              path: edit_trainee_course_details_path(@trainee),
-              confirm_path: trainee_course_details_confirm_path(@trainee),
-              classes: "course-details",
-              status: ProgressService.call(
-                validator: CourseDetailsForm.new(@trainee),
-                progress_value: @trainee.progress.course_details,
-              ).status,
-            )
-          end
+          },
+          classes: "course-details",
+          status: ProgressService.call(
+            validator: form,
+            progress_value: @trainee.progress.course_details,
+          ).status,
+        )
+      else
+        component.slot(
+          :row,
+          task_name: "Course details",
+          path: edit_trainee_course_details_path(@trainee),
+          confirm_path: trainee_course_details_confirm_path(@trainee),
+          classes: "course-details",
+          status: ProgressService.call(
+            validator: CourseDetailsForm.new(@trainee),
+            progress_value: @trainee.progress.course_details,
+          ).status,
+        )
+      end
 
-          component.slot(
+      component.slot(
+        :row,
+        task_name: "Trainee start date and ID",
+        path: edit_trainee_training_details_path(@trainee),
+        confirm_path: trainee_training_details_confirm_path(@trainee),
+        classes: "training-details",
+        status: ProgressService.call(
+          validator: TrainingDetailsForm.new(@trainee),
+          progress_value: @trainee.progress.training_details,
+        ).status,
+      )
+
+      if @trainee.requires_schools?
+        component.slot(
             :row,
-            task_name: "Trainee start date and ID",
-            path: edit_trainee_training_details_path(@trainee),
-            confirm_path: trainee_training_details_confirm_path(@trainee),
-            classes: "training-details",
-            status: ProgressService.call(
-              validator: TrainingDetailsForm.new(@trainee),
-              progress_value: @trainee.progress.training_details,
-            ).status,
+            task_name: "Schools",
+            path: review_draft_trainee_path(@trainee),
+            confirm_path: review_draft_trainee_path(@trainee),
+            classes: "school-details",
+            status: "not started",
           )
+      end
 
-          if @trainee.requires_schools?
-            component.slot(
-                :row,
-                task_name: "Schools",
-                path: review_draft_trainee_path(@trainee),
-                confirm_path: review_draft_trainee_path(@trainee),
-                classes: "school-details",
-                status: "not started",
-              )
-          end
-
-      # TODO: Populate with correct paths when created
-          if @trainee.requires_placement_details?
-            component.slot(
-              :row,
-              task_name: "Placement details",
-              path: review_draft_trainee_path(@trainee),
-              confirm_path: review_draft_trainee_path(@trainee),
-              classes: "placement-details",
-              status: ProgressService.call(
-                validator: PlacementDetailForm.new(@trainee),
-                progress_value: @trainee.progress.placement_details,
-              ).status,
-            )
-          end
-        end %>
+      if @trainee.requires_placement_details?
+        component.slot(
+          :row,
+          task_name: "Placement details",
+          path: review_draft_trainee_path(@trainee),
+          confirm_path: review_draft_trainee_path(@trainee),
+          classes: "placement-details",
+          status: ProgressService.call(
+            validator: PlacementDetailForm.new(@trainee),
+            progress_value: @trainee.progress.placement_details,
+          ).status,
+        )
+      end
+    end %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,8 @@ en:
           sort_by: Sort by
           date_updated: Date updated
           last_name: Last name
+        employing_schools:
+          index: Select the employing school
       providers:
         index: Providers
         new: Add a provider
@@ -168,6 +170,8 @@ en:
         page_title_no_results: No results
         sub_text_results: Results for
         sub_text_no_results: No results for
+      search_employing_schools:
+        page_title_results: Select the employing school
     filter:
       training_route: Training route
       state: Status
@@ -623,9 +627,13 @@ en:
             trainee_id:
               blank: You must enter a trainee ID
               max_char_exceeded: Your entry must not exceed 100 characters
-        trainee_lead_school_form:
+        lead_school_form:
           attributes:
             lead_school_id:
+              blank: You must choose a school
+        employing_school_form:
+          attributes:
+            employing_school_id:
               blank: You must choose a school
   page_headings:
     start_page: "Register trainee teachers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,8 @@ Rails.application.routes.draw do
 
       resources :lead_schools, only: %i[index], path: "/lead-schools"
       resource :lead_schools, only: %i[update], path: "/lead-schools"
+      resources :employing_schools, only: %i[index], path: "/employing-schools"
+      resource :employing_schools, only: %i[update], path: "/employing-schools"
 
       resource :timeline, only: :show
     end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -12,6 +12,7 @@ features:
   routes:
     provider_led_postgrad: true
     early_years_undergrad: true
+    school_direct_salaried: true
 
 pagination:
   records_per_page: 30

--- a/db/migrate/20210426162034_add_employing_school_to_trainee.rb
+++ b/db/migrate/20210426162034_add_employing_school_to_trainee.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEmployingSchoolToTrainee < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :trainees, :employing_school, foreign_key: { to_table: "schools" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_22_143630) do
+ActiveRecord::Schema.define(version: 2021_04_26_162034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -251,9 +251,11 @@ ActiveRecord::Schema.define(version: 2021_04_22_143630) do
     t.date "reinstate_date"
     t.uuid "dormancy_dttp_id"
     t.bigint "lead_school_id"
+    t.bigint "employing_school_id"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"
     t.index ["dttp_id"], name: "index_trainees_on_dttp_id"
+    t.index ["employing_school_id"], name: "index_trainees_on_employing_school_id"
     t.index ["ethnic_group"], name: "index_trainees_on_ethnic_group"
     t.index ["gender"], name: "index_trainees_on_gender"
     t.index ["lead_school_id"], name: "index_trainees_on_lead_school_id"
@@ -301,6 +303,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_143630) do
   add_foreign_key "trainee_disabilities", "disabilities"
   add_foreign_key "trainee_disabilities", "trainees"
   add_foreign_key "trainees", "providers"
+  add_foreign_key "trainees", "schools", column: "employing_school_id"
   add_foreign_key "trainees", "schools", column: "lead_school_id"
   add_foreign_key "users", "providers"
 end

--- a/spec/features/trainees/non_js_employing_school_search_spec.rb
+++ b/spec/features/trainees/non_js_employing_school_search_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Non-JS employing schools search" do
+  before do
+    given_i_am_authenticated
+    given_a_school_direct_salaried_trainee_exists
+    and_a_number_of_school_exists
+    and_i_am_on_the_employing_schools_page_filtered_by_my_query
+  end
+
+  scenario "choosing a lead school" do
+    and_i_choose_my_employing_school
+    and_i_continue
+    then_i_am_redirected_to_the_confirm_training_details_page
+  end
+
+private
+
+  def given_a_school_direct_salaried_trainee_exists
+    given_a_trainee_exists(:school_direct_salaried)
+  end
+
+  def and_i_choose_my_employing_school
+    employing_schools_search_page.choose_school(id: my_employing_school.id)
+  end
+
+  def and_i_continue
+    employing_schools_search_page.continue.click
+  end
+
+  def and_a_number_of_school_exists
+    @schools = create_list(:school, 5)
+  end
+
+  def and_i_am_on_the_employing_schools_page_filtered_by_my_query
+    employing_schools_search_page.load(trainee_id: trainee.slug, query: query)
+  end
+
+  def query
+    my_employing_school.name.split(" ").first
+  end
+
+  def my_employing_school
+    @my_employing_school ||= @schools.sample
+  end
+
+  def then_i_am_redirected_to_the_confirm_training_details_page
+    expect(confirm_training_details_page).to be_displayed(id: trainee.slug)
+  end
+end

--- a/spec/forms/employing_school_form_spec.rb
+++ b/spec/forms/employing_school_form_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe EmployingSchoolForm, type: :model do
+  let(:trainee) { create(:trainee) }
+  let(:form_store) { class_double(FormStore) }
+  let(:school_id) { create(:school).id }
+  let(:params) { { "employing_school_id" => school_id } }
+
+  subject { described_class.new(trainee, params: params, store: form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:employing_school_id) }
+
+    context "empty form data" do
+      let(:params) { { "employing_school_id" => "" } }
+
+      before { subject.valid? }
+
+      it "returns an error" do
+        expect(subject.errors[:employing_school_id]).to include(I18n.t("activemodel.errors.models.employing_school_form.attributes.employing_school_id.blank"))
+      end
+    end
+  end
+
+  describe "#stash" do
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and employing_school" do
+      expect(form_store).to receive(:set).with(trainee.id, :employing_school, subject.fields)
+
+      subject.stash
+    end
+  end
+
+  describe "#save!" do
+    before do
+      allow(form_store).to receive(:get).and_return({ "employing_school_id" => school_id })
+      allow(form_store).to receive(:set).with(trainee.id, :employing_school, nil)
+    end
+
+    it "takes any data from the form store and saves it to the database" do
+      expect { subject.save! }.to change(trainee, :employing_school_id).to(school_id)
+    end
+  end
+end

--- a/spec/forms/lead_school_form_spec.rb
+++ b/spec/forms/lead_school_form_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe TraineeLeadSchoolForm, type: :model do
+describe LeadSchoolForm, type: :model do
   let(:trainee) { create(:trainee) }
   let(:form_store) { class_double(FormStore) }
   let(:lead_school_id) { create(:school, lead_school: true).id }
@@ -23,14 +23,14 @@ describe TraineeLeadSchoolForm, type: :model do
       before { subject.valid? }
 
       it "returns an error" do
-        expect(subject.errors[:lead_school_id]).to include(I18n.t("activemodel.errors.models.trainee_lead_school_form.attributes.lead_school_id.blank"))
+        expect(subject.errors[:lead_school_id]).to include(I18n.t("activemodel.errors.models.lead_school_form.attributes.lead_school_id.blank"))
       end
     end
   end
 
   describe "#stash" do
-    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and trainee_lead_school" do
-      expect(form_store).to receive(:set).with(trainee.id, :trainee_lead_school, subject.fields)
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and lead_school" do
+      expect(form_store).to receive(:set).with(trainee.id, :lead_school, subject.fields)
 
       subject.stash
     end
@@ -39,7 +39,7 @@ describe TraineeLeadSchoolForm, type: :model do
   describe "#save!" do
     before do
       allow(form_store).to receive(:get).and_return({ "lead_school_id" => lead_school_id })
-      allow(form_store).to receive(:set).with(trainee.id, :trainee_lead_school, nil)
+      allow(form_store).to receive(:set).with(trainee.id, :lead_school, nil)
     end
 
     it "takes any data from the form store and saves it to the database" do

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -44,7 +44,7 @@ describe TrainingRouteManager do
           end
         end
 
-        context "with the :routes_#{route} feature flag enabled", "feature_routes.#{route}": false do
+        context "with the :routes_#{route} feature flag disabled", "feature_routes.#{route}": false do
           context "with a non school direct trainee" do
             let(:trainee) { build(:trainee) }
 
@@ -53,6 +53,34 @@ describe TrainingRouteManager do
             end
           end
         end
+      end
+    end
+  end
+
+  describe "#requires_employing_school?" do
+    context "with the :routes_school_direct_salaried feature flag enabled", "feature_routes.school_direct_salaried": true do
+      context "with a school direct salaried trainee" do
+        let(:trainee) { build(:trainee, :school_direct_salaried) }
+
+        it "returns true" do
+          expect(subject.requires_employing_school?).to be true
+        end
+      end
+
+      context "with a non school direct trainee" do
+        let(:trainee) { build(:trainee) }
+
+        it "returns false" do
+          expect(subject.requires_employing_school?).to be false
+        end
+      end
+    end
+
+    context "with the :routes_school_direct_salaried feature flag disabled", "feature_routes.school_direct_salaried": false do
+      let(:trainee) { build(:trainee) }
+
+      it "returns false" do
+        expect(subject.requires_employing_school?).to be false
       end
     end
   end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -183,7 +183,11 @@ module Features
     end
 
     def lead_schools_search_page
-      @lead_schools_search_page ||= PageObjects::Trainees::LeadSchoolsSearchPage.new
+      @lead_schools_search_page ||= PageObjects::Trainees::LeadSchoolsSearch.new
+    end
+
+    def employing_schools_search_page
+      @employing_schools_search_page ||= PageObjects::Trainees::EmployingSchoolsSearch.new
     end
 
     def accessibility_page

--- a/spec/support/page_objects/trainees/employing_schools_search.rb
+++ b/spec/support/page_objects/trainees/employing_schools_search.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class EmployingSchoolsSearch < PageObjects::Base
+      set_url "/trainees/{trainee_id}/employing-schools?query={query}"
+
+      element :continue, "input[name='commit']"
+
+      def choose_school(id:)
+        find("#employing-school-form-employing-school-id-#{id}-field").choose
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/lead_schools_search.rb
+++ b/spec/support/page_objects/trainees/lead_schools_search.rb
@@ -2,13 +2,13 @@
 
 module PageObjects
   module Trainees
-    class LeadSchoolsSearchPage < PageObjects::Base
+    class LeadSchoolsSearch < PageObjects::Base
       set_url "/trainees/{trainee_id}/lead-schools?query={query}"
 
       element :continue, "input[name='commit']"
 
       def choose_school(id:)
-        find("#trainee-lead-school-form-lead-school-id-#{id}-field").choose
+        find("#lead-school-form-lead-school-id-#{id}-field").choose
       end
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/uRMbZcBM/1565-no-js-employing-schools-results-page

### Changes proposed in this pull request

Similar to this PR for lead schools: https://github.com/DFE-Digital/register-trainee-teachers/pull/794

This PR:
- Adds `employing_school_id` onto trainees and creates the association
- Creates `Trainees::EmployingSchoolsController` to drive the search/results page for employing schools
- Creates `TraineeEmployingSchoolForm` to validate and save/stash school selection

### Guidance to review

As per John's PR:

Run the following code to seed the schools table:

```ruby
require_relative "config/environment"
require "factory_bot_rails"
require "faker"
FactoryBot.find_definitions rescue nil
FactoryBot.create_list(:school, 20)
```

Add the following settings to your `development.local.yml`:

```yaml
features:
  routes:
    school_direct_salaried: true
```

- Create a new “School direct (salaried)” trainee
- Visit `/trainee/<trainee_id>/employing-schools?query=urn`
- Click "Continue" without choosing a school - it should display a validation error
- Select a school and click "Continue" - it will save the choice and redirect you back to the training details confirm page
