### PR TITLE
[1761] Bug fix - wrong DTTP ID sent for no disability

### DIFF
--- a/app/lib/dttp/params/contact.rb
+++ b/app/lib/dttp/params/contact.rb
@@ -82,7 +82,7 @@ module Dttp
       end
 
       def trainee_not_disabled?
-        trainee.disability_disclosure == Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_disabled]
+        trainee.disability_disclosure == Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability]
       end
 
       def trainee_disability_not_provided?

--- a/spec/lib/dttp/params/contact_spec.rb
+++ b/spec/lib/dttp/params/contact_spec.rb
@@ -163,8 +163,8 @@ module Dttp
                 end
               end
 
-              context "not disabled" do
-                let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_disabled] }
+              context "no disability" do
+                let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability] }
                 let(:dttp_disability) { Diversities::NO_KNOWN_DISABILITY }
 
                 it "returns a hash with a foreign key of DTTP's 'No known disability' entity" do


### PR DESCRIPTION
### Context
https://trello.com/c/AgkmJjaj/1761-no-disabilities-being-sent-to-dttp-as-lots-of-disabilities

### Changes proposed in this pull request
- Update `Dttp::Params::Contact` to use the correct DTTP key for no disability.

The key was changed from `:not_disabled` to `:no_disability` a few months back, and because the code wasn't updated to reflect the new key, the guard clause failed leading to the code that eventually picks `Diversities::MULTIPLE_DISABILITIES`.

