### PR TITLE
Attempt to fix lead schools flakeys

### DIFF
--- a/spec/features/trainees/lead_school_search_spec.rb
+++ b/spec/features/trainees/lead_school_search_spec.rb
@@ -44,11 +44,11 @@ private
   end
 
   def and_i_click_the_first_item_in_the_list
-    edit_lead_school_page.autocomplete_list_item.click
+    click(edit_lead_school_page.autocomplete_list_item)
   end
 
   def and_i_continue
-    edit_lead_school_page.submit.click
+    click(edit_lead_school_page.submit)
   end
 
   def and_a_number_of_lead_schools_exist

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -7,6 +7,7 @@ require_relative "features/common_steps"
 require_relative "features/page_helpers"
 require_relative "features/diversity_steps"
 require_relative "features/confirmation_steps"
+require_relative "features/js_helpers"
 require_relative "dfe_sign_in_user_helper"
 
 RSpec.configure do |config|
@@ -32,6 +33,7 @@ RSpec.configure do |config|
   config.include Features::PageHelpers, type: :feature
   config.include Features::DiversitySteps, type: :feature
   config.include Features::ConfirmationSteps, type: :feature
+  config.include Features::JsHelpers, type: :feature
   config.include DfESignInUserHelper, type: :feature
 
   config.around :each do |example|

--- a/spec/support/features/js_helpers.rb
+++ b/spec/support/features/js_helpers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Features
+  module JsHelpers
+    def js_true?
+      RSpec.current_example.metadata[:js]
+    end
+
+    def click(node)
+      if js_true?
+        node.trigger(:click)
+      else
+        node.click
+      end
+    end
+  end
+end


### PR DESCRIPTION
Capybara sometimes has a problem triggering click events:
https://medium.com/@yuliaoletskaya/capybara-inconsistent-click-behavior-and-flickering-tests-f50b5fae8ab2

> The reason behind that is the fact that web driver’s click() method is asynchronous and sometimes Capybara starts the code execution before JS finishes initializing its listeners

Manually triggering a click event on the objects we are trying to click
Is a known workaround

