### PR TITLE
[1900] Disable features in non-production

### DIFF
--- a/app/jobs/dttp/sync_providers_job.rb
+++ b/app/jobs/dttp/sync_providers_job.rb
@@ -5,6 +5,8 @@ module Dttp
     queue_as :dttp
 
     def perform(request_uri = nil)
+      return unless FeatureService.enabled?(:sync_from_dttp)
+
       @provider_list = Dttp::RetrieveProviders.call(request_uri: request_uri)
 
       Dttp::Provider.upsert_all(provider_attributes, unique_by: :dttp_id)

--- a/app/jobs/dttp/sync_schools_job.rb
+++ b/app/jobs/dttp/sync_schools_job.rb
@@ -5,6 +5,8 @@ module Dttp
     queue_as :dttp
 
     def perform(request_uri = nil)
+      return unless FeatureService.enabled?(:sync_from_dttp)
+
       @school_list = Dttp::RetrieveSchools.call(request_uri: request_uri)
 
       Dttp::School.upsert_all(school_attributes, unique_by: :dttp_id)

--- a/app/jobs/dttp/sync_users_job.rb
+++ b/app/jobs/dttp/sync_users_job.rb
@@ -5,6 +5,8 @@ module Dttp
     queue_as :dttp
 
     def perform(request_uri = nil)
+      return unless FeatureService.enabled?(:sync_from_dttp)
+
       @user_list = Dttp::RetrieveUsers.call(request_uri: request_uri)
 
       Dttp::User.upsert_all(user_attributes, unique_by: :dttp_id)

--- a/app/services/dttp/contact_update.rb
+++ b/app/services/dttp/contact_update.rb
@@ -15,6 +15,8 @@ module Dttp
     end
 
     def call
+      return unless FeatureService.enabled?(:persist_to_dttp)
+
       dttp_update("/contacts(#{trainee.dttp_id})", contact_payload)
 
       dttp_update("/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})",

--- a/app/services/dttp/create_dormancy.rb
+++ b/app/services/dttp/create_dormancy.rb
@@ -13,6 +13,8 @@ module Dttp
     end
 
     def call
+      return unless FeatureService.enabled?(:persist_to_dttp)
+
       response = Client.post("/dfe_dormantperiods", body: params.to_json)
 
       if response.code != 204

--- a/app/services/dttp/recommend_for_award.rb
+++ b/app/services/dttp/recommend_for_award.rb
@@ -13,6 +13,8 @@ module Dttp
     end
 
     def call
+      return unless FeatureService.enabled?(:persist_to_dttp)
+
       response = Client.patch(
         "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})",
         body: params.to_json,

--- a/app/services/dttp/register_for_trn.rb
+++ b/app/services/dttp/register_for_trn.rb
@@ -13,6 +13,8 @@ module Dttp
     end
 
     def call
+      return unless FeatureService.enabled?(:persist_to_dttp)
+
       build_contact_change_set
       build_placement_assignment_change_set
       build_degree_qualification_change_sets

--- a/app/services/dttp/update_dormancy.rb
+++ b/app/services/dttp/update_dormancy.rb
@@ -13,6 +13,8 @@ module Dttp
     end
 
     def call
+      return unless FeatureService.enabled?(:persist_to_dttp)
+
       response = Client.patch(
         "/dfe_dormantperiods(#{trainee.dormancy_dttp_id})",
         body: params.to_json,

--- a/app/services/dttp/update_trainee_status.rb
+++ b/app/services/dttp/update_trainee_status.rb
@@ -22,6 +22,8 @@ module Dttp
     end
 
     def call
+      return unless FeatureService.enabled?(:persist_to_dttp)
+
       response = Client.patch(path, body: params.to_json)
       if response.code != 204
         raise Error, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}"

--- a/app/services/dttp/withdraw_trainee.rb
+++ b/app/services/dttp/withdraw_trainee.rb
@@ -13,6 +13,8 @@ module Dttp
     end
 
     def call
+      return unless FeatureService.enabled?(:persist_to_dttp)
+
       response = Client.patch(
         "/dfe_placementassignments(#{trainee.placement_assignment_dttp_id})",
         body: params.to_json,

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -8,6 +8,7 @@ class SendWelcomeEmailService
   end
 
   def call
+    return unless FeatureService.enabled?(:send_emails)
     return if current_user.welcome_email_sent_at
 
     WelcomeEmailMailer.generate(

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,6 +37,7 @@ features:
   publish_course_details: false
   run_consistency_check_job: true
   sync_from_dttp: false
+  send_emails: false
   routes:
     early_years_assessment_only: false
     early_years_salaried: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,6 +36,7 @@ features:
   import_courses_from_ttapi: false
   publish_course_details: false
   run_consistency_check_job: true
+  sync_from_dttp: false
   routes:
     early_years_assessment_only: false
     early_years_salaried: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,6 +38,7 @@ features:
   run_consistency_check_job: false
   sync_from_dttp: false
   send_emails: false
+  persist_to_dttp: false
   routes:
     early_years_assessment_only: false
     early_years_salaried: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,7 +35,7 @@ features:
   import_applications_from_apply: false
   import_courses_from_ttapi: false
   publish_course_details: false
-  run_consistency_check_job: true
+  run_consistency_check_job: false
   sync_from_dttp: false
   send_emails: false
   routes:

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -24,6 +24,7 @@ dfe_sign_in:
 features:
   basic_auth: false
   enable_feedback_link: true
+  sync_from_dttp: true
 
 environment:
   name: beta

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -27,6 +27,7 @@ features:
   sync_from_dttp: true
   send_emails: true
   run_consistency_check_job: true
+  persist_to_dttp: true
 
 environment:
   name: beta

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -26,6 +26,7 @@ features:
   enable_feedback_link: true
   sync_from_dttp: true
   send_emails: true
+  run_consistency_check_job: true
 
 environment:
   name: beta

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -25,6 +25,7 @@ features:
   basic_auth: false
   enable_feedback_link: true
   sync_from_dttp: true
+  send_emails: true
 
 environment:
   name: beta

--- a/spec/jobs/dttp/sync_providers_job_spec.rb
+++ b/spec/jobs/dttp/sync_providers_job_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Dttp::SyncProvidersJob, type: :job do
   include ActiveJob::TestHelper
 
   before do
+    enable_features(:sync_from_dttp)
     allow(Dttp::RetrieveProviders).to receive(:call).with(request_uri: request_uri).and_return(provider_list)
   end
 

--- a/spec/jobs/dttp/sync_schools_job_spec.rb
+++ b/spec/jobs/dttp/sync_schools_job_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Dttp::SyncSchoolsJob, type: :job do
   include ActiveJob::TestHelper
 
   before do
+    enable_features(:sync_from_dttp)
     allow(Dttp::RetrieveSchools).to receive(:call).with(request_uri: request_uri).and_return(school_list)
   end
 

--- a/spec/jobs/dttp/sync_users_job_spec.rb
+++ b/spec/jobs/dttp/sync_users_job_spec.rb
@@ -20,6 +20,7 @@ module Dttp
     subject { described_class.perform_now }
 
     before do
+      enable_features(:sync_from_dttp)
       allow(Dttp::RetrieveUsers).to receive(:call) { user_list }
     end
 

--- a/spec/services/dttp/contact_update_spec.rb
+++ b/spec/services/dttp/contact_update_spec.rb
@@ -21,6 +21,7 @@ module Dttp
       let(:placement_payload) { Params::PlacementAssignment.new(trainee).to_json }
 
       before do
+        enable_features(:persist_to_dttp, "routes.school_direct_salaried")
         allow(AccessToken).to receive(:fetch).and_return("token")
         trainee.degrees << create(:degree)
       end

--- a/spec/services/dttp/create_dormancy_spec.rb
+++ b/spec/services/dttp/create_dormancy_spec.rb
@@ -14,6 +14,7 @@ module Dttp
       let(:expected_dormant_id) { SecureRandom.uuid }
 
       before do
+        enable_features(:persist_to_dttp)
         allow(AccessToken).to receive(:fetch).and_return("token")
         allow(Client).to receive(:post).and_return(dttp_response)
         allow(Dttp::OdataParser).to receive(:entity_id).with(trainee.id, dttp_response).and_return(expected_dormant_id)

--- a/spec/services/dttp/recommend_for_award_spec.rb
+++ b/spec/services/dttp/recommend_for_award_spec.rb
@@ -15,6 +15,7 @@ module Dttp
       let(:expected_params) { { test: "value" }.to_json }
 
       before do
+        enable_features(:persist_to_dttp)
         allow(AccessToken).to receive(:fetch).and_return("token")
         allow(Client).to receive(:patch).and_return(dttp_response)
         allow(Params::PlacementOutcomes::Qts)

--- a/spec/services/dttp/register_for_trn_spec.rb
+++ b/spec/services/dttp/register_for_trn_spec.rb
@@ -39,6 +39,7 @@ module Dttp
       end
 
       before do
+        enable_features(:persist_to_dttp, "routes.school_direct_salaried")
         allow(AccessToken).to receive(:fetch).and_return("token")
         allow(BatchRequest).to receive(:new).and_return(batch_request)
         trainee.degrees << degree

--- a/spec/services/dttp/update_dormancy_spec.rb
+++ b/spec/services/dttp/update_dormancy_spec.rb
@@ -13,6 +13,7 @@ module Dttp
       let(:expected_params) { { test: "value" }.to_json }
 
       before do
+        enable_features(:persist_to_dttp)
         allow(AccessToken).to receive(:fetch).and_return("token")
         allow(Client).to receive(:patch).and_return(dttp_response)
         allow(Params::Dormancy).to receive(:new).with(trainee: trainee)

--- a/spec/services/dttp/update_trainee_status_spec.rb
+++ b/spec/services/dttp/update_trainee_status_spec.rb
@@ -14,6 +14,7 @@ module Dttp
       let(:expected_path) { "/contacts(#{entity_id})" }
 
       before do
+        enable_features(:persist_to_dttp)
         allow(AccessToken).to receive(:fetch).and_return("token")
       end
 

--- a/spec/services/dttp/withdraw_trainee_spec.rb
+++ b/spec/services/dttp/withdraw_trainee_spec.rb
@@ -15,6 +15,7 @@ module Dttp
       let(:expected_params) { { test: "value" }.to_json }
 
       before do
+        enable_features(:persist_to_dttp)
         allow(AccessToken).to receive(:fetch).and_return("token")
         allow(Client).to receive(:patch).and_return(dttp_response)
         allow(Params::PlacementOutcomes::Withdrawn)

--- a/spec/services/send_welcome_email_service_spec.rb
+++ b/spec/services/send_welcome_email_service_spec.rb
@@ -3,7 +3,11 @@
 require "rails_helper"
 
 describe SendWelcomeEmailService do
-  before { Timecop.freeze }
+  before do
+    enable_features(:send_emails)
+    Timecop.freeze
+  end
+
   after { Timecop.return }
 
   context "when the user has not logged in before" do

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+def enable_features(*feature_keys)
+  feature_keys.each do |feature_key|
+    allow(FeatureService).to receive(:enabled?).with(feature_key).and_return(true)
+  end
+end
+
+def disable_features(*feature_keys)
+  feature_keys.each do |feature_key|
+    allow(FeatureService).to receive(:enabled?).with(feature_key).and_return(false)
+  end
+end


### PR DESCRIPTION
### Context

Our non-production environments are reporting a lot of errors due to various lacking configuration.

### Changes proposed in this pull request

Add feature flags for some of the integrations and disable them in non-production. Once these are in and we reduce the number of errors we can review further. This should cover the bulk of those being reported from the review apps.


### Guidance to review

