### PR TITLE
[1899] Handle DTTP users with nil email

### DIFF
--- a/app/view_objects/system_admin/users_view.rb
+++ b/app/view_objects/system_admin/users_view.rb
@@ -14,7 +14,7 @@ module SystemAdmin
       @not_registered ||= ::Dttp::User.not_registered_with_provider(
         provider.dttp_id,
         registered.pluck(:dttp_id),
-      )
+      ).where.not(email: nil)
     end
 
   private

--- a/spec/view_objects/system_admin/users_view_spec.rb
+++ b/spec/view_objects/system_admin/users_view_spec.rb
@@ -26,5 +26,15 @@ describe SystemAdmin::UsersView do
       expect(subject.not_registered.count).to eq 1
       expect(subject.not_registered.first).to eq dttp_user
     end
+
+    context "user with nil email" do
+      before do
+        dttp_user.update(email: nil)
+      end
+
+      it "does not return them" do
+        expect(subject.not_registered).not_to include(dttp_user)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

There are a number of users in DTTP with no email address. This is
causing the provider#show page to error as we don't handle it. These
users should not be imported into register without an email so don't
display them.

The operations team will review the other users and sync should update
them. There are currently 11.

### Changes proposed in this pull request

* Filter out users without an email address from the view

### Guidance to review

