### PR TITLE
[1781] Freetext autocomplete entries checked if valid

### DIFF
--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -175,12 +175,12 @@ private
       next unless find_nationality(raw_value)
 
       public_send("other_nationality#{index + 1}=", raw_value)
-      new_attributes[:"other_nationality#{index + 1}"] << raw_value
+      new_attributes[:"other_nationality#{index + 1}"] = raw_value
       nationality_ids[index] = find_nationality(raw_value).id
     end
   end
 
   def find_nationality(raw_value)
-    Nationality.find_by(name: raw_value)
+    Nationality.find_by(name: raw_value&.downcase)
   end
 end

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -27,6 +27,7 @@ class PersonalDetailsForm < TraineeForm
   validate :date_of_birth_valid
   validate :date_of_birth_not_in_future
   validates :gender, presence: true, inclusion: { in: Trainee.genders.keys }
+  validate :check_raw_values
   validates :other_nationality1, :other_nationality2, :other_nationality3, autocomplete: true, allow_nil: true
   validate :nationalities_cannot_be_empty
 
@@ -158,5 +159,28 @@ private
     raw_values = params.slice(*NATIONALITY_FIELD_MAPPINGS.keys).transform_keys { |key| NATIONALITY_FIELD_MAPPINGS[key.to_sym] }.select { |_key, value| value.blank? }
 
     params.merge!(raw_values)
+  end
+
+  def raw_values_nationalities_array
+    [other_nationality1_raw, other_nationality2_raw, other_nationality3_raw]
+  end
+
+  def check_raw_values
+    # check the freetext responses of the user, and if
+    # they are valid responses, we use them by populating new attributes.
+    # This was to fix a bug where valid responses were not being used
+    # as they were not selected from the dropdown list
+
+    raw_values_nationalities_array.each_with_index do |raw_value, index|
+      next unless find_nationality(raw_value)
+
+      public_send("other_nationality#{index + 1}=", raw_value)
+      new_attributes[:"other_nationality#{index + 1}"] << raw_value
+      nationality_ids[index] = find_nationality(raw_value).id
+    end
+  end
+
+  def find_nationality(raw_value)
+    Nationality.find_by(name: raw_value)
   end
 end

--- a/spec/features/form_sections/personal_and_education_details/edit_personal_details_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/edit_personal_details_spec.rb
@@ -50,6 +50,15 @@ feature "edit personal details", type: :feature do
     then_i_see_error_messages_for_partially_completed_nationalities
   end
 
+  scenario "entering valid nationalities without selecting a value", js: true do
+    given_a_trainee_exists
+    and_nationalities_exist_in_the_system
+    when_i_visit_the_personal_details_page
+    and_i_fill_in_nationalities_without_selecting_a_value(with: ["british", "french", "south african"])
+    and_i_submit_the_form
+    then_i_am_redirected_to_the_confirm_page
+  end
+
   context "as a non-draft trainee" do
     before do
       given_a_trainee_exists(:submitted_for_trn)
@@ -87,6 +96,12 @@ private
     and_i_submit_the_form
     and_i_confirm_my_details
     then_i_am_redirected_to_the_review_draft_page
+  end
+
+  def and_nationalities_exist_in_the_system
+    @british ||= create(:nationality, name: "british")
+    @french ||= create(:nationality, name: "french")
+    @south_african ||= create(:nationality, name: "south african")
   end
 
   def when_i_visit_the_personal_details_page
@@ -154,5 +169,9 @@ private
         "activemodel.errors.validators.autocomplete.other_nationality1",
       ),
     )
+  end
+
+  def then_i_am_redirected_to_the_confirm_page
+    expect(page.current_path).to eq "/trainees/#{trainee.slug}/personal-details/confirm"
   end
 end


### PR DESCRIPTION
### Context

- [This bug ticket](https://trello.com/c/sEoHux0Z/1781-code-checking-for-free-typed-autocomplete-entries-doesnt-check-caselessly)

### Changes proposed in this pull request

- Freetext responses of nationalities stored in raw value placeholders are cross-referenced to ensure their validity (ie, a freetext response of `france` is still valid, but was throwing the error of invalid response before). If they are valid, they are used. 

### Guidance to review

- Rails console `rails c`
- Direct yourself to any draft trainee
- Click on their personal details
- Go to their nationality section. 
- Click `Other`
- From the dropdown, type in `france` but DO NOT click the dropdown selection. 
- Instead, click `escape` to escape out of the selection process
- When you submit, the value is deemed valid. 

