### PR TITLE
[1935] Fix missing course subject 2 & 3 from timeline

### DIFF
--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -27,8 +27,8 @@ module Trainees
       additional_ethnic_background
       disability_disclosure
       subject
-      course_min_age
-      course_max_age
+      subject_two
+      subject_three
       course_start_date
       course_end_date
       commencement_date
@@ -40,6 +40,8 @@ module Trainees
       country
       other_grade
     ].freeze
+
+    AGE_RANGE_FIELDS = %w[course_min_age course_max_age].freeze
 
     delegate :user, :created_at, :auditable_type, :audited_changes, :auditable, to: :audit
 
@@ -56,7 +58,9 @@ module Trainees
         )
       else
         audited_changes.map do |field, _|
-          next unless FIELDS.include?(field)
+          next unless FIELDS.include?(field) || AGE_RANGE_FIELDS.include?(field)
+
+          field = "course_age_range" if AGE_RANGE_FIELDS.include?(field)
 
           TimelineEvent.new(
             title: I18n.t("components.timeline.titles.#{model}.#{field}", default: "#{field.humanize} updated"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,9 +234,10 @@ en:
           qts_awarded: QTS awarded
           eyts_awarded: EYTS awarded
           reinstated: Trainee reinstated
-          course_min_age: Course min age updated
-          course_max_age: Course max age updated
+          course_age_range: Course age range updated
           subject: Course subject updated
+          subject_two: Course subject two updated
+          subject_three: Course subject three updated
           commencement_date: Start date updated
           trainee_id: Trainee ID updated
           disability_disclosure: Disability disclosures updated


### PR DESCRIPTION
### Context
https://trello.com/c/dyEZOnTS/1935-bug-course-subject-2-3-not-displayed-in-timeline

### Changes proposed in this pull request
- Add `subject_two` anf `subject_three` to `Trainees::CreateTimelineEvents::FIELDS`

### Result
<img width="718" alt="Screenshot 2021-06-09 at 16 05 56" src="https://user-images.githubusercontent.com/28728/121380200-96ca6780-c93c-11eb-81f7-fce7ccd038a8.png">

