### PR TITLE
[1625] Fixed scitts gone a missed as well as status reasoning

### DIFF
--- a/app/lib/dttp/code_sets/institution_types.rb
+++ b/app/lib/dttp/code_sets/institution_types.rb
@@ -11,6 +11,7 @@ module Dttp
         "ITT Provider - Non-HESA" => { entity_id: "bdec33aa-216d-e711-80d2-005056ac45bb" },
         "NonHEI (data gathered under Scitt process)" => { entity_id: "bfec33aa-216d-e711-80d2-005056ac45bb" },
         "Non-HESA HEI" => { entity_id: "c1ec33aa-216d-e711-80d2-005056ac45bb" },
+        "SCITT" => { entity_id: "cdec33aa-216d-e711-80d2-005056ac45bb" },
       }.freeze
     end
   end

--- a/app/services/dttp/retrieve_providers.rb
+++ b/app/services/dttp/retrieve_providers.rb
@@ -15,9 +15,10 @@ module Dttp
     INSTITUTION_TYPES = CodeSets::InstitutionTypes::MAPPING.values.flat_map { |institution| "_dfe_institutiontypeid_value eq #{institution[:entity_id]}" }.join(" or ")
 
     ACTIVE_STATECODE = 0
-    ACTIVE_STATUSCODE = 1
+    CLOSED_STATUSCODE = 300_000_002
+
     FILTER = {
-      "$filter" => "dfe_provider eq true and (#{INSTITUTION_TYPES}) and statecode eq #{ACTIVE_STATECODE} and statuscode eq #{ACTIVE_STATUSCODE}",
+      "$filter" => "dfe_provider eq true and (statecode eq #{ACTIVE_STATECODE} and statuscode ne #{CLOSED_STATUSCODE}) and (#{INSTITUTION_TYPES})",
     }.freeze
 
     SELECT = {

--- a/spec/services/dttp/retrieve_providers_spec.rb
+++ b/spec/services/dttp/retrieve_providers_spec.rb
@@ -16,7 +16,7 @@ module Dttp
     end
 
     let(:expected_path) do
-      "/accounts?%24filter=dfe_provider+eq+true+and+%28_dfe_institutiontypeid_value+eq+b5ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b7ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b9ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bbec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bdec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bfec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+c1ec33aa-216d-e711-80d2-005056ac45bb%29+and+statecode+eq+0+and+statuscode+eq+1&%24select=name%2Cdfe_ukprn%2Caccountid"
+      "/accounts?%24filter=dfe_provider+eq+true+and+%28statecode+eq+0+and+statuscode+ne+300000002%29+and+%28_dfe_institutiontypeid_value+eq+b5ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b7ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b9ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bbec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bdec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bfec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+c1ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+cdec33aa-216d-e711-80d2-005056ac45bb%29&%24select=name%2Cdfe_ukprn%2Caccountid"
     end
 
     it "requests active organisations matching the institution type codeset" do


### PR DESCRIPTION
### Context
DTTP
SCITTS (institution type) and  Status Reason (accounts/organisation)

### Changes proposed in this pull request
Added scitts code set to be used for query for provider as well.

### Guidance to review

`statuscode` is an extension of `statecode` either of which can be configured as part of CRM offerings.
But generally `statecode` is the actual `Status` and can only fall in to `Active` or `Inactive`.
And `statuscode` is the underlying `Status Reason` of which it can `Closed` is 1 of 10 options for `Status` with `Active`

