### PR TITLE
[xxx] Don't consistency check drafts

### DIFF
--- a/app/jobs/create_or_update_consistency_check_job.rb
+++ b/app/jobs/create_or_update_consistency_check_job.rb
@@ -4,6 +4,8 @@ class CreateOrUpdateConsistencyCheckJob < ApplicationJob
   queue_as :default
 
   def perform(trainee)
+    return if trainee.draft?
+
     contact = Dttp::Contacts::Fetch.call(dttp_id: trainee.dttp_id)
     placement_assignment = Dttp::PlacementAssignments::Fetch.call(dttp_id: trainee.placement_assignment_dttp_id)
 


### PR DESCRIPTION
### Context

We shouldn't create consistency check records for trainees that have not
been sent to DTTP.

There were a few of these in the DB and they error. I've removed them.

### Changes proposed in this pull request

* Add a guard to prevent them being created.

### Guidance to review

