### PR TITLE
[1986] Link to funding forms

### DIFF
--- a/app/components/review_draft/apply_draft/view.html.erb
+++ b/app/components/review_draft/apply_draft/view.html.erb
@@ -32,6 +32,10 @@
             if @trainee.requires_placement_details?
               component.row(**row_helper(@trainee, :placement_details))
             end
+
+            if FeatureService.enabled?("funding")
+              component.row(**row_helper(@trainee, funding_options(@trainee)))
+            end
           end %>
   </div>
 </div>

--- a/app/components/review_draft/apply_draft/view.rb
+++ b/app/components/review_draft/apply_draft/view.rb
@@ -5,6 +5,7 @@ module ReviewDraft
     class View < GovukComponent::Base
       include TraineeHelper
       include TaskListHelper
+      include FundingHelper
 
       attr_reader :trainee
 

--- a/app/components/review_draft/draft/view.html.erb
+++ b/app/components/review_draft/draft/view.html.erb
@@ -32,6 +32,10 @@
           component.row(**row_helper(@trainee, :school_details))
         end
 
+        if FeatureService.enabled?("funding")
+          component.row(**row_helper(@trainee, funding_options(@trainee)))
+        end
+
         # This will be uncommented once the form is built
         # if @trainee.requires_placement_details?
         #   component.row(**row_helper(@trainee, :placement_details))

--- a/app/components/review_draft/draft/view.rb
+++ b/app/components/review_draft/draft/view.rb
@@ -5,6 +5,7 @@ module ReviewDraft
     class View < GovukComponent::Base
       include TraineeHelper
       include TaskListHelper
+      include FundingHelper
 
       attr_reader :trainee
 

--- a/app/components/task_list/view.html.erb
+++ b/app/components/task_list/view.html.erb
@@ -1,9 +1,16 @@
 <%= tag.ol(class: classes, **html_attributes) do %>
   <% rows.each do |row| %>
     <%= tag.li(class: row.classes, **row.html_attributes) do %>
-      <a href="<%= row.get_path %>" class="govuk-link app-task-list__key" aria-describedby="<%= row.status_id %>">
-        <%= row.task_name %>
-      </a>
+      <% if row.active %>
+        <a href="<%= row.get_path %>" class="govuk-link app-task-list__key" aria-describedby="<%= row.status_id %>">
+          <%= row.task_name %>
+        </a>
+      <% else %>
+        <span class="app-task-list__key" aria-describedby="<%= row.status_id %>">
+          <%= row.task_name %>
+        </span>
+      <% end %>
+
       <% if any_row_has_status? %>
         <%= render GovukComponent::Tag.new(
           text: "<span class='govuk-visually-hidden'>Status </span>".html_safe + row.status,
@@ -11,6 +18,7 @@
           html_attributes: { id: row.status_id },
         ) %>
       <% end %>
+
       <% if row.hint_text.present? %>
         <br>
         <span class="app-task-list__hint govuk-hint"><%= row.hint_text %></span>

--- a/app/components/task_list/view.rb
+++ b/app/components/task_list/view.rb
@@ -14,9 +14,9 @@ private
   end
 
   class Row < GovukComponent::Slot
-    attr_accessor :task_name, :status, :hint_text
+    attr_accessor :task_name, :status, :hint_text, :active
 
-    def initialize(task_name:, path:, confirm_path: nil, status:, hint_text: nil, classes: [], html_attributes: {})
+    def initialize(task_name:, path:, confirm_path: nil, status:, hint_text: nil, active: true, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
 
       @task_name = task_name
@@ -24,6 +24,7 @@ private
       @confirm_path = confirm_path
       @status = status
       @hint_text = hint_text
+      @active = active
     end
 
     def get_path

--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module FundingHelper
+  def funding_options(trainee)
+    cannot_start_funding?(trainee) ? :funding_inactive : :funding_active
+  end
+
+private
+
+  def cannot_start_funding?(trainee)
+    CalculateBursary.available_for_route?(trainee.training_route.to_sym) &&
+      trainee.course_subject_one.blank?
+  end
+end

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -120,6 +120,26 @@ module TaskListHelper
           ).status,
           classes: "degree-details",
         },
+
+      funding_active:
+        {
+          task_name: "Funding",
+          path: "#",
+          confirm_path: "#",
+          status: "not started",
+          classes: "funding",
+        },
+
+      funding_inactive:
+        {
+          task_name: "Funding",
+          path: nil,
+          confirm_path: nil,
+          status: "cannot start yet",
+          classes: "funding",
+          hint_text: "Complete course details first",
+          active: false,
+        },
     }
 
     task_list[task]

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -18,6 +18,7 @@ class Trainee < ApplicationRecord
 
   delegate :award_type, :requires_placement_details?, :requires_schools?,
            :requires_employing_school?, :early_years_route?, to: :training_route_manager
+
   delegate :update_training_route!, to: :route_data_manager
 
   validates :training_route, presence: {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,6 +39,7 @@ features:
   sync_from_dttp: false
   send_emails: false
   persist_to_dttp: false
+  funding: false
   use_subject_specialisms: false
   routes:
     early_years_assessment_only: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,6 +6,7 @@ features:
   basic_auth: false
   import_courses_from_ttapi: true
   publish_course_details: true
+  funding: true
   use_subject_specialisms: true
   routes:
     provider_led_postgrad: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -3,6 +3,7 @@ features:
   use_dfe_sign_in: false
   enable_feedback_link: true
   publish_course_details: true
+  funding: true
   use_subject_specialisms: true
   routes:
     provider_led_postgrad: true

--- a/spec/components/review_draft/apply_draft/view_spec.rb
+++ b/spec/components/review_draft/apply_draft/view_spec.rb
@@ -41,5 +41,7 @@ RSpec.describe ReviewDraft::ApplyDraft::View do
         end
       end
     end
+
+    include_examples "rendering the funding section"
   end
 end

--- a/spec/components/review_draft/draft/view_spec.rb
+++ b/spec/components/review_draft/draft/view_spec.rb
@@ -52,4 +52,6 @@ RSpec.describe ReviewDraft::Draft::View do
       end
     end
   end
+
+  include_examples "rendering the funding section"
 end

--- a/spec/components/task_list/view_preview.rb
+++ b/spec/components/task_list/view_preview.rb
@@ -11,6 +11,18 @@ class TaskList::ViewPreview < ViewComponent::Preview
     end
   end
 
+  def with_inactive_row
+    render TaskList::View.new do |component|
+      component.row(
+        task_name: "Funding",
+        path: nil,
+        status: "cannot start yet",
+        hint_text: "Complete course details first",
+        active: false,
+      )
+    end
+  end
+
   def with_multiple_status
     render TaskList::View.new do |component|
       component.row(

--- a/spec/components/task_list/view_spec.rb
+++ b/spec/components/task_list/view_spec.rb
@@ -3,9 +3,8 @@
 require "rails_helper"
 
 RSpec.describe TaskList::View do
-  alias_method :component, :page
-
   let(:status) { nil }
+  let(:active) { true }
 
   before(:each) do
     render_inline(TaskList::View.new) do |component|
@@ -13,6 +12,7 @@ RSpec.describe TaskList::View do
         task_name: "some key",
         path: "some_path",
         status: status,
+        active: active,
       )
     end
   end
@@ -22,11 +22,11 @@ RSpec.describe TaskList::View do
 
     context status do
       it "renders the correct tag status" do
-        expect(component.find(".govuk-tag").text).to include(status)
+        expect(rendered_component).to have_text(status)
       end
 
       it "renders the correct tag colour" do
-        expect(component).to have_selector(".govuk-tag--#{colour}")
+        expect(rendered_component).to have_selector(".govuk-tag--#{colour}")
       end
     end
   end
@@ -34,11 +34,11 @@ RSpec.describe TaskList::View do
   context "when task data is provided" do
     context "rendered tasks" do
       it "renders a list of tasks" do
-        expect(component).to have_selector(".app-task-list__item")
+        expect(rendered_component).to have_selector(".app-task-list__item")
       end
 
       it "renders the task name" do
-        expect(component).to have_link("some key", href: "some_path")
+        expect(rendered_component).to have_link("some key", href: "some_path")
       end
     end
 
@@ -46,6 +46,15 @@ RSpec.describe TaskList::View do
     it_behaves_like("status indicator", "in progress", "grey")
     it_behaves_like("status indicator", "review", "pink")
     it_behaves_like("status indicator", "not started", "grey")
+  end
+
+  context "when the task is inactive" do
+    let(:active) { false }
+
+    it "does not render a link" do
+      expect(rendered_component).to_not have_link("some key", href: "some_path")
+      expect(rendered_component).to have_text("some key")
+    end
   end
 
   describe "#status_id" do

--- a/spec/support/shared_examples/rendering_the_funding_section.rb
+++ b/spec/support/shared_examples/rendering_the_funding_section.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "rendering the funding section" do
+  context "when a the funding feature flag is off" do
+    let(:trainee) { create(:trainee) }
+
+    it "does not render the funding section" do
+      expect(rendered_component).to_not have_text("Funding")
+    end
+  end
+
+  context "when a the funding feature flag is on", "feature_funding": true do
+    context "when a trainee on a route with a bursary" do
+      let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
+      let(:trainee) { create(:trainee, :draft, route) }
+      before { create(:bursary, :with_bursary_subjects, training_route: route) }
+
+      context "and has not entered their course details" do
+        it "renders the funding section as 'cannot start yet'" do
+          render_inline(described_class.new(trainee: trainee))
+          expect(rendered_component).to have_css "#funding-status", text: "cannot start yet"
+        end
+      end
+
+      context "and has entered their course details" do
+        before { trainee.update!(course_subject_one: "subject") }
+
+        it "renders the funding section as 'not started'" do
+          render_inline(described_class.new(trainee: trainee))
+          expect(rendered_component).to have_css "#funding-status", text: "not started"
+        end
+      end
+    end
+
+    context "when a trainee on a route with no bursary" do
+      let(:trainee) { create(:trainee, :draft, TRAINING_ROUTE_ENUMS[:assessment_only]) }
+
+      before { create(:bursary, :with_bursary_subjects, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad]) }
+
+      it "renders the funding section as 'not started'" do
+        render_inline(described_class.new(trainee: trainee))
+        expect(rendered_component).to have_css "#funding-status", text: "not started"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/OBU0jXKA/1986-m-funding-ui-conditional-link-to-funding-form

### Changes proposed in this pull request

- Adds a new `active` property to a 'TaskList' row so that we can render a link or not.
- Renders an 'inactive' Funding section when:
  1. a trainee is on a route that has bursaries available
  2. the trainee has not filled in their course subject details
- Renders a normal (placeholder for now) Funding section in all other cases as per the Trello ticket.

**Case 1**
Route has no bursaries:

<img width="696" alt="Screenshot 2021-06-18 at 17 30 02" src="https://user-images.githubusercontent.com/18436946/122591476-ea366700-d05a-11eb-885e-9b9dc9702dd9.png">

**Case 2**
Route has bursaries, trainee has not completed course details:

<img width="704" alt="Screenshot 2021-06-18 at 17 30 07" src="https://user-images.githubusercontent.com/18436946/122591531-ff12fa80-d05a-11eb-9ef7-aef18bd3250b.png">

**Case 3**
Route has bursaries, trainee has completed course details:

<img width="693" alt="Screenshot 2021-06-18 at 17 30 24" src="https://user-images.githubusercontent.com/18436946/122591581-0df9ad00-d05b-11eb-8ea7-142071b882d5.png">

### Guidance to review
**Check 1**
- Go to a draft assessment only trainee
- Check that there is a link to Funding at the bottom of the table with the status 'not started'

**Check 2**
- Go to a draft provider led (postgrad) trainee with no course subject
- Check that there is **no link** to Funding, extra hint text about filling in their course details, and a new state 'cannot start yet'

**Check 3**
- Complete the course details for that provider led trainee
- Check that there is now a link to Funding with the status 'not started'