### PR TITLE
[1619] Add schools component and render it in the record page

### DIFF
--- a/app/components/trainees/school_details/view.html.erb
+++ b/app/components/trainees/school_details/view.html.erb
@@ -1,0 +1,1 @@
+<%= render SummaryCard::View.new(trainee: trainee, title: t("components.school_details.summary_title"), heading_level: 2, rows: school_rows) %>

--- a/app/components/trainees/school_details/view.rb
+++ b/app/components/trainees/school_details/view.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Trainees
+  module SchoolDetails
+    class View < GovukComponent::Base
+      attr_reader :trainee, :lead_school, :employing_school
+
+      TYPES = {
+        lead: "lead",
+        employing: "employing",
+      }.freeze
+
+      def initialize(trainee)
+        @trainee = trainee
+        @lead_school = trainee.lead_school
+        @employing_school = trainee.employing_school
+      end
+
+      def school_rows
+        [lead_school_row, employing_school_row].compact
+      end
+
+      def lead_school_row
+        return if lead_school.blank?
+
+        {
+          key: t("components.school_details.lead_school_key"),
+          value: school_detail(lead_school),
+          action: change_link(TYPES[:lead]),
+
+        }
+      end
+
+      def employing_school_row
+        return if employing_school.blank?
+
+        {
+          key: t("components.school_details.employing_school_key"),
+          value: school_detail(employing_school),
+          action: change_link(TYPES[:employing]),
+        }
+      end
+
+    private
+
+      def school_detail(school)
+        tag.p(school.name, class: "govuk-body") + tag.span(location(school), class: "govuk-hint")
+      end
+
+      def location(school)
+        ["URN #{school.urn}", school.town, school.postcode].select(&:present?).join(", ")
+      end
+
+      def change_link(school_type)
+        govuk_link_to("Change<span class='govuk-visually-hidden'> #{school_type} school</span>".html_safe, change_paths(school_type))
+      end
+
+      def change_paths(school_type)
+        {
+          lead: trainee_lead_schools_path(trainee),
+          employing: trainee_employing_schools_path(trainee),
+        }[school_type.to_sym]
+      end
+    end
+  end
+end

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -10,6 +10,12 @@
   <%= render Trainees::Confirmation::CourseDetails::View.new(data_model: @trainee) %>
 </div>
 
+<% if @trainee.requires_schools? %>
+  <div class="school-details">
+    <%= render Trainees::SchoolDetails::View.new(@trainee) %>
+  </div>
+<% end %>
+
 <% if @trainee.requires_placement_details? %>
   <div class="placement-details">
     <%= render Trainees::Confirmation::PlacementDetails::View.new(trainee: @trainee) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,10 @@ en:
         trainee_start_date: start date
     course_detail:
       title: Course details
+    school_details:
+        summary_title: Schools
+        lead_school_key: Lead school
+        employing_school_key: Employing school
     placement_detail:
       title: Placement details
     degrees:

--- a/spec/components/trainees/school_details/view_preview.rb
+++ b/spec/components/trainees/school_details/view_preview.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module Trainees
+  module SchoolDetails
+    class ViewPreview < ViewComponent::Preview
+      def default
+        render(View.new(mock_trainee(with_employing: true)))
+      end
+
+      def with_only_one_school
+        render(View.new(mock_trainee))
+      end
+
+    private
+
+      def mock_trainee(with_employing: false)
+        @mock_trainee ||= Trainee.new(
+          id: 1,
+          lead_school: mock_school(lead: true),
+          employing_school: with_employing ? mock_school : nil,
+        )
+      end
+
+      def mock_school(lead: false)
+        @mock_school ||= School.new(
+          id: 1,
+          urn: "12345",
+          name: "Test School",
+          postcode: "E1 5DJ",
+          town: "London",
+          open_date: Time.zone.today,
+          lead_school: lead,
+        )
+      end
+    end
+  end
+end

--- a/spec/components/trainees/school_details/view_spec.rb
+++ b/spec/components/trainees/school_details/view_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  module SchoolDetails
+    describe View do
+      alias_method :component, :page
+
+      shared_examples("school row") do |field_name|
+        subject do
+          component.find(".govuk-summary-list__row.#{field_name.parameterize}")
+        end
+
+        it "renders the school type" do
+          expect(subject).to have_text(field_name.humanize)
+        end
+
+        it "renders the school name" do
+          expect(subject).to have_text(school.name)
+        end
+
+        it "renders the school location" do
+          expected_location_format = "URN #{school.urn}, #{school.town}, #{school.postcode}"
+          expect(subject).to have_text(expected_location_format)
+        end
+
+        it "renders the school change link" do
+          expect(subject).to have_link(t("change"))
+        end
+      end
+
+      context "with lead school" do
+        let(:trainee) { create(:trainee, :school_direct_salaried, :with_lead_school) }
+        let(:school) { trainee.lead_school }
+
+        before do
+          render_inline(View.new(trainee))
+        end
+
+        it_behaves_like("school row", "lead school")
+      end
+
+      context "with employing school" do
+        let(:trainee) { create(:trainee, :school_direct_salaried, :with_employing_school) }
+        let(:school) { trainee.employing_school }
+
+        before do
+          render_inline(View.new(trainee))
+        end
+
+        it_behaves_like("school row", "employing school")
+      end
+    end
+  end
+end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
       open_date { Faker::Date.in_date_period }
       close_date { Faker::Date.in_date_period }
     end
+
+    trait :lead do
+      lead_school { true }
+    end
   end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -213,5 +213,13 @@ FactoryBot.define do
         trainee.reload
       end
     end
+
+    trait :with_lead_school do
+      association :lead_school, factory: %i[school lead]
+    end
+
+    trait :with_employing_school do
+      association :employing_school, factory: :school
+    end
   end
 end

--- a/spec/features/trainees/edit_trainee_record_spec.rb
+++ b/spec/features/trainees/edit_trainee_record_spec.rb
@@ -7,21 +7,29 @@ feature "edit trainee record", type: :feature do
 
   background do
     given_i_am_authenticated
-    given_a_trainee_exists_with_a_degree
-    when_i_visit_the_trainee_record_page
   end
 
   describe "about trainee view" do
     scenario "viewing the trainee's details" do
+      given_a_trainee_exists_with_a_degree
+      when_i_visit_the_trainee_record_page
       then_i_see_the_trainee_name
       then_i_see_the_trn_status
       then_i_see_the_record_details
       then_i_see_the_course_details
     end
+
+    scenario "viewing the trainee's school details,", "feature_routes.school_direct_salaried": true do
+      given_a_trainee_exists(:school_direct_salaried)
+      when_i_visit_the_trainee_record_page
+      then_i_see_the_school_details
+    end
   end
 
   describe "personal details and education view" do
     scenario "viewing the trainee's personal details and education" do
+      given_a_trainee_exists_with_a_degree
+      when_i_visit_the_trainee_record_page
       and_i_visit_the_personal_details
       then_i_see_the_personal_details
       then_i_see_the_contact_details
@@ -73,5 +81,9 @@ feature "edit trainee record", type: :feature do
 
   def then_i_see_the_degree_details
     expect(record_page).to have_degree_detail
+  end
+
+  def then_i_see_the_school_details
+    expect(record_page).to have_school_detail
   end
 end

--- a/spec/support/page_objects/sections/summaries/school_detail.rb
+++ b/spec/support/page_objects/sections/summaries/school_detail.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "../base"
+
+module PageObjects
+  module Sections
+    module Summaries
+      class SchoolDetail < PageObjects::Sections::Base
+        element :lead_school_row, ".govuk-summary-list__row.lead-school"
+        element :employing_school_row, ".govuk-summary-list__row.employing-school"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/record.rb
+++ b/spec/support/page_objects/trainees/record.rb
@@ -17,6 +17,7 @@ module PageObjects
 
       section :record_detail, PageObjects::Sections::Summaries::RecordDetail, ".record-details"
       section :course_detail, PageObjects::Sections::Summaries::CourseDetail, ".course-details"
+      section :school_detail, PageObjects::Sections::Summaries::SchoolDetail, ".school-details"
 
       section :personal_detail, PageObjects::Sections::Summaries::PersonalDetail, ".personal-details"
       section :contact_detail, PageObjects::Sections::Summaries::ContactDetail, ".contact-details"


### PR DESCRIPTION
### Context

- https://trello.com/c/thldQc4L/1620-add-schools-section-to-trainee-show-page-ie-non-draft

### Changes proposed in this pull request

- Builds the schools component to be used in the record page and `/check-details`

<img width="1048" alt="Screenshot 2021-04-30 at 14 09 13" src="https://user-images.githubusercontent.com/616080/116699608-ad84b280-a9bd-11eb-951c-f1502a847b58.png">


### Guidance to review

- Needs a bit of manual prep to set up the trainee as the school work is still in flux. But you'll need to attach a school record as the `lead_school` or `employing_school` on a trainee and head to their record page to see it.

