### PR TITLE
[1711] Add route message to publish courses selection

### DIFF
--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -19,6 +19,10 @@ module CourseDetailsHelper
     to_options(age_ranges(option: :additional))
   end
 
+  def route_title(route)
+    t("views.forms.publish_course_details.route_titles.#{route}")
+  end
+
 private
 
   def age_ranges(option:)

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -8,7 +8,10 @@
   <%= f.govuk_error_summary %>
 
   <div class="govuk-form-group">
-    <%= f.govuk_radio_buttons_fieldset :code, legend: { text: t(".heading"), tag: "h1", size: "l" } do %>
+    <%= f.govuk_radio_buttons_fieldset :code,
+      legend: { text: t(".heading"), tag: "h1", size: "l" },
+      hint: { text: t("views.forms.publish_course_details.route_message", route: route_title(@trainee.training_route)) } do %>
+
       <% @courses.each do |course| %>
         <%= f.govuk_radio_button :code, course.code,
           label: { text: "#{course.name} (#{course.code})" },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,6 +346,10 @@ en:
           hint:
             This will help you to identify them and search for them in your trainee records.
             We may also use it if we need to get in touch with you about this trainee.
+      publish_course_details:
+        route_message: "Your %{route} courses in the Publish service"
+        route_titles:
+          provider_led_postgrad: provider-led postgrad
   pages:
     home:
       heading: Register trainee teacher

--- a/spec/support/page_objects/trainees/publish_course_details.rb
+++ b/spec/support/page_objects/trainees/publish_course_details.rb
@@ -14,6 +14,8 @@ module PageObjects
       sections :course_options, CourseOptions, ".govuk-radios__item"
 
       element :submit_button, "input[name='commit']"
+
+      element :route_message, "#publish-course-details-form-code-hint"
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/b/BBEuhbHM/publish-register-sprint-board

### Changes proposed in this pull request

<img width="1105" alt="Screenshot 2021-05-20 at 14 31 54" src="https://user-images.githubusercontent.com/616080/118988954-8cd6c980-b979-11eb-8c59-e69ad5ed5bf8.png">

### Guidance to review

- Toggle the `provider_led_postgrad` flag locally, run the sample data and create a provider-led trainee. 
- Head to the course details section and assert the hint is shown below the heading
