### PR TITLE
Don't access secrets for dependabot PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,42 +8,47 @@ on:
     branches:
     - master
 
-env:
-  DOCKER_REPO: dfedigital/register-trainee-teachers
-  DOCKER_IMAGE: register-trainee-teachers
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      sha_tag: ${{ steps.set_env.outputs.SHA_TAG }}
-
     env:
+      DOCKER_REPO: dfedigital/register-trainee-teachers
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
       DB_HOSTNAME: localhost
 
     steps:
     - uses: actions/checkout@v2
-    - name: Get values for current commit
-      id: set_env
+      name: Checkout
+
+    - name: Set environment variables
       run: |
         GIT_SHA_SHORT=$(echo ${GITHUB_SHA} | cut -c 1-7)
-        GIT_BRANCH="${GITHUB_REF##*/}"
         echo "GIT_SHA_SHORT=$GIT_SHA_SHORT" >> $GITHUB_ENV
-        echo "GIT_BRANCH=$GIT_BRANCH" >> $GITHUB_ENV
-        echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
         echo "SHA_TAG=$GIT_SHA_SHORT" >> $GITHUB_ENV
-        echo "::set-output name=SHA_TAG::$GIT_SHA_SHORT"
 
-    - name: Login to docker hub
-      run: echo "${{secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN}}" | docker login -u ${{secrets.DOCKERHUB_USERNAME}} --password-stdin
+    - name: Login to DockerHub
+      if: github.actor != 'dependabot[bot]'
+      uses: docker/login-action@v1.9.0
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
 
-    - name: "docker pull ${{env.DOCKER_REPO}}:${{env.BRANCH_TAG}}"
-      run: docker pull $DOCKER_REPO:$BRANCH_TAG || true
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1.3.0
 
-    - name: "docker-compose build"
-      run:  docker-compose build --build-arg COMMIT_SHA=$GITHUB_SHA
+    - name: Build Docker Image
+      uses: docker/build-push-action@v2
+      with:
+        tags: ${{env.DOCKER_REPO}}:${{env.SHA_TAG}}
+        builder: ${{ steps.buildx.outputs.name }}
+        load: true
+        cache-to: type=inline
+        cache-from: | 
+          type=registry,ref=${{env.DOCKER_REPO}}:master
+          type=registry,ref=${{env.DOCKER_REPO}}:${{env.SHA_TAG}}
+        build-args: COMMIT_SHA=${{ github.sha }}
 
     - name: Bring images up
       run: |
@@ -72,13 +77,15 @@ jobs:
     - name: Run Javascript tests
       run: docker-compose exec -T web /bin/sh -c 'yarn run test'
 
-    - name: Tag docker images
-      run: docker tag ${{env.DOCKER_REPO}}:${{env.BRANCH_TAG}} ${{env.DOCKER_REPO}}:${{env.SHA_TAG}}
+    - name: Tag master image
+      if: github.ref == 'refs/heads/master'
+      run: docker tag ${{env.DOCKER_REPO}}:${{env.SHA_TAG}} ${{env.DOCKER_REPO}}:master
 
-    - name: Push docker images to Docker Hub
+    - name: Push Docker Image
+      if: github.actor != 'dependabot[bot]'
       run: |
-        docker push ${{env.DOCKER_REPO}}:${{env.BRANCH_TAG}}
-        docker push ${{env.DOCKER_REPO}}:${{env.SHA_TAG}}
+        docker push ${{env.DOCKER_REPO}}:${{env.SHA_TAG}} 
+        docker push ${{env.DOCKER_REPO}}:master
 
     - name: Trigger QA Deployment
       if: ${{ success() && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       if: github.actor != 'dependabot[bot]'
       run: |
         docker push ${{env.DOCKER_REPO}}:${{env.SHA_TAG}} 
-        docker push ${{env.DOCKER_REPO}}:master
+        docker push ${{env.DOCKER_REPO}}:master || true
 
     - name: Trigger QA Deployment
       if: ${{ success() && github.ref == 'refs/heads/master' }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     build:
       context: .
       cache_from:
-        - dfedigital/register-trainee-teachers:${BRANCH_TAG:-latest}
-    image: dfedigital/register-trainee-teachers:${BRANCH_TAG:-latest}
+        - dfedigital/register-trainee-teachers:${SHA_TAG:-master}
+    image: dfedigital/register-trainee-teachers:${SHA_TAG:-master}
     command: ash -c "bundle exec rails server -p 3001 -b '0.0.0.0'"
     ports:
       - 3001:3001
@@ -31,7 +31,7 @@ services:
       - REDIS_URL=redis://redis:6379
 
   bg-jobs:
-    image: dfedigital/register-trainee-teachers:${BRANCH_TAG:-latest}
+    image: dfedigital/register-trainee-teachers:${SHA_TAG:-master}
     command: bundle exec sidekiq -c 5 -C config/sidekiq.yml
     depends_on:
       - web


### PR DESCRIPTION
### Context
Dependatbot PR checks are failing because secrets are inaccessible for dependabot PRs. 

### Changes proposed in this pull request

Use `docker/` actions
Don't access GitHub secrets when building `dependabot` PRs

