### PR TITLE
[1912] Make email check case insensitive when finding current user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ private
   end
 
   def current_user
-    @current_user ||= User.find_by(email: dfe_sign_in_user&.email)
+    @current_user ||= User.find_by("LOWER(email) = ?", dfe_sign_in_user&.email)
   end
 
   def authenticated?

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ApplicationController, type: :controller do
+  let!(:user) { create(:user, email: "Lovely.User@example.com") }
+
+  let(:dfe_sign_in_user) do
+    {
+      "email" => dfe_sign_in_email,
+      "last_active_at" => 1.hour.ago,
+    }
+  end
+
+  before do
+    session["dfe_sign_in_user"] = dfe_sign_in_user
+  end
+
+  describe "current_user" do
+    controller do
+      skip_before_action :authenticate
+
+      def index
+        if current_user
+          render plain: "found user: #{current_user.email}"
+        else
+          render plain: "current user is nil!"
+        end
+      end
+    end
+
+    context "if the email in session is not a case sensitive match for a user" do
+      let(:dfe_sign_in_email) { "LOVELY.USER@example.com" }
+
+      it "still finds the user via case insensitive search" do
+        get :index
+        expect(response.body).to include "found user: Lovely.User@example.com"
+      end
+    end
+
+    context "if the email doesn't match at all" do
+      let(:dfe_sign_in_email) { "lovely.youser@example.com" }
+
+      it "returns nil" do
+        get :index
+        expect(response.body).to include "current user is nil!"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/tqL5XYlK/1912-register-signin-email-comparison-is-case-sensitive

We already downcase emails that are returned from dfe sign in, but there
are users in production whose emails in the register db are not all
lowercase.

### Changes proposed in this pull request

Lowercase emails when doing a find_by for current user

### Guidance to review

Tricky one to test, maybe go and edit an email manually in the review app db if you have the good fortune of having a dfe sign in account.