### PR TITLE
[1759] Remove underline on sort links prefix text

### DIFF
--- a/app/components/trainees/sort_links/style.scss
+++ b/app/components/trainees/sort_links/style.scss
@@ -2,7 +2,6 @@
 
 .app-sort-links {
   @include govuk-font($size: 19);
-  @include govuk-link-common;
   @include govuk-link-style-text;
   @include govuk-clearfix;
 


### PR DESCRIPTION
### Context
Remove text-underline which is expected only on the links instead of "Sort By" prefix

### Changes proposed in this pull request
Remove `   @include govuk-link-common;` from `.app-sort-links`

### Guidance to review
"Sort By:" is rendered without an underline.
