### PR TITLE
[1934] Fix trainee state update on reinstatement

### DIFF
--- a/app/controllers/trainees/confirm_reinstatements_controller.rb
+++ b/app/controllers/trainees/confirm_reinstatements_controller.rb
@@ -11,7 +11,7 @@ module Trainees
 
     def update
       if reinstatement.save!
-        trainee.trn.present? ? trainee.trn_received! : trainee.submit_for_trn!
+        trainee.trn.present? ? trainee.receive_trn! : trainee.submit_for_trn!
 
         ReinstateJob.perform_later(trainee)
 

--- a/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
@@ -22,6 +22,28 @@ describe Trainees::ConfirmReinstatementsController do
           post :update, params: { trainee_id: trainee }
         }.to have_enqueued_job(ReinstateJob).with(trainee)
       end
+
+      context "trainee has a trn" do
+        it "updates the state of the trainee to trn_received" do
+          expect {
+            post :update, params: { trainee_id: trainee }
+          }.to change {
+            trainee.reload.state.to_sym
+          }.from(:deferred).to(:trn_received)
+        end
+      end
+
+      context "trainee doesn't have a trn" do
+        let(:trn) { nil }
+
+        it "updates the state of the trainee to submitted_for_trn" do
+          expect {
+            post :update, params: { trainee_id: trainee }
+          }.to change {
+            trainee.reload.state.to_sym
+          }.from(:deferred).to(:submitted_for_trn)
+        end
+      end
     end
 
     context "with a trainee with no trn" do


### PR DESCRIPTION

### Context

https://trello.com/c/tKmwy4r8/1934-reinstating-trainees-doesnt-update-their-state-if-they-have-a-trn

There is a check in `trin_received!` that explicitly prevents transition
If the trainee is in a deferred or withdrawn state (for if the trainee
receives a trn when they are in that state). So we can use one of the
built-in methods provided by the state machine

### Changes proposed in this pull request

Fix it

### Guidance to review

Find a deferred or withdrawn trainee on the review app and reinstate them.

