### PR TITLE
[1963] Turn on EY routes in QA

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,7 +8,8 @@ features:
   publish_course_details: true
   routes:
     provider_led_postgrad: true
-    early_years_undergrad: true
+    early_years_assessment_only: true
+    early_years_postgrad: true
     school_direct_salaried: true
     school_direct_tuition_fee: true
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -13,7 +13,8 @@ features:
   publish_course_details: true
   routes:
     provider_led_postgrad: true
-    early_years_undergrad: true
+    early_years_assessment_only: true
+    early_years_postgrad: true
     school_direct_salaried: true
     school_direct_tuition_fee: true
 

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -5,9 +5,7 @@ features:
   publish_course_details: true
   routes:
     provider_led_postgrad: true
-    early_years_undergrad: true
     early_years_assessment_only: true
-    early_years_salaried: true
     early_years_postgrad: true
     school_direct_salaried: true
     school_direct_tuition_fee: true


### PR DESCRIPTION
### Context

https://trello.com/c/O86GRNid/1963-turn-on-ey-routes-in-qa

### Changes proposed in this pull request

Switch on `early_years_assessment_only` and `early_years_postgrad` in QA for testing.

I also changed the review apps and development env to show the same routes for consistency.

### Guidance to review

- Check that the only two early years routes available when creating a trainee are `early_years_assessment_only` and `early_years_postgrad`