### PR TITLE
[1875] Enable notifications in Register so we can send a welcome email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,9 @@ gem "skylight"
 # Run data migrations alongside schema migrations
 gem "data_migrate"
 
+# Gov Notify
+gem "govuk_notify_rails"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,9 @@ GEM
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       deep_merge (~> 1.2.1)
+    govuk_notify_rails (2.1.2)
+      notifications-ruby-client (~> 5.1)
+      rails (>= 4.1.0)
     hashdiff (1.0.1)
     hashie (4.1.0)
     html_tokenizer (0.0.7)
@@ -221,6 +224,7 @@ GEM
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
+    jwt (2.2.3)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -259,6 +263,8 @@ GEM
     nokogiri (1.11.6)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    notifications-ruby-client (5.3.0)
+      jwt (>= 1.5, < 3)
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
@@ -533,6 +539,7 @@ DEPENDENCIES
   foreman
   govuk-components (~> 1.2)
   govuk_design_system_formbuilder
+  govuk_notify_rails
   httparty (~> 0.18)
   kaminari
   launchy

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,6 +8,7 @@ class SessionsController < ApplicationController
 
     if current_user
       DfESignInUsers::Update.call(user: current_user, dfe_sign_in_user: dfe_sign_in_user)
+      SendWelcomeEmailService.call(current_user: current_user)
 
       redirect_to session.delete(:requested_path) || root_path
     else

--- a/app/mailers/welcome_email_mailer.rb
+++ b/app/mailers/welcome_email_mailer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class WelcomeEmailMailer < GovukNotifyRails::Mailer
+  def generate(first_name:, email:)
+    set_template(Settings.govuk_notify.welcome_email_template_id)
+
+    set_personalisation(
+      first_name: first_name,
+    )
+
+    mail(to: email)
+  end
+end

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class SendWelcomeEmailService
+  include ServicePattern
+
+  def initialize(current_user:)
+    @current_user = current_user
+  end
+
+  def call
+    return if current_user.welcome_email_sent_at
+
+    WelcomeEmailMailer.generate(
+      first_name: current_user.first_name,
+      email: current_user.email,
+    ).deliver_later
+
+    current_user.update!(
+      welcome_email_sent_at: Time.zone.now,
+    )
+  end
+
+private
+
+  attr_reader :current_user
+end

--- a/config/initializers/mailers.rb
+++ b/config/initializers/mailers.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery, api_key: Settings.govuk_notify.api_key

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -87,3 +87,7 @@ slack:
   publish_register_alerts_channel: "#twd_publish_register_support"
 
 track_validation_errors: true
+
+govuk_notify:
+  api_key: please_change_me
+  welcome_email_template_id: 7765732c-f068-4c7f-abbc-ea5275a4b6ca

--- a/db/migrate/20210602105639_add_welcome_email_sent_at_to_users.rb
+++ b/db/migrate/20210602105639_add_welcome_email_sent_at_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWelcomeEmailSentAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :welcome_email_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_19_111721) do
+ActiveRecord::Schema.define(version: 2021_06_02_105639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -291,6 +291,7 @@ ActiveRecord::Schema.define(version: 2021_05_19_111721) do
     t.datetime "last_signed_in_at"
     t.uuid "dttp_id"
     t.boolean "system_admin", default: false
+    t.datetime "welcome_email_sent_at"
     t.index ["dfe_sign_in_uid"], name: "index_users_on_dfe_sign_in_uid", unique: true
     t.index ["dttp_id"], name: "index_users_on_dttp_id", unique: true
     t.index ["email"], name: "index_users_on_email"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -12,6 +12,11 @@ describe SessionsController, type: :controller do
 
   describe "#callback" do
     context "existing database user" do
+      it "calls send welcome email service" do
+        expect(SendWelcomeEmailService).to receive(:call).with(current_user: user).once
+        request_callback
+      end
+
       it "creates a session for the signed in user" do
         request_callback
         expect(session[:dfe_sign_in_user]["dfe_sign_in_uid"]).to eq(user.dfe_sign_in_uid)
@@ -41,6 +46,12 @@ describe SessionsController, type: :controller do
 
     context "non existing database user" do
       let(:user) { build(:user) }
+
+      it "does not call send welcome email service" do
+        expect(SendWelcomeEmailService).to_not receive(:call)
+        request_callback
+      end
+
       it "do not creates a session for the user" do
         request_callback
         expect(session[:dfe_sign_in_user]).to be_nil

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     email { Faker::Internet.email }
     dttp_id { SecureRandom.uuid }
+    welcome_email_sent_at { Faker::Time.backward(days: 1).utc }
 
     provider
 

--- a/spec/mailers/welcome_email_mailer_spec.rb
+++ b/spec/mailers/welcome_email_mailer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe WelcomeEmailMailer, type: :mailer do
+  context "sending an email to a user" do
+    let(:mail) { described_class.generate(first_name: "meow", email: "cat@meow.cat") }
+    before { mail }
+
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.welcome_email_template_id)
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq(["cat@meow.cat"])
+    end
+
+    it "includes the first name in the personalisation" do
+      expect(mail.govuk_notify_personalisation).to eq(first_name: "meow")
+    end
+  end
+end

--- a/spec/services/send_welcome_email_service_spec.rb
+++ b/spec/services/send_welcome_email_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SendWelcomeEmailService do
+  before { Timecop.freeze }
+  after { Timecop.return }
+
+  context "when the user has not logged in before" do
+    let(:current_user_spy) do
+      spy(
+        first_name: "Meowington",
+        email: "meowington@cat.net",
+        welcome_email_sent_at: nil,
+      )
+    end
+
+    before do
+      allow(WelcomeEmailMailer).to receive_message_chain(:generate, :deliver_later)
+      described_class.call(current_user: current_user_spy)
+    end
+
+    it "sets their welcome email date to now" do
+      expect(current_user_spy).to have_received(:update!).with(hash_including(welcome_email_sent_at: Time.zone.now))
+    end
+
+    it "sends the welcome email" do
+      expect(WelcomeEmailMailer).to have_received(:generate)
+    end
+
+    it "sends the email to the user" do
+      expect(WelcomeEmailMailer).to have_received(:generate).with(hash_including(email: "meowington@cat.net"))
+    end
+
+    it "sends the users first name in the email" do
+      expect(WelcomeEmailMailer).to have_received(:generate).with(hash_including(first_name: "Meowington"))
+    end
+  end
+
+  context "when the user has logged in before" do
+    let(:current_user_spy) do
+      spy(
+        first_name: "Meowington",
+        welcome_email_sent_at: Time.zone.local(2021, 1, 1),
+      )
+    end
+
+    before do
+      allow(WelcomeEmailMailer).to receive_message_chain(:generate, :deliver_later)
+      described_class.call(current_user: current_user_spy)
+    end
+
+    context "and has received a welcome email" do
+      it "does not update their welcome email date" do
+        expect(current_user_spy).not_to have_received(:update!).with(hash_including(welcome_email_sent_at: Time.zone.now))
+      end
+
+      it "does not send the welcome email" do
+        expect(WelcomeEmailMailer).not_to have_received(:generate)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/wt7e8oNu/1875-enable-notifications-in-register-so-we-can-send-a-welcome-email

### Changes proposed in this pull request

* New mailer `WelcomeEmailMailer`
* New welcome email template created on notify service
* New service `SendWelcomeEmailService` gets called after successful login

### Guidance to review

