### PR TITLE
[1807] Hide course details row if there are no published courses

### DIFF
--- a/app/components/trainees/confirmation/course_details/view.html.erb
+++ b/app/components/trainees/confirmation/course_details/view.html.erb
@@ -1,38 +1,4 @@
-<%= render SummaryCard::View.new(trainee: trainee, title: summary_title,
+<%= render SummaryCard::View.new(trainee: trainee,
+                                 title: summary_title,
                                  heading_level: 2,
-                                 rows: [
-      {
-        key: "Course details",
-        value: course_details,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> course details</span>'.html_safe,
-                              edit_trainee_publish_course_details_path(trainee)), 
-      },                          
-      {
-        key: "Type of course",
-        value: course_type,
-      },
-      {
-        key: t(".subject", count: trainee.subjects.count),
-        value: subject,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> subject</span>'.html_safe,
-                              edit_trainee_course_details_path(trainee)),
-      },
-      {
-        key: "Age range",
-        value: course_age_range,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> age range</span>'.html_safe,
-                              edit_trainee_course_details_path(trainee)),
-      },
-      {
-        key: "Course start date",
-        value: course_start_date,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> course start date</span>'.html_safe,
-                              edit_trainee_course_details_path(trainee)),
-      },
-      {
-        key: "Course end date",
-        value: course_end_date,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> course end date</span>'.html_safe,
-                              edit_trainee_course_details_path(trainee)),
-      },
-    ]) %>
+                                 rows: rows) %>

--- a/app/components/trainees/confirmation/course_details/view.rb
+++ b/app/components/trainees/confirmation/course_details/view.rb
@@ -6,6 +6,7 @@ module Trainees
       class View < GovukComponent::Base
         include SummaryHelper
         include CourseDetailsHelper
+        include TraineeHelper
 
         attr_accessor :data_model
 
@@ -22,14 +23,34 @@ module Trainees
           t("components.course_detail.title")
         end
 
+        def rows
+          [
+            { key: t("components.course_detail.type_of_course"), value: course_type },
+            { key: t("components.course_detail.subject"), value: subject, action: action_link("subject") },
+            { key: t("components.course_detail.age_range"), value: course_age_range, action: action_link("age range") },
+            { key: t("components.course_detail.course_start_date"), value: course_start_date, action: action_link("course start date") },
+            { key: t("components.course_detail.course_end_date"), value: course_end_date, action: action_link("course end date") },
+          ].tap do |collection|
+            if show_publish_courses?(trainee)
+              collection.unshift({
+                key: t("components.course_detail.course_details"),
+                value: course_details,
+                action: action_link("course details", path: edit_trainee_publish_course_details_path(trainee)),
+              })
+            end
+          end
+        end
+
+      private
+
+        def action_link(text, path: edit_trainee_course_details_path(trainee))
+          govuk_link_to("#{t(:change)}<span class='govuk-visually-hidden'> #{text}</span>".html_safe, path)
+        end
+
         def course_details
           return t("components.course_detail.details_not_on_publish") if data_model.course_code.blank?
 
           "#{course.name} (#{course.code})"
-        end
-
-        def course
-          @course ||= Course.find_by(code: data_model.course_code)
         end
 
         def subject
@@ -60,6 +81,10 @@ module Trainees
           return @not_provided_copy if data_model.course_end_date.blank?
 
           date_for_summary_view(data_model.course_end_date)
+        end
+
+        def course
+          @course ||= Course.find_by(code: data_model.course_code)
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,12 @@ en:
         trainee_start_date: start date
     course_detail:
       title: Course details
+      type_of_course: Type of course
+      subject: Subject
+      age_range: Age range
+      course_start_date: Course start date
+      course_end_date: Course end date
+      course_details: Course details
       details_not_on_publish: Details not on Publish
     school_details:
         summary_title: Schools
@@ -424,15 +430,20 @@ en:
     confirmation:
       confirm_publish_course:
         view:
+          change: Change
           change_course: Change course
           heading: Is this the course you want to add?
           heading_text: These are the course details as listed on Publish teacher training courses.
           summary_title: Course details
+          type_of_course: Subject
           subject: Subject
           level: Level
           age_range: Age range
           start_date: Start date
+          course_start_date: Course start date
+          course_end_date: Course end date
           duration: Duration
+          course_details: Course details
           incorrect_details_title: What if the details are incorrect?
           incorrect_details_text:
             If the details are incorrect for all trainees, you should <a class="govuk-link" href="https://www.publish-teacher-training-courses.service.gov.uk/">update the course on Publish</a>.


### PR DESCRIPTION
### Context
https://trello.com/c/ItUkrYxQ/1807-bug-a-change-link-in-course-details-leads-to-missing-translation-page

### Changes proposed in this pull request
- Update `Trainees::Confirmation::CourseDetails::View` to only show course details information if the trainee's provider has available courses

### Guidance to review
- Create an AO trainee and fill in the course details
- Then the confirm page should not display the row titled "Course details"
- Create an Provider-led trainee and choose a course
- Then the confirm page should display the row titled "Course details"


