### PR TITLE
[1901] Display "Answer missing" on confirmation pages if data missing

### DIFF
--- a/app/components/trainees/confirmation/diversity/view.rb
+++ b/app/components/trainees/confirmation/diversity/view.rb
@@ -21,7 +21,7 @@ module Trainees
           rows = [
             {
               key: "Diversity information",
-              value: I18n.t("components.confirmation.diversity.diversity_disclosure.#{diversity_disclosure_key}"),
+              value: t("components.confirmation.diversity.diversity_disclosure.#{diversity_disclosure_key}"),
               action: govuk_link_to('Change<span class="govuk-visually-hidden"> diversity information</span>'.html_safe,
                                     edit_trainee_diversity_disclosure_path(trainee)),
             },
@@ -47,22 +47,21 @@ module Trainees
         end
 
         def ethnic_group_content
-          value = I18n.t("components.confirmation.diversity.ethnic_groups.#{data_model.ethnic_group}")
+          return t(:answer_missing) unless data_model.ethnic_group
+
+          value = t("components.confirmation.diversity.ethnic_groups.#{data_model.ethnic_group}")
 
           if data_model.ethnic_background.present? && data_model.ethnic_background != Diversities::NOT_PROVIDED
             value += " (#{trainee_ethnic_background})"
           end
+
           value
         end
 
         def disability_selection
-          if data_model.disabled?
-            "They shared that they’re disabled"
-          elsif data_model.no_disability?
-            "They shared that they’re not disabled"
-          else
-            "Not provided"
-          end
+          return t(:answer_missing) unless data_model.disability_disclosure
+
+          t("components.confirmation.diversity.disability_disclosure.#{data_model.disability_disclosure}")
         end
 
         def selected_disability_options

--- a/app/components/trainees/confirmation/schools/view.rb
+++ b/app/components/trainees/confirmation/schools/view.rb
@@ -7,22 +7,16 @@ module Trainees
         include SummaryHelper
         include SchoolHelper
 
-        attr_accessor :data_model
+        attr_accessor :data_model, :lead_school, :employing_school
 
         def initialize(data_model:)
           @data_model = data_model
+          @lead_school = trainee.lead_school
+          @employing_school = trainee.employing_school
         end
 
         def trainee
           data_model.is_a?(Trainee) ? data_model : data_model.trainee
-        end
-
-        def lead_school
-          @lead_school ||= School.where(id: data_model.lead_school_id).first
-        end
-
-        def employing_school
-          @employing_school ||= School.where(id: data_model.employing_school_id).first
         end
 
       private

--- a/app/helpers/school_helper.rb
+++ b/app/helpers/school_helper.rb
@@ -6,7 +6,7 @@ module SchoolHelper
   end
 
   def school_detail(school)
-    return t("components.confirmation.not_provided") unless school
+    return t(:answer_missing) unless school
 
     tag.p(school.name, class: "govuk-body") + tag.span(school_urn_and_location(school), class: "govuk-hint")
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
   education: Education
   personal_details: Personal details
   return_to_draft_later: Return to this draft record later
+  answer_missing: Answer missing
   header:
     items:
       sign_out: Sign out
@@ -56,6 +57,10 @@ en:
           white_ethnic_group: White
           other_ethnic_group: Another ethnic group
           not_provided_ethnic_group: Not provided
+        disability_disclosure:
+          disabled: They shared that they’re disabled
+          no_disability: They shared that they’re not disabled
+          disability_not_provided: Not provided
       personal_detail:
         gender:
           male: Male

--- a/spec/components/trainees/confirmation/diversity/view_spec.rb
+++ b/spec/components/trainees/confirmation/diversity/view_spec.rb
@@ -3,62 +3,41 @@
 require "rails_helper"
 
 RSpec.describe Trainees::Confirmation::Diversity::View do
-  alias_method :component, :page
-
-  let(:trainee) { create(:trainee) }
+  before { render_inline(Trainees::Confirmation::Diversity::View.new(data_model: trainee)) }
 
   describe "Diversity information" do
-    context "when the trainee has not answered any diversity questions" do
-      # This is different to the trainee explicitly choosing not to share
-      before do
-        trainee.diversity_disclosure = nil
-        render_inline(Trainees::Confirmation::Diversity::View.new(data_model: trainee))
-      end
-
-      it "renders with one line to say the trainee hasn't anwered the question" do
-        expect(component.find(".diversity-information .govuk-summary-list__value")).to have_text("Not provided")
-        expect(component).to have_selector(".govuk-summary-list__row", count: 1)
-      end
-    end
-
     context "when trainee has not shared any ethnic or disability information" do
-      before do
-        trainee.diversity_disclosure = "diversity_not_disclosed"
-        render_inline(Trainees::Confirmation::Diversity::View.new(data_model: trainee))
-      end
+      let(:trainee) { build(:trainee, :diversity_not_disclosed) }
 
       it "renders with one line to say the trainee haven't shared data" do
-        expect(component.find(".diversity-information .govuk-summary-list__value")).to have_text("Not shared")
-        expect(component).to have_selector(".govuk-summary-list__row", count: 1)
+        expect(rendered_component).to have_text("Not shared")
+        expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 1)
       end
 
       it "has one change links" do
-        expect(component).to have_link("Change diversity information")
-        expect(component).not_to have_link("Change ethnicity")
-        expect(component).not_to have_link("Change disability")
+        expect(rendered_component).to have_link("Change diversity information")
+        expect(rendered_component).not_to have_link("Change ethnicity")
+        expect(rendered_component).not_to have_link("Change disability")
       end
     end
 
     context "when trainee has shared their diversity information " do
-      before do
-        trainee.diversity_disclosure = "diversity_disclosed"
-        render_inline(Trainees::Confirmation::Diversity::View.new(data_model: trainee))
-      end
+      let(:trainee) { build(:trainee, :diversity_disclosed) }
 
-      it "renders with one line to say the trainee haven't shared data" do
-        expect(component.find(".diversity-information .govuk-summary-list__value")).to have_text("Information disclosed")
-        expect(component).to have_selector(".govuk-summary-list__row", count: 3)
+      it "renders with one line to say the trainee has shared data" do
+        expect(rendered_component).to have_text("Information disclosed")
+        expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 3)
       end
 
       it "has three change links" do
-        expect(component).to have_link("Change diversity information")
-        expect(component).to have_link("Change ethnicity")
-        expect(component).to have_link("Change disability")
+        expect(rendered_component).to have_link("Change diversity information")
+        expect(rendered_component).to have_link("Change ethnicity")
+        expect(rendered_component).to have_link("Change disability")
       end
     end
   end
 
-  describe "#ethnic_group_content" do
+  describe "ethnic selection" do
     let(:trainee) { build(:trainee, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:asian]) }
     let(:expected_locale_key) { t("components.confirmation.diversity.ethnic_groups.asian_ethnic_group") }
 
@@ -93,34 +72,48 @@ RSpec.describe Trainees::Confirmation::Diversity::View do
     end
   end
 
-  describe "#get_disability_selection" do
-    it "returns a message stating the user is disabled" do
-      allow(trainee).to receive(:disabled?).and_return(true)
-      component = Trainees::Confirmation::Diversity::View.new(data_model: trainee)
-      expect(component.disability_selection).to eq "They shared that they’re disabled"
+  describe "#disability_selection" do
+    let(:disability_disclosure) { nil }
+    let(:trainee) { build(:trainee, disability_disclosure: disability_disclosure) }
+
+    let(:rendered_component) { Trainees::Confirmation::Diversity::View.new(data_model: trainee) }
+
+    it "returns answer missing" do
+      expect(rendered_component.disability_selection).to eq("Answer missing")
     end
 
-    it "returns a message stating the user is not disabled" do
-      allow(trainee).to receive(:disabled?).and_return(false)
-      allow(trainee).to receive(:no_disability?).and_return(true)
-      component = Trainees::Confirmation::Diversity::View.new(data_model: trainee)
-      expect(component.disability_selection).to eq "They shared that they’re not disabled"
+    context "disabled" do
+      let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled] }
+
+      it "returns a message stating the user is disabled" do
+        expect(rendered_component.disability_selection).to eq("They shared that they’re disabled")
+      end
     end
 
-    it "returns a message stating the user did not provide details" do
-      allow(trainee).to receive(:disabled?).and_return(false)
-      allow(trainee).to receive(:no_disability?).and_return(false)
-      component = Trainees::Confirmation::Diversity::View.new(data_model: trainee)
-      expect(component.disability_selection).to eq "Not provided"
+    context "not disabled" do
+      let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability] }
+
+      it "returns a message stating the user is not disabled" do
+        expect(rendered_component.disability_selection).to eq("They shared that they’re not disabled")
+      end
+    end
+
+    context "not provided" do
+      let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] }
+
+      it "returns a message stating the user did not provide details" do
+        expect(rendered_component.disability_selection).to eq("Not provided")
+      end
     end
   end
 
-  describe "#selected_disability_options" do
-    let(:component) { Trainees::Confirmation::Diversity::View.new(data_model: trainee) }
+  describe "selected disability options" do
+    let(:trainee) { build(:trainee) }
+    let(:rendered_component) { Trainees::Confirmation::Diversity::View.new(data_model: trainee) }
 
     context "when there are no disabilities" do
       it "returns a empty string if no disabilities" do
-        expect(component.selected_disability_options).to be_empty
+        expect(rendered_component.selected_disability_options).to be_empty
       end
     end
 
@@ -133,7 +126,7 @@ RSpec.describe Trainees::Confirmation::Diversity::View do
 
       it "renders the disability names" do
         trainee.disabilities.each do |disability|
-          expect(component.selected_disability_options).to include(disability.name)
+          expect(rendered_component.selected_disability_options).to include(disability.name)
         end
       end
     end
@@ -145,7 +138,7 @@ RSpec.describe Trainees::Confirmation::Diversity::View do
 
       it "renders the additional disability" do
         expected_text = "#{disability.name.downcase} (#{trainee_disability.additional_disability})"
-        expect(component.selected_disability_options).to include(expected_text)
+        expect(rendered_component.selected_disability_options).to include(expected_text)
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/LZtcths6/1826-pre-filled-invalid-entries-get-suggested-by-autocomplete

Some sections such as diversity information and schools have multi-page journeys. If the user happens to exit that journary somewhere along the way without finishing, the confirmation page needs to inform the user that some parts are unfinished.

### Changes proposed in this pull request
- Add the message "Answer missing" to diversity and school confirmation pages if they are incomplete

### Guidance to review
#### Diversity information 
- Create a "School direct (salaried)" trainee
- Enter "Diversity information" page and click "Yes"
- Go back to review draft page using back button
- Re-enter "Diversity information"
- Confirmation page should display the message "Answer missing" for Ethnicity and Disability

#### Schools
- Enter "Schools" page and chose a lead school
- Go back to review draft page using back button
- Re-enter "Schools"
- Confirmation page should display the message "Answer missing" for employing school
