### PR TITLE
[2030] Don't compile assets in test

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -80,7 +80,8 @@ development:
 
 test:
   <<: *default
-  compile: true
+  compile: false
+  cache_manifest: true
 
 production: &production
   <<: *default


### PR DESCRIPTION
### Context

Webpacker seems to be compiling assets on every feature spec which is making the tests slow. 

### Changes proposed in this pull request

Don't do that...

This reduces the suite runtime on my machine from ~3mins to ~1min.

### Guidance to review

Run the specs on master. Go and get a brew. On your return note the time taken.

Run the specs on this branch. Don't blink. Marvel at the amazing speed 🚀 
