### PR TITLE
[1928] Fix edit link on course details page

### DIFF
--- a/app/controllers/trainees/confirm_publish_course_controller.rb
+++ b/app/controllers/trainees/confirm_publish_course_controller.rb
@@ -7,6 +7,7 @@ module Trainees
     before_action :set_course
 
     def edit
+      page_tracker.save_as_origin!
       @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee)
     end
 

--- a/app/views/trainees/confirm_publish_course/edit.html.erb
+++ b/app/views/trainees/confirm_publish_course/edit.html.erb
@@ -12,7 +12,7 @@
       <%= f.hidden_field :code, value: @course.code %>
       <%= f.govuk_submit t(".confirm_course") %>
     <% end %>
-    <p class="govuk-body"><%= govuk_link_to(t(".edit_details"), "#") %></p>
+    <p class="govuk-body"><%= govuk_link_to(t(".edit_details"),  edit_trainee_publish_course_details_path(@trainee)) %></p>
   </div>
 </div>
 


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/13QTIZor/1928-s-fix-edit-details-for-this-trainee-link)

### Changes proposed in this pull request

- The link that had a placeholder of `#` was changed to `edit_trainee_publish_course_details_path(@trainee)` which links back to the edit publish course details page
- Page tracker tracks the confirm publish course details page so dynamic back links track it

### Guidance to review

- Find a trainee on the Provider Led route who is assigned to a publish course
- Click on change the publish course
- Select a course and follow onto the next page
- Theres a link at the bottom of the page called `Edit details for this trainee only`
- Click that link. You will now be redirected to the course selection page


