### PR TITLE
[1983] Bursary calculator

### DIFF
--- a/app/models/allocation_subject.rb
+++ b/app/models/allocation_subject.rb
@@ -2,4 +2,6 @@
 
 class AllocationSubject < ApplicationRecord
   has_many :subject_specialisms, inverse_of: :allocation_subject
+  has_many :bursary_subjects, inverse_of: :allocation_subject
+  has_many :bursaries, through: :bursary_subjects, inverse_of: :allocation_subjects
 end

--- a/app/models/bursary.rb
+++ b/app/models/bursary.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Bursary < ApplicationRecord
+  has_many :bursary_subjects, inverse_of: :bursary, dependent: :destroy
+  has_many :allocation_subjects, through: :bursary_subjects, inverse_of: :bursaries
+
+  validates :training_route, presence: true, inclusion: { in: TRAINING_ROUTE_ENUMS.values }
+  validates :amount, presence: true
+end

--- a/app/models/bursary_subject.rb
+++ b/app/models/bursary_subject.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BursarySubject < ApplicationRecord
+  belongs_to :bursary
+  belongs_to :allocation_subject
+
+  validates :bursary, presence: true
+  validates :allocation_subject, presence: true, uniqueness: { scope: :bursary_id }
+end

--- a/app/services/calculate_bursary.rb
+++ b/app/services/calculate_bursary.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CalculateBursary
+  class << self
+    # Returns true/false if there are any bursaries available for a given route.
+    def available_for_route?(route)
+      raise_if_route_not_recognised!(route)
+
+      Bursary.find_by(training_route: route)&.bursary_subjects.present?
+    end
+
+    # Returns the amount in pounds of bursary available for a given route/subject combo.
+    def for_route_and_subject(route, subject)
+      raise_if_route_not_recognised!(route)
+
+      # Bursaries are awarded based on the allocation subject for a given
+      # subject specialism.
+      allocation_subject = SubjectSpecialism.find_by!(name: subject).allocation_subject
+      allocation_subject.bursaries.find_by(training_route: route)&.amount
+    end
+
+  private
+
+    def raise_if_route_not_recognised!(route)
+      raise "Training route '#{route}' not recognised" unless TRAINING_ROUTE_ENUMS.dig(route)
+    end
+  end
+end

--- a/db/migrate/20210616102540_create_bursaries.rb
+++ b/db/migrate/20210616102540_create_bursaries.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateBursaries < ActiveRecord::Migration[6.1]
+  def change
+    create_table :bursaries do |t|
+      t.string :training_route, null: false
+      t.integer :amount, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210617084351_create_bursary_subjects.rb
+++ b/db/migrate/20210617084351_create_bursary_subjects.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateBursarySubjects < ActiveRecord::Migration[6.1]
+  def change
+    create_table :bursary_subjects do |t|
+      t.belongs_to :bursary
+      t.belongs_to :allocation_subject
+
+      t.timestamps
+    end
+
+    add_index :bursary_subjects, %i[allocation_subject_id bursary_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_16_124359) do
+ActiveRecord::Schema.define(version: 2021_06_17_084351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,23 @@ ActiveRecord::Schema.define(version: 2021_06_16_124359) do
     t.index ["created_at"], name: "index_audits_on_created_at"
     t.index ["request_uuid"], name: "index_audits_on_request_uuid"
     t.index ["user_id", "user_type"], name: "user_index"
+  end
+
+  create_table "bursaries", force: :cascade do |t|
+    t.string "training_route", null: false
+    t.integer "amount", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "bursary_subjects", force: :cascade do |t|
+    t.bigint "bursary_id"
+    t.bigint "allocation_subject_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["allocation_subject_id", "bursary_id"], name: "index_bursary_subjects_on_allocation_subject_id_and_bursary_id", unique: true
+    t.index ["allocation_subject_id"], name: "index_bursary_subjects_on_allocation_subject_id"
+    t.index ["bursary_id"], name: "index_bursary_subjects_on_bursary_id"
   end
 
   create_table "consistency_checks", force: :cascade do |t|

--- a/spec/factories/allocation_subjects.rb
+++ b/spec/factories/allocation_subjects.rb
@@ -2,5 +2,6 @@
 
 FactoryBot.define do
   factory :allocation_subject do
+    sequence(:name) { |s| "subject #{s}" }
   end
 end

--- a/spec/factories/bursaries.rb
+++ b/spec/factories/bursaries.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bursary do
+    training_route { TRAINING_ROUTE_ENUMS.keys.sample }
+    amount { Faker::Number.number(digits: 5) }
+
+    trait :with_bursary_subjects do
+      after(:create) do |bursary, _|
+        create_list(:bursary_subject, 2, bursary: bursary)
+      end
+    end
+  end
+end

--- a/spec/factories/bursary_subjects.rb
+++ b/spec/factories/bursary_subjects.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :subject_specialism do
+  factory :bursary_subject do
+    bursary
     allocation_subject
-
-    sequence(:name) { |s| "subject #{s}" }
   end
 end

--- a/spec/models/allocation_subject_spec.rb
+++ b/spec/models/allocation_subject_spec.rb
@@ -5,5 +5,6 @@ require "rails_helper"
 RSpec.describe AllocationSubject, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:subject_specialisms) }
+    it { is_expected.to have_many(:bursaries).through(:bursary_subjects) }
   end
 end

--- a/spec/models/bursary_spec.rb
+++ b/spec/models/bursary_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Bursary do
+  subject { create(:bursary) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:training_route) }
+    it { is_expected.to validate_inclusion_of(:training_route).in_array(TRAINING_ROUTE_ENUMS.values) }
+    it { is_expected.to validate_presence_of(:amount) }
+  end
+
+  describe "associations" do
+    it { is_expected.to have_many(:bursary_subjects) }
+    it { is_expected.to have_many(:allocation_subjects).through(:bursary_subjects) }
+  end
+end

--- a/spec/models/bursary_subject_spec.rb
+++ b/spec/models/bursary_subject_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe BursarySubject do
+  subject { create(:bursary_subject) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:bursary) }
+    it { is_expected.to validate_presence_of(:allocation_subject) }
+
+    it { is_expected.to validate_uniqueness_of(:allocation_subject).scoped_to(:bursary_id) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:bursary) }
+    it { is_expected.to belong_to(:allocation_subject) }
+  end
+end

--- a/spec/services/calculate_bursary_spec.rb
+++ b/spec/services/calculate_bursary_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CalculateBursary do
+  describe "#available_for_route?" do
+    let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
+
+    context "when there is a bursary available for a given route" do
+      before { create(:bursary, :with_bursary_subjects, training_route: route) }
+
+      it "returns true" do
+        expect(described_class.available_for_route?(route.to_sym)).to be_truthy
+      end
+    end
+
+    context "when there is a bursary available for a given route but it has no subjects" do
+      before { create(:bursary, training_route: route) }
+
+      it "returns true" do
+        expect(described_class.available_for_route?(route.to_sym)).to be_falsey
+      end
+    end
+
+    context "when there is no bursary available for a given route" do
+      it "returns false" do
+        expect(described_class.available_for_route?(route.to_sym)).to be_falsey
+      end
+    end
+
+    context "when the route is not recognised" do
+      it "raises an error" do
+        expect {
+          described_class.available_for_route?("not_a_route")
+        }.to raise_error("Training route 'not_a_route' not recognised")
+      end
+    end
+  end
+
+  describe "#for_route_and_subject" do
+    let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
+    let(:subject_specialism) { create(:subject_specialism) }
+    let(:amount) { 24_000 }
+
+    context "when there is a bursary available for a given route and subject" do
+      let(:bursary) { create(:bursary, training_route: route, amount: amount) }
+
+      before do
+        create(:bursary_subject, bursary: bursary, allocation_subject: subject_specialism.allocation_subject)
+      end
+
+      it "returns bursary amount" do
+        expect(described_class.for_route_and_subject(route.to_sym, subject_specialism.name)).to eq amount
+      end
+    end
+
+    context "when there is a bursary for the route but not the subject" do
+      let(:bursary) { create(:bursary, training_route: route) }
+
+      it "returns nil" do
+        expect(described_class.for_route_and_subject(route.to_sym, subject_specialism.name)).to be_nil
+      end
+    end
+
+    context "when there is a bursary for subject but not the route" do
+      let(:bursary) { create(:bursary, training_route: TRAINING_ROUTE_ENUMS[:assessment_only]) }
+
+      before do
+        create(:bursary_subject, bursary: bursary, allocation_subject: subject_specialism.allocation_subject)
+      end
+
+      it "returns nil" do
+        expect(described_class.for_route_and_subject(route.to_sym, subject_specialism.name)).to be_nil
+      end
+    end
+
+    context "when there is no bursary for the route nor the subject" do
+      it "returns nil" do
+        expect(described_class.for_route_and_subject(route.to_sym, subject_specialism.name)).to be_nil
+      end
+    end
+
+    context "when the route is not recognised" do
+      it "raises an error" do
+        expect {
+          described_class.for_route_and_subject("not_a_route", subject_specialism.name)
+        }.to raise_error("Training route 'not_a_route' not recognised")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/J7qEEOP6/1983-m-funding-bursary-calculator

Based off https://github.com/DFE-Digital/register-trainee-teachers/pull/1017 for `AllocationSubject` and `SubjectSpecialism`.

### Changes proposed in this pull request

- Creates `Bursary` and `BursarySubject` models
- Adds a backend service that implements two methods:
  1. **`for_route_and_subject`**: given a training route and a subject specialism, returns the amount of an available bursary e.g. `CalculateBursary.for_route_and_subject("provider_led_postgrad", "maths") => 24_000`
  2. **`available_for_route?`**: given a training route, returns true or false whether there are any bursaries available e.g `CalculateBursary.available_for_route?("assessment_only") => false`

The first can be used to display the amount available for a trainee.
The second can be used to decide whether we need to restrict access to the 'Funding' section until a course is chosen.
