### PR TITLE
[1841] Sort function for autocompletes

### DIFF
--- a/app/components/form_components/autocomplete/sort.js
+++ b/app/components/form_components/autocomplete/sort.js
@@ -1,0 +1,64 @@
+// Returns an array of integers representing the position of each regex match.
+const matchPositions = (string, regexes) => regexes.map(regex => string.search(regex)).filter(i => i >= 0)
+
+// Returns a lowercase string with some common punctation removed.
+const clean = s => s.trim().replace(/[.,'"/#!$%^&*;:{}=\-_`~()]/g, '').toLowerCase()
+
+// Determines how closely a query matches either an option's name/synonyms.
+// Returns an integer ranging from 0 (no match) to 100 (exact name match).
+const calculateWeight = (rawName, query, rawSynonyms = []) => {
+  const regexes = clean(query).split(/\s+/).map(word => new RegExp('\\b' + word, 'i'))
+  const name = clean(rawName)
+  const synonyms = rawSynonyms.map(s => clean(s))
+
+  const nameMatchPositions = matchPositions(name, regexes)
+  const synonymMatchPositions = synonyms.map(synonym => matchPositions(synonym, regexes)).flat()
+
+  // Require either all parts of a name to be matched, or all parts of a synonym
+  const allNameMatches = nameMatchPositions.length === regexes.length
+  const allSynonymMatches = synonymMatchPositions.length >= regexes.length
+  if (!allNameMatches && !allSynonymMatches) return 0
+
+  // Case insensitive exact matches:
+  const nameIsExactMatch = query === name.toLowerCase()
+  const synonymIsExactMatch = synonyms.some(s => query === s.toLowerCase())
+
+  // Case insensitive 'starts with':
+  const nameStartsWithQuery = nameMatchPositions.includes(0)
+  const synonymStartsWithQuery = synonymMatchPositions.includes(0)
+  const wordInNameStartsWithQuery = nameMatchPositions.length > 0
+
+  if (nameIsExactMatch) return 100
+  if (synonymIsExactMatch) return 75
+  if (nameStartsWithQuery) return 60
+  if (synonymStartsWithQuery) return 50
+  if (wordInNameStartsWithQuery) return 25
+
+  return 0
+}
+
+const byWeightThenAlphabetically = (a, b) => {
+  if (a.weight > b.weight) return -1
+  if (a.weight < b.weight) return 1
+  if (a.name < b.name) return -1
+  if (a.name > b.name) return 1
+
+  return 0
+}
+
+export default (query, options) => {
+  // Calculate a weight for each option and multiply by any boost supplied.
+  //
+  // The boost amount is a float and can be as large as the user wants. It is
+  // meant to be 'tweakable' per option and should be fine-tuned based on user
+  // research.
+  //
+  // For example a boost of 1.5 maked low matches (synonymStartsWithQuery and
+  // wordInNameStartsWithQuery) bump up the list a lot, but would not position
+  // them above an exact name match.
+  options.forEach(o => { o.weight = calculateWeight(o.name, query, o.synonyms) * (o.boost || 1) })
+
+  return options.filter(o => o.weight > 0)
+    .sort(byWeightThenAlphabetically)
+    .map(o => o.name)
+}

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -3,15 +3,19 @@
 module DegreesHelper
   include ApplicationHelper
 
-  def hesa_degree_types_options
-    options = [OpenStruct.new(option_name: nil, option_value: nil)]
-    Dttp::CodeSets::DegreeTypes::MAPPING.each do |key, value|
-      unless Dttp::CodeSets::DegreeTypes::NON_UK.include?(key)
-        name_with_abbreviation = value[:abbreviation] ? "#{key} (#{value[:abbreviation]})" : key
-        options << OpenStruct.new(option_name: name_with_abbreviation, option_value: key)
-      end
+  def degree_options
+    options = Dttp::CodeSets::DegreeTypes::MAPPING.map do |name, attributes|
+      next if Dttp::CodeSets::DegreeTypes::NON_UK.include?(name)
+
+      data = {
+        "data-synonyms" => attributes[:abbreviation],
+        "data-append" => attributes[:abbreviation] && tag.strong("(#{attributes[:abbreviation]})"),
+        "data-boost" => (Dttp::CodeSets::DegreeTypes::COMMON.include?(name) ? 1.5 : 1),
+      }
+      [name, name, data]
     end
-    options
+    empty_result = [nil, nil, nil]
+    options.unshift(empty_result).compact
   end
 
   def institutions_options

--- a/app/helpers/nationalities_helper.rb
+++ b/app/helpers/nationalities_helper.rb
@@ -1,26 +1,23 @@
 # frozen_string_literal: true
 
 module NationalitiesHelper
-  def format_nationalities(nationalities, description: true, empty_option: false)
-    formatted_nationalities = []
+  include ApplicationHelper
 
-    formatted_nationalities << OpenStruct.new(id: "", name: "") if empty_option
-
-    nationalities.each do |nationality|
-      formatted_nationality = OpenStruct.new(
+  def checkbox_nationalities(nationalities)
+    nationalities.map do |nationality|
+      OpenStruct.new(
         id: nationality.name.titleize,
         name: nationality.name.titleize,
+        description: I18n.t("views.default_nationalities.#{nationality.name}.description"),
       )
-
-      if description
-        formatted_nationality.description = I18n.t(
-          "views.default_nationalities.#{nationality.name}.description",
-        )
-      end
-
-      formatted_nationalities << formatted_nationality
     end
+  end
 
-    formatted_nationalities
+  def nationalities_options(nationalities)
+    result = nationalities.map do |nationality|
+      OpenStruct.new(id: nationality.name.titleize, name: nationality.name.titleize)
+    end
+    result.unshift(OpenStruct.new(id: "", name: ""))
+    result
   end
 end

--- a/app/lib/dttp/code_sets/degree_types.rb
+++ b/app/lib/dttp/code_sets/degree_types.rb
@@ -5,6 +5,8 @@ module Dttp
     module DegreeTypes
       NON_UK = ["Degree equivalent", "Unknown"].freeze
 
+      COMMON = ["Bachelor of Arts", "Bachelor of Science", "Master of Arts", "PhD"].freeze
+
       MAPPING = {
         "Bachelor of Arts" => { entity_id: "db695652-c197-e711-80d8-005056ac45bb", abbreviation: "BA" },
         "Bachelor of Arts Economics" => { entity_id: "dd695652-c197-e711-80d8-005056ac45bb", abbreviation: "BAEcon" },

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -24,9 +24,7 @@
   <%= render FormComponents::Autocomplete::View.new(
     f,
     attribute_name: :uk_degree,
-    form_field: f.govuk_collection_select(:uk_degree, hesa_degree_types_options, :option_value, :option_name,
-                                          label: { text: "Type of degree", size: "s" },
-                                          hint: { text: "For example, BA, BSc or other (please specify)" }),
+    form_field: f.govuk_select(:uk_degree, options_for_select(degree_options, @degree_form.degree.uk_degree), label: { text: "Type of degree", size: "s" }, hint: { text: "For example, BA, BSc or other (please specify)" })
   ) %>
 
   <%= f.govuk_radio_buttons_fieldset(:grade,

--- a/app/views/trainees/personal_details/_nationality_select_field.html.erb
+++ b/app/views/trainees/personal_details/_nationality_select_field.html.erb
@@ -1,6 +1,6 @@
 <%= render FormComponents::Autocomplete::View.new(
   form,
   attribute_name: field,
-  form_field: form.govuk_collection_select(field, format_nationalities(nationalities, empty_option: true, description: false), :id, :name, label: { text: "Other nationality", size: "s", aria: { label: "#{(index + 1).ordinalize} additional nationality" } }),
-  classes: "govuk-!-margin-bottom-6",
+  form_field: form.govuk_collection_select(field, nationalities_options(nationalities), :id, :name, label: { text: "Other nationality", size: "s", aria: { label: "#{(index + 1).ordinalize} additional nationality" } }),
+  classes: "govuk-!-margin-bottom-6"
 ) %>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -43,7 +43,7 @@
                                        legend: { text: "Nationality", size: "s" },
                                        hint: { text: "Select all that apply" },
                                        classes: "nationality" do %>
-        <% format_nationalities(@nationalities).each do |nationality| %>
+        <% checkbox_nationalities(@nationalities).each do |nationality| %>
           <%= f.govuk_check_box(
               :nationality_names,
               nationality.id,

--- a/app/webpacker/scripts/autocomplete_sort.spec.js
+++ b/app/webpacker/scripts/autocomplete_sort.spec.js
@@ -1,0 +1,92 @@
+import sort from '../../components/form_components/autocomplete/sort.js'
+
+describe('sort', () => {
+  it('returns an empty array for no matches', () => {
+    const options = [{ name: 'flower' }]
+    expect(sort('cat', options)).toEqual([])
+  })
+
+  it('sorts alphabetically if weights are equal', () => {
+    const options = [
+      { name: 'flower a' },
+      { name: 'flower b' }
+    ]
+    expect(sort('flower', options)).toEqual(['flower a', 'flower b'])
+  })
+
+  it('prioritises exact name matches over synyonm matches', () => {
+    const options = [
+      { name: 'flower' },
+      { name: 'rose', synonyms: ['flower'] }
+    ]
+    expect(sort('flower', options)).toEqual(['flower', 'rose'])
+  })
+
+  it('prioritises exact synonym matches over name starts with', () => {
+    const options = [
+      { name: 'pretty flower' },
+      { name: 'cat', synonyms: ['pretty'] }
+    ]
+
+    expect(sort('pretty', options)).toEqual(['cat', 'pretty flower'])
+  })
+
+  it('prioritises name starts with over synonym starts with', () => {
+    const options = [
+      { name: 'plant', synonyms: ['flower'] },
+      { name: 'flower' }
+    ]
+    expect(sort('flo', options)).toEqual(['flower', 'plant'])
+  })
+
+  it('prioritises synonym starts with over word in name starts with', () => {
+    const options = [
+      { name: 'pretty flower' },
+      { name: 'plant', synonyms: ['flower'] }
+    ]
+    expect(sort('flo', options)).toEqual(['plant', 'pretty flower'])
+  })
+
+  it('requires all parts of the query to be matched in either name or synonym', () => {
+    const options = [
+      { name: 'flower', synonyms: [] },
+      { name: 'cat', synonyms: ['pretty'] },
+      { name: 'tulip', synonyms: ['pretty flower'] },
+      { name: 'rose', synonyms: ['pretty flower', 'gesture'] }
+    ]
+
+    expect(sort('pretty flower', options)).toEqual(['rose', 'tulip'])
+  })
+
+  it('allows custom boosting of results', () => {
+    const options = [
+      { name: 'plant a' },
+      { name: 'plant b', boost: 2 }
+    ]
+    expect(sort('plant', options)).toEqual(['plant b', 'plant a'])
+  })
+
+  it('can handle multiple synonyms', () => {
+    const options = [
+      { name: 'plant', synonyms: ['flower', 'leaf'] }
+    ]
+    expect(sort('leaf flower', options)).toEqual(['plant'])
+  })
+
+  it('can handle query with extra punctuation', () => {
+    const options = [
+      { name: 'plants' }
+    ]
+    expect(sort("plant's", options)).toEqual(['plants'])
+    expect(sort("'plant'", options)).toEqual(['plants'])
+    expect(sort('plant(s)', options)).toEqual(['plants'])
+  })
+
+  it('can handle query with missing punctuation', () => {
+    const options = [
+      { name: "plant's leaf" },
+      { name: 'flower', synonyms: ["plant's leaf"] }
+    ]
+    expect(sort('plants leaf', options)).toEqual(["plant's leaf", 'flower'])
+  })
+})

--- a/spec/features/form_sections/personal_and_education_details/degrees/adding_degree_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/degrees/adding_degree_spec.rb
@@ -160,9 +160,7 @@ private
 
   def and_i_fill_in_the_uk_form(other_grade)
     template = build(:degree, :uk_degree_with_details)
-    degree_abbreviation = Dttp::CodeSets::DegreeTypes::MAPPING[template.uk_degree][:abbreviation]
-    option_text = degree_abbreviation ? "#{template.uk_degree} (#{degree_abbreviation})" : template.uk_degree
-    degree_details_page.uk_degree.select(option_text)
+    degree_details_page.uk_degree.select(template.uk_degree)
     degree_details_page.subject.select(template.subject)
     degree_details_page.institution.select(template.institution)
 

--- a/spec/helpers/degree_helper_spec.rb
+++ b/spec/helpers/degree_helper_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe DegreesHelper do
   include DegreesHelper
 
-  describe "#hesa_degree_types_options" do
+  describe "#degree_options" do
     let(:degree_type) { "Bachelor of Arts" }
     let(:degree_abbreviation) { "BA" }
     let(:non_uk_degree_type) { "Unknown" }
@@ -17,12 +17,17 @@ describe DegreesHelper do
         degree_type => { abbreviation: degree_abbreviation },
         non_uk_degree_type => { abbreviation: nil },
       })
+      stub_const("Dttp::CodeSets::DegreeTypes::COMMON", [degree_type])
     end
 
-    it "iterates over array and prints out correct hesa_degree_types values" do
-      expect(hesa_degree_types_options).to match([
-        OpenStruct.new(option_name: nil, option_value: nil),
-        OpenStruct.new(option_name: "#{degree_type} (#{degree_abbreviation})", option_value: degree_type),
+    it "iterates over array and prints out correct degree options" do
+      expect(degree_options).to match([
+        [nil, nil, nil],
+        [
+          degree_type,
+          degree_type,
+          { "data-append" => "<strong>(#{degree_abbreviation})</strong>", "data-boost" => 1.5, "data-synonyms" => degree_abbreviation },
+        ],
       ])
     end
   end

--- a/spec/helpers/nationalities_helper_spec.rb
+++ b/spec/helpers/nationalities_helper_spec.rb
@@ -5,74 +5,28 @@ require "rails_helper"
 describe NationalitiesHelper do
   include NationalitiesHelper
 
-  describe "#format_nationalities" do
-    let(:nationality) { build(:nationality, name: name) }
+  let(:nationality) { build(:nationality, name: "british") }
 
-    context "default nationalities" do
-      let(:expected_nationality) do
-        OpenStruct.new(
-          id: nationality.name.titleize,
-          name: nationality.name.titleize,
-          description: t("views.default_nationalities.#{nationality.name}.description"),
-        )
-      end
-
-      context "british" do
-        let(:name) { "british" }
-
-        it "returns formatted versions of given nationality records" do
-          expect(format_nationalities([nationality])).to include(expected_nationality)
-        end
-      end
-
-      context "irish" do
-        let(:name) { "irish" }
-
-        it "returns formatted versions of given nationality records" do
-          expect(format_nationalities([nationality])).to include(expected_nationality)
-        end
-      end
-
-      context "other" do
-        let(:name) { "other" }
-
-        it "returns formatted versions of given nationality records" do
-          expect(format_nationalities([nationality])).to include(expected_nationality)
-        end
-      end
+  describe "#checkbox_nationalities" do
+    let(:expected_nationality) do
+      OpenStruct.new(
+        id: nationality.name.titleize,
+        name: nationality.name.titleize,
+        description: t("views.default_nationalities.#{nationality.name}.description"),
+      )
     end
 
-    context "with description: false" do
-      let(:name) { "british" }
-
-      let(:expected_nationality) do
-        OpenStruct.new(
-          id: nationality.name.titleize,
-          name: nationality.name.titleize,
-        )
-      end
-
-      it "returns formatted versions of given nationality records" do
-        expect(format_nationalities([nationality], description: false)).to include(expected_nationality)
-      end
+    it "returns formatted versions of given nationality records" do
+      expect(checkbox_nationalities([nationality])).to include(expected_nationality)
     end
+  end
 
-    context "with empty_option: true" do
-      let(:name) { "british" }
-      let(:empty_option) { OpenStruct.new(id: "", name: "") }
-
-      let(:expected_nationality) do
-        OpenStruct.new(
-          id: nationality.name.titleize,
-          name: nationality.name.titleize,
-          description: t("views.default_nationalities.#{nationality.name}.description"),
-        )
-      end
-
-      it "returns formatted versions of given nationality records with an empty option first" do
-        format_nationalities = format_nationalities([nationality], empty_option: true)
-        expect(format_nationalities).to eq([empty_option, expected_nationality])
-      end
+  describe "#nationalities_options" do
+    it "returns correct nationality option array" do
+      result = nationalities_options([nationality])
+      expect(result.size).to be 2
+      expect(result.first.name).to be ""
+      expect(result.second.name).to eq nationality.name.titleize
     end
   end
 end

--- a/spec/support/features/degree_information_steps.rb
+++ b/spec/support/features/degree_information_steps.rb
@@ -14,9 +14,7 @@ module Features
 
     def and_i_fill_in_the_uk_degree_form
       template = build(:degree, :uk_degree_with_details)
-      degree_abbreviation = Dttp::CodeSets::DegreeTypes::MAPPING[template.uk_degree][:abbreviation]
-      option_text = degree_abbreviation ? "#{template.uk_degree} (#{degree_abbreviation})" : template.uk_degree
-      degree_details_page.uk_degree.select(option_text)
+      degree_details_page.uk_degree.select(template.uk_degree)
       degree_details_page.subject.select(template.subject)
       degree_details_page.institution.select(template.institution)
       degree_details_page.grade.choose(template.grade)


### PR DESCRIPTION
### Context

https://trello.com/c/yVBgFUSO/1841-l-productionize-the-sorted-autocomplete-code

This PR contains the implementation of this spike: https://github.com/DFE-Digital/register-trainee-teachers/pull/749

The aim was to add a sort function to all autocompletes and develop a wider 'options' API such that we could:
- sort autocomplete results in an intelligent, weighted way
- use synonyms specified in select options
- boost specific entries
- work with richer data

### Changes proposed in this pull request

Adds a client-side sort function to all our standard autocompletes - not schools (where the results are determined on the backend) and not countries (external lib).

There are two parts to this - changes to the native select input, and changes to the autocomplete JS.

**The select input**
- The options within the targeted select input now have the ability to provide more information in a structured way to the autocomplete code. (see `degree_options` in `degree_helper.rb`). The html looks like this:

```html
<select id="degree-type">
    <option value="PhD" data-synonyms="Doctor of Philosophy"  data-append="(PhD)" data-boost="2">PhD</option>
    <option value="Bachelor of Science" data-synonyms="BSc" data-append="(BSc)">Bachelor of Science</option>
    <option value="Bachelor of Arts" data-synonyms="BA" data-append="(BA)">"Bachelor of Arts"</option>
</select>
```

The supported attributes are:
- `data-synonyms` - pipe-separated string - the synonyms for the option
- `data-append` - string/html - appears after each autocomplete result, not currently searched over (but could be)
- `data-boost` - integer - the amount by which the normal weighting should be boosted for that particular result. 2 = x 2

The options can still be supplied as simple string, you do not need to add any data attributes if you don't need them. As such,  the other autocompletes are largely unchanged, but the custom sort function (discussed below) still works.

**The autocomplete**
We provide a custom function as the autocomplete's `source`. This function:
  - Pulls out the extra data from the options' data attributes.
  - Compares the inputted query to the results and calculates weights based on these rules:
 
  ```
  1. nameIsExactMatch
  2. synonymIsExactMatch
  3. nameStartsWithQuery
  4. synonymStartsWithQuery
  5. wordInNameStartsWithQuery
  ``` 
  - Applies any additional boost as per the `data-boost` attribute for options
  - Filters, sorts and returns the results.

### Guidance to review

- Review all autocompletes, except the schools and countries autocomplete (this are unchanged)
- Check that they returned 'nicely' sorted results
- Pay particular attention to the degree type autocomplete which should display synonyms bolded in brackets and searches 'intelligently' on the synonyms too.
