### PR TITLE
[1649] Add apply_application to trainees

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -5,6 +5,7 @@ class Trainee < ApplicationRecord
   include PgSearch::Model
 
   belongs_to :provider
+  belongs_to :apply_application, optional: true
   has_many :degrees, dependent: :destroy
   has_many :nationalisations, dependent: :destroy, inverse_of: :trainee
   has_many :nationalities, through: :nationalisations
@@ -187,5 +188,9 @@ class Trainee < ApplicationRecord
 
   def clear_disabilities
     disabilities.clear
+  end
+
+  def apply_application?
+    apply_application.present?
   end
 end

--- a/db/migrate/20210505144011_add_apply_applications_to_trainees.rb
+++ b/db/migrate/20210505144011_add_apply_applications_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddApplyApplicationsToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :trainees, :apply_application, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_26_162034) do
+ActiveRecord::Schema.define(version: 2021_05_05_144011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -255,6 +255,8 @@ ActiveRecord::Schema.define(version: 2021_04_26_162034) do
     t.uuid "dormancy_dttp_id"
     t.bigint "lead_school_id"
     t.bigint "employing_school_id"
+    t.bigint "apply_application_id"
+    t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"
     t.index ["dttp_id"], name: "index_trainees_on_dttp_id"
@@ -305,6 +307,7 @@ ActiveRecord::Schema.define(version: 2021_04_26_162034) do
   add_foreign_key "nationalisations", "trainees"
   add_foreign_key "trainee_disabilities", "disabilities"
   add_foreign_key "trainee_disabilities", "trainees"
+  add_foreign_key "trainees", "apply_applications"
   add_foreign_key "trainees", "providers"
   add_foreign_key "trainees", "schools", column: "employing_school_id"
   add_foreign_key "trainees", "schools", column: "lead_school_id"

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -221,5 +221,9 @@ FactoryBot.define do
     trait :with_employing_school do
       association :employing_school, factory: :school
     end
+
+    trait :with_apply_application do
+      apply_application
+    end
   end
 end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -48,12 +48,14 @@ describe Trainee do
 
   context "associations" do
     it { is_expected.to belong_to(:provider) }
+    it { is_expected.to belong_to(:apply_application).optional }
     it { is_expected.to have_many(:degrees).dependent(:destroy) }
     it { is_expected.to have_many(:nationalisations).dependent(:destroy).inverse_of(:trainee) }
     it { is_expected.to have_many(:nationalities).through(:nationalisations) }
     it { is_expected.to have_many(:trainee_disabilities).dependent(:destroy).inverse_of(:trainee) }
     it { is_expected.to have_many(:disabilities).through(:trainee_disabilities) }
     it { is_expected.to belong_to(:lead_school).class_name("School").optional }
+    it { is_expected.to belong_to(:employing_school).class_name("School").optional }
   end
 
   context "validations" do
@@ -149,6 +151,20 @@ describe Trainee do
       it "is delegated to TrainingRouteManager" do
         expect(subject.training_route_manager).to receive(:requires_placement_details?)
         subject.requires_placement_details?
+      end
+    end
+
+    describe "#apply_application?" do
+      subject { trainee.apply_application? }
+
+      context "the trainee has an associated apply application" do
+        let(:trainee) { create(:trainee, :with_apply_application) }
+        it { is_expected.to be true }
+      end
+
+      context "the trainee does not have an associated apply application" do
+        let(:trainee) { create(:trainee) }
+        it { is_expected.to be false }
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/U8UCQsW9/1649-s-add-applyapplicationid

### Changes proposed in this pull request
- Migration to add apply_application association to trainees
- Helper method to flag if a trainee has an apply application or not
