### PR TITLE
[1898] Render correct title depending on school route type

### DIFF
--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -54,7 +54,7 @@ module TaskListHelper
 
       school_details:
         {
-          task_name: "Lead and employing schools",
+          task_name: school_details_title(trainee.training_route),
           path: edit_trainee_lead_schools_path(trainee),
           confirm_path: trainee_schools_confirm_path(trainee),
           classes: "school-details",
@@ -123,5 +123,17 @@ module TaskListHelper
     }
 
     task_list[task]
+  end
+
+private
+
+  def school_details_title(route)
+    tuition_title = I18n.t("components.review_draft.draft.schools.titles.tuition")
+    salaried_title = I18n.t("components.review_draft.draft.schools.titles.salaried")
+
+    {
+      school_direct_tuition_fee: tuition_title,
+      school_direct_salaried: salaried_title,
+    }[route.to_sym || salaried_title]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,6 +276,12 @@ en:
     school_result_notice:
       result_text: "1 more school matches your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."
       multiple_result_text: "%{remaining_search_count} more schools match your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."
+    review_draft:
+      draft:
+        schools:
+          titles:
+            tuition: Lead school
+            salaried: Schools
   views:
     all_records: All records
     trainees:

--- a/spec/components/review_draft/apply_draft/view_spec.rb
+++ b/spec/components/review_draft/apply_draft/view_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ReviewDraft::ApplyDraft::View do
-  alias_method :component, :page
+  include TaskListHelper
 
   describe "sections that appear for application draft trainee" do
     before do
@@ -14,30 +14,30 @@ RSpec.describe ReviewDraft::ApplyDraft::View do
       let(:trainee) { create(:trainee, :provider_led_postgrad, :with_placement_assignment, :with_apply_application) }
 
       it "renders the correct provider-led sections" do
-        expect(component).to have_text("Course details")
-        expect(component).to have_text("Trainee data")
-        expect(component).to have_text("Placement details")
-        expect(component).to have_text("Training details")
+        expect(rendered_component).to have_text("Course details")
+        expect(rendered_component).to have_text("Trainee data")
+        expect(rendered_component).to have_text("Placement details")
+        expect(rendered_component).to have_text("Training details")
       end
 
       it "does not render non provider-led sections" do
-        expect(component).to_not have_text("Lead and employing schools")
+        expect(rendered_component).to_not have_text(I18n.t("components.review_draft.draft.schools.titles.tuition"))
       end
     end
 
     %i[school_direct_salaried school_direct_tuition_fee].each do |route|
       context "when the trainee is on the #{route} routes", "feature_routes.#{route}": true do
-        let(:trainee) { create(:trainee, route, :with_apply_application) }
+        let(:trainee) { build(:trainee, route, :with_apply_application) }
 
         it "renders the correct school direct sections" do
-          expect(component).to have_text("Course details")
-          expect(component).to have_text("Trainee data")
-          expect(component).to have_text("Training details")
-          expect(component).to have_text("Lead and employing schools")
+          expect(rendered_component).to have_text("Course details")
+          expect(rendered_component).to have_text("Trainee data")
+          expect(rendered_component).to have_text("Training details")
+          expect(rendered_component).to have_text(school_details_title(route))
         end
 
         it "does not render non school-direct sections" do
-          expect(component).to_not have_text("Placement details")
+          expect(rendered_component).to_not have_text("Placement details")
         end
       end
     end

--- a/spec/components/review_draft/draft/view_spec.rb
+++ b/spec/components/review_draft/draft/view_spec.rb
@@ -3,27 +3,27 @@
 require "rails_helper"
 
 RSpec.describe ReviewDraft::Draft::View do
-  alias_method :component, :page
+  include TaskListHelper
 
   before do
     render_inline(described_class.new(trainee: trainee))
   end
 
   context "sections that appear for assessment-only trainees" do
-    let(:trainee) { create(:trainee) }
+    let(:trainee) { build(:trainee) }
 
     it "renders correct sections for assessment-only trainees" do
-      expect(component).to have_text("Personal details")
-      expect(component).to have_text("Contact details")
-      expect(component).to have_text("Diversity information")
-      expect(component).to have_text("Degree")
-      expect(component).to have_text("Course details")
-      expect(component).to have_text("Trainee start date and ID")
+      expect(rendered_component).to have_text("Personal details")
+      expect(rendered_component).to have_text("Contact details")
+      expect(rendered_component).to have_text("Diversity information")
+      expect(rendered_component).to have_text("Degree")
+      expect(rendered_component).to have_text("Course details")
+      expect(rendered_component).to have_text("Trainee start date and ID")
     end
 
     it "does not render non assessment-only sections" do
-      expect(component).to_not have_text("Placement details")
-      expect(component).to_not have_text("Lead and employing schools")
+      expect(rendered_component).to_not have_text("Placement details")
+      expect(rendered_component).to_not have_text("Lead and employing schools")
     end
   end
 
@@ -31,11 +31,11 @@ RSpec.describe ReviewDraft::Draft::View do
     let(:trainee) { create(:trainee, :provider_led_postgrad, :with_placement_assignment) }
 
     xit "renders additional provider-led specific sections" do
-      expect(component).to have_text("Placement details")
+      expect(rendered_component).to have_text("Placement details")
     end
 
     it "does not render non provider-led sections" do
-      expect(component).to_not have_text("Lead and employing schools")
+      expect(rendered_component).to_not have_text(I18n.t("components.review_draft.draft.schools.titles.tuition"))
     end
   end
 
@@ -44,11 +44,11 @@ RSpec.describe ReviewDraft::Draft::View do
       let(:trainee) { create(:trainee, route) }
 
       it "renders additional school-direct specific sections" do
-        expect(component).to have_text("Lead and employing schools")
+        expect(rendered_component).to have_text(school_details_title(route))
       end
 
       it "does not render non school direct sections" do
-        expect(component).to_not have_text("Placement details")
+        expect(rendered_component).to_not have_text("Placement details")
       end
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/WQbHBsj2/1898-bug-school-direct-tuition-fee-trainees-have-a-lead-and-employing-schools-section-even-though-they-dont-have-employing-schools

### Changes proposed in this pull request

- Render the correct school details section title based on the school route type

### Guidance to review

- Choose a trainee on the school direct (tuition fee) route and assert the section title is "Lead school"
- Choose a trainee on the school direct (salaried) route and assert the section title is "Schools"

