### PR TITLE
1879 include some trainees for all routes in the example data

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -23,8 +23,8 @@ namespace :example_data do
                            trn_received: [%i[with_start_date trn_received with_placement_assignment with_course_details_wip diversity_disclosed],
                                           %i[with_start_date trn_received with_placement_assignment with_course_details_wip diversity_not_disclosed]],
 
-                           recommend_for_award: [%i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details_wip  diversity_disclosed],
-                                                 %i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details_wip  diversity_not_disclosed]],
+                           recommend_for_award: [%i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details_wip diversity_disclosed],
+                                                 %i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details_wip diversity_not_disclosed]],
 
                            withdrawn: [%i[with_start_date withdrawn with_placement_assignment with_course_details_wip diversity_disclosed],
                                        %i[with_start_date withdrawn with_placement_assignment with_course_details_wip diversity_not_disclosed]],
@@ -89,7 +89,7 @@ namespace :example_data do
             trn: trn,
             progress: progress,
             updated_at: submitted_for_trn_at || created_at,
-            training_route: training_route
+            training_route: training_route,
           }
 
           trainee_attributes.merge!(provider: provider) if provider

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -13,23 +13,27 @@ namespace :example_data do
     FactoryBot.create_list(:school, 50)
     FactoryBot.create_list(:school, 50, lead_school: true)
 
-    trait_combinations = [
-      [],
-      %i[with_start_date with_course_details diversity_disclosed],
-      %i[with_start_date with_course_details diversity_not_disclosed],
-      %i[with_start_date submitted_for_trn with_placement_assignment with_course_details diversity_disclosed],
-      %i[with_start_date submitted_for_trn with_placement_assignment with_course_details diversity_not_disclosed],
-      %i[with_start_date trn_received with_placement_assignment with_course_details diversity_disclosed],
-      %i[with_start_date trn_received with_placement_assignment with_course_details diversity_not_disclosed],
-      %i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details diversity_disclosed],
-      %i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details diversity_not_disclosed],
-      %i[with_start_date withdrawn with_placement_assignment with_course_details diversity_disclosed],
-      %i[with_start_date withdrawn with_placement_assignment with_course_details diversity_not_disclosed],
-      %i[with_start_date deferred with_placement_assignment with_course_details diversity_disclosed],
-      %i[with_start_date deferred with_placement_assignment with_course_details diversity_not_disclosed],
-      %i[with_start_date awarded with_placement_assignment with_outcome_date with_course_details diversity_disclosed],
-      %i[with_start_date awarded with_placement_assignment with_outcome_date with_course_details diversity_not_disclosed],
-    ]
+    trait_combinations = { draft: [[],
+                                   %i[with_start_date with_course_details_wip diversity_disclosed],
+                                   %i[with_start_date with_course_details_wip diversity_not_disclosed]],
+
+                           submitted_for_trn: [%i[with_start_date submitted_for_trn with_placement_assignment with_course_details_wip diversity_disclosed],
+                                               %i[with_start_date submitted_for_trn with_placement_assignment with_course_details_wip diversity_not_disclosed]],
+
+                           trn_received: [%i[with_start_date trn_received with_placement_assignment with_course_details_wip diversity_disclosed],
+                                          %i[with_start_date trn_received with_placement_assignment with_course_details_wip diversity_not_disclosed]],
+
+                           recommend_for_award: [%i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details_wip  diversity_disclosed],
+                                                 %i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details_wip  diversity_not_disclosed]],
+
+                           withdrawn: [%i[with_start_date withdrawn with_placement_assignment with_course_details_wip diversity_disclosed],
+                                       %i[with_start_date withdrawn with_placement_assignment with_course_details_wip diversity_not_disclosed]],
+
+                           deferred: [%i[with_start_date deferred with_placement_assignment with_course_details_wip diversity_disclosed],
+                                      %i[with_start_date deferred with_placement_assignment with_course_details_wip diversity_not_disclosed]],
+
+                           awarded: [%i[with_start_date awarded with_placement_assignment with_outcome_date with_course_details_wip diversity_disclosed],
+                                     %i[with_start_date awarded with_placement_assignment with_outcome_date with_course_details_wip diversity_not_disclosed]] }.freeze
 
     PERSONAS.each do |persona_attributes|
       persona = Persona.find_or_create_by!(first_name: persona_attributes[:first_name],
@@ -45,58 +49,62 @@ namespace :example_data do
         dttp_id: SecureRandom.uuid,
         code: Faker::Alphanumeric.alphanumeric(number: 3).upcase,
       )
-      FactoryBot.create_list(:course, rand(30..70), accredited_body_code: provider.code, route: "provider_led_postgrad")
+      FactoryBot.create_list(:course, 5, accredited_body_code: provider.code, route: "provider_led_postgrad")
       persona.update!(provider: provider)
 
-      rand(50...100).times do
-        traits = trait_combinations.sample
+      # rand(50...100).times do
+      trait_combinations.keys.each do |state|
+        trait_combinations[state].each do |traits|
+          created_at = Faker::Date.between(from: 100.days.ago, to: 50.days.ago)
+          submitted_for_trn_at = nil
+          trn = nil
+          progress = {}
 
-        created_at = Faker::Date.between(from: 100.days.ago, to: 50.days.ago)
-        submitted_for_trn_at = nil
-        trn = nil
-        progress = {}
+          if traits.length > 3 # this trainee isn't draft
 
-        if traits.length > 3 # this trainee isn't draft
+            # mark the sections complete
+            progress = {
+              personal_details: true,
+              contact_details: true,
+              degrees: true,
+              diversity: true,
+              course_details: true,
+              training_details: true,
+            }
 
-          # mark the sections complete
-          progress = {
-            personal_details: true,
-            contact_details: true,
-            degrees: true,
-            diversity: true,
-            course_details: true,
-            training_details: true,
+            # set the submitted_for_trn_at date as they will have at least been submitted
+            submitted_for_trn_at = traits.any? ? Faker::Date.between(from: created_at, to: created_at + 40.days) : nil
+
+            unless traits.include?(:submitted_for_trn)
+              # this trainee is past getting trn so set it
+              trn = Faker::Number.number(digits: 10)
+            end
+          end
+
+          training_route = "provider_led_postgrad"
+
+          trainee_attributes = {
+            created_at: created_at,
+            submitted_for_trn_at: submitted_for_trn_at,
+            trn: trn,
+            progress: progress,
+            updated_at: submitted_for_trn_at || created_at,
+            training_route: training_route
           }
 
-          # set the submitted_for_trn_at date as they will have at least been submitted
-          submitted_for_trn_at = traits.any? ? Faker::Date.between(from: created_at, to: created_at + 40.days) : nil
+          trainee_attributes.merge!(provider: provider) if provider
 
-          unless traits.include?(:submitted_for_trn)
-            # this trainee is past getting trn so set it
-            trn = Faker::Number.number(digits: 10)
+          trainee = FactoryBot.create(:trainee, *traits, trainee_attributes)
+
+          [1, 1, 1, 1, 1, 2].sample.times do # multiple nationalities are less common
+            trainee.nationalities << Nationality.all.sample
           end
-        end
 
-        trainee_attributes = {
-          created_at: created_at,
-          submitted_for_trn_at: submitted_for_trn_at,
-          trn: trn,
-          progress: progress,
-          updated_at: submitted_for_trn_at || created_at,
-        }
+          next if trainee.draft?
 
-        trainee_attributes.merge!(provider: provider) if provider
-
-        trainee = FactoryBot.create(:trainee, *traits, trainee_attributes)
-
-        [1, 1, 1, 1, 1, 2].sample.times do # multiple nationalities are less common
-          trainee.nationalities << Nationality.all.sample
-        end
-
-        next if trainee.draft?
-
-        [1, 2].sample.times do
-          trainee.degrees << FactoryBot.build(:degree, %i[uk_degree_with_details non_uk_degree_with_details].sample)
+          [1, 2].sample.times do
+            trainee.degrees << FactoryBot.build(:degree, %i[uk_degree_with_details non_uk_degree_with_details].sample)
+          end
         end
       end
     end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
     qualification { %i[qts pgce_with_qts pgde_with_qts pgce pgde].sample }
     course_length { %w[OneYear TwoYears].sample }
     route { TRAINING_ROUTES_FOR_COURSE.keys.sample }
-    subjects { [association(:subject)] }
 
     summary do |builder|
       qualifications = builder.qualification.to_s.gsub("_", " ").upcase.gsub("WITH", "with")

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :course do
     sequence(:name) { |c| "Course #{c}" }
-    code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
+    code { Faker::Alphanumeric.unique.alphanumeric(number: 4).upcase }
     accredited_body_code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     start_date { Time.zone.today }
     level { :primary }

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     qualification { %i[qts pgce_with_qts pgde_with_qts pgce pgde].sample }
     course_length { %w[OneYear TwoYears].sample }
     route { TRAINING_ROUTES_FOR_COURSE.keys.sample }
+    subjects { [association(:subject)] }
 
     summary do |builder|
       qualifications = builder.qualification.to_s.gsub("_", " ").upcase.gsub("WITH", "with")

--- a/spec/factories/nationalities.rb
+++ b/spec/factories/nationalities.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :nationality do
-    sequence(:name) { |n| "nationality #{n}" }
+    name { Dttp::CodeSets::Nationalities::MAPPING.keys.sample }
 
     trait :british do
       name { Dttp::CodeSets::Nationalities::BRITISH }

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -2,9 +2,8 @@
 
 FactoryBot.define do
   factory :subject do
-    sequence(:name) { |c| "Subject #{c}" }
-    code { Faker::Alphanumeric.alphanumeric(number: 2).upcase }
-    # subject { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
+    code { Faker::Alphanumeric.unique.alphanumeric(number: 2).upcase }
+    name { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
   end
 
   trait :music do

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :subject do
     sequence(:name) { |c| "Subject #{c}" }
     code { Faker::Alphanumeric.alphanumeric(number: 2).upcase }
+    # subject { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
   end
 
   trait :music do

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -16,18 +16,22 @@ FactoryBot.define do
     additional_ethnic_background { nil }
     disability_disclosure { (Diversities::DISABILITY_DISCLOSURE_ENUMS.values - %w[disabled]).sample }
 
-    address_line_one { Faker::Address.street_address }
-    address_line_two { Faker::Address.street_name }
-    town_city { Faker::Address.city }
-    postcode { Faker::Address.postcode }
-    international_address { nil }
-    locale_code { :uk }
     email { "#{first_names}.#{last_name}@example.com" }
 
     updated_at { submitted_for_trn_at || created_at }
 
+    with_uk_contact_details
     with_personal_details
     with_training_details
+
+    trait :with_uk_contact_details do
+      address_line_one { Faker::Address.street_address }
+      address_line_two { Faker::Address.street_name }
+      town_city { Faker::Address.city }
+      postcode { Faker::Address.postcode }
+      international_address { nil }
+      locale_code { :uk }
+    end
 
     trait :with_personal_details do
       first_names { Faker::Name.first_name }
@@ -219,6 +223,7 @@ FactoryBot.define do
     end
 
     trait :awarded do
+      recommended_for_award
       state { "awarded" }
     end
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -206,6 +206,7 @@ FactoryBot.define do
     end
 
     trait :withdrawn do
+      submitted_for_trn
       state { "withdrawn" }
       withdraw_date { Faker::Date.in_date_period }
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -110,7 +110,7 @@ FactoryBot.define do
 
     trait :with_course_details_wip do
       with_early_years_course_details_wip
-      after(:build) do |trainee, evaluator|
+      after(:build) do |trainee|
         if trainee.training_route == "assessment_only"
           trainee.subject = Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample
           # trainee.subject = create(:subject)  create using factory here?


### PR DESCRIPTION
### Context

Adding a sample of trainees on different routes to our example data, to make product reviews easier.

At the moment it's difficult to review early years trainees past the `submitted_for_trn` state, since review apps are not hooked up to DTTP.

Also a few small fixes from the ERB linter in a separate commit.

### Guidance to review

- Pull down the code and run ` bundle exec rake example_data:generate`
- Check that there are now trainees on different routes in your local environment 

- Based on 

  - The trainee routes switched on in settings (currently 8) - (`r`) 
  - whichever state a trainee can be (total of 7) - (`s`) 
  - whichever diversity options is selected (total of 2) - (`d`)
  
`r` x (`s` x `d`) is the `default combination` which is created every time.

`default combination` per `s` x random number to multiply. 

Also 
- minimised over supplying of `Subject`
- progress of trainee is correctly represented
- schools ie lead/employing is correctly represented