### PR TITLE
Update page object element to use correct markup

### DIFF
--- a/spec/support/page_objects/funding/burary.rb
+++ b/spec/support/page_objects/funding/burary.rb
@@ -9,7 +9,7 @@ module PageObjects
         element :applying_for_bursary, "#funding-bursary-form-applying-for-bursary-true-field"
         element :not_applying_for_bursary, "#funding-bursary-form-applying-for-bursary-false-field"
 
-        element :submit_button, "input[name='commit']"
+        element :submit_button, "button[type='submit']"
       end
     end
   end


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/register-trainee-teachers/pull/1047 <-- This PR changed how the govuk formbuidler renders submit buttons for forms (`button` instead of `input`) so a few of our tests broke.  

This PR fixes the remaining one.

### Changes proposed in this pull request

### Guidance to review

