### PR TITLE
[1890] Add sync job for dttp schools

### DIFF
--- a/app/jobs/dttp/sync_schools_job.rb
+++ b/app/jobs/dttp/sync_schools_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Dttp
+  class SyncSchoolsJob < ApplicationJob
+    queue_as :dttp
+
+    def perform(request_uri = nil)
+      @school_list = Dttp::RetrieveSchools.call(request_uri: request_uri)
+
+      Dttp::School.upsert_all(school_attributes, unique_by: :dttp_id)
+
+      Dttp::SyncSchoolsJob.perform_later(next_page_url) if has_next_page?
+    end
+
+  private
+
+    attr_reader :school_list
+
+    def school_attributes
+      Dttp::Parsers::Account.to_school_attributes(schools: school_list[:items])
+    end
+
+    def next_page_url
+      school_list[:meta][:next_page_url]
+    end
+
+    def has_next_page?
+      next_page_url.present?
+    end
+  end
+end

--- a/app/jobs/dttp/sync_users_job.rb
+++ b/app/jobs/dttp/sync_users_job.rb
@@ -4,8 +4,8 @@ module Dttp
   class SyncUsersJob < ApplicationJob
     queue_as :dttp
 
-    def perform(path = nil)
-      @user_list = Dttp::RetrieveUsers.call(path: path)
+    def perform(request_uri = nil)
+      @user_list = Dttp::RetrieveUsers.call(request_uri: request_uri)
 
       Dttp::User.upsert_all(user_attributes, unique_by: :dttp_id)
 

--- a/app/lib/dttp/parsers/account.rb
+++ b/app/lib/dttp/parsers/account.rb
@@ -13,6 +13,16 @@ module Dttp
             }
           end
         end
+
+        def to_school_attributes(schools:)
+          schools.map do |school|
+            {
+              name: school["name"],
+              urn: school["dfe_urn"],
+              dttp_id: school["accountid"],
+            }
+          end
+        end
       end
     end
   end

--- a/app/lib/dttp/sync_pattern.rb
+++ b/app/lib/dttp/sync_pattern.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Dttp
+  module SyncPattern
+    MAX_PAGE_SIZE = 5000
+
+    HEADERS = {
+      "Prefer" => "odata.maxpagesize=#{SyncPattern::MAX_PAGE_SIZE}",
+    }.freeze
+
+    class Error < StandardError; end
+
+    def initialize(request_uri: nil)
+      @request_uri = request_uri.presence || default_path
+    end
+
+    def call
+      if response.code != 200
+        raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
+
+      {
+        items: response_body["value"],
+        meta: {
+          next_page_url: response_body["@odata.nextLink"],
+        },
+      }
+    end
+
+  private
+
+    attr_reader :request_uri
+
+    def default_path
+      raise NotImplementedError("#default_path must be implemented")
+    end
+
+    def response_body
+      @response_body ||= JSON(response.body)
+    end
+
+    def response
+      @response ||= Client.get(request_uri, headers: SyncPattern::HEADERS)
+    end
+  end
+end

--- a/app/models/dttp/school.rb
+++ b/app/models/dttp/school.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Dttp
+  class School < ApplicationRecord
+    self.table_name = "dttp_schools"
+  end
+end

--- a/app/services/dttp/retrieve_providers.rb
+++ b/app/services/dttp/retrieve_providers.rb
@@ -3,14 +3,7 @@
 module Dttp
   class RetrieveProviders
     include ServicePattern
-
-    class Error < StandardError; end
-
-    MAX_PAGE_SIZE = 5000
-
-    HEADERS = {
-      "Prefer" => "odata.maxpagesize=#{MAX_PAGE_SIZE}",
-    }.freeze
+    include SyncPattern
 
     INSTITUTION_TYPES = CodeSets::InstitutionTypes::MAPPING.values.flat_map { |institution| "_dfe_institutiontypeid_value eq #{institution[:entity_id]}" }.join(" or ")
 
@@ -31,35 +24,10 @@ module Dttp
 
     QUERY = FILTER.merge(SELECT).to_query
 
-    DEFAULT_PATH = "/accounts?#{QUERY}"
-
-    def initialize(request_uri: nil)
-      @request_uri = request_uri.presence || DEFAULT_PATH
-    end
-
-    def call
-      if response.code != 200
-        raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
-      end
-
-      {
-        items: response_body["value"],
-        meta: {
-          next_page_url: response_body["@odata.nextLink"],
-        },
-      }
-    end
-
   private
 
-    attr_reader :request_uri
-
-    def response_body
-      @response_body ||= JSON(response.body)
-    end
-
-    def response
-      @response ||= Client.get(request_uri, headers: HEADERS)
+    def default_path
+      @default_path ||= "/accounts?#{QUERY}"
     end
   end
 end

--- a/app/services/dttp/retrieve_schools.rb
+++ b/app/services/dttp/retrieve_schools.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Dttp
+  class RetrieveSchools
+    include ServicePattern
+
+    class Error < StandardError; end
+
+    MAX_PAGE_SIZE = 5000
+
+    HEADERS = {
+      "Prefer" => "odata.maxpagesize=#{MAX_PAGE_SIZE}",
+    }.freeze
+
+    FILTER = {
+      "$filter" => "dfe_provider eq false",
+    }.freeze
+
+    SELECT = {
+      "$select" => %w[
+        name
+        dfe_urn
+        accountid
+      ].join(","),
+    }.freeze
+
+    QUERY = FILTER.merge(SELECT).to_query
+
+    DEFAULT_PATH = "/accounts?#{QUERY}"
+
+    def initialize(request_uri: nil)
+      @request_uri = request_uri.presence || DEFAULT_PATH
+    end
+
+    def call
+      if response.code != 200
+        raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
+      end
+
+      {
+        items: response_body["value"],
+        meta: {
+          next_page_url: response_body["@odata.nextLink"],
+        },
+      }
+    end
+
+  private
+
+    attr_reader :request_uri
+
+    def response_body
+      @response_body ||= JSON(response.body)
+    end
+
+    def response
+      @response ||= Client.get(request_uri, headers: HEADERS)
+    end
+  end
+end

--- a/app/services/dttp/retrieve_schools.rb
+++ b/app/services/dttp/retrieve_schools.rb
@@ -3,14 +3,7 @@
 module Dttp
   class RetrieveSchools
     include ServicePattern
-
-    class Error < StandardError; end
-
-    MAX_PAGE_SIZE = 5000
-
-    HEADERS = {
-      "Prefer" => "odata.maxpagesize=#{MAX_PAGE_SIZE}",
-    }.freeze
+    include SyncPattern
 
     FILTER = {
       "$filter" => "dfe_provider eq false",
@@ -26,35 +19,10 @@ module Dttp
 
     QUERY = FILTER.merge(SELECT).to_query
 
-    DEFAULT_PATH = "/accounts?#{QUERY}"
-
-    def initialize(request_uri: nil)
-      @request_uri = request_uri.presence || DEFAULT_PATH
-    end
-
-    def call
-      if response.code != 200
-        raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
-      end
-
-      {
-        items: response_body["value"],
-        meta: {
-          next_page_url: response_body["@odata.nextLink"],
-        },
-      }
-    end
-
   private
 
-    attr_reader :request_uri
-
-    def response_body
-      @response_body ||= JSON(response.body)
-    end
-
-    def response
-      @response ||= Client.get(request_uri, headers: HEADERS)
+    def default_path
+      @default_path ||= "/accounts?#{QUERY}"
     end
   end
 end

--- a/app/services/dttp/retrieve_users.rb
+++ b/app/services/dttp/retrieve_users.rb
@@ -3,14 +3,7 @@
 module Dttp
   class RetrieveUsers
     include ServicePattern
-
-    class Error < StandardError; end
-
-    MAX_PAGE_SIZE = 5000
-
-    HEADERS = {
-      "Prefer" => "odata.maxpagesize=#{MAX_PAGE_SIZE}",
-    }.freeze
+    include SyncPattern
 
     SELECT = {
       "$select" => %w[
@@ -29,35 +22,11 @@ module Dttp
     }.freeze
 
     QUERY = FILTER.merge(SELECT).to_query
-    DEFAULT_PATH = "/contacts?#{QUERY}"
-
-    def initialize(path: nil)
-      @path = path.presence || DEFAULT_PATH
-    end
-
-    def call
-      if response.code != 200
-        raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"
-      end
-
-      {
-        items: response_body["value"],
-        meta: {
-          next_page_url: response_body["@odata.nextLink"],
-        },
-      }
-    end
 
   private
 
-    attr_reader :path
-
-    def response
-      @response ||= Client.get(path, headers: HEADERS)
-    end
-
-    def response_body
-      @response_body ||= JSON(response.body)
+    def default_path
+      @default_path ||= "/contacts?#{QUERY}"
     end
   end
 end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -22,11 +22,15 @@ import_courses_from_ttapi:
   cron: "0 3 * * *"
   class: "TeacherTrainingApi::ImportCoursesJob"
   queue: default
-import_users_from_dttp:
-  cron: "0 4 * * *"
-  class: "Dttp::SyncUsersJob"
-  queue: dttp
 import_providers_from_dttp:
   cron: "0 4 * * *"
   class: "Dttp::SyncProvidersJob"
+  queue: dttp
+import_schools_from_dttp:
+  cron: "0 4 * * *"
+  class: "Dttp::SyncSchoolsJob"
+  queue: dttp
+import_users_from_dttp:
+  cron: "0 4 * * *"
+  class: "Dttp::SyncUsersJob"
   queue: dttp

--- a/db/migrate/20210603171313_create_dttp_schools.rb
+++ b/db/migrate/20210603171313_create_dttp_schools.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateDttpSchools < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dttp_schools do |t|
+      t.string :name
+      t.string :dttp_id, index: { unique: true }
+      t.string :urn
+
+      t.timestamps default: -> { "CURRENT_TIMESTAMP" }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_02_105639) do
+ActiveRecord::Schema.define(version: 2021_06_03_171313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,6 +129,15 @@ ActiveRecord::Schema.define(version: 2021_06_02_105639) do
     t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["dttp_id"], name: "index_dttp_providers_on_dttp_id", unique: true
+  end
+
+  create_table "dttp_schools", force: :cascade do |t|
+    t.string "name"
+    t.string "dttp_id"
+    t.string "urn"
+    t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.index ["dttp_id"], name: "index_dttp_schools_on_dttp_id", unique: true
   end
 
   create_table "dttp_users", force: :cascade do |t|

--- a/spec/factories/dttp/schools.rb
+++ b/spec/factories/dttp/schools.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dttp_school, class: "Dttp::School" do
+    sequence :name do |n|
+      "School #{n}"
+    end
+    dttp_id { SecureRandom.uuid }
+    urn { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
+  end
+end

--- a/spec/jobs/dttp/sync_schools_job_spec.rb
+++ b/spec/jobs/dttp/sync_schools_job_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Dttp::SyncSchoolsJob, type: :job do
   end
 
   context "when Dttp::School exist" do
-    let!(:dttp_school_one) { create(:dttp_school, dttp_id: school_one_hash["accountid"]) }
+    let!(:dttp_school_one) { create(:dttp_school, name: "Westminster School", dttp_id: school_one_hash["accountid"]) }
 
     it "adds new records" do
       expect {
@@ -44,8 +44,7 @@ RSpec.describe Dttp::SyncSchoolsJob, type: :job do
     end
 
     it "updates the existing record" do
-      subject
-      expect(dttp_school_one.reload.name).to eq("Test School")
+      expect { subject }.to change { dttp_school_one.reload.name }.from("Westminster School").to("Test School")
     end
   end
 

--- a/spec/jobs/dttp/sync_schools_job_spec.rb
+++ b/spec/jobs/dttp/sync_schools_job_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Dttp::SyncSchoolsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  before do
+    allow(Dttp::RetrieveSchools).to receive(:call).with(request_uri: request_uri).and_return(school_list)
+  end
+
+  let(:school_one_hash) { ApiStubs::Dttp::School.attributes }
+  let(:school_two_hash) { ApiStubs::Dttp::School.attributes }
+
+  let(:request_uri) { nil }
+  let(:school_list) do
+    {
+      items: [school_two_hash, school_one_hash],
+      meta: { next_page_url: "https://example.com" },
+    }
+  end
+
+  subject { described_class.perform_now }
+
+  it "enqueues job with the next_page_url" do
+    expect {
+      subject
+    }.to have_enqueued_job(described_class).with("https://example.com")
+  end
+
+  it "creates a Dttp::School record for each unique school" do
+    expect {
+      subject
+    }.to change(Dttp::School, :count).by(2)
+  end
+
+  context "when Dttp::School exist" do
+    let!(:dttp_school_one) { create(:dttp_school, dttp_id: school_one_hash["accountid"]) }
+
+    it "adds new records" do
+      expect {
+        subject
+      }.to change(Dttp::School, :count).by(1)
+    end
+
+    it "updates the existing record" do
+      subject
+      expect(dttp_school_one.reload.name).to eq("Test School")
+    end
+  end
+
+  context "when next_page_url is not available" do
+    let(:school_list) do
+      {
+        items: [school_one_hash],
+        meta: { next_page_url: nil },
+      }
+    end
+
+    it "does not enqueue any further jobs" do
+      expect {
+        subject
+      }.not_to have_enqueued_job(described_class)
+    end
+  end
+end

--- a/spec/models/dttp/school_spec.rb
+++ b/spec/models/dttp/school_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Dttp::School, type: :model do
+  subject { create(:dttp_school) }
+
+  it { is_expected.to have_db_index(:dttp_id) }
+end

--- a/spec/services/dttp/retrieve_providers_spec.rb
+++ b/spec/services/dttp/retrieve_providers_spec.rb
@@ -4,42 +4,14 @@ require "rails_helper"
 
 module Dttp
   describe RetrieveProviders do
-    let(:request_uri) { nil }
-    let(:request_headers) { { headers: { "Prefer" => "odata.maxpagesize=5000" } } }
-    let(:dttp_response) { double(code: 200, body: { value: [1, 2, 3], '@odata.nextLink': "https://example.com" }.to_json) }
-
     subject { described_class.call(request_uri: request_uri) }
-
-    before do
-      allow(AccessToken).to receive(:fetch).and_return("token")
-      allow(Client).to receive(:get).with(String, request_headers).and_return(dttp_response)
-    end
 
     let(:expected_path) do
       "/accounts?%24filter=dfe_provider+eq+true+and+%28statecode+eq+0+and+statuscode+ne+300000002%29+and+%28_dfe_institutiontypeid_value+eq+b5ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b7ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b9ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bbec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bdec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bfec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+c1ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+cdec33aa-216d-e711-80d2-005056ac45bb%29&%24select=name%2Cdfe_ukprn%2Caccountid"
     end
 
-    it "requests active organisations matching the institution type codeset" do
-      expect(Client).to receive(:get).with(expected_path, request_headers).and_return(dttp_response)
-      subject
-    end
+    let(:request_uri) { nil }
 
-    it "returns a hash containing expected items" do
-      expect(subject).to eq({ items: [1, 2, 3], meta: { next_page_url: "https://example.com" } })
-    end
-
-    context "HTTP error" do
-      let(:status) { 400 }
-      let(:body) { "error" }
-      let(:headers) { { foo: "bar" } }
-      let(:dttp_response) { double(code: status, body: body, headers: headers) }
-
-      it "raises an Error with the response body as the message" do
-        expect(Client).to receive(:get).with(String, request_headers).and_return(dttp_response)
-        expect {
-          subject
-        }.to raise_error(described_class::Error, "status: #{status}, body: #{body}, headers: #{headers}")
-      end
-    end
+    it_behaves_like "dttp info retriever"
   end
 end

--- a/spec/services/dttp/retrieve_schools_spec.rb
+++ b/spec/services/dttp/retrieve_schools_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe RetrieveSchools do
+    let(:request_uri) { nil }
+    let(:request_headers) { { headers: { "Prefer" => "odata.maxpagesize=5000" } } }
+    let(:dttp_response) { double(code: 200, body: { value: [1, 2, 3], '@odata.nextLink': "https://example.com" }.to_json) }
+
+    subject { described_class.call(request_uri: request_uri) }
+
+    before do
+      allow(AccessToken).to receive(:fetch).and_return("token")
+      allow(Client).to receive(:get).with(String, request_headers).and_return(dttp_response)
+    end
+
+    let(:expected_path) do
+      "/accounts?%24filter=dfe_provider+eq+false&%24select=name%2Cdfe_urn%2Caccountid"
+    end
+
+    it "requests schools" do
+      expect(Client).to receive(:get).with(expected_path, request_headers).and_return(dttp_response)
+      subject
+    end
+
+    it "returns a hash containing expected items" do
+      expect(subject).to eq({ items: [1, 2, 3], meta: { next_page_url: "https://example.com" } })
+    end
+
+    context "HTTP error" do
+      let(:status) { 400 }
+      let(:body) { "error" }
+      let(:headers) { { foo: "bar" } }
+      let(:dttp_response) { double(code: status, body: body, headers: headers) }
+
+      it "raises an Error with the response body as the message" do
+        expect(Client).to receive(:get).with(String, request_headers).and_return(dttp_response)
+        expect {
+          subject
+        }.to raise_error(described_class::Error, "status: #{status}, body: #{body}, headers: #{headers}")
+      end
+    end
+  end
+end

--- a/spec/services/dttp/retrieve_users_spec.rb
+++ b/spec/services/dttp/retrieve_users_spec.rb
@@ -4,53 +4,15 @@ require "rails_helper"
 
 module Dttp
   describe RetrieveUsers do
+    subject { described_class.call }
+
+    let(:expected_path) { "/contacts?%24filter=dfe_portaluser+eq+true+and+statecode+eq+0&%24select=firstname%2Clastname%2Cemailaddress1%2Ccontactid%2C_parentcustomerid_value" }
+
+    it_behaves_like "dttp info retriever"
+
     describe "::FILTER" do
       it "has correct filter params" do
         expect(described_class::FILTER).to match({ "$filter" => "dfe_portaluser eq true and statecode eq 0" })
-      end
-    end
-
-    describe "#call" do
-      let(:options) { { headers: RetrieveUsers::HEADERS } }
-      let(:path) { RetrieveUsers::DEFAULT_PATH }
-
-      before do
-        allow(AccessToken).to receive(:fetch).and_return("token")
-      end
-
-      context "when code 200" do
-        let(:status) { 200 }
-        let(:body) { { value: [{ "first_name" => "Jon" }], "@odata.nextLink" => "some_path" } }
-        let(:dttp_response) { double(code: status, body: body.to_json) }
-
-        before do
-          allow(Client).to receive(:get).with(path, options).and_return(dttp_response)
-        end
-
-        it "returns parsed json content" do
-          expected_hash = {
-            items: body[:value],
-            meta: {
-              next_page_url: body["@odata.nextLink"],
-            },
-          }
-
-          expect(described_class.call).to eq(expected_hash)
-        end
-      end
-
-      context "HTTP error" do
-        let(:status) { 400 }
-        let(:body) { "error" }
-        let(:headers) { { foo: "bar" } }
-        let(:dttp_response) { double(code: status, body: body, headers: headers) }
-
-        it "raises a HttpError error with the response body as the message" do
-          expect(Client).to receive(:get).with(path, options).and_return(dttp_response)
-          expect {
-            described_class.call
-          }.to raise_error(Dttp::RetrieveUsers::Error, "status: #{status}, body: #{body}, headers: #{headers}")
-        end
       end
     end
   end

--- a/spec/support/api_stubs/dttp/school.rb
+++ b/spec/support/api_stubs/dttp/school.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ApiStubs
+  module Dttp
+    module School
+      def self.attributes
+        {
+          "name" => "Test School",
+          "dfe_urn" => "145694",
+          "accountid" => SecureRandom.uuid,
+        }
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/sync_pattern.rb
+++ b/spec/support/shared_examples/sync_pattern.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "dttp info retriever" do |_parameter|
+  let(:request_headers) { { headers: { "Prefer" => "odata.maxpagesize=5000" } } }
+  let(:dttp_response) { double(code: 200, body: { value: [1, 2, 3], '@odata.nextLink': "https://example.com" }.to_json) }
+
+  before do
+    allow(Dttp::Client).to receive(:get).with(expected_path, request_headers).and_return(dttp_response)
+  end
+
+  it "requests dttp info matching query parameters" do
+    expect(Dttp::Client).to receive(:get).with(expected_path, request_headers).and_return(dttp_response)
+    subject
+  end
+
+  it "returns a hash containing expected items" do
+    expect(subject).to eq({ items: [1, 2, 3], meta: { next_page_url: "https://example.com" } })
+  end
+
+  context "HTTP error" do
+    let(:status) { 400 }
+    let(:body) { "error" }
+    let(:headers) { { foo: "bar" } }
+    let(:dttp_response) { double(code: status, body: body, headers: headers) }
+
+    it "raises an Error with the response body as the message" do
+      expect(Dttp::Client).to receive(:get).with(expected_path, request_headers).and_return(dttp_response)
+      expect {
+        subject
+      }.to raise_error(Dttp::SyncPattern::Error, "status: #{status}, body: #{body}, headers: #{headers}")
+    end
+  end
+end


### PR DESCRIPTION
### Context
Like https://github.com/DFE-Digital/register-trainee-teachers/pull/752 and https://github.com/DFE-Digital/register-trainee-teachers/pull/752, add a sync job to fetch dttp schools into a lookup table.

### Changes proposed in this pull request
1. `Dttp::SyncSchoolsJob` fetches Schools in batches, and runs an upsert_all to insert/update the records to Dttp::School
2. Refactor retreive service objects to reduce code duplication.

### Guidance to review
1. Ensure sidekiq and rails are running
2. Visit https://localhost:5000/sidekiq/cron/import_schools_from_dttp, and click "Enqueue Now"
3. As of this writing 50640 records should be matched and created in dttp_schools


