### PR TITLE
[2052] Check if trainee ticks not provided in ethnic group before validating the ethnic background

### DIFF
--- a/app/forms/diversities/form_validator.rb
+++ b/app/forms/diversities/form_validator.rb
@@ -75,9 +75,15 @@ module Diversities
     def disclosed_and_invalid?
       trainee.diversity_disclosed? && (
         trainee.ethnic_group.blank? ||
-        trainee.ethnic_background.blank? ||
+        ethnic_background_blank? ||
         trainee.disability_disclosure.blank?
       )
+    end
+
+    def ethnic_background_blank?
+      return false if trainee.ethnic_group == Diversities::ETHNIC_GROUP_ENUMS[:not_provided]
+
+      trainee.ethnic_background.blank?
     end
 
     def disability_disclosed_and_invalid?


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/PQwvlUUw/2052-bug-selecting-not-provided-in-the-ethnicity-part-of-the-diversity-form-doesnt-allow-completion-of-form)

### Changes proposed in this pull request

- At the moment the form was deemed invalid because ethnic background was nil, even though the trainee had selected `Not Provided` as their ethnic group (meaning that their ethnic background WAS indeed nil)
- I didn't remove the validator for the ethnic background, but rather checked if the trainee had selected `Not provided` as their ethnic group, meaning we would exit early if they had and not look for their ethnic background

### Guidance to review

- Make a trainee
- On their review draft page
- Go to `diversities`
- Select `Yes` for `Has trainee shared diversity information`
- Select `Not provided` when prompted `What is their ethnic group?`
- Select `Theyve shared they are not disabled` when prompted `Has the trainee shared they're disabled?`
- Select `Ive completed the form`
- and you should be taken back to review draft and the form should be complete

