### PR TITLE
[1917] Ensure searches can be made without including punctuation/special characters

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -68,6 +68,6 @@ private
   end
 
   def name_without_punctuation
-    name.gsub(/['’.“”"]/, "").gsub(/[^0-9A-Za-z\s]/, " ")
+    StripPunctuation.call(string: name)
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -12,8 +12,7 @@ class School < ApplicationRecord
                       prefix: true,
                       tsvector_column: "searchable",
                     },
-                  },
-                  order_within_rank: :name
+                  }
 
   scope :open, -> { where(close_date: nil) }
   scope :lead_only, -> { where(lead_school: true) }

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -50,7 +50,7 @@ private
   #   "'100000':1 '5de':6 'aldgate':3 'ec3a':5 'ec3a5de':7 'london':8 'school':4 'the':2"
   #
   def update_searchable
-    ts_vector_value = [urn, name, name.gsub(/[^0-9A-Za-z\s]/, ""), postcode, postcode.delete(" "), town].join(" ")
+    ts_vector_value = [urn, name, name_without_punctuation, postcode, postcode.delete(" "), town].join(" ")
 
     to_tsvector = Arel::Nodes::NamedFunction.new(
       "TO_TSVECTOR", [
@@ -66,5 +66,9 @@ private
         .first
         .values
         .first
+  end
+
+  def name_without_punctuation
+    name.gsub(/['’.“”"]/, "").gsub(/[^0-9A-Za-z\s]/, " ")
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -28,12 +28,16 @@ private
   #
   #      TO_TSVECTOR(
   #        'pg_catalog.simple',
-  #        '1000000 The Aldgate School ec3a 5de ec3a5de London'
+  #        '1000000 St Mary''s School ec3a 5de ec3a5de London'
   #      );
   #
   # and assigns the result to the "searchable" field, which is used by pg_search_scope above.
   # This creates a space seperated string with all the searchable info about a school such as:
-  #   "1000000 The Aldgate School ec3a 5de ec3a5de London"
+  #   "1000000 St Marys School ec3a 5de ec3a5de London"
+  #
+  # Special characters are stripped off in the search to ensure that a search matches with
+  # or without them, for example, searching by "mary's" or "marys" will have results including
+  # St Mary's
   #
   # The reason for mentioning the postcode twice is that postgres will split text up by spaces
   # into "words" when converting it into a tsvector. We would like someone to be able to type
@@ -46,7 +50,7 @@ private
   #   "'100000':1 '5de':6 'aldgate':3 'ec3a':5 'ec3a5de':7 'london':8 'school':4 'the':2"
   #
   def update_searchable
-    ts_vector_value = [urn, name, postcode, postcode.delete(" "), town].join(" ")
+    ts_vector_value = [urn, name, name.gsub(/[^0-9A-Za-z\s]/, ""), postcode, postcode.delete(" "), town].join(" ")
 
     to_tsvector = Arel::Nodes::NamedFunction.new(
       "TO_TSVECTOR", [

--- a/app/services/school_search.rb
+++ b/app/services/school_search.rb
@@ -9,7 +9,7 @@ class SchoolSearch
   DEFAULT_LIMIT = 15
 
   def initialize(query: nil, limit: DEFAULT_LIMIT, lead_schools_only: false)
-    @query = query&.gsub(/[^0-9A-Za-z\s]/, "")
+    @query = query&.gsub(/['’.“”"]/, "")&.gsub(/[^0-9A-Za-z\s]/, " ")
     @limit = limit
     @lead_schools_only = lead_schools_only
   end

--- a/app/services/school_search.rb
+++ b/app/services/school_search.rb
@@ -3,13 +3,11 @@
 class SchoolSearch
   include ServicePattern
 
-  attr_reader :query, :limit, :lead_schools_only
-
   MIN_QUERY_LENGTH = 2
   DEFAULT_LIMIT = 15
 
   def initialize(query: nil, limit: DEFAULT_LIMIT, lead_schools_only: false)
-    @query = query&.gsub(/['’.“”"]/, "")&.gsub(/[^0-9A-Za-z\s]/, " ")
+    @query = StripPunctuation.call(string: query)
     @limit = limit
     @lead_schools_only = lead_schools_only
   end
@@ -21,4 +19,8 @@ class SchoolSearch
     schools = schools.lead_only if lead_schools_only
     schools.reorder(:name)
   end
+
+private
+
+  attr_reader :query, :limit, :lead_schools_only
 end

--- a/app/services/school_search.rb
+++ b/app/services/school_search.rb
@@ -19,6 +19,6 @@ class SchoolSearch
     schools = schools.search(query) if query
     schools = schools.limit(limit) if limit
     schools = schools.lead_only if lead_schools_only
-    schools.order(:name)
+    schools.reorder(:name)
   end
 end

--- a/app/services/school_search.rb
+++ b/app/services/school_search.rb
@@ -9,7 +9,7 @@ class SchoolSearch
   DEFAULT_LIMIT = 15
 
   def initialize(query: nil, limit: DEFAULT_LIMIT, lead_schools_only: false)
-    @query = query
+    @query = query&.gsub(/[^0-9A-Za-z\s]/, "")
     @limit = limit
     @lead_schools_only = lead_schools_only
   end

--- a/app/services/strip_punctuation.rb
+++ b/app/services/strip_punctuation.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class StripPunctuation
+  include ServicePattern
+
+  def initialize(string: nil)
+    @string = string
+  end
+
+  def call
+    string&.gsub(/['’.“”"]/, "")&.gsub(/[^0-9A-Za-z\s]/, " ")
+  end
+
+private
+
+  attr_reader :string
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -7,9 +7,9 @@ describe School do
     it "updates the tsvector column with relevant info when the school is updated" do
       school = create(:school)
       expect {
-        school.update(urn: "12345678", name: "St Leo's and Southmead", postcode: "sw1a 1aa", town: "london")
+        school.update(urn: "12345678", name: "St Leo's and Southmead/School", postcode: "sw1a 1aa", town: "london")
       }.to change { school.reload.searchable }.to(
-        "'12345678':1 '1aa':12 'and':5,9 'leo':3 'leos':8 'london':14 's':4 'southmead':6,10 'st':2,7 'sw1a':11 'sw1a1aa':13",
+        "'12345678':1 '1aa':13 'and':5,9 'leo':3 'leos':8 'london':15 's':4 'school':11 'southmead':10 'southmead/school':6 'st':2,7 'sw1a':12 'sw1a1aa':14",
       )
     end
   end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -7,9 +7,9 @@ describe School do
     it "updates the tsvector column with relevant info when the school is updated" do
       school = create(:school)
       expect {
-        school.update(urn: "12345678", name: "School of life", postcode: "sw1a 1aa", town: "london")
+        school.update(urn: "12345678", name: "St Leo's and Southmead", postcode: "sw1a 1aa", town: "london")
       }.to change { school.reload.searchable }.to(
-        "'12345678':1 '1aa':6 'life':4 'london':8 'of':3 'school':2 'sw1a':5 'sw1a1aa':7",
+        "'12345678':1 '1aa':12 'and':5,9 'leo':3 'leos':8 'london':14 's':4 'southmead':6,10 'st':2,7 'sw1a':11 'sw1a1aa':13",
       )
     end
   end

--- a/spec/services/school_search_spec.rb
+++ b/spec/services/school_search_spec.rb
@@ -57,6 +57,19 @@ describe SchoolSearch do
       end
     end
 
+    context "with special characters" do
+      let!(:school_two) { create(:school, name: "St Mary's Kilburn") }
+      let!(:school_one) { create(:school, name: "St Marys the Mount School") }
+
+      it "matches all" do
+        expect(described_class.call(query: "mary's")).to match_array([school_one, school_two])
+      end
+
+      it "matches all without punctuations" do
+        expect(described_class.call(query: "marys")).to match_array([school_one, school_two])
+      end
+    end
+
     context "searching lead schools" do
       let(:lead_school) { create(:school, lead_school: true) }
 

--- a/spec/services/school_search_spec.rb
+++ b/spec/services/school_search_spec.rb
@@ -43,16 +43,17 @@ describe SchoolSearch do
     end
 
     context "search order" do
-      let!(:school_two) { create(:school, name: "The London Acorn School") }
-      let!(:school_one) { create(:school, name: "Acorn Park School") }
+      let!(:school_one) { create(:school, name: "Acorn Park School, London") }
+      let!(:school_two) { create(:school, name: "Beaumont Parking School", town: "London") }
+      let!(:school_three) { create(:school, name: "Parking School, London") }
 
       it "orders the results alphabetically" do
-        expect(described_class.call).to eq([school_one, school_two])
+        expect(described_class.call).to eq([school_one, school_two, school_three])
       end
 
       context "with a search query" do
         it "orders the results alphabetically" do
-          expect(described_class.call(query: "acorn")).to eq([school_one, school_two])
+          expect(described_class.call(query: "London")).to eq([school_one, school_two, school_three])
         end
       end
     end

--- a/spec/services/school_search_spec.rb
+++ b/spec/services/school_search_spec.rb
@@ -58,8 +58,9 @@ describe SchoolSearch do
     end
 
     context "with special characters" do
-      let!(:school_two) { create(:school, name: "St Mary's Kilburn") }
       let!(:school_one) { create(:school, name: "St Marys the Mount School") }
+      let!(:school_two) { create(:school, name: "St Mary's Kilburn") }
+      let!(:school_three) { create(:school, name: "Beaumont College - A Salutem/Ambito College") }
 
       it "matches all" do
         expect(described_class.call(query: "mary's")).to match_array([school_one, school_two])
@@ -67,6 +68,10 @@ describe SchoolSearch do
 
       it "matches all without punctuations" do
         expect(described_class.call(query: "marys")).to match_array([school_one, school_two])
+      end
+
+      it "ignores non-punctuation characters" do
+        expect(described_class.call(query: "Salutem Ambito")).to eq([school_three])
       end
     end
 

--- a/spec/services/strip_punctuation_spec.rb
+++ b/spec/services/strip_punctuation_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe StripPunctuation do
+  it "returns nil" do
+    expect(described_class.call(string: nil)).to be_nil
+  end
+
+  it "strips quotes" do
+    expect(described_class.call(string: 'Samantha "Sam" O\'Hara')).to eq("Samantha Sam OHara")
+  end
+
+  it "strips curly quotes" do
+    expect(described_class.call(string: "Samantha “Sam” O’Hara")).to eq("Samantha Sam OHara")
+  end
+
+  it "strips out full stops" do
+    expect(described_class.call(string: "St. Paul's With St. Michael's")).to eq("St Pauls With St Michaels")
+  end
+
+  it "replaces special characters with spaces" do
+    expect(described_class.call(string: "Peakirk-Cum-Glinton School,Peterborough")).to eq("Peakirk Cum Glinton School Peterborough")
+  end
+end


### PR DESCRIPTION
### Context
This change will ensure that apostrophes and other special characters are stripped off when searching, as well as when updating the ts_vector

### Changes proposed in this pull request
1. Strip non alphabetic characters when querying
2. Strip non alphabetic characters when updating the ts vector 

### Guidance to review
1. Ensure that you have schools with names containing non-alphabetic characters (eg, St Mary's/Andrew's). 
  If not, they can be loaded using `bundle exec rake schools_data:import`.
2. Create a Trainee in the school direct route, and visit the Schools section.
3. In the School picker, search for the name with and without, eg: `Marys` or `Mary's`. Both should return the same results.

