### PR TITLE
[1865] Add e2e feature specs for early years assessment_only & postgrad routes

### DIFF
--- a/spec/features/end_to_end/early_years_assessment_only_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_assessment_only_journey_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "early_years_assessment_only end-to-end journey", type: :feature do
+  background { given_i_am_authenticated }
+
+  scenario "submit for TRN", "feature_routes.early_years_assessment_only": true do
+    given_i_have_created_an_early_years_assessment_only_trainee
+    and_the_personal_details_is_complete
+    and_the_contact_details_is_complete
+    and_the_diversity_information_is_complete
+    and_the_degree_details_is_complete
+    and_the_ey_course_details_is_complete
+    and_the_trainee_start_date_and_id_is_complete
+    and_the_draft_record_has_been_reviewed
+    and_all_sections_are_complete
+    when_i_submit_for_trn
+    then_i_am_redirected_to_the_trn_success_page
+  end
+end

--- a/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "early_years_postgrad end-to-end journey", type: :feature do
+  background { given_i_am_authenticated }
+
+  scenario "submit for TRN", "feature_routes.early_years_postgrad": true do
+    given_i_have_created_an_early_years_postgrad_trainee
+    and_the_personal_details_is_complete
+    and_the_contact_details_is_complete
+    and_the_diversity_information_is_complete
+    and_the_degree_details_is_complete
+    and_the_ey_course_details_is_complete
+    and_the_trainee_start_date_and_id_is_complete
+    and_the_draft_record_has_been_reviewed
+    and_all_sections_are_complete
+    when_i_submit_for_trn
+    then_i_am_redirected_to_the_trn_success_page
+  end
+end

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -16,12 +16,15 @@ module Features
       course_details_page.load(id: trainee_from_url.slug)
       course_details_page.subject.select(Dttp::CodeSets::CourseSubjects::MAPPING.keys.first)
       course_details_page.main_age_range_3_to_11.choose
-      course_details_page.set_date_fields("course_start_date", "11/3/2021")
-      course_details_page.set_date_fields("course_end_date", "11/3/2022")
-      course_details_page.submit_button.click
-      confirm_details_page.confirm.click
-      confirm_details_page.continue_button.click
+      and_the_course_date_fields_are_completed
+      and_the_course_details_are_submitted
+      and_the_course_details_is_marked_completed
+    end
 
+    def and_the_ey_course_details_is_complete
+      course_details_page.load(id: trainee_from_url.slug)
+      and_the_course_date_fields_are_completed
+      and_the_course_details_are_submitted
       and_the_course_details_is_marked_completed
     end
 
@@ -32,6 +35,17 @@ module Features
 
     def and_the_course_details_is_marked_completed
       expect(review_draft_page).to have_course_details_completed
+    end
+
+    def and_the_course_date_fields_are_completed
+      course_details_page.set_date_fields("course_start_date", "11/3/2021")
+      course_details_page.set_date_fields("course_end_date", "11/3/2022")
+    end
+
+    def and_the_course_details_are_submitted
+      course_details_page.submit_button.click
+      confirm_details_page.confirm.click
+      confirm_details_page.continue_button.click
     end
   end
 end

--- a/spec/support/features/training_route_steps.rb
+++ b/spec/support/features/training_route_steps.rb
@@ -18,6 +18,14 @@ module Features
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee])
     end
 
+    def given_i_have_created_an_early_years_assessment_only_trainee
+      choose_training_route_for(TRAINING_ROUTE_ENUMS[:early_years_assessment_only])
+    end
+
+    def given_i_have_created_an_early_years_postgrad_trainee
+      choose_training_route_for(TRAINING_ROUTE_ENUMS[:early_years_postgrad])
+    end
+
   private
 
     def choose_training_route_for(route)

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -13,7 +13,7 @@ module PageObjects
 
       element :early_years_assessment_only, "#trainee-training-route-early-years-assessment-only-field"
       element :early_years_salaried, "#trainee-training-route-early-years-graduate-placement-based-field"
-      element :early_years_postgrad, "#trainee-training-route-early-years-graduate-entry-field"
+      element :early_years_postgrad, "#trainee-training-route-early-years-postgrad-field"
       element :school_direct_salaried, "#trainee-training-route-school-direct-salaried-field"
       element :school_direct_tuition_fee, "#trainee-training-route-school-direct-tuition-fee-field"
 


### PR DESCRIPTION
### Context

https://trello.com/c/axXKqAxy/1865-m-ey-end-to-end-feature-spec-for-each-route

### Changes proposed in this pull request

- End to end feature specs for both `assessment_only` and `postgrad` early years routes

### Guidance to review

