### PR TITLE
[1615] Bug fix - updating non-draft trainee degrees broken

### DIFF
--- a/app/controllers/trainees/degrees/confirm_details_controller.rb
+++ b/app/controllers/trainees/degrees/confirm_details_controller.rb
@@ -12,7 +12,7 @@ module Trainees
           @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.degrees)
         end
 
-        data_model = trainee.draft? ? trainee : degree_form
+        data_model = trainee.draft? ? trainee : degrees_form
 
         @confirmation_component = if trainee.degrees.empty?
                                     IncompleteSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), error: false)
@@ -23,8 +23,8 @@ module Trainees
 
     private
 
-      def degree_form
-        @degree_form ||= DegreeForm.new(trainee)
+      def degrees_form
+        @degrees_form ||= DegreesForm.new(trainee)
       end
     end
   end

--- a/spec/features/trainees/degrees/editing_degree_spec.rb
+++ b/spec/features/trainees/degrees/editing_degree_spec.rb
@@ -6,50 +6,66 @@ feature "editing a degree" do
   background { given_i_am_authenticated }
 
   context "UK degree" do
-    scenario "the user enters valid details" do
-      given_a_trainee_with_a_uk_degree
-      when_i_visit_the_edit_degree_details_page
-      and_i_enter_valid_uk_degree_details
-      and_i_click_the_continue_button
-      then_i_am_redirected_to_confirm_page
+    context "draft trainee" do
+      scenario "the user enters valid details" do
+        given_a_trainee_with_a_uk_degree
+        when_i_visit_the_edit_degree_details_page
+        and_i_enter_valid_uk_degree_details
+        and_i_click_the_continue_button
+        then_i_am_redirected_to_confirm_page
+      end
+
+      scenario "the user enters invalid details" do
+        given_a_trainee_with_a_uk_degree
+        when_i_visit_the_edit_degree_details_page
+        and_i_click_the_continue_button
+        then_i_see_the_error_summary
+      end
+
+      # As we are not doing an autocomplete validation on uk_degree (type)
+      # the uk form is a superset of the non_uk one, so we just need one
+      # test for autocompletes
+      scenario "user partially submits autocompletes", js: true do
+        given_a_trainee_with_a_uk_degree
+        when_i_visit_the_edit_degree_details_page
+        and_i_fill_in_subject_without_selecting_a_value(with: "moose")
+        and_i_fill_in_institution_without_selecting_a_value(with: "obtuse")
+        and_i_click_the_continue_button
+        then_subject_is_populated(with: "moose")
+        then_institution_is_populated(with: "obtuse")
+        then_i_see_error_messages_for_partially_submitted_fields(:subject, :institution)
+      end
     end
 
-    scenario "the user enters invalid details" do
-      given_a_trainee_with_a_uk_degree
-      when_i_visit_the_edit_degree_details_page
-      and_i_click_the_continue_button
-      then_i_see_the_error_summary
-    end
-
-    # As we are not doing an autocomplete validation on uk_degree (type)
-    # the uk form is a superset of the non_uk one, so we just need one
-    # test for autocompletes
-    scenario "user partially submits autocompletes", js: true do
-      given_a_trainee_with_a_uk_degree
-      when_i_visit_the_edit_degree_details_page
-      and_i_fill_in_subject_without_selecting_a_value(with: "moose")
-      and_i_fill_in_institution_without_selecting_a_value(with: "obtuse")
-      and_i_click_the_continue_button
-      then_subject_is_populated(with: "moose")
-      then_institution_is_populated(with: "obtuse")
-      then_i_see_error_messages_for_partially_submitted_fields(:subject, :institution)
+    context "non-draft trainee" do
+      scenario "the user enters valid details" do
+        given_a_non_trainee_with_a_uk_degree
+        when_i_visit_the_edit_degree_details_page
+        and_i_enter_valid_uk_degree_details
+        and_i_click_the_continue_button
+        then_i_am_redirected_to_confirm_page
+        and_i_click_update_record
+        then_i_am_redirected_to_the_record_page
+      end
     end
   end
 
   context "Non UK degree" do
-    scenario "the user enters valid details" do
-      given_a_trainee_with_a_non_uk_degree
-      when_i_visit_the_edit_degree_details_page
-      and_i_enter_valid_non_uk_degree_details
-      and_i_click_the_continue_button
-      then_i_am_redirected_to_confirm_page
-    end
+    context "draft trainee" do
+      scenario "the user enters valid details" do
+        given_a_trainee_with_a_non_uk_degree
+        when_i_visit_the_edit_degree_details_page
+        and_i_enter_valid_non_uk_degree_details
+        and_i_click_the_continue_button
+        then_i_am_redirected_to_confirm_page
+      end
 
-    scenario "the user enters invalid details" do
-      given_a_trainee_with_a_non_uk_degree
-      when_i_visit_the_edit_degree_details_page
-      and_i_click_the_continue_button
-      then_i_see_the_error_summary
+      scenario "the user enters invalid details" do
+        given_a_trainee_with_a_non_uk_degree
+        when_i_visit_the_edit_degree_details_page
+        and_i_click_the_continue_button
+        then_i_see_the_error_summary
+      end
     end
   end
 
@@ -57,6 +73,10 @@ private
 
   def given_a_trainee_with_a_uk_degree
     uk_trainee
+  end
+
+  def given_a_non_trainee_with_a_uk_degree
+    uk_trainee(trait: :submitted_for_trn)
   end
 
   def given_a_trainee_with_a_non_uk_degree
@@ -84,12 +104,10 @@ private
   end
 
   def when_i_visit_the_edit_degree_details_page
-    edit_degree_details_page.load(trainee_id: trainee.slug,
-                                  id: trainee.degrees.first.slug)
+    edit_degree_details_page.load(trainee_id: trainee.slug, id: trainee.degrees.first.slug)
   end
 
   def then_i_am_redirected_to_confirm_page
-    degrees_confirm_page.load(trainee_id: trainee.slug)
     expect(degrees_confirm_page).to be_displayed(trainee_id: trainee.slug)
   end
 
@@ -97,12 +115,39 @@ private
     expect(edit_degree_details_page.error_summary).to be_visible
   end
 
+  def and_i_click_update_record
+    degrees_confirm_page.update_record_button.click
+  end
+
+  def then_i_see_error_messages_for_partially_submitted_fields(*fields)
+    fields.each do |f|
+      message = I18n.t("activemodel.errors.validators.autocomplete.#{f}")
+      expect(degree_details_page).to have_content(message)
+    end
+  end
+
+  def and_i_fill_in_subject_without_selecting_a_value(with:)
+    degree_details_page.subject_raw.fill_in(with: with)
+  end
+
+  def then_subject_is_populated(with:)
+    expect(degree_details_page.subject_raw.value).to eq(with)
+  end
+
+  def and_i_fill_in_institution_without_selecting_a_value(with:)
+    degree_details_page.institution_raw.fill_in(with: with)
+  end
+
+  def then_institution_is_populated(with:)
+    expect(degree_details_page.institution_raw.value).to eq(with)
+  end
+
   def trainee
     (@uk_trainee || @non_uk_trainee)
   end
 
-  def uk_trainee
-    @uk_trainee ||= create(:trainee, provider: current_user.provider).tap do |t|
+  def uk_trainee(trait: :draft)
+    @uk_trainee ||= create(:trainee, trait, provider: current_user.provider).tap do |t|
       t.degrees << build(:degree, :uk_degree_type)
     end
   end
@@ -111,30 +156,5 @@ private
     @non_uk_trainee ||= create(:trainee, provider: current_user.provider).tap do |t|
       t.degrees << build(:degree, :non_uk_degree_type)
     end
-  end
-
-  def then_i_see_error_messages_for_partially_submitted_fields(*fields)
-    fields.each do |f|
-      message = I18n.t(
-        "activemodel.errors.validators.autocomplete.#{f}",
-      )
-      expect(degree_details_page).to have_content(message)
-    end
-  end
-
-  def and_i_fill_in_subject_without_selecting_a_value(with:)
-    degree_details_page.subject_raw.fill_in with: with
-  end
-
-  def then_subject_is_populated(with:)
-    expect(degree_details_page.subject_raw.value).to eq(with)
-  end
-
-  def and_i_fill_in_institution_without_selecting_a_value(with:)
-    degree_details_page.institution_raw.fill_in with: with
-  end
-
-  def then_institution_is_populated(with:)
-    expect(degree_details_page.institution_raw.value).to eq(with)
   end
 end

--- a/spec/support/page_objects/trainees/degrees_confirm.rb
+++ b/spec/support/page_objects/trainees/degrees_confirm.rb
@@ -9,6 +9,7 @@ module PageObjects
       element :main_content, "#main-content"
       element :delete_degree, "input[value='Delete degree']"
       element :inset_text, ".govuk-inset-text"
+      element :update_record_button, "input[name='commit'][value='Update record']"
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/pUgEHOAS/1615-bug-updating-degree-from-a-non-draft-trainee

### Changes proposed in this pull request
- Replace `DegreeForm` with `DegreesForm` in `Trainees::Degrees::ConfirmDetailsController`
- Add spec to ensure the code is covered for updating degrees for non-draft trainees which uses the `FormStore`

### Guidance to review
- Visit `/trainees`
- Filter by "Pending TRN" and choose a trainee
- Under the personal details tab, edit a degree, make change and update
- It should now work as expected
