### PR TITLE
[1654] Course details added to route indicator for apply trainees

### DIFF
--- a/app/components/trainees/route_indicator/view.html.erb
+++ b/app/components/trainees/route_indicator/view.html.erb
@@ -1,1 +1,1 @@
-<%= render GovukComponent::InsetText.new(text: "Trainee on the #{training_route_link} route".html_safe) %>
+<%= render GovukComponent::InsetText.new(text: display_text) %>

--- a/app/components/trainees/route_indicator/view.rb
+++ b/app/components/trainees/route_indicator/view.rb
@@ -15,8 +15,34 @@ module Trainees
         trainee.training_route.present? && trainee.draft?
       end
 
+      def display_text
+        if trainee.apply_application?
+          "Trainee enrolled on #{course_with_code}, #{training_route}"
+        else
+          "Trainee on the #{training_route_link} route".html_safe
+        end
+      end
+
+      def course_with_code
+        "#{trainee.subject} #{course_code}".strip
+      end
+
+      def course_code
+        return unless course&.code
+
+        "(#{course.code})"
+      end
+
+      def course
+        @course ||= trainee.provider.courses.find_by(name: trainee.subject)
+      end
+
+      def training_route
+        t("activerecord.attributes.trainee.training_routes.#{trainee.training_route}")
+      end
+
       def training_route_link
-        govuk_link_to t("activerecord.attributes.trainee.training_routes.#{trainee.training_route}").downcase, edit_trainee_training_route_path(trainee)
+        govuk_link_to training_route.downcase, edit_trainee_training_route_path(trainee)
       end
     end
   end

--- a/app/components/trainees/route_indicator/view.rb
+++ b/app/components/trainees/route_indicator/view.rb
@@ -17,9 +17,9 @@ module Trainees
 
       def display_text
         if trainee.apply_application?
-          "Trainee enrolled on #{course_with_code}, #{training_route}"
+          t(".apply_display_text", course_with_code: course_with_code, training_route: training_route)
         else
-          "Trainee on the #{training_route_link} route".html_safe
+          t(".display_text", training_route_link: training_route_link).html_safe
         end
       end
 
@@ -28,13 +28,9 @@ module Trainees
       end
 
       def course_code
-        return unless course&.code
+        return if trainee.course_code.blank?
 
-        "(#{course.code})"
-      end
-
-      def course
-        @course ||= trainee.provider.courses.find_by(name: trainee.subject)
+        "(#{trainee.course_code})"
       end
 
       def training_route

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -43,6 +43,7 @@ module Trainees
         email: raw_contact_details["email"],
         training_route: course&.route,
         subject: course&.name,
+        course_code: course&.code,
         course_age_range: course&.age_range,
         course_start_date: course&.start_date,
         course_end_date: course&.end_date,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,6 +435,10 @@ en:
       edit:
         heading: Employing school
         hint: Search for a school by its unique reference number (URN), name or postcode
+    route_indicator:
+      view:
+        display_text: "Trainee on the %{training_route_link} route"
+        apply_display_text: "Trainee enrolled on %{course_with_code}, %{training_route}"
 
   activerecord:
     attributes:

--- a/db/migrate/20210512153010_add_course_code_to_trainees.rb
+++ b/db/migrate/20210512153010_add_course_code_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCourseCodeToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :course_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_10_132823) do
+ActiveRecord::Schema.define(version: 2021_05_12_153010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,9 +88,6 @@ ActiveRecord::Schema.define(version: 2021_05_10_132823) do
     t.integer "min_age", null: false
     t.integer "max_age", null: false
     t.index ["code"], name: "index_courses_on_code", unique: true
-  end
-
-  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "degrees", force: :cascade do |t|
@@ -262,6 +259,7 @@ ActiveRecord::Schema.define(version: 2021_05_10_132823) do
     t.bigint "apply_application_id"
     t.integer "course_min_age"
     t.integer "course_max_age"
+    t.string "course_code"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"

--- a/spec/components/trainees/route_indicator/view_preview.rb
+++ b/spec/components/trainees/route_indicator/view_preview.rb
@@ -6,6 +6,15 @@ module RouteIndicator
       define_method training_route.to_s do
         render(Trainees::RouteIndicator::View.new(trainee: Trainee.new(training_route: training_route)))
       end
+
+      define_method "apply_#{training_route}" do
+        render(Trainees::RouteIndicator::View.new(trainee: Trainee.new(
+          training_route: training_route,
+          apply_application: ApplyApplication.new,
+          subject: Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample,
+          course_code: Faker::Alphanumeric.alphanumeric(number: 4).upcase,
+        )))
+      end
     end
   end
 end

--- a/spec/components/trainees/route_indicator/view_spec.rb
+++ b/spec/components/trainees/route_indicator/view_spec.rb
@@ -24,4 +24,15 @@ RSpec.describe Trainees::RouteIndicator::View do
       expect(component).to have_no_content
     end
   end
+
+  describe "apply application" do
+    let(:provider) { create(:provider) }
+    let(:course) { create(:course, accredited_body_code: provider.code) }
+    let(:trainee) { create(:trainee, :with_apply_application, provider: provider, subject: course.name) }
+
+    it "renders" do
+      expect(component).to have_content(course.name)
+      expect(component).to have_content(course.code)
+    end
+  end
 end

--- a/spec/components/trainees/route_indicator/view_spec.rb
+++ b/spec/components/trainees/route_indicator/view_spec.rb
@@ -26,13 +26,11 @@ RSpec.describe Trainees::RouteIndicator::View do
   end
 
   describe "apply application" do
-    let(:provider) { create(:provider) }
-    let(:course) { create(:course, accredited_body_code: provider.code) }
-    let(:trainee) { create(:trainee, :with_apply_application, provider: provider, subject: course.name) }
+    let(:trainee) { create(:trainee, :with_apply_application, :with_course_details) }
 
     it "renders" do
-      expect(component).to have_content(course.name)
-      expect(component).to have_content(course.code)
+      expect(component).to have_content(trainee.subject)
+      expect(component).to have_content(trainee.course_code)
     end
   end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -94,6 +94,7 @@ FactoryBot.define do
 
     trait :with_course_details do
       subject { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
+      course_code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
       course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.keys.sample }
       course_start_date { Faker::Date.between(from: 10.years.ago, to: 2.days.ago) }
       course_end_date { Faker::Date.between(from: course_start_date + 1.day, to: Time.zone.today) }

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -33,6 +33,7 @@ module Trainees
         email: contact_details["email"],
         training_route: course.route,
         subject: course.name,
+        course_code: course.code,
         course_min_age: course.min_age,
         course_max_age: course.max_age,
         course_start_date: course.start_date,


### PR DESCRIPTION
### Context

https://trello.com/c/Dhw51PSS/1654-m-add-course-details-to-route-indicator

### Changes proposed in this pull request

* updated `RouteIndicator` component to show course details for apply trainees
* New column `course_code` added to `Trainee`
* `Trainees::CreateFromApply` updated to save `course_code` on `Trainee`

### Guidance to review

