### PR TITLE
[1929], [1930] and [1931] - A couple of small provider-led snags

### DIFF
--- a/app/components/summary_card/style.scss
+++ b/app/components/summary_card/style.scss
@@ -22,11 +22,7 @@
   .app-summary-card__title {
     @include govuk-font($size: 19);
     margin-top: 0;
-    margin-bottom: govuk-spacing(2);
-
-    @include govuk-media-query($from: desktop) {
-      margin: 0;
-    }
+    margin-bottom: 0;
   }
 
   .app-summary-card__actions {

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -9,8 +9,8 @@
 
 <%= render ReviewDraft::View.new(trainee: @trainee) %>
 
-<h2 class="govuk-heading-m">Review and submit</h2>
-  <%= render GovukButtonLinkTo::View.new(body: "Review this record", url: check_details_trainee_path(@trainee), id: "check-details") %>
+<h2 class="govuk-heading-m">Final check</h2>
+  <%= render GovukButtonLinkTo::View.new(body: "Check this record", url: check_details_trainee_path(@trainee), id: "check-details") %>
 <p class="govuk-body"><%= govuk_link_to("Return to this draft record later", trainees_path) %></p>
 
 <p class="govuk-body govuk-!-margin-top-8">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,7 +126,7 @@ en:
       trn_submissions:
         show: Successfully submitted
       check_details:
-        show: Review trainee record
+        show: Check trainee record
       trainees:
         delete: Delete this draft record
         index: Trainee records (%{total_trainees_count_text})


### PR DESCRIPTION
### Context

- https://trello.com/c/f5rQzGTW/1929-s-replace-review-and-submit-with-final-check
- https://trello.com/c/NjL0oeqK/1930-s-check-h2-margins
- https://trello.com/c/tiZZ3nUj/1931-s-change-page-title-to-record-submitted-on-trn-record-submission-page

### Changes proposed in this pull request

- A couple of snags from the provider-led demo

### Guidance to review

- https://register-pr-980.london.cloudapps.digital/