### PR TITLE
[1707] Update TRN submission + recommended for award pages

### DIFF
--- a/app/components/feedback_link/view.html.erb
+++ b/app/components/feedback_link/view.html.erb
@@ -1,6 +1,12 @@
 <% if enabled %>
-  <div class="govuk-inset-text">
-    <h2 class="govuk-heading-s">How are you finding this process?</h2>
-    <%= govuk_link_to "Give feedback to help improve the process of recommending trainees for QTS", feedback_link_url, { class: "govuk-body" } %>
-  </div>
+  <h2 class="govuk-heading-m">Giving us feedback</h2>
+  <p class="govuk-body govuk-!-margin-bottom-5">
+    Tell us how <%= feedback_type_text %> with the new service is working for you.
+    We use this to make improvements. It takes 3 minutes to complete
+  </p>
+  <%= render GovukButtonLinkTo::View.new(
+    body: "Give feedback (opens in a new tab)",
+    url: feedback_link_url,
+    target: "_blank"
+  ) %>
 <% end %>

--- a/app/components/feedback_link/view.html.erb
+++ b/app/components/feedback_link/view.html.erb
@@ -7,6 +7,7 @@
   <%= render GovukButtonLinkTo::View.new(
     body: "Give feedback (opens in a new tab)",
     url: feedback_link_url,
-    target: "_blank"
+    target: "_blank",
+    rel: "noreferrer noopener"
   ) %>
 <% end %>

--- a/app/components/feedback_link/view.html.erb
+++ b/app/components/feedback_link/view.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-m">Giving us feedback</h2>
   <p class="govuk-body govuk-!-margin-bottom-5">
     Tell us how <%= feedback_type_text %> with the new service is working for you.
-    We use this to make improvements. It takes 3 minutes to complete
+    We use this to make improvements. It takes 3 minutes to complete.
   </p>
   <%= render GovukButtonLinkTo::View.new(
     body: "Give feedback (opens in a new tab)",

--- a/app/components/feedback_link/view.rb
+++ b/app/components/feedback_link/view.rb
@@ -2,11 +2,12 @@
 
 module FeedbackLink
   class View < GovukComponent::Base
-    attr_reader :feedback_link_url, :enabled
+    attr_reader :feedback_link_url, :enabled, :feedback_type_text
 
-    def initialize(enabled: true, feedback_link_url:)
+    def initialize(enabled: true, feedback_link_url:, feedback_type_text:)
       @enabled = enabled
       @feedback_link_url = feedback_link_url
+      @feedback_type_text = feedback_type_text
     end
   end
 end

--- a/app/views/trainees/outcome_details/recommended.html.erb
+++ b/app/views/trainees/outcome_details/recommended.html.erb
@@ -11,6 +11,7 @@
         <%= trainee_name(@trainee) %> recommended for <%= @trainee.award_type %>
       </h1>
     </div>
+    <h2 class="govuk-heading-m">Getting <%= @trainee.award_type %> status</h2>
     <p class="govuk-body">
       The Department for Education will award <%= @trainee.award_type %> where appropriate within 3
       working days.
@@ -18,10 +19,15 @@
   </div>
 </div>
 
-<p class="govuk-body govuk-!-margin-bottom-9"><%= govuk_link_to("Check trainee statuses from your list of records", trainees_path) %></p>
-
 <%= render FeedbackLink::View.new(
   enabled: Settings.features.enable_feedback_link,
   feedback_link_url: Settings.recommended_for_award_feedback_url,
   feedback_type_text: "recommending a trainee for #{@trainee.award_type}",
 ) %>
+
+<h2 class="govuk-heading-m">Next steps</h2>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li><%= govuk_link_to("view #{trainee_name(@trainee)}’s record", trainee_path(@trainee)) %></li>
+  <li><%= govuk_link_to("view all your records", trainees_path) %></li>
+</ul>  

--- a/app/views/trainees/outcome_details/recommended.html.erb
+++ b/app/views/trainees/outcome_details/recommended.html.erb
@@ -22,5 +22,6 @@
 
 <%= render FeedbackLink::View.new(
   enabled: Settings.features.enable_feedback_link,
-  feedback_link_url: Settings.feedback_link_url,
+  feedback_link_url: Settings.recommended_for_award_feedback_url,
+  feedback_type_text: "recommending a trainee for #{@trainee.award_type}",
 ) %>

--- a/app/views/trn_submissions/show.html.erb
+++ b/app/views/trn_submissions/show.html.erb
@@ -15,18 +15,26 @@
       </h1>
     </div>
 
+    <h2 class="govuk-heading-m">Getting a TRN</h2>
+
     <p class="govuk-body">The Department for Education (DfE) will issue a teacher reference number (TRN) within 3 working days.</p>
 
+    <h2 class="govuk-heading-m">Notifying your trainees</h2>
+
     <p class="govuk-body">DfE will contact trainees to give them their TRN.</p>
-
-    <%= render GovukButtonLinkTo::View.new(body: "Add another record", url: new_trainee_path) %>
-
-    <p class="govuk-body govuk-!-margin-bottom-9">or <%= govuk_link_to("check trainee statuses and manage records", trainees_path) %></p>
 
     <%= render FeedbackLink::View.new(
       enabled: Settings.features.enable_feedback_link,
       feedback_link_url: Settings.trn_submitted_feedback_url,
       feedback_type_text: "registering the trainee",
     ) %>
+
+    <h2 class="govuk-heading-m">Next steps</h2>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= govuk_link_to("view #{trainee_name(@trainee)}’s record", trainee_path(@trainee)) %></li>
+      <li><%= govuk_link_to("add a new trainee", new_trainee_path) %></li>
+      <li><%= govuk_link_to("view all your records", trainees_path) %></li>
+    </ul>
   </div>
 </div>

--- a/app/views/trn_submissions/show.html.erb
+++ b/app/views/trn_submissions/show.html.erb
@@ -25,7 +25,8 @@
 
     <%= render FeedbackLink::View.new(
       enabled: Settings.features.enable_feedback_link,
-      feedback_link_url: Settings.feedback_link_url,
+      feedback_link_url: Settings.trn_submitted_feedback_url,
+      feedback_type_text: "registering the trainee",
     ) %>
   </div>
 </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,8 +3,11 @@ port: 5000
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://localhost:5000
 
-# The url for the google doc feedback link (live version)
-feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSfhdvlUkg7oxPjl1C6FcJ2pnlc1OQ82r7o3ZMNKthhVAt_h5g/viewform?usp=sf_link"
+# The url for the google doc feedback link for recommended for award (live version)
+recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLScqCdDNyDHNBuUDG5YGWL7TzFI2WdmL6ib5326tUsphtC7PfQ/viewform"
+
+# The url for the google doc feedback link for submitting a trainee for trn (live version)
+trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSd-Jc3ef8yNYmIps3H905TuUkVfLYqpwP5ouQilNbHMSElCkg/viewform"
 
 # The email address for support queries
 support_email: becomingateacher@digital.education.gov.uk

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,11 +3,14 @@ port: 5000
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://localhost:5000
 
-# The url for the google doc feedback link for recommended for award (live version)
-recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLScqCdDNyDHNBuUDG5YGWL7TzFI2WdmL6ib5326tUsphtC7PfQ/viewform"
+# The url for the google doc feedback link (non-live version)
+feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSdYg4IA2tMiSfqIjM9CslVgFzsSazznD6VoT41g19sJYCwsLQ/viewform"
 
-# The url for the google doc feedback link for submitting a trainee for trn (live version)
-trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSd-Jc3ef8yNYmIps3H905TuUkVfLYqpwP5ouQilNbHMSElCkg/viewform"
+# The url for the google doc feedback link for recommended for award (non-live version)
+recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSc5ZEOkwsd8NTh3USbaDIL2OSBUtzVFonm7whuXhzFmQK5DHw/viewform"
+
+# The url for the google doc feedback link for submitting a trainee for trn (non-live version)
+trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSeewi8Fl9b90dXjyEX3tE72De8r9yxcFyl51vgOi7hE_fFp1g/viewform"
 
 # The email address for support queries
 support_email: becomingateacher@digital.education.gov.uk

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,5 +1,8 @@
-# The url for the google doc feedback link (non-live version)
-feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSdYg4IA2tMiSfqIjM9CslVgFzsSazznD6VoT41g19sJYCwsLQ/viewform"
+# The url for the google doc feedback link for recommended for award (non-live version)
+recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSc5ZEOkwsd8NTh3USbaDIL2OSBUtzVFonm7whuXhzFmQK5DHw/viewform"
+
+# The url for the google doc feedback link for submitting a trainee for trn (non-live version)
+trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSeewi8Fl9b90dXjyEX3tE72De8r9yxcFyl51vgOi7hE_fFp1g/viewform"
 
 dttp:
   api_base_url: "https://dttp-dev.api.crm4.dynamics.com"

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,9 +1,3 @@
-# The url for the google doc feedback link for recommended for award (non-live version)
-recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSc5ZEOkwsd8NTh3USbaDIL2OSBUtzVFonm7whuXhzFmQK5DHw/viewform"
-
-# The url for the google doc feedback link for submitting a trainee for trn (non-live version)
-trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSeewi8Fl9b90dXjyEX3tE72De8r9yxcFyl51vgOi7hE_fFp1g/viewform"
-
 dttp:
   api_base_url: "https://dttp-dev.api.crm4.dynamics.com"
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,6 +1,15 @@
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://www.register-trainee-teachers.education.gov.uk
 
+# The url for the google doc feedback link (live version)
+feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSfhdvlUkg7oxPjl1C6FcJ2pnlc1OQ82r7o3ZMNKthhVAt_h5g/viewform?usp=sf_link"
+
+# The url for the google doc feedback link for recommended for award (live version)
+recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLScqCdDNyDHNBuUDG5YGWL7TzFI2WdmL6ib5326tUsphtC7PfQ/viewform"
+
+# The url for the google doc feedback link for submitting a trainee for trn (live version)
+trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSd-Jc3ef8yNYmIps3H905TuUkVfLYqpwP5ouQilNbHMSElCkg/viewform"
+
 dttp:
   back_office_url: https://dttp.crm4.dynamics.com/
   scope: https://dttp.crm4.dynamics.com/.default

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,9 +1,3 @@
-# The url for the google doc feedback link for recommended for award (non-live version)
-recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSc5ZEOkwsd8NTh3USbaDIL2OSBUtzVFonm7whuXhzFmQK5DHw/viewform"
-
-# The url for the google doc feedback link for submitting a trainee for trn (non-live version)
-trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSeewi8Fl9b90dXjyEX3tE72De8r9yxcFyl51vgOi7hE_fFp1g/viewform"
-
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://qa.register-trainee-teachers.education.gov.uk
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,5 +1,8 @@
-# The url for the google doc feedback link (non-live version)
-feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSdYg4IA2tMiSfqIjM9CslVgFzsSazznD6VoT41g19sJYCwsLQ/viewform"
+# The url for the google doc feedback link for recommended for award (non-live version)
+recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSc5ZEOkwsd8NTh3USbaDIL2OSBUtzVFonm7whuXhzFmQK5DHw/viewform"
+
+# The url for the google doc feedback link for submitting a trainee for trn (non-live version)
+trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSeewi8Fl9b90dXjyEX3tE72De8r9yxcFyl51vgOi7hE_fFp1g/viewform"
 
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://qa.register-trainee-teachers.education.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -1,9 +1,3 @@
-# The url for the google doc feedback link for recommended for award (non-live version)
-recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSc5ZEOkwsd8NTh3USbaDIL2OSBUtzVFonm7whuXhzFmQK5DHw/viewform"
-
-# The url for the google doc feedback link for submitting a trainee for trn (non-live version)
-trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSeewi8Fl9b90dXjyEX3tE72De8r9yxcFyl51vgOi7hE_fFp1g/viewform"
-
 features:
   home_text: true
   use_dfe_sign_in: false

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -1,5 +1,8 @@
-# The url for the google doc feedback link (non-live version)
-feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSdYg4IA2tMiSfqIjM9CslVgFzsSazznD6VoT41g19sJYCwsLQ/viewform"
+# The url for the google doc feedback link for recommended for award (non-live version)
+recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSc5ZEOkwsd8NTh3USbaDIL2OSBUtzVFonm7whuXhzFmQK5DHw/viewform"
+
+# The url for the google doc feedback link for submitting a trainee for trn (non-live version)
+trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSeewi8Fl9b90dXjyEX3tE72De8r9yxcFyl51vgOi7hE_fFp1g/viewform"
 
 features:
   home_text: true

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,5 +1,8 @@
-# The url for the google doc feedback link (non-live version)
-feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSdYg4IA2tMiSfqIjM9CslVgFzsSazznD6VoT41g19sJYCwsLQ/viewform"
+# The url for the google doc feedback link for recommended for award (non-live version)
+recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSc5ZEOkwsd8NTh3USbaDIL2OSBUtzVFonm7whuXhzFmQK5DHw/viewform"
+
+# The url for the google doc feedback link for submitting a trainee for trn (non-live version)
+trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSeewi8Fl9b90dXjyEX3tE72De8r9yxcFyl51vgOi7hE_fFp1g/viewform"
 
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://staging.register-trainee-teachers.education.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,9 +1,3 @@
-# The url for the google doc feedback link for recommended for award (non-live version)
-recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSc5ZEOkwsd8NTh3USbaDIL2OSBUtzVFonm7whuXhzFmQK5DHw/viewform"
-
-# The url for the google doc feedback link for submitting a trainee for trn (non-live version)
-trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSeewi8Fl9b90dXjyEX3tE72De8r9yxcFyl51vgOi7hE_fFp1g/viewform"
-
 # The url for this app, also used by `dfe_sign_in`
 base_url: https://staging.register-trainee-teachers.education.gov.uk
 

--- a/spec/components/feedback_link/view_preview.rb
+++ b/spec/components/feedback_link/view_preview.rb
@@ -5,7 +5,7 @@ require "govuk/components"
 module FeedbackLink
   class ViewPreview < ViewComponent::Preview
     def default
-      render(FeedbackLink::View.new(enabled: true, feedback_link_url: "https://www.google.com"))
+      render(FeedbackLink::View.new(enabled: true, feedback_link_url: "https://www.google.com", feedback_type_text: "recommending the trainee for QTS"))
     end
   end
 end

--- a/spec/components/feedback_link/view_spec.rb
+++ b/spec/components/feedback_link/view_spec.rb
@@ -9,7 +9,8 @@ module FeedbackLink
     describe "feedback link" do
       before do
         render_inline(described_class.new(enabled: enabled,
-                                          feedback_link_url: "https://www.google.com"))
+                                          feedback_link_url: "https://www.google.com",
+                                          feedback_type_text: "recommend a trainee for QTS"))
       end
 
       context "when enabled" do
@@ -17,7 +18,7 @@ module FeedbackLink
 
         it "renders the feedback link" do
           expect(component).to have_link(
-            "Give feedback to help improve the process of recommending trainees for QTS",
+            "Give feedback (opens in a new tab)",
             href: "https://www.google.com",
           )
         end

--- a/spec/features/trainees/recommending_for_qts_spec.rb
+++ b/spec/features/trainees/recommending_for_qts_spec.rb
@@ -11,6 +11,7 @@ feature "Recommending for QTS", type: :feature do
     when_i_record_the_outcome_date
     and_i_confirm_the_outcome_details
     then_the_trainee_is_recommended_for_qts
+    and_the_page_has_the_correct_links
   end
 
   def then_the_trainee_is_recommended_for_qts
@@ -30,5 +31,11 @@ feature "Recommending for QTS", type: :feature do
 
   def and_i_confirm_the_outcome_details
     confirm_outcome_details_page.record_outcome.click
+  end
+
+  def and_the_page_has_the_correct_links
+    recommended_for_qts_page.load(trainee_id: trainee.slug)
+    expect(recommended_for_qts_page).to have_link("view #{trainee_name(@trainee)}", href: trainee_path(@trainee))
+    expect(recommended_for_qts_page).to have_link("view all your records", href: trainees_path)
   end
 end

--- a/spec/features/trainees/submit_for_trn_spec.rb
+++ b/spec/features/trainees/submit_for_trn_spec.rb
@@ -20,6 +20,7 @@ feature "submit for TRN" do
         then_i_review_the_trainee_data
         and_i_click_the_submit_for_trn_button
         and_i_am_redirected_to_the_success_page
+        with_the_correct_content
       end
 
       scenario "displays trainee name" do
@@ -114,5 +115,12 @@ feature "submit for TRN" do
 
   def then_i_am_redirected_to_the_trainee_records_page
     expect(trainee_index_page).to be_displayed
+  end
+
+  def with_the_correct_content
+    expect(trn_success_page).to have_text("Record submitted for #{trainee_name(trainee)}")
+    expect(trn_success_page).to have_link("view #{trainee_name(trainee)}", href: trainee_path(trainee))
+    expect(trn_success_page).to have_link("add a new trainee", href: new_trainee_path)
+    expect(trn_success_page).to have_link("view all your records", href: trainees_path)
   end
 end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -210,6 +210,10 @@ module Features
       @accessibility_page ||= PageObjects::Accessibility.new
     end
 
+    def recommended_for_qts_page
+      @recommended_for_qts_page ||= PageObjects::Trainees::RecommendedForQts.new
+    end
+
     def apply_trainee_data_page
       @apply_trainee_data_pate ||= PageObjects::Trainees::ApplyTraineeData.new
     end

--- a/spec/support/page_objects/trainees/recommended_for_qts.rb
+++ b/spec/support/page_objects/trainees/recommended_for_qts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class RecommendedForQts < PageObjects::Base
+      set_url "/trainees/{trainee_id}/outcome-details/recommended"
+    end
+  end
+end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/R8ITYv2V/1707-s-updates-to-our-2-submitted-pages-to-support-survey)

### Changes proposed in this pull request

- Changed the `FeedbackLink::View` component to support the new button and dynamic text and opens on new tab
- Changed each of the `feedback_url`'s in the Settings for Prod, QA, dev, staging
- Updated the entire page to fit the current designs in the prototype

### Guidance to review

- Fire up your rails server `rails s`
- Navigate to a trainee *who is submitted for trn*
- Use that trainee hash and direct to `https://localhost:5000/trn_submissions/#{trainee_hash}`
- Navigate to a trainee *who is recommended for qts*
- Use that trainee hash and direct to `https://localhost:5000/trainees/#{trainee_hash}/outcome-details/recommended`
- Both of these pages will display the feedback component and will be up to date with the prototype

