### PR TITLE
[1559] Employing school form page

### DIFF
--- a/app/components/form_components/schools_autocomplete/script.js
+++ b/app/components/form_components/schools_autocomplete/script.js
@@ -2,7 +2,7 @@ import accessibleAutocomplete from 'accessible-autocomplete'
 import { nodeListForEach } from 'govuk-frontend/govuk/common'
 
 const $allAutocompleteElements = document.querySelectorAll('[data-module="app-schools-autocomplete"]')
-const idElement = document.getElementById('lead-school-id')
+const idElement = document.getElementById('school-id')
 
 let statusMessage = ' '
 
@@ -24,14 +24,14 @@ const tryUpdateStatusMessage = (schools) => {
   return schools
 }
 
-const findSchools = (query, populateResults) => {
+const findSchools = ({ query, populateResults, onlyLeadSchools }) => {
   idElement.value = ''
 
   const encodedQuery = encodeURIComponent(query)
 
   statusMessage = 'Loading...' // Shared state
 
-  window.fetch(`/api/schools?query=${encodedQuery}&lead_school=true`)
+  window.fetch(`/api/schools?query=${encodedQuery}&lead_school=${onlyLeadSchools ? 'true' : 'false'}`)
     .then(response => response.json())
     .then(guard)
     .then(mapToSchools)
@@ -59,7 +59,7 @@ const renderTemplate = {
   suggestion: suggestionTemplate
 }
 
-const setLeadSchoolHiddenField = (value) => {
+const setSchoolHiddenField = (value) => {
   if (value === undefined) {
     return
   }
@@ -77,9 +77,15 @@ const setupAutoComplete = (form) => {
         element: element,
         id: input.id,
         minLength: 3,
-        source: findSchools,
+        source: (query, populateResults) => {
+          return findSchools({
+            query,
+            populateResults,
+            onlyLeadSchools: element.dataset.onlyLeadSchools
+          })
+        },
         templates: renderTemplate,
-        onConfirm: setLeadSchoolHiddenField,
+        onConfirm: setSchoolHiddenField,
         showAllValues: false,
         tNoResults: () => statusMessage
       })

--- a/app/controllers/api/schools_controller.rb
+++ b/app/controllers/api/schools_controller.rb
@@ -8,7 +8,7 @@ module Api
       @schools = SchoolSearch.call(
         query: params[:query],
         limit: params[:limit],
-        lead_schools_only: params[:lead_school],
+        lead_schools_only: lead_schools_only,
       )
 
       render json: { schools: @schools.as_json(only: %i[id name urn town postcode]) }
@@ -22,6 +22,10 @@ module Api
 
     def error_response
       render_json_error(message: I18n.t("api.schools.errors.bad_request"), status: :bad_request)
+    end
+
+    def lead_schools_only
+      ActiveModel::Type::Boolean.new.cast(params[:lead_school])
     end
   end
 end

--- a/app/controllers/trainees/employing_schools_controller.rb
+++ b/app/controllers/trainees/employing_schools_controller.rb
@@ -4,10 +4,15 @@ module Trainees
   class EmployingSchoolsController < ApplicationController
     before_action :authorize_trainee
     before_action :load_schools
+    before_action :redirect_to_search_page, only: :update
 
     helper_method :query
 
     def index
+      @employing_school_form = EmployingSchoolForm.new(trainee)
+    end
+
+    def edit
       @employing_school_form = EmployingSchoolForm.new(trainee)
     end
 
@@ -21,13 +26,19 @@ module Trainees
       save_strategy = trainee.draft? ? :save! : :stash
 
       if @employing_school_form.public_send(save_strategy)
-        redirect_to trainee_training_details_confirm_path(trainee)
+        redirect_to trainee_lead_school_confirm_path(trainee)
       else
-        render :index
+        render :edit
       end
     end
 
   private
+
+    def redirect_to_search_page
+      return if params["input-autocomplete"] && params["input-autocomplete"].length < 3
+
+      redirect_to trainee_employing_schools_path(trainee, query: params["input-autocomplete"]) if trainee_params[:employing_school_id].blank?
+    end
 
     def load_schools
       @schools = SchoolSearch.call(query: query)

--- a/app/controllers/trainees/lead_schools_controller.rb
+++ b/app/controllers/trainees/lead_schools_controller.rb
@@ -26,13 +26,17 @@ module Trainees
       save_strategy = trainee.draft? ? :save! : :stash
 
       if @lead_school_form.public_send(save_strategy)
-        redirect_to trainee_lead_school_confirm_path(trainee)
+        redirect_to redirect_url
       else
         render :edit
       end
     end
 
   private
+
+    def redirect_url
+      trainee.requires_employing_school? ? edit_trainee_employing_schools_path(trainee) : trainee_lead_school_confirm_path(trainee)
+    end
 
     def redirect_to_search_page
       return if params["input-autocomplete"] && params["input-autocomplete"].length < 3

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -15,7 +15,7 @@ class Trainee < ApplicationRecord
 
   attribute :progress, Progress.to_type
 
-  delegate :requires_placement_details?, :requires_schools?, to: :training_route_manager
+  delegate :requires_placement_details?, :requires_schools?, :requires_employing_school?, to: :training_route_manager
   delegate :award_type, to: :training_route_manager
 
   validates :training_route, presence: { message: I18n.t("activerecord.errors.models.trainee.attributes.training_route") }

--- a/app/views/trainees/employing_schools/edit.html.erb
+++ b/app/views/trainees/employing_schools/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.lead_schools.edit", has_errors: @lead_school_form.errors.present?) %>
+<%= render PageTitle::View.new(title: "trainees.employing_schools.edit", has_errors: @employing_school_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -6,20 +6,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with model: @lead_school_form, url: trainee_lead_schools_path(@trainee), local: true, html: { data: { module: "app-schools-autocomplete" } } do |f| %>
+    <%= register_form_with model: @employing_school_form, url: trainee_employing_schools_path(@trainee), local: true, html: { data: { module: "app-schools-autocomplete" } } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field(
-        :lead_school_id,
+        :employing_school_id,
         label: { text: t(".heading"), size: 'l', tag: 'h1' },
         hint: { text: t(".hint") },
         name: :'input-autocomplete',
         value: nil,
         'data-field' => "schools-autocomplete"
       ) %>
-      <div id="schools-autocomplete-element" data-only-lead-schools=true></div>
+      <div id="schools-autocomplete-element"></div>
 
-      <%= f.hidden_field :lead_school_id, id: "school-id", value: nil %>
+      <%= f.hidden_field :employing_school_id, id: "school-id", value: nil %>
       <%= f.govuk_submit t("continue") %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,7 @@ en:
           index: Select the lead school
         employing_schools:
           index: Select the employing school
+          edit: Employing school
       providers:
         index: Providers
         new: Add a provider
@@ -414,6 +415,10 @@ en:
     lead_schools:
       edit:
         heading: Lead school
+        hint: Search for a school by its unique reference number (URN), name or postcode
+    employing_schools:
+      edit:
+        heading: Employing school
         hint: Search for a school by its unique reference number (URN), name or postcode
 
   activerecord:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
       resources :lead_schools, only: %i[index], path: "/lead-schools"
       resource :lead_schools, only: %i[update edit], path: "/lead-schools"
       resources :employing_schools, only: %i[index], path: "/employing-schools"
-      resource :employing_schools, only: %i[update], path: "/employing-schools"
+      resource :employing_schools, only: %i[update edit], path: "/employing-schools"
 
       resource :timeline, only: :show
     end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -13,6 +13,7 @@ features:
     provider_led_postgrad: true
     early_years_undergrad: true
     school_direct_salaried: true
+    school_direct_tuition_fee: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -9,6 +9,7 @@ features:
     provider_led_postgrad: true
     early_years_undergrad: true
     school_direct_salaried: true
+    school_direct_tuition_fee: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -7,6 +7,7 @@ features:
   basic_auth: false
   routes:
     school_direct_salaried: true
+    school_direct_tuition_fee: true
 
 environment:
   name: beta

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -200,11 +200,6 @@ FactoryBot.define do
       additional_withdraw_reason { Faker::Lorem.paragraph }
     end
 
-    trait :with_lead_school do
-      school_direct_salaried
-      association :lead_school, factory: %i[school lead]
-    end
-
     trait :with_related_courses do
       training_route { (TRAINING_ROUTES_FOR_TRAINEE.keys & TRAINING_ROUTES_FOR_COURSE.keys).sample }
 

--- a/spec/features/trainees/employing_school_search_spec.rb
+++ b/spec/features/trainees/employing_school_search_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "EmployingSchoolSearch", type: :feature do
+  before do
+    given_i_am_authenticated
+    given_a_school_direct_salaried_trainee_exists
+    and_a_number_of_schools_exist
+    and_i_visit_the_trainee_edit_employing_school_page
+  end
+
+  scenario "choosing a employing school", js: true do
+    and_i_fill_in_my_employing_school
+    and_i_click_the_first_item_in_the_list
+    and_i_continue
+    then_i_am_redirected_to_the_confirm_lead_school_page
+  end
+
+  scenario "choosing a employing school without javascript" do
+    and_i_fill_in_my_employing_school_without_js
+    and_i_continue
+    then_i_am_redirected_to_the_employing_schools_page_filtered_by_my_query
+  end
+
+  scenario "when a employing school is not selected", js: true do
+    and_i_fill_in_my_employing_school
+    and_i_continue
+    then_i_am_redirected_to_the_employing_schools_page_filtered_by_my_query
+  end
+
+private
+
+  def given_a_school_direct_salaried_trainee_exists
+    given_a_trainee_exists(training_route: :school_direct_salaried)
+  end
+
+  def and_i_fill_in_my_employing_school
+    edit_employing_school_page.employing_school.fill_in with: my_employing_school_name
+  end
+
+  def and_i_fill_in_my_employing_school_without_js
+    edit_employing_school_page.no_js_employing_school.fill_in with: my_employing_school_name
+  end
+
+  def and_i_click_the_first_item_in_the_list
+    edit_employing_school_page.autocomplete_list_item.click
+  end
+
+  def and_i_continue
+    edit_employing_school_page.submit.click
+  end
+
+  def and_a_number_of_schools_exist
+    @employing_schools = create_list(:school, 5)
+  end
+
+  def and_i_visit_the_trainee_edit_employing_school_page
+    edit_employing_school_page.load(trainee_id: trainee.slug)
+  end
+
+  def my_employing_school_name
+    my_employing_school.name.split(" ").first
+  end
+
+  def my_employing_school
+    @my_employing_school ||= @employing_schools.sample
+  end
+
+  def then_i_am_redirected_to_the_confirm_lead_school_page
+    expect(confirm_schools_page).to be_displayed(id: trainee.slug)
+  end
+
+  def then_i_am_redirected_to_the_employing_schools_page_filtered_by_my_query
+    expect(employing_schools_search_page).to be_displayed(trainee_id: trainee.slug, query: my_employing_school_name)
+  end
+end

--- a/spec/features/trainees/lead_school_search_spec.rb
+++ b/spec/features/trainees/lead_school_search_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.feature "LeadSchoolSearch", type: :feature do
   before do
     given_i_am_authenticated
-    given_a_school_direct_salaried_trainee_exists
+    given_a_school_direct_tuition_fee_trainee_exists
     and_a_number_of_lead_schools_exist
     and_i_visit_the_trainee_edit_lead_school_page
   end
@@ -31,8 +31,8 @@ RSpec.feature "LeadSchoolSearch", type: :feature do
 
 private
 
-  def given_a_school_direct_salaried_trainee_exists
-    given_a_trainee_exists(:with_lead_school)
+  def given_a_school_direct_tuition_fee_trainee_exists
+    given_a_trainee_exists(:school_direct_tuition_fee, :with_lead_school)
   end
 
   def and_i_fill_in_my_lead_school

--- a/spec/features/trainees/non_js_employing_school_search_spec.rb
+++ b/spec/features/trainees/non_js_employing_school_search_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Non-JS employing schools search" do
   scenario "choosing a lead school" do
     and_i_choose_my_employing_school
     and_i_continue
-    then_i_am_redirected_to_the_confirm_training_details_page
+    then_i_am_redirected_to_the_confirm_lead_school_page
   end
 
   scenario "choosing search again option" do
@@ -58,8 +58,8 @@ private
     employing_schools_search_page.load(trainee_id: trainee.slug, query: query)
   end
 
-  def then_i_am_redirected_to_the_confirm_training_details_page
-    expect(confirm_training_details_page).to be_displayed(id: trainee.slug)
+  def then_i_am_redirected_to_the_confirm_lead_school_page
+    expect(confirm_schools_page).to be_displayed(id: trainee.slug)
   end
 
   def and_i_continue

--- a/spec/features/trainees/non_js_lead_school_search_spec.rb
+++ b/spec/features/trainees/non_js_lead_school_search_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.feature "Non-JS lead schools search" do
   before do
     given_i_am_authenticated
-    given_a_school_direct_salaried_trainee_exists
+    given_a_school_direct_tuition_fee_trainee_exists
     and_a_number_of_lead_school_exists
     and_i_am_on_the_lead_schools_page_filtered_by_my_query
   end
@@ -26,8 +26,8 @@ RSpec.feature "Non-JS lead schools search" do
 
 private
 
-  def given_a_school_direct_salaried_trainee_exists
-    given_a_trainee_exists(:school_direct_salaried)
+  def given_a_school_direct_tuition_fee_trainee_exists
+    given_a_trainee_exists(:school_direct_tuition_fee)
   end
 
   def and_i_choose_my_lead_school

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -198,6 +198,10 @@ module Features
       @edit_lead_school_page ||= PageObjects::Trainees::EditLeadSchool.new
     end
 
+    def edit_employing_school_page
+      @edit_employing_school_page ||= PageObjects::Trainees::EditEmployingSchool.new
+    end
+
     def accessibility_page
       @accessibility_page ||= PageObjects::Accessibility.new
     end

--- a/spec/support/page_objects/trainees/edit_employing_school.rb
+++ b/spec/support/page_objects/trainees/edit_employing_school.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class EditEmployingSchool < PageObjects::Base
+      set_url "/trainees/{trainee_id}/employing-schools/edit"
+
+      element :employing_school, "#employing-school-form-employing-school-id-field"
+      element :no_js_employing_school, "#employing-school-form-employing-school-id-field"
+      element :autocomplete_list_item, "#employing-school-form-employing-school-id-field__listbox li:first-child"
+      element :submit, 'input.govuk-button[type="submit"]'
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/Fzlrmd01/1559-m-employing-school-form-page

### Changes proposed in this pull request

This is based off this PR: https://github.com/DFE-Digital/register-trainee-teachers/pull/800

- Created a new edit page for trainee employing schools, with the JS autocomplete containing both lead and non-lead 
schools
- Is the JS is disabled, then a separate input submits a query to the no-js employing school form page

### Guidance to review
- Populate your database with some lead schools, like so:
- `FactoryBot.create_list(:school, 10)`
- Navigate to a draft trainee
- Navigate to `trainees/:slug/employing-schools/edit`
- Search for one of the schools you created, select and continue
- Return to the form, search again, but don't select anything from the dropdown.
- Check that you're redirected to the no-JS version of the employing school page with your query, and a list of matching schools
- Select one and continue
