### PR TITLE
[2021] Prefix subject columns on trainees table with "course_"

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -23,9 +23,9 @@ module ApplicationRecordCard
 
     def subject
       return I18n.t("components.application_record_card.subject.early_years") if record.early_years_route?
-      return I18n.t("components.application_record_card.subject.blank") if record.subject.blank?
+      return I18n.t("components.application_record_card.subject.blank") if record.course_subject_one.blank?
 
-      subjects_for_summary_view(record.subject, record.subject_two, record.subject_three)
+      subjects_for_summary_view(record.course_subject_one, record.course_subject_two, record.course_subject_three)
     end
 
     def route

--- a/app/components/trainees/confirmation/course_details/view.rb
+++ b/app/components/trainees/confirmation/course_details/view.rb
@@ -68,9 +68,11 @@ module Trainees
         end
 
         def subject
-          return @not_provided_copy if data_model.subject.blank?
+          return @not_provided_copy if data_model.course_subject_one.blank?
 
-          subjects_for_summary_view(data_model.subject, data_model.subject_two, data_model.subject_three)
+          subjects_for_summary_view(data_model.course_subject_one,
+                                    data_model.course_subject_two,
+                                    data_model.course_subject_three)
         end
 
         def course_age_range

--- a/app/components/trainees/route_indicator/view.rb
+++ b/app/components/trainees/route_indicator/view.rb
@@ -24,7 +24,7 @@ module Trainees
       end
 
       def course_with_code
-        "#{trainee.subject} #{course_code}".strip
+        "#{trainee.course_subject_one} #{course_code}".strip
       end
 
       def course_code

--- a/app/forms/confirm_publish_course_form.rb
+++ b/app/forms/confirm_publish_course_form.rb
@@ -53,9 +53,9 @@ private
   def update_trainee_attributes
     trainee.progress.course_details = true
     trainee.assign_attributes({
-      subject: course.subject_one&.name,
-      subject_two: course.subject_two&.name,
-      subject_three: course.subject_three&.name,
+      course_subject_one: course.subject_one&.name,
+      course_subject_two: course.subject_two&.name,
+      course_subject_three: course.subject_three&.name,
       course_code: course_code,
       course_age_range: course&.age_range,
       course_start_date: course_start_date,

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -2,12 +2,12 @@
 
 class CourseDetailsForm < TraineeForm
   FIELDS = %i[
-    subject
-    subject_raw
-    subject_two
-    subject_two_raw
-    subject_three
-    subject_three_raw
+    course_subject_one
+    course_subject_one_raw
+    course_subject_two
+    course_subject_two_raw
+    course_subject_three
+    course_subject_three_raw
     start_day
     start_month
     start_year
@@ -33,15 +33,17 @@ class CourseDetailsForm < TraineeForm
   before_validation :sanitise_course_dates
   before_validation :sanitise_subjects
 
-  validates :subject, autocomplete: true, presence: true, if: :require_subject?
-  validates :subject_two, autocomplete: true, if: :require_subject?
-  validates :subject_three, autocomplete: true, if: :require_subject?
+  validates :course_subject_one, autocomplete: true, presence: true, if: :require_subject?
+  validates :course_subject_two, autocomplete: true, if: :require_subject?
+  validates :course_subject_three, autocomplete: true, if: :require_subject?
   validates :additional_age_range, autocomplete: true, if: -> { other_age_range? && require_age_range? }
-  validate :age_range_valid, if: :require_age_range?
+
   validate :course_start_date_valid
   validate :course_end_date_valid
-  validate :subject_two_valid, if: :require_subject?
-  validate :subject_three_valid, if: :require_subject?
+
+  validate :age_range_valid, if: :require_age_range?
+  validate :course_subject_two_valid, if: :require_subject?
+  validate :course_subject_three_valid, if: :require_subject?
 
   delegate :apply_application?, to: :trainee
 
@@ -78,7 +80,7 @@ class CourseDetailsForm < TraineeForm
   end
 
   def has_additional_subjects?
-    subject_two.present? || subject_three.present?
+    course_subject_two.present? || course_subject_three.present?
   end
 
   def require_subject?
@@ -102,9 +104,9 @@ private
   def update_trainee_attributes
     trainee.assign_attributes({
       course_code: course_code,
-      subject: subject,
-      subject_two: subject_two,
-      subject_three: subject_three,
+      course_subject_one: course_subject_one,
+      course_subject_two: course_subject_two,
+      course_subject_three: course_subject_three,
       course_age_range: course_age_range,
       course_start_date: course_start_date,
       course_end_date: course_end_date,
@@ -113,9 +115,9 @@ private
 
   def compute_attributes_from_trainee
     attributes = {
-      subject: trainee.subject,
-      subject_two: trainee.subject_two,
-      subject_three: trainee.subject_three,
+      course_subject_one: trainee.course_subject_one,
+      course_subject_two: trainee.course_subject_two,
+      course_subject_three: trainee.course_subject_three,
       start_day: trainee.course_start_date&.day,
       start_month: trainee.course_start_date&.month,
       start_year: trainee.course_start_date&.year,
@@ -179,16 +181,16 @@ private
     end
   end
 
-  def subject_two_valid
-    return if subject_two.blank?
+  def course_subject_two_valid
+    return if course_subject_two.blank?
 
-    errors.add(:subject_two, :duplicate) if subject == subject_two
+    errors.add(:course_subject_two, :duplicate) if course_subject_one == course_subject_two
   end
 
-  def subject_three_valid
-    return if subject_three.blank?
+  def course_subject_three_valid
+    return if course_subject_three.blank?
 
-    errors.add(:subject_three, :duplicate) if [subject, subject_two].include?(subject_three)
+    errors.add(:course_subject_three, :duplicate) if [course_subject_one, course_subject_two].include?(course_subject_three)
   end
 
   def next_year
@@ -200,13 +202,13 @@ private
   end
 
   def sanitise_subjects
-    return if subject_two.present? || subject_two_raw.present?
+    return if course_subject_two.present? || course_subject_two_raw.present?
 
-    self.subject_two = subject_three
-    self.subject_two_raw = subject_three_raw
+    self.course_subject_two = course_subject_three
+    self.course_subject_two_raw = course_subject_three_raw
 
-    self.subject_three = nil
-    self.subject_three_raw = nil
+    self.course_subject_three = nil
+    self.course_subject_three_raw = nil
   end
 
   def sanitise_course_dates

--- a/app/forms/validate_publish_course_form.rb
+++ b/app/forms/validate_publish_course_form.rb
@@ -2,7 +2,7 @@
 
 class ValidatePublishCourseForm < TraineeForm
   FIELDS = %i[
-    subject
+    course_subject_one
     course_age_range
     course_start_date
     course_end_date
@@ -10,7 +10,7 @@ class ValidatePublishCourseForm < TraineeForm
 
   attr_accessor(*FIELDS)
 
-  validates :subject, presence: true
+  validates :course_subject_one, presence: true
 
   delegate :apply_application?, to: :trainee
 
@@ -18,7 +18,7 @@ private
 
   def compute_fields
     {
-      subject: trainee.subject,
+      course_subject_one: trainee.course_subject_one,
       course_age_range: trainee.course_age_range,
       course_start_date: trainee.course_start_date,
       course_end_date: trainee.course_end_date,

--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -23,10 +23,10 @@ module CourseDetailsHelper
     t("views.forms.publish_course_details.route_titles.#{route}")
   end
 
-  def subjects_for_summary_view(subject, subject_two, subject_three)
+  def subjects_for_summary_view(subject_one, subject_two, subject_three)
     additional_subjects = [subject_two, subject_three].reject(&:blank?).join(" and ")
 
-    [subject, additional_subjects].reject(&:blank?).join(" with ")
+    [subject_one, additional_subjects].reject(&:blank?).join(" with ")
   end
 
 private

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -65,7 +65,7 @@ module Dttp
       end
 
       def subject_entity_id
-        trainee.early_years_route? ? EARLY_YEARS_SUBJECT : course_subject_id(trainee.subject)
+        trainee.early_years_route? ? EARLY_YEARS_SUBJECT : course_subject_id(trainee.course_subject_one)
       end
 
       def uk_specific_params

--- a/app/lib/route_data_manager.rb
+++ b/app/lib/route_data_manager.rb
@@ -17,9 +17,9 @@ private
   def reset_course_details
     {
       course_code: nil,
-      subject: nil,
-      subject_two: nil,
-      subject_three: nil,
+      course_subject_one: nil,
+      course_subject_two: nil,
+      course_subject_three: nil,
       course_age_range: nil,
       course_start_date: nil,
       course_end_date: nil,

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -120,7 +120,7 @@ class Trainee < ApplicationRecord
 
   scope :ordered_by_date, -> { order(updated_at: :desc) }
   scope :ordered_by_last_name, -> { order(last_name: :asc) }
-  scope :with_subject, ->(subject) { where("subject = :subject OR subject_two = :subject OR subject_three = :subject", subject: subject) }
+  scope :with_subject, ->(subject) { where("course_subject_one = :subject OR course_subject_two = :subject OR course_subject_three = :subject", subject: subject) }
 
   # Returns draft trainees first, then all trainees in any other state.
   scope :ordered_by_drafts, -> { order(ordered_by_drafts_clause) }

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -35,7 +35,7 @@ module Exports
           "TRN" => trainee.trn,
           "Status" => status(trainee),
           "Route" => trainee.training_route,
-          "Subject" => trainee.subject,
+          "Subject" => trainee.course_subject_one,
           "Course start date" => trainee.course_start_date,
           "Course end date" => trainee.course_end_date,
           "Created date" => trainee.created_at,

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -42,7 +42,7 @@ module Trainees
         diversity_disclosure: diversity_disclosure,
         email: raw_contact_details["email"],
         training_route: course&.route,
-        subject: course&.name,
+        course_subject_one: course&.name,
         course_code: course&.code,
         course_age_range: course&.age_range,
         course_start_date: course&.start_date,

--- a/app/views/trainees/course_details/_additional_subjects.html.erb
+++ b/app/views/trainees/course_details/_additional_subjects.html.erb
@@ -11,8 +11,8 @@
 
       <%= render FormComponents::Autocomplete::View.new(
         f,
-        attribute_name: :subject_two,
-        form_field: f.govuk_collection_select(:subject_two, course_subjects_options,
+        attribute_name: :course_subject_two,
+        form_field: f.govuk_collection_select(:course_subject_two, course_subjects_options,
                                               :name, :name, label: { text: t(".subject_two") },
                                                             hint: { text: t(".subject_hint") }),
       ) %>
@@ -21,8 +21,8 @@
     <div class="govuk-!-margin-bottom-6 app-!-autocomplete--max-width-two-thirds ">
       <%= render FormComponents::Autocomplete::View.new(
         f,
-        attribute_name: :subject_three,
-        form_field: f.govuk_collection_select(:subject_three, course_subjects_options,
+        attribute_name: :course_subject_three,
+        form_field: f.govuk_collection_select(:course_subject_three, course_subjects_options,
                                               :name, :name, label: { text: t(".subject_three") },
                                                             hint: { text: t(".subject_hint") }),
       ) %>

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -16,8 +16,8 @@
       <% if f.object.require_subject? %>
         <%= render FormComponents::Autocomplete::View.new(
           f,
-          attribute_name: :subject,
-          form_field: f.govuk_collection_select(:subject, course_subjects_options,
+          attribute_name: :course_subject_one,
+          form_field: f.govuk_collection_select(:course_subject_one, course_subjects_options,
                                                 :name, :name, label: { text: "Subject", size: "s" },
                                                               hint: { text: "Search for the closest matching subject" }),
         ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -612,9 +612,9 @@ en:
         email:
           invalid: Enter an email address in the correct format, like name@example.com
         autocomplete:
-          subject: &subject Select a subject from the list - your entry is not recognised
-          subject_two: *subject
-          subject_three: *subject
+          course_subject_one: &subject Select a subject from the list - your entry is not recognised
+          course_subject_two: *subject
+          course_subject_three: *subject
           additional_age_range: Select an age range from the list - your entry is not recognised
           institution: Select an institution from the list - your entry is not recognised
           other_nationality1: &nationality Select a nationality from the list - your entry is not recognised
@@ -705,11 +705,11 @@ en:
               blank: If you have an additional nationality, select it from the list
         course_details_form:
           attributes:
-            subject:
+            course_subject_one:
               blank: Select a subject
-            subject_two:
+            course_subject_two:
               duplicate: Enter a different second subject
-            subject_three:
+            course_subject_three:
               duplicate: Enter a different third subject
             main_age_range:
               blank: Select an age range

--- a/db/migrate/20210618085011_prefix_trainee_subject_columns_with_course.rb
+++ b/db/migrate/20210618085011_prefix_trainee_subject_columns_with_course.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PrefixTraineeSubjectColumnsWithCourse < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :trainees, :subject, :course_subject_one
+    rename_column :trainees, :subject_two, :course_subject_two
+    rename_column :trainees, :subject_three, :course_subject_three
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_17_084351) do
+ActiveRecord::Schema.define(version: 2021_06_18_085011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -275,7 +275,7 @@ ActiveRecord::Schema.define(version: 2021_06_17_084351) do
     t.text "ethnic_background"
     t.text "additional_ethnic_background"
     t.integer "disability_disclosure"
-    t.text "subject"
+    t.text "course_subject_one"
     t.date "course_start_date"
     t.jsonb "progress", default: {}
     t.bigint "provider_id", null: false
@@ -301,8 +301,8 @@ ActiveRecord::Schema.define(version: 2021_06_17_084351) do
     t.integer "course_min_age"
     t.integer "course_max_age"
     t.string "course_code"
-    t.text "subject_two"
-    t.text "subject_three"
+    t.text "course_subject_two"
+    t.text "course_subject_three"
     t.datetime "awarded_at"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"

--- a/spec/components/application_record_card/view_preview.rb
+++ b/spec/components/application_record_card/view_preview.rb
@@ -31,7 +31,7 @@ module ApplicationRecordCard
         first_names: "Tom",
         last_name: "Jones",
         training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
-        subject: "Primary",
+        course_subject_one: "Primary",
       )
     end
 
@@ -42,8 +42,8 @@ module ApplicationRecordCard
         first_names: "Tom",
         last_name: "Jones",
         training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
-        subject: "Primary",
-        subject_two: "Science",
+        course_subject_one: "Primary",
+        course_subject_two: "Science",
       )
     end
 
@@ -54,18 +54,18 @@ module ApplicationRecordCard
         first_names: "Tom",
         last_name: "Jones",
         training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
-        subject: "Primary",
-        subject_two: "Science",
-        subject_three: "Mathematics",
+        course_subject_one: "Primary",
+        course_subject_two: "Science",
+        course_subject_three: "Mathematics",
       )
     end
 
     def mock_multiple_trainees
       [
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], subject: "Primary", subject_two: "Mathematics", subject_three: "Latin"),
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Paddington", last_name: "Bear", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], subject: "Science", subject_two: "Mathematics"),
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Primary", course_subject_two: "Mathematics", course_subject_three: "Latin"),
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Paddington", last_name: "Bear", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Science", course_subject_two: "Mathematics"),
         Trainee.new(id: 1, created_at: Time.zone.now),
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tim", last_name: "Knight", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], subject: "Maths"),
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tim", last_name: "Knight", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Maths"),
         Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Toby", last_name: "Rocker"),
       ]
     end

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -85,7 +85,7 @@ module ApplicationRecordCard
             id: 1,
             first_names: "Teddy",
             last_name: "Smith",
-            subject: "Designer",
+            course_subject_one: "Designer",
             training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
             trainee_id: "132456",
             created_at: Time.zone.now,
@@ -95,9 +95,7 @@ module ApplicationRecordCard
       end
 
       before do
-        render_inline(described_class.new(
-                        record: trainee,
-                      ))
+        render_inline(described_class.new(record: trainee))
       end
 
       it "renders trainee ID" do

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -57,7 +57,7 @@ module Pages
                       ethnic_background: "ethnic_background",
                       additional_ethnic_background: "additional_ethnic_background",
                       training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
-                      subject: "subject",
+                      course_subject_one: "subject",
                       degrees: [Degree.new(id: 1)])
         end
 
@@ -75,7 +75,6 @@ module Pages
                       international_address: "international_address",
                       ethnic_background: "ethnic_background",
                       additional_ethnic_background: "additional_ethnic_background",
-                      subject: "subject",
                       gender: 1,
                       date_of_birth: Time.zone.now,
                       locale_code: 1,
@@ -83,6 +82,7 @@ module Pages
                       email: "email@example.com",
                       course_min_age: 0,
                       course_max_age: 5,
+                      course_subject_one: "subject",
                       course_start_date: 6.months.ago,
                       course_end_date: Time.zone.now,
                       nationalities: nationalities,

--- a/spec/components/trainees/confirmation/confirm_publish_course/view_preview.rb
+++ b/spec/components/trainees/confirmation/confirm_publish_course/view_preview.rb
@@ -21,7 +21,7 @@ module Trainees
         def mock_trainee
           @mock_trainee ||= Trainee.new(
             id: 1,
-            subject: "Primary",
+            course_subject_one: "Primary",
             course_age_range: [3, 11],
             course_start_date: Date.new(2020, 0o1, 28),
             training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],

--- a/spec/components/trainees/confirmation/course_details/view_preview.rb
+++ b/spec/components/trainees/confirmation/course_details/view_preview.rb
@@ -22,7 +22,7 @@ module Trainees
         def mock_trainee
           @mock_trainee ||= Trainee.new(
             id: 1,
-            subject: "Primary",
+            course_subject_one: "Primary",
             course_age_range: [3, 11],
             course_start_date: Date.new(2020, 1, 28),
             training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
@@ -32,8 +32,8 @@ module Trainees
         def mock_trainee_with_multiple_subjects
           Trainee.new(
             id: 1,
-            subject: "Primary",
-            subject_two: "Science",
+            course_subject_one: "Primary",
+            course_subject_two: "Science",
             course_age_range: [3, 11],
             course_start_date: Date.new(2020, 1, 28),
             training_route: TRAINING_ROUTE_ENUMS[:assessment_only],

--- a/spec/components/trainees/confirmation/course_details/view_spec.rb
+++ b/spec/components/trainees/confirmation/course_details/view_spec.rb
@@ -14,7 +14,7 @@ module Trainees
           let(:trainee) do
             build(:trainee, id: 1,
                             training_route: nil,
-                            subject: nil,
+                            course_subject_one: nil,
                             course_code: nil,
                             course_min_age: nil,
                             course_max_age: nil,
@@ -58,7 +58,7 @@ module Trainees
 
             it "renders the subject" do
               expect(component.find(".govuk-summary-list__row.subject .govuk-summary-list__value"))
-                .to have_text(trainee.subject)
+                .to have_text(trainee.course_subject_one)
             end
 
             it "renders the course age range" do

--- a/spec/components/trainees/confirmation/schools/view_preview.rb
+++ b/spec/components/trainees/confirmation/schools/view_preview.rb
@@ -18,7 +18,7 @@ module Trainees
         def mock_trainee
           @mock_trainee ||= Trainee.new(
             id: 1,
-            subject: "Primary",
+            course_subject_one: "Primary",
             course_age_range: [3, 11],
             course_start_date: Date.new(2020, 0o1, 28),
             training_route: TRAINING_ROUTE_ENUMS[:assessment_only],

--- a/spec/components/trainees/route_indicator/view_preview.rb
+++ b/spec/components/trainees/route_indicator/view_preview.rb
@@ -11,7 +11,7 @@ module RouteIndicator
         render(Trainees::RouteIndicator::View.new(trainee: Trainee.new(
           training_route: training_route,
           apply_application: ApplyApplication.new,
-          subject: Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample,
+          course_subject_one: Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample,
           course_code: Faker::Alphanumeric.alphanumeric(number: 4).upcase,
         )))
       end

--- a/spec/components/trainees/route_indicator/view_spec.rb
+++ b/spec/components/trainees/route_indicator/view_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Trainees::RouteIndicator::View do
     let(:trainee) { create(:trainee, :with_apply_application, :with_course_details) }
 
     it "renders" do
-      expect(component).to have_content(trainee.subject)
+      expect(component).to have_content(trainee.course_subject_one)
       expect(component).to have_content(trainee.course_code)
     end
   end

--- a/spec/components/trainees/sections/view_preview.rb
+++ b/spec/components/trainees/sections/view_preview.rb
@@ -55,7 +55,7 @@ module Trainees
           international_address: "international_address",
           ethnic_background: "ethnic_background",
           additional_ethnic_background: "additional_ethnic_background",
-          subject: "subject",
+          course_subject_one: "subject",
           training_route: TRAINING_ROUTE_ENUMS[training_route(section)],
           lead_school: School.new(id: 1),
           degrees: [Degree.new(id: 1)]

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -97,7 +97,7 @@ FactoryBot.define do
     end
 
     trait :with_course_details do
-      subject { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
+      course_subject_one { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
       course_code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
       course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.keys.sample }
       course_start_date { Faker::Date.between(from: 10.years.ago, to: 2.days.ago) }

--- a/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
@@ -63,7 +63,7 @@ private
   end
 
   def and_i_enter_valid_parameters
-    course_details_page.subject.select(trainee.subject)
+    course_details_page.subject.select(trainee.course_subject_one)
     course_details_page.set_date_fields("course_start_date", trainee.course_start_date.strftime("%d/%m/%Y"))
     course_details_page.set_date_fields("course_end_date", trainee.course_end_date.strftime("%d/%m/%Y"))
 
@@ -84,7 +84,7 @@ private
   def and_the_course_details_are_updated
     when_i_visit_the_course_details_page
 
-    expect(course_details_page.subject.value).to eq(trainee.subject)
+    expect(course_details_page.subject.value).to eq(trainee.course_subject_one)
     expect(course_details_page.course_start_date_day.value).to eq(trainee.course_start_date.day.to_s)
     expect(course_details_page.course_start_date_month.value).to eq(trainee.course_start_date.month.to_s)
     expect(course_details_page.course_start_date_year.value).to eq(trainee.course_start_date.year.to_s)
@@ -136,7 +136,7 @@ private
     translation_key_prefix = "activemodel.errors.models.course_details_form.attributes"
 
     expect(course_details_page).to have_content(
-      I18n.t("#{translation_key_prefix}.subject.blank"),
+      I18n.t("#{translation_key_prefix}.course_subject_one.blank"),
     )
     expect(course_details_page).to have_content(
       I18n.t("#{translation_key_prefix}.main_age_range.blank"),
@@ -148,7 +148,7 @@ private
 
   def then_i_see_error_messages_for_partially_submitted_fields
     expect(course_details_page).to have_content(
-      I18n.t("activemodel.errors.validators.autocomplete.subject"),
+      I18n.t("activemodel.errors.validators.autocomplete.course_subject_one"),
     )
     expect(course_details_page).to have_content(
       I18n.t("activemodel.errors.validators.autocomplete.additional_age_range"),
@@ -157,10 +157,10 @@ private
 
   def then_i_see_error_messages_for_blank_submitted_fields
     expect(course_details_page).to have_content(
-      I18n.t("activemodel.errors.models.course_details_form.attributes.subject.blank"),
+      I18n.t("activemodel.errors.models.course_details_form.attributes.course_subject_one.blank"),
     )
     expect(course_details_page).not_to have_content(
-      I18n.t("activemodel.errors.validators.autocomplete.subject"),
+      I18n.t("activemodel.errors.validators.autocomplete.course_subject_one"),
     )
   end
 

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -83,8 +83,8 @@ private
   def given_trainees_exist_in_the_system
     @assessment_only_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
     @provider_led_postgrad_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
-    @biology_trainee ||= create(:trainee, subject: "Biology")
-    @history_trainee ||= create(:trainee, subject: "History")
+    @biology_trainee ||= create(:trainee, course_subject_one: "Biology")
+    @history_trainee ||= create(:trainee, course_subject_one: "History")
     @searchable_trainee ||= create(:trainee, trn: "123")
     Trainee.update_all(provider_id: @current_user.provider.id)
   end

--- a/spec/forms/confirm_publish_course_form_spec.rb
+++ b/spec/forms/confirm_publish_course_form_spec.rb
@@ -22,8 +22,8 @@ describe ConfirmPublishCourseForm, type: :model do
       describe "#save" do
         it "changed related trainee attributes" do
           expect { subject.save }
-            .to change { trainee.subject }
-            .from(nil).to(course.subjects.first.name)
+            .to change { trainee.course_subject_one }
+            .from(nil).to(course.subject_one.name)
             .and change { trainee.course_min_age }
             .from(nil).to(course.min_age)
             .and change { trainee.course_max_age }
@@ -42,8 +42,8 @@ describe ConfirmPublishCourseForm, type: :model do
 
         it "stores the second subject" do
           expect { subject.save }
-            .to change { trainee.subject_two }
-            .from(nil).to(course.subjects.second.name)
+            .to change { trainee.course_subject_two }
+            .from(nil).to(course.subject_two.name)
         end
       end
 
@@ -52,8 +52,8 @@ describe ConfirmPublishCourseForm, type: :model do
 
         it "stores the third subject" do
           expect { subject.save }
-            .to change { trainee.subject_three }
-            .from(nil).to(course.subjects.third.name)
+            .to change { trainee.course_subject_three }
+            .from(nil).to(course.subject_three.name)
         end
       end
     end

--- a/spec/forms/course_detail_form_spec.rb
+++ b/spec/forms/course_detail_form_spec.rb
@@ -36,13 +36,15 @@ describe CourseDetailsForm, type: :model do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:subject) }
+    it { is_expected.to validate_presence_of(:course_subject_one) }
 
     context "when subjects are duplicated" do
       let(:params) do
-        { subject: "Psychology",
-          subject_two: "Psychology",
-          subject_three: "Psychology" }
+        {
+          course_subject_one: "Psychology",
+          course_subject_two: "Psychology",
+          course_subject_three: "Psychology",
+        }
       end
 
       before do
@@ -50,23 +52,23 @@ describe CourseDetailsForm, type: :model do
       end
 
       it "returns an error against subject two" do
-        expect(subject.errors[:subject_two]).not_to be_empty
+        expect(subject.errors[:course_subject_two]).not_to be_empty
       end
 
       it "returns an error against subject three" do
-        expect(subject.errors[:subject_three]).not_to be_empty
+        expect(subject.errors[:course_subject_three]).not_to be_empty
       end
     end
 
     context "when the first and third subjects are provided" do
       let(:params) do
         {
-          subject: "Psychology",
-          subject_raw: "Psychology",
-          subject_two: "",
-          subject_two_raw: "",
-          subject_three: "Mathematics",
-          subject_three_raw: "Mathematics",
+          course_subject_one: "Psychology",
+          course_subject_one_raw: "Psychology",
+          course_subject_two: "",
+          course_subject_two_raw: "",
+          course_subject_three: "Mathematics",
+          course_subject_three_raw: "Mathematics",
         }
       end
 
@@ -75,13 +77,13 @@ describe CourseDetailsForm, type: :model do
       end
 
       it "populates subject two with the third subject" do
-        expect(subject.subject_two).to eq("Mathematics")
-        expect(subject.subject_two_raw).to eq("Mathematics")
+        expect(subject.course_subject_two).to eq("Mathematics")
+        expect(subject.course_subject_two_raw).to eq("Mathematics")
       end
 
       it "clears the third subject slot" do
-        expect(subject.subject_three).to be_blank
-        expect(subject.subject_three_raw).to be_blank
+        expect(subject.course_subject_three).to be_blank
+        expect(subject.course_subject_three_raw).to be_blank
       end
     end
 
@@ -288,16 +290,18 @@ describe CourseDetailsForm, type: :model do
     let(:max_age) { 19 }
 
     let(:params) do
-      { start_day: valid_start_date.day.to_s,
+      {
+        start_day: valid_start_date.day.to_s,
         start_month: valid_start_date.month.to_s,
         start_year: valid_start_date.year.to_s,
         end_day: valid_end_date.day.to_s,
         end_month: valid_end_date.month.to_s,
         end_year: valid_end_date.year.to_s,
         main_age_range: "#{min_age} to #{max_age}",
-        subject: "Psychology",
-        subject_two: "Chemistry",
-        subject_three: "Art and design" }
+        course_subject_one: "Psychology",
+        course_subject_two: "Chemistry",
+        course_subject_three: "Art and design",
+      }
     end
 
     let(:trainee) { create(:trainee) }
@@ -309,8 +313,8 @@ describe CourseDetailsForm, type: :model do
 
       it "changed related trainee attributes" do
         expect { subject.save! }
-          .to change { trainee.subject }
-          .from(nil).to(params[:subject])
+          .to change { trainee.course_subject_one }
+          .from(nil).to(params[:course_subject_one])
           .and change { trainee.course_min_age }
           .from(nil).to(min_age)
           .and change { trainee.course_max_age }

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -38,7 +38,7 @@ module Dttp
                      trainee.course_age_range => { entity_id: dttp_age_range_entity_id },
                    })
         stub_const("Dttp::CodeSets::CourseSubjects::MAPPING",
-                   { trainee.subject => { entity_id: dttp_course_subject_entity_id } })
+                   { trainee.course_subject_one => { entity_id: dttp_course_subject_entity_id } })
         stub_const("Dttp::CodeSets::DegreeSubjects::MAPPING",
                    { degree.subject => { entity_id: dttp_degree_subject_entity_id } })
         stub_const("Dttp::CodeSets::Institutions::MAPPING",

--- a/spec/lib/route_data_manager_spec.rb
+++ b/spec/lib/route_data_manager_spec.rb
@@ -16,8 +16,8 @@ describe RouteDataManager do
             .from(trainee.progress.course_details).to(false)
             .and change { trainee.course_code }
             .from(trainee.course_code).to(nil)
-            .and change { trainee.subject }
-            .from(trainee.subject).to(nil)
+            .and change { trainee.course_subject_one }
+            .from(trainee.course_subject_one).to(nil)
             .and change { trainee.course_age_range }
             .from(trainee.course_age_range).to([])
             .and change { trainee.course_start_date }
@@ -41,7 +41,7 @@ describe RouteDataManager do
 
         it "does not clear the course details section of the trainee" do
           expect(trainee.course_code).to be_present
-          expect(trainee.subject).to be_present
+          expect(trainee.course_subject_one).to be_present
           expect(trainee.course_age_range).to be_present
           expect(trainee.course_start_date).to be_present
           expect(trainee.course_end_date).to be_present

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -276,16 +276,26 @@ describe Trainee do
   end
 
   describe "#with_subject" do
-    let!(:trainee_with_subject) { create(:trainee, subject: "Art and design") }
-    let!(:trainee_without_subject) { create(:trainee, subject: "Mathematics") }
+    let!(:trainee_with_subject) { create(:trainee, course_subject_one: "Art and design") }
+    let!(:trainee_without_subject) { create(:trainee, course_subject_one: "Mathematics") }
 
     subject { described_class.with_subject("Art and design") }
 
     it { is_expected.to eq([trainee_with_subject]) }
 
     context "with multiple subjects" do
-      let!(:trainee_with_subject_two) { create(:trainee, subject: "Mathematics", subject_two: "Art and design") }
-      let!(:trainee_with_subject_three) { create(:trainee, subject: "Mathematics", subject_two: "Science", subject_three: "Art and design") }
+      let!(:trainee_with_subject_two) do
+        create(:trainee,
+               course_subject_one: "Mathematics",
+               course_subject_two: "Art and design")
+      end
+
+      let!(:trainee_with_subject_three) do
+        create(:trainee,
+               course_subject_one: "Mathematics",
+               course_subject_two: "Science",
+               course_subject_three: "Art and design")
+      end
 
       it { is_expected.to match_array([trainee_with_subject, trainee_with_subject_two, trainee_with_subject_three]) }
     end

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -19,7 +19,7 @@ module Exports
           "TRN" => trainee.trn,
           "Status" => t("activerecord.attributes.trainee.states.#{trainee.state}", award_type: trainee.award_type),
           "Route" => trainee.training_route,
-          "Subject" => trainee.subject,
+          "Subject" => trainee.course_subject_one,
           "Course start date" => trainee.course_start_date,
           "Course end date" => trainee.course_end_date,
           "Created date" => trainee.created_at,

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -32,7 +32,7 @@ module Trainees
         diversity_disclosure: Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed],
         email: contact_details["email"],
         training_route: course.route,
-        subject: course.name,
+        course_subject_one: course.name,
         course_code: course.code,
         course_min_age: course.min_age,
         course_max_age: course.max_age,

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -29,7 +29,7 @@ module Trainees
     end
 
     context "with subject filter" do
-      let!(:trainee_with_subject) { create(:trainee, subject: Dttp::CodeSets::CourseSubjects::MAPPING.keys.first) }
+      let!(:trainee_with_subject) { create(:trainee, course_subject_one: Dttp::CodeSets::CourseSubjects::MAPPING.keys.first) }
       let(:filters) { { subject: "Art and design" } }
 
       it { is_expected.to eq([trainee_with_subject]) }

--- a/spec/support/page_objects/trainees/course_details.rb
+++ b/spec/support/page_objects/trainees/course_details.rb
@@ -6,8 +6,8 @@ module PageObjects
       include PageObjects::Helpers
       set_url "/trainees/{id}/course-details/edit"
 
-      element :subject, "#course-details-form-subject-field"
-      element :subject_raw, "input[data-nameoriginal='course_details_form[subject_raw]']"
+      element :subject, "#course-details-form-course-subject-one-field"
+      element :subject_raw, "input[data-nameoriginal='course_details_form[course_subject_one_raw]']"
 
       element :course_start_date_day, "#course_details_form_course_start_date_3i"
       element :course_start_date_month, "#course_details_form_course_start_date_2i"


### PR DESCRIPTION
### Context
https://trello.com/c/4PJ1vOc5/2021-prefix-subject-columns-on-trainees-table-with-course

### Changes proposed in this pull request
- Rename `Trainee#subject` to `Trainee#course_subject_one`
- Rename `Trainee#subject_two` to `Trainee#course_subject_two`
- Rename `Trainee#subject_three` to `Trainee#course_subject_three`

