### PR TITLE
[2000] Fix flaky spec

### DIFF
--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -8,7 +8,7 @@ module Dttp
       let(:time_now_in_zone) { Time.zone.now }
       let(:provider) { create(:provider, dttp_id: dttp_provider_id) }
       let(:trainee) do
-        create(:trainee, :with_course_details, :with_start_date, dttp_id: dttp_contact_id, provider: provider)
+        create(:trainee, :with_course_details, :with_start_date, dttp_id: dttp_contact_id, provider: provider, course_age_range: AgeRange::ZERO_TO_FIVE)
       end
 
       let(:contact_change_set_id) { SecureRandom.uuid }

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -8,7 +8,7 @@ module Dttp
       let(:time_now_in_zone) { Time.zone.now }
       let(:provider) { create(:provider, dttp_id: dttp_provider_id) }
       let(:trainee) do
-        create(:trainee, :with_course_details, :with_start_date, dttp_id: dttp_contact_id, provider: provider, course_age_range: AgeRange::ZERO_TO_FIVE)
+        create(:trainee, :with_course_details, :with_start_date, dttp_id: dttp_contact_id, provider: provider)
       end
 
       let(:contact_change_set_id) { SecureRandom.uuid }
@@ -34,8 +34,8 @@ module Dttp
 
         stub_const("Dttp::CodeSets::AgeRanges::MAPPING",
                    {
-                     trainee.course_age_range => { entity_id: dttp_age_range_entity_id },
                      AgeRange::ZERO_TO_FIVE => { entity_id: dttp_ey_age_range_entity_id },
+                     trainee.course_age_range => { entity_id: dttp_age_range_entity_id },
                    })
         stub_const("Dttp::CodeSets::CourseSubjects::MAPPING",
                    { trainee.subject => { entity_id: dttp_course_subject_entity_id } })


### PR DESCRIPTION
### Context
Fixed the stubbing of the constant `Dttp::CodeSets::AgeRanges::MAPPING` in the test. If a trainee is generated with age_range 0-5, then this constant is stubbed with two identical keys.

### Changes proposed in this pull request

### Guidance to review

