### PR TITLE
[1679] Add lead and employing school to DTTP params

### DIFF
--- a/app/lib/dttp/mappable.rb
+++ b/app/lib/dttp/mappable.rb
@@ -57,5 +57,9 @@ module Dttp
     def dttp_qualification_aim_id(training_route)
       CodeSets::QualificationAims::MAPPING.dig(training_route, :entity_id)
     end
+
+    def dttp_school_id(urn)
+      Dttp::School.find_by(urn: urn)&.dttp_id
+    end
   end
 end

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -47,7 +47,7 @@ module Dttp
           "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{dttp_qualification_aim_id(trainee.training_route)})",
           "dfe_programmeyear" => 1, # TODO: this will need to be derived for other routes. It's n of x year course e.g. 1 of 2
           "dfe_programmelength" => 1, # TODO: this will change for other routes as above. So these two are course_year of course_length
-        }.merge(qualifying_degree.uk? ? uk_specific_params : non_uk_specific_params)
+        }.merge(qualifying_degree.uk? ? uk_specific_params : non_uk_specific_params).merge(school_params)
       end
 
       def course_level
@@ -69,6 +69,18 @@ module Dttp
         {
           "dfe_CountryofStudyId@odata.bind" => "/dfe_countries(#{degree_country_id(qualifying_degree.country)})",
         }
+      end
+
+      def school_params
+        return {} unless trainee.requires_schools?
+
+        params = { "dfe_LeadSchoolId@odata.bind" => "/accounts(#{dttp_school_id(trainee.lead_school.urn)})" }
+
+        if trainee.requires_employing_school?
+          params.merge!("dfe_EmployingSchoolId@odata.bind" => "/accounts(#{dttp_school_id(trainee.employing_school.urn)})")
+        end
+
+        params
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/dobeslWP/1679-l-add-employing-and-lead-school-to-the-params

### Changes proposed in this pull request
- Update `Dttp::Params::PlacementAssignment` to include school params if certain conditions are met

### Guidance to review
- It's a bit messy running it manually, but I managed to submit for TRN via console using reall school DTTP IDs
- Open Postman => Retrieve Placement Assignments List Show (DTTP ID should be e338f0c7-67c8-eb11-bacc-000d3ab7dc55)
- Look out for `_dfe_leadschoolid_value` and `_dfe_employingschoolid_value` - they should be populated

