### PR TITLE
[1902] Cache timeline computation

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -35,7 +35,7 @@ module ApplicationRecordCard
     end
 
     def updated_at
-      date_stamp = record.updated_at.presence || record.created_at
+      date_stamp = record.timeline&.first&.date.presence || record.created_at
       date_text = tag.span(date_stamp.strftime("%-d %B %Y"))
       class_list = "govuk-caption-m govuk-!-font-size-16 govuk-!-margin-top-2 govuk-!-margin-bottom-0 app-application-card__submitted"
 

--- a/app/controllers/trainees/timelines_controller.rb
+++ b/app/controllers/trainees/timelines_controller.rb
@@ -5,7 +5,7 @@ module Trainees
     before_action :authorize_trainee
 
     def show
-      @timeline_events = Trainees::CreateTimeline.call(trainee: trainee)
+      @timeline_events = trainee.timeline
       render layout: "trainee_record"
     end
 

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -41,10 +41,6 @@ module TraineeHelper
     FeatureService.enabled?(:publish_course_details) && courses_available
   end
 
-  def last_updated_event_for(trainee)
-    Trainees::CreateTimeline.call(trainee: trainee).first
-  end
-
   def trainee_draft_title(trainee)
     name = trainee_name(trainee)
     title_suffix = "#{name.present? ? " for #{name}" : ''} "

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -217,4 +217,10 @@ class Trainee < ApplicationRecord
       state
     end
   end
+
+  def timeline
+    Rails.cache.fetch([self, :timeline]) do
+      Trainees::CreateTimeline.call(trainee: self)
+    end
+  end
 end

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div class="record-details">
-  <%= render Trainees::RecordDetails::View.new(trainee: @trainee, last_updated_event: last_updated_event_for(@trainee)) %>
+  <%= render Trainees::RecordDetails::View.new(trainee: @trainee, last_updated_event: @trainee.timeline.first) %>
 </div>
 
 <div class="course-details">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require Rails.root.join("config/initializers/redis")
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -49,7 +51,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :file_store
+  config.cache_store = :redis_cache_store, { url: RedisSetting.new(ENV["VCAP_SERVICES"]).url }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,12 +1,30 @@
 # frozen_string_literal: true
 
-if ENV.key?("VCAP_SERVICES")
-  service_config = JSON.parse(ENV["VCAP_SERVICES"])
-  redis_config = service_config["redis"]
-  redis_cache_config = redis_config.select { |r| r["instance_name"].include?("cache") }.first
-  redis_credentials = redis_cache_config["credentials"]
+class RedisSetting
+  attr_reader :config
 
-  Redis.current = Redis.new(url: redis_credentials["uri"])
-else
-  Redis.current = Redis.new(url: ENV["REDIS_URL"])
+  def initialize(config = nil)
+    @config = {
+      url: ENV["REDIS_URL"],
+    }.merge(parse_config(config))
+  end
+
+  def url
+    config[:url]
+  end
+
+private
+
+  def parse_config(config)
+    service_config = JSON.parse(config.presence || "{}")
+    redis_config = service_config["redis"]
+    redis_cache_config = redis_config&.select { |r| r["instance_name"].include?("cache") }&.first
+
+    return {} if redis_cache_config.nil?
+
+    redis_credentials = redis_cache_config["credentials"]
+    { url: redis_credentials["uri"] }
+  end
 end
+
+Redis.current = Redis.new(url: RedisSetting.new(ENV["VCAP_SERVICES"]).url)

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -4,49 +4,48 @@ require "rails_helper"
 
 module ApplicationRecordCard
   describe View do
-    alias_method :component, :page
-
     let(:trainee) { Trainee.new(created_at: Time.zone.now) }
 
     before do
+      allow(trainee).to receive(:timeline).and_return([double(date: Time.zone.now)])
       render_inline(described_class.new(record: trainee))
     end
 
     context "when the Trainee has no names" do
       it "renders 'Draft record'" do
-        expect(component.find("h3")).to have_text("Draft record")
+        expect(rendered_component).to have_text("Draft record")
       end
     end
 
     context "when the Trainee has no subject" do
       it "renders 'No subject provided'" do
-        expect(component.find(".app-application-card__subject")).to have_text("No subject provided")
+        expect(rendered_component).to have_text("No subject provided")
       end
 
       context "and is an Early Years trainee" do
         let(:trainee) { Trainee.new(created_at: Time.zone.now, training_route: TRAINING_ROUTE_ENUMS[:early_years_undergrad]) }
 
         it "renders 'Early uears teaching'" do
-          expect(component.find(".app-application-card__subject")).to have_text("Early years teaching")
+          expect(rendered_component).to have_text("Early years teaching")
         end
       end
     end
 
     context "when the Trainee has no route" do
       it "renders 'No route provided'" do
-        expect(component.find(".app-application-card__route")).to have_text("No route provided")
+        expect(rendered_component).to have_text("No route provided")
       end
     end
 
     context "when the Trainee has no trainee_id" do
       it "does not render trainee ID" do
-        expect(component).to_not have_selector(".app-application-card__id")
+        expect(rendered_component).to_not have_selector(".app-application-card__id")
       end
     end
 
     context "when the Trainee has no trn" do
       it "does not render trn" do
-        expect(component).to_not have_selector(".app-application-card__trn")
+        expect(rendered_component).to_not have_selector(".app-application-card__trn")
       end
     end
 
@@ -64,7 +63,7 @@ module ApplicationRecordCard
           let(:trainee) { build(:trainee, state_expectation[:state], training_route: TRAINING_ROUTE_ENUMS[:assessment_only], created_at: Time.zone.now) }
 
           it "renders '#{state_expectation[:text]}'" do
-            expect(component).to have_selector(".govuk-tag", text: state_expectation[:text])
+            expect(rendered_component).to have_selector(".govuk-tag", text: state_expectation[:text])
           end
 
           it "sets the colour to #{state_expectation[:colour]}" do
@@ -72,7 +71,7 @@ module ApplicationRecordCard
             expected_tag_class = ".govuk-tag"
             expected_tag_class = "#{expected_tag_class}--#{colour}" if colour.present?
 
-            expect(component).to have_selector(expected_tag_class)
+            expect(rendered_component).to have_selector(expected_tag_class)
           end
         end
       end
@@ -102,27 +101,27 @@ module ApplicationRecordCard
       end
 
       it "renders trainee ID" do
-        expect(component.find(".app-application-card__id")).to have_text("Trainee ID: 132456")
+        expect(rendered_component).to have_text("Trainee ID: 132456")
       end
 
       it "renders trn" do
-        expect(component.find(".app-application-card__trn")).to have_text("TRN: 789456")
+        expect(rendered_component).to have_text("TRN: 789456")
       end
 
       it "renders updated at" do
-        expect(component.find(".app-application-card__submitted")).to have_text("Updated: 1 January 2020")
+        expect(rendered_component).to have_text("Updated: #{Time.zone.now.strftime('%-d %B %Y')}")
       end
 
       it "renders trainee name " do
-        expect(component.find("h3")).to have_text("Teddy Smith")
+        expect(rendered_component).to have_text("Teddy Smith")
       end
 
       it "renders subject" do
-        expect(component.find(".app-application-card__subject")).to have_text("Designer")
+        expect(rendered_component).to have_text("Designer")
       end
 
       it "renders route if there is no route" do
-        expect(component.find(".app-application-card__route")).to have_text(t("activerecord.attributes.trainee.training_routes.assessment_only"))
+        expect(rendered_component).to have_text(t("activerecord.attributes.trainee.training_routes.assessment_only"))
       end
     end
   end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -183,6 +183,28 @@ describe Trainee do
         it { is_expected.to be false }
       end
     end
+
+    describe "#timeline" do
+      context "with cache" do
+        before do
+          allow(Rails.cache).to receive(:fetch).and_return(double)
+        end
+
+        it "caches the timeline event after the initial request" do
+          expect(Trainees::CreateTimeline).to receive(:call).never
+
+          subject.timeline
+        end
+      end
+
+      context "without cache" do
+        it "calls Trainees::CreateTimeline" do
+          expect(Trainees::CreateTimeline).to receive(:call).once
+
+          subject.timeline
+        end
+      end
+    end
   end
 
   describe "#with_name_trainee_id_or_trn_like" do


### PR DESCRIPTION
### Context

https://trello.com/c/ea3RZgLY/1902-record-updated-date-doesnt-match-on-records-list-and-within-record

At the moment, we generate a timeline of events for the trainee which is rendered in the timeline view `trainees/{trainee_slug}/timeline`. We decided that the `updated_at` field used in the UI should reflect the last updated timeline event.

The problem is we compute the timeline entries every time we need to reference this date somewhere other than the timeline view. It's amplified even more on the record list as it'll do the computation per trainee. This might be ok for the small number of trainees but can quickly become a problem as the list of the trainees grow.

Two approaches were considered:

**Compute a hash table of trainee_ids matched to the last updated date** - this means we could look up the date by providing the trainee id but we'd have to run the query every time. I considered doing it in SQL but it would end being quite a large piece of raw SQL since we do quite a bit filtering to generate the events.

**Cache the timeline computation** - use `Rails.cache` scoped to the trainee's id to cache the timeline events. If a trainee is updated we re-compute otherwise we re-use what's already been computed. 

Decided to go with option 2 since it was a little simpler. 

### Changes proposed in this pull request:

- Cache the timeline computation under a `timeline` method on the trainee
- Refactor some failing specs

### Guidance to review

- Run `bin/rails dev:cache` to enable local caching
- View the trainee index page and assert multiple queries for audit look ups in the logs
- Reload the page and assert no additional queries were performed
- Update a trainee, assert a new timeline event is created
