### PR TITLE
[1673] Fix Tristanian DTTP mapping

### DIFF
--- a/app/lib/dttp/code_sets/nationalities.rb
+++ b/app/lib/dttp/code_sets/nationalities.rb
@@ -211,7 +211,7 @@ module Dttp
         "togolese" => { entity_id: "cf7e640e-5c62-e711-80d1-005056ac45bb" },
         "tongan" => { entity_id: "db7e640e-5c62-e711-80d1-005056ac45bb" },
         "trinidadian" => { entity_id: "df7e640e-5c62-e711-80d1-005056ac45bb" },
-        "tristanian" => { entity_id: "d17d640e-5c62-e711-80d1-005056ac45bb" },
+        "tristanian" => { entity_id: "77c297b7-5c62-e711-80d1-005056ac45bb" },
         "tunisian" => { entity_id: "d97e640e-5c62-e711-80d1-005056ac45bb" },
         "turkish" => { entity_id: "dd7e640e-5c62-e711-80d1-005056ac45bb" },
         "turkmen" => { entity_id: "dd7e640e-5c62-e711-80d1-005056ac45bb" },


### PR DESCRIPTION
### Context

Tristanian was mapped to 'British'. It should be the same as St Helenian.

### Changes proposed in this pull request

Update the mapping.

### Guidance to review

Check that the UUID matches St Helenian. 

In the 'Nations' section of DTTP you can also check the ID of that St Helena, Ascension and Tristan da Cunha

