### PR TITLE
[1867] Add field-widths helper from the prototype to match autocomplete widths

### DIFF
--- a/app/views/trainees/employing_schools/_no_results.html.erb
+++ b/app/views/trainees/employing_schools/_no_results.html.erb
@@ -13,6 +13,7 @@
 <%= f.hidden_field :employing_school_id, value: :no_results_search_again %>
 
 <%= f.govuk_text_field :no_results_search_again_query,
-                       label: { text: t("components.page_titles.search_schools.search_hint") } %>
+                       label: { text: t("components.page_titles.search_schools.search_hint") },
+                       class: "app-!-max-width-two-thirds" %>
 
 <%= f.govuk_submit t("components.page_titles.search_schools.search_button") %>

--- a/app/views/trainees/employing_schools/edit.html.erb
+++ b/app/views/trainees/employing_schools/edit.html.erb
@@ -16,8 +16,9 @@
         name: :'input-autocomplete',
         value: nil,
         "data-field" => "schools-autocomplete",
+        class: "app-!-max-width-two-thirds"
       ) %>
-      <div id="schools-autocomplete-element"></div>
+      <div id="schools-autocomplete-element" class="app-!-autocomplete--max-width-two-thirds"></div>
 
       <%= f.hidden_field :employing_school_id, id: "school-id", value: nil %>
       <%= f.govuk_submit t("continue") %>

--- a/app/views/trainees/lead_schools/_no_results.html.erb
+++ b/app/views/trainees/lead_schools/_no_results.html.erb
@@ -13,6 +13,7 @@
 <%= f.hidden_field :lead_school_id, value: :no_results_search_again %>
 
 <%= f.govuk_text_field :no_results_search_again_query,
-                       label: { text: t("components.page_titles.search_schools.search_hint") } %>
+                       label: { text: t("components.page_titles.search_schools.search_hint") },
+                       class: "app-!-max-width-two-thirds" %>
 
 <%= f.govuk_submit t("components.page_titles.search_schools.search_button") %>

--- a/app/views/trainees/lead_schools/edit.html.erb
+++ b/app/views/trainees/lead_schools/edit.html.erb
@@ -16,8 +16,9 @@
         name: :'input-autocomplete',
         value: nil,
         "data-field" => "schools-autocomplete",
+        class: "app-!-max-width-two-thirds"
       ) %>
-      <div id="schools-autocomplete-element" data-only-lead-schools=true></div>
+      <div id="schools-autocomplete-element" class="app-!-autocomplete--max-width-two-thirds" data-only-lead-schools=true></div>
 
       <%= f.hidden_field :lead_school_id, id: "school-id", value: nil %>
       <%= f.govuk_submit t("continue") %>

--- a/app/views/trainees/lead_schools/index.html.erb
+++ b/app/views/trainees/lead_schools/index.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(title: "trainees.lead_schools.index", has_errors: @lead_school_form.errors.present?) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(model: @lead_school_form,
                            url: trainee_lead_schools_path(@trainee, query: params[:query]),
                            method: :put,

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -3,6 +3,8 @@
 @import "~@ministryofjustice/frontend/moj/all";
 @import "./filter_toggle_button";
 
+@import "helpers/field-widths";
+
 .govuk-cookie-banner__hide {
   display: none;
 }

--- a/app/webpacker/styles/helpers/_field-widths.scss
+++ b/app/webpacker/styles/helpers/_field-widths.scss
@@ -1,0 +1,90 @@
+// Custom width overrides so inputs can be fixed width regardless of display width.
+
+// Widths are constant rather than being % of column so that
+// they relate to the size of the content they contain. Applies from tablet
+// breakpoint only so they go full width on mobile to match other GOV.UK
+// services.
+@include govuk-media-query($from: tablet) {
+
+  // Widths chosen by eye to correspond to govuk widths at desktop 960px.
+  // Using ex to match govuk fixed width inputs, so they will scale acording
+  // to font size.
+  .app-\!-max-width-three-quarters {
+    max-width: 50ex !important;
+  }
+
+  .app-\!-max-width-two-thirds {
+    max-width: 44ex !important;
+  }
+
+  .app-\!-max-width-one-half {
+    max-width: 33ex !important;
+  }
+
+  .app-\!-max-width-one-third {
+    max-width: 22ex !important;
+  }
+
+  .app-\!-max-width-one-quarter {
+    max-width: 17ex !important;
+  }
+
+}
+
+
+
+// Set autocomplete widths
+
+// TODO: It would be better to add a wrapper to autocompletes instead.
+// Autocompletes need a wrapper width to be set rather than on
+// input directly because of our 'clear' button
+@mixin autocomplete-set-width($max-width) {
+
+  // Explicitly set font size on container so ex units work
+  // Assumes all autocompletes are default size.
+  // This matches govuk fixed width inputs which scale with
+  // font size.
+  @include govuk-font(19);
+
+  // Set on govuk-selects and autocompletes (clear and non-clear)
+  // There is no one selector currently we can target, so we target
+  // both, then unset where we don't need.
+  .govuk-select,
+  .autocomplete__wrapper,
+  .autocomplete-select-with-clear {
+    max-width: $max-width !important;
+  }
+
+  // Unset on autocompletes clear button is used
+  // Easier to unset than to have more complex selector above
+  .autocomplete-select-with-clear .autocomplete__wrapper {
+    max-width: inherit !important;
+  }
+
+}
+
+// Custom width overrides so inputs can be fixed width regardless of resolution.
+@include govuk-media-query($from: tablet) {
+
+  // These widths should match those set in helpers/field-widths.scss
+  .app-\!-autocomplete--max-width-three-quarters {
+    @include autocomplete-set-width(50ex);
+  }
+
+  .app-\!-autocomplete--max-width-two-thirds {
+    @include autocomplete-set-width(44ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-half {
+    @include autocomplete-set-width(33ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-third {
+    @include autocomplete-set-width(22ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-quarter {
+    @include autocomplete-set-width(17ex);
+  }
+
+}


### PR DESCRIPTION
### Context
Adding some autocomplete styles picked from [this commit in the prototype](https://github.com/DFE-Digital/register-trainee-teachers-prototype/commit/dda5944b9d00356eadebfbc4eb9598db38c89fdd#diff-90740db670e272570cc9560b7313350cce14c2c5db61106870b1572eb333a533)

### Changes proposed in this pull request

### Guidance to review
Lead and employing school inputs should match the prototype for the following situations
- Lead school search
- Lead school search again field
- Non-js Lead school search
- Non-js Lead school search again field
- Employing school search
- Employing school search again field
- Non-js Employing school search
- Non-js Employing school search again field
