### PR TITLE
[1669] Fix flakey diversities test

### DIFF
--- a/spec/forms/diversities/ethnic_background_form_spec.rb
+++ b/spec/forms/diversities/ethnic_background_form_spec.rb
@@ -27,7 +27,7 @@ module Diversities
     end
 
     describe "#save!" do
-      let(:ethnic_background) { Dttp::CodeSets::Ethnicities::MAPPING.keys.sample }
+      let(:ethnic_background) { (Dttp::CodeSets::Ethnicities::MAPPING.keys - [trainee.ethnic_background]).sample }
 
       before do
         allow(form_store).to receive(:get).and_return({ "ethnic_background" => ethnic_background })


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/EAfyKH8S/1669-fix-flakey-diversities-test)
- There was a flakey diversities test, which sometimes tried to change the diversity of a trainee but with the diversity they were already registered on

### Changes proposed in this pull request

- Removed the trainees diversity from the list of diversities to ensure uniqueness

### Guidance to review

- Run the spec as many times as you like

