### PR TITLE
[1987] Training initiative form

### DIFF
--- a/app/controllers/trainees/funding/training_initiatives_controller.rb
+++ b/app/controllers/trainees/funding/training_initiatives_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Funding
+    class TrainingInitiativesController < ApplicationController
+      before_action :authorize_trainee
+
+      def edit
+        @training_initiatives_form = ::Funding::TrainingInitiativesForm.new(trainee)
+      end
+
+      def update
+        @training_initiatives_form = ::Funding::TrainingInitiativesForm.new(trainee, params: trainee_params, user: current_user)
+
+        save_strategy = trainee.draft? ? :save! : :stash
+
+        if @training_initiatives_form.public_send(save_strategy)
+          redirect_to review_draft_trainee_path(trainee)
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def trainee
+        @trainee ||= Trainee.from_param(params[:trainee_id])
+      end
+
+      def trainee_params
+        return { training_initiative: nil } if params[:funding_training_initiatives_form].blank?
+
+        params.require(:funding_training_initiatives_form).permit(*::Funding::TrainingInitiativesForm::FIELDS)
+      end
+
+      def authorize_trainee
+        authorize(trainee)
+      end
+    end
+  end
+end

--- a/app/forms/funding/training_initiatives_form.rb
+++ b/app/forms/funding/training_initiatives_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Funding
+  class TrainingInitiativesForm < TraineeForm
+    FIELDS = %i[
+      training_initiative
+    ].freeze
+
+    attr_accessor(*FIELDS)
+
+    validates :training_initiative,
+              presence: true,
+              inclusion: { in: ROUTE_INITIATIVES_ENUMS.values }
+
+  private
+
+    def compute_fields
+      trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+
+    def form_store_key
+      :training_initiative
+    end
+  end
+end

--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module FundingHelper
+  def training_initiative_options(trainee)
+    TRAINING_ROUTE_INITIATIVES[trainee.training_route]
+  end
+
   def funding_options(trainee)
     cannot_start_funding?(trainee) ? :funding_inactive : :funding_active
   end

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -124,9 +124,12 @@ module TaskListHelper
       funding_active:
         {
           task_name: "Funding",
-          path: "#",
-          confirm_path: "#",
-          status: "not started",
+          path: edit_trainee_funding_training_initiative_path(trainee),
+          confirm_path: edit_trainee_funding_training_initiative_path(trainee),
+          status: ProgressService.call(
+            validator: Funding::TrainingInitiativesForm.new(trainee),
+            progress_value: trainee.progress.funding,
+          ).status,
           classes: "funding",
         },
 

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -18,4 +18,5 @@ class Progress
   attribute :training_details, :boolean
   attribute :placement_details, :boolean
   attribute :schools, :boolean
+  attribute :funding, :boolean
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -27,6 +27,8 @@ class Trainee < ApplicationRecord
 
   enum training_route: TRAINING_ROUTES_FOR_TRAINEE
 
+  enum training_initiative: ROUTE_INITIATIVES
+
   enum locale_code: { uk: 0, non_uk: 1 }
 
   enum gender: {

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -24,6 +24,7 @@ class FormStore
     lead_school
     employing_school
     schools
+    training_initiative
   ].freeze
 
   class << self

--- a/app/views/trainees/funding/training_initiatives/edit.html.erb
+++ b/app/views/trainees/funding/training_initiatives/edit.html.erb
@@ -1,0 +1,34 @@
+<%= render PageTitle::View.new(i18n_key: "trainees.funding.training_initiatives.edit",
+                               has_errors: @training_initiatives_form.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: @training_initiatives_form, url: trainee_funding_training_initiative_path(@trainee), method: :put, local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.training_initiatives.edit") %><h1>
+      <p class="govuk-body"><%= t("views.forms.funding.training_initiatives.description") %></p>
+
+        <%= f.govuk_radio_buttons_fieldset(:training_initiative, legend: { text: t("views.forms.funding.training_initiatives.#{training_initiative_options(@trainee).count == 2 ? "title_two" : "title"}"), size: "m" }) do %>
+          <% training_initiative_options(@trainee).each_with_index do |training_initiative, index| %>
+            <%= f.govuk_radio_button(
+              :training_initiative,
+              training_initiative,
+              label: { text: t("activerecord.attributes.trainee.training_initiatives.#{training_initiative}") },
+              link_errors: index.zero?,
+            ) %>
+          <% end %>
+
+          <%= f.govuk_radio_divider %>
+          <%= f.govuk_radio_button :training_initiative, ROUTE_INITIATIVES_ENUMS[:no_initiative],
+                                   label: { text: t("activerecord.attributes.trainee.training_initiatives.no_initiative") } %>
+        <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -20,6 +20,7 @@ ROUTE_INITIATIVES_ENUMS = {
   now_teach: "now_teach",
   maths_physics_chairs_programme_researchers_in_schools: "maths_physics_chairs_programme_researchers_in_schools",
   future_teaching_scholars: "future_teaching_scholars",
+  no_initiative: "no_initiative",
 }.freeze
 
 TRAINING_ROUTES = {
@@ -35,6 +36,14 @@ TRAINING_ROUTES = {
   TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => 9,
   TRAINING_ROUTE_ENUMS[:opt_in_undergrad] => 10,
   TRAINING_ROUTE_ENUMS[:hpitt_postgrad] => 11,
+}.freeze
+
+ROUTE_INITIATIVES = {
+  ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars] => 0,
+  ROUTE_INITIATIVES_ENUMS[:maths_physics_chairs_programme_researchers_in_schools] => 1,
+  ROUTE_INITIATIVES_ENUMS[:now_teach] => 2,
+  ROUTE_INITIATIVES_ENUMS[:transition_to_teach] => 3,
+  ROUTE_INITIATIVES_ENUMS[:no_initiative] => 4,
 }.freeze
 
 TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,6 +212,9 @@ en:
         employing_schools:
           index: Select the employing school
           edit: Employing school
+        funding:
+          training_initiatives:
+            edit: Training initiatives
       providers:
         index: Providers
         new: Add a provider
@@ -394,6 +397,11 @@ en:
         route_titles:
           provider_led_postgrad: provider-led postgrad
           school_direct_salaried: School direct salaried
+      funding:
+        training_initiatives:
+          title: Is the trainee on any of these training initiatives?
+          title_two: Is the trainee on either of these training initiatives?
+          description: Training initiatives are sometimes referred to as programmes or schemes. They provide incentives and support for people training to teach. They’re separate from bursaries and scholarships.
   pages:
     request_an_account:
       inviting_limited_itt: We are only inviting a limited amount of initial teacher training providers to use Register,
@@ -562,6 +570,12 @@ en:
           qts_awarded: QTS awarded
           eyts_recommended: EYTS recommended
           eyts_awarded: EYTS awarded
+        training_initiatives:
+          transition_to_teach: Transition to teach
+          now_teach: Now teach
+          maths_physics_chairs_programme_researchers_in_schools: Maths and physics chairs programme / Researchers in schools
+          future_teaching_scholars: Future teaching scholars
+          no_initiative: Not on a training initiative
     errors:
       models:
         trainee:
@@ -682,6 +696,10 @@ en:
               not_valid: The disability disclosure section is not valid for this trainee
             disability_ids:
               not_valid: Trainee has been disclosed as disabled but no disabilities exist
+        funding/training_initiatives_form:
+          attributes:
+            training_initiative:
+              blank: Select if the trainee is on a training initiative
         outcome_date_form:
           attributes:
             date_string:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,10 @@ Rails.application.routes.draw do
         resource :disability_detail, only: %i[edit update], path: "/disabilities"
       end
 
+      namespace :funding do
+        resource :training_initiative, only: %i[edit update], path: "/training-initiative"
+      end
+
       resource :outcome_details, only: [], path: "outcome-details" do
         get "confirm"
         get "recommended"

--- a/db/migrate/20210622090328_add_training_initiative_to_trainee.rb
+++ b/db/migrate/20210622090328_add_training_initiative_to_trainee.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTrainingInitiativeToTrainee < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :training_initiative, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -304,6 +304,7 @@ ActiveRecord::Schema.define(version: 2021_06_22_120839) do
     t.text "course_subject_two"
     t.text "course_subject_three"
     t.datetime "awarded_at"
+    t.integer "training_initiative"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"

--- a/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "edit training initiative", type: :feature do
+  background { given_i_am_authenticated }
+
+  before do
+    given_a_trainee_exists
+    when_i_visit_the_training_initiative_page
+  end
+
+  scenario "edit with valid parameters" do
+    and_i_update_the_training_initiative
+    and_i_submit_the_form
+    then_i_am_redirected_to_the_trainee_page
+  end
+
+  scenario "submitting with invalid parameters" do
+    and_i_submit_the_form
+    then_i_see_error_messages
+  end
+
+private
+
+  def when_i_visit_the_training_initiative_page
+    training_initiative_page.load(id: trainee.slug)
+  end
+
+  def and_i_update_the_training_initiative
+    training_initiative_page.transition_to_teach.click
+  end
+
+  def and_i_submit_the_form
+    training_initiative_page.submit_button.click
+  end
+
+  def then_i_am_redirected_to_the_trainee_page
+    expect(review_draft_page).to be_displayed
+  end
+
+  def then_i_see_error_messages
+    expect(new_provider_page).to have_text(
+      I18n.t("activemodel.errors.models.funding/training_initiatives_form.attributes.training_initiative.blank"),
+    )
+  end
+end

--- a/spec/forms/funding/training_initiatives_form_spec.rb
+++ b/spec/forms/funding/training_initiatives_form_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Funding
+  describe TrainingInitiativesForm, type: :model do
+    let(:params) { {} }
+    let(:trainee) { create(:trainee, training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative]) }
+    let(:form_store) { class_double(FormStore) }
+
+    subject { described_class.new(trainee, params: params, store: form_store) }
+
+    before do
+      allow(form_store).to receive(:get).and_return(nil)
+    end
+
+    describe "validations" do
+      it { is_expected.to validate_presence_of(:training_initiative) }
+      it { is_expected.to validate_inclusion_of(:training_initiative).in_array(ROUTE_INITIATIVES_ENUMS.values) }
+    end
+
+    describe "#stash" do
+      it "uses FormStore to temporarily save the fields under a key combination of trainee ID and training_initiative" do
+        expect(form_store).to receive(:set).with(trainee.id, :training_initiative, subject.fields)
+
+        subject.stash
+      end
+    end
+
+    describe "#save!" do
+      let(:transition_to_teach) { ROUTE_INITIATIVES_ENUMS[:transition_to_teach] }
+
+      before do
+        allow(form_store).to receive(:get).and_return({ "training_initiative" => transition_to_teach })
+        allow(form_store).to receive(:set).with(trainee.id, :training_initiative, nil)
+      end
+
+      it "takes any data from the form store and saves it to the database" do
+        expect { subject.save! }.to change(trainee, :training_initiative).to(transition_to_teach)
+      end
+    end
+  end
+end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -38,6 +38,16 @@ describe Trainee do
     end
 
     it do
+      is_expected.to define_enum_for(:training_initiative).with_values(
+        ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars] => 0,
+        ROUTE_INITIATIVES_ENUMS[:maths_physics_chairs_programme_researchers_in_schools] => 1,
+        ROUTE_INITIATIVES_ENUMS[:now_teach] => 2,
+        ROUTE_INITIATIVES_ENUMS[:transition_to_teach] => 3,
+        ROUTE_INITIATIVES_ENUMS[:no_initiative] => 4,
+      )
+    end
+
+    it do
       is_expected.to define_enum_for(:ethnic_group).with_values(
         Diversities::ETHNIC_GROUP_ENUMS[:asian] => 0,
         Diversities::ETHNIC_GROUP_ENUMS[:black] => 1,

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -22,6 +22,10 @@ module Features
       @training_details_page ||= PageObjects::Trainees::TrainingDetails.new
     end
 
+    def training_initiative_page
+      @training_initiative_page ||= PageObjects::Trainees::Funding::TrainingInitiative.new
+    end
+
     def confirm_training_details_page
       @confirm_training_details_page ||= PageObjects::Trainees::ConfirmTrainingDetails.new
     end

--- a/spec/support/page_objects/trainees/funding/training_initiative.rb
+++ b/spec/support/page_objects/trainees/funding/training_initiative.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    module Funding
+      class TrainingInitiative < PageObjects::Base
+        set_url "/trainees/{id}/funding/training-initiative/edit"
+
+        element :transition_to_teach, "#funding-training-initiatives-form-training-initiative-transition-to-teach-field"
+
+        element :submit_button, "input[name='commit']"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/Y8z7YIHu/1987-m-funding-ui-training-initiative-radio-button-form

### Changes proposed in this pull request

- Adds a new enum to `trainee` called `training_initiative`
- Adds a new form to record the `training_initiative`
- Links to the new form from the Funding link on `/review-draft`
- Adds a new progress field `funding` (not currently used, but needed to render the status of the section on `/review-draft`)

<img width="697" alt="Screenshot 2021-06-22 at 13 13 18" src="https://user-images.githubusercontent.com/18436946/122922539-a2b22280-d35b-11eb-95a2-5a3e5406bfb0.png">

And in error:

<img width="684" alt="Screenshot 2021-06-22 at 15 08 56" src="https://user-images.githubusercontent.com/18436946/122939801-d9903480-d36b-11eb-93f3-520d1760c42a.png">

### Guidance to review

- Choose a an assessment only trainee
- Click on the link to 'Funding'
- Check that you cannot submit an empty form
- Check that the correct training initiatives are rendered as per the spreadsheet in the Trello ticket
- Choose a training initiative and submit the form
- Check that the status for the funding section is now in progress
- Check that if you return to the form, your previous selection is selected