### PR TITLE
[2024] Ensure 'Cancel and return' links go back to the correct origin page

### DIFF
--- a/app/components/cancel_link/view.html.erb
+++ b/app/components/cancel_link/view.html.erb
@@ -1,1 +1,3 @@
-<p class="govuk-body"><%= govuk_link_to(t("components.confirmation.cancel_and_return"), view_trainee(trainee)) %></p>
+<p class="govuk-body">
+  <%= govuk_link_to(t("components.confirmation.cancel_and_return"), path) %>
+</p>

--- a/app/components/cancel_link/view.rb
+++ b/app/components/cancel_link/view.rb
@@ -14,6 +14,13 @@ module CancelLink
       !@trainee.draft?
     end
 
+    def path
+      page_tracker = PageTracker.new(trainee_slug: trainee.slug, session: session, request: request)
+      # If you've arrived direcly onto a page with no history, then there will
+      # be no origin pages. view_trainee provides a sensible default.
+      page_tracker.last_non_confirm_origin_page_path || view_trainee(trainee)
+    end
+
   private
 
     attr_reader :trainee

--- a/app/lib/page_tracker.rb
+++ b/app/lib/page_tracker.rb
@@ -37,6 +37,10 @@ class PageTracker
     on_confirm_page? ? origin_pages[-2] : origin_pages.last
   end
 
+  def last_non_confirm_origin_page_path
+    origin_pages.reject { |path| path.include?("confirm") }.last
+  end
+
 private
 
   attr_reader :session, :request, :history_session_key, :origin_pages_session_key

--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -15,6 +15,4 @@
   },
 ) %>
 
-<% unless @trainee.draft? %>
-  <p class="govuk-body"><%= govuk_link_to(t("components.confirmation.cancel_and_return"), view_trainee(@trainee)) %></p>
-<% end %>
+<%= render(CancelLink::View.new(@trainee)) %>

--- a/app/views/trainees/diversity/confirm_details/show.html.erb
+++ b/app/views/trainees/diversity/confirm_details/show.html.erb
@@ -15,6 +15,4 @@
   },
 ) %>
 
-<% unless @trainee.draft? %>
-  <p class="govuk-body"><%= govuk_link_to(t("components.confirmation.cancel_and_return"), view_trainee(@trainee)) %></p>
-<% end %>
+<%= render(CancelLink::View.new(@trainee)) %>

--- a/spec/lib/page_tracker_spec.rb
+++ b/spec/lib/page_tracker_spec.rb
@@ -165,4 +165,16 @@ describe PageTracker do
       end
     end
   end
+
+  describe "#last_non_confirm_origin_page_path" do
+    context "when you've been to a confirm page" do
+      let(:session) { { origin_pages_sesssion_key => [path_a, path_b] } }
+      let(:request) { double(fullpath: path_c, head?: false, get?: true, patch?: false, put?: false) }
+
+      it "returns the path to the previous origin page" do
+        page_tracker = PageTracker.new(trainee_slug: trainee.slug, session: session, request: request)
+        expect(page_tracker.last_non_confirm_origin_page_path).to eq(path_a)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/RODutady/2024-bug-cancel-and-return-to-record-links-dont-respect-origin-pages

We have many "Cancel and return to record" links across the service, however they did not 'remember' the tabs for non-draft trainees. They all returned to 'About their teacher training'.

### Changes proposed in this pull request

This PR uses the `PageTracker` to return to the correct origin page.
- Added a new method to the `PageTracker` called `last_non_confirm_origin_page`, since these links should never return to a confirm page even if that page is in the history. They explicitly just go back to the 'record'.
- Used this method in the `CancelLink` component.
- Ensured that this `CancelLink` component is being used everywhere we need it (there were a couple of places we'd missed).

### Guidance to review

- Head to a non-draft trainee

**Check 1**
- Click the 'Personal details and education' tab
- Click into 'Change' the address
- Click 'Cancel and return to record' and it should return to the 'Personal details and education' tab

**Check 2**
- Click into 'Change' the address again
- Click 'Continue'
- Click 'Cancel and return to record' and it should return to the 'Personal details and education' tab

**Check 3**
- Click into 'Change' the address again
- Click 'Continue'
- Click 'Change' from the confirm details page
- Click 'Cancel and return to record' and it should return to the 'Personal details and education' tab