### PR TITLE
[1802] Changing to publish course deletes surplus subjects from trainee

### DIFF
--- a/app/forms/confirm_publish_course_form.rb
+++ b/app/forms/confirm_publish_course_form.rb
@@ -28,8 +28,11 @@ class ConfirmPublishCourseForm
   def save
     return false unless valid?
 
-    update_trainee_attributes
-    trainee.save!
+    ActiveRecord::Base.transaction do
+      trainee.clear_additional_subjects if trainee.additional_subjects?
+      update_trainee_attributes
+      trainee.save!
+    end
   end
 
   def subject

--- a/app/forms/confirm_publish_course_form.rb
+++ b/app/forms/confirm_publish_course_form.rb
@@ -28,11 +28,8 @@ class ConfirmPublishCourseForm
   def save
     return false unless valid?
 
-    ActiveRecord::Base.transaction do
-      trainee.clear_additional_subjects if trainee.additional_subjects?
-      update_trainee_attributes
-      trainee.save!
-    end
+    update_trainee_attributes
+    trainee.save!
   end
 
   def subject
@@ -61,6 +58,8 @@ private
     trainee.progress.course_details = true
     trainee.assign_attributes({
       subject: subject,
+      subject_two: nil,
+      subject_three: nil,
       course_code: course_code,
       course_age_range: course&.age_range,
       course_start_date: course_start_date,

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -186,4 +186,12 @@ class Trainee < ApplicationRecord
   def subjects
     [subject, subject_two, subject_three].reject(&:blank?)
   end
+
+  def additional_subjects?
+    subject_two || subject_three
+  end
+
+  def clear_additional_subjects
+    subject_two&.clear && subject_three&.clear
+  end
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -186,12 +186,4 @@ class Trainee < ApplicationRecord
   def subjects
     [subject, subject_two, subject_three].reject(&:blank?)
   end
-
-  def additional_subjects?
-    subject_two || subject_three
-  end
-
-  def clear_additional_subjects
-    subject_two&.clear && subject_three&.clear
-  end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -237,5 +237,11 @@ FactoryBot.define do
     trait :with_apply_application do
       apply_application
     end
+
+    trait :with_multiple_subjects do
+      with_course_details
+      subject_two { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
+      subject_three { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
+    end
   end
 end

--- a/spec/forms/confirm_publish_course_form_spec.rb
+++ b/spec/forms/confirm_publish_course_form_spec.rb
@@ -11,25 +11,40 @@ describe ConfirmPublishCourseForm, type: :model do
     it { is_expected.to validate_presence_of(:code) }
   end
 
-  context "valid trainee" do
+  context "with valid params" do
+    subject { described_class.new(trainee, params) }
     let(:course) { create(:course) }
     let(:params) { { code: course.code } }
-    let(:trainee) { create(:trainee) }
-    subject { described_class.new(trainee, params) }
 
-    describe "#save" do
-      it "changed related trainee attributes" do
+    context "valid trainee" do
+      let(:trainee) { create(:trainee) }
+
+      describe "#save" do
+        it "changed related trainee attributes" do
+          expect { subject.save }
+            .to change { trainee.subject }
+            .from(nil).to(course.name)
+            .and change { trainee.course_min_age }
+            .from(nil).to(course.min_age)
+            .and change { trainee.course_max_age }
+            .from(nil).to(course.max_age)
+            .and change { trainee.course_start_date }
+            .from(nil).to(course.start_date)
+            .and change { trainee.course_end_date }
+            .from(nil).to((course.start_date + course.duration_in_years.years).to_date.prev_day)
+        end
+      end
+    end
+
+    context "when trainee is assigned to multiple subjects" do
+      let(:trainee) { create(:trainee, :with_multiple_subjects) }
+
+      it "removed the surplus subjects on save" do
         expect { subject.save }
-          .to change { trainee.subject }
-          .from(nil).to(course.name)
-          .and change { trainee.course_min_age }
-          .from(nil).to(course.min_age)
-          .and change { trainee.course_max_age }
-          .from(nil).to(course.max_age)
-          .and change { trainee.course_start_date }
-          .from(nil).to(course.start_date)
-          .and change { trainee.course_end_date }
-          .from(nil).to((course.start_date + course.duration_in_years.years).to_date.prev_day)
+            .to change { trainee.subject_two }
+            .from(trainee.subject_two).to("")
+            .and change { trainee.subject_three }
+            .from(trainee.subject_three).to("")
       end
     end
   end

--- a/spec/forms/confirm_publish_course_form_spec.rb
+++ b/spec/forms/confirm_publish_course_form_spec.rb
@@ -42,9 +42,9 @@ describe ConfirmPublishCourseForm, type: :model do
       it "removed the surplus subjects on save" do
         expect { subject.save }
             .to change { trainee.subject_two }
-            .from(trainee.subject_two).to("")
+            .from(trainee.subject_two).to(nil)
             .and change { trainee.subject_three }
-            .from(trainee.subject_three).to("")
+            .from(trainee.subject_three).to(nil)
       end
     end
   end


### PR DESCRIPTION
### Context

- []()

### Changes proposed in this pull request

- When the `ConfirmPublishCours` form is saved, we check that a trainee has multiple subjects saved to their name. If they do, those subjects are cleared

### Guidance to review

- Rails server `rails s`
- Create a trainee on the assessment only route
- Go to the `Course Details` section
- Complete it, but make sure to include multiple subjects (ie `Religious Education with Mathematics and French`)
- Save the form and go back to the trainee record
- Change their route to `Provider-led(postgrad)`
- Go back to the `Course Details` section
- Change the course (not the subject) to a valid publish course
- The extra subjects (which were `with Mathematics and French`) do not persist

