### PR TITLE
[xxx] Fix flakey example_rake specs

### DIFF
--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :school do
-    urn { rand.to_s[2..7] }
+    urn { Faker::Number.unique.number(digits: 7) }
     name { Faker::University.name }
     town { Faker::Address.city }
     postcode { Faker::Address.postcode }

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :subject do
     sequence(:name) { |c| "Subject #{c}" }
-    code { Faker::Alphanumeric.alphanumeric(number: 2).upcase }
+    code { Faker::Alphanumeric.unique.alphanumeric(number: 2).upcase }
   end
 
   trait :music do


### PR DESCRIPTION
### Context

The example data generator specs were failing intermittently on schools (URN) and subjects (code) validations:

```
  1) example_data:generate creates two providers
     Failure/Error: subjects = FactoryBot.create_list(:subject, 20)
     ActiveRecord::RecordInvalid:
       Validation failed: Code has already been taken
```

### Changes proposed in this pull request

Adds a `.unique` to the Faker calls to return all unique values.

### Guidance to review

