### PR TITLE
[1594][SPIKE] schools search performance spike

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -146,3 +146,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
+
+gem "activerecord-analyze"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
     activerecord (6.1.3.1)
       activemodel (= 6.1.3.1)
       activesupport (= 6.1.3.1)
+    activerecord-analyze (0.9.1)
+      rails (>= 5.1.0)
     activerecord-session_store (2.0.0)
       actionpack (>= 5.2.4.1)
       activerecord (>= 5.2.4.1)
@@ -501,6 +503,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-analyze
   activerecord-session_store
   amazing_print (~> 1.3)
   audited (~> 4.9)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -8,6 +8,7 @@ class School < ApplicationRecord
     using: {
       tsearch: {
         prefix: true,
+        tsvector_column: 'searchable',
       }
     }
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -3,7 +3,13 @@
 class School < ApplicationRecord
   include PgSearch::Model
 
-  pg_search_scope :search, against: %i[urn name town postcode], using: { tsearch: { prefix: true } }
+  pg_search_scope :search,
+    against: %i[urn name town postcode],
+    using: {
+      tsearch: {
+        prefix: true,
+      }
+    }
 
   scope :open, -> { where(close_date: nil) }
   scope :lead_only, -> { where(lead_school: true) }

--- a/db/migrate/20210426105838_add_searchable_to_schools.rb
+++ b/db/migrate/20210426105838_add_searchable_to_schools.rb
@@ -14,16 +14,26 @@ class AddSearchableToSchools < ActiveRecord::Migration[6.1]
       ALTER TEXT SEARCH CONFIGURATION public.schools_search_config
       ALTER MAPPING FOR asciiword WITH public.school_dict;
 
+      CREATE FUNCTION school_trigger() RETURNS trigger AS $$
+      begin
+        new.searchable := to_tsvector(
+          'public.schools_search_config',
+          CONCAT(new.urn, ' ', new.name, ' ', new.postcode, ' ', REPLACE(new.postcode, ' ', ''), ' ', new.town)
+        );
+        return new;
+      end
+      $$ LANGUAGE plpgsql;
+
       CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE
-      ON schools FOR EACH ROW EXECUTE PROCEDURE
-      tsvector_update_trigger(searchable, 'public.schools_search_config', urn, name, postcode, town);
+      ON schools FOR EACH ROW EXECUTE PROCEDURE school_trigger();
     SQL
   end
 
   def down
     execute <<-SQL
-      DROP TEXT SEARCH CONFIGURATION public.schools_search_config
-      DROP TEXT SEARCH DICTIONARY public.schools_search_config
+      DROP TEXT SEARCH CONFIGURATION public.schools_search_config;
+      DROP TEXT SEARCH DICTIONARY public.schools_search_config;
+      DROP FUNCTION school_trigger;
       DROP TRIGGER tsvectorupdate ON schools;
     SQL
 
@@ -33,7 +43,7 @@ class AddSearchableToSchools < ActiveRecord::Migration[6.1]
 end
 
 __END__
-irb(main):013:0> SchoolSearch.call(query: "a").analyze
+irb(main):015:0> SchoolSearch.call(query: "a").analyze
 =>
 EXPLAIN ANALYZE for: SELECT "schools".* FROM "schools" INNER JOIN (SELECT "schools"."id" AS pg_search_id, (ts_rank(("schools"."searchable"), (to_
 tsquery('simple', ''' ' || 'a' || ' ''' || ':*')), 0)) AS rank FROM "schools" WHERE (("schools"."searchable") @@ (to_tsquery('simple', ''' ' || '
@@ -42,27 +52,27 @@ ose_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "schools"
                                                                          QUERY PLAN
 -------------------------------------------------------------------------------------------------------------------------------------------------
 ------------
- Sort  (cost=3962.35..3971.37 rows=3606 width=207) (actual time=42.427..42.885 rows=6318 loops=1)
+ Sort  (cost=4152.66..4161.57 rows=3562 width=222) (actual time=41.338..41.775 rows=6318 loops=1)
    Sort Key: (ts_rank(schools_1.searchable, '''a'':*'::tsquery, 0)) DESC, schools.id
-   Sort Method: quicksort  Memory: 2320kB
-   ->  Hash Join  (cost=1711.45..3749.30 rows=3606 width=207) (actual time=10.447..31.089 rows=6318 loops=1)
+   Sort Method: quicksort  Memory: 2531kB
+   ->  Hash Join  (cost=1806.76..3942.53 rows=3562 width=222) (actual time=10.235..30.962 rows=6318 loops=1)
          Hash Cond: (schools.id = schools_1.id)
-         ->  Seq Scan on schools  (cost=0.00..1957.29 rows=27252 width=203) (actual time=0.006..11.824 rows=27283 loops=1)
+         ->  Seq Scan on schools  (cost=0.00..2055.29 rows=27263 width=218) (actual time=0.006..12.135 rows=27283 loops=1)
                Filter: (close_date IS NULL)
                Rows Removed by Filter: 21746
-         ->  Hash  (cost=1630.36..1630.36 rows=6487 width=125) (actual time=10.422..10.423 rows=8955 loops=1)
-               Buckets: 16384 (originally 8192)  Batches: 1 (originally 1)  Memory Usage: 1586kB
-               ->  Bitmap Heap Scan on schools schools_1  (cost=82.28..1630.36 rows=6487 width=125) (actual time=3.023..7.221 rows=8955 loops=1)
+         ->  Hash  (cost=1726.70..1726.70 rows=6405 width=140) (actual time=10.215..10.216 rows=8955 loops=1)
+               Buckets: 16384 (originally 8192)  Batches: 1 (originally 1)  Memory Usage: 1718kB
+               ->  Bitmap Heap Scan on schools schools_1  (cost=81.64..1726.70 rows=6405 width=140) (actual time=2.999..7.133 rows=8955 loops=1)
                      Recheck Cond: (searchable @@ '''a'':*'::tsquery)
-                     Heap Blocks: exact=1379
-                     ->  Bitmap Index Scan on index_schools_on_searchable  (cost=0.00..80.66 rows=6487 width=0) (actual time=2.849..2.849 rows=89
+                     Heap Blocks: exact=1469
+                     ->  Bitmap Index Scan on index_schools_on_searchable  (cost=0.00..80.03 rows=6405 width=0) (actual time=2.817..2.817 rows=89
 55 loops=1)
                            Index Cond: (searchable @@ '''a'':*'::tsquery)
- Planning Time: 0.365 ms
- Execution Time: 44.405 ms
+ Planning Time: 0.368 ms
+ Execution Time: 43.233 ms
 (17 rows)
 
-irb(main):019:0> SchoolSearch.call(query: "alper").analyze
+irb(main):016:0> SchoolSearch.call(query: "alper").analyze
 =>
 EXPLAIN ANALYZE for: SELECT "schools".* FROM "schools" INNER JOIN (SELECT "schools"."id" AS pg_search_id, (ts_rank(("schools"."searchable"), (to_
 tsquery('simple', ''' ' || 'alper' || ' ''' || ':*')), 0)) AS rank FROM "schools" WHERE (("schools"."searchable") @@ (to_tsquery('simple', ''' '
@@ -71,18 +81,19 @@ ols"."close_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "
                                                                     QUERY PLAN
 -------------------------------------------------------------------------------------------------------------------------------------------------
 -
- Sort  (cost=247.96..247.98 rows=11 width=207) (actual time=0.048..0.049 rows=1 loops=1)
+ Sort  (cost=248.16..248.19 rows=11 width=222) (actual time=0.048..0.049 rows=1 loops=1)
    Sort Key: (ts_rank(schools_1.searchable, '''alper'':*'::tsquery, 0)) DESC, schools.id
    Sort Method: quicksort  Memory: 25kB
-   ->  Nested Loop  (cost=24.44..247.77 rows=11 width=207) (actual time=0.041..0.043 rows=1 loops=1)
-         ->  Bitmap Heap Scan on schools schools_1  (cost=24.15..93.90 rows=19 width=125) (actual time=0.020..0.022 rows=2 loops=1)
+   ->  Nested Loop  (cost=24.44..247.97 rows=11 width=222) (actual time=0.041..0.042 rows=1 loops=1)
+         ->  Bitmap Heap Scan on schools schools_1  (cost=24.15..94.10 rows=19 width=140) (actual time=0.021..0.023 rows=2 loops=1)
                Recheck Cond: (searchable @@ '''alper'':*'::tsquery)
                Heap Blocks: exact=2
                ->  Bitmap Index Scan on index_schools_on_searchable  (cost=0.00..24.14 rows=19 width=0) (actual time=0.017..0.017 rows=2 loops=1)
                      Index Cond: (searchable @@ '''alper'':*'::tsquery)
-         ->  Index Scan using schools_pkey on schools  (cost=0.29..8.10 rows=1 width=203) (actual time=0.007..0.007 rows=0 loops=2)
+         ->  Index Scan using schools_pkey on schools  (cost=0.29..8.10 rows=1 width=218) (actual time=0.006..0.006 rows=0 loops=2)
                Index Cond: (id = schools_1.id)
                Filter: (close_date IS NULL)
                Rows Removed by Filter: 0
- Planning Time: 0.481 ms
- Execution Time: 1.250 ms
+ Planning Time: 0.487 ms
+ Execution Time: 0.095 ms
+(15 rows)

--- a/db/migrate/20210426105838_add_searchable_to_schools.rb
+++ b/db/migrate/20210426105838_add_searchable_to_schools.rb
@@ -4,49 +4,65 @@ class AddSearchableToSchools < ActiveRecord::Migration[6.1]
     add_index :schools, :searchable, using: :gin
 
     execute <<-SQL
+      CREATE TEXT SEARCH CONFIGURATION public.schools_search_config (copy=simple);
+
+      CREATE TEXT SEARCH DICTIONARY public.school_dict (
+        TEMPLATE = pg_catalog.simple,
+        STOPWORDS = english
+      );
+
+      ALTER TEXT SEARCH CONFIGURATION public.schools_search_config
+      ALTER MAPPING FOR asciiword WITH public.school_dict;
+
       CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE
       ON schools FOR EACH ROW EXECUTE PROCEDURE
-      tsvector_update_trigger(searchable, 'pg_catalog.simple', urn, name, postcode, town);
+      tsvector_update_trigger(searchable, 'public.schools_search_config', urn, name, postcode, town);
     SQL
   end
 
   def down
-    execute "DROP TRIGGER tsvectorupdate ON schools"
+    execute <<-SQL
+      DROP TEXT SEARCH CONFIGURATION public.schools_search_config
+      DROP TEXT SEARCH DICTIONARY public.schools_search_config
+      DROP TRIGGER tsvectorupdate ON schools;
+    SQL
 
     remove_index :schools, :searchable
     remove_column :schools, :searchable
   end
 end
 
-
 __END__
-
 irb(main):013:0> SchoolSearch.call(query: "a").analyze
-                                                                          QUERY PLAN
+=>
+EXPLAIN ANALYZE for: SELECT "schools".* FROM "schools" INNER JOIN (SELECT "schools"."id" AS pg_search_id, (ts_rank(("schools"."searchable"), (to_
+tsquery('simple', ''' ' || 'a' || ' ''' || ':*')), 0)) AS rank FROM "schools" WHERE (("schools"."searchable") @@ (to_tsquery('simple', ''' ' || '
+a' || ' ''' || ':*')))) AS pg_search_f79e2ecc220dc52eaea688 ON "schools"."id" = pg_search_f79e2ecc220dc52eaea688.pg_search_id WHERE "schools"."cl
+ose_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "schools"."id" ASC
+                                                                         QUERY PLAN
 -------------------------------------------------------------------------------------------------------------------------------------------------
---------------
- Sort  (cost=4288.64..4301.39 rows=5098 width=211) (actual time=50.240..50.776 rows=7667 loops=1)
+------------
+ Sort  (cost=3962.35..3971.37 rows=3606 width=207) (actual time=42.427..42.885 rows=6318 loops=1)
    Sort Key: (ts_rank(schools_1.searchable, '''a'':*'::tsquery, 0)) DESC, schools.id
-   Sort Method: quicksort  Memory: 3004kB
-   ->  Hash Join  (cost=1910.39..3974.72 rows=5098 width=211) (actual time=12.923..35.951 rows=7667 loops=1)
+   Sort Method: quicksort  Memory: 2320kB
+   ->  Hash Join  (cost=1711.45..3749.30 rows=3606 width=207) (actual time=10.447..31.089 rows=6318 loops=1)
          Hash Cond: (schools.id = schools_1.id)
-         ->  Seq Scan on schools  (cost=0.00..1980.81 rows=26954 width=207) (actual time=0.005..12.401 rows=27283 loops=1)
+         ->  Seq Scan on schools  (cost=0.00..1957.29 rows=27252 width=203) (actual time=0.006..11.824 rows=27283 loops=1)
                Filter: (close_date IS NULL)
                Rows Removed by Filter: 21746
-         ->  Hash  (cost=1794.59..1794.59 rows=9264 width=129) (actual time=12.902..12.903 rows=11608 loops=1)
-               Buckets: 16384  Batches: 1  Memory Usage: 2140kB
-               ->  Bitmap Heap Scan on schools schools_1  (cost=187.79..1794.59 rows=9264 width=129) (actual time=3.920..9.041 rows=11608 loops=1
-)
+         ->  Hash  (cost=1630.36..1630.36 rows=6487 width=125) (actual time=10.422..10.423 rows=8955 loops=1)
+               Buckets: 16384 (originally 8192)  Batches: 1 (originally 1)  Memory Usage: 1586kB
+               ->  Bitmap Heap Scan on schools schools_1  (cost=82.28..1630.36 rows=6487 width=125) (actual time=3.023..7.221 rows=8955 loops=1)
                      Recheck Cond: (searchable @@ '''a'':*'::tsquery)
-                     Heap Blocks: exact=1464
-                     ->  Bitmap Index Scan on index_schools_on_searchable  (cost=0.00..185.48 rows=9264 width=0) (actual time=3.737..3.737 rows=1
-1608 loops=1)
+                     Heap Blocks: exact=1379
+                     ->  Bitmap Index Scan on index_schools_on_searchable  (cost=0.00..80.66 rows=6487 width=0) (actual time=2.849..2.849 rows=89
+55 loops=1)
                            Index Cond: (searchable @@ '''a'':*'::tsquery)
- Planning Time: 0.431 ms
- Execution Time: 52.593 ms
+ Planning Time: 0.365 ms
+ Execution Time: 44.405 ms
 (17 rows)
 
-irb(main):013:0> SchoolSearch.call(query: "alper").analyze
+irb(main):019:0> SchoolSearch.call(query: "alper").analyze
 =>
 EXPLAIN ANALYZE for: SELECT "schools".* FROM "schools" INNER JOIN (SELECT "schools"."id" AS pg_search_id, (ts_rank(("schools"."searchable"), (to_
 tsquery('simple', ''' ' || 'alper' || ' ''' || ':*')), 0)) AS rank FROM "schools" WHERE (("schools"."searchable") @@ (to_tsquery('simple', ''' '
@@ -54,23 +70,19 @@ tsquery('simple', ''' ' || 'alper' || ' ''' || ':*')), 0)) AS rank FROM "schools
 ols"."close_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "schools"."id" ASC
                                                                     QUERY PLAN
 -------------------------------------------------------------------------------------------------------------------------------------------------
---
- Sort  (cost=327.98..328.01 rows=10 width=211) (actual time=0.453..0.454 rows=1 loops=1)
+-
+ Sort  (cost=247.96..247.98 rows=11 width=207) (actual time=0.048..0.049 rows=1 loops=1)
    Sort Key: (ts_rank(schools_1.searchable, '''alper'':*'::tsquery, 0)) DESC, schools.id
    Sort Method: quicksort  Memory: 25kB
-   ->  Nested Loop  (cost=104.44..327.82 rows=10 width=211) (actual time=0.447..0.448 rows=1 loops=1)
-         ->  Bitmap Heap Scan on schools schools_1  (cost=104.15..173.95 rows=19 width=129) (actual time=0.426..0.429 rows=2 loops=1)
+   ->  Nested Loop  (cost=24.44..247.77 rows=11 width=207) (actual time=0.041..0.043 rows=1 loops=1)
+         ->  Bitmap Heap Scan on schools schools_1  (cost=24.15..93.90 rows=19 width=125) (actual time=0.020..0.022 rows=2 loops=1)
                Recheck Cond: (searchable @@ '''alper'':*'::tsquery)
                Heap Blocks: exact=2
-               ->  Bitmap Index Scan on index_schools_on_searchable  (cost=0.00..104.14 rows=19 width=0) (actual time=0.423..0.423 rows=2 loops=1
-)
+               ->  Bitmap Index Scan on index_schools_on_searchable  (cost=0.00..24.14 rows=19 width=0) (actual time=0.017..0.017 rows=2 loops=1)
                      Index Cond: (searchable @@ '''alper'':*'::tsquery)
-         ->  Index Scan using schools_pkey on schools  (cost=0.29..8.10 rows=1 width=207) (actual time=0.006..0.006 rows=0 loops=2)
+         ->  Index Scan using schools_pkey on schools  (cost=0.29..8.10 rows=1 width=203) (actual time=0.007..0.007 rows=0 loops=2)
                Index Cond: (id = schools_1.id)
                Filter: (close_date IS NULL)
                Rows Removed by Filter: 0
- Planning Time: 0.475 ms
- Execution Time: 0.497 ms
-(15 rows)
-
-irb(main):014:0>
+ Planning Time: 0.481 ms
+ Execution Time: 1.250 ms

--- a/db/migrate/20210426105838_add_searchable_to_schools.rb
+++ b/db/migrate/20210426105838_add_searchable_to_schools.rb
@@ -2,6 +2,7 @@ class AddSearchableToSchools < ActiveRecord::Migration[6.1]
   def up
     add_column :schools, :searchable, :tsvector
     add_index :schools, :searchable, using: :gin
+    add_index :schools, :close_date, where: "close_date is NULL"
 
     execute <<-SQL
       CREATE TEXT SEARCH CONFIGURATION public.schools_search_config (copy=simple);
@@ -38,49 +39,44 @@ class AddSearchableToSchools < ActiveRecord::Migration[6.1]
     SQL
 
     remove_index :schools, :searchable
+    remove_index :schools, :close_date
     remove_column :schools, :searchable
   end
 end
 
 __END__
-irb(main):015:0> SchoolSearch.call(query: "a").analyze
+irb(main):078:0> SchoolSearch.call(query: "a").analyze
 =>
-EXPLAIN ANALYZE for: SELECT "schools".* FROM "schools" INNER JOIN (SELECT "schools"."id" AS pg_search_id, (ts_rank(("schools"."searchable"), (to_
-tsquery('simple', ''' ' || 'a' || ' ''' || ':*')), 0)) AS rank FROM "schools" WHERE (("schools"."searchable") @@ (to_tsquery('simple', ''' ' || '
-a' || ' ''' || ':*')))) AS pg_search_f79e2ecc220dc52eaea688 ON "schools"."id" = pg_search_f79e2ecc220dc52eaea688.pg_search_id WHERE "schools"."cl
-ose_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "schools"."id" ASC
+EXPLAIN ANALYZE for: SELECT "schools".* FROM "schools" INNER JOIN (SELECT "schools"."id" AS pg_search_id, (ts_rank(("schools"."searchable"), (to_tsquery('simple', ''' ' || 'a' || ' ''' || ':*')), 0)) AS rank FROM "schools" WHERE (("schools"."searchable") @@ (to_tsquery('simple', ''' ' || 'a
+' || ' ''' || ':*')))) AS pg_search_f79e2ecc220dc52eaea688 ON "schools"."id" = pg_search_f79e2ecc220dc52eaea688.pg_search_id WHERE "schools"."close_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "schools"."id" ASC
                                                                          QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------
-------------
- Sort  (cost=4152.66..4161.57 rows=3562 width=222) (actual time=41.338..41.775 rows=6318 loops=1)
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=4041.88..4050.85 rows=3586 width=222) (actual time=35.829..36.244 rows=6318 loops=1)
    Sort Key: (ts_rank(schools_1.searchable, '''a'':*'::tsquery, 0)) DESC, schools.id
    Sort Method: quicksort  Memory: 2531kB
-   ->  Hash Join  (cost=1806.76..3942.53 rows=3562 width=222) (actual time=10.235..30.962 rows=6318 loops=1)
+   ->  Hash Join  (cost=1912.33..3830.16 rows=3586 width=222) (actual time=12.265..26.560 rows=6318 loops=1)
          Hash Cond: (schools.id = schools_1.id)
-         ->  Seq Scan on schools  (cost=0.00..2055.29 rows=27263 width=218) (actual time=0.006..12.135 rows=27283 loops=1)
-               Filter: (close_date IS NULL)
-               Rows Removed by Filter: 21746
-         ->  Hash  (cost=1726.70..1726.70 rows=6405 width=140) (actual time=10.215..10.216 rows=8955 loops=1)
+         ->  Bitmap Heap Scan on schools  (cost=103.90..1941.26 rows=27236 width=218) (actual time=2.068..7.509 rows=27283 loops=1)
+               Recheck Cond: (close_date IS NULL)
+               Heap Blocks: exact=1481
+               ->  Bitmap Index Scan on index_schools_on_close_date  (cost=0.00..97.09 rows=27236 width=0) (actual time=1.872..1.872 rows=27283 loops=1)
+         ->  Hash  (cost=1727.73..1727.73 rows=6456 width=140) (actual time=10.187..10.188 rows=8955 loops=1)
                Buckets: 16384 (originally 8192)  Batches: 1 (originally 1)  Memory Usage: 1718kB
-               ->  Bitmap Heap Scan on schools schools_1  (cost=81.64..1726.70 rows=6405 width=140) (actual time=2.999..7.133 rows=8955 loops=1)
+               ->  Bitmap Heap Scan on schools schools_1  (cost=82.03..1727.73 rows=6456 width=140) (actual time=3.010..7.222 rows=8955 loops=1)
                      Recheck Cond: (searchable @@ '''a'':*'::tsquery)
                      Heap Blocks: exact=1469
-                     ->  Bitmap Index Scan on index_schools_on_searchable  (cost=0.00..80.03 rows=6405 width=0) (actual time=2.817..2.817 rows=89
-55 loops=1)
+                     ->  Bitmap Index Scan on index_schools_on_searchable  (cost=0.00..80.42 rows=6456 width=0) (actual time=2.819..2.819 rows=8955 loops=1)
                            Index Cond: (searchable @@ '''a'':*'::tsquery)
- Planning Time: 0.368 ms
- Execution Time: 43.233 ms
-(17 rows)
+ Planning Time: 0.386 ms
+ Execution Time: 37.850 ms
+(18 rows)
 
-irb(main):016:0> SchoolSearch.call(query: "alper").analyze
+irb(main):079:0> SchoolSearch.call(query: "alper").analyze
 =>
-EXPLAIN ANALYZE for: SELECT "schools".* FROM "schools" INNER JOIN (SELECT "schools"."id" AS pg_search_id, (ts_rank(("schools"."searchable"), (to_
-tsquery('simple', ''' ' || 'alper' || ' ''' || ':*')), 0)) AS rank FROM "schools" WHERE (("schools"."searchable") @@ (to_tsquery('simple', ''' '
-|| 'alper' || ' ''' || ':*')))) AS pg_search_f79e2ecc220dc52eaea688 ON "schools"."id" = pg_search_f79e2ecc220dc52eaea688.pg_search_id WHERE "scho
-ols"."close_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "schools"."id" ASC
+EXPLAIN ANALYZE for: SELECT "schools".* FROM "schools" INNER JOIN (SELECT "schools"."id" AS pg_search_id, (ts_rank(("schools"."searchable"), (to_tsquery('simple', ''' ' || 'alper' || ' ''' || ':*')), 0)) AS rank FROM "schools" WHERE (("schools"."searchable") @@ (to_tsquery('simple', ''' ' |
+| 'alper' || ' ''' || ':*')))) AS pg_search_f79e2ecc220dc52eaea688 ON "schools"."id" = pg_search_f79e2ecc220dc52eaea688.pg_search_id WHERE "schools"."close_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "schools"."id" ASC
                                                                     QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------
--
+--------------------------------------------------------------------------------------------------------------------------------------------------
  Sort  (cost=248.16..248.19 rows=11 width=222) (actual time=0.048..0.049 rows=1 loops=1)
    Sort Key: (ts_rank(schools_1.searchable, '''alper'':*'::tsquery, 0)) DESC, schools.id
    Sort Method: quicksort  Memory: 25kB
@@ -94,6 +90,6 @@ ols"."close_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "
                Index Cond: (id = schools_1.id)
                Filter: (close_date IS NULL)
                Rows Removed by Filter: 0
- Planning Time: 0.487 ms
- Execution Time: 0.095 ms
+ Planning Time: 0.506 ms
+ Execution Time: 0.094 ms
 (15 rows)

--- a/db/migrate/20210426105838_add_searchable_to_schools.rb
+++ b/db/migrate/20210426105838_add_searchable_to_schools.rb
@@ -1,0 +1,87 @@
+class AddSearchableToSchools < ActiveRecord::Migration[6.1]
+  def change
+    execute "CREATE EXTENSION btree_gin"
+    add_index :schools, :close_date, where: "close_date is NULL"
+    add_index :schools, :name, using: :gin
+    add_index :schools, :postcode, using: :gin
+    add_index :schools, :town, using: :gin
+  end
+end
+
+__END__
+
+irb(main):004:0> SchoolSearch.call(query: "a").analyze
+=>
+EXPLAIN ANALYZE for: SELECT "schools".* FROM "schools" INNER JOIN (SELECT "schools"."id" AS pg_search_id, (ts_rank((to_tsvector('simple', coalesc
+e("schools"."urn"::text, '')) || to_tsvector('simple', coalesce("schools"."name"::text, '')) || to_tsvector('simple', coalesce("schools"."town"::
+text, '')) || to_tsvector('simple', coalesce("schools"."postcode"::text, ''))), (to_tsquery('simple', ''' ' || 'a' || ' ''' || ':*')), 0)) AS ran
+k FROM "schools" WHERE ((to_tsvector('simple', coalesce("schools"."urn"::text, '')) || to_tsvector('simple', coalesce("schools"."name"::text, '')
+) || to_tsvector('simple', coalesce("schools"."town"::text, '')) || to_tsvector('simple', coalesce("schools"."postcode"::text, ''))) @@ (to_tsque
+ry('simple', ''' ' || 'a' || ' ''' || ':*')))) AS pg_search_f79e2ecc220dc52eaea688 ON "schools"."id" = pg_search_f79e2ecc220dc52eaea688.pg_search
+_id WHERE "schools"."close_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "schools"."id" ASC
+
+                                                QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------
+ Gather Merge  (cost=29606.58..29641.77 rows=306 width=90) (actual time=244.603..248.447 rows=7667 loops=1)
+   Workers Planned: 1
+   Workers Launched: 1
+   ->  Sort  (cost=28606.57..28607.33 rows=306 width=90) (actual time=241.919..242.225 rows=3834 loops=2)
+         Sort Key: (ts_rank((((to_tsvector('simple'::regconfig, COALESCE((schools_1.urn)::text, ''::text)) || to_tsvector('simple'::regconfig, CO
+ALESCE((schools_1.name)::text, ''::text))) || to_tsvector('simple'::regconfig, COALESCE((schools_1.town)::text, ''::text))) || to_tsvector('simpl
+e'::regconfig, COALESCE((schools_1.postcode)::text, ''::text))), '''a'':*'::tsquery, 0)) DESC, schools.id
+         Sort Method: quicksort  Memory: 733kB
+         Worker 0:  Sort Method: quicksort  Memory: 710kB
+         ->  Nested Loop  (cost=0.29..28593.93 rows=306 width=90) (actual time=0.214..235.947 rows=3834 loops=2)
+               ->  Parallel Seq Scan on schools  (cost=0.00..2387.41 rows=15306 width=86) (actual time=0.010..11.852 rows=13642 loops=2)
+                     Filter: (close_date IS NULL)
+                     Rows Removed by Filter: 10873
+               ->  Index Scan using schools_pkey on schools schools_1  (cost=0.29..1.69 rows=1 width=61) (actual time=0.013..0.013 rows=0 loops=2
+7283)
+                     Index Cond: (id = schools.id)
+                     Filter: ((((to_tsvector('simple'::regconfig, COALESCE((urn)::text, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((
+name)::text, ''::text))) || to_tsvector('simple'::regconfig, COALESCE((town)::text, ''::text))) || to_tsvector('simple'::regconfig, COALESCE((pos
+tcode)::text, ''::text))) @@ '''a'':*'::tsquery)
+                     Rows Removed by Filter: 1
+ Planning Time: 0.403 ms
+ Execution Time: 249.218 ms
+(17 rows)
+
+irb(main):005:0> SchoolSearch.call(query: "alper").analyze
+=>
+EXPLAIN ANALYZE for: SELECT "schools".* FROM "schools" INNER JOIN (SELECT "schools"."id" AS pg_search_id, (ts_rank((to_tsvector('simple', coalesc
+e("schools"."urn"::text, '')) || to_tsvector('simple', coalesce("schools"."name"::text, '')) || to_tsvector('simple', coalesce("schools"."town"::
+text, '')) || to_tsvector('simple', coalesce("schools"."postcode"::text, ''))), (to_tsquery('simple', ''' ' || 'alper' || ' ''' || ':*')), 0)) AS
+ rank FROM "schools" WHERE ((to_tsvector('simple', coalesce("schools"."urn"::text, '')) || to_tsvector('simple', coalesce("schools"."name"::text,
+ '')) || to_tsvector('simple', coalesce("schools"."town"::text, '')) || to_tsvector('simple', coalesce("schools"."postcode"::text, ''))) @@ (to_t
+squery('simple', ''' ' || 'alper' || ' ''' || ':*')))) AS pg_search_f79e2ecc220dc52eaea688 ON "schools"."id" = pg_search_f79e2ecc220dc52eaea688.p
+g_search_id WHERE "schools"."close_date" IS NULL ORDER BY pg_search_f79e2ecc220dc52eaea688.rank DESC, "schools"."id" ASC
+
+                                                  QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------
+ Gather Merge  (cost=29606.58..29641.77 rows=306 width=90) (actual time=199.228..200.617 rows=1 loops=1)
+   Workers Planned: 1
+   Workers Launched: 1
+   ->  Sort  (cost=28606.57..28607.33 rows=306 width=90) (actual time=196.112..196.113 rows=0 loops=2)
+         Sort Key: (ts_rank((((to_tsvector('simple'::regconfig, COALESCE((schools_1.urn)::text, ''::text)) || to_tsvector('simple'::regconfig, CO
+ALESCE((schools_1.name)::text, ''::text))) || to_tsvector('simple'::regconfig, COALESCE((schools_1.town)::text, ''::text))) || to_tsvector('simpl
+e'::regconfig, COALESCE((schools_1.postcode)::text, ''::text))), '''alper'':*'::tsquery, 0)) DESC, schools.id
+         Sort Method: quicksort  Memory: 25kB
+         Worker 0:  Sort Method: quicksort  Memory: 25kB
+         ->  Nested Loop  (cost=0.29..28593.93 rows=306 width=90) (actual time=122.281..196.059 rows=0 loops=2)
+               ->  Parallel Seq Scan on schools  (cost=0.00..2387.41 rows=15306 width=86) (actual time=0.008..11.247 rows=13642 loops=2)
+                     Filter: (close_date IS NULL)
+                     Rows Removed by Filter: 10873
+               ->  Index Scan using schools_pkey on schools schools_1  (cost=0.29..1.69 rows=1 width=61) (actual time=0.013..0.013 rows=0 loops=2
+7283)
+                     Index Cond: (id = schools.id)
+                     Filter: ((((to_tsvector('simple'::regconfig, COALESCE((urn)::text, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((
+name)::text, ''::text))) || to_tsvector('simple'::regconfig, COALESCE((town)::text, ''::text))) || to_tsvector('simple'::regconfig, COALESCE((pos
+tcode)::text, ''::text))) @@ '''alper'':*'::tsquery)
+                     Rows Removed by Filter: 1
+ Planning Time: 0.382 ms
+ Execution Time: 200.672 ms
+(17 rows)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -180,6 +180,7 @@ ActiveRecord::Schema.define(version: 2021_04_26_105838) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "lead_school", null: false
     t.tsvector "searchable"
+    t.index ["close_date"], name: "index_schools_on_close_date", where: "(close_date IS NULL)"
     t.index ["lead_school"], name: "index_schools_on_lead_school", where: "(lead_school IS TRUE)"
     t.index ["searchable"], name: "index_schools_on_searchable", using: :gin
     t.index ["urn"], name: "index_schools_on_urn", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,10 @@
 ActiveRecord::Schema.define(version: 2021_04_26_105838) do
 
   # These are extensions that must be enabled in order to support this database
+<<<<<<< HEAD
   enable_extension "btree_gin"
+=======
+>>>>>>> 430ecdd3... Using a tsvector column - much faster
   enable_extension "plpgsql"
 
   create_table "apply_application_sync_requests", force: :cascade do |t|
@@ -176,11 +179,9 @@ ActiveRecord::Schema.define(version: 2021_04_26_105838) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "lead_school", null: false
-    t.index ["close_date"], name: "index_schools_on_close_date", where: "(close_date IS NULL)"
+    t.tsvector "searchable"
     t.index ["lead_school"], name: "index_schools_on_lead_school", where: "(lead_school IS TRUE)"
-    t.index ["name"], name: "index_schools_on_name", using: :gin
-    t.index ["postcode"], name: "index_schools_on_postcode", using: :gin
-    t.index ["town"], name: "index_schools_on_town", using: :gin
+    t.index ["searchable"], name: "index_schools_on_searchable", using: :gin
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_22_143630) do
+ActiveRecord::Schema.define(version: 2021_04_26_105838) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "btree_gin"
   enable_extension "plpgsql"
 
   create_table "apply_application_sync_requests", force: :cascade do |t|
@@ -83,8 +84,8 @@ ActiveRecord::Schema.define(version: 2021_04_22_143630) do
     t.integer "duration_in_years", null: false
     t.string "course_length", null: false
     t.integer "qualification", null: false
-    t.string "summary", null: false
     t.integer "route", null: false
+    t.string "summary", null: false
     t.integer "level", null: false
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
     t.index ["provider_id"], name: "index_courses_on_provider_id"
@@ -160,8 +161,8 @@ ActiveRecord::Schema.define(version: 2021_04_22_143630) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.string "code"
     t.boolean "apply_sync_enabled", default: false
+    t.string "code"
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
 
@@ -175,7 +176,11 @@ ActiveRecord::Schema.define(version: 2021_04_22_143630) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "lead_school", null: false
+    t.index ["close_date"], name: "index_schools_on_close_date", where: "(close_date IS NULL)"
     t.index ["lead_school"], name: "index_schools_on_lead_school", where: "(lead_school IS TRUE)"
+    t.index ["name"], name: "index_schools_on_name", using: :gin
+    t.index ["postcode"], name: "index_schools_on_postcode", using: :gin
+    t.index ["town"], name: "index_schools_on_town", using: :gin
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 


### PR DESCRIPTION
### Context

https://trello.com/c/EAY7n1vR/1594-spike-improve-schools-search-performance

### Changes proposed in this pull request

**TLDR: Why wait 200ms for search results when you can wait 0.094 ms**

4 different commits showing different iterations of improving performance and functionality of the schools search.

If we choose one of these approaches (I presume the last one), we will need to change CI to run migrations from scratch rather that using a schema load, or change the schema structure to sql, as the raw sql used in the migration cannot be represented in the .rb schema. Neither of these are ideal, but I think the performance boost justifies it.

### Guidance to review

This PR is laid out to be reviewed commit by commit. In each commit there is a description of the change, and in the migration file there is a comment at the bottom comparing the performance of a search for a single character (as we will be doing searches on keypress), and then for a partial place name.  It will probably be easier to open the migration file rather than viewing the diff for each commit. 

If you want to try this out locally and check the results. check out a particular commit and run:
```
bundle exec rake db:migrate schools_data:import

bundle exec rails c

=> SchoolSearch.call(query: "whatever").analyze
```

If you jump around different commits you will need to reset the database each time:
```
bundle exec rake db:drop db:create db:migrate schools_data:import
```

_edit: I meant to make this draft but now I seem to be unable to take that back, definitely don't merge this, it requires a couple of changes to make CI pass as mentioned above_