### PR TITLE
[xxx] Ignore concurrent migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,6 @@ ENV ENV="/root/.ashrc"
 RUN bundle exec rake assets:precompile && \
     rm -rf node_modules tmp
 
-CMD bundle exec rails db:migrate:with_data && bundle exec rails server -b 0.0.0.0
+CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && \ 
+    bundle exec rails data:migrate && \
+    bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
### Context

We get concurrent migration errors occasionally when more than one instance is started. We used to ignore these but we've lost that when we added data migrations.

### Changes proposed in this pull request

Update the start command to use the db migration script that we added that catches concurrent migration errors.

### Guidance to review

This restores behaviour we had before but we'll need to consider now that the data migrations could be started in a race condition in a similar way to the db migrations and possibly run twice at the same time. 

