### PR TITLE
[1988] funding bursary form

### DIFF
--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -46,8 +46,10 @@ module Trainees
       end
     end
 
+    # Returns the route that the confirm path is nested under for each confirm path
+    # eg /trainees/HxA35kmiNdtwNGnWYjr6FbJZ/funding/confirm returns 'funding'
     def trainee_section_key
-      @trainee_section_key ||= request.path.split("/").intersection(trainee_paths).first&.underscore
+      @trainee_section_key ||= request.path.split("/")[-2]&.underscore
     end
 
     def confirm_section_title
@@ -67,19 +69,6 @@ module Trainees
     def toggle_trainee_progress_field
       trainee.progress.public_send("#{trainee_section_key}=", mark_as_completed_params)
       trainee.save!
-    end
-
-    def trainee_paths
-      @trainee_paths ||= [
-        trainee_personal_details_path,
-        trainee_contact_details_path,
-        trainee_degrees_path,
-        trainee_course_details_path,
-        trainee_training_details_path,
-        trainee_trainee_id_path,
-        trainee_start_date_path,
-        trainee_schools_path,
-      ].map { |path| path.split("/").last }
     end
 
     def mark_as_completed_params

--- a/app/controllers/trainees/funding/bursaries_controller.rb
+++ b/app/controllers/trainees/funding/bursaries_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Funding
+    class BursariesController < ApplicationController
+      before_action :authorize_trainee
+
+      def edit
+        load_bursary_info!
+        @bursary_form = ::Funding::BursaryForm.new(trainee)
+      end
+
+      def update
+        @bursary_form = ::Funding::BursaryForm.new(trainee, params: bursary_params)
+
+        save_strategy = trainee.draft? ? :save! : :stash
+
+        if @bursary_form.public_send(save_strategy)
+          redirect_to(trainee_funding_confirm_path)
+        else
+          load_bursary_info!
+          render :edit
+        end
+      end
+
+    private
+
+      def trainee
+        @trainee ||= Trainee.from_param(params[:trainee_id])
+      end
+
+      def bursary_params
+        return { applying_for_bursary: nil } if params[:funding_bursary_form].blank?
+
+        params.require(:funding_bursary_form).permit(:applying_for_bursary).transform_values do |v|
+          ActiveModel::Type::Boolean.new.cast(v)
+        end
+      end
+
+      def authorize_trainee
+        authorize(trainee)
+      end
+
+      def load_bursary_info!
+        @subject = @trainee.course_subject_one
+        @amount = CalculateBursary.for_route_and_subject(@trainee.training_route.to_sym, @subject)
+      end
+    end
+  end
+end

--- a/app/forms/funding/bursary_form.rb
+++ b/app/forms/funding/bursary_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Funding
+  class BursaryForm < TraineeForm
+    FIELDS = %i[
+      applying_for_bursary
+    ].freeze
+
+    attr_accessor(*FIELDS)
+
+    validates :applying_for_bursary, inclusion: { in: [true, false] }
+
+  private
+
+    def compute_fields
+      trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+
+    def form_store_key
+      :bursary
+    end
+  end
+end

--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -9,6 +9,15 @@ module FundingHelper
     cannot_start_funding?(trainee) ? :funding_inactive : :funding_active
   end
 
+  def format_currency(amount)
+    number_to_currency(
+      amount,
+      unit: "£",
+      locale: :uk,
+      strip_insignificant_zeros: true,
+    )
+  end
+
 private
 
   def cannot_start_funding?(trainee)

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -25,6 +25,7 @@ class FormStore
     employing_school
     schools
     training_initiative
+    bursary
   ].freeze
 
   class << self

--- a/app/views/trainees/funding/bursaries/edit.html.erb
+++ b/app/views/trainees/funding/bursaries/edit.html.erb
@@ -1,0 +1,33 @@
+<%= render PageTitle::View.new(i18n_key: "trainees.funding.bursaries.edit",
+                               has_errors: @bursary_form.errors.present?) %>
+<%= content_for(:breadcrumbs) do %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: @bursary_form, url: trainee_funding_bursary_path(@trainee), method: :put, local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %><h1>
+      <p class="govuk-body"><%= t("views.forms.funding.bursaries.description_html", amount: format_currency(@amount), subject: @subject) %></p>
+
+        <%= f.govuk_radio_buttons_fieldset(:applying_for_bursary, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
+            <%= f.govuk_radio_button(
+              :applying_for_bursary,
+              "true",
+              label: { text: t("views.forms.funding.bursaries.true") },
+              link_errors: true,
+            ) %>
+
+            <%= f.govuk_radio_button(
+              :applying_for_bursary,
+              "false",
+              hint: { text: t("views.forms.funding.bursaries.false_hint") },
+              label: { text: t("views.forms.funding.bursaries.false") },
+            ) %>
+        <% end %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,6 +215,8 @@ en:
         funding:
           training_initiatives:
             edit: Training initiatives
+          bursaries:
+            edit: Bursary funding
       providers:
         index: Providers
         new: Add a provider
@@ -402,6 +404,12 @@ en:
           title: Is the trainee on any of these training initiatives?
           title_two: Is the trainee on either of these training initiatives?
           description: Training initiatives are sometimes referred to as programmes or schemes. They provide incentives and support for people training to teach. They’re separate from bursaries and scholarships.
+        bursaries:
+          description_html: The course you have selected has a bursary available of %{amount} for %{subject}. You need to check if the trainee is eligible for this bursary </br></br> <a target="_blank" href="www.google.com">DfE bursary guidance for the academic year 2021 to 2022 (opens in new tab)</a>
+          title: Are you applying for a bursary for this trainee?
+          true: Yes, apply for a bursary
+          false: No, do not apply for a bursary
+          false_hint: For example, the trainee is not eligible or has applied for a scholarship
   pages:
     request_an_account:
       inviting_limited_itt: We are only inviting a limited amount of initial teacher training providers to use Register,
@@ -700,6 +708,10 @@ en:
           attributes:
             training_initiative:
               blank: Select if the trainee is on a training initiative
+        funding/bursary_form:
+          attributes:
+            applying_for_bursary:
+              inclusion: Select an option
         outcome_date_form:
           attributes:
             date_string:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -711,7 +711,7 @@ en:
         funding/bursary_form:
           attributes:
             applying_for_bursary:
-              inclusion: Select an option
+              inclusion: Select if you are applying for a bursary for this trainee
         outcome_date_form:
           attributes:
             date_string:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -405,7 +405,7 @@ en:
           title_two: Is the trainee on either of these training initiatives?
           description: Training initiatives are sometimes referred to as programmes or schemes. They provide incentives and support for people training to teach. They’re separate from bursaries and scholarships.
         bursaries:
-          description_html: The course you have selected has a bursary available of %{amount} for %{subject}. You need to check if the trainee is eligible for this bursary </br></br> <a target="_blank" href="www.google.com">DfE bursary guidance for the academic year 2021 to 2022 (opens in new tab)</a>
+          description_html: The course you have selected has a bursary available of %{amount} for %{subject}. You need to check if the trainee is eligible for this bursary </br></br> <a target="_blank" href="https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-fu[…]er-training-bursaries-funding-manual-2021-to-2022-academic-year">DfE bursary guidance for the academic year 2021 to 2022 (opens in new tab)</a>
           title: Are you applying for a bursary for this trainee?
           true: Yes, apply for a bursary
           false: No, do not apply for a bursary

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,23 +56,23 @@ Rails.application.routes.draw do
       get "/confirm-delete", to: "confirm_delete#show"
 
       namespace :degrees do
+        concerns :confirmable
         get "/new/type", to: "type#new"
         post "/new/type", to: "type#create"
         get "/confirm", to: "confirm_details#show"
       end
 
-      resources :degrees do
-        collection do
-          resource :confirm_details, as: :degrees_confirm, only: :update, path: "/confirm"
-        end
+      resources :degrees, only: %i[new edit create update destroy]
+
+      namespace :funding do
+        concerns :confirmable
+        resource :bursary, only: %i[edit update], path: "/bursary"
       end
 
       resource :personal_details, concerns: :confirmable, only: %i[show edit update], path: "/personal-details"
 
       namespace :diversity do
-        get "/confirm", to: "confirm_details#show"
-        post "/confirm", to: "confirm_details#update"
-        put "/confirm", to: "confirm_details#update"
+        concerns :confirmable
         resource :disclosure, only: %i[edit update], path: "/information-disclosed"
         resource :ethnic_group, only: %i[edit update], path: "/ethnic-group"
         resource :ethnic_background, only: %i[edit update], path: "/ethnic-background"

--- a/db/migrate/20210621161519_add_applying_for_bursary_to_traine.rb
+++ b/db/migrate/20210621161519_add_applying_for_bursary_to_traine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddApplyingForBursaryToTraine < ActiveRecord::Migration[6.1]
   def change
     add_column :trainees, :applying_for_bursary, :boolean

--- a/db/migrate/20210621161519_add_applying_for_bursary_to_traine.rb
+++ b/db/migrate/20210621161519_add_applying_for_bursary_to_traine.rb
@@ -1,0 +1,5 @@
+class AddApplyingForBursaryToTraine < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :applying_for_bursary, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -304,6 +304,7 @@ ActiveRecord::Schema.define(version: 2021_06_22_120839) do
     t.text "course_subject_two"
     t.text "course_subject_three"
     t.datetime "awarded_at"
+    t.boolean "applying_for_bursary"
     t.integer "training_initiative"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     international_address { nil }
     locale_code { :uk }
     email { "#{first_names}.#{last_name}@example.com" }
+    applying_for_bursary { nil }
 
     factory :trainee do
       date_of_birth { Faker::Date.birthday(min_age: 18, max_age: 65) }

--- a/spec/features/form_sections/teacher_training_data/edit_bursary_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_bursary_spec.rb
@@ -5,8 +5,10 @@ require "rails_helper"
 feature "edit bursary", type: :feature do
   background { given_i_am_authenticated }
 
+  let(:course_subject) { Dttp::CodeSets::CourseSubjects::LAW }
+
   before do
-    given_a_trainee_exists(:provider_led_postgrad, course_subject_one: "astrology")
+    given_a_trainee_exists(:provider_led_postgrad, course_subject_one: course_subject)
     and_a_bursary_exists_for_their_subject
     when_i_visit_the_bursary_page
   end
@@ -53,6 +55,6 @@ private
   def and_a_bursary_exists_for_their_subject
     bursary = create(:bursary, training_route: :provider_led_postgrad, amount: 100_000)
     allocation_subject = create(:allocation_subject, name: "magic", bursaries: [bursary])
-    create(:subject_specialism, allocation_subject: allocation_subject, name: "astrology")
+    create(:subject_specialism, allocation_subject: allocation_subject, name: course_subject)
   end
 end

--- a/spec/features/form_sections/teacher_training_data/edit_bursary_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_bursary_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "edit bursary", type: :feature do
+  background { given_i_am_authenticated }
+
+  before do
+    given_a_trainee_exists(:provider_led_postgrad, course_subject_one: "astrology")
+    and_a_bursary_exists_for_their_subject
+    when_i_visit_the_bursary_page
+  end
+
+  scenario "edit with valid parameters" do
+    and_i_update_the_bursary
+
+    # TODO: uncomment this when the confrimation page is added
+    # and_i_submit_the_form
+    # then_i_am_redirected_to_the_funding_confirmation_page
+  end
+
+  scenario "submitting with invalid parameters" do
+    and_i_submit_the_form
+    then_i_see_error_messages
+  end
+
+private
+
+  def when_i_visit_the_bursary_page
+    bursary_page.load(id: trainee.slug)
+  end
+
+  def and_i_update_the_bursary
+    bursary_page.applying_for_bursary.click
+  end
+
+  def and_i_submit_the_form
+    bursary_page.submit_button.click
+  end
+
+  def and_i_see_how_much_the_bursary_is_for
+    expect(bursary_page).to have_text(
+      "The course you have selected has a bursary available of £100,000 for astrology",
+    )
+  end
+
+  def then_i_see_error_messages
+    expect(bursary_page).to have_text(
+      I18n.t("activemodel.errors.models.funding/bursary_form.attributes.applying_for_bursary.inclusion"),
+    )
+  end
+
+  def and_a_bursary_exists_for_their_subject
+    bursary = create(:bursary, training_route: :provider_led_postgrad, amount: 100_000)
+    allocation_subject = create(:allocation_subject, name: "magic", bursaries: [bursary])
+    create(:subject_specialism, allocation_subject: allocation_subject, name: "astrology")
+  end
+end

--- a/spec/forms/funding/bursary_form_spec.rb
+++ b/spec/forms/funding/bursary_form_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Funding
+  describe BursaryForm, type: :model do
+    let(:params) { {} }
+    let(:trainee) { create(:trainee, applying_for_bursary: true) }
+    let(:form_store) { class_double(FormStore) }
+
+    subject { described_class.new(trainee, params: params, store: form_store) }
+
+    before do
+      allow(form_store).to receive(:get).and_return(nil)
+    end
+
+    describe "validations" do
+      it { is_expected.to validate_inclusion_of(:applying_for_bursary).in_array([true, false]) }
+    end
+
+    describe "#stash" do
+      it "uses FormStore to temporarily save the fields under a key combination of trainee ID and bursary" do
+        expect(form_store).to receive(:set).with(trainee.id, :bursary, subject.fields)
+
+        subject.stash
+      end
+    end
+
+    describe "#save!" do
+      let(:applying_for_bursary) { false }
+
+      before do
+        allow(form_store).to receive(:get).and_return({ "applying_for_bursary" => applying_for_bursary })
+        allow(form_store).to receive(:set).with(trainee.id, :bursary, nil)
+      end
+
+      it "takes any data from the form store and saves it to the database" do
+        expect { subject.save! }.to change(trainee.reload, :applying_for_bursary).to(false)
+      end
+    end
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -222,6 +222,10 @@ module Features
       @recommended_for_qts_page ||= PageObjects::Trainees::RecommendedForQts.new
     end
 
+    def bursary_page
+      @bursary_page ||= PageObjects::Trainees::Funding::Bursary.new
+    end
+
     def apply_trainee_data_page
       @apply_trainee_data_pate ||= PageObjects::Trainees::ApplyTraineeData.new
     end

--- a/spec/support/page_objects/funding/burary.rb
+++ b/spec/support/page_objects/funding/burary.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    module Funding
+      class Bursary < PageObjects::Base
+        set_url "/trainees/{id}/funding/bursary/edit"
+
+        element :applying_for_bursary, "#funding-bursary-form-applying-for-bursary-true-field"
+        element :not_applying_for_bursary, "#funding-bursary-form-applying-for-bursary-false-field"
+
+        element :submit_button, "input[name='commit']"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/QjRvOnc5/1988-m-funding-ui-bursary-radio-button-form

### Changes proposed in this pull request

- Small refactor to routes and the way confirmation pages are calculated (see commit message for f3d6bcf)
- Adds edit bursary form (yes or no)
<img width="1398" alt="Screenshot 2021-06-23 at 16 27 50" src="https://user-images.githubusercontent.com/823643/123124965-057cea00-d440-11eb-9cd2-bcb239a85091.png">


### Guidance to review
Can't really be tested easily as the page can't be navigated to, and it the form doesn't have a confirmation page to go to. You can manually visit the url of the format `trainees/HxA35kmiNdtwNGnWYjr6FbJZ/funding/bursary/edit`

You will need to make sure that there is a bursary for your given trainee training route/course subject, see `SEED_BURSARIES` for inspiration.
