### PR TITLE
[1914] Ensure school search results are ordered by name

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -12,7 +12,8 @@ class School < ApplicationRecord
                       prefix: true,
                       tsvector_column: "searchable",
                     },
-                  }
+                  },
+                  order_within_rank: :name
 
   scope :open, -> { where(close_date: nil) }
   scope :lead_only, -> { where(lead_school: true) }

--- a/app/services/school_search.rb
+++ b/app/services/school_search.rb
@@ -18,6 +18,6 @@ class SchoolSearch
     schools = schools.search(query) if query
     schools = schools.limit(limit) if limit
     schools = schools.lead_only if lead_schools_only
-    schools
+    schools.order(:name)
   end
 end

--- a/spec/services/school_search_spec.rb
+++ b/spec/services/school_search_spec.rb
@@ -42,6 +42,21 @@ describe SchoolSearch do
       end
     end
 
+    context "search order" do
+      let!(:school_two) { create(:school, name: "The London Acorn School") }
+      let!(:school_one) { create(:school, name: "Acorn Park School") }
+
+      it "orders the results alphabetically" do
+        expect(described_class.call).to eq([school_one, school_two])
+      end
+
+      context "with a search query" do
+        it "orders the results alphabetically" do
+          expect(described_class.call(query: "acorn")).to eq([school_one, school_two])
+        end
+      end
+    end
+
     context "searching lead schools" do
       let(:lead_school) { create(:school, lead_school: true) }
 


### PR DESCRIPTION
### Context
Ensure alphabetical search ordering based on name when searching schools in the picker. 

### Changes proposed in this pull request
1. Add a order clause to the `SchoolSearch` service.
2. Add `order_within_rank` to the pg_search scope to ensure consistency.

