### PR TITLE
[1804] Fix consistency alert link

### DIFF
--- a/app/jobs/dttp/check_consistency_job.rb
+++ b/app/jobs/dttp/check_consistency_job.rb
@@ -9,7 +9,7 @@ module Dttp
       @dttp_contact_updated_date = Dttp::Contacts::Fetch.call(dttp_id: trainee.dttp_id).updated_at
       @dttp_placement_assignment_updated_date = Dttp::PlacementAssignments::Fetch.call(dttp_id: trainee.placement_assignment_dttp_id).updated_at
       if contact_conflict || placement_assignment_conflict
-        SlackNotifierService.call(channel: Settings.slack.publish_register_alerts_channel, message: "<#{Rails.application.routes.url_helpers.trainees_url(trainee, host: Settings.base_url)}|Trainee #{trainee.id} has been updated in DTTP>", username: "DTTP Conflict Error")
+        SlackNotifierService.call(channel: Settings.slack.publish_register_alerts_channel, message: "<#{Rails.application.routes.url_helpers.trainee_url(trainee, host: Settings.base_url)}|Trainee #{trainee.id} has been updated in DTTP>", username: "DTTP Conflict Error")
       end
     end
 


### PR DESCRIPTION
### Context

We run a check against DTTP. When it fails we post a link to Slack that should take the user to the trainee record in Register. It does now.

### Changes proposed in this pull request

Fix the link format in the slack alert.

It was:

`/trainees.<id>`

It is now:

`/trainees/<id>`

### Guidance to review

I've just fixed the link. There aren't any specs for this worker but we're going to have to change how this works as I think they'll always fail after the state updates at the DTTP end from DQT so we can add them for the new behaviour we add. Let's let them run for a few more days to confirm as we manually ran all of these yesterday to start the process off.

I think they will work as is and catch the issues we're looking for but it looks like we'll get false alarms too.

