### PR TITLE
[1849] Add training route filter for trainees

### DIFF
--- a/app/components/paginated_filter/view.html.erb
+++ b/app/components/paginated_filter/view.html.erb
@@ -1,5 +1,6 @@
 <div class='moj-filter-layout'>
-  <%= render Trainees::Filters::View.new(filters: filters, filter_actions: filter_actions) %>
+  <%= render Trainees::Filters::View.new(filters: filters, filter_actions: filter_actions, filter_options: filter_options) %>
+
   <div class='moj-filter-layout__content'>
     <div class="moj-action-bar">
       <div class="moj-action-bar__filter"></div>

--- a/app/components/paginated_filter/view.rb
+++ b/app/components/paginated_filter/view.rb
@@ -5,6 +5,7 @@ module PaginatedFilter
     attr_reader :filters, :collection, :filter_params
 
     renders_many :filter_actions
+    renders_many :filter_options
 
     def initialize(filters:, collection:, filter_params:)
       @filters = filters

--- a/app/components/trainees/filters/view.html.erb
+++ b/app/components/trainees/filters/view.html.erb
@@ -44,31 +44,9 @@
             <%= submit_tag "Apply filters", class: "govuk-button" %>
             <%= hidden_field_tag :sort_by, params[:sort_by] %>
 
-            <div class="govuk-form-group">
-              <%= label_tag "text_search", "Search records", class: "govuk-label govuk-label--s" %>
-              <%= text_field_tag "text_search", (filters[:text_search] if filters), spellcheck: false, class: "govuk-input" %>
-            </div>
-
-            <div class="govuk-form-group">
-              <fieldset class="govuk-fieldset">
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                  Status
-                </legend>
-                <div class="govuk-checkboxes govuk-checkboxes--small">
-                  <% TraineeFilter::STATES.map do |state, _| %>
-                    <div class="govuk-checkboxes__item">
-                      <%= check_box_tag "state[]", state, checked?(:state, state), id: "state-#{state}", class: "govuk-checkboxes__input" %>
-                      <%= label_tag "state-#{state}", label_for("state", state), class: "govuk-label govuk-checkboxes__label" %>
-                    </div>
-                  <% end %>
-                </div>
-              </fieldset>
-            </div>
-
-            <div class="govuk-form-group">
-              <%= label_tag "subject", "Subject", class: "govuk-label govuk-label--s" %>
-              <%= select_tag :subject, options_from_collection_for_select(filter_course_subjects_options, :name, :name, (filters[:subject] if filters)), class: "govuk-select" %>
-            </div>
+            <% filter_options.each do |filter_option| %>
+              <%= filter_option %>
+            <% end %>
           </form>
         </div>
       </div>

--- a/app/components/trainees/filters/view.rb
+++ b/app/components/trainees/filters/view.rb
@@ -4,15 +4,13 @@ module Trainees
   module Filters
     class View < GovukComponent::Base
       include CourseDetailsHelper
-      attr_accessor :filters, :filter_actions
+      include TraineeHelper
+      attr_accessor :filters, :filter_actions, :filter_options
 
-      def initialize(filters:, filter_actions: nil)
+      def initialize(filters:, filter_options:, filter_actions: nil)
         @filters = filters
         @filter_actions = filter_actions
-      end
-
-      def label_for(attribute, value)
-        I18n.t("activerecord.attributes.trainee.#{attribute.pluralize}.#{value}", award_type: "QTS")
+        @filter_options = filter_options
       end
 
       def filter_label_for(filter)
@@ -21,10 +19,6 @@ module Trainees
 
       def title_html(filter, value)
         tag.span("Remove ", class: "govuk-visually-hidden") + value + tag.span(" #{filter.humanize.downcase} filter", class: "govuk-visually-hidden")
-      end
-
-      def checked?(filter, value)
-        filters && filters[filter]&.include?(value)
       end
 
       def tags_for_filter(filter, value)

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -15,6 +15,7 @@ class TraineesController < ApplicationController
     # clause, removing Kaminari's pagination. Hence the use of `#select`.
     @draft_trainees = paginated_trainees.select(&:draft?)
     @completed_trainees = paginated_trainees.reject(&:draft?)
+    @training_routes = policy_scope(Trainee).group(:training_route).count.keys
 
     respond_to do |format|
       format.html

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -48,4 +48,12 @@ module TraineeHelper
 
     "#{translation_prefix}#{title_suffix}"
   end
+
+  def checked?(filters, filter, value)
+    filters && filters[filter]&.include?(value)
+  end
+
+  def label_for(attribute, value)
+    I18n.t("activerecord.attributes.trainee.#{attribute.pluralize}.#{value}")
+  end
 end

--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -10,8 +10,6 @@ class HomeView
 
 private
 
-  attr_reader :trainees
-
   def populate_state_counts!
     defaults = Trainee.states.keys.index_with { 0 }
     counts = @trainees.group(:state).count.reverse_merge(defaults)

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -14,8 +14,7 @@
   </p>
 <% end %>
 
-<%= render PaginatedFilter::View.new(filters: @filters, collection: @paginated_trainees, filter_params: filter_params) do %>
-
+<%= render PaginatedFilter::View.new(filters: @filters, collection: @paginated_trainees, filter_params: filter_params) do |component| %>
   <% if @paginated_trainees.any? %>
     <% if @draft_trainees.any? %>
       <div class="govuk-!-margin-bottom-8 app-draft-records">
@@ -50,5 +49,57 @@
     <h2 class="govuk-heading-m">
       <%= t("views.trainees.index.no_records") %>
     </h2>
+  <% end %>
+
+  <% component.filter_option do %>
+    <div class="govuk-form-group">
+      <%= label_tag "text_search", "Search records", class: "govuk-label govuk-label--s" %>
+      <%= text_field_tag "text_search", (@filters[:text_search] if @filters), spellcheck: false, class: "govuk-input" %>
+    </div>
+  <% end %>
+
+  <% unless @training_routes.count < 2 %>
+    <% component.filter_option do %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            Type of training
+          </legend>
+          <div class="govuk-checkboxes govuk-checkboxes--small">
+            <% @training_routes.map do |training_route, _| %>
+              <div class="govuk-checkboxes__item">
+                <%= check_box_tag "training_route[]", training_route, checked?(@filters, :training_route, training_route), id: "training_route-#{training_route}", class: "govuk-checkboxes__input" %>
+                <%= label_tag "training_route-#{training_route}", label_for("training_route", training_route), class: "govuk-label govuk-checkboxes__label" %>
+              </div>
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% component.filter_option do %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          Status
+        </legend>
+        <div class="govuk-checkboxes govuk-checkboxes--small">
+          <% TraineeFilter::STATES.map do |state, _| %>
+            <div class="govuk-checkboxes__item">
+              <%= check_box_tag "state[]", state, checked?(@filters, :state, state), id: "state-#{state}", class: "govuk-checkboxes__input" %>
+              <%= label_tag "state-#{state}", label_for("state", state), class: "govuk-label govuk-checkboxes__label" %>
+            </div>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+  <% end %>
+
+  <% component.filter_option do %>
+    <div class="govuk-form-group">
+      <%= label_tag "subject", "Subject", class: "govuk-label govuk-label--s" %>
+      <%= select_tag :subject, options_from_collection_for_select(filter_course_subjects_options, :name, :name, (@filters[:subject] if @filters)), class: "govuk-select" %>
+    </div>
   <% end %>
 <% end %>

--- a/spec/components/trainees/filters/view_preview.rb
+++ b/spec/components/trainees/filters/view_preview.rb
@@ -5,7 +5,7 @@ module Trainees
   module Filters
     class ViewPreview < ViewComponent::Preview
       def default_view
-        render Trainees::Filters::View.new(filters: filter_mock)
+        render Trainees::Filters::View.new(filters: filter_mock, filter_options: [])
       end
 
     private

--- a/spec/components/trainees/filters/view_spec.rb
+++ b/spec/components/trainees/filters/view_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Trainees::Filters::View do
   let(:trainees_path) { "/trainees" }
   let(:selected_text) { "Selected filters" }
-  let(:result) { render_inline(described_class.new(filters: filters)) }
+  let(:result) { render_inline(described_class.new(filters: filters, filter_options: [])) }
 
   before do
     # When link_to() is called with a nil path, it normally renders a href using the current URL path without
@@ -32,11 +32,6 @@ RSpec.describe Trainees::Filters::View do
   context "when checkboxes have been pre-selected" do
     let(:filters) { { state: %w[draft] }.with_indifferent_access }
 
-    it "marks the correct ones as selected" do
-      expect(result.css("#state-draft").attr("checked").value).to eq("checked")
-      expect(result.css("#state-submitted_for_trn").attr("checked")).to eq(nil)
-    end
-
     it "shows a 'Selected filters' dialogue" do
       expect(result.text).to include(selected_text)
     end
@@ -44,11 +39,6 @@ RSpec.describe Trainees::Filters::View do
 
   context "when a subject has been pre-selected" do
     let(:filters) { { subject: "Business studies" }.with_indifferent_access }
-
-    it "retains the input" do
-      selected_value = result.css('#subject option[@selected="selected"]').attr("value").value
-      expect(selected_value).to eq("Business studies")
-    end
 
     it "shows a 'Selected filters' dialogue" do
       expect(result.text).to include(selected_text)

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -168,7 +168,7 @@ private
       @provider_led_postgrad_trainee,
       @history_trainee,
       @biology_trainee,
-      @draft_trainee
+      @draft_trainee,
     ].each do |trainee|
       expect(trainee_index_page).to_not have_text(full_name(trainee))
     end

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -21,6 +21,7 @@ module PageObjects
 
       element :text_search, "#text_search"
       element :assessment_only_checkbox, "#training_route-assessment_only"
+      element :draft_checkbox, "#state-draft"
       element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"
       element :subject, "#subject"
 


### PR DESCRIPTION
### Context
https://trello.com/c/Fv84bibz/1849-m-training-route-filter-on-trainees-list

### Changes proposed in this pull request
- Add training route option to trainee filter
- Split out filtering options from the trainee filter so we don't perform db queries etc in the component

### Guidance to review
Check with a user that only has trainees with one type of training route, and one with multiple, also in conjunction with other filters

