### PR TITLE
[1744] Retrieve(Trn|Award)Job can be re-enqueued after polling timeout

### DIFF
--- a/app/jobs/retrieve_award_job.rb
+++ b/app/jobs/retrieve_award_job.rb
@@ -7,9 +7,14 @@ class RetrieveAwardJob < ApplicationJob
 
   class TraineeAttributeError < StandardError; end
 
-  def perform(trainee, timeout_after)
+  def perform(trainee, timeout_after = nil)
     @timeout_after = timeout_after
     @trainee = trainee
+
+    if @timeout_after.nil?
+      self.class.perform_later(trainee, trainee.recommended_for_award_at + Settings.jobs.max_poll_duration_days.days)
+      return
+    end
 
     awarded = Dttp::RetrieveAward.call(trainee: trainee)
 

--- a/app/jobs/retrieve_trn_job.rb
+++ b/app/jobs/retrieve_trn_job.rb
@@ -7,9 +7,14 @@ class RetrieveTrnJob < ApplicationJob
 
   class TraineeAttributeError < StandardError; end
 
-  def perform(trainee, timeout_after)
+  def perform(trainee, timeout_after = nil)
     @timeout_after = timeout_after
     @trainee = trainee
+
+    if @timeout_after.nil?
+      self.class.perform_later(trainee, trainee.submitted_for_trn_at + Settings.jobs.max_poll_duration_days.days)
+      return
+    end
 
     trn = Dttp::RetrieveTrn.call(trainee: trainee)
 

--- a/app/jobs/retrieve_trn_job.rb
+++ b/app/jobs/retrieve_trn_job.rb
@@ -7,13 +7,16 @@ class RetrieveTrnJob < ApplicationJob
 
   class TraineeAttributeError < StandardError; end
 
-  def perform(trainee)
+  def perform(trainee, timeout_after)
+    @timeout_after = timeout_after
+    @trainee = trainee
+
     trn = Dttp::RetrieveTrn.call(trainee: trainee)
 
     if trn
       trainee.trn_received!(trn)
-    elsif continue_polling?(trainee)
-      self.class.set(wait: Settings.jobs.poll_delay_hours.hours).perform_later(trainee)
+    elsif continue_polling?
+      requeue
     else
       send_message_to_slack(trainee, self.class.name)
     end
@@ -21,17 +24,24 @@ class RetrieveTrnJob < ApplicationJob
 
   class << self
     def perform_with_default_delay(trainee)
-      set(wait: Settings.jobs.poll_delay_hours.hours).perform_later(trainee)
+      set(wait: Settings.jobs.poll_delay_hours.hours)
+        .perform_later(trainee, Settings.jobs.max_poll_duration_days.days.from_now)
     end
   end
 
 private
 
-  def continue_polling?(trainee)
+  attr_reader :trainee, :timeout_after
+
+  def continue_polling?
     if trainee.submitted_for_trn_at.nil?
       raise TraineeAttributeError, "Trainee#submitted_for_trn_at is nil - it should be timestamped (id: #{trainee.id})"
     end
 
-    trainee.submitted_for_trn_at > Settings.jobs.max_poll_duration_days.days.ago
+    Time.zone.now.utc < timeout_after
+  end
+
+  def requeue
+    self.class.set(wait: Settings.jobs.poll_delay_hours.hours).perform_later(trainee, timeout_after)
   end
 end

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/app/webpacker/$1'
   },
   roots: ['app/webpacker'],
+  testEnvironment: 'jsdom',
   testMatch: ['**/app/webpacker/**/*.spec.js'],
   testURL: 'http://localhost/',
   testPathIgnorePatterns: []

--- a/spec/jobs/retrieve_award_job_spec.rb
+++ b/spec/jobs/retrieve_award_job_spec.rb
@@ -18,6 +18,18 @@ describe RetrieveAwardJob do
     allow(SlackNotifierService).to receive(:call)
   end
 
+  context "when timeout_after is nil" do
+    let(:timeout_date) { trainee.recommended_for_award_at + configured_poll_timeout_days.days }
+
+    it "reenqueues RetrieveAwardJob with the trainee and default timeout_after" do
+      Timecop.freeze(Time.zone.now) do
+        expect {
+          described_class.perform_now(trainee, nil)
+        }.to enqueue_job(RetrieveAwardJob).with(trainee, timeout_date)
+      end
+    end
+  end
+
   context "Award is awarded in DTTP" do
     let(:award_flag) { true }
 

--- a/spec/jobs/retrieve_award_job_spec.rb
+++ b/spec/jobs/retrieve_award_job_spec.rb
@@ -7,9 +7,15 @@ describe RetrieveAwardJob do
 
   let(:award_flag) { nil }
   let(:trainee) { create(:trainee, :recommended_for_award) }
+  let(:configured_delay) { 6 }
+  let(:configured_poll_timeout_days) { 4 }
+  let(:timeout_date) { configured_poll_timeout_days.days.from_now }
 
   before do
     allow(Dttp::RetrieveAward).to receive(:call).with(trainee: trainee).and_return(award_flag)
+    allow(Settings.jobs).to receive(:poll_delay_hours).and_return(configured_delay)
+    allow(Settings.jobs).to receive(:max_poll_duration_days).and_return(configured_poll_timeout_days)
+    allow(SlackNotifierService).to receive(:call)
   end
 
   context "Award is awarded in DTTP" do
@@ -17,44 +23,31 @@ describe RetrieveAwardJob do
 
     it "transitions the trainee to awarded" do
       expect {
-        described_class.perform_now(trainee)
+        described_class.perform_now(trainee, timeout_date)
         trainee.reload
       }.to change(trainee, :state).to("awarded")
     end
 
     it "doesn't queue another job" do
-      described_class.perform_now(trainee)
+      described_class.perform_now(trainee, timeout_date)
       expect(RetrieveAwardJob).to_not have_been_enqueued
     end
   end
 
   context "Award is not awarded in DTTP" do
     let(:award_flag) { false }
-    let(:configured_delay) { 6 }
-
-    before do
-      allow(Settings.jobs).to receive(:poll_delay_hours).and_return(configured_delay)
-    end
 
     it "queues another job to fetch the Award the configured number of hours from now" do
       Timecop.freeze(Time.zone.now) do
-        described_class.perform_now(trainee)
-        expect(RetrieveAwardJob).to have_been_enqueued.at(configured_delay.hours.from_now).with(trainee)
+        described_class.perform_now(trainee, timeout_date)
+        expect(RetrieveAwardJob).to have_been_enqueued.at(configured_delay.hours.from_now).with(trainee, timeout_date)
       end
     end
 
-    context "timing out after after 4 days of polling" do
-      let(:trainee) { create(:trainee, recommended_for_award_at: configured_limit.days.ago) }
-      let(:configured_limit) { 4 }
-
-      before do
-        allow(Settings.jobs).to receive(:max_poll_duration_days).and_return(configured_limit)
-        allow(SlackNotifierService).to receive(:call)
-      end
-
-      it "doesn't queue another job after 4 days have passed with no QTS" do
+    context "timeout_after has passed" do
+      it "doesn't queue another job" do
         expect(SlackNotifierService).to receive(:call)
-        described_class.perform_now(trainee)
+        described_class.perform_now(trainee, Time.zone.now - 1.minute)
         expect(RetrieveAwardJob).to_not have_been_enqueued
       end
     end
@@ -66,22 +59,16 @@ describe RetrieveAwardJob do
 
     it "raises a TraineeAttributeError" do
       expect {
-        described_class.perform_now(trainee)
+        described_class.perform_now(trainee, timeout_date)
       }.to raise_error(RetrieveAwardJob::TraineeAttributeError, error_msg)
     end
   end
 
   describe ".perform_with_default_delay" do
-    let(:configured_delay) { 6 }
-
-    before do
-      allow(Settings.jobs).to receive(:poll_delay_hours).and_return(configured_delay)
-    end
-
     it "enqueues the job with the configured delay" do
       Timecop.freeze(Time.zone.now) do
-        described_class.perform_now(trainee)
-        expect(RetrieveAwardJob).to have_been_enqueued.at(configured_delay.hours.from_now).with(trainee)
+        described_class.perform_now(trainee, timeout_date)
+        expect(RetrieveAwardJob).to have_been_enqueued.at(configured_delay.hours.from_now).with(trainee, timeout_date)
       end
     end
   end

--- a/spec/jobs/retrieve_trn_job_spec.rb
+++ b/spec/jobs/retrieve_trn_job_spec.rb
@@ -18,6 +18,18 @@ describe RetrieveTrnJob do
     allow(SlackNotifierService).to receive(:call)
   end
 
+  context "when timeout_after is nil" do
+    let(:timeout_date) { trainee.submitted_for_trn_at + configured_poll_timeout_days.days }
+
+    it "reenqueues RetrieveTrnJob with the trainee and default timeout_after" do
+      Timecop.freeze(Time.zone.now) do
+        expect {
+          described_class.perform_now(trainee, nil)
+        }.to enqueue_job(RetrieveTrnJob).with(trainee, timeout_date)
+      end
+    end
+  end
+
   context "TRN is available" do
     let(:trn) { "123" }
 


### PR DESCRIPTION
### Context

We have two jobs - `RetrieveTrnJob` and `RetrieveAwardJob`, that poll DTTP for data and if they don't receive it re-enqueue themselves. After a timeout period (stored in settings and currently 4 days), they stop polling and notify us of failure on Slack.

Generally we would want to investigate and then probably set the polling running again to pick up the value when it arrives. The way the jobs were written this wasn't possible as the job was being run > 4 days after it was originally submitted so it immediately cancelled itself and notified again on Slack.

### Changes proposed in this pull request

* Pass in a `timeout_after` date as an argument to allow us to specify a date that is different than the default in situations as described above.
* Update the `perform_with_default_delay` method to set the date using the existing logic ie `trainee.recommended_for_award_at + 4.days` to avoid calling code needing to understand the polling timeout logic to create a date.

### Guidance to review

With redis running...

Run the app and submit for TRN/QTS. The scheduled job should still be scheduled to run after the configured delay and should contain now + 4.days as an argument.

```
t = Trainee.last
RetrieveAwardJob.perform_with_default_delay(t)
ss = Sidekiq::ScheduledSet.new
ss.select {|j| puts j.args}

```

