### PR TITLE
Separate redis instances for app cache and worker

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -2,8 +2,9 @@
 
 if ENV.key?("VCAP_SERVICES")
   service_config = JSON.parse(ENV["VCAP_SERVICES"])
-  redis_config = service_config["redis"].first
-  redis_credentials = redis_config["credentials"]
+  redis_config = service_config["redis"]
+  redis_cache_config = redis_config.select { |r| r["instance_name"].include?("cache") }.first
+  redis_credentials = redis_cache_config["credentials"]
 
   Redis.current = Redis.new(url: redis_credentials["uri"])
 else

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,8 +2,9 @@
 
 if ENV.key?("VCAP_SERVICES")
   service_config = JSON.parse(ENV["VCAP_SERVICES"])
-  redis_config = service_config["redis"].first
-  redis_credentials = redis_config["credentials"]
+  redis_config = service_config["redis"]
+  redis_worker_config = redis_config.select { |r| r["instance_name"].include?("worker") }.first
+  redis_credentials = redis_worker_config["credentials"]
 
   Sidekiq.configure_server do |config|
     config.redis = {

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -33,15 +33,22 @@ variable app_config_variable { type = map } #from yml file
 variable worker_app_stopped { default = false }
 
 locals {
-  app_name_suffix          = var.app_environment != "review" ? var.app_environment : "pr-${var.web_app_hostname}"
-  postgres_service_name    = "register-postgres-${local.app_name_suffix}"
-  redis_service_name       = "register-redis-${local.app_name_suffix}"
-  web_app_name             = "register-${local.app_name_suffix}"
-  app_environment          = merge(var.app_config_variable, var.app_secrets_variable)
-  review_app_start_command = "bundle exec rake db:schema:load db:seed example_data:generate && bundle exec rails server -b 0.0.0.0"
-  web_app_start_command    = var.app_environment == "review" ? local.review_app_start_command : "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
-  worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
-  worker_app_name          = "register-worker-${local.app_name_suffix}"
-  logging_service_name     = "register-logit-${local.app_name_suffix}"
-  web_app_routes           = [cloudfoundry_route.web_app_service_gov_uk_route.id, cloudfoundry_route.web_app_route.id]
+  app_name_suffix           = var.app_environment != "review" ? var.app_environment : "pr-${var.web_app_hostname}"
+  postgres_service_name     = "register-postgres-${local.app_name_suffix}"
+  redis_worker_service_name = "register-redis-worker-${local.app_name_suffix}"
+  redis_cache_service_name  = "register-redis-cache-${local.app_name_suffix}"
+  web_app_name              = "register-${local.app_name_suffix}"
+  app_environment           = merge(var.app_config_variable, var.app_secrets_variable)
+  review_app_start_command  = "bundle exec rake db:schema:load db:seed example_data:generate && bundle exec rails server -b 0.0.0.0"
+  web_app_start_command     = var.app_environment == "review" ? local.review_app_start_command : "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
+  worker_app_start_command  = "bundle exec sidekiq -C config/sidekiq.yml"
+  worker_app_name           = "register-worker-${local.app_name_suffix}"
+  logging_service_name      = "register-logit-${local.app_name_suffix}"
+  web_app_routes            = [cloudfoundry_route.web_app_service_gov_uk_route.id, cloudfoundry_route.web_app_route.id]
+  noeviction_maxmemory_policy = {
+    maxmemory_policy = "noeviction"
+  }
+  allkeys_lru_maxmemory_policy = {
+    maxmemory_policy = "allkeys-lru"
+  }
 }


### PR DESCRIPTION
### Context

We need redis instances with different eviction policies configured for app cache and worker queues.

### Changes proposed in this pull request

Create two different redis instances with different eviction policies.

Initialise `Redis.current` with the app cache instance's connection string.
Initialise sidekiq with the redis worker connection string.


