### PR TITLE
[1575] Allow validation tracking to be turned off locally

### DIFF
--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -45,6 +45,7 @@ private
   end
 
   def track_validation_error
+    return unless Settings.track_validation_errors
     ValidationError.create(form_object: self.class.name, user: user, details: validation_error_details.to_h)
   end
 

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -46,7 +46,8 @@ private
 
   def track_validation_error
     return unless Settings.track_validation_errors
-    ValidationError.create(form_object: self.class.name, user: user, details: validation_error_details.to_h)
+
+    ValidationError.create!(form_object: self.class.name, user: user, details: validation_error_details.to_h)
   end
 
   def validation_error_details

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -119,16 +119,16 @@
             ).status,
           )
 
-        if @trainee.requires_schools?
-          component.slot(
-              :row,
-              task_name: "Schools",
-              path: review_draft_trainee_path(@trainee),
-              confirm_path: review_draft_trainee_path(@trainee),
-              classes: "school-details",
-              status: "not started",
-            )
-        end 
+          if @trainee.requires_schools?
+            component.slot(
+                :row,
+                task_name: "Schools",
+                path: review_draft_trainee_path(@trainee),
+                confirm_path: review_draft_trainee_path(@trainee),
+                classes: "school-details",
+                status: "not started",
+              )
+          end
 
       # TODO: Populate with correct paths when created
           if @trainee.requires_placement_details?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -77,3 +77,5 @@ environment:
 
 slack:
   publish_register_alerts_channel: "#twd_publish_register_tech"
+
+track_validation_errors: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -18,3 +18,5 @@ pagination:
 
 environment:
   name: development
+
+track_validation_errors: false

--- a/spec/forms/trainee_form_spec.rb
+++ b/spec/forms/trainee_form_spec.rb
@@ -30,8 +30,6 @@ describe TraineeForm, type: :model do
 
       subject.valid?
       expect(ValidationError.count).to eql(2)
-
-      # expect(subject.errors[:course_end_date]).to be_empty
     end
   end
 

--- a/spec/forms/trainee_form_spec.rb
+++ b/spec/forms/trainee_form_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class TestForm < TraineeForm
+  attr_accessor :test1, :test2, :test3
+  validates_presence_of :test1, :test2, :test3
+  private
+  def compute_fields
+    {}
+  end
+end
+
+describe TraineeForm, type: :model do
+  let(:user) { create(:user) }
+  let(:trainee) { create(:trainee) }
+  subject { TestForm.new(trainee, user: user) }
+
+  describe "track_validation_errors: true" do
+    before do
+      allow(Settings).to receive(:track_validation_errors).and_return(true)
+    end
+
+    it "saves validation errors" do
+      subject.valid?
+      expect(ValidationError.last.form_object).to eql("TestForm")
+      expect(ValidationError.count).to eql(1)
+
+      subject.valid?
+      expect(ValidationError.count).to eql(2)
+
+      # expect(subject.errors[:course_end_date]).to be_empty
+    end
+  end
+
+  describe "track_validation_errors: false" do
+    before do
+      allow(Settings).to receive(:track_validation_errors).and_return(false)
+    end
+
+    it "saves validation errors" do
+      subject.valid?
+      expect(ValidationError.count).to eql(0)
+
+      subject.valid?
+      expect(ValidationError.count).to eql(0)
+    end
+  end
+
+end

--- a/spec/forms/trainee_form_spec.rb
+++ b/spec/forms/trainee_form_spec.rb
@@ -5,7 +5,9 @@ require "rails_helper"
 class TestForm < TraineeForm
   attr_accessor :test1, :test2, :test3
   validates_presence_of :test1, :test2, :test3
-  private
+
+private
+
   def compute_fields
     {}
   end
@@ -46,5 +48,4 @@ describe TraineeForm, type: :model do
       expect(ValidationError.count).to eql(0)
     end
   end
-
 end


### PR DESCRIPTION
### Context

https://trello.com/c/yi8K7QwO/1575-allow-validation-tracking-to-be-turned-off-locally

### Changes proposed in this pull request

* New setting added `Settings.track_validation_errors`
* Default is `true`

### Guidance to review

* Set `Settings.track_validation_errors` true/false
* Add new trainee, go to one of the forms and save without entering data
* Check `/system-admin/validation_errors` 