### PR TITLE
[1875] mailer queue added to sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,4 @@
 :queues:
   - default
   - dttp
+  - mailers


### PR DESCRIPTION
### Context

https://trello.com/c/wt7e8oNu/1875-enable-notifications-in-register-so-we-can-send-a-welcome-email

### Changes proposed in this pull request

* `mailers` added to sidekiq queue.

### Guidance to review

