### PR TITLE
[1614] Active providers only

### DIFF
--- a/app/services/dttp/retrieve_providers.rb
+++ b/app/services/dttp/retrieve_providers.rb
@@ -14,8 +14,10 @@ module Dttp
 
     INSTITUTION_TYPES = CodeSets::InstitutionTypes::MAPPING.values.flat_map { |institution| "_dfe_institutiontypeid_value eq #{institution[:entity_id]}" }.join(" or ")
 
+    ACTIVE_STATECODE = 0
+    ACTIVE_STATUSCODE = 1
     FILTER = {
-      "$filter" => "dfe_provider eq true and (#{INSTITUTION_TYPES})",
+      "$filter" => "dfe_provider eq true and (#{INSTITUTION_TYPES}) and statecode eq #{ACTIVE_STATECODE} and statuscode eq #{ACTIVE_STATUSCODE}",
     }.freeze
 
     SELECT = {

--- a/spec/services/dttp/retrieve_providers_spec.rb
+++ b/spec/services/dttp/retrieve_providers_spec.rb
@@ -15,6 +15,15 @@ module Dttp
       allow(Client).to receive(:get).with(String, request_headers).and_return(dttp_response)
     end
 
+    let(:expected_path) do
+      "/accounts?%24filter=dfe_provider+eq+true+and+%28_dfe_institutiontypeid_value+eq+b5ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b7ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b9ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bbec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bdec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bfec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+c1ec33aa-216d-e711-80d2-005056ac45bb%29+and+statecode+eq+0+and+statuscode+eq+1&%24select=name%2Cdfe_ukprn%2Caccountid"
+    end
+
+    it "requests active organisations matching the institution type codeset" do
+      expect(Client).to receive(:get).with(expected_path, request_headers).and_return(dttp_response)
+      subject
+    end
+
     it "returns a hash containing expected items" do
       expect(subject).to eq({ items: [1, 2, 3], meta: { next_page_url: "https://example.com" } })
     end


### PR DESCRIPTION
### Context

We were retrieving inactive providers and they were often listed instead of their active counterparts where a provider has been recreated in DTTP. This seems to have happened a lot when names have been changed from <provider> (EBITT) to <provider>.

We'll need to clear the providers table and repopulate but I'll do that manually when deployed.

This may still not be the totally correct list of providers but it will be less broken than it currently is. I'm checking with the operations team and will update in another PR when I get some feedback.

### Changes proposed in this pull request

Retrieve only providers that are active from DTTP.

### Guidance to review

Check the DTTP providers list in the support bit. There are lots of (EBITT)-ses in the provider names. They have all been deactivated in DTTP.

Delete them all from your local DB and repopulate the table. They should have gone and be replaced by the correct version that you can cross reference with the DTTP back office.



