### PR TITLE
[1858] Show EYTS and QTS trainee progress row

### DIFF
--- a/app/components/trainees/record_details/view.html.erb
+++ b/app/components/trainees/record_details/view.html.erb
@@ -8,6 +8,7 @@
       action: govuk_link_to('Change<span class="govuk-visually-hidden"> trainee ID</span>'.html_safe, edit_trainee_trainee_id_path(trainee)),
     },
     trn_row,
+    trainee_progress_row,
     trainee_status_row,
     {
       key: "Last updated",

--- a/app/components/trainees/record_details/view.rb
+++ b/app/components/trainees/record_details/view.rb
@@ -44,21 +44,22 @@ module Trainees
         end
       end
 
+      def trainee_progress_row
+        return unless trainee.recommended_for_award? || trainee.awarded?
+
+        {
+          key: trainee.award_type,
+          value: render(StatusTag::View.new(trainee: trainee, classes: "govuk-!-margin-bottom-2")) + tag.br + progress_date,
+        }
+      end
+
       def trainee_status_row
         return unless trainee.deferred? || trainee.withdrawn?
 
         {
           key: "Trainee status",
-          value: render(StatusTag::View.new(trainee: trainee, classes: "govuk-!-margin-bottom-2")) + tag.br + trainee_status_date,
+          value: render(StatusTag::View.new(trainee: trainee, classes: "govuk-!-margin-bottom-2")) + tag.br + status_date,
         }
-      end
-
-      def trainee_status_date
-        status_date = trainee.deferred? ? trainee.defer_date : trainee.withdraw_date
-        return unless status_date
-
-        status_date_prefix = trainee.deferred? ? "Deferral date: " : "Withdrawal date: "
-        status_date_prefix + date_for_summary_view(status_date)
       end
 
     private
@@ -67,6 +68,32 @@ module Trainees
         hint_text = tag.span(time_ago_in_words(date).concat(" ago"), class: "govuk-hint")
 
         sanitize(tag.p(date_for_summary_view(date), class: "govuk-body") + hint_text)
+      end
+
+      def progress_date
+        return unless trainee_progress_date
+
+        I18n.t("components.record_details.progress_date_prefix.#{trainee.state}") + date_for_summary_view(trainee_progress_date)
+      end
+
+      def status_date
+        return unless trainee_status_date
+
+        I18n.t("components.record_details.status_date_prefix.#{trainee.state}") + date_for_summary_view(trainee_status_date)
+      end
+
+      def trainee_progress_date
+        {
+          recommended_for_award: trainee.recommended_for_award_at,
+          awarded: trainee.awarded_at,
+        }[trainee.state.to_sym]
+      end
+
+      def trainee_status_date
+        {
+          deferred: trainee.defer_date,
+          withdrawn: trainee.withdraw_date,
+        }[trainee.state.to_sym]
       end
     end
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -106,6 +106,10 @@ class Trainee < ApplicationRecord
     end
 
     event :award do
+      before do
+        self.awarded_at = Time.zone.now
+      end
+
       transition %i[recommended_for_award] => :awarded
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,13 @@ en:
     incomplete_section:
       degree_details_not_provided: Degree details not provided
       add_degree_details: Add degree details
+    record_details:
+      progress_date_prefix:
+        recommended_for_award: "Recommended: "
+        awarded: "Awarded: "
+      status_date_prefix:
+        deferred: "Deferral date: "
+        withdrawn: "Withdrawal date: "
     page_titles:
       personas: Personas
       pages:

--- a/db/data/20210607164459_add_awarded_at_to_trainees.rb
+++ b/db/data/20210607164459_add_awarded_at_to_trainees.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddAwardedAtToTrainees < ActiveRecord::Migration[6.1]
+  # We want to start saving an awarded_at timestamp on a trainee, since the only
+  # way to find out is to deduce from the audits.
+  def up
+    Trainee.awarded.each do |trainee|
+      # state == 3 => "recommended_for_award"
+      # state == 6 => "awarded"
+      award_audit = trainee.audits.find { |audit| audit.audited_changes["state"] == [3, 6] }
+      next unless award_audit
+
+      trainee.update!(awarded_at: award_audit.created_at)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-DataMigrate::Data.define(version: 20_210_510_142_715)
+DataMigrate::Data.define(version: 20_210_607_164_459)

--- a/db/migrate/20210607164204_add_awarded_at_to_trainees.rb
+++ b/db/migrate/20210607164204_add_awarded_at_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAwardedAtToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :awarded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_03_171313) do
+ActiveRecord::Schema.define(version: 2021_06_07_164204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -273,6 +273,7 @@ ActiveRecord::Schema.define(version: 2021_06_03_171313) do
     t.string "course_code"
     t.text "subject_two"
     t.text "subject_three"
+    t.datetime "awarded_at"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -45,6 +45,7 @@ namespace :example_data do
       )
       persona.update!(provider: provider)
 
+      courses = nil
       # For each of the course routes enabled...
       enabled_course_routes.each do |route|
         # Create some courses for that provider with some subjects
@@ -66,6 +67,7 @@ namespace :example_data do
             # Some route-specific logic, but could move into factories too
             attrs.merge!(lead_school: lead_schools.sample) if %i[school_direct_salaried school_direct_tuition_fee].include?(route)
             attrs.merge!(employing_school: employing_schools.sample) if route == :school_direct_salaried
+            attrs.merge!(course_code: courses.sample.code) unless state == :draft
 
             trainee = FactoryBot.create(:trainee, route, state, attrs)
 

--- a/spec/components/trainees/record_details/view_preview.rb
+++ b/spec/components/trainees/record_details/view_preview.rb
@@ -21,18 +21,38 @@ module Trainees
         render(View.new(trainee: mock_trainee("withdrawn", :withdrawn), last_updated_event: last_updated_event))
       end
 
+      def with_qts_recommended
+        render(View.new(trainee: mock_trainee("qts_recommended", :recommended_for_award), last_updated_event: last_updated_event))
+      end
+
+      def with_eyts_recommended
+        trainee = mock_trainee("eyts_recommended", :recommended_for_award, TRAINING_ROUTE_ENUMS[:early_years_undergrad])
+        render(View.new(trainee: trainee, last_updated_event: last_updated_event))
+      end
+
+      def with_qts_awarded
+        render(View.new(trainee: mock_trainee("qts_awarded", :awarded), last_updated_event: last_updated_event))
+      end
+
+      def with_eyts_awarded
+        trainee = mock_trainee("eyts_awarded", :awarded, TRAINING_ROUTE_ENUMS[:early_years_undergrad])
+        render(View.new(trainee: trainee, last_updated_event: last_updated_event))
+      end
+
     private
 
-      def mock_trainee(trainee_id, state = :draft)
+      def mock_trainee(trainee_id, state = :draft, training_route = TRAINING_ROUTE_ENUMS[:assessment_only])
         @mock_trainee ||= Trainee.new(
           id: 1,
-          training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+          training_route: training_route,
           trainee_id: trainee_id,
           created_at: Time.zone.today,
           state: state,
           submitted_for_trn_at: Time.zone.today,
           defer_date: state == :deferred ? Time.zone.today : nil,
           withdraw_date: state == :withdrawn ? Time.zone.today : nil,
+          recommended_for_award_at: state == :recommended_for_award ? Time.zone.now : nil,
+          awarded_at: state == :awarded ? Time.zone.now : nil,
         )
       end
 

--- a/spec/components/trainees/record_details/view_spec.rb
+++ b/spec/components/trainees/record_details/view_spec.rb
@@ -7,11 +7,11 @@ module Trainees
     describe View do
       include SummaryHelper
 
-      alias_method :component, :page
-
       let(:state) { :trn_received }
-      let(:trainee) { create(:trainee, state, trn: Faker::Number.number(digits: 10)) }
+      let(:training_route) { TRAINING_ROUTE_ENUMS[:assessment_only] }
+      let(:trainee) { create(:trainee, state, training_route, trn: Faker::Number.number(digits: 10)) }
       let(:trainee_status) { "trainee-status" }
+      let(:trainee_progress) { "trainee-progress" }
       let(:timeline_event) { double(date: Time.zone.today) }
 
       context "when trainee_id data has not been provided" do
@@ -21,7 +21,7 @@ module Trainees
         end
 
         it "tells the user that no data has been entered for trainee ID" do
-          expect(component.find(".govuk-summary-list__row.trainee-id .govuk-summary-list__value")).to have_text(t("components.confirmation.not_provided"))
+          expect(rendered_component).to have_text(t("components.confirmation.not_provided"))
         end
       end
 
@@ -31,22 +31,22 @@ module Trainees
         end
 
         it "renders the trainee ID" do
-          expect(component.find(summary_card_row_for("trainee-id"))).to have_text(trainee.trainee_id)
+          expect(rendered_component).to have_text(trainee.trainee_id)
         end
 
         it "renders the trainee's last timeline event date" do
-          expect(component.find(summary_card_row_for("last-updated"))).to have_text(date_for_summary_view(timeline_event.date))
+          expect(rendered_component).to have_text(date_for_summary_view(timeline_event.date))
         end
 
         it "renders the trainee record created date" do
-          expect(component.find(summary_card_row_for("record-created"))).to have_text(date_for_summary_view(trainee.created_at))
+          expect(rendered_component).to have_text(date_for_summary_view(trainee.created_at))
         end
 
         context "when trainee state is submitted_for_trn" do
           let(:trainee) { create(:trainee, :submitted_for_trn) }
 
           it "renders the trn submission date" do
-            expect(component.find(summary_card_row_for("submitted-for-trn"))).to have_text(date_for_summary_view(trainee.submitted_for_trn_at))
+            expect(rendered_component).to have_text(date_for_summary_view(trainee.submitted_for_trn_at))
           end
         end
 
@@ -54,11 +54,11 @@ module Trainees
           let(:state) { :deferred }
 
           it "renders the trainee deferral date" do
-            expect(component.find(summary_card_row_for(trainee_status))).to have_text(date_for_summary_view(trainee.defer_date))
+            expect(rendered_component).to have_text(date_for_summary_view(trainee.defer_date))
           end
 
           it "renders the trainee status tag" do
-            expect(component.find(summary_card_row_for(trainee_status))).to have_text("deferred")
+            expect(rendered_component).to have_text("deferred")
           end
         end
 
@@ -66,7 +66,39 @@ module Trainees
           let(:state) { :withdrawn }
 
           it "renders the trainee withdrawal date" do
-            expect(component.find(summary_card_row_for(trainee_status))).to have_text(date_for_summary_view(trainee.withdraw_date))
+            expect(rendered_component).to have_text(date_for_summary_view(trainee.withdraw_date))
+          end
+        end
+
+        context "when trainee state is recommended_for_award" do
+          let(:state) { :recommended_for_award }
+
+          it "renders the trainee recommended date" do
+            expect(rendered_component).to have_text(date_for_summary_view(trainee.recommended_for_award_at))
+          end
+
+          context "and the trainee is an EY trainee" do
+            let(:training_route) { TRAINING_ROUTE_ENUMS[:early_years_undergrad] }
+
+            it "renders the trainee recommended date" do
+              expect(rendered_component).to have_text(date_for_summary_view(trainee.recommended_for_award_at))
+            end
+          end
+        end
+
+        context "when trainee state is awarded" do
+          let(:state) { :awarded }
+
+          it "renders the trainee awarded date" do
+            expect(rendered_component).to have_text(date_for_summary_view(trainee.awarded_at))
+          end
+
+          context "and the trainee is an EY trainee" do
+            let(:training_route) { TRAINING_ROUTE_ENUMS[:early_years_undergrad] }
+
+            it "renders the trainee awarded date" do
+              expect(rendered_component).to have_text(date_for_summary_view(trainee.awarded_at))
+            end
           end
         end
       end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -193,6 +193,7 @@ FactoryBot.define do
     trait :awarded do
       recommended_for_award
       state { "awarded" }
+      awarded_at { Time.zone.now }
     end
 
     trait :with_dttp_dormancy do


### PR DESCRIPTION
### Context

https://trello.com/c/yO2sDcCi/1858-s-ey-trainee-show-page-show-correct-award-row-with-status-tag

### Changes proposed in this pull request

**This PR:**
- Makes the changes to the view (see screenshots below)
- Adds a migration to add a new field to trainees `awarded_at`, which get updated as part of the state transition to `awarded`. This is similar to all our other fields `recommended_for_award_at` and `submitted_for_trn_at`.
- Adds a data migration to backfill all trainees `awarded_at` with the correct timestamp. This is pulled out of the audits table.

**Visual changes:**
For trainees who have been recommended for EYTS / QTS there is a new row in the trainee progress card on the trainee show page:

<img width="1030" alt="Screenshot 2021-06-08 at 13 05 02" src="https://user-images.githubusercontent.com/18436946/121181792-4a0e6000-c85a-11eb-8f75-e9c5ff8a8a46.png">

The label of the row is EYTS or QTS depending on the award they are receiving, and the detail should show the correct status tag and the date on which it happened.

There is a similar row for when they are awarded EYTS / QTS:

<img width="1016" alt="Screenshot 2021-06-08 at 13 05 07" src="https://user-images.githubusercontent.com/18436946/121181975-80e47600-c85a-11eb-84be-4cdb62492f4c.png">

### Guidance to review
- Head to a trainee that is recommended for QTS and check that the row is populated as above (but with QTS)
- Head to a trainee that is recommended for EYTS and check that the row is populated as above
- Head to a trainee that is awarded QTS and check that the row is populated as above (but with QTS)
- Head to a trainee that is awarded EYTS and check that the row is populated as above
