### PR TITLE
[1995] Map publish subjects to subject specialism

### DIFF
--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -36,9 +36,7 @@ module TraineeHelper
   end
 
   def show_publish_courses?(trainee)
-    courses_available = trainee.available_courses.present?
-
-    FeatureService.enabled?(:publish_course_details) && courses_available
+    FeatureService.enabled?(:publish_course_details) && trainee.available_courses.present?
   end
 
   def trainee_draft_title(trainee)

--- a/app/lib/dttp/code_sets/allocation_subjects.rb
+++ b/app/lib/dttp/code_sets/allocation_subjects.rb
@@ -199,12 +199,19 @@ module Dttp
           entity_id: "e9f10516-aac2-e611-80be-00155d010316",
           subject_specialisms: [
             { name: CourseSubjects::PRIMARY_TEACHING, publish_equivalent: PRIMARY },
-          ],
-        },
-        PRIMARY_WITH_MATHEMATICS => {
-          entity_id: "51d3114a-01b5-e811-812e-5065f38b6471",
-          subject_specialisms: [
-            { name: CourseSubjects::SPECIALIST_TEACHING_PRIMARY_WITH_MATHEMETICS, publish_equivalent: nil },
+            { name: CourseSubjects::ENGLISH_STUDIES, publish_equivalent: "Primary with English" },
+            { name: CourseSubjects::PRIMARY_TEACHING, publish_equivalent: "Primary with geography and history" },
+            { name: CourseSubjects::GEOGRAPHY, publish_equivalent: "Primary with geography and history" },
+            { name: CourseSubjects::HISTORY, publish_equivalent: "Primary with geography and history" },
+            { name: CourseSubjects::PRIMARY_TEACHING, publish_equivalent: "Primary with modern languages" },
+            { name: CourseSubjects::MODERN_LANGUAGES, publish_equivalent: "Primary with modern languages" },
+            { name: CourseSubjects::PRIMARY_TEACHING, publish_equivalent: "Primary with physical education" },
+            { name: CourseSubjects::SPORTS_MANAGEMENT, publish_equivalent: "Primary with physical education" },
+            { name: CourseSubjects::SPORT_AND_EXERCISE_SCIENCES, publish_equivalent: "Primary with physical education" },
+            { name: CourseSubjects::PRIMARY_TEACHING, publish_equivalent: "Primary with science" },
+            { name: CourseSubjects::SCIENCE, publish_equivalent: "Primary with science" },
+            { name: CourseSubjects::PRIMARY_TEACHING, publish_equivalent: "English as a second or other language" },
+            { name: CourseSubjects::SPECIALIST_TEACHING_PRIMARY_WITH_MATHEMETICS, publish_equivalent: PRIMARY_WITH_MATHEMATICS },
           ],
         },
       }.freeze

--- a/app/lib/dttp/code_sets/course_subjects.rb
+++ b/app/lib/dttp/code_sets/course_subjects.rb
@@ -65,6 +65,7 @@ module Dttp
       RUSSIAN_LANGUAGES = "Russian languages"
       SOCIAL_SCIENCES = "social sciences"
       SPANISH_LANGUAGE = "Spanish language"
+      SCIENCE = "science"
       SPECIALIST_TEACHING_PRIMARY_WITH_MATHEMETICS = "specialist teaching (primary with mathematics)"
       SPORT_AND_EXERCISE_SCIENCES = "sport and exercise sciences"
       SPORTS_MANAGEMENT = "sports management"

--- a/app/services/calculate_subject_specialisms.rb
+++ b/app/services/calculate_subject_specialisms.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class CalculateSubjectSpecialisms
+  include ServicePattern
+
+  MAX_SUBJECTS_ALLOWED = 3
+
+  def initialize(subjects:)
+    @subjects = subjects
+  end
+
+  def call
+    return attributes_for_language_subject if all_subjects_are_language?
+    return attributes_for_primary_subject if primary_subject?
+    return attributes_for_single_subject if single_subject?
+
+    attributes_for_multiple_subjects
+  end
+
+private
+
+  attr_accessor :subjects
+
+  def attributes_for_language_subject
+    specialisms = subjects.flat_map { |subject| lookup_subject_specialism(subject) }
+
+    {
+      course_subject_one: specialisms, course_subject_two: [], course_subject_three: []
+    }
+  end
+
+  def attributes_for_single_subject
+    {
+      course_subject_one: lookup_subject_specialism(subjects.first), course_subject_two: [], course_subject_three: []
+    }
+  end
+
+  def attributes_for_primary_subject
+    specialisms = lookup_subject_specialism(subjects.first)
+
+    {
+      course_subject_one: [specialisms.first].compact,
+      course_subject_two: [specialisms.second].compact,
+      course_subject_three: [specialisms.third].compact,
+    }
+  end
+
+  def attributes_for_multiple_subjects
+    first_subject, second_subject, third_subject = subjects.first(MAX_SUBJECTS_ALLOWED)
+
+    {
+      course_subject_one: lookup_subject_specialism(first_subject),
+      course_subject_two: lookup_subject_specialism(second_subject),
+      course_subject_three: lookup_subject_specialism(third_subject),
+    }
+  end
+
+  def single_subject?
+    subjects.size == 1
+  end
+
+  def primary_subject?
+    single_subject? && subjects.first.include?(Dttp::CodeSets::AllocationSubjects::PRIMARY)
+  end
+
+  def all_subjects_are_language?
+    subjects.all? { |subject| PUBLISH_LANGUAGE_SUBJECTS.include?(subject) }
+  end
+
+  def lookup_subject_specialism(subject)
+    PUBLISH_SUBJECT_SPECIALISM_MAPPING.fetch(subject, [])
+  end
+end

--- a/config/initializers/publish_subject_mapping.rb
+++ b/config/initializers/publish_subject_mapping.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+PUBLISH_SUBJECT_SPECIALISM_MAPPING = Dttp::CodeSets::AllocationSubjects::MAPPING.values.each_with_object({}) do |metadata, hash|
+  metadata[:subject_specialisms].each do |subject_specialism|
+    if (publish_subject = subject_specialism[:publish_equivalent])
+      hash[publish_subject] ||= []
+      hash[publish_subject] << subject_specialism[:name]
+    end
+  end
+end
+
+PUBLISH_LANGUAGE_SUBJECTS = Dttp::CodeSets::AllocationSubjects::MAPPING[
+  Dttp::CodeSets::AllocationSubjects::MODERN_LANGUAGES][:subject_specialisms
+].map { |subject_specialism|
+  subject_specialism[:publish_equivalent]
+}.uniq

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,8 +20,12 @@ end
 
 Dttp::CodeSets::AllocationSubjects::MAPPING.each do |allocation_subject, metadata|
   allocation_subject = AllocationSubject.find_or_create_by!(name: allocation_subject)
-  metadata[:subject_specialisms].each do |subject_specialism|
-    allocation_subject.subject_specialisms.find_or_create_by!(name: subject_specialism[:name])
+  if allocation_subject.name == Dttp::CodeSets::AllocationSubjects::PRIMARY
+    allocation_subject.subject_specialisms.find_or_create_by!(name: Dttp::CodeSets::CourseSubjects::PRIMARY_TEACHING)
+  else
+    metadata[:subject_specialisms].each do |subject_specialism|
+      allocation_subject.subject_specialisms.find_or_create_by!(name: subject_specialism[:name])
+    end
   end
 end
 
@@ -29,6 +33,6 @@ SEED_BURSARIES.each do |b|
   bursary = Bursary.find_or_create_by!(training_route: b.training_route, amount: b.amount)
   b.allocation_subjects.map do |subject|
     allocation_subject = AllocationSubject.find_by!(name: subject)
-    bursary.bursary_subjects.create!(allocation_subject: allocation_subject)
+    bursary.bursary_subjects.find_or_create_by!(allocation_subject: allocation_subject)
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :course do
-    sequence(:name) { |c| "Course #{c}" }
+    name { PUBLISH_SUBJECT_SPECIALISM_MAPPING.keys.sample }
     code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
     accredited_body_code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     start_date { Time.zone.today }
@@ -23,10 +23,17 @@ FactoryBot.define do
     factory :course_with_subjects do
       transient do
         subjects_count { 1 }
+        subject_names { [] }
       end
 
       after(:create) do |course, evaluator|
-        create_list(:course_subjects, evaluator.subjects_count, course: course)
+        if evaluator.subject_names.any?
+          evaluator.subject_names.each do |subject_name|
+            course.subjects << create(:subject, name: subject_name)
+          end
+        else
+          create_list(:course_subjects, evaluator.subjects_count, course: course)
+        end
       end
     end
   end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :subject do
-    sequence(:name) { |c| "Subject #{c}" }
+    sequence(:name) { PUBLISH_SUBJECT_SPECIALISM_MAPPING.keys.sample }
     code { Faker::Alphanumeric.unique.alphanumeric(number: 2).upcase }
   end
 

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -7,8 +7,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
 
   background do
     given_i_am_authenticated
-    given_a_trainee_exists(:with_related_courses, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
-    given_some_courses_exist
+    given_a_trainee_exists_with_some_courses
     given_i_am_on_the_review_draft_page
   end
 
@@ -76,6 +75,11 @@ feature "publish course details", type: :feature, feature_publish_course_details
     end
   end
 
+  def given_a_trainee_exists_with_some_courses
+    given_a_trainee_exists(:with_related_courses, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
+    @matching_courses = trainee.provider.courses.where(route: trainee.training_route)
+  end
+
   def then_the_section_should_be(status)
     expect(review_draft_page.course_details.status.text).to eq(status)
   end
@@ -126,10 +130,6 @@ feature "publish course details", type: :feature, feature_publish_course_details
 
   def then_i_see_the_course_details_page
     expect(course_details_page).to be_displayed(id: trainee.slug)
-  end
-
-  def given_some_courses_exist
-    @matching_courses = trainee.provider.courses.where(route: trainee.training_route)
   end
 
   def given_there_arent_any_courses

--- a/spec/services/calculate_subject_specialisms_spec.rb
+++ b/spec/services/calculate_subject_specialisms_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CalculateSubjectSpecialisms do
+  before do
+    stub_const("PUBLISH_SUBJECT_SPECIALISM_MAPPING", subject_specialism_mapping)
+  end
+
+  subject { described_class.call(subjects: subjects) }
+
+  context "course has one subject" do
+    let(:subjects) { %w[Chemistry] }
+
+    context "subject has many subject specialisms" do
+      let(:subject_specialism_mapping) do
+        { "Chemistry" => ["chemistry", "applied chemistry"] }
+      end
+
+      it "returns a hash with values for course_subject_one" do
+        expect(subject).to match({
+          course_subject_one: ["chemistry", "applied chemistry"],
+          course_subject_two: [],
+          course_subject_three: [],
+        })
+      end
+    end
+
+    context "course has one Primary subject" do
+      let(:subjects) { ["Primary with geography and history"] }
+
+      let(:subject_specialism_mapping) do
+        { "Primary with geography and history" => ["primary teaching", "geography", "history"] }
+      end
+
+      it "returns a hash with values for course_subject_one, course_subject_two and course_subject_three" do
+        expect(subject).to match({
+          course_subject_one: ["primary teaching"],
+          course_subject_two: %w[geography],
+          course_subject_three: %w[history],
+        })
+      end
+    end
+  end
+
+  context "course subject is modern languages" do
+    let(:subjects) { %w[German French] }
+
+    let(:subject_specialism_mapping) do
+      { "German" => ["German language"], "French" => ["French language"] }
+    end
+
+    it "returns a hash with values for course_subject_one" do
+      expect(subject).to match({
+        course_subject_one: ["German language", "French language"],
+        course_subject_two: [],
+        course_subject_three: [],
+      })
+    end
+  end
+
+  context "course with different subjects" do
+    let(:subjects) { %w[Drama English] }
+
+    let(:subject_specialism_mapping) do
+      { "Drama" => ["Drama", "Performing Arts"], "English" => ["English Studies"] }
+    end
+
+    it "returns a hash with values for course_subject_one and course_subject_two" do
+      expect(subject).to match({
+        course_subject_one: ["Drama", "Performing Arts"],
+        course_subject_two: ["English Studies"],
+        course_subject_three: [],
+      })
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/EsEeJeEx/1995-l-map-publish-subjects-to-subject-specialism

### Changes proposed in this pull request
- New `CalculateSubjectSpecialisms` class to work out how to populate `Trainee` attributes `course_subject_one`, `course_subject_two` and `course_subject_three` which are now meant to store a "subject specialism" instead of the subject name.
- Update `ConfirmPublishCourseForm` to use `CalculateSubjectSpecialisms`

### Guidance to review
- Create a "Provider-led (postgrad)" trainee (make sure the trainee's provider has courses)
- Visit "Course details" and choose a course that has a subject with mulitple specialisms (see [here](https://docs.google.com/spreadsheets/d/1MRDfp6KUSEL9RslzidpWzqvlbli0H6iuibLXno5Gd6E/edit?ts=60c0f4ce#gid=597746131) for spreadsheet)
- Continue and confirm course
- Open console and find the trainee
- Inspect the attributes `course_subject_one`, `course_subject_two` and `course_subject_three`. They should be populated with the first specialism from the list (Ed's working on the design to allow the user to choose the specialism).

**Read the spec file for `CalculateSubjectSpecialisms` carefully and let me know if it makes sense.**