### PR TITLE
[1851] EY - Remove subject and age range from course details form

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -22,7 +22,7 @@ module ApplicationRecordCard
     end
 
     def subject
-      return I18n.t("components.application_record_card.subject.early_years") if record.is_early_years?
+      return I18n.t("components.application_record_card.subject.early_years") if record.early_years_route?
       return I18n.t("components.application_record_card.subject.blank") if record.subject.blank?
 
       subjects_for_summary_view(record.subject, record.subject_two, record.subject_three)

--- a/app/components/trainees/confirmation/course_details/view.rb
+++ b/app/components/trainees/confirmation/course_details/view.rb
@@ -26,11 +26,11 @@ module Trainees
         def rows
           [
             { key: t("components.course_detail.type_of_course"), value: course_type },
-            { key: t("components.course_detail.subject"), value: subject, action: action_link("subject") },
-            { key: t("components.course_detail.age_range"), value: course_age_range, action: action_link("age range") },
+            ({ key: t("components.course_detail.subject"), value: subject, action: action_link("subject") } if require_subject?),
+            ({ key: t("components.course_detail.age_range"), value: course_age_range, action: action_link("age range") } if require_age_range?),
             { key: t("components.course_detail.course_start_date"), value: course_start_date, action: action_link("course start date") },
             { key: t("components.course_detail.course_end_date"), value: course_end_date, action: action_link("course end date") },
-          ].tap do |collection|
+          ].compact.tap do |collection|
             if show_publish_courses?(trainee)
               collection.unshift({
                 key: t("components.course_detail.course_details"),
@@ -42,6 +42,14 @@ module Trainees
         end
 
       private
+
+        def require_subject?
+          !trainee.early_years_route?
+        end
+
+        def require_age_range?
+          !trainee.early_years_route?
+        end
 
         def action_link(text, path: edit_trainee_course_details_path(trainee))
           govuk_link_to("#{t(:change)}<span class='govuk-visually-hidden'> #{text}</span>".html_safe, path)

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -33,21 +33,23 @@ class CourseDetailsForm < TraineeForm
   before_validation :sanitise_course_dates
   before_validation :sanitise_subjects
 
-  validates :subject, autocomplete: true, presence: true
-  validates :subject_two, autocomplete: true
-  validates :subject_three, autocomplete: true
-  validates :additional_age_range, autocomplete: true, if: -> { other_age_range? }
-  validate :age_range_valid
+  validates :subject, autocomplete: true, presence: true, if: :require_subject?
+  validates :subject_two, autocomplete: true, if: :require_subject?
+  validates :subject_three, autocomplete: true, if: :require_subject?
+  validates :additional_age_range, autocomplete: true, if: -> { other_age_range? && require_age_range? }
+  validate :age_range_valid, if: :require_age_range?
   validate :course_start_date_valid
   validate :course_end_date_valid
-  validate :subject_two_valid
-  validate :subject_three_valid
+  validate :subject_two_valid, if: :require_subject?
+  validate :subject_three_valid, if: :require_subject?
 
   delegate :apply_application?, to: :trainee
 
   MAX_END_YEARS = 4
 
   def course_age_range
+    return unless require_age_range?
+
     (other_age_range? ? additional_age_range : main_age_range).split(" to ")
   end
 
@@ -77,6 +79,14 @@ class CourseDetailsForm < TraineeForm
 
   def has_additional_subjects?
     subject_two.present? || subject_three.present?
+  end
+
+  def require_subject?
+    !trainee.early_years_route?
+  end
+
+  def require_age_range?
+    !trainee.early_years_route?
   end
 
 private

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -17,17 +17,12 @@ class TrainingRouteManager
     feature_enabled?("routes.school_direct_salaried") && schools_direct_salaried?
   end
 
-  def is_early_years?
-    TRAINING_ROUTE_ENUMS.values_at(
-      :early_years_assessment_only,
-      :early_years_postgrad,
-      :early_years_salaried,
-      :early_years_undergrad,
-    ).include? training_route
-  end
-
   def award_type
     TRAINING_ROUTE_AWARD_TYPE[training_route&.to_sym]
+  end
+
+  def early_years_route?
+    @trainee.training_route.to_s.starts_with?("early_years")
   end
 
 private

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -17,7 +17,7 @@ class Trainee < ApplicationRecord
   attribute :progress, Progress.to_type
 
   delegate :award_type, :requires_placement_details?, :requires_schools?,
-           :requires_employing_school?, :is_early_years?, to: :training_route_manager
+           :requires_employing_school?, :early_years_route?, to: :training_route_manager
   delegate :update_training_route!, to: :route_data_manager
 
   validates :training_route, presence: {

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -13,37 +13,41 @@
 
       <h1 class="govuk-heading-l">Course details</h1>
 
-      <%= render FormComponents::Autocomplete::View.new(
-        f,
-        attribute_name: :subject,
-        form_field: f.govuk_collection_select(:subject, course_subjects_options,
-                                              :name, :name, label: { text: "Subject", size: "s" },
-                                                            hint: { text: "Search for the closest matching subject" }),
-      ) %>
+      <% if f.object.require_subject? %>
+        <%= render FormComponents::Autocomplete::View.new(
+          f,
+          attribute_name: :subject,
+          form_field: f.govuk_collection_select(:subject, course_subjects_options,
+                                                :name, :name, label: { text: "Subject", size: "s" },
+                                                              hint: { text: "Search for the closest matching subject" }),
+        ) %>
 
-      <%= render "additional_subjects", f: f %>
+        <%= render "additional_subjects", f: f %>
+      <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:main_age_range, legend: { text: "Age range", size: "s" }, classes: "age_range") do %>
-        <% main_age_ranges_options.each_with_index do |age_range, index| %>
-          <%= f.govuk_radio_button(:main_age_range, age_range,
-                                   label: { text: age_range },
-                                   link_errors: index.zero?) %>
-        <% end %>
+      <% if f.object.require_age_range? %>
+        <%= f.govuk_radio_buttons_fieldset(:main_age_range, legend: { text: "Age range", size: "s" }, classes: "age_range") do %>
+          <% main_age_ranges_options.each_with_index do |age_range, index| %>
+            <%= f.govuk_radio_button(:main_age_range, age_range,
+                                     label: { text: age_range },
+                                     link_errors: index.zero?) %>
+          <% end %>
 
-        <%= f.govuk_radio_divider %>
+          <%= f.govuk_radio_divider %>
 
-        <%= f.govuk_radio_button(:main_age_range,
-                                 :other,
-                                 label: { text: "Other age range" }) do %>
-          <%= render FormComponents::Autocomplete::View.new(
-            f,
-            attribute_name: :additional_age_range,
-            form_field: f.govuk_collection_select(:additional_age_range, additional_age_ranges_options,
-                                                  :name,
-                                                  :name,
-                                                  label: { text: "Other age range", size: "s" }),
-          ) %>
+          <%= f.govuk_radio_button(:main_age_range,
+                                   :other,
+                                   label: { text: "Other age range" }) do %>
+            <%= render FormComponents::Autocomplete::View.new(
+              f,
+              attribute_name: :additional_age_range,
+              form_field: f.govuk_collection_select(:additional_age_range, additional_age_ranges_options,
+                                                    :name,
+                                                    :name,
+                                                    label: { text: "Other age range", size: "s" }),
+            ) %>
 
+          <% end %>
         <% end %>
       <% end %>
 

--- a/app/views/trainees/employing_schools/edit.html.erb
+++ b/app/views/trainees/employing_schools/edit.html.erb
@@ -16,7 +16,7 @@
         name: :'input-autocomplete',
         value: nil,
         "data-field" => "schools-autocomplete",
-        width: "three-quarters"
+        width: "three-quarters",
       ) %>
       <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters"></div>
 

--- a/app/views/trainees/lead_schools/edit.html.erb
+++ b/app/views/trainees/lead_schools/edit.html.erb
@@ -16,7 +16,7 @@
         name: :'input-autocomplete',
         value: nil,
         "data-field" => "schools-autocomplete",
-        width: "three-quarters"
+        width: "three-quarters",
       ) %>
       <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-only-lead-schools=true></div>
 

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -84,4 +84,22 @@ describe TrainingRouteManager do
       end
     end
   end
+
+  describe "#early_years_route?" do
+    context "non early years route" do
+      let(:trainee) { build(:trainee, :school_direct_salaried) }
+
+      it "returns false" do
+        expect(subject.early_years_route?).to be false
+      end
+    end
+
+    context "early years route" do
+      let(:trainee) { build(:trainee, :early_years_undergrad) }
+
+      it "returns true" do
+        expect(subject.early_years_route?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/77dx3rGp/1851-s-ey-remove-subject-and-age-range-from-course-details-form

### Changes proposed in this pull request

* Updated course details form to hide subject and age range for early years routes

### Guidance to review

