### PR TITLE
[1932] Course details form persists course_code if exists

### DIFF
--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -19,6 +19,7 @@ module Trainees
       end
 
       if @publish_course_details.manual_entry_chosen?
+        trainee.update!(course_code: nil)
         redirect_to edit_trainee_course_details_path
       else
         redirect_to edit_trainee_confirm_publish_course_path(id: @publish_course_details.code, trainee_id: @trainee.slug)

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -101,7 +101,7 @@ private
 
   def update_trainee_attributes
     trainee.assign_attributes({
-      course_code: nil,
+      course_code: course_code,
       subject: subject,
       subject_two: subject_two,
       subject_three: subject_three,

--- a/spec/forms/course_detail_form_spec.rb
+++ b/spec/forms/course_detail_form_spec.rb
@@ -320,6 +320,19 @@ describe CourseDetailsForm, type: :model do
           .and change { trainee.course_end_date }
           .from(nil).to(Date.parse(valid_end_date.to_s))
       end
+
+      context "when a trainee has a course code" do
+        let(:trainee) { create(:trainee, course_code: Faker::Alphanumeric.alphanumeric(number: 4).upcase) }
+
+        before do
+          subject.save!
+          trainee.reload
+        end
+
+        it "doesnt wipe course code" do
+          expect(trainee.course_code).to_not eq nil
+        end
+      end
     end
 
     describe "#stash" do


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/OiYr9UZr/1932-m-when-you-edit-the-details-fro-a-publish-course-it-forgets-that-its-a-publish-course)

### Changes proposed in this pull request

- `course_code` param in the form was being set to nil, but there was a `course_code` method already implemented which persists the trainee course code. I set the params to use this `course_code` method

### Guidance to review

- Create a trainee on a Provider Led Postgrad route
- Assign them to a Publish Course
- Confirm the course
- Change that course subject
- The publish course will now not be wiped and the course will persist on the next confirm page, with the new subject attached to the trainee

