### PR TITLE
[2025] PageTitle has better param names

### DIFF
--- a/app/components/page_title/view.rb
+++ b/app/components/page_title/view.rb
@@ -1,32 +1,28 @@
 # frozen_string_literal: true
 
 class PageTitle::View < GovukComponent::Base
-  I18N_FORMAT = /^\S*\.\S*$/.freeze
-
-  attr_accessor :title
-
-  def initialize(title: "", has_errors: false)
-    @title = title
+  def initialize(i18n_key: nil, text: nil, has_errors: false)
+    @text = text
+    @i18n_key = i18n_key
     @has_errors = has_errors
   end
 
   def build_page_title
-    [build_error + build_title + build_service_name, "GOV.UK"].join(" - ")
+    [build_error + build_title, I18n.t("service_name"), "GOV.UK"].select(&:present?).join(" - ")
   end
 
 private
 
-  attr_reader :has_errors
+  attr_reader :text, :i18n_key, :has_errors
 
   def build_error
     has_errors ? "Error: " : ""
   end
 
   def build_title
-    title.match?(I18N_FORMAT) ? I18n.t("components.page_titles." + title) : title
-  end
+    return text if text.present?
+    return "" if i18n_key.blank?
 
-  def build_service_name
-    title.present? ? " - " + I18n.t("service_name") : I18n.t("service_name")
+    I18n.t("components.page_titles." + i18n_key)
   end
 end

--- a/app/components/trainees/apply_trainee_data/view.html.erb
+++ b/app/components/trainees/apply_trainee_data/view.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "check_details.show") %>
+<%= render PageTitle::View.new(i18n_key: "check_details.show") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,5 +1,5 @@
 <%= extends_layout :error do %>
-  <%= render PageTitle::View.new(title: "pages.forbidden") %>
+  <%= render PageTitle::View.new(i18n_key: "pages.forbidden") %>
 
   <h1 class="govuk-heading-l">You do not have access to view details for this trainee</h1>
 

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,5 +1,5 @@
 <%= extends_layout :error do %>
-  <%= render PageTitle::View.new(title: "pages.internal_server_error") %>
+  <%= render PageTitle::View.new(i18n_key: "pages.internal_server_error") %>
 
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,5 +1,5 @@
 <%= extends_layout :error do %>
-  <%= render PageTitle::View.new(title: "pages.not_found") %>
+  <%= render PageTitle::View.new(i18n_key: "pages.not_found") %>
 
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,5 +1,5 @@
 <%= extends_layout :error do %>
-  <%= render PageTitle::View.new(title: "pages.unprocessable_entity") %>
+  <%= render PageTitle::View.new(i18n_key: "pages.unprocessable_entity") %>
 
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -1,5 +1,5 @@
 <%= extends_layout :application do %>
-  <%= render PageTitle::View.new(title: "trainees.show.overview") %>
+  <%= render PageTitle::View.new(i18n_key: "trainees.show.overview") %>
 
   <%= content_for(:breadcrumbs) do %>
     <%= render FilteredBackLink::View.new(

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "pages.accessibility") %>
+<%= render PageTitle::View.new(i18n_key: "pages.accessibility") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/pages/cookie_policy.html.erb
+++ b/app/views/pages/cookie_policy.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "pages.cookie_policy") %>
+<%= render PageTitle::View.new(i18n_key: "pages.cookie_policy") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "pages.guidance") %>
+<%= render PageTitle::View.new(i18n_key: "pages.guidance") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "pages.home") %>
+<%= render PageTitle::View.new(i18n_key: "pages.home") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "pages.privacy_policy") %>
+<%= render PageTitle::View.new(i18n_key: "pages.privacy_policy") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,5 +1,5 @@
 
-<%= render PageTitle::View.new(title: "Personas") %>
+<%= render PageTitle::View.new(text: "Personas") %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">

--- a/app/views/request_an_account/index.html.erb
+++ b/app/views/request_an_account/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: t("components.page_titles.pages.request_an_account")) %>
+<%= render PageTitle::View.new(text: t("components.page_titles.pages.request_an_account")) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "sign_in.index") %>
+<%= render PageTitle::View.new(i18n_key: "sign_in.index") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/system_admin/dttp_providers/index.html.erb
+++ b/app/views/system_admin/dttp_providers/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "dttp_providers.index") %>
+<%= render PageTitle::View.new(i18n_key: "dttp_providers.index") %>
 
 <h1 class="govuk-heading-l">Dttp Providers</h1>
 

--- a/app/views/system_admin/dttp_providers/show.html.erb
+++ b/app/views/system_admin/dttp_providers/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: @provider.name, has_errors: @provider.errors.present?) %>
+<%= render PageTitle::View.new(text: @provider.name, has_errors: @provider.errors.present?) %>
 
 <%= render GovukComponent::BackLink.new(
   text: "Back",

--- a/app/views/system_admin/providers/edit.html.erb
+++ b/app/views/system_admin/providers/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "providers.edit", has_errors: @provider.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "providers.edit", has_errors: @provider.errors.present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/system_admin/providers/index.html.erb
+++ b/app/views/system_admin/providers/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "providers.index") %>
+<%= render PageTitle::View.new(i18n_key: "providers.index") %>
 
 <h1 class="govuk-heading-l">Providers</h1>
 

--- a/app/views/system_admin/providers/new.html.erb
+++ b/app/views/system_admin/providers/new.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "providers.new", has_errors: @provider.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "providers.new", has_errors: @provider.errors.present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/app/views/system_admin/providers/show.html.erb
+++ b/app/views/system_admin/providers/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: @provider.name, has_errors: @provider.errors.present?) %>
+<%= render PageTitle::View.new(text: @provider.name, has_errors: @provider.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/system_admin/users/new.html.erb
+++ b/app/views/system_admin/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "users.new", has_errors: @user.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "users.new", has_errors: @user.errors.present?) %>
 
 <%= render GovukComponent::BackLink.new(
       text: "Back",

--- a/app/views/system_admin/validation_errors/index.html.erb
+++ b/app/views/system_admin/validation_errors/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "validation_errors.page_title") %>
+<%= render PageTitle::View.new(i18n_key: "validation_errors.page_title") %>
 
 <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "check_details.show") %>
+<%= render PageTitle::View.new(i18n_key: "check_details.show") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/trainees/confirm_deferrals/show.html.erb
+++ b/app/views/trainees/confirm_deferrals/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.deferral_details.confirm") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.deferral_details.confirm") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>

--- a/app/views/trainees/confirm_delete/show.html.erb
+++ b/app/views/trainees/confirm_delete/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.delete") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.delete") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(text: I18n.t("back_to_draft"), href: trainee_path(@trainee)) %>

--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: t("components.confirmation.heading", section_title: confirm_section_title)) %>
+<%= render PageTitle::View.new(text: t("components.confirmation.heading", section_title: confirm_section_title)) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee) %>

--- a/app/views/trainees/confirm_publish_course/edit.html.erb
+++ b/app/views/trainees/confirm_publish_course/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.confirm_publish_course.edit") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.confirm_publish_course.edit") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(text: t(:back), href: edit_trainee_publish_course_details_path(@trainee)) %>

--- a/app/views/trainees/confirm_reinstatements/show.html.erb
+++ b/app/views/trainees/confirm_reinstatements/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.confirm_reinstatement.show") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.confirm_reinstatement.show") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>

--- a/app/views/trainees/confirm_withdrawals/show.html.erb
+++ b/app/views/trainees/confirm_withdrawals/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.confirm_withdrawal.show") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.confirm_withdrawal.show") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.contact_details.edit", has_errors: @contact_details_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.contact_details.edit", has_errors: @contact_details_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.course_details.edit", has_errors: @course_details_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.course_details.edit", has_errors: @course_details_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/deferrals/show.html.erb
+++ b/app/views/trainees/deferrals/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.deferral.show", has_errors: @deferral_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.deferral.show", has_errors: @deferral_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>

--- a/app/views/trainees/degrees/edit.html.erb
+++ b/app/views/trainees/degrees/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.degrees.edit", has_errors: @degree_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.degrees.edit", has_errors: @degree_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/degrees/new.html.erb
+++ b/app/views/trainees/degrees/new.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.degrees.edit", has_errors: @degree_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.degrees.edit", has_errors: @degree_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/trainees/degrees/type/new.html.erb
+++ b/app/views/trainees/degrees/type/new.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: (@trainee.degrees.size > 1 ? "Add another degree" : "Add undergraduate degree"), has_errors: @degree.errors.present?) %>
+<%= render PageTitle::View.new(text: (@trainee.degrees.size > 1 ? "Add another degree" : "Add undergraduate degree"), has_errors: @degree.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>

--- a/app/views/trainees/diversity/confirm_details/show.html.erb
+++ b/app/views/trainees/diversity/confirm_details/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.diversity.confirm") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.diversity.confirm") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/diversity/disability_details/edit.html.erb
+++ b/app/views/trainees/diversity/disability_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.diversity.disabilities.edit",
+<%= render PageTitle::View.new(i18n_key: "trainees.diversity.disabilities.edit",
                                has_errors: @disability_detail_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>

--- a/app/views/trainees/diversity/disability_disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disability_disclosures/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.diversity.disability_disclosure.edit",
+<%= render PageTitle::View.new(i18n_key: "trainees.diversity.disability_disclosure.edit",
                                has_errors: @disability_disclosure_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>

--- a/app/views/trainees/diversity/disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disclosures/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.diversity.disclosures.edit",
+<%= render PageTitle::View.new(i18n_key: "trainees.diversity.disclosures.edit",
                                has_errors: @disclosure_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render PageTitle::View.new(
-  title: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")),
+  text: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")),
   has_errors: @ethnic_background_form.errors.present?,
 ) %>
 

--- a/app/views/trainees/diversity/ethnic_groups/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_groups/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.diversity.ethnic_group.edit", has_errors: @ethnic_group_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.diversity.ethnic_group.edit", has_errors: @ethnic_group_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/employing_schools/edit.html.erb
+++ b/app/views/trainees/employing_schools/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.employing_schools.edit", has_errors: @employing_school_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.employing_schools.edit", has_errors: @employing_school_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/employing_schools/index.html.erb
+++ b/app/views/trainees/employing_schools/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.employing_schools.index",
+<%= render PageTitle::View.new(i18n_key: "trainees.employing_schools.index",
                                has_errors: @employing_school_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: trainees_page_title(@paginated_trainees, @total_trainees_count)) %>
+<%= render PageTitle::View.new(text: trainees_page_title(@paginated_trainees, @total_trainees_count)) %>
 
 <% if @paginated_trainees.current_page > 1 %>
   <span class="govuk-caption-xl">Page <%= @paginated_trainees.current_page %> of <%= @paginated_trainees.total_pages %></span>

--- a/app/views/trainees/lead_schools/edit.html.erb
+++ b/app/views/trainees/lead_schools/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.lead_schools.edit", has_errors: @lead_school_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.lead_schools.edit", has_errors: @lead_school_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/lead_schools/index.html.erb
+++ b/app/views/trainees/lead_schools/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.lead_schools.index", has_errors: @lead_school_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.lead_schools.index", has_errors: @lead_school_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.training_routes.edit", has_errors: @trainee.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.training_routes.edit", has_errors: @trainee.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/trainees/not_supported_route.html.erb
+++ b/app/views/trainees/not_supported_route.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.not_supported_route") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.not_supported_route") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/trainees/outcome_dates/edit.html.erb
+++ b/app/views/trainees/outcome_dates/edit.html.erb
@@ -1,6 +1,6 @@
 <% text = @trainee.early_years_route? ? I18n.t("components.page_titles.trainees.outcome_date.eyts_edit") : I18n.t("components.page_titles.trainees.outcome_date.edit") %>
 
-<%= render PageTitle::View.new(title: text, has_errors: @outcome_form.errors.present?) %>
+<%= render PageTitle::View.new(text: text, has_errors: @outcome_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/trainees/outcome_details/confirm.html.erb
+++ b/app/views/trainees/outcome_details/confirm.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.outcome_details.confirm_#{@trainee.award_type.downcase}") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.outcome_details.confirm_#{@trainee.award_type.downcase}") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>

--- a/app/views/trainees/outcome_details/recommended.html.erb
+++ b/app/views/trainees/outcome_details/recommended.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.outcome_details.recommended_#{@trainee.award_type.downcase}") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.outcome_details.recommended_#{@trainee.award_type.downcase}") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.personal_details.edit", has_errors: @personal_detail_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.personal_details.edit", has_errors: @personal_detail_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.course_details.edit", has_errors: @publish_course_details.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.course_details.edit", has_errors: @publish_course_details.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/reinstatements/show.html.erb
+++ b/app/views/trainees/reinstatements/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.reinstatement.show", has_errors: @reinstatement_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.reinstatement.show", has_errors: @reinstatement_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>

--- a/app/views/trainees/review_draft/show.html.erb
+++ b/app/views/trainees/review_draft/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: t("components.page_titles.trainees.show.#{@trainee.apply_application? ? 'apply_draft' : 'draft'}"), has_errors: @trainee.errors.present?) %>
+<%= render PageTitle::View.new(text: t("components.page_titles.trainees.show.#{@trainee.apply_application? ? 'apply_draft' : 'draft'}"), has_errors: @trainee.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render FilteredBackLink::View.new(

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.trainee_start_date.edit") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.trainee_start_date.edit") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/trainee_ids/edit.html.erb
+++ b/app/views/trainees/trainee_ids/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.trainee_ids.edit") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.trainee_ids.edit") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: t("views.forms.training_details.title")) %>
+<%= render PageTitle::View.new(text: t("views.forms.training_details.title")) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/training_routes/edit.html.erb
+++ b/app/views/trainees/training_routes/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.training_routes.edit", has_errors: @trainee.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.training_routes.edit", has_errors: @trainee.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trainees.withdrawal.show", has_errors: @withdrawal_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.withdrawal.show", has_errors: @withdrawal_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>

--- a/app/views/trn_submissions/show.html.erb
+++ b/app/views/trn_submissions/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(title: "trn_submissions.show") %>
+<%= render PageTitle::View.new(i18n_key: "trn_submissions.show") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render FilteredBackLink::View.new(

--- a/spec/components/page_title/view_preview.rb
+++ b/spec/components/page_title/view_preview.rb
@@ -3,11 +3,19 @@
 require "govuk/components"
 
 class PageTitle::ViewPreview < ViewComponent::Preview
-  def default_heading
-    render(PageTitle::View.new(title: "trainees.new"))
+  def key_heading
+    render(PageTitle::View.new(i18n_key: "trainees.new"))
   end
 
-  def heading_with_error
-    render(PageTitle::View.new(title: "trainees.new", has_errors: true))
+  def key_heading_with_error
+    render(PageTitle::View.new(i18n_key: "trainees.new", has_errors: true))
+  end
+
+  def text_heading
+    render(PageTitle::View.new(text: "Test heading"))
+  end
+
+  def text_heading_with_error
+    render(PageTitle::View.new(text: "Test heading", has_errors: true))
   end
 end

--- a/spec/components/page_title/view_spec.rb
+++ b/spec/components/page_title/view_spec.rb
@@ -7,31 +7,45 @@ RSpec.describe PageTitle::View do
     allow(I18n).to receive(:t).with("service_name").and_return("Cool Service")
   end
 
-  context "given a string that is not in the format of an i18n path" do
+  it "constructs a page title with empty params" do
+    component = PageTitle::View.new
+    page_title = component.build_page_title
+    expect(page_title).to eq("Cool Service - GOV.UK")
+  end
+
+  context "title as text" do
     it "constructs a page title using the provided value" do
-      component = PageTitle::View.new(title: "Some title")
+      component = PageTitle::View.new(text: "Some title")
       page_title = component.build_page_title
       expect(page_title).to eq("Some title - Cool Service - GOV.UK")
     end
-  end
 
-  context "when has_errors is true" do
-    it "constructs a page title value with an error" do
-      component = PageTitle::View.new(title: "Some title", has_errors: true)
-      page_title = component.build_page_title
-      expect(page_title).to eq("Error: Some title - Cool Service - GOV.UK")
+    context "when has_errors is true" do
+      it "constructs a page title value with an error" do
+        component = PageTitle::View.new(text: "Some title", has_errors: true)
+        page_title = component.build_page_title
+        expect(page_title).to eq("Error: Some title - Cool Service - GOV.UK")
+      end
     end
   end
 
-  context "given an i18n key format" do
+  context "title as i18n key" do
     before do
       allow(I18n).to receive(:t).with("components.page_titles.trainee.new").and_return("New Trainee")
     end
 
     it "constructs a page title value" do
-      component = PageTitle::View.new(title: "trainee.new")
+      component = PageTitle::View.new(i18n_key: "trainee.new")
       page_title = component.build_page_title
       expect(page_title).to eq("New Trainee - Cool Service - GOV.UK")
+    end
+
+    context "when has_errors is true" do
+      it "constructs a page title value with an error" do
+        component = PageTitle::View.new(i18n_key: "trainee.new", has_errors: true)
+        page_title = component.build_page_title
+        expect(page_title).to eq("Error: New Trainee - Cool Service - GOV.UK")
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/U62RHvav/2025-for-pagetitleview-use-titlekey-instead-of-title

### Changes proposed in this pull request

* `PageTitle` component param: `i18n_key` used for translation key and `text` used for translated text.

### Guidance to review

