### PR TITLE
[1881] Fix markup on results pages

### DIFF
--- a/app/views/trainees/employing_schools/_results.html.erb
+++ b/app/views/trainees/employing_schools/_results.html.erb
@@ -11,26 +11,22 @@
 <%= f.govuk_error_summary %>
 
 <%= f.govuk_radio_buttons_fieldset :employing_school_id, legend: nil do %>
-  <div class="govuk-!-margin-bottom-6">
     <% @schools.each_with_index do |school, index| %>
       <%= f.govuk_radio_button :employing_school_id, school.id,
-                               label: { text: school.name },
-                               link_errors: index.zero?,
-                               hint: { text: school_urn_and_location(school) } %>
+                              label: { text: school.name },
+                              link_errors: index.zero?,
+                              hint: { text: school_urn_and_location(school) } %>
     <% end %>
-  </div>
 
-  <div class="govuk-!-margin-bottom-6"><%= f.govuk_radio_divider %></div>
+  <%= f.govuk_radio_divider %>
 
-  <div class="govuk-!-margin-bottom-6">
-    <%= f.govuk_radio_button :employing_school_id,
-                             :results_search_again,
-                             label: { text: t("components.page_titles.search_schools.search_button") } do %>
-      <%= f.govuk_text_field :results_search_again_query,
-                             label: { text: t("components.page_titles.search_schools.search_hint") },
-                             width: "three-quarters" %>
-    <% end %>
-  </div>
+  <%= f.govuk_radio_button :employing_school_id,
+                          :results_search_again,
+                          label: { text: t("components.page_titles.search_schools.search_button") } do %>
+    <%= f.govuk_text_field :results_search_again_query,
+                          label: { text: t("components.page_titles.search_schools.search_hint") },
+                          width: "three-quarters" %>
+  <% end %>
 <% end %>
 
 <%= f.govuk_submit %>

--- a/app/views/trainees/lead_schools/_results.html.erb
+++ b/app/views/trainees/lead_schools/_results.html.erb
@@ -11,26 +11,22 @@
 <%= f.govuk_error_summary %>
 
 <%= f.govuk_radio_buttons_fieldset :lead_school_id, legend: nil do %>
-  <div class="govuk-!-margin-bottom-6">
     <% @schools.each_with_index do |school, index| %>
       <%= f.govuk_radio_button :lead_school_id, school.id,
-                               label: { text: school.name },
-                               link_errors: index.zero?,
-                               hint: { text: school_urn_and_location(school) } %>
+                              label: { text: school.name },
+                              link_errors: index.zero?,
+                              hint: { text: school_urn_and_location(school) } %>
     <% end %>
-  </div>
 
-  <div class="govuk-!-margin-bottom-6"><%= f.govuk_radio_divider %></div>
-
-  <div class="govuk-!-margin-bottom-6">
-    <%= f.govuk_radio_button :lead_school_id,
-                             :results_search_again,
-                             label: { text: t("components.page_titles.search_schools.search_button") } do %>
-      <%= f.govuk_text_field :results_search_again_query,
-                             label: { text: t("components.page_titles.search_schools.search_hint") },
-                             width: "three-quarters" %>
-    <% end %>
-  </div>
+  <%= f.govuk_radio_divider %>
+  
+  <%= f.govuk_radio_button :lead_school_id,
+                          :results_search_again,
+                          label: { text: t("components.page_titles.search_schools.search_button") } do %>
+    <%= f.govuk_text_field :results_search_again_query,
+                          label: { text: t("components.page_titles.search_schools.search_hint") },
+                          width: "three-quarters" %>
+  <% end %>
 <% end %>
 
 <%= f.govuk_submit %>


### PR DESCRIPTION
### Context
https://trello.com/c/mBUxbYhP/1881-s-non-javascript-lead-school-search-the-or-is-weirdly-placed-is-it-using-the-formbuilder
For both lead schools and employing schools results partial

### Changes proposed in this pull request
Formbuilder was being used but uses of gov css margin override classes was making it look weird and not like the prototype
css classes removed 
### Guidance to review
Turn js off and search for schools on lead schools edit and employing schools edit page


![screencapture-localhost-5000-trainees-BKhhpezjVVRhemqZ46GDXytd-employing-schools-2021-06-07-12_26_28](https://user-images.githubusercontent.com/58793682/121009078-a191ca80-c78b-11eb-9085-28f43799f295.png)

![screencapture-localhost-5000-trainees-5cVdKA6mhxWMH781UTBdZQpr-lead-schools-2021-06-07-12_29_07](https://user-images.githubusercontent.com/58793682/121009359-f9303600-c78b-11eb-9626-76295739ceb6.png)
