### PR TITLE
1646 confirm course marks the section complete

### DIFF
--- a/app/forms/validate_publish_course_form.rb
+++ b/app/forms/validate_publish_course_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ValidatePublishCourseForm < TraineeForm
+  FIELDS = %i[
+    subject
+    age_range
+    course_start_date
+    course_end_date
+  ].freeze
+
+  attr_accessor(*FIELDS)
+
+  validates :subject, presence: true
+
+private
+
+  def compute_fields
+    {
+      subject: trainee.subject,
+      age_range: trainee.age_range,
+      course_start_date: trainee.course_start_date,
+      course_end_date: trainee.course_end_date,
+    }
+  end
+end

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -72,16 +72,11 @@
 
     <%= render TaskList::View.new(classes: "record-setup") do |component|
       if show_publish_courses?(@trainee)
-        form = PublishCourseDetailsForm.new(@trainee)
+        form = ValidatePublishCourseForm.new(@trainee)
         component.row(
           task_name: "Course details",
           path: edit_trainee_publish_course_details_path(@trainee),
-          confirm_path: lambda {
-            edit_trainee_confirm_publish_course_path(
-              id: form.code,
-              trainee_id: @trainee.to_param,
-            )
-          },
+          confirm_path: trainee_course_details_confirm_path(@trainee),
           classes: "course-details",
           status: ProgressService.call(
             validator: form,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,8 @@ en:
           show: When did the trainee return?
         confirm_reinstatement:
           show: Check reinstatement details
+        confirm_publish_course:
+          edit: Is this the course you want to add?
         sort_links:
           sort_switcher: Change record sort order
           sort_by: Sort by

--- a/spec/features/trainees/edit_publish_course_details_spec.rb
+++ b/spec/features/trainees/edit_publish_course_details_spec.rb
@@ -28,12 +28,13 @@ feature "publish course details", type: :feature, feature_publish_course_details
       then_the_section_should_be(not_started)
     end
 
-    scenario "renders an 'in progress' status when details partially provided" do
+    scenario "renders a 'completed' status when details fully provided" do
       when_i_visit_the_publish_course_details_page
       and_i_select_a_course
       and_i_submit_the_form
+      and_i_confirm_the_course
       and_i_visit_the_review_draft_page
-      then_the_section_should_be(in_progress)
+      then_the_section_should_be(completed)
     end
   end
 
@@ -98,6 +99,10 @@ feature "publish course details", type: :feature, feature_publish_course_details
 
   def and_i_submit_the_form
     publish_course_details_page.submit_button.click
+  end
+
+  def and_i_confirm_the_course
+    confirm_publish_course_page.submit_button.click
   end
 
   def and_i_select_another_course_not_listed

--- a/spec/support/page_objects/trainees/confirm_publish_course.rb
+++ b/spec/support/page_objects/trainees/confirm_publish_course.rb
@@ -7,6 +7,7 @@ module PageObjects
       set_url "/trainees/{trainee_id}/confirm-publish-course/{id}/edit"
 
       element :confirm_course_button, "input[name='commit'][value='Confirm course']"
+      element :submit_button, "input[name='commit']"
     end
   end
 end


### PR DESCRIPTION
### Context

The confirm course button now marks the progress as complete when a provider has related courses. 

### Changes proposed in this pull request

- Add `validate_publish_course_form` - to allow for progress check
- Remove redundant test
- Fix translation on page title

### Guidance to review

- Add courses to a specific persona E.G `FactoryBot.create_list :course, 50, provider_id: 125`
- Add a trainee doing `Provider-led (postgrad)` training
- Navigate to `trainees/{trainee-id}/publish-course-details/edit`  - Check that the page title has been fixed here too. 
- Select a course, click `Continue`, then `Confirm course`
- Check the progress next to course details has changed to `COMPLETED`


### Screenshot

![image](https://user-images.githubusercontent.com/50492247/117466473-aa07a300-af4a-11eb-89f4-4fd8e8309122.png)

