### PR TITLE
[1933] Show a query is shorter than the limit error message

### DIFF
--- a/app/components/form_components/schools_autocomplete/script.js
+++ b/app/components/form_components/schools_autocomplete/script.js
@@ -70,6 +70,8 @@ const setSchoolHiddenField = (value) => {
 const setupAutoComplete = (form) => {
   const element = form.querySelector('#schools-autocomplete-element')
   const inputs = form.querySelectorAll('[data-field="schools-autocomplete"]')
+  const defaultValueOption = element.getAttribute('data-default-value') || ''
+  const fieldName = element.getAttribute('data-field-name') || ''
 
   try {
     inputs.forEach(input => {
@@ -77,6 +79,8 @@ const setupAutoComplete = (form) => {
         element: element,
         id: input.id,
         minLength: 2,
+        defaultValue: defaultValueOption,
+        name: fieldName,
         source: (query, populateResults) => {
           return findSchools({
             query,

--- a/app/controllers/api/schools_controller.rb
+++ b/app/controllers/api/schools_controller.rb
@@ -25,7 +25,7 @@ module Api
     end
 
     def error_response
-      render_json_error(message: I18n.t("api.schools.errors.bad_request"), status: :bad_request)
+      render_json_error(message: I18n.t("api.schools.errors.bad_request", length: SchoolSearch::MIN_QUERY_LENGTH), status: :bad_request)
     end
 
     def lead_schools_only

--- a/app/controllers/trainees/employing_schools_controller.rb
+++ b/app/controllers/trainees/employing_schools_controller.rb
@@ -4,7 +4,6 @@ module Trainees
   class EmployingSchoolsController < ApplicationController
     before_action :authorize_trainee
     before_action :load_schools
-    before_action :redirect_to_search_page, only: :update
 
     helper_method :query
 
@@ -19,7 +18,7 @@ module Trainees
     def update
       @employing_school_form = Schools::EmployingSchoolForm.new(trainee, params: trainee_params, user: current_user)
 
-      if @employing_school_form.searching_again? && @employing_school_form.valid?
+      if @employing_school_form.school_not_selected? && @employing_school_form.valid?
         return redirect_to trainee_employing_schools_path(@trainee, query: query)
       end
 
@@ -33,13 +32,6 @@ module Trainees
     end
 
   private
-
-    def redirect_to_search_page
-      return if params["input-autocomplete"] && params["input-autocomplete"].length < SchoolSearch::MIN_QUERY_LENGTH
-      return if query.present?
-
-      redirect_to trainee_employing_schools_path(trainee, query: params["input-autocomplete"]) if trainee_params[:employing_school_id].blank?
-    end
 
     def load_schools
       @schools = SchoolSearch.call(query: query)
@@ -59,7 +51,7 @@ module Trainees
       # submits the form with results but hasn't made a choice, we re-render the page with the previous results
       # including a validation message. Even though the search again field is hidden in this scenario, it will be
       # included in the form data, therefore we have to take that into account.
-      trainee_params[:results_search_again_query].presence || trainee_params[:no_results_search_again_query] || params[:query]
+      trainee_params[:results_search_again_query].presence || trainee_params[:no_results_search_again_query] || trainee_params[:query] || params[:query]
     end
 
     def index_or_edit_page

--- a/app/controllers/trainees/lead_schools_controller.rb
+++ b/app/controllers/trainees/lead_schools_controller.rb
@@ -4,7 +4,6 @@ module Trainees
   class LeadSchoolsController < ApplicationController
     before_action :authorize_trainee
     before_action :load_schools
-    before_action :redirect_to_search_page, only: :update
 
     helper_method :query
 
@@ -19,7 +18,7 @@ module Trainees
     def update
       @lead_school_form = Schools::LeadSchoolForm.new(trainee, params: trainee_params, user: current_user)
 
-      if @lead_school_form.searching_again? && @lead_school_form.valid?
+      if @lead_school_form.school_not_selected? && @lead_school_form.valid?
         return redirect_to trainee_lead_schools_path(@trainee, query: query)
       end
 
@@ -36,13 +35,6 @@ module Trainees
 
     def redirect_url
       trainee.requires_employing_school? ? edit_trainee_employing_schools_path(trainee) : trainee_schools_confirm_path(trainee)
-    end
-
-    def redirect_to_search_page
-      return if params["input-autocomplete"] && params["input-autocomplete"].length < SchoolSearch::MIN_QUERY_LENGTH
-      return if query.present?
-
-      redirect_to trainee_lead_schools_path(trainee, query: params["input-autocomplete"]) if trainee_params[:lead_school_id].blank?
     end
 
     def load_schools
@@ -72,7 +64,7 @@ module Trainees
       # submits the form with results but hasn't made a choice, we re-render the page with the previous results
       # including a validation message. Even though the search again field is hidden in this scenario, it will be
       # included in the form data, therefore we have to take that into account.
-      trainee_params[:results_search_again_query].presence || trainee_params[:no_results_search_again_query] || params[:query]
+      trainee_params[:results_search_again_query].presence || trainee_params[:no_results_search_again_query] || trainee_params[:query] || params[:query]
     end
 
     def index_or_edit_page

--- a/app/forms/schools/employing_school_form.rb
+++ b/app/forms/schools/employing_school_form.rb
@@ -8,7 +8,7 @@ module Schools
 
     attr_accessor(*FIELDS)
 
-    validates :employing_school_id, presence: true, unless: -> { searching_again? }
+    validates :employing_school_id, presence: true, unless: -> { school_not_selected? }
 
     alias_method :school_id, :employing_school_id
 

--- a/app/forms/schools/form.rb
+++ b/app/forms/schools/form.rb
@@ -3,6 +3,7 @@
 module Schools
   class Form < TraineeForm
     NON_TRAINEE_FIELDS = %i[
+      query
       results_search_again_query
       no_results_search_again_query
       school_value
@@ -10,15 +11,33 @@ module Schools
 
     attr_accessor(*NON_TRAINEE_FIELDS)
 
-    validates :results_search_again_query, presence: true, if: -> { results_search_again_query? }
-    validates :no_results_search_again_query, presence: true, if: -> { no_results_searching_again? }
+    validates :query,
+              length: {
+                minimum: SchoolSearch::MIN_QUERY_LENGTH,
+                message: I18n.t("activemodel.errors.models.schools_form.attributes.query.length"),
+              },
+              if: -> { initial_incomplete_search? }
+
+    validates :results_search_again_query,
+              length: {
+                minimum: SchoolSearch::MIN_QUERY_LENGTH,
+                message: I18n.t("activemodel.errors.models.schools_form.attributes.query.length"),
+              },
+              if: -> { results_searching_again? }
+
+    validates :no_results_search_again_query,
+              length: {
+                minimum: SchoolSearch::MIN_QUERY_LENGTH,
+                message: I18n.t("activemodel.errors.models.schools_form.attributes.query.length"),
+              },
+              if: -> { no_results_searching_again? }
 
     def searching_again?
-      results_search_again_query? || no_results_searching_again?
+      results_searching_again? || no_results_searching_again?
     end
 
-    def results_search_again_query?
-      school_id == "results_search_again"
+    def results_searching_again?
+      school_id == "results_search_again" || results_search_again_query.present?
     end
 
     def no_results_searching_again?
@@ -27,6 +46,14 @@ module Schools
 
     def index_page_radio_buttons?
       school_value == "true"
+    end
+
+    def initial_incomplete_search?
+      query.present? && school_id.blank?
+    end
+
+    def school_not_selected?
+      searching_again? || initial_incomplete_search?
     end
 
   private

--- a/app/forms/schools/lead_school_form.rb
+++ b/app/forms/schools/lead_school_form.rb
@@ -8,7 +8,7 @@ module Schools
 
     attr_accessor(*FIELDS)
 
-    validates :lead_school_id, presence: true, unless: -> { searching_again? }
+    validates :lead_school_id, presence: true, unless: -> { school_not_selected? }
 
     alias_method :school_id, :lead_school_id
 

--- a/app/views/trainees/employing_schools/_results.html.erb
+++ b/app/views/trainees/employing_schools/_results.html.erb
@@ -10,11 +10,15 @@
   </div>
 <% end %>
 
+
+<%= f.hidden_field :employing_school_id, value: nil %>
+
 <%= f.govuk_radio_buttons_fieldset :employing_school_id, legend: nil do %>
   <%= f.hidden_field :school_value, value: "true" %>
-  
+
     <% @schools.each_with_index do |school, index| %>
       <%= f.govuk_radio_button :employing_school_id, school.id,
+                              checked: false,
                               label: { text: school.name },
                               link_errors: index.zero?,
                               hint: { text: school_urn_and_location(school) } %>

--- a/app/views/trainees/employing_schools/edit.html.erb
+++ b/app/views/trainees/employing_schools/edit.html.erb
@@ -10,15 +10,14 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field(
-        :employing_school_id,
+        :query,
         label: { text: t(".heading"), size: "l", tag: "h1" },
         hint: { text: t(".hint") },
-        name: :'input-autocomplete',
-        value: nil,
+        value: query,
         "data-field" => "schools-autocomplete",
         width: "three-quarters",
       ) %>
-      <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters"></div>
+      <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-default-value="<%= query %>" data-field-name="schools_employing_school_form[query]"></div>
 
       <%= f.hidden_field :employing_school_id, id: "school-id", value: nil %>
       <%= f.govuk_submit t("continue") %>

--- a/app/views/trainees/employing_schools/index.html.erb
+++ b/app/views/trainees/employing_schools/index.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(model: @employing_school_form,
                            url: trainee_employing_schools_path(@trainee, query: params[:query]),
                            method: :put,

--- a/app/views/trainees/lead_schools/_results.html.erb
+++ b/app/views/trainees/lead_schools/_results.html.erb
@@ -10,11 +10,15 @@
   </div>
 <% end %>
 
+
+<%= f.hidden_field :lead_school_id, value: nil %>
+
 <%= f.govuk_radio_buttons_fieldset :lead_school_id, legend: nil do %>
   <%= f.hidden_field :school_value, value: "true" %>
 
     <% @schools.each_with_index do |school, index| %>
       <%= f.govuk_radio_button :lead_school_id, school.id,
+                              checked: false,
                               label: { text: school.name },
                               link_errors: index.zero?,
                               hint: { text: school_urn_and_location(school) } %>
@@ -30,7 +34,6 @@
                           width: "three-quarters" %>
   <% end %>
 <% end %>
-
 
 <%= render SchoolResultNotice::View.new(
   search_query: query, 

--- a/app/views/trainees/lead_schools/edit.html.erb
+++ b/app/views/trainees/lead_schools/edit.html.erb
@@ -10,15 +10,14 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field(
-        :lead_school_id,
+        :query,
         label: { text: t(".heading"), size: "l", tag: "h1" },
         hint: { text: "#{t('.description')}<p>#{t('.hint')}</p>".html_safe },
-        name: :'input-autocomplete',
-        value: nil,
+        value: query,
         "data-field" => "schools-autocomplete",
         width: "three-quarters",
       ) %>
-      <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-only-lead-schools=true></div>
+      <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-only-lead-schools=true data-default-value="<%= query %>" data-field-name="schools_lead_school_form[query]"></div>
 
       <%= f.hidden_field :lead_school_id, id: "school-id", value: nil %>
       <%= f.govuk_submit t("continue") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -761,6 +761,12 @@ en:
             trainee_id:
               blank: Enter a trainee ID
               max_char_exceeded: Your entry must not exceed 100 characters
+        schools_form:
+          attributes:
+            query:
+              length:
+                one: "Enter at least one character"
+                other: "Enter at least %{count} characters"
         schools/lead_school_form:
           attributes:
             lead_school_id:
@@ -795,4 +801,4 @@ en:
   api:
     schools:
       errors:
-        bad_request: The query param needs to be at least 3 characters
+        bad_request: The query param needs to be at least %{length} characters

--- a/spec/forms/schools/employing_school_form_spec.rb
+++ b/spec/forms/schools/employing_school_form_spec.rb
@@ -15,33 +15,7 @@ module Schools
       allow(form_store).to receive(:get).and_return(nil)
     end
 
-    describe "validations" do
-      before { subject.valid? }
-
-      context "empty form data" do
-        let(:params) { { "query" => "w" } }
-
-        it "returns an error" do
-          expect(subject.errors[:query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
-        end
-      end
-
-      context "when searching again" do
-        let(:params) { { "results_search_again_query" => "a" } }
-
-        it "returns an error against the search again query" do
-          expect(subject.errors[:results_search_again_query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
-        end
-
-        context "with no employing school chosen and no query provided" do
-          let(:params) { { "results_search_again_query" => "", "employing_school_id" => "" } }
-
-          it "returns an error" do
-            expect(subject.errors[:employing_school_id]).to include(I18n.t("activemodel.errors.models.schools/employing_school_form.attributes.employing_school_id.blank"))
-          end
-        end
-      end
-    end
+    include_examples "school form validations", "employing_school_id"
 
     describe "#stash" do
       it "uses FormStore to temporarily save the fields under a key combination of trainee ID and employing_school" do

--- a/spec/forms/schools/employing_school_form_spec.rb
+++ b/spec/forms/schools/employing_school_form_spec.rb
@@ -16,15 +16,29 @@ module Schools
     end
 
     describe "validations" do
-      it { is_expected.to validate_presence_of(:employing_school_id) }
+      before { subject.valid? }
 
       context "empty form data" do
-        let(:params) { { "employing_school_id" => "" } }
-
-        before { subject.valid? }
+        let(:params) { { "query" => "w" } }
 
         it "returns an error" do
-          expect(subject.errors[:employing_school_id]).to include(I18n.t("activemodel.errors.models.schools/employing_school_form.attributes.employing_school_id.blank"))
+          expect(subject.errors[:query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
+        end
+      end
+
+      context "when searching again" do
+        let(:params) { { "results_search_again_query" => "a" } }
+
+        it "returns an error against the search again query" do
+          expect(subject.errors[:results_search_again_query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
+        end
+
+        context "with no employing school chosen and no query provided" do
+          let(:params) { { "results_search_again_query" => "", "employing_school_id" => "" } }
+
+          it "returns an error" do
+            expect(subject.errors[:employing_school_id]).to include(I18n.t("activemodel.errors.models.schools/employing_school_form.attributes.employing_school_id.blank"))
+          end
         end
       end
     end

--- a/spec/forms/schools/lead_school_form_spec.rb
+++ b/spec/forms/schools/lead_school_form_spec.rb
@@ -16,15 +16,29 @@ module Schools
     end
 
     describe "validations" do
-      it { is_expected.to validate_presence_of(:lead_school_id) }
+      before { subject.valid? }
 
-      context "empty form data" do
-        let(:params) { { "lead_school_id" => "" } }
-
-        before { subject.valid? }
+      context "when query length is too short" do
+        let(:params) { { "query" => "a" } }
 
         it "returns an error" do
-          expect(subject.errors[:lead_school_id]).to include(I18n.t("activemodel.errors.models.schools/lead_school_form.attributes.lead_school_id.blank"))
+          expect(subject.errors[:query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
+        end
+      end
+
+      context "when searching again" do
+        let(:params) { { "results_search_again_query" => "a" } }
+
+        it "returns an error against the search again query" do
+          expect(subject.errors[:results_search_again_query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
+        end
+
+        context "with no lead school chosen and no query provided" do
+          let(:params) { { "results_search_again_query" => "", "lead_school_id" => "" } }
+
+          it "returns an error" do
+            expect(subject.errors[:lead_school_id]).to include(I18n.t("activemodel.errors.models.schools/lead_school_form.attributes.lead_school_id.blank"))
+          end
         end
       end
     end

--- a/spec/forms/schools/lead_school_form_spec.rb
+++ b/spec/forms/schools/lead_school_form_spec.rb
@@ -15,33 +15,7 @@ module Schools
       allow(form_store).to receive(:get).and_return(nil)
     end
 
-    describe "validations" do
-      before { subject.valid? }
-
-      context "when query length is too short" do
-        let(:params) { { "query" => "a" } }
-
-        it "returns an error" do
-          expect(subject.errors[:query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
-        end
-      end
-
-      context "when searching again" do
-        let(:params) { { "results_search_again_query" => "a" } }
-
-        it "returns an error against the search again query" do
-          expect(subject.errors[:results_search_again_query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
-        end
-
-        context "with no lead school chosen and no query provided" do
-          let(:params) { { "results_search_again_query" => "", "lead_school_id" => "" } }
-
-          it "returns an error" do
-            expect(subject.errors[:lead_school_id]).to include(I18n.t("activemodel.errors.models.schools/lead_school_form.attributes.lead_school_id.blank"))
-          end
-        end
-      end
-    end
+    include_examples "school form validations", "lead_school_id"
 
     describe "#stash" do
       it "uses FormStore to temporarily save the fields under a key combination of trainee ID and lead_school" do

--- a/spec/support/page_objects/trainees/edit_employing_school.rb
+++ b/spec/support/page_objects/trainees/edit_employing_school.rb
@@ -5,9 +5,9 @@ module PageObjects
     class EditEmployingSchool < PageObjects::Base
       set_url "/trainees/{trainee_id}/employing-schools/edit"
 
-      element :employing_school, "#schools-employing-school-form-employing-school-id-field"
-      element :no_js_employing_school, "#schools-employing-school-form-employing-school-id-field"
-      element :autocomplete_list_item, "#schools-employing-school-form-employing-school-id-field__listbox li:first-child"
+      element :employing_school, "#schools-employing-school-form-query-field"
+      element :no_js_employing_school, "#schools-employing-school-form-query-field"
+      element :autocomplete_list_item, "#schools-employing-school-form-query-field__listbox li:first-child"
       element :submit, 'input.govuk-button[type="submit"]'
     end
   end

--- a/spec/support/page_objects/trainees/edit_lead_school.rb
+++ b/spec/support/page_objects/trainees/edit_lead_school.rb
@@ -5,9 +5,9 @@ module PageObjects
     class EditLeadSchool < PageObjects::Base
       set_url "/trainees/{trainee_id}/lead-schools/edit"
 
-      element :lead_school, "#schools-lead-school-form-lead-school-id-field"
-      element :no_js_lead_school, "#schools-lead-school-form-lead-school-id-field"
-      element :autocomplete_list_item, "#schools-lead-school-form-lead-school-id-field__listbox li:first-child"
+      element :lead_school, "#schools-lead-school-form-query-field"
+      element :no_js_lead_school, "#schools-lead-school-form-query-field"
+      element :autocomplete_list_item, "#schools-lead-school-form-query-field__listbox li:first-child"
       element :submit, 'input.govuk-button[type="submit"]'
     end
   end

--- a/spec/support/shared_examples/school_form_validations.rb
+++ b/spec/support/shared_examples/school_form_validations.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "school form validations" do |school_id_key|
+  before { subject.valid? }
+
+  context "empty form data" do
+    let(:params) { { "query" => "w" } }
+
+    it "returns an error" do
+      expect(subject.errors[:query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
+    end
+  end
+
+  context "when searching again" do
+    let(:params) { { "results_search_again_query" => "a" } }
+
+    it "returns an error against the search again query" do
+      expect(subject.errors[:results_search_again_query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
+    end
+  end
+
+  context "with no school chosen and no query provided" do
+    let(:params) { { "results_search_again_query" => "", school_id_key => "" } }
+
+    it "returns an error" do
+      expect(subject.errors[school_id_key]).to include(I18n.t("activemodel.errors.models.schools/employing_school_form.attributes.employing_school_id.blank"))
+    end
+  end
+end


### PR DESCRIPTION
### Context
Extending from https://github.com/DFE-Digital/register-trainee-teachers/pull/964, this change adds an error messaeg if the query is shorter than expected.

### Changes proposed in this pull request
1. Query a (lead/employing) school with zero or one characters to get a new error: "Enter at least two characters".
2. In the results page (radio buttons), the option values are intentionally unselected
3. (Non-js) Not explicitly selecting "Search again", but providing a search query will allow the user to search again, instead of skipping to the confirm page.


