### PR TITLE
[1803] Make all trainee states human readable in CSV export

### DIFF
--- a/app/components/trainee_status_card/view.rb
+++ b/app/components/trainee_status_card/view.rb
@@ -25,7 +25,7 @@ module TraineeStatusCard
     end
 
     def state_name
-      I18n.t("activerecord.attributes.trainee.states.#{state}")
+      I18n.t("activerecord.attributes.trainee.states.#{state}", award_type: "QTS")
     end
 
     def status_colour

--- a/app/components/trainees/filters/view.rb
+++ b/app/components/trainees/filters/view.rb
@@ -12,7 +12,7 @@ module Trainees
       end
 
       def label_for(attribute, value)
-        I18n.t("activerecord.attributes.trainee.#{attribute.pluralize}.#{value}")
+        I18n.t("activerecord.attributes.trainee.#{attribute.pluralize}.#{value}", award_type: "QTS")
       end
 
       def filter_label_for(filter)

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -33,7 +33,7 @@ module Exports
           "Last name" => trainee.last_name,
           "Trainee Id" => trainee.trainee_id,
           "TRN" => trainee.trn,
-          "Status" => award_state(trainee),
+          "Status" => status(trainee),
           "Route" => trainee.training_route,
           "Subject" => trainee.subject,
           "Course start date" => trainee.course_start_date,
@@ -48,11 +48,8 @@ module Exports
       end
     end
 
-    def award_state(trainee)
-      {
-        recommended_for_award: I18n.t("exports.trainees.award_recommended", award_type: trainee.award_type),
-        awarded: I18n.t("exports.trainees.award_given", award_type: trainee.award_type),
-      }[trainee.state.to_sym] || trainee.state
+    def status(trainee)
+      I18n.t("activerecord.attributes.trainee.states.#{trainee.state}", award_type: trainee.award_type)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,10 +490,10 @@ en:
           draft: Draft
           submitted_for_trn: Pending TRN
           trn_received: TRN received
-          recommended_for_award: QTS recommended
+          recommended_for_award: "%{award_type} recommended"
           withdrawn: Withdrawn
           deferred: Deferred
-          awarded: QTS awarded
+          awarded: "%{award_type} awarded"
     errors:
       models:
         trainee:
@@ -743,7 +743,3 @@ en:
     schools:
       errors:
         bad_request: The query param needs to be at least 3 characters
-  exports:
-    trainees:
-      award_recommended: Recommended for %{award_type}
-      award_given: Awarded %{award_type}

--- a/spec/components/trainee_status_card/view_spec.rb
+++ b/spec/components/trainee_status_card/view_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe TraineeStatusCard::View do
     it "returns state name in correct format" do
       %i[draft withdrawn deferred awarded trn_received submitted_for_trn recommended_for_award].each do |state|
         expect(described_class.new(state: state,
-                                   target: target, trainees: trainees).state_name).to eql(I18n.t("activerecord.attributes.trainee.states.#{state}"))
+                                   target: target, trainees: trainees).state_name)
+          .to eql(I18n.t("activerecord.attributes.trainee.states.#{state}", award_type: "QTS"))
       end
     end
   end
@@ -24,8 +25,8 @@ RSpec.describe TraineeStatusCard::View do
   describe "#status_colour" do
     it "returns the correct colour for given state" do
       described_class::STATUS_COLOURS.each_key do |state|
-        expect(described_class.new(state: state,
-                                   target: target, trainees: trainees).status_colour).to eql(described_class::STATUS_COLOURS[state])
+        expect(described_class.new(state: state, target: target, trainees: trainees).status_colour)
+          .to eql(described_class::STATUS_COLOURS[state])
       end
     end
   end

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Exports
   describe TraineeSearchData do
     let(:trainee) do
-      create(:trainee, :with_course_details, :submitted_for_trn, :trn_received, :recommended_for_award, :awarded)
+      build(:trainee, :with_course_details, :submitted_for_trn, :trn_received, :recommended_for_award, :awarded)
     end
 
     subject { described_class.new([trainee]) }
@@ -17,7 +17,7 @@ module Exports
           "Last name" => trainee.last_name,
           "Trainee Id" => trainee.trainee_id,
           "TRN" => trainee.trn,
-          "Status" => t("exports.trainees.award_given", award_type: trainee.award_type),
+          "Status" => t("activerecord.attributes.trainee.states.#{trainee.state}", award_type: trainee.award_type),
           "Route" => trainee.training_route,
           "Subject" => trainee.subject,
           "Course start date" => trainee.course_start_date,
@@ -42,6 +42,22 @@ module Exports
 
         it "includes the provider name" do
           expect(subject.data).to include(trainee.provider.name)
+        end
+      end
+
+      context "rendering various states in human readable terms" do
+        shared_examples "state is humanised" do |state|
+          context state do
+            let(:trainee) { build(:trainee, state) }
+
+            specify do
+              expect(subject.data).to include(I18n.t("activerecord.attributes.trainee.states.#{state}"))
+            end
+          end
+        end
+
+        (Trainee.states.keys - %w[recommended_for_award awarded]).each do |state|
+          it_behaves_like "state is humanised", state
         end
       end
     end


### PR DESCRIPTION
### Context
https://trello.com/c/5GeWBUUn/1803-inconsistent-trainee-states-in-export

### Changes proposed in this pull request
- Update `Exports::TraineeSearchData` to render trainee states in humane readable format in CSV export

### Guidance to review
- Visit `/trainees`
- Export CSV
- Verify that all the various states are human readable and not converted symbols which is what it was before

