### PR TITLE
[1713] Allow courses to be changed from confirmation components

### DIFF
--- a/app/components/cancel_link/view.html.erb
+++ b/app/components/cancel_link/view.html.erb
@@ -1,1 +1,1 @@
-<p class="govuk-body"><%= govuk_link_to(t("cancel"), view_trainee(trainee)) %></p>
+<p class="govuk-body"><%= govuk_link_to(t("components.confirmation.cancel_and_return"), view_trainee(trainee)) %></p>

--- a/app/components/trainees/confirmation/course_details/view.html.erb
+++ b/app/components/trainees/confirmation/course_details/view.html.erb
@@ -2,6 +2,12 @@
                                  heading_level: 2,
                                  rows: [
       {
+        key: "Course details",
+        value: course_details,
+        action: govuk_link_to('Change<span class="govuk-visually-hidden"> course details</span>'.html_safe,
+                              edit_trainee_publish_course_details_path(trainee)), 
+      },                          
+      {
         key: "Type of course",
         value: course_type,
       },

--- a/app/components/trainees/confirmation/course_details/view.rb
+++ b/app/components/trainees/confirmation/course_details/view.rb
@@ -10,7 +10,7 @@ module Trainees
 
         def initialize(data_model:)
           @data_model = data_model
-          @not_provided_copy = I18n.t("components.confirmation.not_provided")
+          @not_provided_copy = t("components.confirmation.not_provided")
         end
 
         def trainee
@@ -18,7 +18,17 @@ module Trainees
         end
 
         def summary_title
-          I18n.t("components.course_detail.title")
+          t("components.course_detail.title")
+        end
+
+        def course_details
+          return t("components.course_detail.details_not_on_publish") if data_model.course_code.blank?
+
+          "#{course.name} (#{course.code})"
+        end
+
+        def course
+          @course ||= Course.find_by(code: data_model.course_code)
         end
 
         def subject

--- a/app/forms/confirm_publish_course_form.rb
+++ b/app/forms/confirm_publish_course_form.rb
@@ -48,12 +48,17 @@ class ConfirmPublishCourseForm
     course&.end_date
   end
 
+  def course_code
+    course&.code
+  end 
+  
 private
 
   def update_trainee_attributes
     trainee.progress.course_details = true
     trainee.assign_attributes({
       subject: subject,
+      course_code: course_code, 
       course_age_range: course&.age_range,
       course_start_date: course_start_date,
       course_end_date: course_end_date,

--- a/app/forms/confirm_publish_course_form.rb
+++ b/app/forms/confirm_publish_course_form.rb
@@ -50,15 +50,15 @@ class ConfirmPublishCourseForm
 
   def course_code
     course&.code
-  end 
-  
+  end
+
 private
 
   def update_trainee_attributes
     trainee.progress.course_details = true
     trainee.assign_attributes({
       subject: subject,
-      course_code: course_code, 
+      course_code: course_code,
       course_age_range: course&.age_range,
       course_start_date: course_start_date,
       course_end_date: course_end_date,

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -50,6 +50,12 @@ class CourseDetailsForm < TraineeForm
     new_date({ year: end_year, month: end_month, day: end_day })
   end
 
+  def course_code
+    return nil unless trainee.draft?
+
+    trainee.course_code
+  end
+
   def save!
     if valid?
       update_trainee_attributes
@@ -72,6 +78,7 @@ private
 
   def update_trainee_attributes
     trainee.assign_attributes({
+      course_code: nil,
       subject: subject,
       course_age_range: course_age_range,
       course_start_date: course_start_date,

--- a/app/views/trainees/confirm_publish_course/edit.html.erb
+++ b/app/views/trainees/confirm_publish_course/edit.html.erb
@@ -15,3 +15,5 @@
     <p class="govuk-body"><%= govuk_link_to(t(".edit_details"), "#") %></p>
   </div>
 </div>
+
+<%= render(CancelLink::View.new(@trainee)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,7 @@ en:
         trainee_start_date: start date
     course_detail:
       title: Course details
+      details_not_on_publish: Details not on Publish
     school_details:
         summary_title: Schools
         lead_school_key: Lead school

--- a/spec/components/trainees/confirmation/course_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/course_details/view_spec.rb
@@ -15,6 +15,7 @@ module Trainees
             build(:trainee, id: 1,
                             training_route: nil,
                             subject: nil,
+                            course_code: nil,
                             course_min_age: nil,
                             course_max_age: nil,
                             course_start_date: nil)
@@ -24,42 +25,64 @@ module Trainees
             render_inline(View.new(data_model: trainee))
           end
 
-          it "tells the user that no data has been entered for course type, subject, age range, course start date and course end date" do
+          it "tells the user that no data has been entered for course details, course type, subject, age range, course start date and course end date" do
             found = component.find_all(".govuk-summary-list__row")
 
-            expect(found.size).to eq(5)
+            expect(found.size).to eq(6)
 
-            found.each do |row|
+            found.at(1..5).each do |row|
               expect(row.find(".govuk-summary-list__value")).to have_text(t("components.confirmation.not_provided"))
             end
           end
         end
 
         context "when data has been provided" do
-          let(:trainee) { build(:trainee, :with_course_details, id: 1) }
+          subject { component.find(".govuk-summary-list__row.course-details .govuk-summary-list__value") }
 
-          before do
-            render_inline(View.new(data_model: trainee))
+          context "with a publish course" do
+            let(:trainee) { create(:trainee, :with_course_details, id: 1) }
+            let(:course) { instance_double("course", name: "some_name", code: "some_code") }
+
+            before do
+              expect(Course).to receive(:find_by).with(code: trainee.course_code).and_return(course)
+              render_inline(View.new(data_model: trainee))
+            end
+
+            it "renders the course details" do
+              expect(subject).to have_text("#{course.name} (#{course.code})")
+            end
+
+            it "renders the course type" do
+              expect(component.find(".govuk-summary-list__row.type-of-course .govuk-summary-list__value"))
+                .to have_text(trainee.training_route.humanize)
+            end
+
+            it "renders the subject" do
+              expect(component.find(".govuk-summary-list__row.subject .govuk-summary-list__value"))
+                .to have_text(trainee.subject)
+            end
+
+            it "renders the course age range" do
+              expect(component.find(".govuk-summary-list__row.age-range .govuk-summary-list__value"))
+                .to have_text(age_range_for_summary_view(trainee.course_age_range))
+            end
+
+            it "renders the course start date" do
+              expect(component.find(".govuk-summary-list__row.course-start-date .govuk-summary-list__value"))
+                .to have_text(date_for_summary_view(trainee.course_start_date))
+            end
           end
 
-          it "renders the course type" do
-            expect(component.find(".govuk-summary-list__row.type-of-course .govuk-summary-list__value"))
-              .to have_text(trainee.training_route.humanize)
-          end
+          context "without a publish course" do
+            let(:trainee) { create(:trainee, :with_course_details, course_code: nil) }
 
-          it "renders the subject" do
-            expect(component.find(".govuk-summary-list__row.subject .govuk-summary-list__value"))
-              .to have_text(trainee.subject)
-          end
+            before do
+              render_inline(View.new(data_model: trainee))
+            end
 
-          it "renders the course age range" do
-            expect(component.find(".govuk-summary-list__row.age-range .govuk-summary-list__value"))
-              .to have_text(age_range_for_summary_view(trainee.course_age_range))
-          end
-
-          it "renders the course start date" do
-            expect(component.find(".govuk-summary-list__row.course-start-date .govuk-summary-list__value"))
-              .to have_text(date_for_summary_view(trainee.course_start_date))
+            it "renders the not on publish message" do
+              expect(subject).to have_text(t("components.course_detail.details_not_on_publish"))
+            end
           end
         end
       end

--- a/spec/components/trainees/sections/view_spec.rb
+++ b/spec/components/trainees/sections/view_spec.rb
@@ -81,7 +81,7 @@ module Trainees
 
       context "trainee completed" do
         let(:trainee) do
-          create(:trainee, :completed)
+          create(:trainee, :completed, course_code: nil)
         end
 
         include_examples renders_confirmation, :personal_details

--- a/spec/features/trainees/submit_for_trn_spec.rb
+++ b/spec/features/trainees/submit_for_trn_spec.rb
@@ -12,7 +12,7 @@ feature "submit for TRN" do
 
   describe "submission" do
     context "when all sections are completed" do
-      let(:trainee) { create(:trainee, :completed, provider: current_user.provider) }
+      let(:trainee) { create(:trainee, :completed, provider: current_user.provider, course_code: nil) }
 
       scenario "can submit the application" do
         when_i_am_viewing_the_review_draft_page


### PR DESCRIPTION
### Context

- https://trello.com/c/eMZwfzbp/1713-s-publish-courses-allow-courses-to-be-changed-from-confirmation-component

### Changes proposed in this pull request

- Allow courses to be changed from confirmation components in both draft and non draft workflows
- Handle stashing/undoing behaviour

### Guidance to review


