### PR TITLE
[1844] Update not supported route content

### DIFF
--- a/app/views/trainees/not_supported_route.html.erb
+++ b/app/views/trainees/not_supported_route.html.erb
@@ -11,11 +11,10 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <%= t(".heading") %>
-      Other routes not supported
     </h1>
 
     <p class="govuk-body">
-      <%= t(".body", route: t("activerecord.attributes.trainee.training_routes.assessment_only")) %>
+      <%= t(".body") %>
     </p>
 
     <p class="govuk-body"><%= t(".bullet_desc") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -454,7 +454,7 @@ en:
         heading_2: "Trainee Data"
     not_supported_route:
       heading: Other routes not supported
-      body: "%{route} is the only route currently supported by this service. More routes will be added soon."
+      body: You can only add trainees for the routes listed on the previous page. We’ll be adding more routes soon.
       bullet_desc: "You can:"
       go_back: go back and change your answer
       use_dttp: use DTTP to register a different route


### PR DESCRIPTION
### Context

- https://trello.com/b/BBEuhbHM/publish-register-sprint-board

### Changes proposed in this pull request

- Update the copy on the `/trainees/not-supported-route`

### Guidance to review

- https://register-pr-1009.london.cloudapps.digital/trainees/not-supported-route