### PR TITLE
[1954] Add request an account page

### DIFF
--- a/app/components/start_page_banner/view.html.erb
+++ b/app/components/start_page_banner/view.html.erb
@@ -12,7 +12,7 @@
                                                       href: sign_in_path,
                                                       classes: "app-button--inverted app-start-page-banner__button") %>
         <p class="govuk-body app-body--inverted">
-          or <a class="govuk-link app-link--inverted govuk-link--no-visited-state" href="/sign-in">request an account</a>
+          or <a class="govuk-link app-link--inverted govuk-link--no-visited-state app-link--request-account" href="/request-an-account">request an account</a>
         </p>
       </div>
     </div>

--- a/app/controllers/request_an_account_controller.rb
+++ b/app/controllers/request_an_account_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RequestAnAccountController < ApplicationController
+  skip_before_action :authenticate
+
+  def index; end
+end

--- a/app/views/request_an_account/index.html.erb
+++ b/app/views/request_an_account/index.html.erb
@@ -1,0 +1,30 @@
+<%= render PageTitle::View.new(title: t("components.page_titles.pages.request_an_account")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l"><%=t("components.page_titles.pages.request_an_account") %></h1>
+      <h2 class="govuk-body-m">
+        <%= t("pages.request_an_account.inviting_limited_itt") %>
+      </h2>
+      <h2 class="govuk-body-m">
+        <%= t("pages.request_an_account.to_get_setup") %>
+      </h2>
+      <h2 class="govuk-body-m  govuk-!-margin-bottom-9">
+        Get a <%= govuk_link_to t("pages.request_an_account.sign_in_account"), "https://services.signin.education.gov.uk" %> if you do not already have one.
+      </h2>
+    <hr class='govuk-section-break govuk-section-break--m govuk-section-break'>
+      <h2 class="govuk-body-m"><%= t("pages.request_an_account.send_email")  %>
+        <%= govuk_mail_to(Settings.support_email,
+                          Settings.support_email,
+                          subject: t("pages.request_an_account.email_subject")) %>
+      </h2>
+
+      <h2 class="govuk-body-m"><%= t("pages.request_an_account.tell_us") %>:</h2>
+
+    <ul class='govuk-list govuk-list--bullet'>
+      <li><%= t("pages.request_an_account.bullets.1") %></li>
+      <li><%= t("pages.request_an_account.bullets.2") %></li>
+      <li><%= t("pages.request_an_account.bullets.3") %></li>
+    </ul>
+  </div>
+</div>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -19,13 +19,5 @@
     <% else %>
       <%= render GovukButtonLinkTo::View.new(body: t(".persona_sign_in_button"), url: "/personas", class_option: "qa-sign_in_button") %>
     <% end %>
-
-    <p class="govuk-body-m">
-      <%= t(
-          ".get_access_html",
-          link: support_email(subject: "Get access to Register trainee teachers"),
-        ) %>
-    </p>
-
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,7 @@ en:
         privacy_policy: How we use your personal data and trainee data in Register trainee teachers
         forbidden: You do not have access to view details for this trainee
         home: Home
+        request_an_account: Request an account
         not_found: Page not found
         internal_server_error: Sorry, something went wrong
         unprocessable_entity: Sorry, the change you wanted was rejected
@@ -393,6 +394,18 @@ en:
         route_titles:
           provider_led_postgrad: provider-led postgrad
   pages:
+    request_an_account:
+      inviting_limited_itt: We are only inviting a limited amount of initial teacher training providers to use Register,
+                            to begin with. If your organisation has not received an invite from the DfE you cannot request an account yet.
+      to_get_setup: To get set up on Register trainee teachers you need a DfE Sign-in account.
+      sign_in_account: DfE Sign-in account
+      send_email: To request an account, send an email to
+      tell_us: In your email, tell us
+      email_subject: Get set up on Register
+      bullets:
+        1: the name of your training provider
+        2: that you would like to start using Register trainee teachers
+        3: the email address associated with your DfE Sign-in account
     home:
       heading: Register trainee teachers
       body:
@@ -433,7 +446,6 @@ en:
       body: Use DfE Sign-in to access your account.
       dfe_sign_in_button: Sign in using DfE Sign-in
       persona_sign_in_button: Sign in using Persona
-      get_access_html: If you do not have a DfE Sign-in account but need access to Register trainee teachers, email %{link}.
   errors:
     not_found:
       heading: Page not found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
 
   get "/sign-in/user-not-found", to: "sign_in#new"
 
+  get "request-an-account", to: "request_an_account#index"
+
   if FeatureService.enabled?("use_dfe_sign_in")
     get "/auth/dfe/callback" => "sessions#callback"
     get "/auth/dfe/sign-out" => "sessions#signout"

--- a/spec/features/static_pages_spec.rb
+++ b/spec/features/static_pages_spec.rb
@@ -33,6 +33,12 @@ feature "static pages" do
     then_the_start_page_is_displayed
   end
 
+  scenario "navigate to request an account" do
+    given_i_am_on_the_start_page
+    when_i_click_on_request_an_account
+    then_the_request_an_account_page_is_displayed
+  end
+
 private
 
   def given_i_am_on_the_start_page
@@ -82,5 +88,14 @@ private
   def then_i_should_see_the_privacy_policy
     expect(privacy_policy_page).to be_displayed
     expect(privacy_policy_page.page_heading).to have_text(t("components.page_titles.pages.privacy_policy"))
+  end
+
+  def when_i_click_on_request_an_account
+    start_page.request_an_account.click
+  end
+
+  def then_the_request_an_account_page_is_displayed
+    expect(request_an_account_page).to be_displayed
+    expect(request_an_account_page).to have_text("Request an account")
   end
 end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -6,6 +6,10 @@ module Features
       @trainee_index_page ||= PageObjects::Trainees::Index.new
     end
 
+    def request_an_account_page
+      @request_an_account_page ||= PageObjects::RequestAnAccount.new
+    end
+
     def new_trainee_page
       @new_trainee_page ||= PageObjects::Trainees::New.new
     end

--- a/spec/support/page_objects/request_an_account.rb
+++ b/spec/support/page_objects/request_an_account.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PageObjects
+  class RequestAnAccount < PageObjects::Base
+    set_url "/request-an-account"
+  end
+end

--- a/spec/support/page_objects/start.rb
+++ b/spec/support/page_objects/start.rb
@@ -6,7 +6,9 @@ module PageObjects
 
     element :page_heading, ".govuk-heading-xl"
 
-    element :sign_in, ".app-link--inverted"
+    element :sign_in, ".app-start-page-banner__button"
+
+    element :request_an_account, ".app-link--request-account"
 
     element :phase_banner, ".govuk-phase-banner"
 


### PR DESCRIPTION
### Context

https://register-pr-1013.london.cloudapps.digital/

We are creating a new request account page. The `request an account` link on the start page will take us there. 

### Changes proposed in this pull request

- Add HTML for request account page
- Add `/request-an-account` route
- Add controller with `index` method
- Remove text from DfE sign in page

### Guidance to review

- Navigate to the start page and click on `request an account`
- Inspect the page, check that the links works as per the Trello ticket
- Ensure the email subject populates correctly 

### Screenshot

![image](https://user-images.githubusercontent.com/50492247/121980492-ecab6f00-cd83-11eb-8d34-843f2b6ffcf4.png)
