### PR TITLE
[2061] Added missing translation for subject

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -629,7 +629,8 @@ en:
         email:
           invalid: Enter an email address in the correct format, like name@example.com
         autocomplete:
-          course_subject_one: &subject Select a subject from the list - your entry is not recognised
+          subject: &subject Select a subject from the list - your entry is not recognised
+          course_subject_one: *subject
           course_subject_two: *subject
           course_subject_three: *subject
           additional_age_range: Select an age range from the list - your entry is not recognised


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/GrnyBweS/2061-bug-missing-translation-for-invalid-degree-subject)

### Changes proposed in this pull request

- Added missing translation for Subject

### Guidance to review

- Go to degree form and input an invalid subject (not blank though) and you will see the invalid subject error

