### PR TITLE
[1864] Move export link above trainees list

### DIFF
--- a/app/components/paginated_filter/view.html.erb
+++ b/app/components/paginated_filter/view.html.erb
@@ -1,16 +1,21 @@
 <div class='moj-filter-layout'>
   <%= render Trainees::Filters::View.new(filters: filters, filter_actions: filter_actions) %>
-
   <div class='moj-filter-layout__content'>
-
     <div class="moj-action-bar">
       <div class="moj-action-bar__filter"></div>
     </div>
+    <div class="app-records-actions">
     <% unless @collection.empty? %>
+      <% if FeatureService.enabled?(:trainee_export) %>
+        <div class="app-export--link">
+          <%= govuk_link_to(
+                I18n.t("views.trainees.index.export"), trainees_path(filter_params.merge(format: "csv")), class: "app-trainee-export") %>
+        </div>
+      <% end %>
       <%= render Trainees::SortLinks::View.new %>
     <% end %>
+    </div>
     <%= content %>
-
     <%= render Paginator::View.new(scope: collection) %>
   </div>
 </div>

--- a/app/components/paginated_filter/view.rb
+++ b/app/components/paginated_filter/view.rb
@@ -2,13 +2,14 @@
 
 module PaginatedFilter
   class View < ViewComponent::Base
-    attr_reader :filters, :collection
+    attr_reader :filters, :collection, :filter_params
 
     renders_many :filter_actions
 
-    def initialize(filters:, collection:)
+    def initialize(filters:, collection:, filter_params:)
       @filters = filters
       @collection = collection
+      @filter_params = filter_params
     end
   end
 end

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -14,12 +14,7 @@
   </p>
 <% end %>
 
-<%= render PaginatedFilter::View.new(filters: @filters, collection: @paginated_trainees) do |component| %>
-  <% if FeatureService.enabled?(:trainee_export) && (@paginated_trainees).any?(&:present?) %>
-    <% component.filter_action do %>
-      <p class="govuk-body govuk-!-margin-top-3"><%= govuk_link_to("Export these records", trainees_path(filter_params.merge(format: "csv")), class: "app-trainee-export") %></p>
-    <% end %>
-  <% end %>
+<%= render PaginatedFilter::View.new(filters: @filters, collection: @paginated_trainees, filter_params: filter_params) do %>
 
   <% if @paginated_trainees.any? %>
     <% if @draft_trainees.any? %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -82,3 +82,15 @@
   @include govuk-link-style-error;
 }
 
+@media (min-width: 54.5em) {
+  .app-records-actions {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: row-reverse;
+    align-items: baseline;
+  }
+}
+
+.app-trainee-export {
+  @include govuk-font($size: 19);
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,6 +296,7 @@ en:
     trainees:
       index:
         no_records: Your trainee records will appear here. You do not have any records yet.
+        export: Export these records
       edit:
         defer: Defer
         withdraw: withdraw

--- a/spec/components/trainees/sort_links/view_spec.rb
+++ b/spec/components/trainees/sort_links/view_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Trainees::SortLinks::View do
     render_inline(described_class.new)
   end
 
-  let(:params) { {} }
+  let(:params) { ActionController::Parameters.new({}) }
   let(:date_updated_link_text) { t("components.page_titles.trainees.sort_links.date_updated") }
   let(:last_name_link_text) { t("components.page_titles.trainees.sort_links.last_name") }
 
@@ -26,7 +26,7 @@ RSpec.describe Trainees::SortLinks::View do
   end
 
   context "query params has sort_by=date_updated" do
-    let(:params) { { sort_by: :date_updated } }
+    let(:params) { ActionController::Parameters.new({ sort_by: :date_updated }) }
 
     it "changes the date_updated link to text only" do
       expect(component).to have_text(date_updated_link_text)


### PR DESCRIPTION
### Context

 Moving the `Export these records` link to above the trainees list. 

### Guidance to review

- Navigate to the trainees page and inspect the `Export these records` link
- Check that it still exports filtered results
- Check the responsiveness of the page and that when the window becomes too small the link moves to the correct place
- Mobile format is excluded from this ticket as it is in another

### Screenshot

![image](https://user-images.githubusercontent.com/50492247/121559195-47ed0280-ca0e-11eb-9e1a-e9279ce31fbf.png)


