### PR TITLE
[1854] Change Recommend for QTS button to say EYTS for early years

### DIFF
--- a/app/components/trainees/record_actions/view.html.erb
+++ b/app/components/trainees/record_actions/view.html.erb
@@ -2,7 +2,7 @@
   <div class="record-actions">
 
     <% if can_recommend_for_award? %>
-      <%= render GovukButtonLinkTo::View.new(body: t("views.trainees.edit.recommend_for_award"), url: edit_trainee_outcome_details_outcome_date_path(trainee), class_option: "govuk-!-margin-bottom-0") %>
+      <%= render GovukButtonLinkTo::View.new(body: button_text, url: edit_trainee_outcome_details_outcome_date_path(trainee), class_option: "govuk-!-margin-bottom-0") %>
     <% else %>
       <div class="govuk-inset-text govuk-!-margin-0">
         <%= t("views.trainees.edit.status_summary.#{trainee.state}") %>

--- a/app/components/trainees/record_actions/view.rb
+++ b/app/components/trainees/record_actions/view.rb
@@ -27,6 +27,14 @@ module Trainees
 
     private
 
+      def button_text
+        if trainee.is_early_years?
+          t("views.trainees.edit.recommend_for_eyts")
+        else
+          t("views.trainees.edit.recommend_for_award")
+        end
+      end
+
       def defer_link
         govuk_link_to t("views.trainees.edit.defer"), trainee_deferral_path(trainee), class: "defer"
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,6 +284,7 @@ en:
         reinstate: Reinstate
         this_trainee: this trainee
         recommend_for_award: Recommend trainee for QTS
+        recommend_for_eyts: Recommend trainee for EYTS
         status_summary:
           submitted_for_trn: This record is pending a TRN
           deferred: This record is deferred

--- a/spec/views/trainees/show.html.erb_spec.rb
+++ b/spec/views/trainees/show.html.erb_spec.rb
@@ -23,4 +23,23 @@ describe "trainees/show.html.erb", 'feature_routes.provider_led_postgrad': true 
       expect(rendered).to have_text("Placement details")
     end
   end
+
+  context "with non early year trainees that have status trn_received" do
+    let(:non_early_year_trainees) { TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :school_direct_tuition_fee, :school_direct_salaried) }
+    let(:trainee) { create(:trainee, :trn_received, non_early_year_trainees.sample) }
+
+    it "renders the correct text on the button" do
+      expect(rendered).to have_text("Recommend trainee for QTS")
+    end
+  end
+
+  context "with early year trainees that have status trn_received" do
+    let(:early_years_trainees) { TRAINING_ROUTE_ENUMS.values_at(:early_years_assessment_only, :early_years_postgrad, :early_years_salaried, :early_years_undergrad) }
+
+    let(:trainee) { create(:trainee, :trn_received, early_years_trainees.sample) }
+
+    it "renders the correct text on the button" do
+      expect(rendered).to have_text("Recommend trainee for EYTS")
+    end
+  end
 end


### PR DESCRIPTION
### Context

The text on the recommended for QTS button is being changed form `Recommend trainee for QTS` to `Recommend trainee for EYTS` for all early year routes.

### Screenshots

![image](https://user-images.githubusercontent.com/50492247/121196608-8943ad80-c868-11eb-918f-6b05feae3484.png)
![image](https://user-images.githubusercontent.com/50492247/121196650-92cd1580-c868-11eb-8a19-e824aeb6fb88.png)


### Guidance to review

- Navigate to a non early year trainee with a status of `TRN received` and ensure that the green button at the top still says `Recommend trainee for QTS`
- Navigate to a early year trainee with a status of `TRN received` and ensure that the green button at the top now says `Recommend trainee for EYTS`

