### PR TITLE
[xxx] Raise on missing translations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,8 @@ module RegisterTraineeTeachers
 
     config.exceptions_app = routes
 
+    config.action_view.raise_on_missing_translations = true
+
     config.view_component.preview_paths = [Rails.root.join("spec/components")]
     config.view_component.preview_route = "/view_components"
     config.view_component.show_previews = !Rails.env.production?


### PR DESCRIPTION
### Context

We want an error to be reported if a translation is missing to avoid
them being silently displayed to users as missing translation text.

### Changes proposed in this pull request

Raise when they're missing in all envs.

### Guidance to review

