### PR TITLE
[xxxx] Migrate Primary subjects to Primary teaching

### DIFF
--- a/db/data/20210624155310_change_primary_to_primary_teaching.rb
+++ b/db/data/20210624155310_change_primary_to_primary_teaching.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangePrimaryToPrimaryTeaching < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.where(course_subject_one: "Primary").update_all(course_subject_one: Dttp::CodeSets::CourseSubjects::PRIMARY_TEACHING)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

- At the moment, trainees with `Primary` as their `course_subject_one` are raising errors when being submitted for TRN as we have phased out the subject, and its replaced with `Primary teaching`. This PR changes that field for the trainees. 

### Changes proposed in this pull request

- Added a DB migration to migrate trainees with `Primary` as their first course subject to instead have `Primary teaching`

### Guidance to review

- Run `rake db:migrate`
