### PR TITLE
[2045] Titlelize the subject dropdown

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,9 +3,9 @@
 module ApplicationHelper
   def to_options(array, first_value: nil)
     result = array.map do |name|
-      OpenStruct.new(name: name)
+      OpenStruct.new(value: name, text: name.upcase_first)
     end
-    result.unshift(OpenStruct.new(name: first_value))
+    result.unshift(OpenStruct.new(value: first_value, text: first_value&.upcase_first))
     result
   end
 

--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -41,7 +41,7 @@ private
     @course_subjects ||= begin
       return Dttp::CodeSets::CourseSubjects::MAPPING.keys unless FeatureService.enabled?(:use_subject_specialisms)
 
-      SubjectSpecialism.pluck(:name)
+      SubjectSpecialism.order(:name).pluck(:name)
     end
   end
 end

--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -26,7 +26,7 @@ module CourseDetailsHelper
   def subjects_for_summary_view(subject_one, subject_two, subject_three)
     additional_subjects = [subject_two, subject_three].reject(&:blank?).join(" and ")
 
-    [subject_one, additional_subjects].reject(&:blank?).join(" with ")
+    [subject_one&.upcase_first, additional_subjects].reject(&:blank?).join(" with ")
   end
 
 private

--- a/app/models/subject_specialism.rb
+++ b/app/models/subject_specialism.rb
@@ -2,4 +2,6 @@
 
 class SubjectSpecialism < ApplicationRecord
   belongs_to :allocation_subject, inverse_of: :subject_specialisms
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -120,7 +120,7 @@ class Trainee < ApplicationRecord
 
   scope :ordered_by_date, -> { order(updated_at: :desc) }
   scope :ordered_by_last_name, -> { order(last_name: :asc) }
-  scope :with_subject, ->(subject) { where("course_subject_one = :subject OR course_subject_two = :subject OR course_subject_three = :subject", subject: subject) }
+  scope :with_subject, ->(subject) { where("LOWER(course_subject_one) = :subject OR LOWER(course_subject_two) = :subject OR LOWER(course_subject_three) = :subject", subject: subject.downcase) }
 
   # Returns draft trainees first, then all trainees in any other state.
   scope :ordered_by_drafts, -> { order(ordered_by_drafts_clause) }

--- a/app/validators/autocomplete_validator.rb
+++ b/app/validators/autocomplete_validator.rb
@@ -8,7 +8,7 @@ class AutocompleteValidator < ActiveModel::EachValidator
     return if raw_value.nil?
 
     value = record.send(attribute)
-    if value != raw_value
+    if value.downcase != raw_value.downcase
 
       # If the user hasn't selected something, we need to reset the value so that the autocomplete
       # doesn't clobber the raw value when the page reloads

--- a/app/views/trainees/course_details/_additional_subjects.html.erb
+++ b/app/views/trainees/course_details/_additional_subjects.html.erb
@@ -13,7 +13,7 @@
         f,
         attribute_name: :course_subject_two,
         form_field: f.govuk_collection_select(:course_subject_two, course_subjects_options,
-                                              :name, :name, label: { text: t(".subject_two") },
+                                              :value, :text, label: { text: t(".subject_two") },
                                                             hint: { text: t(".subject_hint") }),
       ) %>
     </div>
@@ -23,7 +23,7 @@
         f,
         attribute_name: :course_subject_three,
         form_field: f.govuk_collection_select(:course_subject_three, course_subjects_options,
-                                              :name, :name, label: { text: t(".subject_three") },
+                                              :value, :text, label: { text: t(".subject_three") },
                                                             hint: { text: t(".subject_hint") }),
       ) %>
     </div>

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -18,7 +18,7 @@
           f,
           attribute_name: :course_subject_one,
           form_field: f.govuk_collection_select(:course_subject_one, course_subjects_options,
-                                                :name, :name, label: { text: "Subject", size: "s" },
+                                                :value, :text, label: { text: "Subject", size: "s" },
                                                               hint: { text: t('.subject_hint') }),
         ) %>
 
@@ -42,8 +42,8 @@
               f,
               attribute_name: :additional_age_range,
               form_field: f.govuk_collection_select(:additional_age_range, additional_age_ranges_options,
-                                                    :name,
-                                                    :name,
+                                                    :value,
+                                                    :text,
                                                     label: { text: "Other age range", size: "s" }),
             ) %>
 

--- a/app/views/trainees/degrees/_non_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_non_uk_degree_form.html.erb
@@ -5,15 +5,15 @@
   <h1 class="govuk-heading-l">Non-UK degree details</h1>
 
   <%= render FormComponents::CountryAutocomplete::View.new(
-    form_field: f.govuk_collection_select(:country, countries_options, :name,
-                                          :name, label: { text: "In which country is the degree institution based?", size: "s" }),
+    form_field: f.govuk_collection_select(:country, countries_options, :value,
+                                          :text, label: { text: "In which country is the degree institution based?", size: "s" }),
   ) %>
 
   <%= render FormComponents::Autocomplete::View.new(
     f,
     attribute_name: :subject,
     form_field: f.govuk_collection_select(:subject, subjects_options,
-                                          :name, :name, label: { text: "Degree subject", size: "s" },
+                                          :value, :text, label: { text: "Degree subject", size: "s" },
                                                         hint: { text: 'Search for the closest matching subject.
                                                          You can start typing to narrow down your search.' }),
   ) %>

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -8,15 +8,15 @@
   <%= render FormComponents::Autocomplete::View.new(
     f,
     attribute_name: :institution,
-    form_field: f.govuk_collection_select(:institution, institutions_options, :name,
-                                          :name, label: { text: "Institution", size: "s" }),
+    form_field: f.govuk_collection_select(:institution, institutions_options, :value,
+                                          :text, label: { text: "Institution", size: "s" }),
   ) %>
 
   <%= render FormComponents::Autocomplete::View.new(
     f,
     attribute_name: :subject,
     form_field: f.govuk_collection_select(:subject, subjects_options,
-                                          :name, :name, label: { text: "Degree subject", size: "s" },
+                                          :value, :text, label: { text: "Degree subject", size: "s" },
                                                         hint: { text: 'Search for the closest matching subject.
                                                          You can start typing to narrow down your search.' }),
   ) %>

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -99,7 +99,7 @@
   <% component.filter_option do %>
     <div class="govuk-form-group">
       <%= label_tag "subject", "Subject", class: "govuk-label govuk-label--s" %>
-      <%= select_tag :subject, options_from_collection_for_select(filter_course_subjects_options, :name, :name, (@filters[:subject] if @filters)), class: "govuk-select" %>
+      <%= select_tag :subject, options_from_collection_for_select(filter_course_subjects_options, :value, :text, (@filters[:subject] if @filters)), class: "govuk-select" %>
     </div>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -393,6 +393,7 @@ en:
         route_message: "Your %{route} courses in the Publish service"
         route_titles:
           provider_led_postgrad: provider-led postgrad
+          school_direct_salaried: School direct salaried
   pages:
     request_an_account:
       inviting_limited_itt: We are only inviting a limited amount of initial teacher training providers to use Register,

--- a/db/migrate/20210622120839_add_case_insensitive_index_to_subject_specialism.rb
+++ b/db/migrate/20210622120839_add_case_insensitive_index_to_subject_specialism.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCaseInsensitiveIndexToSubjectSpecialism < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :subject_specialisms, :name
+    add_index :subject_specialisms, "lower(name)", unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_18_085011) do
+ActiveRecord::Schema.define(version: 2021_06_22_120839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -230,8 +230,8 @@ ActiveRecord::Schema.define(version: 2021_06_18_085011) do
     t.bigint "allocation_subject_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index "lower((name)::text)", name: "index_subject_specialisms_on_lower_name", unique: true
     t.index ["allocation_subject_id"], name: "index_subject_specialisms_on_allocation_subject_id"
-    t.index ["name"], name: "index_subject_specialisms_on_name", unique: true
   end
 
   create_table "subjects", force: :cascade do |t|

--- a/spec/factories/allocation_subjects.rb
+++ b/spec/factories/allocation_subjects.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :allocation_subject do
-    sequence(:name) { |c| "Allocation Subject #{c}" }
+    sequence(:name) { |c| "#{Faker::Educator.course_name} #{c}" }
   end
 end

--- a/spec/factories/subject_specialisms.rb
+++ b/spec/factories/subject_specialisms.rb
@@ -8,6 +8,6 @@ FactoryBot.define do
       subject_name { nil }
     end
 
-    sequence(:name) { |c| subject_name.presence || "Subject Specialism #{c}" }
+    sequence(:name) { |c| subject_name.presence || "#{Faker::Educator.subject.downcase} #{c}" }
   end
 end

--- a/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
@@ -75,7 +75,7 @@ private
   end
 
   def and_i_enter_valid_subject_specialism_parameters
-    course_details_page.subject.select(@subject_specialism.name)
+    course_details_page.subject.select(@subject_specialism.name.upcase_first)
   end
 
   def and_i_enter_valid_dttp_subject_parameters

--- a/spec/helpers/course_details_helper_spec.rb
+++ b/spec/helpers/course_details_helper_spec.rb
@@ -17,11 +17,16 @@ describe CourseDetailsHelper do
     end
 
     context "when the feature flag is turned on", feature_use_subject_specialisms: true do
-      it "iterates over subject specialisms and prints out correct course_subjects values" do
-        expect(course_subjects_options.size).to be 2
+      before do
+        create(:subject_specialism, name: "business and management")
+      end
+
+      it "iterates over subject specialisms and prints out ordered course_subjects" do
+        expect(course_subjects_options.size).to be 3
         expect(course_subjects_options.first.value).to be_nil
-        expect(course_subjects_options.second.value).to eq "travel and tourism"
-        expect(course_subjects_options.second.text).to eq "Travel and tourism"
+        expect(course_subjects_options.second.text).to eq "Business and management"
+        expect(course_subjects_options.third.value).to eq "travel and tourism"
+        expect(course_subjects_options.third.text).to eq "Travel and tourism"
       end
     end
   end

--- a/spec/helpers/course_details_helper_spec.rb
+++ b/spec/helpers/course_details_helper_spec.rb
@@ -7,20 +7,21 @@ describe CourseDetailsHelper do
 
   describe "#course_subjects_options" do
     before do
-      create(:subject_specialism, name: "Travel and Tourism")
+      create(:subject_specialism, name: "travel and tourism")
     end
 
     it "iterates over Dttp::CodeSets::CourseSubjects and prints out correct course_subjects values" do
       expect(course_subjects_options.size).to be 40
-      expect(course_subjects_options.first.name).to be_nil
-      expect(course_subjects_options.second.name).to eq "Art and design"
+      expect(course_subjects_options.first.value).to be_nil
+      expect(course_subjects_options.second.value).to eq "Art and design"
     end
 
     context "when the feature flag is turned on", feature_use_subject_specialisms: true do
       it "iterates over subject specialisms and prints out correct course_subjects values" do
         expect(course_subjects_options.size).to be 2
-        expect(course_subjects_options.first.name).to be_nil
-        expect(course_subjects_options.second.name).to eq "Travel and Tourism"
+        expect(course_subjects_options.first.value).to be_nil
+        expect(course_subjects_options.second.value).to eq "travel and tourism"
+        expect(course_subjects_options.second.text).to eq "Travel and tourism"
       end
     end
   end
@@ -42,8 +43,8 @@ describe CourseDetailsHelper do
 
     it "iterates over array and prints out correct additional_age_ranges values" do
       expect(additional_age_ranges_options.size).to be 2
-      expect(additional_age_ranges_options.first.name).to be_nil
-      expect(additional_age_ranges_options.second.name).to eq "additional_age_range"
+      expect(additional_age_ranges_options.first.value).to be_nil
+      expect(additional_age_ranges_options.second.value).to eq "additional_age_range"
     end
   end
 
@@ -55,6 +56,12 @@ describe CourseDetailsHelper do
     subject { subjects_for_summary_view(subject_one, subject_two, subject_three) }
 
     it { is_expected.to eq("Biology") }
+
+    context "with lowercased first subject" do
+      let(:subject_one) { "applied biology" }
+
+      it { is_expected.to eq("Applied biology") }
+    end
 
     context "with two subjects" do
       let(:subject_two) { "Art and design" }

--- a/spec/helpers/degree_helper_spec.rb
+++ b/spec/helpers/degree_helper_spec.rb
@@ -39,8 +39,9 @@ describe DegreesHelper do
 
     it "iterates over array and prints out correct institutions values" do
       expect(institutions_options.size).to be 2
-      expect(institutions_options.first.name).to be_nil
-      expect(institutions_options.second.name).to eq "institution"
+      expect(institutions_options.first.value).to be_nil
+      expect(institutions_options.second.value).to eq "institution"
+      expect(institutions_options.second.text).to eq "Institution"
     end
   end
 
@@ -51,8 +52,9 @@ describe DegreesHelper do
 
     it "iterates over array and prints out correct subjects values" do
       expect(subjects_options.size).to be 2
-      expect(subjects_options.first.name).to be_nil
-      expect(subjects_options.second.name).to eq "subject"
+      expect(subjects_options.first.value).to be_nil
+      expect(subjects_options.second.value).to eq "subject"
+      expect(subjects_options.second.text).to eq "Subject"
     end
   end
 
@@ -63,8 +65,9 @@ describe DegreesHelper do
 
     it "iterates over array and prints out correct countries values" do
       expect(countries_options.size).to be 2
-      expect(countries_options.first.name).to be_nil
-      expect(countries_options.second.name).to eq "country"
+      expect(countries_options.first.value).to be_nil
+      expect(countries_options.second.value).to eq "country"
+      expect(countries_options.second.text).to eq "Country"
     end
   end
 end

--- a/spec/models/subject_specialism_spec.rb
+++ b/spec/models/subject_specialism_spec.rb
@@ -3,7 +3,12 @@
 require "rails_helper"
 
 RSpec.describe SubjectSpecialism, type: :model do
+  subject { create(:subject_specialism) }
+
   describe "associations" do
     it { is_expected.to belong_to(:allocation_subject) }
   end
+
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
 end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -283,6 +283,12 @@ describe Trainee do
 
     it { is_expected.to eq([trainee_with_subject]) }
 
+    context "with lowercase subject name" do
+      let!(:trainee_with_subject) { create(:trainee, course_subject_one: "art and design") }
+
+      it { is_expected.to eq([trainee_with_subject]) }
+    end
+
     context "with multiple subjects" do
       let!(:trainee_with_subject_two) do
         create(:trainee,

--- a/spec/validators/autocomplete_validator_spec.rb
+++ b/spec/validators/autocomplete_validator_spec.rb
@@ -24,6 +24,12 @@ describe AutocompleteValidator do
     it "does not add an error" do
       expect(subject).to be_valid
     end
+
+    context "with different cases" do
+      let(:search_raw) { "DOes aSk JEEVes sTiLl eXisT?" }
+
+      it { is_expected.to be_valid }
+    end
   end
 
   context "when the field/raw value are different" do


### PR DESCRIPTION
### Context
Ensure that subject names are formatted in correct cases in the UI, as the database may hold re-worded/lower cased names

### Changes proposed in this pull request
1. Add a lowecase uniqueness validation for subject specialism name, and corresponding validations
2. Change Trainee#with_subject scope to search without case-sensitivity
3. Change select dropdowns to render values as is, but upcase the first character in the UI
4. In the autocomplete validator, downcase before comparing the value with the raw value.


