### PR TITLE
[1642] Ensure timeline shows correct translations for QTS/EYTS

### DIFF
--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -40,7 +40,7 @@ module Trainees
       other_grade
     ].freeze
 
-    delegate :user, :created_at, :auditable_type, :audited_changes, to: :audit
+    delegate :user, :created_at, :auditable_type, :audited_changes, :auditable, to: :audit
 
     def initialize(audit:)
       @audit = audit
@@ -91,12 +91,20 @@ module Trainees
     end
 
     def state_change_title
+      I18n.t("components.timeline.titles.trainee.#{state_change_action}")
+    end
+
+    def state_change_action
       change_from, change_to = audited_changes["state"].map { |change| Trainee.states.key(change) }
 
       if change_from == "deferred" && change_to != "withdrawn"
-        I18n.t("components.timeline.titles.trainee.reinstated")
+        "reinstated"
+      elsif change_to == "recommended_for_award"
+        "recommended_for_#{auditable.award_type.downcase}"
+      elsif change_to == "awarded"
+        "#{auditable.award_type.downcase}_awarded"
       else
-        I18n.t("components.timeline.titles.trainee.#{change_to}")
+        change_to
       end
     end
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -130,6 +130,10 @@ FactoryBot.define do
       training_route { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
     end
 
+    trait :early_years_undergrad do
+      training_route { TRAINING_ROUTE_ENUMS[:early_years_undergrad] }
+    end
+
     trait :school_direct_tuition_fee do
       training_route { TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] }
     end

--- a/spec/services/trainees/create_timeline_events_spec.rb
+++ b/spec/services/trainees/create_timeline_events_spec.rb
@@ -61,6 +61,46 @@ module Trainees
         end
       end
 
+      context "with a `recommended_for_award` state change audit" do
+        before do
+          %i[submit_for_trn! receive_trn! recommend_for_award!].each { |m| trainee.public_send(m) }
+        end
+
+        context "with a QTS trainee" do
+          it "returns a 'Recommended for QTS' timeline event" do
+            expect(subject.title).to eq(t("components.timeline.titles.trainee.recommended_for_qts"))
+          end
+        end
+
+        context "with an EYTS trainee" do
+          let(:trainee) { create(:trainee, :early_years_undergrad) }
+
+          it "returns a 'Recommended for EYTS' timeline event" do
+            expect(subject.title).to eq(t("components.timeline.titles.trainee.recommended_for_eyts"))
+          end
+        end
+      end
+
+      context "with an `awarded` state change audit" do
+        before do
+          %i[submit_for_trn! receive_trn! recommend_for_award! award!].each { |m| trainee.public_send(m) }
+        end
+
+        context "with a QTS trainee" do
+          it "returns a 'QTS awarded' timeline event" do
+            expect(subject.title).to eq(t("components.timeline.titles.trainee.qts_awarded"))
+          end
+        end
+
+        context "with an EYTS trainee" do
+          let(:trainee) { create(:trainee, :early_years_undergrad) }
+
+          it "returns a 'EYTS awarded' timeline event" do
+            expect(subject.title).to eq(t("components.timeline.titles.trainee.eyts_awarded"))
+          end
+        end
+      end
+
       context "with an associated audit" do
         let(:degree) { create(:degree, trainee: trainee) }
 


### PR DESCRIPTION
### Context

https://trello.com/c/3H42RsxZ/1642-fix-qts-timeline-translation

### Changes proposed in this pull request

The translations for the timeline were originally mapped from the state name (originally `recommended_for_qts`).

The state is now `recommended_for_award`, but we had two separate translation keys `recommended_for_qts` and `recommended_for_eyts`. Neither of these are states, and the actual state `recommended_for_award` had no translation.

To fix, I've added logic to the `CreateTimelineEvent` that chooses the correct translation based on the trainees `award_type`.

<img width="824" alt="Screenshot 2021-05-05 at 13 09 20" src="https://user-images.githubusercontent.com/18436946/117138581-1e9fdd80-ada3-11eb-9dbf-608fe33c10db.png">

### Guidance to review

- Choose a non-draft trainee on an EYTS route who has been recommended for EYTS
- Check the timeline has the correct translation 'Recommended for EYTS'

- Choose a non-draft trainee on an EYTS route who has received EYTS
- Check the timeline has the correct translation 'EYTS awarded'

- Repeat with a non-EYTS trainee and check the timeline has the correct translations (i.e. EYTS replaces with QTS)