### PR TITLE
[1540] Consistency Checks Scheduled

### DIFF
--- a/app/jobs/dttp/check_consistency_job.rb
+++ b/app/jobs/dttp/check_consistency_job.rb
@@ -8,7 +8,6 @@ module Dttp
       @consistency_check = ConsistencyCheck.find(consistency_check_id)
       @dttp_contact_updated_date = Dttp::Contacts::Fetch.call(dttp_id: trainee.dttp_id).updated_at
       @dttp_placement_assignment_updated_date = Dttp::PlacementAssignments::Fetch.call(dttp_id: trainee.placement_assignment_dttp_id).updated_at
-
       if contact_conflict || placement_assignment_conflict
         SlackNotifierService.call(channel: Settings.slack.publish_register_alerts_channel, message: "<#{Rails.application.routes.url_helpers.trainees_url(trainee, host: Settings.base_url)}|Trainee #{trainee.id} has been updated in DTTP>", username: "DTTP Conflict Error")
       end

--- a/app/jobs/run_consistency_checks_job.rb
+++ b/app/jobs/run_consistency_checks_job.rb
@@ -4,6 +4,8 @@ class RunConsistencyChecksJob < ApplicationJob
   queue_as :default
 
   def perform(*_args)
+    return unless FeatureService.enabled?("run_consistency_check_job") && ConsistencyCheck.any?
+
     ConsistencyCheck.all.each do |consistency_check|
       Dttp::CheckConsistencyJob.perform_later(consistency_check.id)
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,6 +34,7 @@ features:
   import_applications_from_apply: false
   import_courses_from_ttapi: false
   publish_course_details: false
+  run_consistency_check_job: true
   routes:
     early_years_assessment_only: false 
     early_years_graduate_employment_based: false 

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -22,3 +22,7 @@ import_providers_from_dttp:
   cron: "0 4 * * *"
   class: "Dttp::SyncProvidersJob"
   queue: dttp
+run_consistency_check_job:
+  cron: "0 2 * * *"
+  class: "RunConsistencyChecksJob"
+  queue: dttp

--- a/spec/jobs/run_consistency_checks_job_spec.rb
+++ b/spec/jobs/run_consistency_checks_job_spec.rb
@@ -8,14 +8,34 @@ describe RunConsistencyChecksJob do
   let(:trainee) { create(:trainee) }
   let(:consistency_check) { create(:consistency_check, trainee_id: trainee.id) }
 
-  before do
-    consistency_check
+  context "when a consistency check exists" do
+    before do
+      consistency_check
+
+      described_class.perform_now
+    end
+
+    context "when the feature flag is turned on", feature_run_consistency_check_job: true do
+      describe ".perform" do
+        it "runs each check" do
+          expect(Dttp::CheckConsistencyJob).to have_been_enqueued.with(consistency_check.id)
+        end
+      end
+    end
+
+    context "when the feature flag is turned off", feature_run_consistency_check_job: false do
+      describe ".perform" do
+        it "does not run" do
+          expect(Dttp::CheckConsistencyJob).to_not have_been_enqueued.with(consistency_check.id)
+        end
+      end
+    end
   end
 
-  describe ".perform" do
-    it "runs each check" do
-      ConsistencyCheck.all.each do |consistency_check|
-        expect(Dttp::CheckConsistencyJob).not_to have_been_enqueued.with(consistency_check.id)
+  context "when there are no consistency checks", feature_run_consistency_check_job: true do
+    describe ".perform" do
+      it "does not run" do
+        expect(Dttp::CheckConsistencyJob).to_not have_been_enqueued.with(consistency_check.id)
       end
     end
   end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/fuH0ByWq/1540-s-enable-consistency-check)

### Changes proposed in this pull request

- Scheduled the `RunConsistencyChecksJob` to run at 2am nightly
- It will exit early if the feature flag is false
- It will exit early if there arent any `ConsistencyCheck` objects
- Added tests to support both the above

### Guidance to review

- Run `rspec spec/jobs/run_consistency_checks_job_spec.rb`
- OR
- Follow [these instructions](https://github.com/DFE-Digital/register-trainee-teachers/pull/723) and perform the job early from the command line. 
