### PR TITLE
[1668] Fix no truncation on autocomplete schools

### DIFF
--- a/app/controllers/api/schools_controller.rb
+++ b/app/controllers/api/schools_controller.rb
@@ -5,16 +5,20 @@ module Api
     def index
       return error_response if invalid_query?
 
-      @schools = SchoolSearch.call(
-        query: params[:query],
-        limit: params[:limit],
-        lead_schools_only: lead_schools_only,
-      )
+      @schools = SchoolSearch.call(args)
 
       render json: { schools: @schools.as_json(only: %i[id name urn town postcode]) }
     end
 
   private
+
+    def args
+      {
+        query: params[:query],
+        limit: params[:limit],
+        lead_schools_only: lead_schools_only,
+      }.compact
+    end
 
     def invalid_query?
       params[:query].present? && params[:query].length < 3


### PR DESCRIPTION
### Context

https://trello.com/c/Okt410cM/1668-truncate-schools-results-in-autocomplete

### Changes proposed in this pull request

Our school autocomplete does not pass a `limit` parameter to the API. The absence of this parameter should mean that the default is applied (i.e. 15 as per the `SchoolSearch` service).

This PR ensures the API only passes a limit to the search service if one is explicitly set as a param.

### Guidance to review

- Search for a school using the autocomplete
- Check that a maximum of 15 results are returned in the results drop down.
