### PR TITLE
[1547] Show provider name to administrators in CSV export

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -97,6 +97,6 @@ private
   end
 
   def data_export
-    @data_export ||= Exports::TraineeSearchData.new(filtered_trainees)
+    @data_export ||= Exports::TraineeSearchData.new(filtered_trainees, include_provider: current_user.system_admin?)
   end
 end

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -2,8 +2,8 @@
 
 module Exports
   class TraineeSearchData
-    def initialize(trainees)
-      @data_for_export = format_trainees(trainees)
+    def initialize(trainees, include_provider: false)
+      @data_for_export = format_trainees(trainees, include_provider)
     end
 
     def data
@@ -26,7 +26,7 @@ module Exports
 
     attr_reader :data_for_export
 
-    def format_trainees(trainees)
+    def format_trainees(trainees, include_provider)
       trainees.map do |trainee|
         {
           "First name" => trainee.first_names,
@@ -42,7 +42,9 @@ module Exports
           "Last updated date" => trainee.updated_at,
           "TRN Submitted date" => trainee.submitted_for_trn_at,
           "Award submitted date" => trainee.recommended_for_award_at,
-        }
+        }.tap do |fields|
+          fields.merge!("Provider Name" => trainee.provider.name) if include_provider
+        end
       end
     end
 

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -36,6 +36,14 @@ module Exports
       it "sets the correct row values" do
         expect(subject.data).to include(expected_output.values.join(","))
       end
+
+      context "with provider option enabled" do
+        subject { described_class.new([trainee], include_provider: true) }
+
+        it "includes the provider name" do
+          expect(subject.data).to include(trainee.provider.name)
+        end
+      end
     end
 
     describe "#time" do


### PR DESCRIPTION
### Context
 https://trello.com/c/Ak6B5dNc/1547-s-show-provider-name-to-administrators

### Changes proposed in this pull request
- Add option to `Exports::TraineeSearchData` to include provider data
- Update `TraineesController` to enable option if user is system admin

### Guidance to review
- Log in as system admin
- Visit trainees page
- Export CSV
- Last column should have provider name
- Log in as non-system admin
- Export CSV again
- It should not have a column with provider name
