### PR TITLE
[1630] Add searchable column to schools

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -3,7 +3,16 @@
 class School < ApplicationRecord
   include PgSearch::Model
 
-  pg_search_scope :search, against: %i[urn name town postcode], using: { tsearch: { prefix: true } }
+  before_save :update_searchable
+
+  pg_search_scope :search,
+                  against: %i[urn name town postcode],
+                  using: {
+                    tsearch: {
+                      prefix: true,
+                      tsvector_column: "searchable",
+                    },
+                  }
 
   scope :open, -> { where(close_date: nil) }
   scope :lead_only, -> { where(lead_school: true) }
@@ -11,4 +20,46 @@ class School < ApplicationRecord
   validates :urn, presence: true, uniqueness: true
   validates :name, presence: true
   validates :lead_school, inclusion: { in: [true, false] }
+
+private
+
+  # The below generates a query like:
+  #
+  #      TO_TSVECTOR(
+  #        'pg_catalog.simple',
+  #        '1000000 The Aldgate School ec3a 5de ec3a5de London'
+  #      );
+  #
+  # and assigns the result to the "searchable" field, which is used by pg_search_scope above.
+  # This creates a space seperated string with all the searchable info about a school such as:
+  #   "1000000 The Aldgate School ec3a 5de ec3a5de London"
+  #
+  # The reason for mentioning the postcode twice is that postgres will split text up by spaces
+  # into "words" when converting it into a tsvector. We would like someone to be able to type
+  # a postcode without spaces and still get a result. Without doing this, the searchable
+  # vector would look like this:
+  #   "'100000':1 '5de':6 'aldgate':3 'ec3a':5 'london':8 'school':4 'the':2"
+  #
+  # searching for ec3a5de would not match any results as it only matches if a query term is exact, or
+  # a prefix of a word. With the above query we end up with a vector like this:
+  #   "'100000':1 '5de':6 'aldgate':3 'ec3a':5 'ec3a5de':7 'london':8 'school':4 'the':2"
+  #
+  def update_searchable
+    ts_vector_value = [urn, name, postcode, postcode.delete(" "), town].join(" ")
+
+    to_tsvector = Arel::Nodes::NamedFunction.new(
+      "TO_TSVECTOR", [
+        Arel::Nodes::Quoted.new("pg_catalog.simple"),
+        Arel::Nodes::Quoted.new(ts_vector_value),
+      ]
+    )
+
+    self.searchable =
+      ActiveRecord::Base
+        .connection
+        .execute(Arel::SelectManager.new.project(to_tsvector).to_sql)
+        .first
+        .values
+        .first
+  end
 end

--- a/db/migrate/20210426105838_add_searchable_to_schools.rb
+++ b/db/migrate/20210426105838_add_searchable_to_schools.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddSearchableToSchools < ActiveRecord::Migration[6.1]
+  def up
+    add_column :schools, :searchable, :tsvector
+    add_index :schools, :searchable, using: :gin
+    add_index :schools, :close_date, where: "close_date is NULL"
+  end
+
+  def down
+    remove_index :schools, :searchable
+    remove_index :schools, :close_date
+    remove_column :schools, :searchable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,8 +83,8 @@ ActiveRecord::Schema.define(version: 2021_04_26_162034) do
     t.integer "duration_in_years", null: false
     t.string "course_length", null: false
     t.integer "qualification", null: false
-    t.string "summary", null: false
     t.integer "route", null: false
+    t.string "summary", null: false
     t.integer "level", null: false
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
     t.index ["provider_id"], name: "index_courses_on_provider_id"
@@ -160,8 +160,8 @@ ActiveRecord::Schema.define(version: 2021_04_26_162034) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.string "code"
     t.boolean "apply_sync_enabled", default: false
+    t.string "code"
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
 
@@ -175,7 +175,10 @@ ActiveRecord::Schema.define(version: 2021_04_26_162034) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "lead_school", null: false
+    t.tsvector "searchable"
+    t.index ["close_date"], name: "index_schools_on_close_date", where: "(close_date IS NULL)"
     t.index ["lead_school"], name: "index_schools_on_lead_school", where: "(lead_school IS TRUE)"
+    t.index ["searchable"], name: "index_schools_on_searchable", using: :gin
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe School do
+  context "callbacks" do
+    it "updates the tsvector column with relevant info when the school is updated" do
+      school = create(:school)
+      expect {
+        school.update(urn: "12345678", name: "School of life", postcode: "sw1a 1aa", town: "london")
+      }.to change { school.reload.searchable }.to(
+        "'12345678':1 '1aa':6 'life':4 'london':8 'of':3 'school':2 'sw1a':5 'sw1a1aa':7",
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/eDPvoBTN/1630-improve-schools-search-performance 

Following on from spike: https://github.com/DFE-Digital/register-trainee-teachers/pull/807

### Changes proposed in this pull request

This column stores a tsvector that we can index for using in searches,
giving a big performance boost.

We need to update this tsvector column any time the school changes so
that the search index can be kept up to date. This must be done in an
active record callback (alternatively using a database trigger would
require using some raw sql in a migration that couldn’t be represented
in schema.rb, and we don’t want to use an sql formatted schema).

Also add an index on the close_date as we can search for only open 
schools, this also speeds up the search query.

### Guidance to review

If you want to observe the performance difference yourself. Install the `activerecord-analyze` gem locally, and run
```
$ bundle exec rake schools_data:import
```
and then in rails console:
```
SchoolSearch.call(query: "whatever").analyze
```
Before and after this commit
