### PR TITLE
[1577] Use deferral date for withdraw date if deferred

### DIFF
--- a/app/components/trainees/confirmation/withdrawal_details/view.html.erb
+++ b/app/components/trainees/confirmation/withdrawal_details/view.html.erb
@@ -6,7 +6,7 @@
     {
       key: t("components.confirmation.withdrawal_details.withdraw_date_label"),
       value: withdraw_date,
-      action: govuk_link_to(t(:change), trainee_withdrawal_path(data_model.trainee)),
+      action: deferred ? nil : govuk_link_to(t(:change), trainee_withdrawal_path(data_model.trainee)),
     },
     {
       key: t("components.confirmation.withdrawal_details.withdraw_reason_label"),

--- a/app/components/trainees/confirmation/withdrawal_details/view.rb
+++ b/app/components/trainees/confirmation/withdrawal_details/view.rb
@@ -10,10 +10,11 @@ module Trainees
 
         def initialize(data_model)
           @data_model = data_model
+          @deferred = data_model.trainee.deferred?
         end
 
         def withdraw_date
-          date_for_summary_view(data_model.date)
+          deferred ? date_with_deferral_text : withdrawal_date
         end
 
         def withdraw_reason
@@ -21,6 +22,18 @@ module Trainees
 
           I18n.t("components.confirmation.withdrawal_details.reasons.#{data_model.withdraw_reason}")
         end
+
+      private
+
+        def date_with_deferral_text
+          I18n.t("components.confirmation.withdrawal_details.withdrawal_date", date: withdrawal_date)
+        end
+
+        def withdrawal_date
+          date_for_summary_view(data_model.date)
+        end
+
+        attr_reader :deferred
       end
     end
   end

--- a/app/components/trainees/confirmation/withdrawal_details/view.rb
+++ b/app/components/trainees/confirmation/withdrawal_details/view.rb
@@ -6,7 +6,7 @@ module Trainees
       class View < GovukComponent::Base
         include SummaryHelper
 
-        attr_reader :data_model
+        attr_reader :data_model, :deferred
 
         def initialize(data_model)
           @data_model = data_model
@@ -32,8 +32,6 @@ module Trainees
         def withdrawal_date
           date_for_summary_view(data_model.date)
         end
-
-        attr_reader :deferred
       end
     end
   end

--- a/app/forms/withdrawal_form.rb
+++ b/app/forms/withdrawal_form.rb
@@ -13,7 +13,7 @@ private
   end
 
   def date_field
-    @date_field ||= :withdraw_date
+    @date_field ||= trainee.deferred? ? :defer_date : :withdraw_date
   end
 
   def additional_fields

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -16,12 +16,26 @@
         Withdraw trainee
       </h1>
 
-      <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: t("views.forms.withdrawal_reasons.headings.withdrawal_date"), size: "s" }, classes: "withdraw-date") do %>
-        <%= f.govuk_radio_button :date_string, :today, label: { text: t("views.forms.common.today") }, link_errors: true %>
-        <%= f.govuk_radio_button :date_string, :yesterday, label: { text: t("views.forms.common.yesterday") } %>
-        <%= f.govuk_radio_button :date_string, :other, label: { text: t("views.forms.common.specific_date") } do %>
-          <%= f.govuk_date_field :date, legend: { text: t("views.forms.common.on_what_date"), size: "s" }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
+      <% if @trainee.deferred? %>
+        <h3 class="govuk-heading-s">Withdrawal date</h3>
+        <%= render GovukComponent::InsetText.new(classes: "deferral-notice") do %>
+          <p class="govuk-body deferral-notice_text">
+            <%= t("views.forms.withdrawal_date.deferral_notice_html", date: date_for_summary_view(@trainee.defer_date)) %>
+          </p>
+          <p class="govuk-body deferral-notice_link">
+            <%= t("views.forms.withdrawal_date.deferral_notice_link_html", reinstatement_link: govuk_link_to("reinstate this trainee", trainee_reinstatement_path(@trainee))) %>
+          </p>
         <% end %>
+      <% else %>
+
+        <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: t("views.forms.withdrawal_reasons.headings.withdrawal_date"), size: "s" }, classes: "withdraw-date") do %>
+          <%= f.govuk_radio_button :date_string, :today, label: { text: t("views.forms.common.today") }, link_errors: true %>
+          <%= f.govuk_radio_button :date_string, :yesterday, label: { text: t("views.forms.common.yesterday") } %>
+          <%= f.govuk_radio_button :date_string, :other, label: { text: t("views.forms.common.specific_date") } do %>
+            <%= f.govuk_date_field :date, legend: { text: t("views.forms.common.on_what_date"), size: "s" }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
+          <% end %>
+        <% end %>
+
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset(:withdraw_reason, legend: { text: t("views.forms.withdrawal_reasons.headings.withdrawal_reason"), size: "s" }) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
         summary_title: Reinstatement details
       withdrawal_details:
         summary_title: Withdrawal details
+        withdrawal_date: "%{date} (date of deferral)"
         withdraw_date_label: Date of withdrawal
         withdraw_reason_label: Reason for withdrawal
         reasons: &withdrawal_reasons
@@ -293,6 +294,9 @@ en:
           no_disability: "They shared that they’re not disabled"
       reinstatement:
         heading: When did the trainee return?
+      withdrawal_date:
+        deferral_notice_html: We’ll use the trainee’s deferral date of <span class="govuk-!-font-weight-bold">%{date}</span> as their withdrawal date.
+        deferral_notice_link_html: To use a different date, %{reinstatement_link}, then withdraw them.
       withdrawal_reasons:
         headings:
           withdrawal_date: When did the trainee withdraw?

--- a/spec/components/trainees/confirmation/withdrawal_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/withdrawal_details/view_spec.rb
@@ -42,4 +42,14 @@ RSpec.describe Trainees::Confirmation::WithdrawalDetails::View do
       expect(component).to have_text(data_model.additional_withdraw_reason)
     end
   end
+
+  context "when a deferral date is present" do
+    let(:trainee) { build(:trainee, :deferred, id: 1) }
+
+    it "renders the deferral date text " do
+      expect(component).to have_text(
+        I18n.t("components.confirmation.withdrawal_details.withdrawal_date", date: date_for_summary_view(withdraw_date)),
+      )
+    end
+  end
 end

--- a/spec/components/trainees/confirmation/withdrawal_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/withdrawal_details/view_spec.rb
@@ -51,5 +51,9 @@ RSpec.describe Trainees::Confirmation::WithdrawalDetails::View do
         I18n.t("components.confirmation.withdrawal_details.withdrawal_date", date: date_for_summary_view(withdraw_date)),
       )
     end
+
+    it "suppress the change link" do
+      expect(component.find(".date-of-withdrawal")).not_to have_link(t(:change))
+    end
   end
 end

--- a/spec/forms/withdrawal_form_spec.rb
+++ b/spec/forms/withdrawal_form_spec.rb
@@ -48,26 +48,43 @@ describe WithdrawalForm, type: :model do
   end
 
   describe "#fields" do
-    let(:params) do
-      {
-        "day" => "11",
-        "month" => "11",
-        "year" => "1963",
-        "date_string" => "other",
-        "withdraw_reason" => WithdrawalReasons::HEALTH_REASONS,
-        "additional_withdraw_reason" => "",
-      }
+    context "with params" do
+      let(:params) do
+        {
+          "day" => "11",
+          "month" => "11",
+          "year" => "1963",
+          "date_string" => "other",
+          "withdraw_reason" => WithdrawalReasons::HEALTH_REASONS,
+          "additional_withdraw_reason" => "",
+        }
+      end
+
+      it "combines the data from params with the existing trainee data" do
+        expect(subject.fields).to match({
+          date_string: "other",
+          day: "11",
+          month: "11",
+          year: "1963",
+          withdraw_reason: WithdrawalReasons::HEALTH_REASONS,
+          additional_withdraw_reason: "",
+        })
+      end
     end
 
-    it "combines the data from params with the existing trainee data" do
-      expect(subject.fields).to match({
-        date_string: "other",
-        day: "11",
-        month: "11",
-        year: "1963",
-        withdraw_reason: WithdrawalReasons::HEALTH_REASONS,
-        additional_withdraw_reason: "",
-      })
+    context "with deferral" do
+      let(:trainee) { create(:trainee, :deferred) }
+
+      it "hydrates the date values from the deferral date" do
+        expect(subject.fields).to match(
+          a_hash_including(
+            date_string: "other",
+            day: trainee.defer_date.day,
+            month: trainee.defer_date.month,
+            year: trainee.defer_date.year,
+          ),
+        )
+      end
     end
   end
 

--- a/spec/support/page_objects/sections/deferral_notice.rb
+++ b/spec/support/page_objects/sections/deferral_notice.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class DeferralNotice < PageObjects::Sections::Base
+      element :text, ".deferral-notice_text"
+      element :link, ".deferral-notice_link"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/withdrawal.rb
+++ b/spec/support/page_objects/trainees/withdrawal.rb
@@ -14,6 +14,8 @@ module PageObjects
       element :additional_withdraw_reason, "#withdrawal-form-additional-withdraw-reason-field"
 
       element :continue, "input[name='commit']"
+
+      section :deferral_notice, PageObjects::Sections::DeferralNotice, ".deferral-notice"
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/5UK9osuw/1577-s-dev-use-deferral-date-as-withdrawal-date-where-a-deferred-trainee-is-withdrawing

### Changes proposed in this pull request

- Use the deferral date as the withdrawal date when withdrawing a trainee that's been deferred.

![deferral](https://user-images.githubusercontent.com/616080/116544186-b5255800-a8e6-11eb-9d0d-ec902da7feb8.gif)

### Guidance to review

- Load a deferred trainee and withdraw them
- Assert the date is set to the deferral date
