### PR TITLE
[1684] Conditionally hide schools section

### DIFF
--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -61,7 +61,9 @@
 
     <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :course_details) %>
 
-    <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :schools) %>
+    <%- if @trainee.requires_schools? %>
+      <%= render Trainees::Sections::View.new(trainee: @trainee, trn_submission_form: @trn_submission_form, section: :schools) %>
+    <%- end -%>
 
     <%= register_form_with(model: @trn_submission_form, url: trn_submissions_path, method: :post, local: true) do |f| %>
       <%= hidden_field_tag :trainee_id, @trainee.slug %>


### PR DESCRIPTION
### Context

The school section is only visible on the check-details page when the
route requires it.

This section was being shown and consequently required for all routes.

The view with the issue doesn't currently have a view spec and the extra functionality added here isn't in a component although the page has a component preview. I've not added a spec for this as it will delay fixing a production issue that is affecting users but I've carded up a review of this with a view to:

* making this view into a component and adding a spec for this UI
* reviewing/adding an end to end add trainee journey feature spec as this issue didn't cause a feature spec to fail which it should have done

### Changes proposed in this pull request

Conditionally show the section using the `RouteManager#requires_schools?` predicate.

### Guidance to review

* Run the app
* Add an AO trainee
* The check-details page won't have schools
* Add a school direct trainee
* The check-details page will have schools

