### PR TITLE
[1825] Store course subject(s) name not course name

### DIFF
--- a/app/components/feedback_link/view.html.erb
+++ b/app/components/feedback_link/view.html.erb
@@ -8,6 +8,6 @@
     body: "Give feedback (opens in a new tab)",
     url: feedback_link_url,
     target: "_blank",
-    rel: "noreferrer noopener"
+    rel: "noreferrer noopener",
   ) %>
 <% end %>

--- a/app/components/trainees/confirmation/confirm_publish_course/view.rb
+++ b/app/components/trainees/confirmation/confirm_publish_course/view.rb
@@ -33,7 +33,7 @@ module Trainees
               value: course_details,
               action: govuk_link_to(t(".change_course"), edit_trainee_publish_course_details_path(@trainee)),
             },
-            { key: t(".subject"), value: subject_names },
+            { key: subject_key, value: subject_names },
             { key: t(".level"), value: level },
             { key: t(".age_range"), value: age_range },
             { key: t(".start_date"), value: start_date },
@@ -67,6 +67,12 @@ module Trainees
 
         def duration
           pluralize(course.duration_in_years, "year")
+        end
+
+      private
+
+        def subject_key
+          course.subjects.count > 1 ? t(".multiple_subjects") : t(".subject")
         end
       end
     end

--- a/app/components/trainees/confirmation/confirm_publish_course/view.rb
+++ b/app/components/trainees/confirmation/confirm_publish_course/view.rb
@@ -5,6 +5,7 @@ module Trainees
     module ConfirmPublishCourse
       class View < GovukComponent::Base
         include SummaryHelper
+        include CourseDetailsHelper
 
         attr_accessor :trainee, :course
 
@@ -32,26 +33,11 @@ module Trainees
               value: course_details,
               action: govuk_link_to(t(".change_course"), edit_trainee_publish_course_details_path(@trainee)),
             },
-            {
-              key: t(".subject"),
-              value: subject,
-            },
-            {
-              key: t(".level"),
-              value: level,
-            },
-            {
-              key: t(".age_range"),
-              value: age_range,
-            },
-            {
-              key: t(".start_date"),
-              value: start_date,
-            },
-            {
-              key: t(".duration"),
-              value: duration,
-            },
+            { key: t(".subject"), value: subject_names },
+            { key: t(".level"), value: level },
+            { key: t(".age_range"), value: age_range },
+            { key: t(".start_date"), value: start_date },
+            { key: t(".duration"), value: duration },
           ]
         end
 
@@ -59,8 +45,12 @@ module Trainees
           "#{course.name} (#{course.code})"
         end
 
-        def subject
-          course.name
+        def subject_names
+          subjects_for_summary_view(
+            course.subject_one&.name,
+            course.subject_two&.name,
+            course.subject_three&.name,
+          )
         end
 
         def level

--- a/app/forms/confirm_publish_course_form.rb
+++ b/app/forms/confirm_publish_course_form.rb
@@ -32,10 +32,6 @@ class ConfirmPublishCourseForm
     trainee.save!
   end
 
-  def subject
-    course&.name
-  end
-
   def age_range
     course&.age_range
   end
@@ -57,9 +53,9 @@ private
   def update_trainee_attributes
     trainee.progress.course_details = true
     trainee.assign_attributes({
-      subject: subject,
-      subject_two: nil,
-      subject_three: nil,
+      subject: course.subject_one&.name,
+      subject_two: course.subject_two&.name,
+      subject_three: course.subject_three&.name,
       course_code: course_code,
       course_age_range: course&.age_range,
       course_start_date: course_start_date,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -43,4 +43,16 @@ class Course < ApplicationRecord
   def age_range=(range)
     self.min_age, self.max_age = range
   end
+
+  def subject_one
+    subjects&.first
+  end
+
+  def subject_two
+    subjects&.second
+  end
+
+  def subject_three
+    subjects&.third
+  end
 end

--- a/app/views/trainees/course_details/_additional_subjects.html.erb
+++ b/app/views/trainees/course_details/_additional_subjects.html.erb
@@ -1,4 +1,4 @@
-<details class="govuk-details" data-module="govuk-details" <% if f.object.has_additional_subjects? %>open<% end %>>
+<details class="govuk-details" data-module="govuk-details" <% if f.object.has_additional_subjects? %> open<% end %>>
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
       <%= t(".add_additional_subjects") %>
@@ -14,7 +14,7 @@
         attribute_name: :subject_two,
         form_field: f.govuk_collection_select(:subject_two, course_subjects_options,
                                               :name, :name, label: { text: t(".subject_two") },
-                                                            hint: { text: t('.subject_hint') }),
+                                                            hint: { text: t(".subject_hint") }),
       ) %>
     </div>
 
@@ -24,7 +24,7 @@
         attribute_name: :subject_three,
         form_field: f.govuk_collection_select(:subject_three, course_subjects_options,
                                               :name, :name, label: { text: t(".subject_three") },
-                                                            hint: { text: t('.subject_hint') }),
+                                                            hint: { text: t(".subject_hint") }),
       ) %>
     </div>
 

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -18,7 +18,7 @@
     form_field: f.govuk_collection_select(:subject, subjects_options,
                                           :name, :name, label: { text: "Degree subject", size: "s" },
                                                         hint: { text: 'Search for the closest matching subject.
-                                                         You can start typing to narrow down your search.' })
+                                                         You can start typing to narrow down your search.' }),
   ) %>
 
   <%= render FormComponents::Autocomplete::View.new(
@@ -26,7 +26,7 @@
     attribute_name: :uk_degree,
     form_field: f.govuk_collection_select(:uk_degree, hesa_degree_types_options, :option_value, :option_name,
                                           label: { text: "Type of degree", size: "s" },
-                                          hint: { text: "For example, BA, BSc or other (please specify)" })
+                                          hint: { text: "For example, BA, BSc or other (please specify)" }),
   ) %>
 
   <%= f.govuk_radio_buttons_fieldset(:grade,

--- a/app/views/trainees/outcome_details/recommended.html.erb
+++ b/app/views/trainees/outcome_details/recommended.html.erb
@@ -30,4 +30,4 @@
 <ul class="govuk-list govuk-list--bullet">
   <li><%= govuk_link_to("view #{trainee_name(@trainee)}’s record", trainee_path(@trainee)) %></li>
   <li><%= govuk_link_to("view all your records", trainees_path) %></li>
-</ul>  
+</ul>

--- a/app/views/trainees/personal_details/_nationality_select_field.html.erb
+++ b/app/views/trainees/personal_details/_nationality_select_field.html.erb
@@ -2,5 +2,5 @@
   form,
   attribute_name: field,
   form_field: form.govuk_collection_select(field, format_nationalities(nationalities, empty_option: true, description: false), :id, :name, label: { text: "Other nationality", size: "s", aria: { label: "#{(index + 1).ordinalize} additional nationality" } }),
-  classes: "govuk-!-margin-bottom-6"
+  classes: "govuk-!-margin-bottom-6",
 ) %>

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -11,7 +11,7 @@
     <%= f.govuk_radio_buttons_fieldset :code,
                                        legend: { text: t(".heading"), tag: "h1", size: "l" },
                                        hint: { text: t("views.forms.publish_course_details.route_message", route: route_title(@trainee.training_route)) },
-                                       classes: 'published-courses' do %>
+                                       classes: "published-courses" do %>
 
       <% @courses.each do |course| %>
         <%= f.govuk_radio_button :code, course.code,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,6 +437,7 @@ en:
           summary_title: Course details
           type_of_course: Subject
           subject: Subject
+          multiple_subjects: Subjects
           level: Level
           age_range: Age range
           start_date: Start date

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -2,6 +2,7 @@ features:
   home_text: true
   use_dfe_sign_in: false
   enable_feedback_link: true
+  publish_course_details: true
   routes:
     provider_led_postgrad: true
     early_years_undergrad: true

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -10,8 +10,16 @@ import_applications_from_apply:
   cron: "0 1 * * *"
   class: "ApplyApi::ImportApplicationsJob"
   queue: default
-import_courses_from_ttapi:
+run_consistency_check_job:
   cron: "0 2 * * *"
+  class: "RunConsistencyChecksJob"
+  queue: dttp
+import_subjects_from_ttapi:
+  cron: "0 2 * * *"
+  class: "TeacherTrainingApi::ImportSubjectsJob"
+  queue: default
+import_courses_from_ttapi:
+  cron: "0 3 * * *"
   class: "TeacherTrainingApi::ImportCoursesJob"
   queue: default
 import_users_from_dttp:
@@ -21,8 +29,4 @@ import_users_from_dttp:
 import_providers_from_dttp:
   cron: "0 4 * * *"
   class: "Dttp::SyncProvidersJob"
-  queue: dttp
-run_consistency_check_job:
-  cron: "0 2 * * *"
-  class: "RunConsistencyChecksJob"
   queue: dttp

--- a/spec/components/trainees/confirmation/confirm_publish_course/view_preview.rb
+++ b/spec/components/trainees/confirmation/confirm_publish_course/view_preview.rb
@@ -10,6 +10,12 @@ module Trainees
           render(View.new(trainee: mock_trainee, course: build_course))
         end
 
+        def with_multiple_subjects
+          course = build_course
+          course.subjects << Subject.new(name: "Subject two")
+          render(View.new(trainee: mock_trainee, course: course))
+        end
+
       private
 
         def mock_trainee

--- a/spec/components/trainees/confirmation/confirm_publish_course/view_preview.rb
+++ b/spec/components/trainees/confirmation/confirm_publish_course/view_preview.rb
@@ -7,12 +7,7 @@ module Trainees
     module ConfirmPublishCourse
       class ViewPreview < ViewComponent::Preview
         def default
-          render(Trainees::Confirmation::ConfirmPublishCourse::View.new(trainee: mock_trainee, course: mock_course))
-        end
-
-        def with_no_data
-          trainee = Trainee.new(id: 2, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
-          render(Trainees::Confirmation::ConfirmPublishCourse::View.new(trainee: trainee, course: mock_course))
+          render(View.new(trainee: mock_trainee, course: build_course))
         end
 
       private
@@ -23,12 +18,22 @@ module Trainees
             subject: "Primary",
             course_age_range: [3, 11],
             course_start_date: Date.new(2020, 0o1, 28),
-            training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+            training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
           )
         end
 
-        def mock_course
-          @mock_course ||= FactoryBot.build(:course)
+        def build_course
+          Course.new(
+            id: 1,
+            name: "Primary",
+            code: "2CX",
+            level: :primary,
+            min_age: 7,
+            max_age: 11,
+            start_date: Time.zone.today,
+            duration_in_years: 1,
+            subjects: [Subject.new(name: "Subject 1")],
+          )
         end
       end
     end

--- a/spec/components/trainees/confirmation/confirm_publish_course/view_spec.rb
+++ b/spec/components/trainees/confirmation/confirm_publish_course/view_spec.rb
@@ -53,6 +53,10 @@ module Trainees
             it "renders the first subject's name" do
               expect(rendered_component).to have_text(expected_names)
             end
+
+            it "displays the correct subject summary label" do
+              expect(rendered_component).to have_text(I18n.t("trainees.confirmation.confirm_publish_course.view.subject"))
+            end
           end
 
           context "with two subjects" do
@@ -61,6 +65,10 @@ module Trainees
 
             it "renders the first and second subject's name" do
               expect(rendered_component).to have_text(expected_names)
+            end
+
+            it "displays the correct subject summary label" do
+              expect(rendered_component).to have_text(I18n.t("trainees.confirmation.confirm_publish_course.view.multiple_subjects"))
             end
           end
 

--- a/spec/components/trainees/confirmation/confirm_publish_course/view_spec.rb
+++ b/spec/components/trainees/confirmation/confirm_publish_course/view_spec.rb
@@ -7,44 +7,71 @@ module Trainees
     module ConfirmPublishCourse
       describe View do
         include SummaryHelper
+        include CourseDetailsHelper
 
-        alias_method :component, :page
-
-        let(:course) { build(:course, duration_in_years: 2) }
         let(:trainee) { build(:trainee) }
 
-        before do
-          render_inline(View.new(trainee: trainee, course: course))
+        context "default behaviour" do
+          let(:course) { build(:course, duration_in_years: 2) }
+
+          before do
+            render_inline(View.new(trainee: trainee, course: course))
+          end
+
+          it "renders the course details" do
+            expect(rendered_component).to have_text("#{course.name} (#{course.code})")
+          end
+
+          it "renders the level" do
+            expect(rendered_component).to have_text(course.level.capitalize)
+          end
+
+          it "renders the age range" do
+            expect(rendered_component).to have_text(age_range_for_summary_view(course.age_range))
+          end
+
+          it "renders the start date" do
+            expect(rendered_component).to have_text(date_for_summary_view(course.start_date))
+          end
+
+          it "renders the duration" do
+            expect(rendered_component).to have_text("#{course.duration_in_years} years")
+          end
         end
 
-        it "renders the course details" do
-          expect(component.find(".govuk-summary-list__row.course-details .govuk-summary-list__value"))
-            .to have_text("#{course.name} (#{course.code})")
-        end
+        context "course subjects" do
+          let(:course) { create(:course_with_subjects, subjects_count: subject_count) }
 
-        it "renders the subject" do
-          expect(component.find(".govuk-summary-list__row.subject .govuk-summary-list__value"))
-            .to have_text(course.name)
-        end
+          before do
+            render_inline(View.new(trainee: trainee, course: course))
+          end
 
-        it "renders the level" do
-          expect(component.find(".govuk-summary-list__row.level .govuk-summary-list__value"))
-            .to have_text(course.level.capitalize)
-        end
+          context "with one subject" do
+            let(:subject_count) { 1 }
+            let(:expected_names) { subjects_for_summary_view(course.subjects.first.name, nil, nil) }
 
-        it "renders the age range" do
-          expect(component.find(".govuk-summary-list__row.age-range .govuk-summary-list__value"))
-            .to have_text(age_range_for_summary_view(course.age_range))
-        end
+            it "renders the first subject's name" do
+              expect(rendered_component).to have_text(expected_names)
+            end
+          end
 
-        it "renders the start date" do
-          expect(component.find(".govuk-summary-list__row.start-date .govuk-summary-list__value"))
-            .to have_text(date_for_summary_view(course.start_date))
-        end
+          context "with two subjects" do
+            let(:subject_count) { 2 }
+            let(:expected_names) { subjects_for_summary_view(course.subjects.first.name, course.subjects.second.name, nil) }
 
-        it "renders the duration" do
-          expect(component.find(".govuk-summary-list__row.duration .govuk-summary-list__value"))
-            .to have_text("#{course.duration_in_years} years")
+            it "renders the first and second subject's name" do
+              expect(rendered_component).to have_text(expected_names)
+            end
+          end
+
+          context "with three subjects" do
+            let(:subject_count) { 3 }
+            let(:expected_names) { subjects_for_summary_view(course.subjects.first.name, course.subjects.second.name, course.subjects.third.name) }
+
+            it "renders the first, second and third subject's name" do
+              expect(rendered_component).to have_text(expected_names)
+            end
+          end
         end
       end
     end

--- a/spec/factories/course_subjects.rb
+++ b/spec/factories/course_subjects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :course_subjects, class: CourseSubject do
+    association :course
+    association :subject
+  end
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -19,9 +19,15 @@ FactoryBot.define do
       time = ["full time", "part time"].sample
       [qualifications, time].join(" ")
     end
-  end
 
-  factory :course_with_a_subject do
-    subjects { [association(:subject)] }
+    factory :course_with_subjects do
+      transient do
+        subjects_count { 1 }
+      end
+
+      after(:create) do |course, evaluator|
+        create_list(:course_subjects, evaluator.subjects_count, course: course)
+      end
+    end
   end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -218,7 +218,7 @@ FactoryBot.define do
       end
 
       after(:create) do |trainee, evaluator|
-        create_list(:course, evaluator.courses_count,
+        create_list(:course_with_subjects, evaluator.courses_count,
                     accredited_body_code: trainee.provider.code,
                     route: trainee.training_route)
 

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -5,10 +5,6 @@ require "rails_helper"
 feature "publish course details", type: :feature, feature_publish_course_details: true do
   include CourseDetailsHelper
 
-  after do
-    FormStore.clear_all(trainee.id)
-  end
-
   background do
     given_i_am_authenticated
     given_a_trainee_exists(:with_related_courses, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
@@ -137,6 +133,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
   end
 
   def given_there_arent_any_courses
+    CourseSubject.destroy_all
     Course.destroy_all
   end
 

--- a/spec/forms/confirm_publish_course_form_spec.rb
+++ b/spec/forms/confirm_publish_course_form_spec.rb
@@ -13,7 +13,7 @@ describe ConfirmPublishCourseForm, type: :model do
 
   context "with valid params" do
     subject { described_class.new(trainee, params) }
-    let(:course) { create(:course) }
+    let(:course) { create(:course_with_subjects) }
     let(:params) { { code: course.code } }
 
     context "valid trainee" do
@@ -23,7 +23,7 @@ describe ConfirmPublishCourseForm, type: :model do
         it "changed related trainee attributes" do
           expect { subject.save }
             .to change { trainee.subject }
-            .from(nil).to(course.name)
+            .from(nil).to(course.subjects.first.name)
             .and change { trainee.course_min_age }
             .from(nil).to(course.min_age)
             .and change { trainee.course_max_age }
@@ -36,15 +36,25 @@ describe ConfirmPublishCourseForm, type: :model do
       end
     end
 
-    context "when trainee is assigned to multiple subjects" do
-      let(:trainee) { create(:trainee, :with_multiple_subjects) }
+    context "when course has multiple subjects" do
+      context "with two subjects" do
+        let(:course) { create(:course_with_subjects, subjects_count: 2) }
 
-      it "removed the surplus subjects on save" do
-        expect { subject.save }
+        it "stores the second subject" do
+          expect { subject.save }
             .to change { trainee.subject_two }
-            .from(trainee.subject_two).to(nil)
-            .and change { trainee.subject_three }
-            .from(trainee.subject_three).to(nil)
+            .from(nil).to(course.subjects.second.name)
+        end
+      end
+
+      context "with three subjects" do
+        let(:course) { create(:course_with_subjects, subjects_count: 3) }
+
+        it "stores the third subject" do
+          expect { subject.save }
+            .to change { trainee.subject_three }
+            .from(nil).to(course.subjects.third.name)
+        end
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,7 @@ end
 
 RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
   config.include ApiRequestHelpers, type: :controller
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -27,7 +27,7 @@ module Features
 
     def given_a_course_is_available_for_selection
       trainee = trainee_from_url
-      create(:course, accredited_body_code: trainee.provider.code, route: trainee.training_route)
+      create(:course_with_subjects, accredited_body_code: trainee.provider.code, route: trainee.training_route)
     end
 
     def and_the_course_details_is_marked_completed


### PR DESCRIPTION
### Context

- https://trello.com/c/UOyfZ9WX/1825-store-course-subject-name-not-course-name

### Changes proposed in this pull request

- When choosing a publish course, we should store the course's subjects instead of the course name as the subject
- Turns on the job to import subjects which will need to be run before the courses are imported as they look up the subjects from the subjects table (which needs to be populated)
- Configure view components for easier testing using `rendered_component` instead of the `alias_method :component, :page`

Before (using the course as a subject):

<img width="1119" alt="Screenshot 2021-06-03 at 10 06 36" src="https://user-images.githubusercontent.com/616080/120618874-63c33800-c453-11eb-8dd9-a09d7ddf1496.png">

After (using the actual course subjects):

<img width="1067" alt="Screenshot 2021-06-02 at 16 22 48" src="https://user-images.githubusercontent.com/616080/120618777-4c844a80-c453-11eb-8a96-0e2188ef59fd.png">


### Guidance to review

- Head to https://rtt-review-pr-940.herokuapp.com/trainees/3iAYR7zCBVFqZiwRt1wss4Qg/review-draft and click on the course details
- Choose course Course 1 (CEVH) (last option)
- Assert the course's subjects are shown under the subject summary title