### PR TITLE
[1677] Set courselvel to UG if early years undergrad

### DIFF
--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -7,6 +7,7 @@ module Dttp
 
       ACADEMIC_YEAR_2020_2021 = "76bcaeca-2bd1-e711-80df-005056ac45bb"
       COURSE_LEVEL_PG = 12
+      COURSE_LEVEL_UG = 20
       ITT_QUALIFICATION_AIM_QTS = "68cbae32-7389-e711-80d8-005056ac45bb"
 
       attr_reader :trainee, :qualifying_degree, :params
@@ -40,13 +41,21 @@ module Dttp
           "dfe_commencementdate" => trainee.commencement_date.in_time_zone.iso8601,
           "dfe_traineeid" => trainee.trainee_id || "NOTPROVIDED",
           "dfe_AcademicYearId@odata.bind" => "/dfe_academicyears(#{ACADEMIC_YEAR_2020_2021})",
-          "dfe_courselevel" => COURSE_LEVEL_PG, # TODO: this can be PG (12) or UG (20).  Postgrad or undergrad. Hardcoded for now.
+          "dfe_courselevel" => course_level,
           "dfe_sendforregistration" => true,
           "dfe_ProviderId@odata.bind" => "/accounts(#{trainee.provider.dttp_id})",
           "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{dttp_qualification_aim_id(trainee.training_route)})",
           "dfe_programmeyear" => 1, # TODO: this will need to be derived for other routes. It's n of x year course e.g. 1 of 2
           "dfe_programmelength" => 1, # TODO: this will change for other routes as above. So these two are course_year of course_length
         }.merge(qualifying_degree.uk? ? uk_specific_params : non_uk_specific_params)
+      end
+
+      def course_level
+        if trainee.training_route == "early_years_undergrad"
+          COURSE_LEVEL_UG
+        else
+          COURSE_LEVEL_PG
+        end
       end
 
       def uk_specific_params

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -120,6 +120,20 @@ module Dttp
             )
           end
         end
+
+        context "Early years undergrad" do
+          let(:trainee) do
+            create(:trainee, :early_years_undergrad, :with_course_details, :with_start_date,
+                   dttp_id: dttp_contact_id, provider: provider)
+          end
+          subject { described_class.new(trainee).params }
+
+          it "course level is UG" do
+            expect(subject).to include(
+              { "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_UG },
+            )
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/kaIFSi7t/1677-s-early-years-undergrad-needs-to-set-dfecourselevel-to-ug

### Changes proposed in this pull request

* `PlacementAssignment` updated, courselevel is set to UG when route is early years undergrad.

### Guidance to review

