### PR TITLE
Fix ChangeTraineeAgeRangeToEnumType migration

### DIFF
--- a/db/migrate/20210107103656_change_trainee_age_range_to_enum_type.rb
+++ b/db/migrate/20210107103656_change_trainee_age_range_to_enum_type.rb
@@ -2,7 +2,7 @@
 
 class ChangeTraineeAgeRangeToEnumType < ActiveRecord::Migration[6.1]
   def up
-    change_column :trainees, :age_range, :integer
+    change_column :trainees, :age_range, :integer, using: "age_range::integer"
   end
 
   def down


### PR DESCRIPTION
### Context

- https://github.com/DFE-Digital/register-trainee-teachers/pull/885/files#diff-dc82cc784551ae868610d3ebf46552f8d61217a32f76371a9736882c52461279L5

### Changes proposed in this pull request

- Cast with `USING age_range::integer` otherwise migrations bork when running them from scratch

```ruby
== 20210107103656 ChangeTraineeAgeRangeToEnumType: migrating ==================
-- change_column(:trainees, :age_range, :integer)
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:
PG::DatatypeMismatch: ERROR:  column "age_range" cannot be cast automatically to type integer
HINT:  You might need to specify "USING age_range::integer".
/Users/david/Contracting/dfe/register-trainee-teachers/db/migrate/20210107103656_change_trainee_age_range_to_enum_type.rb:5:in `up'
Caused by:
ActiveRecord::StatementInvalid: PG::DatatypeMismatch: ERROR:  column "age_range" cannot be cast automatically to type integer
HINT:  You might need to specify "USING age_range::integer".
/Users/david/Contracting/dfe/register-trainee-teachers/db/migrate/20210107103656_change_trainee_age_range_to_enum_type.rb:5:in `up'
Caused by:
PG::DatatypeMismatch: ERROR:  column "age_range" cannot be cast automatically to type integer
HINT:  You might need to specify "USING age_range::integer".
/Users/david/Contracting/dfe/register-trainee-teachers/db/migrate/20210107103656_change_trainee_age_range_to_enum_type.rb:5:in `up'
```

### Guidance to review

- `db:drop db:migrate` works

