### PR TITLE
[1994] Set up allocation subject + subject specialisms

### DIFF
--- a/app/models/allocation_subject.rb
+++ b/app/models/allocation_subject.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AllocationSubject < ApplicationRecord
+  has_many :subject_specialisms, inverse_of: :allocation_subject
+end

--- a/app/models/subject_specialism.rb
+++ b/app/models/subject_specialism.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SubjectSpecialism < ApplicationRecord
+  belongs_to :allocation_subject, inverse_of: :subject_specialisms
+end

--- a/db/migrate/20210616110455_create_allocation_subjects.rb
+++ b/db/migrate/20210616110455_create_allocation_subjects.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateAllocationSubjects < ActiveRecord::Migration[6.1]
+  def change
+    create_table :allocation_subjects do |t|
+      t.string :name, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210616124359_create_subject_specialisms.rb
+++ b/db/migrate/20210616124359_create_subject_specialisms.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateSubjectSpecialisms < ActiveRecord::Migration[6.1]
+  def change
+    create_table :subject_specialisms do |t|
+      t.string :name, null: false, index: { unique: true }
+      t.references :allocation_subject, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_164204) do
+ActiveRecord::Schema.define(version: 2021_06_16_124359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "allocation_subjects", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_allocation_subjects_on_name", unique: true
+  end
 
   create_table "apply_application_sync_requests", force: :cascade do |t|
     t.integer "response_code"
@@ -201,6 +208,15 @@ ActiveRecord::Schema.define(version: 2021_06_07_164204) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
+  create_table "subject_specialisms", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "allocation_subject_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["allocation_subject_id"], name: "index_subject_specialisms_on_allocation_subject_id"
+    t.index ["name"], name: "index_subject_specialisms_on_name", unique: true
+  end
+
   create_table "subjects", force: :cascade do |t|
     t.string "code", null: false
     t.string "name", null: false
@@ -320,6 +336,7 @@ ActiveRecord::Schema.define(version: 2021_06_07_164204) do
   add_foreign_key "degrees", "trainees"
   add_foreign_key "nationalisations", "nationalities"
   add_foreign_key "nationalisations", "trainees"
+  add_foreign_key "subject_specialisms", "allocation_subjects"
   add_foreign_key "trainee_disabilities", "disabilities"
   add_foreign_key "trainee_disabilities", "trainees"
   add_foreign_key "trainees", "apply_applications"

--- a/spec/factories/allocation_subjects.rb
+++ b/spec/factories/allocation_subjects.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :allocation_subject do
+  end
+end

--- a/spec/factories/subject_specialisms.rb
+++ b/spec/factories/subject_specialisms.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subject_specialism do
+  end
+end

--- a/spec/models/allocation_subject_spec.rb
+++ b/spec/models/allocation_subject_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AllocationSubject, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:subject_specialisms) }
+  end
+end

--- a/spec/models/subject_specialism_spec.rb
+++ b/spec/models/subject_specialism_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubjectSpecialism, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:allocation_subject) }
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/pXx6En7b/1994-s-add-allocation-subjects-and-specialism-subjects

### Changes proposed in this pull request
Add subject specialism and allocation subject model + migrations + associations with fields specified in ticket
Model tests to verify associations
### Guidance to review


