### PR TITLE
[1996] Update the course subjects dropdown to use subject specialisms

### DIFF
--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -38,6 +38,10 @@ private
   end
 
   def course_subjects
-    @course_subjects ||=  SubjectSpecialism.pluck(:name)
+    @course_subjects ||= begin
+      return Dttp::CodeSets::CourseSubjects::MAPPING.keys unless FeatureService.enabled?(:use_subject_specialisms_in_course_details)
+
+      SubjectSpecialism.pluck(:name)
+    end
   end
 end

--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -38,6 +38,6 @@ private
   end
 
   def course_subjects
-    @course_subjects ||= SubjectSpecialism.all.map(&:name)
+    @course_subjects ||=  SubjectSpecialism.pluck(:name)
   end
 end

--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -39,7 +39,7 @@ private
 
   def course_subjects
     @course_subjects ||= begin
-      return Dttp::CodeSets::CourseSubjects::MAPPING.keys unless FeatureService.enabled?(:use_subject_specialisms_in_course_details)
+      return Dttp::CodeSets::CourseSubjects::MAPPING.keys unless FeatureService.enabled?(:use_subject_specialisms)
 
       SubjectSpecialism.pluck(:name)
     end

--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -38,6 +38,6 @@ private
   end
 
   def course_subjects
-    Dttp::CodeSets::CourseSubjects::MAPPING.keys
+    @course_subjects ||= SubjectSpecialism.all.map(&:name)
   end
 end

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -19,7 +19,7 @@
           attribute_name: :course_subject_one,
           form_field: f.govuk_collection_select(:course_subject_one, course_subjects_options,
                                                 :name, :name, label: { text: "Subject", size: "s" },
-                                                              hint: { text: "Search for the closest matching subject" }),
+                                                              hint: { text: t('.subject_hint') }),
         ) %>
 
         <%= render "additional_subjects", f: f %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,10 +510,12 @@ en:
           lead_school: Lead school
           employing_school: Employing school
     course_details:
+      edit:
+        subject_hint: &subject_hint Search for the closest matching subject
       additional_subjects:
         add_additional_subjects: Add additional subjects
         main_subject: The first subject is the main one. It represents the bursary or scholarship available if applicable.
-        subject_hint: Search for the closest matching subject
+        subject_hint: *subject_hint
         subject_two: Second subject (optional)
         subject_three: Third subject (optional)
     confirm_publish_course:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,6 +39,7 @@ features:
   sync_from_dttp: false
   send_emails: false
   persist_to_dttp: false
+  use_subject_specialisms_in_course_details: false
   routes:
     early_years_assessment_only: false
     early_years_salaried: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,7 +39,7 @@ features:
   sync_from_dttp: false
   send_emails: false
   persist_to_dttp: false
-  use_subject_specialisms_in_course_details: false
+  use_subject_specialisms: false
   routes:
     early_years_assessment_only: false
     early_years_salaried: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,6 +6,7 @@ features:
   basic_auth: false
   import_courses_from_ttapi: true
   publish_course_details: true
+  use_subject_specialisms_in_course_details: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,7 +6,7 @@ features:
   basic_auth: false
   import_courses_from_ttapi: true
   publish_course_details: true
-  use_subject_specialisms_in_course_details: true
+  use_subject_specialisms: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -3,7 +3,7 @@ features:
   use_dfe_sign_in: false
   enable_feedback_link: true
   publish_course_details: true
-  use_subject_specialisms_in_course_details: true
+  use_subject_specialisms: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -3,6 +3,7 @@ features:
   use_dfe_sign_in: false
   enable_feedback_link: true
   publish_course_details: true
+  use_subject_specialisms_in_course_details: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/spec/components/trainees/route_indicator/view_preview.rb
+++ b/spec/components/trainees/route_indicator/view_preview.rb
@@ -11,7 +11,7 @@ module RouteIndicator
         render(Trainees::RouteIndicator::View.new(trainee: Trainee.new(
           training_route: training_route,
           apply_application: ApplyApplication.new,
-          course_subject_one: Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample,
+          course_subject_one: "Ancient Hebrew",
           course_code: Faker::Alphanumeric.alphanumeric(number: 4).upcase,
         )))
       end

--- a/spec/factories/allocation_subjects.rb
+++ b/spec/factories/allocation_subjects.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :allocation_subject do
-    sequence(:name) { |s| "subject #{s}" }
+    sequence(:name) { |c| "Allocation Subject #{c}" }
   end
 end

--- a/spec/factories/subject_specialisms.rb
+++ b/spec/factories/subject_specialisms.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
   factory :subject_specialism do
     allocation_subject
 
-    sequence(:name) { |s| "subject #{s}" }
+    transient do
+      subject_name { nil }
+    end
+
+    sequence(:name) { |c| subject_name.presence || "Subject Specialism #{c}" }
   end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -96,8 +96,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_subject do
+      transient do
+        subject_name { nil }
+      end
+
+      course_subject_one { create(:subject_specialism, subject_name: subject_name).name }
+    end
+
     trait :with_course_details do
-      course_subject_one { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
+      with_subject
       course_code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
       course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.keys.sample }
       course_start_date { Faker::Date.between(from: 10.years.ago, to: 2.days.ago) }
@@ -285,8 +293,9 @@ FactoryBot.define do
 
     trait :with_multiple_subjects do
       with_course_details
-      subject_two { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
-      subject_three { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
+
+      course_subject_two { create(:subject_specialism).name }
+      course_subject_three { create(:subject_specialism).name }
     end
   end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -96,7 +96,7 @@ FactoryBot.define do
       end
     end
 
-    trait :with_subject do
+    trait :with_subject_specialism do
       transient do
         subject_name { nil }
       end
@@ -105,7 +105,7 @@ FactoryBot.define do
     end
 
     trait :with_course_details do
-      with_subject
+      course_subject_one { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
       course_code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
       course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.keys.sample }
       course_start_date { Faker::Date.between(from: 10.years.ago, to: 2.days.ago) }

--- a/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
@@ -22,7 +22,7 @@ feature "course details", type: :feature do
       given_i_am_on_the_review_draft_page
     end
 
-    context "when the feature flag is turned on", feature_use_subject_specialisms_in_course_details: true do
+    context "when the feature flag is turned on", feature_use_subject_specialisms: true do
       scenario "submitting with valid parameters" do
         given_a_subject_specialism_is_available_for_selection
         when_i_visit_the_course_details_page
@@ -79,7 +79,7 @@ private
   end
 
   def and_i_enter_valid_dttp_subject_parameters
-    course_details_page.subject.select(trainee.subject)
+    course_details_page.subject.select(trainee.course_subject_one)
   end
 
   def and_i_enter_valid_parameters
@@ -103,7 +103,7 @@ private
   def and_the_course_details_are_updated
     when_i_visit_the_course_details_page
 
-    expect(course_details_page.subject.value).to eq(trainee.course_subject_one)
+    expect(course_details_page.subject.value).to eq(trainee.reload.course_subject_one)
     expect(course_details_page.course_start_date_day.value).to eq(trainee.course_start_date.day.to_s)
     expect(course_details_page.course_start_date_month.value).to eq(trainee.course_start_date.month.to_s)
     expect(course_details_page.course_start_date_year.value).to eq(trainee.course_start_date.year.to_s)

--- a/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
@@ -22,9 +22,21 @@ feature "course details", type: :feature do
       given_i_am_on_the_review_draft_page
     end
 
+    context "when the feature flag is turned on", feature_use_subject_specialisms_in_course_details: true do
+      scenario "submitting with valid parameters" do
+        given_a_subject_specialism_is_available_for_selection
+        when_i_visit_the_course_details_page
+        and_i_enter_valid_subject_specialism_parameters
+        and_i_enter_valid_parameters
+        and_i_submit_the_form
+        and_the_course_details_are_updated
+      end
+    end
+
     describe "tracking the progress" do
       scenario "renders an 'in progress' status when details partially provided" do
         when_i_visit_the_course_details_page
+        and_i_enter_valid_dttp_subject_parameters
         and_i_enter_valid_parameters
         and_i_submit_the_form
         and_i_continue_without_confirming_details
@@ -62,8 +74,15 @@ private
     course_details_page.load(id: trainee.slug)
   end
 
+  def and_i_enter_valid_subject_specialism_parameters
+    course_details_page.subject.select(@subject_specialism.name)
+  end
+
+  def and_i_enter_valid_dttp_subject_parameters
+    course_details_page.subject.select(trainee.subject)
+  end
+
   def and_i_enter_valid_parameters
-    course_details_page.subject.select(trainee.course_subject_one)
     course_details_page.set_date_fields("course_start_date", trainee.course_start_date.strftime("%d/%m/%Y"))
     course_details_page.set_date_fields("course_end_date", trainee.course_end_date.strftime("%d/%m/%Y"))
 
@@ -166,6 +185,10 @@ private
 
   def given_a_trainee_exists_with_course_details
     given_a_trainee_exists(:with_course_details)
+  end
+
+  def given_a_subject_specialism_is_available_for_selection
+    @subject_specialism = create(:subject_specialism)
   end
 
   def then_i_am_redirected_to_the_confirm_page

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -89,8 +89,8 @@ private
   def given_trainees_exist_in_the_system
     @assessment_only_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
     @provider_led_postgrad_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
-    @biology_trainee ||= create(:trainee, :with_subject, subject_name: "Biology")
-    @history_trainee ||= create(:trainee, :with_subject, subject_name: "History")
+    @biology_trainee ||= create(:trainee, :with_subject_specialism, subject_name: "Biology")
+    @history_trainee ||= create(:trainee, :with_subject_specialism, subject_name: "History")
     @searchable_trainee ||= create(:trainee, trn: "123")
     @draft_trainee ||= create(:trainee, :draft)
     @withdrawn_trainee ||= create(:trainee, :withdrawn)

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Filtering trainees" do
   before do
     given_i_am_authenticated
     given_trainees_exist_in_the_system
+    given_a_subject_specialism_is_available_for_selection
     when_i_visit_the_trainee_index_page
     then_all_trainees_are_visible
   end
@@ -88,12 +89,16 @@ private
   def given_trainees_exist_in_the_system
     @assessment_only_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
     @provider_led_postgrad_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
-    @biology_trainee ||= create(:trainee, course_subject_one: "Biology")
-    @history_trainee ||= create(:trainee, course_subject_one: "History")
+    @biology_trainee ||= create(:trainee, :with_subject, subject_name: "Biology")
+    @history_trainee ||= create(:trainee, :with_subject, subject_name: "History")
     @searchable_trainee ||= create(:trainee, trn: "123")
     @draft_trainee ||= create(:trainee, :draft)
     @withdrawn_trainee ||= create(:trainee, :withdrawn)
     Trainee.update_all(provider_id: @current_user.provider.id)
+  end
+
+  def given_a_subject_specialism_is_available_for_selection
+    @subject_specialism ||= create(:subject_specialism, name: "Chemistry")
   end
 
   def when_i_visit_the_trainee_index_page
@@ -131,7 +136,7 @@ private
   end
 
   def when_i_filter_by_a_subject_which_returns_no_matches
-    when_i_filter_by_subject("Chemistry")
+    when_i_filter_by_subject(@subject_specialism.name)
   end
 
   def then_i_see_a_no_records_found_message

--- a/spec/helpers/course_details_helper_spec.rb
+++ b/spec/helpers/course_details_helper_spec.rb
@@ -16,7 +16,7 @@ describe CourseDetailsHelper do
       expect(course_subjects_options.second.name).to eq "Art and design"
     end
 
-    context "when the feature flag is turned on", feature_use_subject_specialisms_in_course_details: true do
+    context "when the feature flag is turned on", feature_use_subject_specialisms: true do
       it "iterates over subject specialisms and prints out correct course_subjects values" do
         expect(course_subjects_options.size).to be 2
         expect(course_subjects_options.first.name).to be_nil

--- a/spec/helpers/course_details_helper_spec.rb
+++ b/spec/helpers/course_details_helper_spec.rb
@@ -7,13 +7,21 @@ describe CourseDetailsHelper do
 
   describe "#course_subjects_options" do
     before do
-      allow(self).to receive(:course_subjects).and_return(%w[course_subject])
+      create(:subject_specialism, name: "Travel and Tourism")
     end
 
-    it "iterates over array and prints out correct course_subjects values" do
-      expect(course_subjects_options.size).to be 2
+    it "iterates over Dttp::CodeSets::CourseSubjects and prints out correct course_subjects values" do
+      expect(course_subjects_options.size).to be 40
       expect(course_subjects_options.first.name).to be_nil
-      expect(course_subjects_options.second.name).to eq "course_subject"
+      expect(course_subjects_options.second.name).to eq "Art and design"
+    end
+
+    context "when the feature flag is turned on", feature_use_subject_specialisms_in_course_details: true do
+      it "iterates over subject specialisms and prints out correct course_subjects values" do
+        expect(course_subjects_options.size).to be 2
+        expect(course_subjects_options.first.name).to be_nil
+        expect(course_subjects_options.second.name).to eq "Travel and Tourism"
+      end
     end
   end
 

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -29,7 +29,7 @@ module Trainees
     end
 
     context "with subject filter" do
-      let!(:trainee_with_subject) { create(:trainee, course_subject_one: Dttp::CodeSets::CourseSubjects::MAPPING.keys.first) }
+      let!(:trainee_with_subject) { create(:trainee, :with_subject, subject_name: "Art and design") }
       let(:filters) { { subject: "Art and design" } }
 
       it { is_expected.to eq([trainee_with_subject]) }

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -29,12 +29,12 @@ module Trainees
     end
 
     context "with subject filter" do
-      let!(:trainee_with_subject) { create(:trainee, subject: Dttp::CodeSets::CourseSubjects::MAPPING.keys.first) }
+      let!(:trainee_with_subject) { create(:trainee, course_subject_one: Dttp::CodeSets::CourseSubjects::MAPPING.keys.first) }
       let(:filters) { { subject: "Art and design" } }
 
       it { is_expected.to eq([trainee_with_subject]) }
 
-      context "when the feature flag is turned on", feature_use_subject_specialisms_in_course_details: true do
+      context "when the feature flag is turned on", feature_use_subject_specialisms: true do
         let!(:trainee_with_subject) { create(:trainee, :with_subject_specialism, subject_name: "Art and design") }
 
         it { is_expected.to eq([trainee_with_subject]) }

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -29,10 +29,16 @@ module Trainees
     end
 
     context "with subject filter" do
-      let!(:trainee_with_subject) { create(:trainee, :with_subject, subject_name: "Art and design") }
+      let!(:trainee_with_subject) { create(:trainee, subject: Dttp::CodeSets::CourseSubjects::MAPPING.keys.first) }
       let(:filters) { { subject: "Art and design" } }
 
       it { is_expected.to eq([trainee_with_subject]) }
+
+      context "when the feature flag is turned on", feature_use_subject_specialisms_in_course_details: true do
+        let!(:trainee_with_subject) { create(:trainee, :with_subject_specialism, subject_name: "Art and design") }
+
+        it { is_expected.to eq([trainee_with_subject]) }
+      end
     end
 
     context "with text_search filter" do

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -13,9 +13,8 @@ module Features
     end
 
     def and_the_course_details_is_complete
-      given_a_subject_specialism_is_available_for_selection
       course_details_page.load(id: trainee_from_url.slug)
-      course_details_page.subject.select(@subject_specialism.name)
+      course_details_page.subject.select(Dttp::CodeSets::CourseSubjects::MAPPING.keys.first)
       course_details_page.main_age_range_3_to_11.choose
       and_the_course_date_fields_are_completed
       and_the_course_details_are_submitted
@@ -32,10 +31,6 @@ module Features
     def given_a_course_is_available_for_selection
       trainee = trainee_from_url
       create(:course_with_subjects, accredited_body_code: trainee.provider.code, route: trainee.training_route)
-    end
-
-    def given_a_subject_specialism_is_available_for_selection
-      @subject_specialism = create(:subject_specialism)
     end
 
     def and_the_course_details_is_marked_completed

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -13,8 +13,9 @@ module Features
     end
 
     def and_the_course_details_is_complete
+      given_a_subject_specialism_is_available_for_selection
       course_details_page.load(id: trainee_from_url.slug)
-      course_details_page.subject.select(Dttp::CodeSets::CourseSubjects::MAPPING.keys.first)
+      course_details_page.subject.select(@subject_specialism.name)
       course_details_page.main_age_range_3_to_11.choose
       and_the_course_date_fields_are_completed
       and_the_course_details_are_submitted
@@ -31,6 +32,10 @@ module Features
     def given_a_course_is_available_for_selection
       trainee = trainee_from_url
       create(:course_with_subjects, accredited_body_code: trainee.provider.code, route: trainee.training_route)
+    end
+
+    def given_a_subject_specialism_is_available_for_selection
+      @subject_specialism = create(:subject_specialism)
     end
 
     def and_the_course_details_is_marked_completed


### PR DESCRIPTION
### Context
Use Subject Specialisms to populate subject dropdown options

### Changes proposed in this pull request
1. Fetch SubjectSpecialisms from the local data store and use those in place of `Dttp::CodeSets::CourseSubjects::MAPPING`
2. Add a feature flag to toggle the new specialisms in the dropdown.

### Guidance to review
1. Create a few subject specialisms (i.e: `FactoryBot.create_list(:subject_specialism, 100)`
2. Attempt to create/update a trainee, and visit the course details section.
3. The subjects dropdown should be using records from the subject specialisms.
4. Ensure that the new specialism subject (and additional subjects, if selected) are saved against the trainee.


