### PR TITLE
[1724] Hide "Placement details" section from review draft page (not ready)

### DIFF
--- a/app/components/review_draft/draft/view.html.erb
+++ b/app/components/review_draft/draft/view.html.erb
@@ -32,9 +32,10 @@
           component.row(**row_helper(@trainee, :school_details))
         end
 
-        if @trainee.requires_placement_details?
-          component.row(**row_helper(@trainee, :placement_details))
-        end
+        # This will be uncommented once the form is built
+        # if @trainee.requires_placement_details?
+        #   component.row(**row_helper(@trainee, :placement_details))
+        # end
       end %>
   </div>
 </div>

--- a/spec/components/review_draft/draft/view_spec.rb
+++ b/spec/components/review_draft/draft/view_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ReviewDraft::Draft::View do
   context "when the trainee is on the provider-led route", 'feature_routes.provider_led_postgrad': true do
     let(:trainee) { create(:trainee, :provider_led_postgrad, :with_placement_assignment) }
 
-    it "renders additional provider-led specific sections" do
+    xit "renders additional provider-led specific sections" do
       expect(component).to have_text("Placement details")
     end
 

--- a/spec/views/trainees/review_draft/show.html.erb_spec.rb
+++ b/spec/views/trainees/review_draft/show.html.erb_spec.rb
@@ -20,7 +20,7 @@ describe "trainees/review_draft/show.html.erb" do
     context "with a Provider-led (postgrad) trainee" do
       let(:trainee) { create(:trainee, :provider_led_postgrad) }
 
-      it "renders the placement details component" do
+      xit "renders the placement details component" do
         expect(rendered).to have_text("Placement details")
       end
     end


### PR DESCRIPTION
### Context
https://trello.com/c/ShYBYxRp/1724-s-remove-placement-details-sections-for-provider-led-draft-page

### Changes proposed in this pull request
- Remove "Placement details" section - the work hasn't been done yet

