### PR TITLE
[1661] Add employing school logic to check details page

### DIFF
--- a/app/components/trainees/sections/view.rb
+++ b/app/components/trainees/sections/view.rb
@@ -35,7 +35,7 @@ module Trainees
       def form_klass
         case section
         when :schools
-          Schools::LeadSchoolForm
+          Schools::FormValidator
         else
           "#{section.to_s.camelcase}Form".constantize
         end

--- a/app/forms/trn_submission_form.rb
+++ b/app/forms/trn_submission_form.rb
@@ -17,7 +17,7 @@ class TrnSubmissionForm
   trn_validator :degrees, form: "DegreesForm"
   trn_validator :course_details, form: "CourseDetailsForm"
   trn_validator :training_details, form: "TrainingDetailsForm"
-  trn_validator :schools, form: "Schools::LeadSchoolForm", if: :requires_schools?
+  trn_validator :schools, form: "Schools::FormValidator", if: :requires_schools?
 
   delegate :requires_schools?, to: :trainee
 

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -59,7 +59,7 @@
 
     <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :training_details) %>
 
-    <%# <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :course_details) %> %>
+    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :course_details) %>
 
     <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :schools) %>
 

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -59,7 +59,7 @@
 
     <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :training_details) %>
 
-    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :course_details) %>
+    <%# <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :course_details) %> %>
 
     <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :schools) %>
 

--- a/spec/forms/trn_submission_form_spec.rb
+++ b/spec/forms/trn_submission_form_spec.rb
@@ -32,7 +32,7 @@ describe TrnSubmissionForm, type: :model do
       end
 
       context "requires school" do
-        let(:trainee) { create(:trainee, :school_direct_salaried, :with_lead_school, :completed, progress: progress.merge(schools: true)) }
+        let(:trainee) { create(:trainee, :school_direct_salaried, :with_lead_school, :with_employing_school, :completed, progress: progress.merge(schools: true)) }
 
         it "is valid" do
           expect(subject.valid?).to be true


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/j56ZaOYb/1661-add-employing-school-logic-to-check-details-page)

### Changes proposed in this pull request

- Added `Schools::FormValidator` in the trainee section view, for the check-details page

### Guidance to review

Create a trainee and fill out all fields. Then navigate to `https://localhost:5000/trainees/#{trainee.slug}/check-details` to see the school section populated
