### PR TITLE
[2029] Rename trainee_creator_dttp_id -> created_by_dttp_id

### DIFF
--- a/app/jobs/register_for_trn_job.rb
+++ b/app/jobs/register_for_trn_job.rb
@@ -4,8 +4,8 @@ class RegisterForTrnJob < ApplicationJob
   queue_as :default
   retry_on Dttp::BatchRequest::Error
 
-  def perform(trainee, trainee_creator_dttp_id)
-    Dttp::RegisterForTrn.call(trainee: trainee, trainee_creator_dttp_id: trainee_creator_dttp_id)
+  def perform(trainee, created_by_dttp_id)
+    Dttp::RegisterForTrn.call(trainee: trainee, created_by_dttp_id: created_by_dttp_id)
 
     ChangeTraineeStatusJob.perform_later(
       trainee,

--- a/app/lib/dttp/params/contact.rb
+++ b/app/lib/dttp/params/contact.rb
@@ -14,14 +14,14 @@ module Dttp
 
       TRAINEE_CONTACT_TYPE_DTTP_ID = "faba11c7-07d9-e711-80e1-005056ac45bb"
 
-      attr_reader :trainee, :trainee_creator_dttp_id, :params
+      attr_reader :trainee, :created_by_dttp_id, :params
 
-      def initialize(trainee, trainee_creator_dttp_id = nil)
+      def initialize(trainee, created_by_dttp_id = nil)
         @trainee = trainee
-        @trainee_creator_dttp_id = trainee_creator_dttp_id
+        @created_by_dttp_id = created_by_dttp_id
         @params = build_params
 
-        append_create_only_params if trainee_creator_dttp_id
+        append_create_only_params if created_by_dttp_id
       end
 
       def to_json(*_args)
@@ -52,7 +52,7 @@ module Dttp
       def append_create_only_params
         params.merge!({
           "dfe_ContactTypeId@odata.bind" => "/dfe_contacttypes(#{TRAINEE_CONTACT_TYPE_DTTP_ID})",
-          "dfe_CreatedById@odata.bind" => "/contacts(#{trainee_creator_dttp_id})",
+          "dfe_CreatedById@odata.bind" => "/contacts(#{created_by_dttp_id})",
           "dfe_trnassessmentdate" => Time.zone.now.iso8601,
         })
       end

--- a/app/services/dttp/register_for_trn.rb
+++ b/app/services/dttp/register_for_trn.rb
@@ -4,11 +4,11 @@ module Dttp
   class RegisterForTrn
     include ServicePattern
 
-    attr_reader :trainee, :trainee_creator_dttp_id, :batch_request
+    attr_reader :trainee, :created_by_dttp_id, :batch_request
 
-    def initialize(trainee:, trainee_creator_dttp_id: nil)
+    def initialize(trainee:, created_by_dttp_id: nil)
       @trainee = trainee
-      @trainee_creator_dttp_id = trainee_creator_dttp_id
+      @created_by_dttp_id = created_by_dttp_id
       @batch_request = BatchRequest.new
     end
 
@@ -59,7 +59,7 @@ module Dttp
     end
 
     def build_contact_change_set
-      contact_payload = Params::Contact.new(trainee, trainee_creator_dttp_id).to_json
+      contact_payload = Params::Contact.new(trainee, created_by_dttp_id).to_json
       @contact_change_set_id = batch_request.add_change_set(entity: "contacts", payload: contact_payload)
     end
 

--- a/spec/jobs/register_for_trn_job_spec.rb
+++ b/spec/jobs/register_for_trn_job_spec.rb
@@ -16,7 +16,7 @@ describe RegisterForTrnJob do
     subject { described_class.perform_now(trainee, creator_dttp_id) }
 
     it "registers the trainee" do
-      expect(Dttp::RegisterForTrn).to receive(:call).with(trainee: trainee, trainee_creator_dttp_id: creator_dttp_id)
+      expect(Dttp::RegisterForTrn).to receive(:call).with(trainee: trainee, created_by_dttp_id: creator_dttp_id)
       subject
     end
 

--- a/spec/lib/dttp/params/contact_spec.rb
+++ b/spec/lib/dttp/params/contact_spec.rb
@@ -9,9 +9,9 @@ module Dttp
       let(:provider) { build(:provider, dttp_id: provider_dttp_id) }
       let(:provider_dttp_id) { SecureRandom.uuid }
       let(:trainee) { create(:trainee, :completed, gender: "female", provider: provider) }
-      let(:trainee_creator_dttp_id) { SecureRandom.uuid }
+      let(:created_by_dttp_id) { SecureRandom.uuid }
 
-      subject { described_class.new(trainee, trainee_creator_dttp_id).params }
+      subject { described_class.new(trainee, created_by_dttp_id).params }
 
       before do
         allow(Time).to receive(:now).and_return(time_now_in_zone)
@@ -35,14 +35,14 @@ module Dttp
             "gendercode" => Dttp::Params::Contact::GENDER_CODES[:female],
             "dfe_traineeid" => trainee.trainee_id,
             "dfe_ContactTypeId@odata.bind" => "/dfe_contacttypes(faba11c7-07d9-e711-80e1-005056ac45bb)",
-            "dfe_CreatedById@odata.bind" => "/contacts(#{trainee_creator_dttp_id})",
+            "dfe_CreatedById@odata.bind" => "/contacts(#{created_by_dttp_id})",
             "parentcustomerid_account@odata.bind" => "/accounts(#{provider_dttp_id})",
             "dfe_trnassessmentdate" => time_now_in_zone.in_time_zone.iso8601,
           })
         end
 
-        context "trainee_creator_dttp_id not passed" do
-          subject { described_class.new(trainee, trainee_creator_dttp_id).params }
+        context "created_by_dttp_id not passed" do
+          subject { described_class.new(trainee, created_by_dttp_id).params }
 
           it "returns a hash with only the basic contact fields" do
             expect(subject).to include({

--- a/spec/services/dttp/register_for_trn_spec.rb
+++ b/spec/services/dttp/register_for_trn_spec.rb
@@ -11,7 +11,7 @@ module Dttp
       let(:degree) { build(:degree, :uk_degree_with_details) }
 
       let(:batch_request) { instance_double(BatchRequest) }
-      let(:trainee_creator_dttp_id) { SecureRandom.uuid }
+      let(:created_by_dttp_id) { SecureRandom.uuid }
 
       let(:contact_change_set_id) { SecureRandom.uuid }
       let(:placement_assignment_change_set_id) { SecureRandom.uuid }
@@ -21,7 +21,7 @@ module Dttp
       let(:placement_assignment_entity_id) { SecureRandom.uuid }
       let(:degree_qualification_entity_id) { SecureRandom.uuid }
 
-      let(:contact_payload) { Params::Contact.new(trainee, trainee_creator_dttp_id).to_json }
+      let(:contact_payload) { Params::Contact.new(trainee, created_by_dttp_id).to_json }
       let(:placement_assignment_payload) { Params::PlacementAssignment.new(trainee, contact_change_set_id).to_json }
       let(:degree_qualification_payload) do
         Params::DegreeQualification.new(degree, contact_change_set_id, placement_assignment_change_set_id).to_json
@@ -71,7 +71,7 @@ module Dttp
         expect(batch_request).to receive(:submit).and_return(dttp_response)
 
         expect {
-          described_class.call(trainee: trainee, trainee_creator_dttp_id: trainee_creator_dttp_id)
+          described_class.call(trainee: trainee, created_by_dttp_id: created_by_dttp_id)
         }.to change(trainee, :dttp_id).to(
           contact_entity_id,
         ).and change(trainee, :placement_assignment_dttp_id).to(


### PR DESCRIPTION
### Context

https://trello.com/c/9B0qGvtA/2029-registerfortrn-argument-naming

We already have context of what this id is for, as the job is about
Creating a trainee/contact, so trainee doesn’t need to be in the name.
This also maps better to how the value is named in http.

### Changes proposed in this pull request

Do the renaming

### Guidance to review

