### PR TITLE
[1856] Make recommended for award page body text 2/3 width

### DIFF
--- a/app/views/trainees/outcome_details/recommended.html.erb
+++ b/app/views/trainees/outcome_details/recommended.html.erb
@@ -16,18 +16,18 @@
       The Department for Education will award <%= @trainee.award_type %> where appropriate within 3
       working days.
     </p>
+
+    <%= render FeedbackLink::View.new(
+      enabled: Settings.features.enable_feedback_link,
+      feedback_link_url: Settings.recommended_for_award_feedback_url,
+      feedback_type_text: "recommending a trainee for #{@trainee.award_type}",
+    ) %>
+
+    <h2 class="govuk-heading-m">Next steps</h2>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= govuk_link_to("view #{trainee_name(@trainee)}’s record", trainee_path(@trainee)) %></li>
+      <li><%= govuk_link_to("view all your records", trainees_path) %></li>
+    </ul>
   </div>
 </div>
-
-<%= render FeedbackLink::View.new(
-  enabled: Settings.features.enable_feedback_link,
-  feedback_link_url: Settings.recommended_for_award_feedback_url,
-  feedback_type_text: "recommending a trainee for #{@trainee.award_type}",
-) %>
-
-<h2 class="govuk-heading-m">Next steps</h2>
-
-<ul class="govuk-list govuk-list--bullet">
-  <li><%= govuk_link_to("view #{trainee_name(@trainee)}’s record", trainee_path(@trainee)) %></li>
-  <li><%= govuk_link_to("view all your records", trainees_path) %></li>
-</ul>


### PR DESCRIPTION
### Context

Making the 'recommended for award' page body text 2/3 width

### Guidance to review

- Navigate to a trainee that can be recommended for QTS for example, one in a `TRN RECEIVED` state.
- Recommend the trainee for QTS or EYTS and check that the whole page is the correct width.

### Screenshot

**Before**

![image](https://user-images.githubusercontent.com/50492247/121887892-4160d280-cd0f-11eb-8a17-aa935c846054.png)


**After**
![image](https://user-images.githubusercontent.com/50492247/121887801-19716f00-cd0f-11eb-9176-12e05faaeb87.png)

