### PR TITLE
[1714] Provider led snags

### DIFF
--- a/app/components/cancel_link/view.html.erb
+++ b/app/components/cancel_link/view.html.erb
@@ -1,0 +1,1 @@
+<p class="govuk-body"><%= govuk_link_to(t("cancel"), view_trainee(trainee)) %></p>

--- a/app/components/cancel_link/view.rb
+++ b/app/components/cancel_link/view.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module CancelLink
+  class View < GovukComponent::Base
+    include TraineeHelper
+
+    attr_reader :draft
+
+    def initialize(trainee)
+      @trainee = trainee
+    end
+
+    def render?
+      !@trainee.draft?
+    end
+
+  private
+
+    attr_reader :trainee
+  end
+end

--- a/app/components/flash_banner/view.rb
+++ b/app/components/flash_banner/view.rb
@@ -23,7 +23,7 @@ module FlashBanner
     end
 
     def degree_deleted?
-      referer&.include?("degrees/confirm")
+      referer&.include?("degrees/confirm") && non_draft_trainee?
     end
   end
 end

--- a/app/components/flash_banner/view.rb
+++ b/app/components/flash_banner/view.rb
@@ -2,14 +2,13 @@
 
 module FlashBanner
   class View < GovukComponent::Base
-    attr_reader :flash, :trainee, :referer
+    attr_reader :flash, :trainee
 
     FLASH_TYPES = %i[success warning info].freeze
 
-    def initialize(flash:, trainee:, referer:)
+    def initialize(flash:, trainee:)
       @flash = flash
       @trainee = trainee
-      @referer = referer
     end
 
     def display?
@@ -23,7 +22,8 @@ module FlashBanner
     end
 
     def degree_deleted?
-      referer&.include?("degrees/confirm") && non_draft_trainee?
+      auditable = trainee.associated_audits.last
+      auditable&.auditable_type == "Degree" && auditable&.action == "destroy"
     end
   end
 end

--- a/app/components/trainees/confirmation/training_details/view.html.erb
+++ b/app/components/trainees/confirmation/training_details/view.html.erb
@@ -2,7 +2,7 @@
                                  heading_level: 2,
                                  rows: [
       {
-        key: t("components.confirmation.start_date.title"),
+        key: t("components.confirmation.training_details.start_date.title"),
         value: trainee_start_date,
         action: govuk_link_to('Change<span class="govuk-visually-hidden"> start date</span>'.html_safe,
                               edit_trainee_training_details_path(trainee)),

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -52,15 +52,10 @@ module Trainees
     end
 
     def confirm_section_title
-      @confirm_section_title ||=
-        begin
-          case trainee_section_key
-          when "training_details"
-            "trainee start date and ID"
-          else
-            trainee_section_key.gsub(/_/, " ").gsub(/id/, "ID")
-          end
-        end
+      @confirm_section_title ||= {
+        training_details: "trainee start date and ID",
+        degrees: "degree details",
+      }[trainee_section_key.to_sym] || trainee_section_key.gsub(/_/, " ").gsub(/id/, "ID")
     end
 
     def flash_message_title

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,7 +78,7 @@
     <main class="govuk-main-wrapper " id="main-content" role="main">
       <%= yield :start_page_banner %>
       <div class="govuk-width-container">
-        <%= render(FlashBanner::View.new(flash: flash, trainee: @trainee, referer: request.referer)) %>
+        <%= render(FlashBanner::View.new(flash: flash, trainee: @trainee)) %>
         <%= yield %>
       </div>
     </main>

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -57,9 +57,9 @@
       About their teacher training
     </h2>
 
-    <%= render Trainees::Sections::View.new(trainee: @trainee, form: @form, section: :training_details) %>
-
     <%= render Trainees::Sections::View.new(trainee: @trainee, form: @form, section: :course_details) %>
+
+    <%= render Trainees::Sections::View.new(trainee: @trainee, form: @form, section: :training_details) %>
 
     <%- if @trainee.requires_schools? %>
       <%= render Trainees::Sections::View.new(trainee: @trainee, form: @form, section: :schools) %>

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -51,4 +51,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), view_trainee(@trainee)) %></p>
+<%= render(CancelLink::View.new(@trainee)) %>

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -62,4 +62,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), view_trainee(@trainee)) %></p>
+<%= render(CancelLink::View.new(@trainee)) %>

--- a/app/views/trainees/employing_schools/index.html.erb
+++ b/app/views/trainees/employing_schools/index.html.erb
@@ -12,4 +12,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), view_trainee(@trainee)) %></p>
+<%= render(CancelLink::View.new(@trainee)) %>

--- a/app/views/trainees/lead_schools/index.html.erb
+++ b/app/views/trainees/lead_schools/index.html.erb
@@ -11,4 +11,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), view_trainee(@trainee)) %></p>
+<%= render(CancelLink::View.new(@trainee)) %>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -65,4 +65,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), view_trainee(@trainee)) %></p>
+<%= render(CancelLink::View.new(@trainee)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,8 @@ en:
         title: Start date
       training_details:
         title: Trainee start date and ID
+        start_date:
+          title: Date trainee started
       diversity:
         diversity_disclosure:
           diversity_disclosed: Information disclosed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -453,8 +453,8 @@ en:
         hint: Search for a school by its unique reference number (URN), name or postcode
     route_indicator:
       view:
-        display_text: "Trainee on the %{training_route_link} route"
-        apply_display_text: "Trainee enrolled on %{course_with_code}, %{training_route}"
+        display_text: "Trainee on the %{training_route_link} route."
+        apply_display_text: "Trainee enrolled on %{course_with_code}, %{training_route}."
 
   activerecord:
     attributes:

--- a/spec/components/cancel_link/view_spec.rb
+++ b/spec/components/cancel_link/view_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module CancelLink
+  describe View do
+    alias_method :component, :page
+
+    describe "rendering" do
+      before do
+        render_inline(described_class.new(trainee))
+      end
+
+      context "when the trainee is a non draft" do
+        let(:trainee) { create(:trainee, :submitted_for_trn) }
+
+        it "renders the record page link" do
+          expect(component).to have_link(t("cancel"), href: "/trainees/#{trainee.slug}")
+        end
+      end
+
+      context "when the trainee is a draft" do
+        let(:trainee) { build(:trainee, :draft) }
+
+        it "does not render the component" do
+          expect(component).to_not have_css("body")
+        end
+      end
+    end
+  end
+end

--- a/spec/components/flash_banner/view_preview.rb
+++ b/spec/components/flash_banner/view_preview.rb
@@ -3,25 +3,21 @@
 module FlashBanner
   class ViewPreview < ViewComponent::Preview
     def with_success
-      render(FlashBanner::View.new(flash: flash(:success), trainee: trainee, referer: referer))
+      render(FlashBanner::View.new(flash: flash(:success), trainee: trainee))
     end
 
     def with_warning
-      render(FlashBanner::View.new(flash: flash(:warning), trainee: trainee, referer: referer))
+      render(FlashBanner::View.new(flash: flash(:warning), trainee: trainee))
     end
 
     def with_info
-      render(FlashBanner::View.new(flash: flash(:info), trainee: trainee, referer: referer))
+      render(FlashBanner::View.new(flash: flash(:info), trainee: trainee))
     end
 
   private
 
     def trainee
       Trainee.new(id: 1, state: :submitted_for_trn)
-    end
-
-    def referer
-      nil
     end
 
     def flash(type)

--- a/spec/components/flash_banner/view_spec.rb
+++ b/spec/components/flash_banner/view_spec.rb
@@ -13,7 +13,7 @@ module FlashBanner
     let(:expected_title) { type == :success ? "Success" : "Important" }
 
     before do
-      render_inline(described_class.new(flash: flash, trainee: trainee, referer: referer))
+      render_inline(described_class.new(flash: flash, trainee: trainee))
     end
 
     context "non draft trainee" do
@@ -33,8 +33,11 @@ module FlashBanner
       end
 
       context "deleting a degree" do
-        let(:trainee) { build(:trainee, :submitted_for_trn) }
-        let(:referer) { "/trainees/123/degrees/confirm" }
+        let(:trainee) { create(:trainee, :submitted_for_trn, :with_degree) }
+
+        before do
+          trainee.degrees.destroy_all
+        end
 
         it "renders flash message" do
           expect(component).to have_text(expected_title)

--- a/spec/components/flash_banner/view_spec.rb
+++ b/spec/components/flash_banner/view_spec.rb
@@ -33,6 +33,7 @@ module FlashBanner
       end
 
       context "deleting a degree" do
+        let(:trainee) { build(:trainee, :submitted_for_trn) }
         let(:referer) { "/trainees/123/degrees/confirm" }
 
         it "renders flash message" do

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -72,6 +72,10 @@ FactoryBot.define do
     trait :in_progress do
       with_course_details
       with_start_date
+      with_degree
+    end
+
+    trait :with_degree do
       degrees { [build(:degree, :uk_degree_with_details)] }
     end
 

--- a/spec/features/trainees/degrees/delete_degree_spec.rb
+++ b/spec/features/trainees/degrees/delete_degree_spec.rb
@@ -36,7 +36,7 @@ private
   end
 
   def then_i_should_not_see_any_degree
-    expect(degrees_confirm_page.page_heading.text).to eql("Confirm degrees")
+    expect(degrees_confirm_page.page_heading.text).to eql("Confirm degree details")
     expect(degrees_confirm_page.main_content.find_all(".govuk-summary-list__row")).to be_empty
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/b/BBEuhbHM/publish-register-sprint-board

### Changes proposed in this pull request

- Remove cancel links from form sections in draft mode (apply draft too)
- Degrees confirm page heading needs to match prototype
- Remove flash message when adding a degree
- Summary card labels on training details confirm page need to match prototype
- Full stop needed in route type inset message on review-draft and check-details
- Summary components in check-details should match order in prototype

### Guidance to review

- Review and test the scenarios above

