### PR TITLE
[1866] Add all routes to the "what type of training" form

### DIFF
--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -25,7 +25,7 @@ TRAINING_ROUTES = {
 }.freeze
 
 TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|
-  TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :early_years_undergrad, :school_direct_tuition_fee, :school_direct_salaried).include? training_route
+  TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :early_years_undergrad, :school_direct_tuition_fee, :school_direct_salaried, :early_years_assessment_only, :early_years_graduate_employment_based, :early_years_graduate_entry).include? training_route
 }.freeze
 
 TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -3,13 +3,13 @@
 TRAINING_ROUTE_ENUMS = {
   assessment_only: "assessment_only",
   early_years_assessment_only: "early_years_assessment_only",
-  early_years_graduate_employment_based: "early_years_graduate_employment_based",
-  early_years_graduate_entry: "early_years_graduate_entry",
+  early_years_postgrad: "early_years_postgrad",
+  early_years_salaried: "early_years_salaried",
   early_years_undergrad: "early_years_undergrad",
   pg_teaching_apprenticeship: "pg_teaching_apprenticeship",
   provider_led_postgrad: "provider_led_postgrad",
-  school_direct_salaried: "school_direct_salaried",
   school_direct_tuition_fee: "school_direct_tuition_fee",
+  school_direct_salaried: "school_direct_salaried",
 }.freeze
 
 TRAINING_ROUTES = {
@@ -20,12 +20,12 @@ TRAINING_ROUTES = {
   TRAINING_ROUTE_ENUMS[:school_direct_salaried] => 4,
   TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => 5,
   TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => 6,
-  TRAINING_ROUTE_ENUMS[:early_years_graduate_employment_based] => 7,
-  TRAINING_ROUTE_ENUMS[:early_years_graduate_entry] => 8,
+  TRAINING_ROUTE_ENUMS[:early_years_salaried] => 7,
+  TRAINING_ROUTE_ENUMS[:early_years_postgrad] => 8,
 }.freeze
 
 TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|
-  TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :early_years_undergrad, :school_direct_tuition_fee, :school_direct_salaried, :early_years_assessment_only, :early_years_graduate_employment_based, :early_years_graduate_entry).include? training_route
+  TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :early_years_undergrad, :school_direct_tuition_fee, :school_direct_salaried, :early_years_assessment_only, :early_years_salaried, :early_years_postgrad).include? training_route
 }.freeze
 
 TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|
@@ -39,8 +39,8 @@ TRAINING_ROUTE_FEATURE_FLAGS = TRAINING_ROUTE_ENUMS.keys.reject { |training_rout
 TRAINING_ROUTE_AWARD_TYPE = {
   assessment_only: "QTS",
   early_years_undergrad: "EYTS",
-  early_years_graduate_employment_based: "EYTS",
-  early_years_graduate_entry: "EYTS",
+  early_years_salaried: "EYTS",
+  early_years_postgrad: "EYTS",
   early_years_assessment_only: "EYTS",
   pg_teaching_apprenticeship: "QTS",
   provider_led_postgrad: "QTS",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -491,8 +491,8 @@ en:
         training_routes:
           assessment_only: Assessment only
           early_years_assessment_only: Early years (assessment only)
-          early_years_graduate_employment_based: Early years (graduate employment based)
-          early_years_graduate_entry: Early years (graduate entry)
+          early_years_postgrad: Early years (postgrad)
+          early_years_salaried: Early years (salaried)
           early_years_undergrad: Early years (undergrad)
           provider_led_postgrad: Provider-led (postgrad)
           school_direct_salaried: School direct (salaried)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,8 +37,8 @@ features:
   run_consistency_check_job: true
   routes:
     early_years_assessment_only: false
-    early_years_graduate_employment_based: false
-    early_years_graduate_entry: false
+    early_years_salaried: false
+    early_years_postgrad: false
     early_years_undergrad: false
     provider_led_postgrad: false
     school_direct_salaried: false

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -6,8 +6,8 @@ features:
     provider_led_postgrad: true
     early_years_undergrad: true
     early_years_assessment_only: true
-    early_years_graduate_employment_based: true
-    early_years_graduate_entry: true
+    early_years_salaried: true
+    early_years_postgrad: true
     school_direct_salaried: true
     school_direct_tuition_fee: true
 

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -5,6 +5,9 @@ features:
   routes:
     provider_led_postgrad: true
     early_years_undergrad: true
+    early_years_assessment_only: true
+    early_years_graduate_employment_based: true
+    early_years_graduate_entry: true
     school_direct_salaried: true
     school_direct_tuition_fee: true
 

--- a/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
@@ -39,12 +39,12 @@ feature "Create trainee journey" do
     and_i_should_not_see_early_years_assessment_only_route
   end
 
-  scenario "early years graduate employment based radio button not shown when feature set to false", 'feature_routes.early_years_graduate_employment_based': false do
-    and_i_should_not_see_early_years_graduate_employment_based_route
+  scenario "early years graduate employment based radio button not shown when feature set to false", 'feature_routes.early_years_salaried': false do
+    and_i_should_not_see_early_years_salaried_route
   end
 
-  scenario "early years graduate entry radio button not shown when feature set to false", 'feature_routes.early_years_graduate_entry': false do
-    and_i_should_not_see_early_years_graduate_entry_route
+  scenario "early years graduate entry radio button not shown when feature set to false", 'feature_routes.early_years_postgrad': false do
+    and_i_should_not_see_early_years_postgrad_route
   end
 
   scenario "school direct salaried radio button not shown when feature set to false", 'feature_routes.school_direct_salaried': false do
@@ -97,14 +97,14 @@ private
     expect(new_trainee_page).to_not have_early_years_assessment_only
   end
 
-  def and_i_should_not_see_early_years_graduate_entry_route
+  def and_i_should_not_see_early_years_postgrad_route
     expect(new_trainee_page).to be_displayed
-    expect(new_trainee_page).to_not have_early_years_graduate_entry
+    expect(new_trainee_page).to_not have_early_years_postgrad
   end
 
-  def and_i_should_not_see_early_years_graduate_employment_based_route
+  def and_i_should_not_see_early_years_salaried_route
     expect(new_trainee_page).to be_displayed
-    expect(new_trainee_page).to_not have_early_years_graduate_employment_based
+    expect(new_trainee_page).to_not have_early_years_salaried
   end
 
   def and_i_should_not_see_school_direct_salaried_route

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -13,6 +13,9 @@ describe Trainee do
         TRAINING_ROUTE_ENUMS[:early_years_undergrad] => 2,
         TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => 3,
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => 4,
+        TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => 6,
+        TRAINING_ROUTE_ENUMS[:early_years_graduate_employment_based] => 7,
+        TRAINING_ROUTE_ENUMS[:early_years_graduate_entry] => 8,
       )
     end
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -14,8 +14,8 @@ describe Trainee do
         TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => 3,
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => 4,
         TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => 6,
-        TRAINING_ROUTE_ENUMS[:early_years_graduate_employment_based] => 7,
-        TRAINING_ROUTE_ENUMS[:early_years_graduate_entry] => 8,
+        TRAINING_ROUTE_ENUMS[:early_years_salaried] => 7,
+        TRAINING_ROUTE_ENUMS[:early_years_postgrad] => 8,
       )
     end
 

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -12,8 +12,8 @@ module PageObjects
       element :early_years_undergrad, "#trainee-training-route-early-years-undergrad-field"
 
       element :early_years_assessment_only, "#trainee-training-route-early-years-assessment-only-field"
-      element :early_years_graduate_employment_based, "#trainee-training-route-early-years-graduate-placement-based-field"
-      element :early_years_graduate_entry, "#trainee-training-route-early-years-graduate-entry-field"
+      element :early_years_salaried, "#trainee-training-route-early-years-graduate-placement-based-field"
+      element :early_years_postgrad, "#trainee-training-route-early-years-graduate-entry-field"
       element :school_direct_salaried, "#trainee-training-route-school-direct-salaried-field"
       element :school_direct_tuition_fee, "#trainee-training-route-school-direct-tuition-fee-field"
 


### PR DESCRIPTION
### Context

Adding all of the early years routes to the `What type of training` form. 

When you select one of the new routes, it now redirects to the correct form.

`Note:` Two routes have been renamed in this PR as detailed below. 

### Changes proposed in this pull request

- All routes now redirect to the correct form
- Early years routes are switched on in the review app

- Rename "Early years (graduate employment based)" to "Early years (salaried)"
- Rename "Early years (graduate entry)" to "Early years (postgrad)"

### Guidance to review

- Add a new trainee 
- Check that choosing an early year route redirects to the correct form
- Repeat with the other early year routes

