### PR TITLE
Fix flakey employing school search spec

### DIFF
--- a/spec/features/trainees/employing_school_search_spec.rb
+++ b/spec/features/trainees/employing_school_search_spec.rb
@@ -44,11 +44,11 @@ private
   end
 
   def and_i_click_the_first_item_in_the_list
-    edit_employing_school_page.autocomplete_list_item.click
+    click(edit_employing_school_page.autocomplete_list_item)
   end
 
   def and_i_continue
-    edit_employing_school_page.submit.click
+    click(edit_employing_school_page.submit)
   end
 
   def and_a_number_of_schools_exist


### PR DESCRIPTION
This fix has already been applied to the lead school search spec.
https://github.com/DFE-Digital/register-trainee-teachers/pull/851

The click method switches between using `.click` and `.trigger(:click)`
depending on if the test is using js or not. `.trigger(:click)` needs
to be used when we are using js as capybara can start running before
the web driver has initialised its event hooks (eg. Triggering the click
event handlers when something is clicked), so we need to trigger it 
manually.
