### PR TITLE
[1712] Publish courses list needs to be correct

### DIFF
--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -21,7 +21,7 @@ module TeacherTrainingApi
 
     def call
       return unless IMPORTABLE_STATES.include?(course_attributes[:state])
-      return if further_education_level_course?
+      return if further_education_level_course? || invalid_age_range?
 
       course.update!(name: course_attributes[:name],
                      start_date: start_date,
@@ -43,6 +43,10 @@ module TeacherTrainingApi
 
     def further_education_level_course?
       course_attributes[:level] == "further_education"
+    end
+
+    def invalid_age_range?
+      course_attributes.values_at(:age_minimum, :age_maximum).include?(nil)
     end
 
     def subjects

--- a/app/services/teacher_training_api/retrieve_courses.rb
+++ b/app/services/teacher_training_api/retrieve_courses.rb
@@ -6,7 +6,7 @@ module TeacherTrainingApi
 
     class Error < StandardError; end
 
-    DEFAULT_PATH = "/courses?filter[findable]=true&include=accredited_body,provider"
+    DEFAULT_PATH = "/courses?filter[findable]=true&include=accredited_body,provider&sort=name,provider.provider_name"
 
     def initialize(request_uri: nil)
       @request_uri = request_uri.presence || DEFAULT_PATH

--- a/spec/services/teacher_training_api/import_course_spec.rb
+++ b/spec/services/teacher_training_api/import_course_spec.rb
@@ -67,6 +67,14 @@ module TeacherTrainingApi
           end
         end
 
+        context "course has an invalid age range" do
+          let(:course_attributes) { { age_minimum: nil } }
+
+          it "doesn't get imported" do
+            expect { subject }.to_not(change { Course.count })
+          end
+        end
+
         context "and it's draft" do
           let(:course_attributes) { { state: "draft" } }
 

--- a/spec/services/teacher_training_api/retrieve_courses_spec.rb
+++ b/spec/services/teacher_training_api/retrieve_courses_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module TeacherTrainingApi
   describe RetrieveCourses do
     describe "#call" do
-      let(:path) { "/courses?filter[findable]=true&include=accredited_body,provider" }
+      let(:path) { "/courses?filter[findable]=true&include=accredited_body,provider&sort=name,provider.provider_name" }
 
       before do
         allow(Client).to receive(:get).with(path).and_return(response)


### PR DESCRIPTION
### Context
https://trello.com/c/ZPAa7LTv/1712-l-publish-courses-course-list-needs-to-be-correct

### Changes proposed in this pull request
- Update the URL for importing courses to include the sort query param as this affects the results returned by the API (appears to be a bug since sorting shouldn't affect the results in this way).
- Add another guard clause to ignore courses that don't have a valid age range

### Import Results
Before adding the sort query param we go about 9,500 courses - now we get 11,769.

### Guidance to review
- Change the code of an existing provider to "2AT"
- Run the following import code:

```ruby
request_uri = nil

loop do
  puts request_uri
  payload = TeacherTrainingApi::RetrieveCourses.call(request_uri: request_uri)

  payload[:data].each do |course_data|
    TeacherTrainingApi::ImportCourse.call(course_data: course_data, provider_data: payload[:included])
  end

  if payload[:links][:next]
    request_uri = payload[:links][:next]
  else
    break
  end
end
```
- Open a rails console and run `Provider.find_by(code: "2AT").courses.count`
- It should give the number 16 whereas before it was only showing 3




