### PR TITLE
[2040] Removed use_subject_specialisms feature flag and old tests

### DIFF
--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -39,8 +39,6 @@ private
 
   def course_subjects
     @course_subjects ||= begin
-      return Dttp::CodeSets::CourseSubjects::MAPPING.keys unless FeatureService.enabled?(:use_subject_specialisms)
-
       SubjectSpecialism.order_by_name.pluck(:name)
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,7 +40,6 @@ features:
   send_emails: false
   persist_to_dttp: false
   funding: false
-  use_subject_specialisms: false
   routes:
     early_years_assessment_only: false
     early_years_salaried: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,7 +7,6 @@ features:
   import_courses_from_ttapi: true
   publish_course_details: true
   funding: true
-  use_subject_specialisms: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -4,7 +4,6 @@ features:
   enable_feedback_link: true
   publish_course_details: true
   funding: true
-  use_subject_specialisms: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
@@ -19,18 +19,17 @@ feature "course details", type: :feature do
   context "trainee has existing course details" do
     background do
       given_a_trainee_exists_with_course_details
+      given_the_trainees_course_subject_specialism_exists
       given_i_am_on_the_review_draft_page
     end
 
-    context "when the feature flag is turned on", feature_use_subject_specialisms: true do
-      scenario "submitting with valid parameters" do
-        given_a_subject_specialism_is_available_for_selection
-        when_i_visit_the_course_details_page
-        and_i_enter_valid_subject_specialism_parameters
-        and_i_enter_valid_parameters
-        and_i_submit_the_form
-        and_the_course_details_are_updated
-      end
+    scenario "submitting with valid parameters" do
+      given_a_subject_specialism_is_available_for_selection
+      when_i_visit_the_course_details_page
+      and_i_enter_valid_subject_specialism_parameters
+      and_i_enter_valid_parameters
+      and_i_submit_the_form
+      then_the_course_details_are_updated
     end
 
     describe "tracking the progress" do
@@ -42,7 +41,7 @@ feature "course details", type: :feature do
         and_i_continue_without_confirming_details
         then_i_am_redirected_to_the_review_draft_page
         and_the_section_should_be(in_progress)
-        and_the_course_details_are_updated
+        then_the_course_details_are_updated
       end
     end
 
@@ -100,7 +99,7 @@ private
     course_details_page.submit_button.click
   end
 
-  def and_the_course_details_are_updated
+  def then_the_course_details_are_updated
     when_i_visit_the_course_details_page
 
     expect(course_details_page.subject.value).to eq(trainee.reload.course_subject_one)
@@ -197,5 +196,9 @@ private
 
   def course_details_section
     "course-details"
+  end
+
+  def given_the_trainees_course_subject_specialism_exists
+    create(:subject_specialism, name: trainee.course_subject_one)
   end
 end

--- a/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
@@ -19,14 +19,13 @@ feature "course details", type: :feature do
   context "trainee has existing course details" do
     background do
       given_a_trainee_exists_with_course_details
-      given_the_trainees_course_subject_specialism_exists
       given_i_am_on_the_review_draft_page
     end
 
     scenario "submitting with valid parameters" do
       given_a_subject_specialism_is_available_for_selection
       when_i_visit_the_course_details_page
-      and_i_enter_valid_subject_specialism_parameters
+      and_i_choose_a_specialism
       and_i_enter_valid_parameters
       and_i_submit_the_form
       then_the_course_details_are_updated
@@ -34,8 +33,9 @@ feature "course details", type: :feature do
 
     describe "tracking the progress" do
       scenario "renders an 'in progress' status when details partially provided" do
+        given_a_subject_specialism_is_available_for_selection
         when_i_visit_the_course_details_page
-        and_i_enter_valid_dttp_subject_parameters
+        and_i_choose_a_specialism
         and_i_enter_valid_parameters
         and_i_submit_the_form
         and_i_continue_without_confirming_details
@@ -73,12 +73,8 @@ private
     course_details_page.load(id: trainee.slug)
   end
 
-  def and_i_enter_valid_subject_specialism_parameters
+  def and_i_choose_a_specialism
     course_details_page.subject.select(@subject_specialism.name.upcase_first)
-  end
-
-  def and_i_enter_valid_dttp_subject_parameters
-    course_details_page.subject.select(trainee.course_subject_one.upcase_first)
   end
 
   def and_i_enter_valid_parameters
@@ -196,9 +192,5 @@ private
 
   def course_details_section
     "course-details"
-  end
-
-  def given_the_trainees_course_subject_specialism_exists
-    create(:subject_specialism, name: trainee.course_subject_one)
   end
 end

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -136,7 +136,7 @@ private
   end
 
   def when_i_filter_by_a_subject_which_returns_no_matches
-    when_i_filter_by_subject(@subject_specialism.name)
+    when_i_filter_by_subject(@subject_specialism.name.capitalize)
   end
 
   def then_i_see_a_no_records_found_message

--- a/spec/helpers/course_details_helper_spec.rb
+++ b/spec/helpers/course_details_helper_spec.rb
@@ -11,23 +11,9 @@ describe CourseDetailsHelper do
     end
 
     it "iterates over Dttp::CodeSets::CourseSubjects and prints out correct course_subjects values" do
-      expect(course_subjects_options.size).to be 71
+      expect(course_subjects_options.size).to be 2
       expect(course_subjects_options.first.value).to be_nil
-      expect(course_subjects_options.second.value).to eq Dttp::CodeSets::CourseSubjects::ANCIENT_HEBREW
-    end
-
-    context "when the feature flag is turned on", feature_use_subject_specialisms: true do
-      before do
-        create(:subject_specialism, name: Dttp::CodeSets::CourseSubjects::BUSINESS_MANAGEMENT)
-      end
-
-      it "iterates over subject specialisms and prints out ordered course_subjects" do
-        expect(course_subjects_options.size).to be 3
-        expect(course_subjects_options.first.value).to be_nil
-        expect(course_subjects_options.second.text).to eq "Business and management"
-        expect(course_subjects_options.third.value).to eq Dttp::CodeSets::CourseSubjects::TRAVEL_AND_TOURISM
-        expect(course_subjects_options.third.text).to eq "Travel and tourism"
-      end
+      expect(course_subjects_options.second.value).to eq Dttp::CodeSets::CourseSubjects::TRAVEL_AND_TOURISM
     end
   end
 

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -34,12 +34,6 @@ module Trainees
       let(:filters) { { subject: subject_name } }
 
       it { is_expected.to eq([trainee_with_subject]) }
-
-      context "when the feature flag is turned on", feature_use_subject_specialisms: true do
-        let!(:trainee_with_subject) { create(:trainee, :with_subject_specialism, subject_name: subject_name) }
-
-        it { is_expected.to eq([trainee_with_subject]) }
-      end
     end
 
     context "with text_search filter" do

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -13,8 +13,9 @@ module Features
     end
 
     def and_the_course_details_is_complete
+      given_subject_specialisms_are_available_for_selection
       course_details_page.load(id: trainee_from_url.slug)
-      course_details_page.subject.select(Dttp::CodeSets::CourseSubjects::MAPPING.keys.first)
+      course_details_page.subject.select(subject_specialism_name)
       course_details_page.main_age_range_3_to_11.choose
       and_the_course_date_fields_are_completed
       and_the_course_details_are_submitted
@@ -31,6 +32,14 @@ module Features
     def given_a_course_is_available_for_selection
       trainee = trainee_from_url
       create(:course_with_subjects, accredited_body_code: trainee.provider.code, route: trainee.training_route)
+    end
+
+    def given_subject_specialisms_are_available_for_selection
+      create(:subject_specialism, name: subject_specialism_name)
+    end
+
+    def subject_specialism_name
+      @subject_specialism_name ||= Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample.capitalize
     end
 
     def and_the_course_details_is_marked_completed


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/Kaoa6t6z/2040-remove-the-usesubjectspecialism-feature-flag)

### Changes proposed in this pull request

- Removed the feature flag for the use_subject_specialisms

### Guidance to review

- Run the test suite and check on the review app for the new subject specialisms being user

