### PR TITLE
[1700] Remove trainee age range column

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ ENV ENV="/root/.ashrc"
 RUN bundle exec rake assets:precompile && \
     rm -rf node_modules tmp
 
-CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions data:migrate && bundle exec rails server -b 0.0.0.0
+CMD bundle exec rails db:migrate:with_data && bundle exec rails server -b 0.0.0.0

--- a/app/forms/validate_publish_course_form.rb
+++ b/app/forms/validate_publish_course_form.rb
@@ -3,7 +3,7 @@
 class ValidatePublishCourseForm < TraineeForm
   FIELDS = %i[
     subject
-    age_range
+    course_age_range
     course_start_date
     course_end_date
   ].freeze
@@ -19,7 +19,7 @@ private
   def compute_fields
     {
       subject: trainee.subject,
-      age_range: trainee.age_range,
+      course_age_range: trainee.course_age_range,
       course_start_date: trainee.course_start_date,
       course_end_date: trainee.course_end_date,
     }

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -106,25 +106,6 @@ class Trainee < ApplicationRecord
     end
   end
 
-  enum age_range: {
-    AgeRange::THREE_TO_ELEVEN => 0,
-    AgeRange::FIVE_TO_ELEVEN => 1,
-    AgeRange::ELEVEN_TO_SIXTEEN => 2,
-    AgeRange::ELEVEN_TO_NINETEEN => 3,
-    AgeRange::ZERO_TO_FIVE => 4,
-    AgeRange::THREE_TO_SEVEN => 5,
-    AgeRange::THREE_TO_EIGHT => 6,
-    AgeRange::THREE_TO_NINE => 7,
-    AgeRange::FIVE_TO_NINE => 8,
-    AgeRange::FIVE_TO_FOURTEEN => 9,
-    AgeRange::SEVEN_TO_ELEVEN => 10,
-    AgeRange::SEVEN_TO_FOURTEEN => 11,
-    AgeRange::SEVEN_TO_SIXTEEN => 12,
-    AgeRange::NINE_TO_FOURTEEN => 13,
-    AgeRange::NINE_TO_SIXTEEN => 14,
-    AgeRange::FOURTEEN_TO_NINETEEN => 15,
-  }
-
   pg_search_scope :with_name_trainee_id_or_trn_like,
                   against: %i[first_names middle_names last_name trainee_id trn],
                   using: { tsearch: { prefix: true } }

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -27,7 +27,8 @@ module Trainees
       additional_ethnic_background
       disability_disclosure
       subject
-      age_range
+      course_min_age
+      course_max_age
       course_start_date
       course_end_date
       commencement_date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,9 +19,9 @@ en:
       system_admin: System admin
   components:
     heading:
-      apply_draft: 
+      apply_draft:
         registration_data_from_apply: Registration data from Apply
-      draft: 
+      draft:
         personal_details_and_education: Personal details and education
         about_their_teaching_training: About their teacher training
     confirmation:
@@ -216,7 +216,8 @@ en:
           qts_awarded: Trainee awarded QTS
           eyts_awarded: Trainee awarded EYTS
           reinstated: Trainee reinstated
-          age_range: Course age range updated
+          course_min_age: Course min age updated
+          course_max_age: Course max age updated
           subject: Course subject updated
           commencement_date: Start date updated
           trainee_id: Trainee ID updated

--- a/db/migrate/20210107103656_change_trainee_age_range_to_enum_type.rb
+++ b/db/migrate/20210107103656_change_trainee_age_range_to_enum_type.rb
@@ -2,12 +2,10 @@
 
 class ChangeTraineeAgeRangeToEnumType < ActiveRecord::Migration[6.1]
   def up
-    sql = Trainee.age_ranges.reduce(String.new) { |s, (k, v)| s << "WHEN '#{k}' THEN #{v}::integer " }
-    change_column :trainees, :age_range, "integer USING (CASE age_range #{sql} END)"
+    change_column :trainees, :age_range, :integer
   end
 
   def down
-    sql = Trainee.age_ranges.reduce(String.new) { |s, (k, v)| s << "WHEN #{v} THEN '#{k}'::text " }
-    change_column :trainees, :age_range, "text USING (CASE age_range #{sql} END)"
+    change_column :trainees, :age_range, :text
   end
 end

--- a/db/migrate/20210517112710_remove_age_range_from_trainees.rb
+++ b/db/migrate/20210517112710_remove_age_range_from_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveAgeRangeFromTrainees < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :trainees, :age_range, type: :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,6 +90,9 @@ ActiveRecord::Schema.define(version: 2021_05_12_153010) do
     t.index ["code"], name: "index_courses_on_code", unique: true
   end
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "degrees", force: :cascade do |t|
     t.integer "locale_code", null: false
     t.string "uk_degree"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_12_153010) do
+ActiveRecord::Schema.define(version: 2021_05_17_112710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -237,7 +237,6 @@ ActiveRecord::Schema.define(version: 2021_05_12_153010) do
     t.text "additional_ethnic_background"
     t.integer "disability_disclosure"
     t.text "subject"
-    t.integer "age_range"
     t.date "course_start_date"
     t.jsonb "progress", default: {}
     t.bigint "provider_id", null: false

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -81,6 +81,8 @@ module Pages
                       locale_code: 1,
                       postcode: "BN1 1AA",
                       email: "email@example.com",
+                      course_min_age: 0,
+                      course_max_age: 5,
                       course_start_date: 6.months.ago,
                       course_end_date: Time.zone.now,
                       nationalities: nationalities,
@@ -92,7 +94,6 @@ module Pages
                         course_details: true,
                         training_details: true,
                       ),
-                      age_range: 1,
                       diversity_disclosure: 1,
                       degrees: [Degree.new(id: 1, locale_code: 1, subject: "subject")],
                       commencement_date: Time.zone.now)

--- a/spec/components/trainees/confirmation/course_details/view_preview.rb
+++ b/spec/components/trainees/confirmation/course_details/view_preview.rb
@@ -19,7 +19,7 @@ module Trainees
           @mock_trainee ||= Trainee.new(
             id: 1,
             subject: "Primary",
-            age_range: [3, 11],
+            course_age_range: [3, 11],
             course_start_date: Date.new(2020, 0o1, 28),
             training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
           )

--- a/spec/components/trainees/confirmation/course_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/course_details/view_spec.rb
@@ -6,6 +6,8 @@ module Trainees
   module Confirmation
     module CourseDetails
       describe View do
+        include SummaryHelper
+
         alias_method :component, :page
 
         context "when data has not been provided" do
@@ -50,14 +52,14 @@ module Trainees
               .to have_text(trainee.subject)
           end
 
-          it "renders the age range" do
+          it "renders the course age range" do
             expect(component.find(".govuk-summary-list__row.age-range .govuk-summary-list__value"))
-              .to have_text(trainee.age_range)
+              .to have_text(age_range_for_summary_view(trainee.course_age_range))
           end
 
           it "renders the course start date" do
             expect(component.find(".govuk-summary-list__row.course-start-date .govuk-summary-list__value"))
-              .to have_text(trainee.course_start_date.strftime("%-d %B %Y"))
+              .to have_text(date_for_summary_view(trainee.course_start_date))
           end
         end
       end

--- a/spec/components/trainees/confirmation/schools/view_preview.rb
+++ b/spec/components/trainees/confirmation/schools/view_preview.rb
@@ -19,7 +19,7 @@ module Trainees
           @mock_trainee ||= Trainee.new(
             id: 1,
             subject: "Primary",
-            age_range: [3, 11],
+            course_age_range: [3, 11],
             course_start_date: Date.new(2020, 0o1, 28),
             training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
             lead_school: mock_school,


### PR DESCRIPTION
### Context
https://trello.com/c/avypTNRm/1700-s-remove-trainee-agerange-column

### Changes proposed in this pull request
- Remove `age_range` column from trainees table
- Update `Trainees::CreateTimelineEvents` and `ValidatePublishCourseForm`  to use `course_min_age` and `course_max_age` instead of `age_range`
- Update `schema.rb` to include the missing create table statement for "data_migrations" (this could be the reason why the data migrations didn't work initially, although the table gets created automatically if it doesn't exist).
- Update `Dockerfile` to use `rails db:migrate:with_data` instead of `rails db:migrate:ignore_concurrent_migration_exceptions data:migrate` (recommended by gem authors, also not sure why `ignore_concurrent_migration_exceptions` was used as it doesn't appear to do anything)



