### PR TITLE
[1850] Render 'Early years teaching' instead of 'No subject provided'

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -16,13 +16,14 @@ module ApplicationRecordCard
     end
 
     def trainee_name
-      return "Draft record" if record.blank? || record.first_names.blank? || record.last_name.blank?
+      return I18n.t("components.application_record_card.trainee_name.blank") if has_no_name?
 
       params[:sort_by] == "last_name" ? last_name_first : first_names_first
     end
 
     def subject
-      return "No subject provided" if record.subject.blank?
+      return I18n.t("components.application_record_card.subject.early_years") if record.is_early_years?
+      return I18n.t("components.application_record_card.subject.blank") if record.subject.blank?
 
       subjects_for_summary_view(record.subject, record.subject_two, record.subject_three)
     end
@@ -54,6 +55,10 @@ module ApplicationRecordCard
     end
 
   private
+
+    def has_no_name?
+      record.blank? || record.first_names.blank? || record.last_name.blank?
+    end
 
     def first_names_first
       [record.first_names, record.last_name].join(" ")

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -17,8 +17,17 @@ class TrainingRouteManager
     feature_enabled?("routes.school_direct_salaried") && schools_direct_salaried?
   end
 
+  def is_early_years?
+    TRAINING_ROUTE_ENUMS.values_at(
+      :early_years_assessment_only,
+      :early_years_postgrad,
+      :early_years_salaried,
+      :early_years_undergrad,
+    ).include? training_route
+  end
+
   def award_type
-    TRAINING_ROUTE_AWARD_TYPE[training_route]
+    TRAINING_ROUTE_AWARD_TYPE[training_route&.to_sym]
   end
 
 private
@@ -26,23 +35,23 @@ private
   attr_reader :trainee
 
   def provider_led_postgrad?
-    training_route == TRAINING_ROUTE_ENUMS[:provider_led_postgrad].to_sym
+    training_route == TRAINING_ROUTE_ENUMS[:provider_led_postgrad]
   end
 
   def assessment_only?
-    training_route == TRAINING_ROUTE_ENUMS[:assessment_only].to_sym
+    training_route == TRAINING_ROUTE_ENUMS[:assessment_only]
   end
 
   def schools_direct?
-    TRAINING_ROUTE_ENUMS.values_at(:school_direct_tuition_fee, :school_direct_salaried).include? training_route.to_s
+    TRAINING_ROUTE_ENUMS.values_at(:school_direct_tuition_fee, :school_direct_salaried).include? training_route
   end
 
   def schools_direct_salaried?
-    training_route == TRAINING_ROUTE_ENUMS[:school_direct_salaried].to_sym
+    training_route == TRAINING_ROUTE_ENUMS[:school_direct_salaried]
   end
 
   def training_route
-    @trainee.training_route&.to_sym
+    @trainee.training_route
   end
 
   def feature_enabled?(feature_name)

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -17,7 +17,7 @@ class Trainee < ApplicationRecord
   attribute :progress, Progress.to_type
 
   delegate :award_type, :requires_placement_details?, :requires_schools?,
-           :requires_employing_school?, to: :training_route_manager
+           :requires_employing_school?, :is_early_years?, to: :training_route_manager
   delegate :update_training_route!, to: :route_data_manager
 
   validates :training_route, presence: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,14 @@ en:
       draft:
         personal_details_and_education: Personal details and education
         about_their_teaching_training: About their teacher training
+    application_record_card:
+      subject:
+        early_years: "Early years teaching"
+        blank: "No subject provided"
+      route:
+        blank: "No route provided"
+      trainee_name:
+        blank: "Draft record"
     confirmation:
       not_provided: Not provided
       heading: Confirm %{section_title}

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -22,6 +22,14 @@ module ApplicationRecordCard
       it "renders 'No subject provided'" do
         expect(component.find(".app-application-card__subject")).to have_text("No subject provided")
       end
+
+      context "and is an Early Years trainee" do
+        let(:trainee) { Trainee.new(created_at: Time.zone.now, training_route: TRAINING_ROUTE_ENUMS[:early_years_undergrad]) }
+
+        it "renders 'Early uears teaching'" do
+          expect(component.find(".app-application-card__subject")).to have_text("Early years teaching")
+        end
+      end
     end
 
     context "when the Trainee has no route" do


### PR DESCRIPTION
### Context

https://trello.com/c/iEYYs4fs/1850-s-ey-show-early-years-teaching-in-place-of-subject-on-trainee-list

### Changes proposed in this pull request

<img width="649" alt="Screenshot 2021-06-07 at 16 54 38" src="https://user-images.githubusercontent.com/18436946/121051087-11667c00-c7b1-11eb-97ed-31efe3bd043f.png">

If a non-EY trainee has not recorded a subject, we say "No subject provided". However, a EY trainee never chooses a subject so it's always empty. 

This PR changes the default text in the trainee list view to say "Early years teaching" for EY trainees.

### Guidance to review
- Create an Early years trainee
- Go to the trainee list
- Check that the new trainee's card says "Early years teaching", not "No subject provided"
- Create a non-Early years trainee (or choose an existing one with no subject added)
- Go to the trainee list
- Check that this trainee's card continues to say "No subject provided" as before