### PR TITLE
[1734] Example data includes provider_led_postgrad courses for providers

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -26,6 +26,7 @@ namespace :example_data do
           dttp_id: SecureRandom.uuid,
           code: Faker::Alphanumeric.alphanumeric(number: 3).upcase,
         )
+        FactoryBot.create_list(:course, rand(30..70), accredited_body_code: provider.code, route: "provider_led_postgrad")
         persona.update!(provider: provider)
       end
 


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/C3Axjtiv/1734-s-update-exampledatagenerate-script-to-create-courses-linked-to-a-persona-provider)

### Changes proposed in this pull request

- Added a `FactoryBot.create_list(:course....)` in the `example_data.rake` file. 
- Upon creation of Personas with Providers, we will create the courses and map them to the provider, mimicking publish for QA and Local development 

### Guidance to review

- Open your rails console `rails c`
- `provider = Provider.find_by(name: "Provider A")`
- `courses = Course.where(accredited_body_code: provider.code)` => this will return `nil`
- Run `rake db:reset` # you need to reset the db to delete all of the old data
- Run `rake example_data:generate`
- Repeat the above steps and you will now have courses populated with the provider code

