### PR TITLE
[1689] Fix review status tag logic

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -34,6 +34,8 @@ class CourseDetailsForm < TraineeForm
   validate :course_start_date_valid
   validate :course_end_date_valid
 
+  delegate :apply_application?, to: :trainee
+
   MAX_END_YEARS = 4
 
   def course_age_range

--- a/app/forms/validate_publish_course_form.rb
+++ b/app/forms/validate_publish_course_form.rb
@@ -12,6 +12,8 @@ class ValidatePublishCourseForm < TraineeForm
 
   validates :subject, presence: true
 
+  delegate :apply_application?, to: :trainee
+
 private
 
   def compute_fields

--- a/app/services/progress_service.rb
+++ b/app/services/progress_service.rb
@@ -41,6 +41,6 @@ private
   attr_reader :validator, :marked_as_completed
 
   def is_apply_application?
-    validator.trainee.apply_application?
+    validator.respond_to?(:apply_application?) && validator.apply_application?
   end
 end

--- a/spec/services/progress_service_spec.rb
+++ b/spec/services/progress_service_spec.rb
@@ -4,11 +4,9 @@ require "spec_helper"
 
 describe ProgressService do
   describe "#status" do
-    let(:trainee_stub) { instance_double(Trainee, apply_application?: false) }
-
     let(:validator_stub) do
       double(
-        trainee: trainee_stub,
+        trainee: instance_double(Trainee),
         valid?: false,
         fields: { first_name: nil },
       )
@@ -36,10 +34,10 @@ describe ProgressService do
       end
 
       context "and in review" do
-        let(:trainee_stub) { instance_double(Trainee, apply_application?: true) }
-
         before do
           allow(validator_stub).to receive(:valid?).and_return(true)
+          allow(validator_stub).to receive(:respond_to?).with(:apply_application?).and_return(true)
+          allow(validator_stub).to receive(:apply_application?).and_return(true)
         end
 
         it "returns a 'review' status" do


### PR DESCRIPTION
### Context

- https://trello.com/c/Lcyb0sWU/1689-review-progress-tags-should-be-limited-to-registration-data-from-apply-sections

### Changes proposed in this pull request

- Only render the review label for validator objects which respond to `apply_application`
- Internally, we'll just delegate this back to the trainee but declare the delegation on validators which could pre-populated from apply data

<img width="920" alt="Screenshot 2021-05-13 at 13 57 16" src="https://user-images.githubusercontent.com/616080/118138348-1f1d2180-b3fe-11eb-83c6-5b35a9756a86.png">

### Guidance to review

In the console do:

```ruby
require Rails.root.join("spec/support/api_stubs/apply_api.rb")
app = create(:apply_application)
trainee = create(:trainee, :school_direct_salaried, apply_application: app)
```

- Visit the `/review-draft` page and assert only the sections under `Registration data from apply` have the review label