### PR TITLE
[1891] End to end feature spec for each school route

### DIFF
--- a/spec/features/end_to_end/school_direct_salaried_journey_spec.rb
+++ b/spec/features/end_to_end/school_direct_salaried_journey_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "school-direct-salaried end-to-end journey", type: :feature do
+  background { given_i_am_authenticated }
+
+  scenario "submit for TRN", "feature_routes.school_direct_salaried": true do
+    given_i_have_created_a_school_direct_salaried_trainee
+    # and_the_personal_details_is_complete
+    # and_the_contact_details_is_complete
+    # and_the_diversity_information_is_complete
+    # and_the_degree_details_is_complete
+    # and_the_course_details_is_complete
+    # and_the_trainee_start_date_and_id_is_complete
+    and_the_lead_and_employing_schools_section_is_complete
+    # and_the_draft_record_has_been_reviewed
+    # and_all_sections_are_complete
+    # when_i_submit_for_trn
+    # then_i_am_redirected_to_the_trn_success_page
+  end
+end

--- a/spec/features/end_to_end/school_direct_tuition_fee_journey_spec.rb
+++ b/spec/features/end_to_end/school_direct_tuition_fee_journey_spec.rb
@@ -2,18 +2,18 @@
 
 require "rails_helper"
 
-feature "school-direct-salaried end-to-end journey", type: :feature do
+feature "school-direct-tuition-fee end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
-  scenario "submit for TRN", "feature_routes.school_direct_salaried": true do
-    given_i_have_created_a_school_direct_salaried_trainee
+  scenario "submit for TRN", "feature_routes.school_direct_tuition_fee": true do
+    given_i_have_created_a_school_direct_tuition_fee_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete
     and_the_diversity_information_is_complete
     and_the_degree_details_is_complete
     and_the_course_details_is_complete
     and_the_trainee_start_date_and_id_is_complete
-    and_the_lead_and_employing_schools_section_is_complete
+    and_the_lead_school_section_is_complete
     and_the_draft_record_has_been_reviewed
     and_all_sections_are_complete
     when_i_submit_for_trn

--- a/spec/support/features/lead_and_employing_school_steps.rb
+++ b/spec/support/features/lead_and_employing_school_steps.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Features
+  module LeadAndEmployingSchoolSteps
+    def and_the_lead_and_employing_schools_section_is_complete
+      given_lead_and_employing_schools_exist_in_the_system
+      review_draft_page.lead_and_employing_schools_section.link.click
+      and_i_fill_in_my_lead_school
+      and_i_continue
+      lead_schools_search_page.choose_school(id: @lead_school.id)
+      and_i_continue
+      and_i_fill_in_my_employing_school
+      and_i_continue
+      employing_schools_search_page.choose_school(id: @employing_school.id)
+      and_i_continue
+      and_i_confirm_my_details
+      and_the_lead_and_employing_schools_section_is_marked_completed
+    end
+
+  private
+
+    def given_lead_and_employing_schools_exist_in_the_system
+      @lead_school = create(:school, :lead)
+      @employing_school = create(:school)
+    end
+
+    def and_i_fill_in_my_lead_school
+      edit_lead_school_page.no_js_lead_school.fill_in with: @lead_school.name.split(" ").first
+    end
+
+    def and_i_fill_in_my_employing_school
+      edit_employing_school_page.no_js_employing_school.fill_in with: @employing_school.name.split(" ").first
+    end
+
+    def and_i_click_the_first_item_in_the_list
+      click(edit_lead_school_page.autocomplete_list_item)
+    end
+
+    def and_i_continue
+      click(edit_lead_school_page.submit)
+    end
+
+    def and_the_lead_and_employing_schools_section_is_marked_completed
+      expect(review_draft_page).to have_lead_and_employing_school_information_completed
+    end
+  end
+end

--- a/spec/support/features/lead_and_employing_school_steps.rb
+++ b/spec/support/features/lead_and_employing_school_steps.rb
@@ -17,11 +17,26 @@ module Features
       and_the_lead_and_employing_schools_section_is_marked_completed
     end
 
+    def and_the_lead_school_section_is_complete
+      given_a_lead_school_exists_in_the_system
+      review_draft_page.lead_and_employing_schools_section.link.click
+      and_i_fill_in_my_lead_school
+      and_i_continue
+      lead_schools_search_page.choose_school(id: @lead_school.id)
+      and_i_continue
+      and_i_confirm_my_details
+      and_the_lead_and_employing_schools_section_is_marked_completed
+    end
+
   private
 
     def given_lead_and_employing_schools_exist_in_the_system
-      @lead_school = create(:school, :lead)
+      given_a_lead_school_exists_in_the_system
       @employing_school = create(:school)
+    end
+
+    def given_a_lead_school_exists_in_the_system
+      @lead_school = create(:school, :lead)
     end
 
     def and_i_fill_in_my_lead_school
@@ -32,12 +47,8 @@ module Features
       edit_employing_school_page.no_js_employing_school.fill_in with: @employing_school.name.split(" ").first
     end
 
-    def and_i_click_the_first_item_in_the_list
-      click(edit_lead_school_page.autocomplete_list_item)
-    end
-
     def and_i_continue
-      click(edit_lead_school_page.submit)
+      find('input.govuk-button[type="submit"]').click
     end
 
     def and_the_lead_and_employing_schools_section_is_marked_completed

--- a/spec/support/features/training_route_steps.rb
+++ b/spec/support/features/training_route_steps.rb
@@ -10,6 +10,14 @@ module Features
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:assessment_only])
     end
 
+    def given_i_have_created_a_school_direct_salaried_trainee
+      choose_training_route_for(TRAINING_ROUTE_ENUMS[:school_direct_salaried])
+    end
+
+    def given_i_have_created_a_school_direct_tuition_fee_trainee
+      choose_training_route_for(TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee])
+    end
+
   private
 
     def choose_training_route_for(route)

--- a/spec/support/page_objects/sections/schools_details.rb
+++ b/spec/support/page_objects/sections/schools_details.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class SchoolsDetails < PageObjects::Sections::Base
+      element :link, ".govuk-link"
+      element :status, ".govuk-tag"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/review_draft.rb
+++ b/spec/support/page_objects/trainees/review_draft.rb
@@ -16,6 +16,7 @@ module PageObjects
       section :degree_details, PageObjects::Sections::DegreeDetails, ".degree-details"
       section :course_details, PageObjects::Sections::CourseDetails, ".app-task-list__item.course-details"
       section :training_details, PageObjects::Sections::TrainingDetails, ".training-details"
+      section :lead_and_employing_schools_section, PageObjects::Sections::SchoolsDetails, ".app-task-list__item.school-details"
 
       element :review_this_record_link, "#check-details"
       element :delete_this_draft_link, ".app-link--warning"
@@ -42,6 +43,10 @@ module PageObjects
 
       def has_training_details_completed?
         training_details.status.text == STATUS_COMPLETED
+      end
+
+      def has_lead_and_employing_school_information_completed?
+        lead_and_employing_schools_section.status.text == STATUS_COMPLETED
       end
     end
   end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/ZTd8DVSm/1891-m-end-to-end-feature-spec-for-each-school-route)

### Changes proposed in this pull request

- End to end feature specs for both `tuition-fee` and `salaried` `school-direct` routes

### Guidance to review

- Run `rspec spec/features/end_to_end/school_direct_salaried_journey_spec.rb `
- Run `rspec spec/features/end_to_end/school_direct_tuition_fee_journey_spec.rb `

