### PR TITLE
[826] Bug fix: pre-filled invalid entries get suggested by autocomplete

### DIFF
--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -26,6 +26,8 @@ const setupAutoComplete = (component) => {
   const selectEl = component.querySelector('select')
   const selectOptions = Array.from(selectEl.options)
   const options = selectOptions.map(o => enhanceOption(o))
+  const inError = component.querySelector('div.govuk-form-group').className.includes('error')
+  const inputValue = defaultValueOption(component)
 
   // We add a name which we base off the name for the select element and add "raw" to it, eg
   // if there is a select input called "course_details[subject]" we add a name to the text input
@@ -34,7 +36,7 @@ const setupAutoComplete = (component) => {
   const rawFieldName = `${matches[1]}[${matches[2]}_raw]`
 
   accessibleAutocomplete.enhanceSelectElement({
-    defaultValue: defaultValueOption(component),
+    defaultValue: inError ? '' : inputValue,
     selectElement: selectEl,
     minLength: 2,
     source: (query, populateResults) => {
@@ -44,6 +46,10 @@ const setupAutoComplete = (component) => {
     templates: { suggestion: (value) => suggestion(value, options) },
     name: rawFieldName
   })
+
+  if (inError) {
+    component.querySelector('input').value = inputValue
+  }
 }
 
 nodeListForEach($allAutocompleteElements, setupAutoComplete)


### PR DESCRIPTION
### Context
https://trello.com/c/LZtcths6/1826-pre-filled-invalid-entries-get-suggested-by-autocomplete

### Problem
If an autocomplete field has a value that yields no results and the user still submits the form, when the form is re-rendered with validation errors, that field no longer displays "No results round" when clicked on. Instead it displays the invalid value currently in the field.

### Workaround
First of all, we need to determine if the field has a validation error. If so, the `defaultValue` needs to be an empty string, otherwise `accessible-autocomplete` will use the `defaultValue` to render the option which we don't want because that's the source of the problem. However, we still need the input field generated by `accessible-autocomplete` to hold the value that was previously submitted. We do this in a separate step after the `accessible-autocomplete` is finished loading.

### Guidance to review
- Switch to `master` branch and load up a form with an autocomplete field (new degree page for example)
- Search for something, but continue entering a few more characters so you get the message "No results found"
- Submit the form
- Click on that same field again - it should diplays a dropdown with the value you entered and not the expected "No results found"
- Switch to PR branch
- Follow the same steps as before
- The dropdown should now display "No results found" after the page is re-rendered with validation errors
