### PR TITLE
[1888] trainee record page change link for lead school

### DIFF
--- a/app/components/trainees/school_details/view.rb
+++ b/app/components/trainees/school_details/view.rb
@@ -17,8 +17,8 @@ module Trainees
 
       def change_paths(school_type)
         {
-          lead: trainee_lead_schools_path(trainee),
-          employing: trainee_employing_schools_path(trainee),
+          lead: edit_trainee_lead_schools_path(trainee),
+          employing: edit_trainee_employing_schools_path(trainee),
         }[school_type.to_sym]
       end
     end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -44,7 +44,12 @@ module Trainees
     end
 
     def form_klass
-      "#{trainee_section_key.underscore.camelcase}Form".constantize
+      case trainee_section_key
+      when "schools"
+        Schools::FormValidator
+      else
+        "#{trainee_section_key.underscore.camelcase}Form".constantize
+      end
     end
 
     def trainee_section_key

--- a/app/controllers/trainees/lead_schools_controller.rb
+++ b/app/controllers/trainees/lead_schools_controller.rb
@@ -57,9 +57,13 @@ module Trainees
     end
 
     def origin_page_or_next_step
-      return page_tracker.last_origin_page_path if page_tracker.last_origin_page_path&.include?("schools/confirm")
+      return trainee_schools_confirm_path if user_come_from_confirm_or_trainee_page?
 
       redirect_url
+    end
+
+    def user_come_from_confirm_or_trainee_page?
+      page_tracker.last_origin_page_path&.include?("schools/confirm") || page_tracker.last_origin_page_path == "/trainees/#{trainee.slug}"
     end
 
     def query

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -752,9 +752,9 @@ en:
               blank: Enter a school unique reference number (URN), name or postcode
         schools/form_validator:
           attributes:
-            lead_school_section:
+            lead_school_id:
               not_valid: The lead school section is not valid for this trainee
-            employing_school_section:
+            employing_school_id:
               not_valid: The employing school is not valid for this trainee
   page_headings:
     start_page: Register trainee teachers

--- a/spec/features/form_sections/teacher_training_data/edit_schools_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_schools_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "edit schools spec", type: :feature do
+  context "as a school direct salaried trn_submitted trainee" do
+    before do
+      given_i_am_authenticated
+      given_a_school_direct_salaried_trainee_submitted_for_trn_exists
+      and_a_number_of_lead_schools_exist
+      and_a_number_of_employing_schools_exist
+      and_i_visit_the_trainee_record_page
+    end
+
+    scenario "changing the lead school", js: true do
+      i_click_on_change_school(:lead_school)
+      and_i_am_on_the_edit_lead_school_page
+      and_i_fill_in_my_lead_school
+      and_i_click_the_first_item_in_the_list_lead_school
+      and_i_continue
+      then_i_am_redirected_to_the_confirm_schools_page
+    end
+
+    scenario "changing the employing school", js: true do
+      i_click_on_change_school(:employing_school)
+      and_i_am_on_the_edit_employing_school_page
+      and_i_fill_in_my_employing_school
+      and_i_click_the_first_item_in_the_list_employing_school
+      and_i_continue
+      then_i_am_redirected_to_the_confirm_schools_page
+    end
+  end
+
+  context "as a school direct tuition fee trn_submitted trainee" do
+    before do
+      given_i_am_authenticated
+      given_a_school_direct_tuition_fee_trainee_submitted_for_trn_exists
+      and_a_number_of_lead_schools_exist
+      and_a_number_of_employing_schools_exist
+      and_i_visit_the_trainee_record_page
+    end
+
+    scenario "changing the lead school", js: true do
+      i_click_on_change_school(:lead_school)
+      and_i_am_on_the_edit_lead_school_page
+      and_i_fill_in_my_lead_school
+      and_i_click_the_first_item_in_the_list_lead_school
+      and_i_continue
+      then_i_am_redirected_to_the_confirm_schools_page
+    end
+  end
+
+private
+
+  def given_a_school_direct_salaried_trainee_submitted_for_trn_exists
+    given_a_trainee_exists(:completed, :school_direct_salaried, :with_lead_school, :with_employing_school, :submitted_for_trn)
+  end
+
+  def given_a_school_direct_tuition_fee_trainee_submitted_for_trn_exists
+    given_a_trainee_exists(:completed, :school_direct_tuition_fee, :with_lead_school, :submitted_for_trn)
+  end
+
+  def and_i_fill_in_my_lead_school
+    edit_lead_school_page.lead_school.fill_in with: my_lead_school_name
+  end
+
+  def and_i_fill_in_my_employing_school
+    edit_employing_school_page.employing_school.fill_in with: my_employing_school_name
+  end
+
+  def and_i_am_on_the_edit_lead_school_page
+    expect(edit_lead_school_page).to be_displayed(trainee_id: trainee.slug)
+  end
+
+  def and_i_am_on_the_edit_employing_school_page
+    expect(edit_employing_school_page).to be_displayed(trainee_id: trainee.slug)
+  end
+
+  def and_i_click_the_first_item_in_the_list_lead_school
+    click(edit_lead_school_page.autocomplete_list_item)
+  end
+
+  def and_i_click_the_first_item_in_the_list_employing_school
+    click(edit_employing_school_page.autocomplete_list_item)
+  end
+
+  def and_i_continue
+    click(edit_lead_school_page.submit)
+  end
+
+  def and_a_number_of_lead_schools_exist
+    @lead_schools = create_list(:school, 1, :lead)
+  end
+
+  def and_a_number_of_employing_schools_exist
+    @employing_schools = create_list(:school, 1)
+  end
+
+  def and_i_visit_the_trainee_record_page
+    record_page.load(id: trainee.slug)
+  end
+
+  def my_lead_school_name
+    my_lead_school.name.split(" ").first
+  end
+
+  def my_employing_school_name
+    my_employing_school.name.split(" ").first
+  end
+
+  def my_lead_school
+    @my_lead_school ||= @lead_schools.sample
+  end
+
+  def my_employing_school
+    @my_employing_school ||= @employing_schools.sample
+  end
+
+  def then_i_am_redirected_to_the_confirm_lead_school_page
+    expect(confirm_schools_page).to be_displayed(id: trainee.slug)
+  end
+
+  def then_i_am_redirected_to_the_lead_schools_page_filtered_by_my_query
+    expect(lead_schools_search_page).to be_displayed(trainee_id: trainee.slug, query: my_lead_school_name)
+  end
+
+  def i_click_on_change_school(school)
+    record_page.public_send("change_#{school}").click
+  end
+
+  def then_i_am_redirected_to_the_confirm_schools_page
+    expect(confirm_schools_page).to be_displayed(id: trainee.slug)
+  end
+end

--- a/spec/forms/schools/form_validator_spec.rb
+++ b/spec/forms/schools/form_validator_spec.rb
@@ -9,10 +9,10 @@ module Schools
     describe "validations" do
       context "with a school_direct_tuition_fee trainee", 'feature_routes.school_direct_tuition_fee': true do
         let(:trainee) { build(:trainee, :school_direct_tuition_fee) }
-        let(:lead_school_form) { instance_double(Schools::LeadSchoolForm) }
+        let(:lead_school_form) { instance_double(Schools::LeadSchoolForm, fields: nil, lead_school_id: nil) }
 
         before do
-          expect(Schools::LeadSchoolForm).to receive(:new).and_return(lead_school_form)
+          allow(Schools::LeadSchoolForm).to receive(:new).and_return(lead_school_form)
         end
 
         context "when LeadSchoolForm is valid" do
@@ -28,12 +28,12 @@ module Schools
             allow(lead_school_form).to receive(:valid?).and_return(false)
           end
 
-          it "returns an error for the lead_school_section key" do
+          it "returns an error for the lead_school_id key" do
             subject.valid?
 
-            expect(subject.errors[:lead_school_section]).to include(
+            expect(subject.errors[:lead_school_id]).to include(
               I18n.t(
-                "activemodel.errors.models.schools/form_validator.attributes.lead_school_section.not_valid",
+                "activemodel.errors.models.schools/form_validator.attributes.lead_school_id.not_valid",
               ),
             )
           end
@@ -42,12 +42,12 @@ module Schools
 
       context "with a school_direct_salaried trainee", 'feature_routes.school_direct_salaried': true do
         let(:trainee) { build(:trainee, :school_direct_salaried) }
-        let(:lead_school_form) { instance_double(Schools::LeadSchoolForm) }
-        let(:employing_school_form) { instance_double(Schools::EmployingSchoolForm) }
+        let(:lead_school_form) { instance_double(Schools::LeadSchoolForm, fields: nil, lead_school_id: nil) }
+        let(:employing_school_form) { instance_double(Schools::EmployingSchoolForm, fields: nil, employing_school_id: nil) }
 
         before do
-          expect(Schools::LeadSchoolForm).to receive(:new).and_return(lead_school_form)
-          expect(Schools::EmployingSchoolForm).to receive(:new).and_return(employing_school_form)
+          allow(Schools::LeadSchoolForm).to receive(:new).and_return(lead_school_form)
+          allow(Schools::EmployingSchoolForm).to receive(:new).and_return(employing_school_form)
         end
 
         context "when LeadSchoolForm is valid" do
@@ -68,12 +68,12 @@ module Schools
               allow(employing_school_form).to receive(:valid?).and_return(false)
             end
 
-            it "returns an error for the employing_school_section key" do
+            it "returns an error for the employing_school_id key" do
               subject.valid?
 
-              expect(subject.errors[:employing_school_section]).to include(
+              expect(subject.errors[:employing_school_id]).to include(
                 I18n.t(
-                  "activemodel.errors.models.schools/form_validator.attributes.employing_school_section.not_valid",
+                  "activemodel.errors.models.schools/form_validator.attributes.employing_school_id.not_valid",
                 ),
               )
             end
@@ -90,12 +90,12 @@ module Schools
               allow(employing_school_form).to receive(:valid?).and_return(true)
             end
 
-            it "returns an error for the lead_school_section key" do
+            it "returns an error for the lead_school_id key" do
               subject.valid?
 
-              expect(subject.errors[:lead_school_section]).to include(
+              expect(subject.errors[:lead_school_id]).to include(
                 I18n.t(
-                  "activemodel.errors.models.schools/form_validator.attributes.lead_school_section.not_valid",
+                  "activemodel.errors.models.schools/form_validator.attributes.lead_school_id.not_valid",
                 ),
               )
             end
@@ -106,17 +106,17 @@ module Schools
               allow(employing_school_form).to receive(:valid?).and_return(false)
             end
 
-            it "returns errors for the lead_school_section and the employing_school_section key" do
+            it "returns errors for the lead_school_id and the employing_school_id key" do
               subject.valid?
 
-              expect(subject.errors[:employing_school_section]).to include(
+              expect(subject.errors[:employing_school_id]).to include(
                 I18n.t(
-                  "activemodel.errors.models.schools/form_validator.attributes.employing_school_section.not_valid",
+                  "activemodel.errors.models.schools/form_validator.attributes.employing_school_id.not_valid",
                 ),
               )
-              expect(subject.errors[:lead_school_section]).to include(
+              expect(subject.errors[:lead_school_id]).to include(
                 I18n.t(
-                  "activemodel.errors.models.schools/form_validator.attributes.lead_school_section.not_valid",
+                  "activemodel.errors.models.schools/form_validator.attributes.lead_school_id.not_valid",
                 ),
               )
             end

--- a/spec/support/page_objects/trainees/record.rb
+++ b/spec/support/page_objects/trainees/record.rb
@@ -23,6 +23,9 @@ module PageObjects
       section :contact_detail, PageObjects::Sections::Summaries::ContactDetail, ".contact-details"
       section :diversity_detail, PageObjects::Sections::Summaries::DiversityDetail, ".diversity-details"
       section :degree_detail, PageObjects::Sections::Summaries::DegreeDetail, ".degree-details"
+
+      element :change_lead_school, "a", text: "Change lead school", visible: false
+      element :change_employing_school, "a", text: "Change employing school", visible: false
     end
   end
 end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/CV72OmiO/1888-m-trainee-record-page-change-link-for-lead-school)
- I also fixed a bug where the `Schools::FormValidator` was not being used for the confirm page
- and that the `Schools::FormValidator` rehydrated the two forms with `new_attributes` from the `FormStore`

### Changes proposed in this pull request

- Confirmation Controller uses the `Schools::FormValidator` for the schools form
- `Schools::FormValidator` uses form-store values as new attributes and merges them with the trainee
- Change link from the record page goes to the schools search page

### Guidance to review

- Create a trainee on the School Direct Tuition Fee AND/OR the School Direct Salaried route and complete them
- Submit the trainee for TRN
- On their record page, change either their lead and/or employing school. 
- You should be redirected to their search page, and once a new school is chosen, you are redirected to the confirm page

