### PR TITLE
[1999] Fix trainees with old subjects

### DIFF
--- a/db/data/20210625135853_update_trainee_subjects.rb
+++ b/db/data/20210625135853_update_trainee_subjects.rb
@@ -18,7 +18,7 @@ class UpdateTraineeSubjects < ActiveRecord::Migration[6.1]
     "Physics" => Dttp::CodeSets::CourseSubjects::PHYSICS,
     "Primary" => Dttp::CodeSets::CourseSubjects::PRIMARY_TEACHING,
     "Psychology" => Dttp::CodeSets::CourseSubjects::PSYCHOLOGY,
-    "Religious education" => Dttp::CodeSets::CourseSubjects::RELIGIOUS_EDUCATION_DTTP_ID,
+    "Religious education" => Dttp::CodeSets::CourseSubjects::RELIGIOUS_STUDIES,
     "Science" => Dttp::CodeSets::CourseSubjects::GENERAL_SCIENCES,
     "Spanish" => Dttp::CodeSets::CourseSubjects::SPANISH_LANGUAGE,
   }.freeze

--- a/db/data/20210625135853_update_trainee_subjects.rb
+++ b/db/data/20210625135853_update_trainee_subjects.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class UpdateTraineeSubjects < ActiveRecord::Migration[6.1]
+  MAPPING = {
+    "Art and design" => Dttp::CodeSets::CourseSubjects::CREATIVE_ARTS_AND_DESIGN,
+    "Biology" => Dttp::CodeSets::CourseSubjects::BIOLOGY,
+    "Business studies" => Dttp::CodeSets::CourseSubjects::BUSINESS_STUDIES,
+    "Chemistry" => Dttp::CodeSets::CourseSubjects::CHEMISTRY,
+    "Communication and media studies" => Dttp::CodeSets::CourseSubjects::MEDIA_AND_COMMUNICATION_STUDIES,
+    "Drama" => Dttp::CodeSets::CourseSubjects::DRAMA,
+    "Economics" => Dttp::CodeSets::CourseSubjects::ECONOMICS,
+    "English" => Dttp::CodeSets::CourseSubjects::ENGLISH_STUDIES,
+    "Health and social care" => Dttp::CodeSets::CourseSubjects::HEALTH_AND_SOCIAL_CARE,
+    "History" => Dttp::CodeSets::CourseSubjects::HISTORY,
+    "Mathematics" => Dttp::CodeSets::CourseSubjects::MATHEMATICS,
+    "Modern languages (other)" => Dttp::CodeSets::CourseSubjects::MODERN_LANGUAGES,
+    "Music" => Dttp::CodeSets::CourseSubjects::MUSIC_EDUCATION_AND_TEACHING,
+    "Physics" => Dttp::CodeSets::CourseSubjects::PHYSICS,
+    "Primary" => Dttp::CodeSets::CourseSubjects::PRIMARY_TEACHING,
+    "Psychology" => Dttp::CodeSets::CourseSubjects::PSYCHOLOGY,
+    "Religious education" => Dttp::CodeSets::CourseSubjects::RELIGIOUS_EDUCATION_DTTP_ID,
+    "Science" => Dttp::CodeSets::CourseSubjects::GENERAL_SCIENCES,
+    "Spanish" => Dttp::CodeSets::CourseSubjects::SPANISH_LANGUAGE,
+  }.freeze
+
+  def up
+    MAPPING.each do |old_subject, new_subject|
+      Trainee.where(course_subject_one: old_subject).update_all(course_subject_one: new_subject)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/hoWiJpQH/1999-fix-the-existing-trainees-subjects-in-prod

### Changes proposed in this pull request

- Create a data migration to fix trainees in prod with old subjects based on the spreadsheet by Andrew

Note, we're skipping:

`Design and technology` - Providers will be contacted manually
`Citizenship` - DTTP subject specialism hasn't been created
`Physical education` - DTTP subject specialism hasn't been created

Trainees in prod only have their `course_subject_one` fields set. No trainees have additional subjects to deal with as of this time/date.

### Guidance to review

- Nothing this is a one time and irreversible data migration