### PR TITLE
[1563] Search again (lead schools results)

### DIFF
--- a/app/controllers/trainees/lead_schools_controller.rb
+++ b/app/controllers/trainees/lead_schools_controller.rb
@@ -5,12 +5,19 @@ module Trainees
     before_action :authorize_trainee
     before_action :load_schools
 
+    helper_method :query
+
     def index
       @lead_school_form = LeadSchoolForm.new(trainee)
     end
 
     def update
       @lead_school_form = LeadSchoolForm.new(trainee, params: trainee_params, user: current_user)
+
+      if @lead_school_form.searching_again? && @lead_school_form.valid?
+        return redirect_to trainee_lead_schools_path(@trainee, query: query)
+      end
+
       save_strategy = trainee.draft? ? :save! : :stash
 
       if @lead_school_form.public_send(save_strategy)
@@ -23,7 +30,7 @@ module Trainees
   private
 
     def load_schools
-      @schools = SchoolSearch.call(query: params[:query], lead_schools_only: true)
+      @schools = SchoolSearch.call(query: query, lead_schools_only: true)
     end
 
     def trainee
@@ -31,7 +38,15 @@ module Trainees
     end
 
     def trainee_params
-      params.fetch(:lead_school_form, {}).permit(:lead_school_id)
+      params.fetch(:lead_school_form, {}).permit(:lead_school_id, *LeadSchoolForm::NON_TRAINEE_FIELDS)
+    end
+
+    def query
+      # Order important here including the use of presence() on the first hash lookup to ensure that if the user
+      # submits the form with results but hasn't made a choice, we re-render the page with the previous results
+      # including a validation message. Even though the search again field is hidden in this scenario, it will be
+      # included in the form data, therefore we have to take that into account.
+      trainee_params[:results_search_again_query].presence || trainee_params[:no_results_search_again_query] || params[:query]
     end
 
     def authorize_trainee

--- a/app/forms/lead_school_form.rb
+++ b/app/forms/lead_school_form.rb
@@ -1,13 +1,36 @@
 # frozen_string_literal: true
 
 class LeadSchoolForm < TraineeForm
-  attr_accessor :lead_school_id
+  NON_TRAINEE_FIELDS = %i[
+    results_search_again_query
+    no_results_search_again_query
+  ].freeze
 
-  validates :lead_school_id, presence: true
+  attr_accessor(*NON_TRAINEE_FIELDS, :lead_school_id)
+
+  validates :lead_school_id, presence: true, unless: -> { searching_again? }
+  validates :results_search_again_query, presence: true, if: -> { results_search_again_query? }
+  validates :no_results_search_again_query, presence: true, if: -> { no_results_searching_again? }
+
+  def searching_again?
+    results_search_again_query? || no_results_searching_again?
+  end
+
+  def results_search_again_query?
+    lead_school_id == "results_search_again"
+  end
+
+  def no_results_searching_again?
+    lead_school_id == "no_results_search_again"
+  end
 
 private
 
   def compute_fields
     trainee.attributes.symbolize_keys.slice(:lead_school_id).merge(new_attributes)
+  end
+
+  def fields_to_ignore_before_stash_or_save
+    NON_TRAINEE_FIELDS
   end
 end

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -22,7 +22,7 @@ class TraineeForm
 
   def save!
     if valid?
-      trainee.assign_attributes(fields)
+      trainee.assign_attributes(fields.except(*fields_to_ignore_before_stash_or_save))
       trainee.save!
       clear_stash
     else
@@ -31,13 +31,17 @@ class TraineeForm
   end
 
   def stash
-    valid? && store.set(id, form_store_key, fields)
+    valid? && store.set(id, form_store_key, fields.except(*fields_to_ignore_before_stash_or_save))
   end
 
 private
 
   def compute_fields
     raise NotImplementedError
+  end
+
+  def fields_to_ignore_before_stash_or_save
+    []
   end
 
   def new_attributes

--- a/app/views/trainees/lead_schools/_no_results.html.erb
+++ b/app/views/trainees/lead_schools/_no_results.html.erb
@@ -1,8 +1,16 @@
 <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
   <%= t("components.page_titles.search_schools.page_title_no_results") %>
 </h1>
+
 <div class="govuk-inset-text">
   <p class="govuk-body"><%= t("components.page_titles.search_schools.sub_text_no_results") %>
-    <span class="govuk-!-font-weight-bold"><%= params[:query] %></span>.
+    <span class="govuk-!-font-weight-bold"><%= query %></span>.
   </p>
 </div>
+
+<%= f.hidden_field :lead_school_id, value: :no_results_search_again %>
+
+<%= f.govuk_text_field :no_results_search_again_query,
+                       label: { text: t("components.page_titles.search_schools.search_hint") } %>
+
+<%= f.govuk_submit t("components.page_titles.search_schools.search_button") %>

--- a/app/views/trainees/lead_schools/_results.html.erb
+++ b/app/views/trainees/lead_schools/_results.html.erb
@@ -1,0 +1,34 @@
+<h1 class="govuk-heading-l govuk-!-margin-bottom-1">
+  <%= t("components.page_titles.search_schools.page_title_results") %>
+</h1>
+
+<% if query.present? %>
+  <div class="govuk-hint">
+    <%= t("components.page_titles.search_schools.sub_text_results") %> ‘<%= query %>’
+  </div>
+<% end %>
+
+<%= f.govuk_error_summary %>
+
+<%= f.govuk_radio_buttons_fieldset :lead_school_id, legend: nil do %>
+  <div class="govuk-!-margin-bottom-6">
+    <% @schools.each do |school| %>
+      <%= f.govuk_radio_button :lead_school_id, school.id,
+                               label: { text: school.name },
+                               hint: { text: school_urn_and_location(school) } %>
+    <% end %>
+  </div>
+
+  <div class="govuk-!-margin-bottom-6"><%= f.govuk_radio_divider %></div>
+
+  <div class="govuk-!-margin-bottom-6">
+    <%= f.govuk_radio_button :lead_school_id,
+                             :results_search_again,
+                             label: { text: t("components.page_titles.search_schools.search_button") } do %>
+      <%= f.govuk_text_field :results_search_again_query,
+                             label: { text: t("components.page_titles.search_schools.search_hint") } %>
+    <% end %>
+  </div>
+<% end %>
+
+<%= f.govuk_submit %>

--- a/app/views/trainees/lead_schools/index.html.erb
+++ b/app/views/trainees/lead_schools/index.html.erb
@@ -2,33 +2,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <% if @schools.empty? %>
-      <%= render "no_results" %>
-    <% else %>
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
-        <%= t("components.page_titles.search_schools.page_title_results") %>
-      </h1>
-
-      <div class="govuk-hint"><%= t("components.page_titles.search_schools.sub_text_results") %>
-        ‘<%= params[:query] %>’
-      </div>
-
-      <%= register_form_with(model: @lead_school_form,
-                             url: trainee_lead_schools_path(@trainee),
-                             method: :put,
-                             local: true) do |f| %>
-        <%= f.govuk_error_summary %>
-
-        <div class="govuk-!-margin-bottom-6">
-          <% @schools.each do |school| %>
-            <%= f.govuk_radio_button :lead_school_id, school.id,
-                                     label: { text: school.name },
-                                     hint: { text: school_urn_and_location(school) } %>
-          <% end %>
-        </div>
-
-        <%= f.govuk_submit %>
-      <% end %>
+    <%= register_form_with(model: @lead_school_form,
+                           url: trainee_lead_schools_path(@trainee, query: params[:query]),
+                           method: :put,
+                           local: true) do |f| %>
+      <% render (@schools.empty? ? "no_results" : "results"), f: f %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,8 @@ en:
         page_title_no_results: No results
         sub_text_results: Results for
         sub_text_no_results: No results for
+        search_hint: Search for a school by it’s unique reference number (URN), name or postcode
+        search_button: Search again
       search_employing_schools:
         page_title_results: Select the employing school
     filter:
@@ -635,6 +637,10 @@ en:
           attributes:
             lead_school_id:
               blank: You must choose a school
+            results_search_again_query:
+              blank: You much enter a search term
+            no_results_search_again_query:
+              blank: You much enter a search term
         employing_school_form:
           attributes:
             employing_school_id:

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -8,6 +8,7 @@ features:
   routes:
     provider_led_postgrad: true
     early_years_undergrad: true
+    school_direct_salaried: true
 
 pagination:
   records_per_page: 30

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -10,6 +10,8 @@ namespace :example_data do
 
     Faker::Config.locale = "en-GB"
 
+    FactoryBot.create_list(:school, 50, lead_school: true)
+
     PERSONAS.each do |persona_attributes|
       persona = Persona.find_or_create_by!(first_name: persona_attributes[:first_name],
                                            last_name: persona_attributes[:last_name],

--- a/spec/features/trainees/non_js_lead_school_search_spec.rb
+++ b/spec/features/trainees/non_js_lead_school_search_spec.rb
@@ -16,6 +16,14 @@ RSpec.feature "Non-JS lead schools search" do
     then_i_am_redirected_to_the_confirm_training_details_page
   end
 
+  scenario "choosing search again option" do
+    and_i_choose_the_search_option
+    and_i_enter_a_search_term_that_should_yield_no_results
+    and_i_continue
+    then_i_should_see_no_results
+    and_i_should_see_a_search_again_field
+  end
+
 private
 
   def given_a_school_direct_salaried_trainee_exists
@@ -24,6 +32,22 @@ private
 
   def and_i_choose_my_lead_school
     lead_schools_search_page.choose_school(id: my_lead_school.id)
+  end
+
+  def and_i_choose_the_search_option
+    lead_schools_search_page.search_again_option.choose
+  end
+
+  def and_i_enter_a_search_term_that_should_yield_no_results
+    lead_schools_search_page.results_search_again_input.set("foo")
+  end
+
+  def then_i_should_see_no_results
+    expect(lead_schools_search_page).to have_text(t("components.page_titles.search_schools.sub_text_no_results") + " foo")
+  end
+
+  def and_i_should_see_a_search_again_field
+    expect(lead_schools_search_page).to have_no_results_search_again_input
   end
 
   def and_i_continue
@@ -38,15 +62,15 @@ private
     lead_schools_search_page.load(trainee_id: trainee.slug, query: query)
   end
 
+  def then_i_am_redirected_to_the_confirm_training_details_page
+    expect(confirm_training_details_page).to be_displayed(id: trainee.slug)
+  end
+
   def query
     my_lead_school.name.split(" ").first
   end
 
   def my_lead_school
     @my_lead_school ||= @lead_schools.sample
-  end
-
-  def then_i_am_redirected_to_the_confirm_training_details_page
-    expect(confirm_training_details_page).to be_displayed(id: trainee.slug)
   end
 end

--- a/spec/support/page_objects/trainees/lead_schools_search.rb
+++ b/spec/support/page_objects/trainees/lead_schools_search.rb
@@ -5,6 +5,9 @@ module PageObjects
     class LeadSchoolsSearch < PageObjects::Base
       set_url "/trainees/{trainee_id}/lead-schools?query={query}"
 
+      element :search_again_option, "input#lead-school-form-lead-school-id-results-search-again-field"
+      element :results_search_again_input, "input#lead-school-form-results-search-again-query-field"
+      element :no_results_search_again_input, "input#lead-school-form-no-results-search-again-query-field"
       element :continue, "input[name='commit']"
 
       def choose_school(id:)


### PR DESCRIPTION
### Context
https://trello.com/c/YjiZoLhp/1563-m-search-again-lead-schools-results

### Changes proposed in this pull request
- Split `app/views/trainees/lead_schools/index.html.erb` into partials: `results` and `no_results`
- Add search again field to `no_results` partial
- Update `LeadSchoolsController` to handle search again operations via `PUT` request
- Add validation to search fields (probably the most complex part)
- Update rake task `example_data:generate` to generation fake schools 

### Guidance to review
Run the following code to seed the schools table and enable the feature:

### Pre-steps
```ruby
require_relative "config/environment"
require "factory_bot_rails"
require "faker"
FactoryBot.find_definitions rescue nil
FactoryBot.create_list(:school, 20, lead_school: true)
```

Add the rollowing settings to your `development.local.yml`:

```yaml
features:
  routes:
    school_direct_salaried: true
```

- Create a new “School direct (salaried)” trainee
- Visit `/trainee/<trainee_id>/lead-schools`

#### Scenario 1 (submit form without choosing an option)
- Click "Continue"
- It should display the validation message "You must choose a school"

#### Scenario 2 (search again with no term)
- Click "Search again" and click "Continue"
- It should display the validation message "You much enter a search term"

#### Scenario 3 (search again with term)
- Search again and enter say "foo"
- It displays the no results page with the search again field
- Click "Search again" without entering a term
- It should display the validation message "You much enter a search term"
- Enter the term "urn_1"
- It displays a number of results