### PR TITLE
[1943] Fix diversity form validator

### DIFF
--- a/app/forms/diversities/form_validator.rb
+++ b/app/forms/diversities/form_validator.rb
@@ -18,10 +18,10 @@ module Diversities
     delegate :id, :persisted?, to: :trainee
 
     validate :disclosure
-    validate :ethnic_group, if: -> { trainee.ethnic_group.present? }
-    validate :ethnic_background, if: -> { trainee.ethnic_background.present? }
-    validate :disability_disclosure, if: -> { trainee.disability_disclosure.present? }
-    validate :disabilities, if: -> { trainee.disabled? }
+    validate :ethnic_group, if: -> { disclosed_and_invalid? || trainee.ethnic_group.present? }
+    validate :ethnic_background, if: -> { disclosed_and_invalid? || trainee.ethnic_background.present? }
+    validate :disability_disclosure, if: -> { disclosed_and_invalid? || trainee.disability_disclosure.present? }
+    validate :disabilities, if: -> { disability_disclosed_and_invalid? }
 
     def initialize(trainee)
       @trainee = trainee
@@ -70,6 +70,18 @@ module Diversities
 
     def add_error_for(key)
       errors.add(key, :not_valid)
+    end
+
+    def disclosed_and_invalid?
+      trainee.diversity_disclosed? && (
+        trainee.ethnic_group.blank? ||
+        trainee.ethnic_background.blank? ||
+        trainee.disability_disclosure.blank?
+      )
+    end
+
+    def disability_disclosed_and_invalid?
+      trainee.disabled? || trainee.disabilities.empty?
     end
   end
 end

--- a/spec/factories/trainee_disabilities.rb
+++ b/spec/factories/trainee_disabilities.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :trainee_disability do
+  factory :trainee_disability, class: TraineeDisability do
     association :trainee
     association :disability
   end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -18,11 +18,11 @@ FactoryBot.define do
     gender { Trainee.genders.keys.sample }
     slug { SecureRandom.base58(Sluggable::SLUG_LENGTH) }
 
-    diversity_disclosure { Diversities::DIVERSITY_DISCLOSURE_ENUMS.values.sample }
-    ethnic_group { Diversities::ETHNIC_GROUP_ENUMS.values.sample }
+    diversity_disclosure { Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed] }
+    ethnic_group { nil }
     ethnic_background { nil }
     additional_ethnic_background { nil }
-    disability_disclosure { (Diversities::DISABILITY_DISCLOSURE_ENUMS.values - %w[disabled]).sample }
+    disability_disclosure { Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] }
 
     address_line_one { Faker::Address.street_address }
     address_line_two { Faker::Address.street_name }
@@ -116,12 +116,31 @@ FactoryBot.define do
       diversity_disclosure { Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed] }
     end
 
+    trait :with_ethnic_group do
+      ethnic_group { Diversities::ETHNIC_GROUP_ENUMS.values.sample }
+    end
+
     trait :with_ethnic_background do
       ethnic_background { Dttp::CodeSets::Ethnicities::MAPPING.keys.sample }
     end
 
     trait :disabled do
       disability_disclosure { Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled] }
+    end
+
+    trait :with_diversity_information do
+      diversity_disclosed
+      with_ethnic_group
+      with_ethnic_background
+      disabled
+
+      transient do
+        disabilities_count { 1 }
+      end
+
+      after(:create) do |trainee, evaluator|
+        create_list(:trainee_disability, evaluator.disabilities_count, trainee: trainee)
+      end
     end
 
     trait :with_placement_assignment do

--- a/spec/features/form_sections/personal_and_education_details/reviewing_apply_trainee_data_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/reviewing_apply_trainee_data_spec.rb
@@ -10,7 +10,7 @@ feature "edit training details" do
   background { given_i_am_authenticated }
 
   scenario "reviewing details" do
-    given_a_trainee_exists(nationalities: [build(:nationality)], degrees: [build(:degree, :uk_degree_with_details)])
+    given_a_trainee_exists(:with_diversity_information, nationalities: [build(:nationality)], degrees: [build(:degree, :uk_degree_with_details)])
     when_i_visit_the_apply_trainee_data_page
     and_i_review_the_trainee_data
     then_i_am_redirected_to_the_review_draft_page
@@ -18,7 +18,7 @@ feature "edit training details" do
   end
 
   scenario "changing an attribute" do
-    given_a_trainee_exists(nationalities: [build(:nationality)])
+    given_a_trainee_exists(:with_diversity_information, nationalities: [build(:nationality)])
     when_i_visit_the_apply_trainee_data_page
     and_i_click_to_change_the_trainee_full_name
     and_i_change_the_first_name_to("Jeff")

--- a/spec/forms/diversities/form_validator_spec.rb
+++ b/spec/forms/diversities/form_validator_spec.rb
@@ -4,186 +4,48 @@ require "rails_helper"
 
 module Diversities
   describe FormValidator do
-    let(:trainee) do
-      build(:trainee, diversity_disclosure: nil, ethnic_group: nil, ethnic_background: nil, disability_disclosure: nil)
-    end
+    let(:trainee) { create(:trainee, :with_diversity_information) }
 
     subject { described_class.new(trainee) }
 
+    let(:disclosure) { instance_double(DisclosureForm, valid?: true) }
+    let(:ethnic_group) { instance_double(EthnicGroupForm, valid?: true) }
+    let(:ethnic_background) { instance_double(EthnicBackgroundForm, valid?: true) }
+    let(:disability_disclosure) { instance_double(DisabilityDisclosureForm, valid?: true) }
+    let(:disability_detail_form) { instance_double(DisabilityDetailForm, valid?: true) }
+
     describe "validations" do
-      context "when trainee has disclosed diversity" do
-        let(:disclosure) { instance_double(DisclosureForm) }
-
+      context "when disclosed and all diversity forms valid" do
         before do
-          trainee.diversity_disclosure = DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed]
           expect(DisclosureForm).to receive(:new).and_return(disclosure)
+          expect(EthnicGroupForm).to receive(:new).and_return(ethnic_group)
+          expect(EthnicBackgroundForm).to receive(:new).and_return(ethnic_background)
+          expect(DisabilityDisclosureForm).to receive(:new).and_return(disability_disclosure)
+          expect(DisabilityDetailForm).to receive(:new).and_return(disability_detail_form)
         end
 
-        context "when DisclosureForm is valid" do
-          let(:validity) { true }
+        it { is_expected.to be_valid }
+      end
 
-          before do
-            allow(disclosure).to receive(:valid?).and_return(true)
-          end
+      context "when disclosure is valid and the value is 'diversity_not_disclosed'" do
+        let(:trainee) { build(:trainee, :diversity_not_disclosed, ethnic_group: nil, ethnic_background: nil, disability_disclosure: nil) }
 
-          it { is_expected.to be_valid }
+        it { is_expected.to be_valid }
+      end
 
-          context "ethnic group" do
-            let(:ethnic_group) { instance_double(EthnicGroupForm) }
-
-            before do
-              trainee.ethnic_group = ETHNIC_GROUP_ENUMS.values.sample
-              expect(EthnicGroupForm).to receive(:new).and_return(ethnic_group)
-            end
-
-            context "when EthnicGroupForm is valid" do
-              before do
-                allow(ethnic_group).to receive(:valid?).and_return(true)
-              end
-
-              it { is_expected.to be_valid }
-
-              context "ethnic background" do
-                let(:ethnic_background) { instance_double(EthnicBackgroundForm) }
-
-                before do
-                  trainee.ethnic_background = "some background"
-                  expect(EthnicBackgroundForm).to receive(:new).and_return(ethnic_background)
-                end
-
-                context "when EthnicBackgroundForm is valid" do
-                  before do
-                    allow(ethnic_background).to receive(:valid?).and_return(true)
-                  end
-
-                  it { is_expected.to be_valid }
-                end
-
-                context "when EthnicBackgroundForm is invalid" do
-                  before do
-                    allow(ethnic_background).to receive(:valid?).and_return(false)
-                  end
-
-                  it "returns an error for the ethnic_background_section key" do
-                    subject.valid?
-
-                    expect(subject.errors[:ethnic_background_section]).to include(
-                      I18n.t(
-                        "activemodel.errors.models.diversities/form_validator.attributes.ethnic_background_section.not_valid",
-                      ),
-                    )
-                  end
-                end
-              end
-            end
-
-            context "when EthnicGroupForm is invalid" do
-              before do
-                allow(ethnic_group).to receive(:valid?).and_return(false)
-              end
-
-              it "returns an error for the ethnic_group_section key" do
-                subject.valid?
-
-                expect(subject.errors[:ethnic_group_section]).to include(
-                  I18n.t(
-                    "activemodel.errors.models.diversities/form_validator.attributes.ethnic_group_section.not_valid",
-                  ),
-                )
-              end
-            end
-          end
-
-          context "disability disclosure" do
-            let(:disability_disclosure) { instance_double(DisabilityDisclosureForm) }
-
-            before do
-              trainee.disability_disclosure = DISABILITY_DISCLOSURE_ENUMS[:no_disability]
-              expect(DisabilityDisclosureForm).to receive(:new).and_return(disability_disclosure)
-            end
-
-            context "when DisabilityDisclosureForm is valid" do
-              before do
-                allow(disability_disclosure).to receive(:valid?).and_return(true)
-              end
-
-              it { is_expected.to be_valid }
-
-              context "when trainee is disabled" do
-                let(:disability_detail_form) { instance_double(DisabilityDetailForm) }
-
-                before do
-                  trainee.disability_disclosure = DISABILITY_DISCLOSURE_ENUMS[:disabled]
-                  expect(DisabilityDetailForm).to receive(:new).and_return(disability_detail_form)
-                end
-
-                context "when DisabilityDetailForm is valid" do
-                  before do
-                    allow(disability_detail_form).to receive(:valid?).and_return(true)
-                  end
-
-                  it { is_expected.to be_valid }
-                end
-
-                context "when DisabilityDetailForm is invalid" do
-                  before do
-                    allow(disability_detail_form).to receive(:valid?).and_return(false)
-                  end
-
-                  it "returns an error for the disability_ids key" do
-                    subject.valid?
-
-                    expect(subject.errors[:disability_ids]).to include(
-                      I18n.t(
-                        "activemodel.errors.models.diversities/form_validator.attributes.disability_ids.not_valid",
-                      ),
-                    )
-                  end
-                end
-              end
-            end
-
-            context "when DisabilityDisclosureForm is invalid" do
-              before do
-                allow(disability_disclosure).to receive(:valid?).and_return(false)
-              end
-
-              it "returns an error for the disability_disclosure_section key" do
-                subject.valid?
-
-                expect(subject.errors[:disability_disclosure_section]).to include(
-                  I18n.t(
-                    "activemodel.errors.models.diversities/form_validator.attributes.disability_disclosure_section.not_valid",
-                  ),
-                )
-              end
-            end
-          end
+      context "when disclosure is valid and a dependent sub form is invalid" do
+        before do
+          trainee.ethnic_group = nil
         end
 
-        context "when DisclosureForm is valid and not disclosed" do
-          before do
-            trainee.diversity_disclosure = DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed]
-            allow(disclosure).to receive(:valid?).and_return(true)
-          end
+        it "returns an error for that sub form" do
+          subject.valid?
 
-          it { is_expected.to be_valid }
-        end
-
-        context "when DisclosureForm is invalid" do
-          before do
-            allow(disclosure).to receive(:valid?).and_return(false)
-          end
-
-          it "returns an error for the disclosure_section key" do
-            subject.valid?
-
-            expect(subject.errors[:disclosure_section]).to include(
-              I18n.t(
-                "activemodel.errors.models.diversities/form_validator.attributes.disclosure_section.not_valid",
-              ),
-            )
-          end
+          expect(subject.errors[:ethnic_group_section]).to include(
+            I18n.t(
+              "activemodel.errors.models.diversities/form_validator.attributes.ethnic_group_section.not_valid",
+            ),
+          )
         end
       end
     end


### PR DESCRIPTION
### Context

- https://trello.com/c/7h3M0Axn/1943-fix-progress-computing-for-diversity-section

The form validator for the diversity information is used by the progress service (and trn submission) to workout whether that section has been started, in progress or completed. It's a coordinator of sorts of other sub form objects for each part of the diversity flow. 

Prior to this change, it didn't validate the scenario where a user could side step some of the forms if they disclosed diversity information and checked the section as completed. The label would still show as completed which is incorrect.

### Changes proposed in this pull request

- Refactor the `Diversities::FormValidator` to validate the scenario above. 
- Simplify the spec for this class, it was becoming a little hard to grok with all the nesting
- Simplify the default trainee factory to be diversity_not_disclosed with a trait to opt in full diversity information, using `sample` creates combinations which are sometimes deemed invalid by the validator

This class acts as a guard and conditionally calls its sub child validators for each form object depending on the currently provided diversity information.

Before this change, you could mark the section as complete with invalid data. After this change, the section will still be "in progress:

**Note**: Ignore the gibberish in the confirmation page, that is fixed in this PR https://github.com/DFE-Digital/register-trainee-teachers/pull/988

**Valid data -> completed**

![happy-path](https://user-images.githubusercontent.com/616080/121534877-8cba6e80-c9f9-11eb-8882-326da4bfdbb1.gif)

**Invalid data -> in progres**

![sad-paths](https://user-images.githubusercontent.com/616080/121534886-8f1cc880-c9f9-11eb-8dee-43ed172fbed5.gif)

### Guidance to review

