### PR TITLE
[1698] Send age range to DTTP

### DIFF
--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -33,7 +33,7 @@ module Dttp
 
       def build_params
         {
-          "dfe_CoursePhaseId@odata.bind" => "/dfe_coursephases(#{course_phase_id(trainee.age_range)})",
+          "dfe_CoursePhaseId@odata.bind" => "/dfe_coursephases(#{course_phase_id(trainee.course_age_range)})",
           "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{course_subject_id(trainee.subject)})",
           "dfe_SubjectofUGDegreeId@odata.bind" => "/dfe_jacses(#{degree_subject_id(qualifying_degree.subject)})",
           "dfe_programmestartdate" => trainee.course_start_date.in_time_zone.iso8601,

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -29,7 +29,7 @@ module Dttp
         trainee.degrees << degree
 
         stub_const("Dttp::CodeSets::AgeRanges::MAPPING",
-                   { trainee.age_range => { entity_id: dttp_age_range_entity_id } })
+                   { trainee.course_age_range => { entity_id: dttp_age_range_entity_id } })
         stub_const("Dttp::CodeSets::CourseSubjects::MAPPING",
                    { trainee.subject => { entity_id: dttp_course_subject_entity_id } })
         stub_const("Dttp::CodeSets::DegreeSubjects::MAPPING",


### PR DESCRIPTION
### Context

https://trello.com/c/3qYP5hTv/1698-bug-adding-a-new-trainee-doesnt-update-the-agerange

https://sentry.io/organizations/dfe-bat/issues/2198667894/?environment=production&project=5552118&query=is%3Aunresolved

### Changes proposed in this pull request

We changed to saving the course age range as two separate fields on trainee. However, we were still sending the value from the old `age_range` column to DTTP (which was nil for all new trainees).

### Guidance to review

