### PR TITLE
[1955] Hint text updated for lead schools

### DIFF
--- a/app/views/trainees/lead_schools/edit.html.erb
+++ b/app/views/trainees/lead_schools/edit.html.erb
@@ -12,7 +12,7 @@
       <%= f.govuk_text_field(
         :lead_school_id,
         label: { text: t(".heading"), size: "l", tag: "h1" },
-        hint: { text: t(".hint") },
+        hint: { text: "#{t('.description')}<p>#{t('.hint')}</p>".html_safe },
         name: :'input-autocomplete',
         value: nil,
         "data-field" => "schools-autocomplete",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -511,6 +511,7 @@ en:
       edit:
         heading: Lead school
         hint: Search for a school by its unique reference number (URN), name or postcode
+        description: The lead school is the main organisation and point of contact for training providers, placements and partner schools in the school direct partnership.
     employing_schools:
       edit:
         heading: Employing school


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/63EGrEH9/1955-s-add-content-to-the-lead-school-page)

### Changes proposed in this pull request

- Changed the hint text to include more info on the edit lead school page

### Guidance to review

- Select a trainee on a school direct route and visit the edit lead school page (`/trainees/{slug}/lead-schools/edit`)

