### PR TITLE
[1886] Validation bug on school search non-js

### DIFF
--- a/app/controllers/trainees/employing_schools_controller.rb
+++ b/app/controllers/trainees/employing_schools_controller.rb
@@ -28,7 +28,7 @@ module Trainees
       if @employing_school_form.public_send(save_strategy)
         redirect_to trainee_schools_confirm_path(trainee)
       else
-        render :edit
+        render index_or_edit_page
       end
     end
 
@@ -36,6 +36,7 @@ module Trainees
 
     def redirect_to_search_page
       return if params["input-autocomplete"] && params["input-autocomplete"].length < SchoolSearch::MIN_QUERY_LENGTH
+      return if query.present?
 
       redirect_to trainee_employing_schools_path(trainee, query: params["input-autocomplete"]) if trainee_params[:employing_school_id].blank?
     end
@@ -59,6 +60,10 @@ module Trainees
       # including a validation message. Even though the search again field is hidden in this scenario, it will be
       # included in the form data, therefore we have to take that into account.
       trainee_params[:results_search_again_query].presence || trainee_params[:no_results_search_again_query] || params[:query]
+    end
+
+    def index_or_edit_page
+      @employing_school_form.index_page_radio_buttons? ? :index : :edit
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/lead_schools_controller.rb
+++ b/app/controllers/trainees/lead_schools_controller.rb
@@ -28,7 +28,7 @@ module Trainees
       if @lead_school_form.public_send(save_strategy)
         redirect_to origin_page_or_next_step
       else
-        render :edit
+        render index_or_edit_page
       end
     end
 
@@ -40,6 +40,7 @@ module Trainees
 
     def redirect_to_search_page
       return if params["input-autocomplete"] && params["input-autocomplete"].length < SchoolSearch::MIN_QUERY_LENGTH
+      return if query.present?
 
       redirect_to trainee_lead_schools_path(trainee, query: params["input-autocomplete"]) if trainee_params[:lead_school_id].blank?
     end
@@ -68,6 +69,10 @@ module Trainees
       # including a validation message. Even though the search again field is hidden in this scenario, it will be
       # included in the form data, therefore we have to take that into account.
       trainee_params[:results_search_again_query].presence || trainee_params[:no_results_search_again_query] || params[:query]
+    end
+
+    def index_or_edit_page
+      @lead_school_form.index_page_radio_buttons? ? :index : :edit
     end
 
     def authorize_trainee

--- a/app/forms/schools/form.rb
+++ b/app/forms/schools/form.rb
@@ -5,6 +5,7 @@ module Schools
     NON_TRAINEE_FIELDS = %i[
       results_search_again_query
       no_results_search_again_query
+      school_value
     ].freeze
 
     attr_accessor(*NON_TRAINEE_FIELDS)
@@ -22,6 +23,10 @@ module Schools
 
     def no_results_searching_again?
       school_id == "no_results_search_again"
+    end
+
+    def index_page_radio_buttons?
+      school_value == "true"
     end
 
   private

--- a/app/views/trainees/employing_schools/_results.html.erb
+++ b/app/views/trainees/employing_schools/_results.html.erb
@@ -1,3 +1,5 @@
+<%= f.govuk_error_summary %>
+
 <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
   <%= t("components.page_titles.trainees.employing_schools.index") %>
 </h1>
@@ -8,9 +10,9 @@
   </div>
 <% end %>
 
-<%= f.govuk_error_summary %>
-
 <%= f.govuk_radio_buttons_fieldset :employing_school_id, legend: nil do %>
+  <%= f.hidden_field :school_value, value: "true" %>
+  
     <% @schools.each_with_index do |school, index| %>
       <%= f.govuk_radio_button :employing_school_id, school.id,
                               label: { text: school.name },

--- a/app/views/trainees/lead_schools/_results.html.erb
+++ b/app/views/trainees/lead_schools/_results.html.erb
@@ -1,3 +1,5 @@
+<%= f.govuk_error_summary %>
+
 <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
   <%= t("components.page_titles.trainees.lead_schools.index") %>
 </h1>
@@ -8,9 +10,9 @@
   </div>
 <% end %>
 
-<%= f.govuk_error_summary %>
-
 <%= f.govuk_radio_buttons_fieldset :lead_school_id, legend: nil do %>
+  <%= f.hidden_field :school_value, value: "true" %>
+
     <% @schools.each_with_index do |school, index| %>
       <%= f.govuk_radio_button :lead_school_id, school.id,
                               label: { text: school.name },


### PR DESCRIPTION
### Context
https://trello.com/c/4BVXl0E0/1886-no-validation-if-no-option-is-chosen-on-non-js-page
### Changes proposed in this pull request
* The before action `redirect_to_search_page` was breaking the validation as the non-js/index page was being reloaded. Added conditional return so that validations are triggered when index page is re-rendered instead on failure to save. 
* Hidden field added on  `_results` partial so that controller action can determine which page to render on failure to save depending on js or non js, edit or index
* Error summary appears above h1 in line with rest of app

### Guidance to review
Test validation on both `/lead-schools/edit` and `/lead-schools?query` (and employing schools). Turns JS off to test `/lead-school?query`(index page)