### PR TITLE
[1863] Update 4th bullet point on signed out homepage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,7 +394,7 @@ en:
         1: register trainee data with the Department for Education, and keep it updated
         2: get a teacher reference number (TRN) for your trainees
         3: share information about a trainee’s progress, such as whether they withdraw or defer
-        4: recommend your trainees for qualified teacher status (QTS)
+        4: recommend your trainees for qualified teacher status (QTS) or early years teacher status (EYTS)
     cookie_policy:
       heading: Cookies on Register trainee teachers
     badges:


### PR DESCRIPTION
### Context

Updating the 4th bullet point on the signed out homepage to reflect early year routes.

### Guidance to review

- Navigate to the [signed out home page](https://register-pr-981.london.cloudapps.digital/)

- Check that the fourth bullet point includes early years and matches the prototype.