### PR TITLE
Fix delete review app timeout

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -12,12 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for Deploy App Workflow for review
+        id: wait_for_deployment
         uses: fountainhead/action-wait-for-check@v1.0.0
         with:
          token: ${{ secrets.GITHUB_TOKEN }}
          checkName: ${{ github.event.pull_request.number }} Deployment
          ref: ${{ github.event.pull_request.head.sha }}
-         timeoutSeconds: 120
+         timeoutSeconds: 1800
+
+      - name: Exit whole workflow if wait was not successful
+        if: steps.wait_for_deployment.outputs.conclusion != 'success'
+        run: exit 1
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### Context
Delete review app may fail if concurrent deployment takes more than 2 min

### Changes proposed in this pull request
Increase to 30 min and fail the workflow immediately if the timeout is reached

### Guidance to review
See same issue in tt api: https://github.com/DFE-Digital/teacher-training-api/runs/2940976784?check_suite_focus=true
