### PR TITLE
[1857] EYTS status tags

### DIFF
--- a/app/components/status_tag/view.rb
+++ b/app/components/status_tag/view.rb
@@ -13,8 +13,8 @@ private
   def status
     {
       submitted_for_trn: "pending trn",
-      recommended_for_award: "qts recommended",
-      awarded: "qts awarded",
+      recommended_for_award: "#{trainee.award_type} recommended",
+      awarded: "#{trainee.award_type} awarded",
     }[trainee.state.to_sym] || trainee.state.gsub("_", " ")
   end
 

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -42,7 +42,7 @@ private
   end
 
   def training_route
-    @trainee.training_route.to_sym
+    @trainee.training_route&.to_sym
   end
 
   def feature_enabled?(feature_name)

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -16,14 +16,17 @@ class Trainee < ApplicationRecord
 
   attribute :progress, Progress.to_type
 
-  delegate :requires_placement_details?, :requires_schools?, :requires_employing_school?, to: :training_route_manager
-  delegate :award_type, to: :training_route_manager
+  delegate :award_type, :requires_placement_details?, :requires_schools?,
+           :requires_employing_school?, to: :training_route_manager
 
-  validates :training_route, presence: { message: I18n.t("activerecord.errors.models.trainee.attributes.training_route") }
+  validates :training_route, presence: {
+    message: I18n.t("activerecord.errors.models.trainee.attributes.training_route"),
+  }
 
   enum training_route: TRAINING_ROUTES_FOR_TRAINEE
 
   enum locale_code: { uk: 0, non_uk: 1 }
+
   enum gender: {
     male: 0,
     female: 1,

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -47,13 +47,13 @@ module ApplicationRecordCard
         { state: :draft, colour: "grey", text: "draft" },
         { state: :submitted_for_trn, colour: "turquoise", text: "pending trn" },
         { state: :trn_received, colour: "blue", text: "trn received" },
-        { state: :recommended_for_award, colour: "purple", text: "qts recommended" },
-        { state: :awarded, colour: "", text: "qts awarded" },
+        { state: :recommended_for_award, colour: "purple", text: "QTS recommended" },
+        { state: :awarded, colour: "", text: "QTS awarded" },
         { state: :deferred, colour: "yellow", text: "deferred" },
         { state: :withdrawn, colour: "red", text: "withdrawn" },
       ].each do |state_expectation|
         context "when state is #{state_expectation[:state]}" do
-          let(:trainee) { build(:trainee, state_expectation[:state], created_at: Time.zone.now) }
+          let(:trainee) { build(:trainee, state_expectation[:state], training_route: TRAINING_ROUTE_ENUMS[:assessment_only], created_at: Time.zone.now) }
 
           it "renders '#{state_expectation[:text]}'" do
             expect(component).to have_selector(".govuk-tag", text: state_expectation[:text])

--- a/spec/components/status_tag/view_preview.rb
+++ b/spec/components/status_tag/view_preview.rb
@@ -3,9 +3,24 @@
 module StatusTag
   class ViewPreview < ViewComponent::Preview
     Trainee.states.keys.each do |state|
-      define_method state.to_s do
-        render(StatusTag::View.new(trainee: Trainee.new(state: state)))
+      if %w[recommended_for_award awarded].include?(state)
+        define_method "#{state}_qts" do
+          render_tag(:assessment_only, state)
+        end
+        define_method "#{state}_eyts" do
+          render_tag(:early_years_undergrad, state)
+        end
+      else
+        define_method state.to_s do
+          render_tag(:assessment_only, state)
+        end
       end
+    end
+
+  private
+
+    def render_tag(route, state)
+      render(StatusTag::View.new(trainee: Trainee.new(training_route: route, state: state)))
     end
   end
 end

--- a/spec/components/status_tag/view_spec.rb
+++ b/spec/components/status_tag/view_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StatusTag::View do
+  alias_method :component, :page
+
+  before do
+    render_inline(described_class.new(trainee: trainee))
+  end
+
+  context "with a trainee recommended for EYTS" do
+    let(:trainee) { create(:trainee, :early_years_undergrad, :recommended_for_award) }
+
+    it "renders the correct status" do
+      expect(component).to have_text("EYTS recommended")
+    end
+  end
+
+  context "with a trainee awarded EYTS" do
+    let(:trainee) { create(:trainee, :early_years_undergrad, :awarded) }
+
+    it "renders the correct status" do
+      expect(component).to have_text("EYTS awarded")
+    end
+  end
+
+  context "with a trainee recommended for QTS" do
+    let(:trainee) { create(:trainee, :recommended_for_award) }
+
+    it "renders the correct status" do
+      expect(component).to have_text("QTS recommended")
+    end
+  end
+
+  context "with a trainee awarded QTS" do
+    let(:trainee) { create(:trainee, :awarded) }
+
+    it "renders the correct status" do
+      expect(component).to have_text("QTS awarded")
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/nqPJSuc6/1857-s-ey-eyts-status-tags

### Changes proposed in this pull request

When any EY trainee is recommended for EYTS, the status tags should read **EYTS recommended** (not QTS recommended).
Similarly, when any EY trainees is awarded EYTS, the status tags should read **EYTS awarded** (not QTS awarded).

<img width="661" alt="Screenshot 2021-06-02 at 10 11 41" src="https://user-images.githubusercontent.com/18436946/120454001-6a867800-c38b-11eb-836e-ce66e7471081.png">

<img width="674" alt="Screenshot 2021-06-02 at 10 09 53" src="https://user-images.githubusercontent.com/18436946/120454026-6d816880-c38b-11eb-9757-1d6bb38fad99.png">

### Guidance to review

- View an early years trainee who has been recommended for EYTS
- Check that the status tag on the trainee list view and the trainee show page is **EYTS recommended** 
- View an assessment only trainee (or provider-led, or school direct) who has been recommended for QTS
- Check that the status tag on the trainee list view and the trainee show page is **QTS recommended**
- Repeat the above steps for an awarded trainee