### PR TITLE
[1882] Add component for rendering school result text

### DIFF
--- a/app/components/school_result_notice/view.html.erb
+++ b/app/components/school_result_notice/view.html.erb
@@ -1,0 +1,5 @@
+<%= render GovukComponent::InsetText.new do %>
+  <p class="govuk-body">
+    <%= school_result_text %>
+  </p>
+<% end %>

--- a/app/components/school_result_notice/view.rb
+++ b/app/components/school_result_notice/view.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module SchoolResultNotice
+  class View < GovukComponent::Base
+    attr_reader :search_query
+
+    def initialize(search_query:, search_limit:, search_count:)
+      @search_query = search_query
+      @search_limit = search_limit
+      @search_count = search_count
+    end
+
+    def render?
+      total.positive?
+    end
+
+    def remaining_search_count
+      total
+    end
+
+    def school_result_text
+      return pluralised_school_result_text if remaining_search_count > 1
+
+      t("components.school_result_notice.result_text", search_query: search_query)
+    end
+
+  private
+
+    attr_reader :search_limit, :search_count
+
+    def total
+      @total ||= search_count - search_limit
+    end
+
+    def pluralised_school_result_text
+      t("components.school_result_notice.multiple_result_text", search_query: search_query, remaining_search_count: remaining_search_count)
+    end
+  end
+end

--- a/app/views/trainees/employing_schools/_results.html.erb
+++ b/app/views/trainees/employing_schools/_results.html.erb
@@ -29,4 +29,10 @@
   <% end %>
 <% end %>
 
+<%= render SchoolResultNotice::View.new(
+  search_query: query, 
+  search_limit: SchoolSearch::DEFAULT_LIMIT, 
+  search_count: @schools.unscope(:limit).count
+) %>
+
 <%= f.govuk_submit %>

--- a/app/views/trainees/lead_schools/_results.html.erb
+++ b/app/views/trainees/lead_schools/_results.html.erb
@@ -29,4 +29,11 @@
   <% end %>
 <% end %>
 
+
+<%= render SchoolResultNotice::View.new(
+  search_query: query, 
+  search_limit: SchoolSearch::DEFAULT_LIMIT, 
+  search_count: @schools.unscope(:limit).count
+) %>
+
 <%= f.govuk_submit %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,6 +273,9 @@ en:
       link_texts:
         not_started: Start section
         in_progress: Continue section
+    school_result_notice:
+      result_text: "1 more school matches your search for ‘%{search_query}’. Try narrowing down your search if the school you're looking for is not listed."
+      multiple_result_text: "%{remaining_search_count} more schools match your search for ‘%{search_query}’. Try narrowing down your search if the school you're looking for is not listed."
   views:
     all_records: All records
     trainees:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,7 +275,7 @@ en:
         in_progress: Continue section
     school_result_notice:
       result_text: "1 more school matches your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."
-      multiple_result_text: "%{remaining_search_count} more schools match your search for ‘%{search_query}’. Try narrowing down your search if the school you're looking for is not listed."
+      multiple_result_text: "%{remaining_search_count} more schools match your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."
   views:
     all_records: All records
     trainees:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,7 +274,7 @@ en:
         not_started: Start section
         in_progress: Continue section
     school_result_notice:
-      result_text: "1 more school matches your search for ‘%{search_query}’. Try narrowing down your search if the school you're looking for is not listed."
+      result_text: "1 more school matches your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."
       multiple_result_text: "%{remaining_search_count} more schools match your search for ‘%{search_query}’. Try narrowing down your search if the school you're looking for is not listed."
   views:
     all_records: All records

--- a/spec/components/school_result_notice/view_preview.rb
+++ b/spec/components/school_result_notice/view_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SchoolResultNotice
+  class ViewPreview < ViewComponent::Preview
+    def with_one_remaining_record
+      render(
+        View.new(
+          search_query: "oxf",
+          search_limit: 15,
+          search_count: 16,
+        ),
+      )
+    end
+
+    def with_multiple_remaining_records
+      render(
+        View.new(
+          search_query: "oxf",
+          search_limit: 15,
+          search_count: 30,
+        ),
+      )
+    end
+  end
+end

--- a/spec/components/school_result_notice/view_spec.rb
+++ b/spec/components/school_result_notice/view_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module SchoolResultNotice
+  describe View, type: :component do
+    let(:search_query) { "oxf" }
+    let(:search_limit) { 15 }
+
+    context "default rendering" do
+      let(:expected_count) { search_count - search_limit }
+
+      before do
+        render_inline(
+          described_class.new(
+            search_query: search_query,
+            search_limit: search_limit,
+            search_count: search_count,
+          ),
+        )
+      end
+
+      context "when difference is 1" do
+        let(:search_count) { 16 }
+
+        it "renders the remaining search count" do
+          expected_text = I18n.t("components.school_result_notice.result_text", search_query: search_query)
+
+          expect(rendered_component).to have_text(expected_text)
+        end
+      end
+
+      context "when difference is more than one" do
+        let(:search_count) { 30 }
+
+        it "renders the pluralised remaining search count" do
+          expected_text = I18n.t(
+            "components.school_result_notice.multiple_result_text",
+            search_query: search_query,
+            remaining_search_count: expected_count,
+          )
+
+          expect(rendered_component).to have_text(expected_text)
+        end
+      end
+    end
+
+    context "when total is negative" do
+      let(:search_count) { 8 }
+
+      it "does not render" do
+        expect(rendered_component).to_not have_css("body")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/Umvfi7n8/1882-s-the-n-more-schools-match-your-search-bit-isnt-there-on-the-results-page

### Changes proposed in this pull request

- If a search term returns more than 15 schools, we render an inset text to help the user narrow down their search

![result](https://user-images.githubusercontent.com/616080/120828747-cb14e100-c554-11eb-924b-135e99f05af4.gif)

### Guidance to review

