### PR TITLE
[1852] Hard code EY subject and age range for DTTP

### DIFF
--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -9,6 +9,8 @@ module Dttp
       COURSE_LEVEL_PG = 12
       COURSE_LEVEL_UG = 20
       ITT_QUALIFICATION_AIM_QTS = "68cbae32-7389-e711-80d8-005056ac45bb"
+      EARLY_YEARS_SUBJECT = "3aa12838-b3cf-e911-a860-000d3ab1da01"
+      EARLY_YEARS_AGE_RANGE = AgeRange::ZERO_TO_FIVE
 
       attr_reader :trainee, :qualifying_degree, :params
 
@@ -33,8 +35,8 @@ module Dttp
 
       def build_params
         {
-          "dfe_CoursePhaseId@odata.bind" => "/dfe_coursephases(#{course_phase_id(trainee.course_age_range)})",
-          "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{course_subject_id(trainee.subject)})",
+          "dfe_CoursePhaseId@odata.bind" => "/dfe_coursephases(#{course_phase_id(course_age_range)})",
+          "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{subject_entity_id})",
           "dfe_SubjectofUGDegreeId@odata.bind" => "/dfe_jacses(#{degree_subject_id(qualifying_degree.subject)})",
           "dfe_programmestartdate" => trainee.course_start_date.in_time_zone.iso8601,
           "dfe_programmeenddate" => trainee.course_end_date.in_time_zone.iso8601,
@@ -50,12 +52,20 @@ module Dttp
         }.merge(qualifying_degree.uk? ? uk_specific_params : non_uk_specific_params)
       end
 
+      def course_age_range
+        trainee.early_years_route? ? EARLY_YEARS_AGE_RANGE : trainee.course_age_range
+      end
+
       def course_level
         if trainee.training_route == "early_years_undergrad"
           COURSE_LEVEL_UG
         else
           COURSE_LEVEL_PG
         end
+      end
+
+      def subject_entity_id
+        trainee.early_years_route? ? EARLY_YEARS_SUBJECT : course_subject_id(trainee.subject)
       end
 
       def uk_specific_params

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -14,7 +14,9 @@ module Dttp
       let(:contact_change_set_id) { SecureRandom.uuid }
       let(:dttp_contact_id) { SecureRandom.uuid }
       let(:dttp_age_range_entity_id) { SecureRandom.uuid }
+      let(:dttp_ey_age_range_entity_id) { SecureRandom.uuid }
       let(:dttp_course_subject_entity_id) { SecureRandom.uuid }
+      let(:dttp_ey_subject_entity_id) { SecureRandom.uuid }
       let(:dttp_degree_subject_entity_id) { SecureRandom.uuid }
       let(:dttp_degree_institution_entity_id) { SecureRandom.uuid }
       let(:dttp_degree_grade_entity_id) { SecureRandom.uuid }
@@ -29,7 +31,10 @@ module Dttp
         trainee.degrees << degree
 
         stub_const("Dttp::CodeSets::AgeRanges::MAPPING",
-                   { trainee.course_age_range => { entity_id: dttp_age_range_entity_id } })
+                   {
+                     trainee.course_age_range => { entity_id: dttp_age_range_entity_id },
+                     AgeRange::ZERO_TO_FIVE => { entity_id: dttp_ey_age_range_entity_id },
+                   })
         stub_const("Dttp::CodeSets::CourseSubjects::MAPPING",
                    { trainee.subject => { entity_id: dttp_course_subject_entity_id } })
         stub_const("Dttp::CodeSets::DegreeSubjects::MAPPING",
@@ -128,9 +133,21 @@ module Dttp
           end
           subject { described_class.new(trainee).params }
 
-          it "course level is UG" do
+          it "returns a hash including the undergrad course level" do
             expect(subject).to include(
               { "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_UG },
+            )
+          end
+
+          it "returns a hash including the Early years 0 to 5 age range" do
+            expect(subject).to include(
+              { "dfe_CoursePhaseId@odata.bind" => "/dfe_coursephases(#{dttp_ey_age_range_entity_id})" },
+            )
+          end
+
+          it "returns a hash containing the Early years subject" do
+            expect(subject).to include(
+              { "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{Dttp::Params::PlacementAssignment::EARLY_YEARS_SUBJECT})" },
             )
           end
         end


### PR DESCRIPTION
### Context

https://trello.com/c/wskrsKOd/1852-m-ey-send-correct-age-range-and-subject-to-dttp

We've removed the subject and age range inputs from the course details form for Early years trainees. However, we still need to send a subject and an age range to DTTP.

### Changes proposed in this pull request

- Hardcodes the Early years subject DTTP ID in the placement assignment params.
- Selects the correct Early years age range (`ZERO_TO_FIVE`) in the placement assignment params.

### Guidance to review