### PR TITLE
[1855] Change title on outcome date edit page for early years trainees

### DIFF
--- a/app/views/trainees/outcome_dates/edit.html.erb
+++ b/app/views/trainees/outcome_dates/edit.html.erb
@@ -1,4 +1,6 @@
-<%= render PageTitle::View.new(title: "trainees.outcome_date.edit", has_errors: @outcome_form.errors.present?) %>
+<% text = @trainee.is_early_years? ? I18n.t("components.page_titles.trainees.outcome_date.eyts_edit") : I18n.t("components.page_titles.trainees.outcome_date.edit") %>
+
+<%= render PageTitle::View.new(title: text, has_errors: @outcome_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
@@ -16,13 +18,13 @@
         <%= trainee_name(@trainee) %>
       </span>
 
-      <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: "When did they meet the standards?", tag: "h1", size: "l" }, classes: "outcome-date") do %>
-        <%= f.govuk_radio_button :date_string, :today, label: { text: "Today" }, link_errors: true %>
-        <%= f.govuk_radio_button :date_string, :yesterday, label: { text: "Yesterday" } %>
-        <%= f.govuk_radio_button :date_string, :other, label: { text: "On another day" } do %>
-          <%= f.govuk_date_field :date, legend: { text: t("views.forms.common.on_what_date"), size: "s" }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
+        <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: text, tag: "h1", size: "l" }, classes: "outcome-date") do %>
+          <%= f.govuk_radio_button :date_string, :today, label: { text: "Today" }, link_errors: true %>
+          <%= f.govuk_radio_button :date_string, :yesterday, label: { text: "Yesterday" } %>
+          <%= f.govuk_radio_button :date_string, :other, label: { text: "On another day" } do %>
+            <%= f.govuk_date_field :date, legend: { text: t("views.forms.common.on_what_date"), size: "s" }, hint: { text: t("views.forms.common.for_example") + ", 3 12 2020" } %>
+          <% end %>
         <% end %>
-      <% end %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,7 +154,8 @@ en:
           edit: Degree details
           new: Add undergraduate degree
         outcome_date:
-          edit: When did they meet the standards?
+          edit: When did they meet the QTS standards?
+          eyts_edit: When did they meet the EYTS standards?
           confirm: Check outcome details
         outcome_details:
           confirm_qts: Check QTS details

--- a/spec/features/trainee_actions/recording_training_outcome_spec.rb
+++ b/spec/features/trainee_actions/recording_training_outcome_spec.rb
@@ -7,17 +7,28 @@ feature "Recording a training outcome", type: :feature do
 
   before do
     given_i_am_authenticated
-    given_a_trainee_exists(:trn_received)
-    and_i_am_on_the_trainee_record_page
-    and_i_click_on_record_training_outcome
   end
 
   scenario "submit empty form" do
+    given_a_trainee_exists(:trn_received)
+    and_i_am_on_the_trainee_record_page
+    and_i_click_on_record_training_outcome
+    and_i_see_the_correct_title_for_non_early_years
     and_i_continue
     then_i_see_the_error_message_for_date_not_chosen
   end
 
+  scenario "view correct title for early years" do
+    given_a_trainee_exists(:trn_received, :early_years_salaried)
+    and_i_am_on_the_trainee_record_page
+    and_i_click_on_record_training_outcome
+    i_see_the_correct_title_for_early_years
+  end
+
   scenario "choosing today records the outcome" do
+    given_a_trainee_exists(:trn_received)
+    and_i_am_on_the_trainee_record_page
+    and_i_click_on_record_training_outcome
     when_i_choose_today
     and_i_continue
     then_i_am_redirected_to_the_confirm_outcome_details_page
@@ -27,6 +38,9 @@ feature "Recording a training outcome", type: :feature do
   end
 
   scenario "choosing yesterday records the outcome" do
+    given_a_trainee_exists(:trn_received)
+    and_i_am_on_the_trainee_record_page
+    and_i_click_on_record_training_outcome
     when_i_choose_yesterday
     and_i_continue
     then_i_am_redirected_to_the_confirm_outcome_details_page
@@ -37,6 +51,9 @@ feature "Recording a training outcome", type: :feature do
 
   context "choosing 'On another day'" do
     before do
+      given_a_trainee_exists(:trn_received)
+      and_i_am_on_the_trainee_record_page
+      and_i_click_on_record_training_outcome
       when_i_choose("On another day")
     end
 
@@ -62,6 +79,9 @@ feature "Recording a training outcome", type: :feature do
   end
 
   scenario "cancelling changes" do
+    given_a_trainee_exists(:trn_received)
+    and_i_am_on_the_trainee_record_page
+    and_i_click_on_record_training_outcome
     when_i_choose_today
     and_i_continue
     then_i_am_redirected_to_the_confirm_outcome_details_page
@@ -133,5 +153,17 @@ feature "Recording a training outcome", type: :feature do
 
   def and_the_outcome_date_i_chose_is_cleared
     expect(trainee.reload.outcome_date).to be_nil
+  end
+
+  def and_i_see_the_correct_title_for_non_early_years
+    expect(record_page).to have_content(
+      I18n.t("components.page_titles.trainees.outcome_date.edit"),
+    )
+  end
+
+  def i_see_the_correct_title_for_early_years
+    expect(record_page).to have_content(
+      I18n.t("components.page_titles.trainees.outcome_date.eyts_edit"),
+    )
   end
 end


### PR DESCRIPTION
### Context

The title on the outcome date edit page, for early year trainees is being changed. 
The title on the same page for non early year trainees is also being updated.  

### Guidance to review

https://register-pr-978.london.cloudapps.digital/

- Navigate to a non early year trainee with a status of `TRN received`, click the green `Recommend trainee for QTS` button and check that the page title and heading now says `When did they meet the QTS standards?`

- Navigate to an early year trainee with a status of `TRN received`, click the green `Recommend trainee for QTS` button and check that the page title and heading now says `When did they meet the EYTS standards?`

### Screenshots

![image](https://user-images.githubusercontent.com/50492247/121227937-0f212200-c884-11eb-9da6-84d2fe87f258.png)
![image](https://user-images.githubusercontent.com/50492247/121227981-1c3e1100-c884-11eb-8c10-1417f215ffb8.png)
