### PR TITLE
[1979] Add all routes to example data rake

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -13,25 +13,22 @@ namespace :example_data do
     FactoryBot.create_list(:school, 50)
     FactoryBot.create_list(:school, 50, lead_school: true)
 
-    trait_combinations = [
-      [],
-      %i[with_start_date with_course_details diversity_disclosed],
-      %i[with_start_date with_course_details diversity_not_disclosed],
-      %i[with_start_date submitted_for_trn with_placement_assignment with_course_details diversity_disclosed],
-      %i[with_start_date submitted_for_trn with_placement_assignment with_course_details diversity_not_disclosed],
-      %i[with_start_date trn_received with_placement_assignment with_course_details diversity_disclosed],
-      %i[with_start_date trn_received with_placement_assignment with_course_details diversity_not_disclosed],
-      %i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details diversity_disclosed],
-      %i[with_start_date recommended_for_award with_placement_assignment with_outcome_date with_course_details diversity_not_disclosed],
-      %i[with_start_date withdrawn with_placement_assignment with_course_details diversity_disclosed],
-      %i[with_start_date withdrawn with_placement_assignment with_course_details diversity_not_disclosed],
-      %i[with_start_date deferred with_placement_assignment with_course_details diversity_disclosed],
-      %i[with_start_date deferred with_placement_assignment with_course_details diversity_not_disclosed],
-      %i[with_start_date awarded with_placement_assignment with_outcome_date with_course_details diversity_disclosed],
-      %i[with_start_date awarded with_placement_assignment with_outcome_date with_course_details diversity_not_disclosed],
-    ]
+    # Base our example data on the currently switched-on feature flags
+    enabled_routes = TRAINING_ROUTE_FEATURE_FLAGS.select { |flag| FeatureService.enabled?("routes.#{flag}") }
+                                                 .compact
+                                                 .push(:assessment_only)
+    enabled_course_routes = enabled_routes & TRAINING_ROUTES_FOR_COURSE.keys.map(&:to_sym)
 
+    # Create some schools
+    employing_schools = FactoryBot.create_list(:school, 50)
+    lead_schools = FactoryBot.create_list(:school, 50, lead_school: true)
+
+    # Create some subjects
+    subjects = FactoryBot.create_list(:subject, 20)
+
+    # For each persona...
     PERSONAS.each do |persona_attributes|
+      # Create the persona
       persona = Persona.find_or_create_by!(first_name: persona_attributes[:first_name],
                                            last_name: persona_attributes[:last_name],
                                            email: persona_attributes[:email],
@@ -40,63 +37,41 @@ namespace :example_data do
 
       next unless persona_attributes[:provider]
 
+      # Create the provider for that persona
       provider = Provider.find_or_create_by!(
         name: persona_attributes[:provider],
         dttp_id: SecureRandom.uuid,
         code: Faker::Alphanumeric.alphanumeric(number: 3).upcase,
       )
-      FactoryBot.create_list(:course, rand(30..70), accredited_body_code: provider.code, route: "provider_led_postgrad")
       persona.update!(provider: provider)
 
-      rand(50...100).times do
-        traits = trait_combinations.sample
+      # For each of the course routes enabled...
+      enabled_course_routes.each do |route|
+        # Create some courses for that provider with some subjects
+        courses = FactoryBot.build_list(:course, rand(10..70), accredited_body_code: provider.code, route: route) do |course|
+          course.subjects = subjects.sample(rand(1..3))
+        end
+        courses.each(&:save!)
+      end
 
-        created_at = Faker::Date.between(from: 100.days.ago, to: 50.days.ago)
-        submitted_for_trn_at = nil
-        trn = nil
-        progress = {}
+      # For each route that's enabled...
+      enabled_routes.each do |route|
+        # And for all possible trainee states...
+        Trainee.states.keys.map(&:to_sym).each do |state|
+          # Create small number of trainees
+          rand(1...4).times do
+            attrs = { created_at: Faker::Date.between(from: 100.days.ago, to: 50.days.ago) }
+            attrs.merge!(provider: provider) if provider
 
-        if traits.length > 3 # this trainee isn't draft
+            # Some route-specific logic, but could move into factories too
+            attrs.merge!(lead_school: lead_schools.sample) if %i[school_direct_salaried school_direct_tuition_fee].include?(route)
+            attrs.merge!(employing_school: employing_schools.sample) if route == :school_direct_salaried
 
-          # mark the sections complete
-          progress = {
-            personal_details: true,
-            contact_details: true,
-            degrees: true,
-            diversity: true,
-            course_details: true,
-            training_details: true,
-          }
+            trainee = FactoryBot.create(:trainee, route, state, attrs)
 
-          # set the submitted_for_trn_at date as they will have at least been submitted
-          submitted_for_trn_at = traits.any? ? Faker::Date.between(from: created_at, to: created_at + 40.days) : nil
-
-          unless traits.include?(:submitted_for_trn)
-            # this trainee is past getting trn so set it
-            trn = Faker::Number.number(digits: 10)
+            # Add an extra nationality 20% of the time
+            trainee.nationalities << Nationality.all.sample if rand(10) < 2
           end
-        end
-
-        trainee_attributes = {
-          created_at: created_at,
-          submitted_for_trn_at: submitted_for_trn_at,
-          trn: trn,
-          progress: progress,
-          updated_at: submitted_for_trn_at || created_at,
-        }
-
-        trainee_attributes.merge!(provider: provider) if provider
-
-        trainee = FactoryBot.create(:trainee, *traits, trainee_attributes)
-
-        [1, 1, 1, 1, 1, 2].sample.times do # multiple nationalities are less common
-          trainee.nationalities << Nationality.all.sample
-        end
-
-        next if trainee.draft?
-
-        [1, 2].sample.times do
-          trainee.degrees << FactoryBot.build(:degree, %i[uk_degree_with_details non_uk_degree_with_details].sample)
         end
       end
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -153,40 +153,45 @@ FactoryBot.define do
     end
 
     trait :submitted_for_trn do
-      state { "submitted_for_trn" }
-      submitted_for_trn_at { Time.zone.now }
+      completed
       dttp_id { SecureRandom.uuid }
+      submitted_for_trn_at { Time.zone.now }
+      state { "submitted_for_trn" }
     end
 
     trait :trn_received do
       submitted_for_trn
+      trn { SecureRandom.uuid }
       state { "trn_received" }
-      dttp_id { SecureRandom.uuid }
     end
 
     trait :recommended_for_award do
-      state { "recommended_for_award" }
+      trn_received
       recommended_for_award_at { Time.zone.now }
+      state { "recommended_for_award" }
     end
 
     trait :withdrawn do
-      state { "withdrawn" }
+      trn_received
       withdraw_date { Faker::Date.in_date_period }
+      state { "withdrawn" }
     end
 
     trait :deferred do
-      submitted_for_trn
-      state { "deferred" }
+      trn_received
       defer_date { Faker::Date.in_date_period }
+      state { "deferred" }
     end
 
     trait :reinstated do
-      state { "trn_received" }
+      completed
       defer_date { Faker::Date.in_date_period }
       reinstate_date { Faker::Date.in_date_period }
+      state { "trn_received" }
     end
 
     trait :awarded do
+      recommended_for_award
       state { "awarded" }
     end
 

--- a/spec/features/form_sections/personal_and_education_details/degrees/editing_degree_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/degrees/editing_degree_spec.rb
@@ -39,7 +39,7 @@ feature "editing a degree" do
 
     context "non-draft trainee" do
       scenario "the user enters valid details" do
-        given_a_non_trainee_with_a_uk_degree
+        given_a_non_draft_trainee_with_a_uk_degree
         when_i_visit_the_edit_degree_details_page
         and_i_enter_valid_uk_degree_details
         and_i_click_the_continue_button
@@ -75,8 +75,8 @@ private
     uk_trainee
   end
 
-  def given_a_non_trainee_with_a_uk_degree
-    uk_trainee(trait: :submitted_for_trn)
+  def given_a_non_draft_trainee_with_a_uk_degree
+    @uk_trainee ||= create(:trainee, :submitted_for_trn, provider: current_user.provider)
   end
 
   def given_a_trainee_with_a_non_uk_degree

--- a/spec/models/trainee/state_transitions_spec.rb
+++ b/spec/models/trainee/state_transitions_spec.rb
@@ -29,7 +29,7 @@ describe "Trainee state transitions" do
       end
 
       context "without an existing trn" do
-        let(:trainee) { create(:trainee, :deferred) }
+        let(:trainee) { create(:trainee, :deferred, trn: nil) }
         it "raises an error if no trn is provided" do
           expect {
             trainee.trn_received!
@@ -66,7 +66,7 @@ describe "Trainee state transitions" do
       end
 
       context "without an existing trn" do
-        let(:trainee) { create(:trainee, :withdrawn) }
+        let(:trainee) { create(:trainee, :withdrawn, trn: nil) }
 
         it "doesnt update state but updates trn" do
           trainee.trn_received!(new_trn)


### PR DESCRIPTION
### Context

For discussion re direction of example data.

### Changes proposed in this pull request

- Created a completely new rake task for testing `rake example_data_new:generate`
- This is based on having minimal viable valid `FactoryBot` traits and using them.

### Guidance to review

Truncate your local DB and run `rake example_data_new:generate`.
Check out the created trainees.