### PR TITLE
[1746] Bug fix - adding new degrees to non-draft trainee

### DIFF
--- a/app/forms/degree_form.rb
+++ b/app/forms/degree_form.rb
@@ -29,15 +29,14 @@ class DegreeForm
   validates :subject, :institution, autocomplete: true, allow_nil: true
   validate :validate_with_degree_model
 
-  delegate :uk?, :non_uk?, :non_uk_degree_non_enic?, :persisted?,
-           to: :degree
+  delegate :uk?, :non_uk?, :non_uk_degree_non_enic?, :persisted?, to: :degree
+
+  alias_method :to_param, :slug
 
   def initialize(degrees_form:, degree:, autocomplete_params: {})
     @degrees_form = degrees_form
     @degree = degree
-    self.attributes = degree.attributes
-      .symbolize_keys
-      .slice(*FIELDS)
+    self.attributes = degree.attributes.symbolize_keys.slice(*FIELDS)
     assign_attributes(autocomplete_params)
   end
 
@@ -45,15 +44,8 @@ class DegreeForm
     ActiveModel::Name.new(self, nil, "Degree")
   end
 
-  def id
-    slug
-  end
-
   def fields
-    degree.attributes
-      .symbolize_keys
-      .slice(*FIELDS)
-      .merge(attributes)
+    degree.attributes.symbolize_keys.slice(*FIELDS).merge(attributes)
   end
 
   def attributes


### PR DESCRIPTION
### Context
https://trello.com/c/WERg6gR7/1746-cannot-add-a-new-degree-for-non-draft-trainees

### Changes proposed in this pull request
- Add `to_param` to `DegreeForm` so that rails route helper can compute the URL [this is where `to_param` gets called](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/routing/route_set.rb#L233)

### Guidance to review
- Select a non-draft trainee
- Add new degree
- Confirm page should render without any exceptions thrown
