### PR TITLE
[2065] Regex changed to look for 4 chars

### DIFF
--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -145,7 +145,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
 
   def and_i_only_see_the_courses_for_my_provider_and_route
     course_codes_on_page = publish_course_details_page.course_options
-      .map { |o| o.label.text.match(/\((.*)\)/) }
+      .map { |o| o.label.text.match(/\((.{4})\)/) }
       .compact
       .map { |m| m[1] }
       .sort


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/JICgXpk7/2065-bug-flakey-test)

### Changes proposed in this pull request

- Regex was accidentally thinking that the course code for modern languages included `other` as it was in between brackets, like the code
- Changed regex to only look between brackets that have 4 char length (the same as the code)

### Guidance to review

- Run `rspec spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb`

