### PR TITLE
[2014] Funding handle changing routes subjects

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -72,6 +72,7 @@ class CourseDetailsForm < TraineeForm
   def save!
     if valid?
       update_trainee_attributes
+      clear_bursary_information if course_subjects_changed?
       trainee.save!
       clear_stash
     else
@@ -111,6 +112,18 @@ private
       course_start_date: course_start_date,
       course_end_date: course_end_date,
     })
+  end
+
+  def clear_bursary_information
+    trainee.progress.funding = false
+
+    trainee.assign_attributes({
+      applying_for_bursary: nil,
+    })
+  end
+
+  def course_subjects_changed?
+    trainee.course_subject_one_changed? || trainee.course_subject_two_changed? || trainee.course_subject_three_changed?
   end
 
   def compute_attributes_from_trainee

--- a/app/lib/route_data_manager.rb
+++ b/app/lib/route_data_manager.rb
@@ -1,20 +1,26 @@
 # frozen_string_literal: true
 
 class RouteDataManager
-  attr_reader :trainee
-
   def initialize(trainee:)
     @trainee = trainee
   end
 
   def update_training_route!(route)
     trainee.training_route = route
-    trainee.update!(reset_course_details) if trainee.training_route_changed?
+    reset_trainee_details if trainee.training_route_changed?
+    trainee.save!
   end
 
 private
 
-  def reset_course_details
+  attr_reader :trainee
+
+  def reset_trainee_details
+    trainee.assign_attributes(course_details.merge(funding_details))
+    reset_progress
+  end
+
+  def course_details
     {
       course_code: nil,
       course_subject_one: nil,
@@ -23,9 +29,18 @@ private
       course_age_range: nil,
       course_start_date: nil,
       course_end_date: nil,
-      progress: {
-        course_details: false,
-      },
     }
+  end
+
+  def funding_details
+    {
+      training_initiative: nil,
+      applying_for_bursary: nil,
+    }
+  end
+
+  def reset_progress
+    trainee.progress.course_details = false
+    trainee.progress.funding = false
   end
 end

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -10,13 +10,13 @@ class Progress
     completed: "completed",
   }.freeze
 
-  attribute :personal_details, :boolean
-  attribute :contact_details, :boolean
-  attribute :degrees, :boolean
-  attribute :diversity, :boolean
-  attribute :course_details, :boolean
-  attribute :training_details, :boolean
-  attribute :placement_details, :boolean
-  attribute :schools, :boolean
-  attribute :funding, :boolean
+  attribute :personal_details, :boolean, default: false
+  attribute :contact_details, :boolean, default: false
+  attribute :degrees, :boolean, default: false
+  attribute :diversity, :boolean, default: false
+  attribute :course_details, :boolean, default: false
+  attribute :training_details, :boolean, default: false
+  attribute :placement_details, :boolean, default: false
+  attribute :schools, :boolean, default: false
+  attribute :funding, :boolean, default: false
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -292,11 +292,9 @@ FactoryBot.define do
       apply_application
     end
 
-    trait :with_multiple_subjects do
-      with_course_details
-
-      course_subject_two { create(:subject_specialism).name }
-      course_subject_three { create(:subject_specialism).name }
+    trait :with_funding do
+      training_initiative { ROUTE_INITIATIVES_ENUMS.keys.sample }
+      applying_for_bursary { Faker::Boolean.boolean }
     end
   end
 end

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -339,6 +339,24 @@ describe CourseDetailsForm, type: :model do
           expect(trainee.course_code).not_to eq nil
         end
       end
+
+      context "when the course_subject has changed" do
+        let(:progress) { Progress.new(course_details: true, funding: true, personal_details: true) }
+        let(:trainee) { create(:trainee, :with_funding, :with_course_details, course_subject_one: Dttp::CodeSets::CourseSubjects::BIOLOGY, progress: progress) }
+        let(:params) do
+          {
+            course_subject_one: Dttp::CodeSets::CourseSubjects::HISTORICAL_LINGUISTICS,
+          }
+        end
+
+        it "nullifies the bursary information and resets funding section progress" do
+          expect { subject.save! }
+          .to change { trainee.applying_for_bursary }
+          .from(trainee.applying_for_bursary).to(nil)
+          .and change { trainee.progress.funding }
+          .from(true).to(false)
+        end
+      end
     end
 
     describe "#stash" do

--- a/spec/lib/route_data_manager_spec.rb
+++ b/spec/lib/route_data_manager_spec.rb
@@ -3,18 +3,28 @@
 require "rails_helper"
 
 describe RouteDataManager do
-  subject { described_class.new(trainee: trainee) }
+  describe "#update_training_route!" do
+    subject do
+      described_class.new(trainee: trainee).update_training_route!("provider_led_postgrad")
+    end
 
-  describe "#update_training_route" do
+    let(:progress) { Progress.new(course_details: true, funding: true, personal_details: true) }
+
     context "when a trainee selects a new route" do
-      context "when a trainee has course details" do
-        let(:trainee) { create(:trainee, :assessment_only, :with_course_details) }
+      let(:trainee) { create(:trainee, :assessment_only) }
 
-        it "wipes the course details and changes route" do
-          expect { subject.update_training_route!("provider_led_postgrad") }
-            .to change { trainee.progress.course_details }
-            .from(trainee.progress.course_details).to(false)
-            .and change { trainee.course_code }
+      it "changes route" do
+        expect { subject }
+          .to change { trainee.training_route }
+          .from(trainee.training_route).to("provider_led_postgrad")
+      end
+
+      context "when a trainee has course details" do
+        let(:trainee) { create(:trainee, :assessment_only, :with_course_details, progress: progress) }
+
+        it "wipes the course details" do
+          expect { subject }
+            .to change { trainee.course_code }
             .from(trainee.course_code).to(nil)
             .and change { trainee.course_subject_one }
             .from(trainee.course_subject_one).to(nil)
@@ -24,20 +34,54 @@ describe RouteDataManager do
             .from(trainee.course_start_date).to(nil)
             .and change { trainee.course_end_date }
             .from(trainee.course_end_date).to(nil)
+        end
+
+        it "resets the course details progress" do
+          expect { subject }
+            .to change { trainee.progress.course_details }
+            .from(true).to(false)
+        end
+
+        it "does not change any other progress" do
+          expect { subject }
+            .not_to change { trainee.progress.personal_details }
+            .from(true)
+        end
+      end
+
+      context "when the trainee has funding" do
+        let(:trainee) { create(:trainee, :assessment_only, :with_funding, progress: progress) }
+
+        it "wipes initiative details" do
+          expect { subject }
+            .to change { trainee.training_initiative }
+            .from(trainee.training_initiative).to(nil)
             .and change { trainee.training_route }
             .from(trainee.training_route).to("provider_led_postgrad")
+        end
+
+        it "wipes bursary details and changes route" do
+          expect { subject }
+            .to change { trainee.applying_for_bursary }
+            .from(trainee.applying_for_bursary).to(nil)
+        end
+
+        it "resets the funding progress" do
+          expect { subject }
+            .to change { trainee.progress.funding }
+            .from(true).to(false)
         end
       end
     end
 
     context "when a trainee selects the same route" do
+      before do
+        subject
+        trainee.reload
+      end
+
       context "when a trainee has course details" do
         let(:trainee) { create(:trainee, :provider_led_postgrad, :with_course_details) }
-
-        before do
-          subject.update_training_route!("provider_led_postgrad")
-          trainee.reload
-        end
 
         it "does not clear the course details section of the trainee" do
           expect(trainee.course_code).to be_present
@@ -45,6 +89,15 @@ describe RouteDataManager do
           expect(trainee.course_age_range).to be_present
           expect(trainee.course_start_date).to be_present
           expect(trainee.course_end_date).to be_present
+        end
+      end
+
+      context "when a trainee has funding" do
+        let(:trainee) { create(:trainee, :provider_led_postgrad, :with_funding) }
+
+        it "does not clear the funding section of the trainee" do
+          expect(trainee.training_initiative).to be_present
+          expect(trainee.applying_for_bursary).to be(true).or be(false)
         end
       end
     end


### PR DESCRIPTION
### Context
Funding - handle changing routes/subjects

### Changes proposed in this pull request
1. When a route is changed for a draft trainee, set the funding (progress) to in progress, and clear funding related information (bursary and intiative)
2. When the course subject is changed, the bursary information is cleared.


### Guidance to review
1. For a draft trainee, enter funding and bursary information, and then change the route. Expect that the funding and bursary information is nullified.
2. For a trainee, enter bursary information, and then change the course subject. Expect that the bursary information is nullified.

