### PR TITLE
[2038] Add bursaries to DB seeds

### DIFF
--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -49,3 +49,36 @@ TRAINING_ROUTE_AWARD_TYPE = {
 }.freeze
 
 EARLY_YEARS_ROUTES = TRAINING_ROUTE_AWARD_TYPE.select { |_, v| v == "EYTS" }.keys.freeze
+
+SEED_BURSARIES = [
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 24_000,
+    allocation_subjects: %w[Chemistry Computing Mathematics Physics],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 10_000,
+    allocation_subjects: ["Modern languages", "Classics"],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 7_000,
+    allocation_subjects: %w[Biology],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 24_000,
+    allocation_subjects: %w[Chemistry Computing Mathematics Physics],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 10_000,
+    allocation_subjects: ["Modern languages", "Classics"],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 7_000,
+    allocation_subjects: %w[Biology],
+  ),
+].freeze

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,3 +24,11 @@ Dttp::CodeSets::AllocationSubjects::MAPPING.each do |allocation_subject, metadat
     allocation_subject.subject_specialisms.find_or_create_by!(name: subject_specialism)
   end
 end
+
+SEED_BURSARIES.each do |b|
+  bursary = Bursary.find_or_create_by!(training_route: b.training_route, amount: b.amount)
+  b.allocation_subjects.map do |subject|
+    allocation_subject = AllocationSubject.find_by!(name: subject)
+    bursary.bursary_subjects.create!(allocation_subject: allocation_subject)
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/DXdxak0I/2038-s-seed-bursaries

### Changes proposed in this pull request

- Seeds bursaries into the DB for trainee routes that we are currently developing as per the spreadsheet linked in the Trello ticket.
- Bursaries are per training route and are related to the (now seeded) allocation subjects.

### Guidance to review

- Run `rake db:seed`