### PR TITLE
[1938] Ability to change course reinstated even if you choose 'another course' option

### DIFF
--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -37,9 +37,8 @@ module TraineeHelper
 
   def show_publish_courses?(trainee)
     courses_available = trainee.available_courses.present?
-    manual_entry_chosen = PublishCourseDetailsForm.new(trainee).manual_entry_chosen?
 
-    FeatureService.enabled?(:publish_course_details) && courses_available && !manual_entry_chosen
+    FeatureService.enabled?(:publish_course_details) && courses_available
   end
 
   def last_updated_event_for(trainee)

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -72,7 +72,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
       and_i_submit_the_form
       then_i_see_the_course_details_page
       and_i_visit_the_review_draft_page
-      then_the_link_takes_me_to_the_course_details_edit_page
+      then_the_link_takes_me_to_the_publish_course_details_page
     end
   end
 


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/AtWL1CYk/1938-choosing-another-course-not-listed-doesnt-allow-you-to-re-choose-a-course)

### Changes proposed in this pull request

- `show_publish_courses(trainee)` was checking if the trainee had also checked the `course not listed` option. This meant that if the trainee had selected this option, they could never change their course as the flow would not allow them to. 
- I removed this conditional to ensure that the confirm page would allow them to change the course. 
- This also meant that from the review-draft page, it would take the user through the whole flow instead of going straight to the subjects section, meaning that one test was changed as well. 

### Guidance to review

- Create a trainee on the `provider_led_postgrad` route
- On the course details section, select `Another course not listed` and fill in the subject
- On the confirm page, you will see an option to change the course, and it will have the title `Course not on Publish`

