### PR TITLE
[1860] Home page squares with EYTS, QTS and generic states

### DIFF
--- a/app/components/badges/view.html.erb
+++ b/app/components/badges/view.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row govuk-!-margin-bottom-6">
+  <% full_width_states.map do |state, count| %>
+    <div class="govuk-grid-column-one-third">
+      <%= render TraineeStatusCard::View.new(state: state, count: count, target: trainees_path("state[]": state)) %>
+    </div>
+  <% end %>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-6">
+  <% narrow_states.map do |state, count| %>
+    <div class="govuk-grid-column-one-quarter">
+      <%= render TraineeStatusCard::View.new(state: state, count: count, target: trainees_path("state[]": state)) %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/badges/view.rb
+++ b/app/components/badges/view.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Badges
+  class View < GovukComponent::Base
+    FULL_WIDTH_STATES = %w[
+      draft
+      submitted_for_trn
+      trn_received
+    ].freeze
+
+    NARROW_STATES = %w[
+      recommended_for_award
+      awarded
+      eyts_recommended
+      eyts_received
+      qts_recommended
+      qts_received
+      deferred
+      withdrawn
+    ].freeze
+
+    def initialize(trainees)
+      @trainees = trainees
+      populate_state_counts!
+    end
+
+    def full_width_states
+      @counts.slice(*FULL_WIDTH_STATES)
+    end
+
+    def narrow_states
+      @counts.slice(*NARROW_STATES)
+    end
+
+    def populate_state_counts!
+      defaults = Trainee.states.keys.index_with do |state|
+        [state, 0]
+      end
+
+      counts = @trainees.group(:state).count.reverse_merge(defaults)
+
+      if eyts_trainees? == qts_trainees?
+        counts["awarded"] ||= 0
+        counts["recommended_for_award"] ||= 0
+      elsif eyts_trainees?
+        awarded = counts.delete("awarded")
+        counts["eyts_received"] = awarded
+
+        recommended = counts.delete("recommended_for_award")
+        counts["eyts_recommended"] = recommended
+      elsif qts_trainees?
+        awarded = counts.delete("awarded")
+        counts["qts_received"] = awarded
+
+        recommended = counts.delete("recommended_for_award")
+        counts["qts_recommended"] = recommended
+      end
+
+      @counts = counts
+    end
+
+    def eyts_trainees?
+      return @_eyts_trainees if defined?(@_eyts_trainees)
+
+      @_eyts_trainees =
+        @trainees.where(training_route: EARLY_YEARS_ROUTES, state: %i[awarded recommended_for_award]).count.positive?
+    end
+
+    def qts_trainees?
+      return @_qts_trainees if defined?(@_qts_trainees)
+
+      @_qts_trainees =
+        @trainees.where(state: %i[awarded recommended_for_award]).where.not(training_route: EARLY_YEARS_ROUTES).count.positive?
+    end
+  end
+end

--- a/app/components/badges/view.rb
+++ b/app/components/badges/view.rb
@@ -12,9 +12,9 @@ module Badges
       recommended_for_award
       awarded
       eyts_recommended
-      eyts_received
+      eyts_awarded
       qts_recommended
-      qts_received
+      qts_awarded
       deferred
       withdrawn
     ].freeze

--- a/app/components/badges/view.rb
+++ b/app/components/badges/view.rb
@@ -19,55 +19,16 @@ module Badges
       withdrawn
     ].freeze
 
-    def initialize(trainees)
-      @trainees = trainees
-      populate_state_counts!
+    def initialize(state_counts)
+      @state_counts = state_counts
     end
 
     def full_width_states
-      @counts.slice(*FULL_WIDTH_STATES)
+      @state_counts.slice(*FULL_WIDTH_STATES)
     end
 
     def narrow_states
-      @counts.slice(*NARROW_STATES)
-    end
-
-    def populate_state_counts!
-      defaults = Trainee.states.keys.index_with { 0 }
-      counts = @trainees.group(:state).count.reverse_merge(defaults)
-
-      if eyts_trainees? == qts_trainees?
-        counts["awarded"] ||= 0
-        counts["recommended_for_award"] ||= 0
-      elsif eyts_trainees?
-        awarded = counts.delete("awarded")
-        counts["eyts_received"] = awarded
-
-        recommended = counts.delete("recommended_for_award")
-        counts["eyts_recommended"] = recommended
-      elsif qts_trainees?
-        awarded = counts.delete("awarded")
-        counts["qts_received"] = awarded
-
-        recommended = counts.delete("recommended_for_award")
-        counts["qts_recommended"] = recommended
-      end
-
-      @counts = counts
-    end
-
-    def eyts_trainees?
-      return @_eyts_trainees if defined?(@_eyts_trainees)
-
-      @_eyts_trainees =
-        @trainees.where(training_route: EARLY_YEARS_ROUTES, state: %i[awarded recommended_for_award]).count.positive?
-    end
-
-    def qts_trainees?
-      return @_qts_trainees if defined?(@_qts_trainees)
-
-      @_qts_trainees =
-        @trainees.where(state: %i[awarded recommended_for_award]).where.not(training_route: EARLY_YEARS_ROUTES).count.positive?
+      @state_counts.slice(*NARROW_STATES)
     end
   end
 end

--- a/app/components/badges/view.rb
+++ b/app/components/badges/view.rb
@@ -33,10 +33,7 @@ module Badges
     end
 
     def populate_state_counts!
-      defaults = Trainee.states.keys.index_with do |state|
-        [state, 0]
-      end
-
+      defaults = Trainee.states.keys.index_with { 0 }
       counts = @trainees.group(:state).count.reverse_merge(defaults)
 
       if eyts_trainees? == qts_trainees?

--- a/app/components/trainee_status_card/view.html.erb
+++ b/app/components/trainee_status_card/view.html.erb
@@ -1,3 +1,3 @@
- <%= render StatusCard::View.new(status_colour: status_colour,
+<%= render StatusCard::View.new(status_colour: status_colour,
                                  count: count, state_name: state_name,
                                  target: target) %>

--- a/app/components/trainee_status_card/view.rb
+++ b/app/components/trainee_status_card/view.rb
@@ -10,6 +10,10 @@ module TraineeStatusCard
       trn_received: "blue",
       recommended_for_award: "purple",
       awarded: "",
+      qts_recommended: "purple",
+      qts_received: "",
+      eyts_recommended: "purple",
+      eyts_received: "",
       deferred: "yellow",
       withdrawn: "red",
     }.freeze

--- a/app/components/trainee_status_card/view.rb
+++ b/app/components/trainee_status_card/view.rb
@@ -2,7 +2,7 @@
 
 module TraineeStatusCard
   class View < GovukComponent::Base
-    attr_reader :state, :trainees, :target
+    attr_reader :state, :count, :target
 
     STATUS_COLOURS = {
       draft: "grey",
@@ -14,18 +14,14 @@ module TraineeStatusCard
       withdrawn: "red",
     }.freeze
 
-    def initialize(state:, trainees:, target:)
+    def initialize(state:, count:, target:)
       @state = state
       @target = target
-      @trainees = trainees
-    end
-
-    def count
-      trainees.where(state: state).count
+      @count = count
     end
 
     def state_name
-      I18n.t("activerecord.attributes.trainee.states.#{state}", award_type: "QTS")
+      I18n.t("activerecord.attributes.trainee.states.#{state}")
     end
 
     def status_colour

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,6 +7,7 @@ class PagesController < ApplicationController
     session[:requested_path] = root_path
     if authenticated?
       @trainees = policy_scope(Trainee.all)
+      @home_view = HomeView.new(@trainees)
       render :home
     else
       render :start

--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HomeView
+  EARLY_YEARS_ROUTES = TRAINING_ROUTE_AWARD_TYPE.select { |_, v| v == "EYTS" }.keys.freeze
+
   def initialize(trainees)
     @trainees = trainees
     populate_state_counts!

--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class HomeView
+  def initialize(trainees)
+    @trainees = trainees
+    populate_state_counts!
+  end
+
+  attr_reader :state_counts
+
+private
+
+  attr_reader :trainees
+
+  def populate_state_counts!
+    defaults = Trainee.states.keys.index_with { 0 }
+    counts = @trainees.group(:state).count.reverse_merge(defaults)
+
+    if eyts_trainees? == qts_trainees?
+      counts["awarded"] ||= 0
+      counts["recommended_for_award"] ||= 0
+    elsif eyts_trainees?
+      awarded = counts.delete("awarded")
+      counts["eyts_received"] = awarded
+
+      recommended = counts.delete("recommended_for_award")
+      counts["eyts_recommended"] = recommended
+    elsif qts_trainees?
+      awarded = counts.delete("awarded")
+      counts["qts_received"] = awarded
+
+      recommended = counts.delete("recommended_for_award")
+      counts["qts_recommended"] = recommended
+    end
+
+    @state_counts = counts
+  end
+
+  def eyts_trainees?
+    return @_eyts_trainees if defined?(@_eyts_trainees)
+
+    @_eyts_trainees =
+      @trainees.where(training_route: EARLY_YEARS_ROUTES, state: %i[awarded recommended_for_award]).count.positive?
+  end
+
+  def qts_trainees?
+    return @_qts_trainees if defined?(@_qts_trainees)
+
+    @_qts_trainees =
+      @trainees.where(state: %i[awarded recommended_for_award]).where.not(training_route: EARLY_YEARS_ROUTES).count.positive?
+  end
+end

--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -23,13 +23,13 @@ private
       counts["recommended_for_award"] ||= 0
     elsif eyts_trainees?
       awarded = counts.delete("awarded")
-      counts["eyts_received"] = awarded
+      counts["eyts_awarded"] = awarded
 
       recommended = counts.delete("recommended_for_award")
       counts["eyts_recommended"] = recommended
     elsif qts_trainees?
       awarded = counts.delete("awarded")
-      counts["qts_received"] = awarded
+      counts["qts_awarded"] = awarded
 
       recommended = counts.delete("recommended_for_award")
       counts["qts_recommended"] = recommended

--- a/app/views/pages/_badges.html.erb
+++ b/app/views/pages/_badges.html.erb
@@ -3,18 +3,5 @@
 <%# TODO:  Make this dynamic once we have a concept of academic years %>
 </h2>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
-  <% %i[draft submitted_for_trn trn_received].map do |state| %>
-    <div class="govuk-grid-column-one-third">
-      <%= render TraineeStatusCard::View.new(state: state, target: trainees_path("state[]": state), trainees: @trainees) %>
-    </div>
-  <% end %>
-</div>
+<%= render Badges::View.new(@trainees) %>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
-  <% %i[recommended_for_award awarded deferred withdrawn].map do |state| %>
-    <div class=" govuk-grid-column-one-quarter ">
-    <%= render TraineeStatusCard::View.new(state: state, target: trainees_path("state[]": state), trainees: @trainees) %>
-  </div>
-  <% end %>
-</div>

--- a/app/views/pages/_badges.html.erb
+++ b/app/views/pages/_badges.html.erb
@@ -3,5 +3,5 @@
 <%# TODO:  Make this dynamic once we have a concept of academic years %>
 </h2>
 
-<%= render Badges::View.new(@trainees) %>
+<%= render Badges::View.new(@home_view.state_counts) %>
 

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -53,5 +53,4 @@ EARLY_YEARS_ROUTES = %i[
   early_years_graduate_employment_based
   early_years_graduate_entry
   early_years_undergrad
-]
-
+].freeze

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -47,3 +47,11 @@ TRAINING_ROUTE_AWARD_TYPE = {
   school_direct_salaried: "QTS",
   school_direct_tuition_fee: "QTS",
 }.freeze
+
+EARLY_YEARS_ROUTES = %i[
+  early_years_assessment_only
+  early_years_graduate_employment_based
+  early_years_graduate_entry
+  early_years_undergrad
+]
+

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -47,10 +47,3 @@ TRAINING_ROUTE_AWARD_TYPE = {
   school_direct_salaried: "QTS",
   school_direct_tuition_fee: "QTS",
 }.freeze
-
-EARLY_YEARS_ROUTES = %i[
-  early_years_assessment_only
-  early_years_graduate_employment_based
-  early_years_graduate_entry
-  early_years_undergrad
-].freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -508,11 +508,11 @@ en:
           recommended_for_award: Qualification recommended
           withdrawn: Withdrawn
           deferred: Deferred
-          awarded: Qualification received
+          awarded: Qualification awarded
           qts_recommended: QTS recommended
-          qts_received: QTS received
+          qts_awarded: QTS awarded
           eyts_recommended: EYTS recommended
-          eyts_received: EYTS received
+          eyts_awarded: EYTS awarded
     errors:
       models:
         trainee:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -505,10 +505,14 @@ en:
           draft: Draft
           submitted_for_trn: Pending TRN
           trn_received: TRN received
-          recommended_for_award: "%{award_type} recommended"
+          recommended_for_award: Qualification recommended
           withdrawn: Withdrawn
           deferred: Deferred
-          awarded: "%{award_type} awarded"
+          awarded: Qualification received
+          qts_recommended: QTS recommended
+          qts_received: QTS received
+          eyts_recommended: EYTS recommended
+          eyts_received: EYTS received
     errors:
       models:
         trainee:

--- a/spec/components/badges/view_preview.rb
+++ b/spec/components/badges/view_preview.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Badges
+  class ViewPreview < ViewComponent::Preview
+    # rake example_data:generate must be run before
+    # viewing these component previews
+
+    def with_no_trainees_in_award_states
+      trainees = Trainee.where.not(state: %i[awarded recommended_for_award])
+      render(Badges::View.new(trainees))
+    end
+
+    def with_trainees_only_in_eyts_states
+      trainees = Trainee.where(training_route: EARLY_YEARS_ROUTES)
+      render(Badges::View.new(trainees))
+    end
+
+    def with_trainees_only_in_qts_states
+      trainees = Trainee.where.not(training_route: EARLY_YEARS_ROUTES)
+      render(Badges::View.new(trainees))
+    end
+
+    def with_trainees_in_qts_and_eyts_states
+      trainees = Trainee.all
+      render(Badges::View.new(trainees))
+    end
+
+    def with_no_trainees
+      trainees = Trainee.none
+      render(Badges::View.new(trainees))
+    end
+  end
+end

--- a/spec/components/badges/view_preview.rb
+++ b/spec/components/badges/view_preview.rb
@@ -2,27 +2,38 @@
 
 module Badges
   class ViewPreview < ViewComponent::Preview
-    # rake example_data:generate must be run before
-    # viewing these component previews
+    include FactoryBot::Syntax::Methods
 
     def with_no_trainees_in_award_states
-      trainees = Trainee.where.not(state: %i[awarded recommended_for_award])
-      render(Badges::View.new(trainees))
+      ActiveRecord::Base.transaction do
+        trainee_id = create(:trainee, state: :draft).id
+        render(Badges::View.new(Trainee.where(id: trainee_id)))
+      end
     end
 
     def with_trainees_only_in_eyts_states
-      trainees = Trainee.where(training_route: EARLY_YEARS_ROUTES)
-      render(Badges::View.new(trainees))
+      ActiveRecord::Base.transaction do
+        trainee_id = create(:trainee, training_route: :early_years_undergrad, state: :awarded).id
+        render(Badges::View.new(Trainee.where(id: trainee_id)))
+      end
     end
 
     def with_trainees_only_in_qts_states
-      trainees = Trainee.where.not(training_route: EARLY_YEARS_ROUTES)
-      render(Badges::View.new(trainees))
+      ActiveRecord::Base.transaction do
+        trainee_id = create(:trainee, training_route: :assessment_only, state: :awarded).id
+        render(Badges::View.new(Trainee.where(id: trainee_id)))
+      end
     end
 
     def with_trainees_in_qts_and_eyts_states
-      trainees = Trainee.all
-      render(Badges::View.new(trainees))
+      ActiveRecord::Base.transaction do
+        trainee_ids = [
+          create(:trainee, training_route: :assessment_only, state: :awarded).id,
+          create(:trainee, training_route: :early_years_undergrad, state: :awarded).id,
+        ]
+
+        render(Badges::View.new(Trainee.where(id: trainee_ids)))
+      end
     end
 
     def with_no_trainees

--- a/spec/components/badges/view_preview.rb
+++ b/spec/components/badges/view_preview.rb
@@ -4,41 +4,44 @@ module Badges
   class ViewPreview < ViewComponent::Preview
     include FactoryBot::Syntax::Methods
 
-    def with_no_trainees_in_award_states
-      ActiveRecord::Base.transaction do
-        trainee_id = create(:trainee, state: :draft).id
-        render(Badges::View.new(Trainee.where(id: trainee_id)))
-      end
+    def with_generic_award_states
+      counts = state_counts.merge(
+        awarded: random_count,
+        recommended_for_award: random_count,
+      )
+      render(Badges::View.new(counts))
     end
 
-    def with_trainees_only_in_eyts_states
-      ActiveRecord::Base.transaction do
-        trainee_id = create(:trainee, training_route: :early_years_undergrad, state: :awarded).id
-        render(Badges::View.new(Trainee.where(id: trainee_id)))
-      end
+    def with_eyts_states
+      counts = state_counts.merge(
+        eyts_recommended: random_count,
+        eyts_received: random_count,
+      )
+      render(Badges::View.new(counts))
     end
 
-    def with_trainees_only_in_qts_states
-      ActiveRecord::Base.transaction do
-        trainee_id = create(:trainee, training_route: :assessment_only, state: :awarded).id
-        render(Badges::View.new(Trainee.where(id: trainee_id)))
-      end
+    def with_qts_states
+      counts = state_counts.merge(
+        qts_recommended: random_count,
+        qts_received: random_count,
+      )
+      render(Badges::View.new(counts))
     end
 
-    def with_trainees_in_qts_and_eyts_states
-      ActiveRecord::Base.transaction do
-        trainee_ids = [
-          create(:trainee, training_route: :assessment_only, state: :awarded).id,
-          create(:trainee, training_route: :early_years_undergrad, state: :awarded).id,
-        ]
+  private
 
-        render(Badges::View.new(Trainee.where(id: trainee_ids)))
-      end
+    def random_count
+      Array(1..100).sample
     end
 
-    def with_no_trainees
-      trainees = Trainee.none
-      render(Badges::View.new(trainees))
+    def state_counts
+      {
+        draft: random_count,
+        submitted_for_trn: random_count,
+        trn_received: random_count,
+        deferred: random_count,
+        withdrawn: random_count,
+      }.with_indifferent_access
     end
   end
 end

--- a/spec/components/badges/view_spec.rb
+++ b/spec/components/badges/view_spec.rb
@@ -5,8 +5,6 @@ require "rails_helper"
 RSpec.describe Badges::View do
   include Rails.application.routes.url_helpers
 
-  alias_method :component, :page
-
   let(:current_user) { create(:user, system_admin: true) }
 
   let(:counts) do
@@ -32,8 +30,8 @@ RSpec.describe Badges::View do
     end
 
     it "renders neutral text for those qualification states" do
-      expect(component).to have_text("Qualification recommended")
-      expect(component).to have_text("Qualification received")
+      expect(rendered_component).to include("Qualification recommended")
+      expect(rendered_component).to include("Qualification received")
     end
   end
 
@@ -46,8 +44,8 @@ RSpec.describe Badges::View do
     end
 
     it "renders eyts text or those qualification states" do
-      expect(component).to have_text("EYTS recommended")
-      expect(component).to have_text("EYTS received")
+      expect(rendered_component).to include("EYTS recommended")
+      expect(rendered_component).to include("EYTS received")
     end
   end
 
@@ -60,8 +58,8 @@ RSpec.describe Badges::View do
     end
 
     it "renders qts text or those qualification states" do
-      expect(component).to have_text("QTS recommended")
-      expect(component).to have_text("QTS received")
+      expect(rendered_component).to include("QTS recommended")
+      expect(rendered_component).to include("QTS received")
     end
   end
 end

--- a/spec/components/badges/view_spec.rb
+++ b/spec/components/badges/view_spec.rb
@@ -9,13 +9,27 @@ RSpec.describe Badges::View do
 
   let(:current_user) { create(:user, system_admin: true) }
 
+  let(:counts) do
+    {
+      draft: 10,
+      submitted_for_trn: 20,
+      trn_received: 150,
+      deferred: 10,
+      withdrawn: 0,
+    }.with_indifferent_access
+  end
+
   before do
-    trainees
-    render_inline(described_class.new(Trainee.all))
+    render_inline(described_class.new(counts))
   end
 
   context "No trainees have received or are recommended for qualifications" do
-    let(:trainees) { [create(:trainee, state: :draft)] }
+    let(:counts) do
+      super().merge(
+        awarded: 0,
+        recommended_for_award: 0,
+      )
+    end
 
     it "renders neutral text for those qualification states" do
       expect(component).to have_text("Qualification recommended")
@@ -24,7 +38,12 @@ RSpec.describe Badges::View do
   end
 
   context "There are trainees recommended or have received eyts" do
-    let(:trainees) { [create(:trainee, state: :awarded, training_route: :early_years_undergrad)] }
+    let(:counts) do
+      super().merge(
+        eyts_recommended: 0,
+        eyts_received: 0,
+      )
+    end
 
     it "renders eyts text or those qualification states" do
       expect(component).to have_text("EYTS recommended")
@@ -33,25 +52,16 @@ RSpec.describe Badges::View do
   end
 
   context "There are trainees recommended or have received qts" do
-    let(:trainees) { [create(:trainee, state: :awarded, training_route: :assessment_only)] }
+    let(:counts) do
+      super().merge(
+        qts_recommended: 0,
+        qts_received: 0,
+      )
+    end
 
     it "renders qts text or those qualification states" do
       expect(component).to have_text("QTS recommended")
       expect(component).to have_text("QTS received")
-    end
-  end
-
-  context "There are trainees recommended or have received qts and eyts" do
-    let(:trainees) do
-      [
-        create(:trainee, state: :awarded, training_route: :assessment_only),
-        create(:trainee, state: :awarded, training_route: :early_years_undergrad),
-      ]
-    end
-
-    it "renders neutral text or those qualification states" do
-      expect(component).to have_text("Qualification recommended")
-      expect(component).to have_text("Qualification received")
     end
   end
 end

--- a/spec/components/badges/view_spec.rb
+++ b/spec/components/badges/view_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Badges::View do
     render_inline(described_class.new(counts))
   end
 
-  context "No trainees have received or are recommended for qualifications" do
+  context "No trainees have been awarded or are recommended for qualifications" do
     let(:counts) do
       super().merge(
         awarded: 0,
@@ -31,35 +31,35 @@ RSpec.describe Badges::View do
 
     it "renders neutral text for those qualification states" do
       expect(rendered_component).to include("Qualification recommended")
-      expect(rendered_component).to include("Qualification received")
+      expect(rendered_component).to include("Qualification awarded")
     end
   end
 
-  context "There are trainees recommended or have received eyts" do
+  context "There are trainees recommended or have been awarded eyts" do
     let(:counts) do
       super().merge(
         eyts_recommended: 0,
-        eyts_received: 0,
+        eyts_awarded: 0,
       )
     end
 
     it "renders eyts text or those qualification states" do
       expect(rendered_component).to include("EYTS recommended")
-      expect(rendered_component).to include("EYTS received")
+      expect(rendered_component).to include("EYTS awarded")
     end
   end
 
-  context "There are trainees recommended or have received qts" do
+  context "There are trainees recommended or have been awarded qts" do
     let(:counts) do
       super().merge(
         qts_recommended: 0,
-        qts_received: 0,
+        qts_awarded: 0,
       )
     end
 
     it "renders qts text or those qualification states" do
       expect(rendered_component).to include("QTS recommended")
-      expect(rendered_component).to include("QTS received")
+      expect(rendered_component).to include("QTS awarded")
     end
   end
 end

--- a/spec/components/badges/view_spec.rb
+++ b/spec/components/badges/view_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Badges::View do
+  include Rails.application.routes.url_helpers
+
+  alias_method :component, :page
+
+  let(:current_user) { create(:user, system_admin: true) }
+
+  before do
+    trainees
+    render_inline(described_class.new(Trainee.all))
+  end
+
+  context "No trainees have received or are recommended for qualifications" do
+    let(:trainees) { [create(:trainee, state: :draft)] }
+
+    it "renders neutral text for those qualification states" do
+      expect(component).to have_text("Qualification recommended")
+      expect(component).to have_text("Qualification received")
+    end
+  end
+
+  context "There are trainees recommended or have received eyts" do
+    let(:trainees) { [create(:trainee, state: :awarded, training_route: :early_years_undergrad)] }
+
+    it "renders eyts text or those qualification states" do
+      expect(component).to have_text("EYTS recommended")
+      expect(component).to have_text("EYTS received")
+    end
+  end
+
+  context "There are trainees recommended or have received qts" do
+    let(:trainees) { [create(:trainee, state: :awarded, training_route: :assessment_only)] }
+
+    it "renders qts text or those qualification states" do
+      expect(component).to have_text("QTS recommended")
+      expect(component).to have_text("QTS received")
+    end
+  end
+
+  context "There are trainees recommended or have received qts and eyts" do
+    let(:trainees) do
+      [
+        create(:trainee, state: :awarded, training_route: :assessment_only),
+        create(:trainee, state: :awarded, training_route: :early_years_undergrad),
+      ]
+    end
+
+    it "renders neutral text or those qualification states" do
+      expect(component).to have_text("Qualification recommended")
+      expect(component).to have_text("Qualification received")
+    end
+  end
+end

--- a/spec/components/trainee_status_card/view_preview.rb
+++ b/spec/components/trainee_status_card/view_preview.rb
@@ -12,7 +12,7 @@ module TraineeStatusCard
 
     (Trainee.states.keys + award_states).each do |state|
       define_method state.to_s do
-        render(TraineeStatusCard::View.new(state: state, target: Rails.application.routes.url_helpers.trainees_path("state[]": state), count: (1..1000).sample))
+        render(TraineeStatusCard::View.new(state: state, target: Rails.application.routes.url_helpers.trainees_path("state[]": state), count: Array(1..1000).sample))
       end
     end
   end

--- a/spec/components/trainee_status_card/view_preview.rb
+++ b/spec/components/trainee_status_card/view_preview.rb
@@ -8,9 +8,11 @@ module TraineeStatusCard
       end
     end
 
-    Trainee.states.keys.each do |state|
+    award_states = %w[qts_recommended qts_received eyts_recommended eyts_received]
+
+    (Trainee.states.keys + award_states).each do |state|
       define_method state.to_s do
-        render(TraineeStatusCard::View.new(state: state, target: Rails.application.routes.url_helpers.trainees_path("state[]": state), trainees: MockTrainees.new))
+        render(TraineeStatusCard::View.new(state: state, target: Rails.application.routes.url_helpers.trainees_path("state[]": state), count: (1..1000).sample))
       end
     end
   end

--- a/spec/components/trainee_status_card/view_preview.rb
+++ b/spec/components/trainee_status_card/view_preview.rb
@@ -8,7 +8,7 @@ module TraineeStatusCard
       end
     end
 
-    award_states = %w[qts_recommended qts_received eyts_recommended eyts_received]
+    award_states = %w[qts_recommended qts_awarded eyts_recommended eyts_awarded]
 
     (Trainee.states.keys + award_states).each do |state|
       define_method state.to_s do

--- a/spec/components/trainee_status_card/view_spec.rb
+++ b/spec/components/trainee_status_card/view_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TraineeStatusCard::View do
 
   describe "#state_name" do
     it "returns state name in correct format" do
-      award_states = %w[qts_recommended qts_received eyts_recommended eyts_received]
+      award_states = %w[qts_recommended qts_awarded eyts_recommended eyts_awarded]
       (Trainee.states.keys + award_states).each do |state|
         expect(described_class.new(state: state,
                                    target: target, count: 1).state_name)

--- a/spec/components/trainee_status_card/view_spec.rb
+++ b/spec/components/trainee_status_card/view_spec.rb
@@ -14,10 +14,11 @@ RSpec.describe TraineeStatusCard::View do
 
   describe "#state_name" do
     it "returns state name in correct format" do
-      %i[draft withdrawn deferred awarded trn_received submitted_for_trn recommended_for_award].each do |state|
+      award_states = %w[qts_recommended qts_received eyts_recommended eyts_received]
+      (Trainee.states.keys + award_states).each do |state|
         expect(described_class.new(state: state,
-                                   target: target, trainees: trainees).state_name)
-          .to eql(I18n.t("activerecord.attributes.trainee.states.#{state}", award_type: "QTS"))
+                                   target: target, count: 1).state_name)
+          .to eql(I18n.t("activerecord.attributes.trainee.states.#{state}"))
       end
     end
   end
@@ -25,7 +26,7 @@ RSpec.describe TraineeStatusCard::View do
   describe "#status_colour" do
     it "returns the correct colour for given state" do
       described_class::STATUS_COLOURS.each_key do |state|
-        expect(described_class.new(state: state, target: target, trainees: trainees).status_colour)
+        expect(described_class.new(state: state, target: target, count: 1).status_colour)
           .to eql(described_class::STATUS_COLOURS[state])
       end
     end
@@ -35,7 +36,7 @@ RSpec.describe TraineeStatusCard::View do
     before do
       trainee
       render_inline(described_class.new(state: "draft",
-                                        target: target, trainees: trainees))
+                                        target: target, count: 1))
     end
 
     it "renders the correct css colour" do

--- a/spec/view_objects/home_view_spec.rb
+++ b/spec/view_objects/home_view_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe HomeView do
+  subject { described_class.new(trainees) }
+
+  context "no trainees in award states" do
+    let(:trainees) do
+      trainee_id = create(:trainee, state: :draft).id
+      Trainee.where(id: trainee_id)
+    end
+
+    it "labels award counts generically" do
+      expect(subject.state_counts.symbolize_keys).to eq(
+        awarded: 0,
+        deferred: 0,
+        draft: 1,
+        recommended_for_award: 0,
+        submitted_for_trn: 0,
+        trn_received: 0,
+        withdrawn: 0,
+      )
+    end
+  end
+
+  context "trainees only in eyts award states" do
+    let(:trainees) do
+      trainee_id = create(:trainee, training_route: :early_years_undergrad, state: :awarded).id
+      Trainee.where(id: trainee_id)
+    end
+
+    it "labels award counts as eyts" do
+      expect(subject.state_counts.symbolize_keys).to eq(
+        deferred: 0,
+        draft: 0,
+        submitted_for_trn: 0,
+        trn_received: 0,
+        withdrawn: 0,
+        eyts_received: 1,
+        eyts_recommended: 0,
+      )
+    end
+  end
+
+  context "trainees only in qts award states" do
+    let(:trainees) do
+      trainee_id = create(:trainee, training_route: :assessment_only, state: :awarded).id
+      Trainee.where(id: trainee_id)
+    end
+
+    it "labels award counts as qts" do
+      expect(subject.state_counts.symbolize_keys).to eq(
+        deferred: 0,
+        draft: 0,
+        submitted_for_trn: 0,
+        trn_received: 0,
+        withdrawn: 0,
+        qts_received: 1,
+        qts_recommended: 0,
+      )
+    end
+  end
+
+  context "trainees in qts and eyts award states" do
+    let(:trainees) do
+      trainee_ids = [
+        create(:trainee, training_route: :assessment_only, state: :awarded).id,
+        create(:trainee, training_route: :early_years_undergrad, state: :awarded).id,
+      ]
+      Trainee.where(id: trainee_ids)
+    end
+
+    it "labels award counts generically" do
+      expect(subject.state_counts.symbolize_keys).to eq(
+        deferred: 0,
+        draft: 0,
+        submitted_for_trn: 0,
+        trn_received: 0,
+        withdrawn: 0,
+        awarded: 2,
+        recommended_for_award: 0,
+      )
+    end
+  end
+end

--- a/spec/view_objects/home_view_spec.rb
+++ b/spec/view_objects/home_view_spec.rb
@@ -37,7 +37,7 @@ describe HomeView do
         submitted_for_trn: 0,
         trn_received: 0,
         withdrawn: 0,
-        eyts_received: 1,
+        eyts_awarded: 1,
         eyts_recommended: 0,
       )
     end
@@ -56,7 +56,7 @@ describe HomeView do
         submitted_for_trn: 0,
         trn_received: 0,
         withdrawn: 0,
-        qts_received: 1,
+        qts_awarded: 1,
         qts_recommended: 0,
       )
     end


### PR DESCRIPTION
### Context

https://trello.com/c/4xPw1rDm/1860-m-ey-home-page-squares-to-distinguish-between-eyts-and-qts

### Changes proposed in this pull request

- Add a new badges component to determine which award states to show on the home page.
- Just perform one db call to get the counts instead of one for each state

### Guidance to review

Have a gander at `/view_components` on the review app 

_or look at the screenshots below if it happens to be broken_

### Screenshots

**QTS only trainees**
<img width="1910" alt="Screenshot 2021-06-08 at 14 42 51" src="https://user-images.githubusercontent.com/823643/121199616-fc4e2380-c86a-11eb-96e3-6615bc414a50.png">

**Mixture of trainees**
<img width="1910" alt="Screenshot 2021-06-08 at 14 42 22" src="https://user-images.githubusercontent.com/823643/121199594-f9ebc980-c86a-11eb-93af-6b9d22513e4f.png">

**Only early years routes**
<img width="1910" alt="Screenshot 2021-06-08 at 14 41 51" src="https://user-images.githubusercontent.com/823643/121199768-1a1b8880-c86b-11eb-9b42-1cbafe9afd38.png">


