### PR TITLE
Run seed data script for review apps

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -29,6 +29,7 @@ resource cloudfoundry_service_instance redis_instance {
 resource cloudfoundry_app web_app {
   name                       = local.web_app_name
   docker_image               = var.app_docker_image
+  command                    = local.web_app_start_command
   health_check_type          = "http"
   health_check_http_endpoint = "/ping"
   instances                  = var.web_app_instances

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -38,6 +38,8 @@ locals {
   redis_service_name       = "register-redis-${local.app_name_suffix}"
   web_app_name             = "register-${local.app_name_suffix}"
   app_environment          = merge(var.app_config_variable, var.app_secrets_variable)
+  review_app_start_command = "bundle exec rake db:schema:load db:seed example_data:generate && bundle exec rails server -b 0.0.0.0"
+  web_app_start_command    = var.app_environment == "review" ? local.review_app_start_command : "bundle exec rails db:migrate:with_data && bundle exec rails server -b 0.0.0.0"
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "register-worker-${local.app_name_suffix}"
   logging_service_name     = "register-logit-${local.app_name_suffix}"


### PR DESCRIPTION
### Context

Populate sample data for the review apps on PaaS.

### Changes proposed in this pull request

Run rake tasks to populate the review app's database with seed data.
Will run the below command on review app start up
```
bundle exec rake db:schema:load db:seed example_data:generate
```


