### PR TITLE
[1990] Add mapping for initiatives and send to DTTP

### DIFF
--- a/app/components/review_draft/apply_draft/view.html.erb
+++ b/app/components/review_draft/apply_draft/view.html.erb
@@ -33,7 +33,7 @@
               component.row(**row_helper(@trainee, :placement_details))
             end
 
-            if FeatureService.enabled?("funding")
+            if FeatureService.enabled?(:show_funding)
               component.row(**row_helper(@trainee, funding_options(@trainee)))
             end
           end %>

--- a/app/components/review_draft/draft/view.html.erb
+++ b/app/components/review_draft/draft/view.html.erb
@@ -32,7 +32,7 @@
           component.row(**row_helper(@trainee, :school_details))
         end
 
-        if FeatureService.enabled?("funding")
+        if FeatureService.enabled?(:show_funding)
           component.row(**row_helper(@trainee, funding_options(@trainee)))
         end
 

--- a/app/lib/dttp/code_sets/training_initiatives.rb
+++ b/app/lib/dttp/code_sets/training_initiatives.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Dttp
+  module CodeSets
+    module TrainingInitiatives
+      MAPPING = {
+        ROUTE_INITIATIVES_ENUMS[:transition_to_teach] => { entity_id: "544a6435-e2af-ea11-a812-000d3ab55801" },
+        ROUTE_INITIATIVES_ENUMS[:now_teach] => { entity_id: "04516b48-e2af-ea11-a812-000d3ab55801" },
+        ROUTE_INITIATIVES_ENUMS[:maths_physics_chairs_programme_researchers_in_schools] => { entity_id: "6a08fd3f-276e-e711-80d2-005056ac45bb" },
+        ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars] => { entity_id: "" },
+      }.freeze
+    end
+  end
+end

--- a/app/lib/dttp/mappable.rb
+++ b/app/lib/dttp/mappable.rb
@@ -61,5 +61,9 @@ module Dttp
     def dttp_school_id(urn)
       Dttp::School.find_by(urn: urn)&.dttp_id
     end
+
+    def training_initiative_id(training_initiative)
+      CodeSets::TrainingInitiatives::MAPPING.dig(training_initiative, :entity_id)
+    end
   end
 end

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -52,6 +52,7 @@ module Dttp
         .merge(qualifying_degree.uk? ? uk_specific_params : non_uk_specific_params)
         .merge(school_params)
         .merge(subject_params)
+        .merge(funding_params)
       end
 
       def course_age_range
@@ -115,6 +116,18 @@ module Dttp
         return {} if trainee.course_subject_three.blank?
 
         { "dfe_ITTSubject3Id@odata.bind" => "/dfe_subjects(#{course_subject_id(trainee.course_subject_three)})" }
+      end
+
+      def funding_params
+        return {} unless send_funding_to_dttp? && trainee.training_initiative != ROUTE_INITIATIVES_ENUMS[:no_initiative]
+
+        {
+          "dfe_initiative1id_value" => "/dfe_initiatives(#{training_initiative_id(trainee.training_initiative)})",
+        }
+      end
+
+      def send_funding_to_dttp?
+        FeatureService.enabled?(:show_funding) && FeatureService.enabled?(:send_funding_to_dttp)
       end
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,7 +39,8 @@ features:
   sync_from_dttp: false
   send_emails: false
   persist_to_dttp: false
-  funding: false
+  show_funding: false
+  send_funding_to_dttp: false
   routes:
     early_years_assessment_only: false
     early_years_salaried: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,7 +7,6 @@ features:
   import_courses_from_ttapi: true
   publish_course_details: true
   show_funding: true
-  use_subject_specialisms: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,7 +6,8 @@ features:
   basic_auth: false
   import_courses_from_ttapi: true
   publish_course_details: true
-  funding: true
+  show_funding: true
+  use_subject_specialisms: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -3,7 +3,8 @@ features:
   use_dfe_sign_in: false
   enable_feedback_link: true
   publish_course_details: true
-  funding: true
+  show_funding: true
+  use_subject_specialisms: true
   persist_to_dttp: false
   routes:
     provider_led_postgrad: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -4,7 +4,6 @@ features:
   enable_feedback_link: true
   publish_course_details: true
   show_funding: true
-  use_subject_specialisms: true
   persist_to_dttp: false
   routes:
     provider_led_postgrad: true

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -133,25 +133,13 @@ module Dttp
             )
           end
 
-          let(:biology_entity_id) do
-            CodeSets::CourseSubjects::MAPPING[CodeSets::CourseSubjects::BIOLOGY][:entity_id]
-          end
-
-          let(:chemistry_entity_id) do
-            CodeSets::CourseSubjects::MAPPING[CodeSets::CourseSubjects::CHEMISTRY][:entity_id]
-          end
-
-          let(:mathematics_entity_id) do
-            CodeSets::CourseSubjects::MAPPING[CodeSets::CourseSubjects::MATHEMATICS][:entity_id]
-          end
-
           subject { described_class.new(trainee).params }
 
           it "sets the dttp itt subject params for all given subjects" do
             expect(subject).to include({
-              "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{biology_entity_id})",
-              "dfe_ITTSubject2Id@odata.bind" => "/dfe_subjects(#{chemistry_entity_id})",
-              "dfe_ITTSubject3Id@odata.bind" => "/dfe_subjects(#{mathematics_entity_id})",
+              "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{CodeSets::CourseSubjects::MAPPING[CodeSets::CourseSubjects::BIOLOGY][:entity_id]})",
+              "dfe_ITTSubject2Id@odata.bind" => "/dfe_subjects(#{CodeSets::CourseSubjects::MAPPING[CodeSets::CourseSubjects::CHEMISTRY][:entity_id]})",
+              "dfe_ITTSubject3Id@odata.bind" => "/dfe_subjects(#{CodeSets::CourseSubjects::MAPPING[CodeSets::CourseSubjects::MATHEMATICS][:entity_id]})",
             })
           end
         end
@@ -258,7 +246,7 @@ module Dttp
 
           context "but the send_funding_to_dttp feature flag is off" do
             it "doesn't send funding information" do
-              expect(subject).to_not include({
+              expect(subject).not_to include({
                 "dfe_initiative1id_value" => "/dfe_initiatives(#{dttp_training_initiative_entity_id})",
               })
             end
@@ -271,7 +259,7 @@ module Dttp
               end
 
               it "doesn't send funding information" do
-                expect(subject).to_not include({
+                expect(subject).not_to include({
                   "dfe_initiative1id_value" => "/dfe_initiatives(#{dttp_training_initiative_entity_id})",
                 })
               end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -27,6 +27,7 @@ module Dttp
       let(:dttp_employing_school_id) { SecureRandom.uuid }
       let(:dttp_route_id) { Dttp::CodeSets::Routes::MAPPING[trainee.training_route][:entity_id] }
       let(:dttp_qualification_aim_id) { Dttp::CodeSets::QualificationAims::MAPPING[trainee.training_route][:entity_id] }
+      let(:dttp_training_initiative_entity_id) { SecureRandom.uuid }
 
       before do
         allow(Time).to receive(:now).and_return(time_now_in_zone)
@@ -247,6 +248,46 @@ module Dttp
               "dfe_LeadSchoolId@odata.bind" => "/accounts(#{dttp_lead_school_id})",
               "dfe_EmployingSchoolId@odata.bind" => "/accounts(#{dttp_employing_school_id})",
             })
+          end
+        end
+
+        context "funding", feature_show_funding: true do
+          before do
+            stub_const("Dttp::CodeSets::TrainingInitiatives::MAPPING", { trainee.training_initiative => { entity_id: dttp_training_initiative_entity_id } })
+          end
+
+          context "but the send_funding_to_dttp feature flag is off" do
+            it "doesn't send funding information" do
+              expect(subject).to_not include({
+                "dfe_initiative1id_value" => "/dfe_initiatives(#{dttp_training_initiative_entity_id})",
+              })
+            end
+          end
+
+          context "and the send_funding_to_dttp feature flag is on", feature_send_funding_to_dttp: true do
+            context "but the trainee has no initiative" do
+              let(:trainee) do
+                create(:trainee, :with_course_details, :with_start_date, dttp_id: dttp_contact_id, training_initiative: ROUTE_INITIATIVES_ENUMS[:no_initiative])
+              end
+
+              it "doesn't send funding information" do
+                expect(subject).to_not include({
+                  "dfe_initiative1id_value" => "/dfe_initiatives(#{dttp_training_initiative_entity_id})",
+                })
+              end
+            end
+
+            context "and the trainee has an initiative" do
+              let(:trainee) do
+                create(:trainee, :with_course_details, :with_start_date, dttp_id: dttp_contact_id, training_initiative: ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars])
+              end
+
+              it "sends funding information" do
+                expect(subject).to include({
+                  "dfe_initiative1id_value" => "/dfe_initiatives(#{dttp_training_initiative_entity_id})",
+                })
+              end
+            end
           end
         end
       end

--- a/spec/services/dttp/contact_update_spec.rb
+++ b/spec/services/dttp/contact_update_spec.rb
@@ -23,7 +23,7 @@ module Dttp
       let(:placement_request_url) { "#{Settings.dttp.api_base_url}#{placement_path}" }
 
       before do
-        enable_features(:persist_to_dttp, "routes.school_direct_salaried")
+        enable_features(:persist_to_dttp, "routes.school_direct_salaried", :show_funding, :send_funding_to_dttp)
         allow(AccessToken).to receive(:fetch).and_return("token")
         stub_request(:patch, contact_request_url).to_return(contact_response)
         stub_request(:patch, placement_request_url).to_return(placement_response)

--- a/spec/services/dttp/register_for_trn_spec.rb
+++ b/spec/services/dttp/register_for_trn_spec.rb
@@ -39,7 +39,7 @@ module Dttp
       end
 
       before do
-        enable_features(:persist_to_dttp, "routes.school_direct_salaried")
+        enable_features(:persist_to_dttp, "routes.school_direct_salaried", :show_funding, :send_funding_to_dttp)
         allow(AccessToken).to receive(:fetch).and_return("token")
         allow(BatchRequest).to receive(:new).and_return(batch_request)
         trainee.degrees << degree

--- a/spec/support/shared_examples/rendering_the_funding_section.rb
+++ b/spec/support/shared_examples/rendering_the_funding_section.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "rendering the funding section" do
     end
   end
 
-  context "when a the funding feature flag is on", feature_funding: true do
+  context "when a the funding feature flag is on", feature_show_funding: true do
     context "when a trainee on a route with a bursary" do
       let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
       let(:trainee) { create(:trainee, :draft, route) }


### PR DESCRIPTION
### Context

https://trello.com/c/ZUzfjqj2/1990-m-funding-send-required-info-to-dttp-training-initiative

### Changes proposed in this pull request

- Adds a mapping between training initiatives and their DTTP entity IDs
- Sending this as part of placement assignment params

### Guidance to review
