### PR TITLE
[1846] add EYTS state filter

### DIFF
--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -55,7 +55,7 @@
                   Status
                 </legend>
                 <div class="govuk-checkboxes govuk-checkboxes--small">
-                  <% Trainee.states.map do |state, _| %>
+                  <% TraineeFilter::STATES.map do |state, _| %>
                     <div class="govuk-checkboxes__item">
                       <%= check_box_tag "state[]", state, checked?(:state, state), id: "state-#{state}", class: "govuk-checkboxes__input" %>
                       <%= label_tag "state-#{state}", label_for("state", state), class: "govuk-label govuk-checkboxes__label" %>

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -121,6 +121,15 @@ class Trainee < ApplicationRecord
   # Returns draft trainees first, then all trainees in any other state.
   scope :ordered_by_drafts, -> { order(ordered_by_drafts_clause) }
 
+  scope :with_award_states, lambda { |*award_states|
+    qts_states = award_states.select { |s| s.start_with? "qts" }.map { |s| genericize_state(s) }
+    eyts_states = award_states.select { |s| s.start_with? "eyts" }.map { |s| genericize_state(s) }
+
+    where(training_route: EARLY_YEARS_ROUTES, state: eyts_states).or(
+      where(state: qts_states).where.not(training_route: EARLY_YEARS_ROUTES),
+    )
+  }
+
   audited associated_with: :provider
   has_associated_audits
 
@@ -193,5 +202,15 @@ class Trainee < ApplicationRecord
 
   def route_data_manager
     @route_data_manager ||= RouteDataManager.new(trainee: self)
+  end
+
+  def self.genericize_state(state)
+    if state.end_with? "awarded"
+      "awarded"
+    elsif state.end_with? "recommended"
+      "recommended_for_award"
+    else
+      state
+    end
   end
 end

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class TraineeFilter
+  AWARD_STATES = %w[qts_recommended qts_awarded eyts_recommended eyts_awarded].freeze
+  STATES = Trainee.states.keys.excluding("recommended_for_award", "awarded") + AWARD_STATES
+
   def initialize(params:)
     @params = params
   end
@@ -42,7 +45,7 @@ private
   end
 
   def state_options
-    Trainee.states.keys.each_with_object([]) do |option, arr|
+    STATES.each_with_object([]) do |option, arr|
       arr << option if params[:state]&.include?(option)
     end
   end

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -25,10 +25,17 @@ module Trainees
       trainees.where(training_route: training_route)
     end
 
-    def state(trainees, state)
-      return trainees if state.blank?
+    def state(trainees, states)
+      return trainees if states.blank?
 
-      trainees.where(state: state)
+      non_award_states = states.dup
+
+      award_states = []
+      states.each do |state|
+        award_states << non_award_states.delete(state) if TraineeFilter::AWARD_STATES.include? state
+      end
+
+      trainees.where(state: non_award_states).or(trainees.with_award_states(*award_states))
     end
 
     def subject(trainees, subject)

--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class HomeView
-  EARLY_YEARS_ROUTES = TRAINING_ROUTE_AWARD_TYPE.select { |_, v| v == "EYTS" }.keys.freeze
-
   def initialize(trainees)
     @trainees = trainees
     populate_state_counts!
@@ -41,14 +39,12 @@ private
   def eyts_trainees?
     return @_eyts_trainees if defined?(@_eyts_trainees)
 
-    @_eyts_trainees =
-      @trainees.where(training_route: EARLY_YEARS_ROUTES, state: %i[awarded recommended_for_award]).count.positive?
+    @_eyts_trainees = @trainees.with_award_states("eyts_recommended", "eyts_awarded").count.positive?
   end
 
   def qts_trainees?
     return @_qts_trainees if defined?(@_qts_trainees)
 
-    @_qts_trainees =
-      @trainees.where(state: %i[awarded recommended_for_award]).where.not(training_route: EARLY_YEARS_ROUTES).count.positive?
+    @_qts_trainees = @trainees.with_award_states("qts_recommended", "qts_awarded").count.positive?
   end
 end

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -47,3 +47,5 @@ TRAINING_ROUTE_AWARD_TYPE = {
   school_direct_salaried: "QTS",
   school_direct_tuition_fee: "QTS",
 }.freeze
+
+EARLY_YEARS_ROUTES = TRAINING_ROUTE_AWARD_TYPE.select { |_, v| v == "EYTS" }.keys.freeze

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,9 +90,6 @@ ActiveRecord::Schema.define(version: 2021_06_03_171313) do
     t.index ["code"], name: "index_courses_on_code", unique: true
   end
 
-  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
-  end
-
   create_table "degrees", force: :cascade do |t|
     t.integer "locale_code", null: false
     t.string "uk_degree"

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -190,6 +190,26 @@ FactoryBot.define do
       state { "awarded" }
     end
 
+    trait :eyts_awarded do
+      training_route { EARLY_YEARS_ROUTES.sample }
+      state { "awarded" }
+    end
+
+    trait :eyts_recommended do
+      training_route { EARLY_YEARS_ROUTES.sample }
+      state { "recommended_for_award" }
+    end
+
+    trait :qts_awarded do
+      training_route { "school_direct_salaried" }
+      state { "awarded" }
+    end
+
+    trait :qts_recommended do
+      training_route { "school_direct_salaried" }
+      state { "recommended_for_award" }
+    end
+
     trait :with_dttp_dormancy do
       deferred
       dormancy_dttp_id { SecureRandom.uuid }

--- a/spec/models/trainee_filter_spec.rb
+++ b/spec/models/trainee_filter_spec.rb
@@ -53,7 +53,7 @@ describe TraineeFilter do
     end
 
     context "with invalid state" do
-      let(:params) { { training_route: %w[not_a_state] } }
+      let(:params) { { state: %w[not_a_state] } }
       include_examples returns_nil
     end
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -49,6 +49,19 @@ describe Trainee do
     end
   end
 
+  context "scopes" do
+    describe "with_award_states" do
+      it "returns tainees with the correct training route and state" do
+        create(:trainee, :trn_received)
+        qts_awarded = create(:trainee, :qts_awarded)
+        eyts_recommended = create(:trainee, :eyts_recommended)
+        create(:trainee, :eyts_awarded)
+
+        expect(Trainee.with_award_states(:qts_awarded, :eyts_recommended)).to contain_exactly(qts_awarded, eyts_recommended)
+      end
+    end
+  end
+
   context "associations" do
     it { is_expected.to belong_to(:provider) }
     it { is_expected.to belong_to(:apply_application).optional }

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -21,9 +21,11 @@ module Trainees
 
     context "with state filter" do
       let!(:submitted_for_trn_trainee) { create(:trainee, :submitted_for_trn) }
-      let(:filters) { { state: "submitted_for_trn" } }
+      let!(:qts_awarded_trainee) { create(:trainee, :qts_awarded) }
+      let!(:eyts_awarded_trainee) { create(:trainee, :eyts_awarded) }
+      let(:filters) { { state: %w[submitted_for_trn qts_awarded] } }
 
-      it { is_expected.to eq([submitted_for_trn_trainee]) }
+      it { is_expected.to contain_exactly(submitted_for_trn_trainee, qts_awarded_trainee) }
     end
 
     context "with subject filter" do


### PR DESCRIPTION
### Context

https://trello.com/c/skmQZxkS/1846-m-ey-add-eyts-states-to-the-state-filter

### Changes proposed in this pull request
- Change the existing state filters for QTS to only return QTS trainees in award states
- Add EYTS state filters to the trainee index page
- rename trainee filter spec so that it runs as part of the test suite
- slight refactor of home view to utilize new scopes

### Guidance to review
<img width="1910" alt="Screenshot 2021-06-10 at 12 13 17" src="https://user-images.githubusercontent.com/823643/121515627-4eb34f80-c9e5-11eb-8cb8-354365a65d3e.png">

