### PR TITLE
1619] Add lead schools component to check-details

### DIFF
--- a/app/components/trainees/sections/view.rb
+++ b/app/components/trainees/sections/view.rb
@@ -44,6 +44,7 @@ module Trainees
           degrees: Trainees::Confirmation::Degrees::View,
           course_details: Trainees::Confirmation::CourseDetails::View,
           training_details: Trainees::Confirmation::TrainingDetails::View,
+          lead_school: Trainees::Confirmation::LeadSchool::View,
         }[section]
       end
 
@@ -72,6 +73,10 @@ module Trainees
           training_details: {
             not_started: "edit_trainee_training_details_path",
             in_progress: "trainee_training_details_confirm_path",
+          },
+          lead_school: {
+            not_started: "edit_trainee_lead_school_path",
+            in_progress: "trainee_lead_school_confirm_path",
           },
         }[section][status]
       end

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -61,6 +61,8 @@
 
     <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :course_details) %>
 
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :lead_school) %>
+
     <%= register_form_with(model: @trn_submission_form, url: trn_submissions_path, method: :post, local: true) do |f| %>
       <%= hidden_field_tag :trainee_id, @trainee.slug %>
       <%= f.govuk_submit "Submit record and request TRN" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,6 +230,7 @@ en:
         course_details: Course details
         training_details: Training details
         placement_details: Placement details
+        lead_school: School details
       statuses:
         not_started: not started
         in_progress: not marked as complete

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -40,7 +40,7 @@ module Pages
         end
 
         def trainee_with_all_sections_not_started
-          Trainee.new(id: 1000)
+          Trainee.new(id: 1000, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
         end
 
         def trainee_with_all_sections_in_progress
@@ -56,6 +56,7 @@ module Pages
                       international_address: "international_address",
                       ethnic_background: "ethnic_background",
                       additional_ethnic_background: "additional_ethnic_background",
+                      training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
                       subject: "subject",
                       degrees: [Degree.new(id: 1)])
         end
@@ -66,6 +67,7 @@ module Pages
           Trainee.new(id: 1000, trainee_id: "trainee_id",
                       first_names: "first_names",
                       last_name: "last_name",
+                      training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
                       address_line_one: "address_line_one",
                       address_line_two: "address_line_two",
                       town_city: "town_city",

--- a/spec/components/trainees/sections/view_preview.rb
+++ b/spec/components/trainees/sections/view_preview.rb
@@ -10,28 +10,29 @@ module Trainees
          degrees
          diversity
          course_details
-         training_details].each do |section|
+         training_details
+         lead_school].each do |section|
         define_method "continue_sections_#{section}" do
-          trainee = continue_sections_trainee
+          trainee = continue_sections_trainee(section)
           trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
           render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission_form: trn_submission_form))
         end
 
         define_method "continue_sections_#{section}_validated" do
-          trainee = continue_sections_trainee
+          trainee = continue_sections_trainee(section)
           trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
           trn_submission_form.validate
           render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission_form: trn_submission_form))
         end
 
         define_method "start_sections_#{section}" do
-          trainee = start_sections_trainee
+          trainee = start_sections_trainee(section)
           trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
           render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission_form: trn_submission_form))
         end
 
         define_method "start_sections_#{section}_validated" do
-          trainee = start_sections_trainee
+          trainee = start_sections_trainee(section)
           trn_submission_form = TrnSubmissionForm.new(trainee: trainee)
           trn_submission_form.validate
           render(Trainees::Sections::View.new(trainee: trainee, section: section, trn_submission_form: trn_submission_form))
@@ -40,25 +41,35 @@ module Trainees
 
     private
 
-      def continue_sections_trainee
-        @continue_sections_trainee ||= Trainee.new(id: 1000, trainee_id: "trainee_id",
-                                                   first_names: "first_names",
-                                                   last_name: "last_name",
-                                                   address_line_one: "address_line_one",
-                                                   address_line_two: "address_line_two",
-                                                   town_city: "town_city",
-                                                   postcode: "postcode",
-                                                   email: "email",
-                                                   middle_names: "middle_names",
-                                                   international_address: "international_address",
-                                                   ethnic_background: "ethnic_background",
-                                                   additional_ethnic_background: "additional_ethnic_background",
-                                                   subject: "subject",
-                                                   degrees: [Degree.new(id: 1)])
+      def continue_sections_trainee(section)
+        @continue_sections_trainee ||= Trainee.new(
+          id: 1000, trainee_id: "trainee_id",
+          first_names: "first_names",
+          last_name: "last_name",
+          address_line_one: "address_line_one",
+          address_line_two: "address_line_two",
+          town_city: "town_city",
+          postcode: "postcode",
+          email: "email",
+          middle_names: "middle_names",
+          international_address: "international_address",
+          ethnic_background: "ethnic_background",
+          additional_ethnic_background: "additional_ethnic_background",
+          subject: "subject",
+          training_route: TRAINING_ROUTE_ENUMS[training_route(section)],
+          lead_school: School.new(id: 1),
+          degrees: [Degree.new(id: 1)]
+        )
       end
 
-      def start_sections_trainee
-        @start_sections_trainee ||= Trainee.new(id: 1000)
+      def start_sections_trainee(section)
+        @start_sections_trainee ||= Trainee.new(id: 1000, training_route: TRAINING_ROUTE_ENUMS[training_route(section)])
+      end
+
+      def training_route(section)
+        return :school_direct_salaried if section == :lead_school
+
+        :assessment_only
       end
     end
   end

--- a/spec/components/trainees/sections/view_spec.rb
+++ b/spec/components/trainees/sections/view_spec.rb
@@ -56,6 +56,10 @@ module Trainees
         include_examples renders_incomplete_section, :degrees, :not_started
         include_examples renders_incomplete_section, :course_details, :not_started
         include_examples renders_incomplete_section, :training_details, :not_started
+
+        context "requires school" do
+          include_examples renders_incomplete_section, :lead_school, :not_started
+        end
       end
 
       context "trainee in progress" do
@@ -67,6 +71,12 @@ module Trainees
         include_examples renders_incomplete_section, :degrees, :in_progress
         include_examples renders_incomplete_section, :course_details, :in_progress
         include_examples renders_incomplete_section, :training_details, :in_progress
+
+        context "requires school" do
+          let(:trainee) { create(:trainee, :with_lead_school, :in_progress) }
+
+          include_examples renders_incomplete_section, :lead_school, :in_progress
+        end
       end
 
       context "trainee completed" do
@@ -80,6 +90,12 @@ module Trainees
         include_examples renders_confirmation, :degrees
         include_examples renders_confirmation, :course_details
         include_examples renders_confirmation, :training_details
+
+        context "requires school" do
+          let(:trainee) { create(:trainee, :with_lead_school, :completed) }
+
+          include_examples renders_confirmation, :lead_school
+        end
       end
 
       def expected_title(section, status)
@@ -121,6 +137,10 @@ module Trainees
             not_started: "edit_trainee_training_details_path",
             in_progress: "trainee_training_details_confirm_path",
           },
+          lead_school: {
+            not_started: "edit_trainee_lead_school_path",
+            in_progress: "trainee_lead_school_confirm_path",
+          },
         }[section][status]
       end
 
@@ -132,6 +152,7 @@ module Trainees
           degrees: Trainees::Confirmation::Degrees::View,
           course_details: Trainees::Confirmation::CourseDetails::View,
           training_details: Trainees::Confirmation::TrainingDetails::View,
+          lead_school: Trainees::Confirmation::LeadSchool::View,
         }[section]
       end
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -87,6 +87,7 @@ FactoryBot.define do
           course_details: true,
           training_details: true,
           placement_details: true,
+          lead_school: true,
         )
       end
     end

--- a/spec/forms/trn_submission_form_spec.rb
+++ b/spec/forms/trn_submission_form_spec.rb
@@ -30,10 +30,20 @@ describe TrnSubmissionForm, type: :model do
         expect(subject.valid?).to be true
         expect(subject.errors).to be_empty
       end
+
+      context "requires school" do
+        let(:trainee) { create(:trainee, :school_direct_salaried, :with_lead_school, :completed, progress: progress.merge(lead_school: true)) }
+
+        it "is valid" do
+          expect(subject.valid?).to be true
+          expect(subject.errors).to be_empty
+        end
+      end
     end
 
     context "when any section is invalid or incomplete" do
       subject { described_class.new(trainee: trainee) }
+
       let(:progress) do
         {
           degrees: nil,
@@ -44,7 +54,14 @@ describe TrnSubmissionForm, type: :model do
           training_details: true,
         }
       end
+
       include_examples "error"
+
+      context "requires school but incomplete" do
+        let(:trainee) { create(:trainee, :school_direct_salaried, :with_lead_school, progress: progress.merge(lead_school: false)) }
+
+        include_examples "error"
+      end
     end
 
     context "with empty progress" do


### PR DESCRIPTION
### Context

- https://trello.com/c/sCThNDo3/1619-add-schools-section-to-check-details-page

### Changes proposed in this pull request

- Render the lead school component in the /check-details
- Refactor the `TrnSubmissionForm` so it's a bit more flexible for which route sections its validating

### Guidance to review

![confirm](https://user-images.githubusercontent.com/616080/117132344-a46b5b00-ad9a-11eb-8cdc-301d6d8ec5a9.gif)

