### PR TITLE
[1548] Alert if retrieve trn or qts/award jobs time out

### DIFF
--- a/app/lib/notify_on_timeout.rb
+++ b/app/lib/notify_on_timeout.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module NotifyOnTimeout
+  def send_message_to_slack(trainee, class_name)
+    SlackNotifierService.call(channel: Settings.slack.publish_register_alerts_channel, message: "#{class_name} for Trainee id: #{trainee.id} has timed out after #{Settings.jobs.max_poll_duration_days} days.",
+                              icon_emoji: ":this-is-fine:", username: "Register Trainee Teachers: Job Failure")
+  end
+end

--- a/spec/jobs/retrieve_award_job_spec.rb
+++ b/spec/jobs/retrieve_award_job_spec.rb
@@ -43,15 +43,17 @@ describe RetrieveAwardJob do
       end
     end
 
-    context "after the configured days of polling" do
+    context "timing out after after 4 days of polling" do
       let(:trainee) { create(:trainee, recommended_for_award_at: configured_limit.days.ago) }
-      let(:configured_limit) { 2 }
+      let(:configured_limit) { 4 }
 
       before do
         allow(Settings.jobs).to receive(:max_poll_duration_days).and_return(configured_limit)
+        allow(SlackNotifierService).to receive(:call)
       end
 
-      it "doesn't queue another job after 2 days have passed with no QTS" do
+      it "doesn't queue another job after 4 days have passed with no QTS" do
+        expect(SlackNotifierService).to receive(:call)
         described_class.perform_now(trainee)
         expect(RetrieveAwardJob).to_not have_been_enqueued
       end

--- a/spec/jobs/retrieve_trn_job_spec.rb
+++ b/spec/jobs/retrieve_trn_job_spec.rb
@@ -43,15 +43,17 @@ describe RetrieveTrnJob do
     end
   end
 
-  context "after 2 days of polling" do
+  context "timing out after 4 days of polling" do
     let(:trainee) { create(:trainee, submitted_for_trn_at: configured_limit.days.ago) }
-    let(:configured_limit) { 2 }
+    let(:configured_limit) { 4 }
 
     before do
       allow(Settings.jobs).to receive(:max_poll_duration_days).and_return(configured_limit)
+      allow(SlackNotifierService).to receive(:call)
     end
 
-    it "doesn't queue another job after 2 days have passed without a TRN" do
+    it "doesn't queue another job after 4 days have passed without a TRN" do
+      expect(SlackNotifierService).to receive(:call)
       described_class.perform_now(trainee)
       expect(RetrieveTrnJob).to_not have_been_enqueued
     end


### PR DESCRIPTION
### Context
https://trello.com/c/cetXU8sR/1548-alert-if-retrievetrn-qts-jobs-time-out
Jobs were timing out silently
### Changes proposed in this pull request
* Adds module with `send_message_to_slack` method that uses `SlackNotifierService`. The method is then used in both jobs, module is included. When polling takes longer than 4 days, the job ceases to continue polling and instead uses that method to send a failure message to #twd_publish_register_tech channel. 
* Adds extra method stub and assertions for job specs
<img width="567" alt="Screenshot 2021-04-28 at 19 52 41" src="https://user-images.githubusercontent.com/58793682/116457424-4ea72800-a85b-11eb-9a6d-bfc11ddba983.png">

### Guidance to review
Create new trainee in console and set required values. Set `trainee.submitted_for_trn_at` and/or `trainee.recommended_for_award_at` to 4 or more days ago, save trainee. Then run job(s)


