### PR TITLE
[1910] Turn off auto correct on the erb linter

### DIFF
--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -10,7 +10,7 @@ namespace :lint do
   desc "Lint erb files"
   task erb: :environment do
     puts "Linting erb files..."
-    system("bundle exec erblint app -a") || exit($CHILD_STATUS.exitstatus)
+    system("bundle exec erblint app") || exit($CHILD_STATUS.exitstatus)
   end
 
   desc "Lint JavaScript code"


### PR DESCRIPTION
### Context

Our ERB linter keeps breaking our translation files. This PR turns off auto correct to help prevent this from happening. 

### Guidance to review

- Pull down the code and run `bundle exec rake`
- Ensure that the erb files are not autocorrected. 

