### PR TITLE
[xxx] Use match_array to fix flakey spec

### DIFF
--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -249,7 +249,7 @@ describe Trainee do
       let!(:trainee_with_subject_two) { create(:trainee, subject: "Mathematics", subject_two: "Art and design") }
       let!(:trainee_with_subject_three) { create(:trainee, subject: "Mathematics", subject_two: "Science", subject_three: "Art and design") }
 
-      it { is_expected.to eq([trainee_with_subject, trainee_with_subject_two, trainee_with_subject_three]) }
+      it { is_expected.to match_array([trainee_with_subject, trainee_with_subject_two, trainee_with_subject_three]) }
     end
   end
 


### PR DESCRIPTION
### Context

This spec shouldn't need to test ordering, only that the elements match.

### Changes proposed in this pull request

Use `match_array` to disregard order.

### Guidance to review

