### PR TITLE
[2053] Clear ethnic background when not selecting group

### DIFF
--- a/app/forms/diversities/ethnic_group_form.rb
+++ b/app/forms/diversities/ethnic_group_form.rb
@@ -4,6 +4,8 @@ module Diversities
   class EthnicGroupForm < TraineeForm
     FIELDS = %i[
       ethnic_group
+      ethnic_background
+      additional_ethnic_background
     ].freeze
 
     attr_accessor(*FIELDS)
@@ -31,7 +33,11 @@ module Diversities
     end
 
     def new_attributes
-      disclosure_form.diversity_disclosed? ? fields_from_store.merge(params).symbolize_keys : { ethnic_group: nil }
+      (disclosure_form.diversity_disclosed? ? fields_from_store.merge(params).symbolize_keys : { ethnic_group: nil }).tap do |attrs|
+        if attrs[:ethnic_group] == Diversities::ETHNIC_GROUP_ENUMS[:not_provided]
+          attrs.merge!(ethnic_background: nil, additional_ethnic_background: nil)
+        end
+      end
     end
   end
 end

--- a/spec/forms/diversities/ethnic_group_form_spec.rb
+++ b/spec/forms/diversities/ethnic_group_form_spec.rb
@@ -5,7 +5,15 @@ require "rails_helper"
 module Diversities
   describe EthnicGroupForm, type: :model do
     let(:params) { {} }
-    let(:trainee) { create(:trainee, :diversity_disclosed, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:asian]) }
+    let(:trainee) do
+      create(
+        :trainee,
+        :diversity_disclosed,
+        ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:other],
+        ethnic_background: Diversities::ANOTHER_ETHNIC_BACKGROUND,
+        additional_ethnic_background: "Crab people",
+      )
+    end
     let(:form_store) { class_double(FormStore) }
 
     subject { described_class.new(trainee, params: params, store: form_store) }
@@ -37,6 +45,24 @@ module Diversities
 
       it "takes any data from the form store and saves it to the database" do
         expect { subject.save! }.to change(trainee, :ethnic_group).to(ethnic_group)
+      end
+
+      context "ethnic_group is set to not provided" do
+        let(:ethnic_background) { Diversities::ETHNIC_GROUP_ENUMS[:not_provided] }
+
+        before do
+          allow(form_store).to receive(:get).and_return(
+            {
+              "ethnic_group" => ethnic_group,
+              "ethnic_background" => Diversities::ANOTHER_ETHNIC_BACKGROUND,
+            },
+          )
+        end
+
+        it "clears any ethnic background info" do
+          expect { subject.save! }.to change(trainee, :ethnic_background).to(nil)
+            .and change(trainee, :additional_ethnic_background).to(nil)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/xqMUFZy8/2053-bug-when-un-assigning-fields-in-trainees-we-assign-the-empty-fields-strings-instead-of-nil

The ethnic background question is hidden when you select (not provided)
as an ethnic group. So previously, if you selected an ethnic group and
background, but then changed the group to not provided, the result
on the confirmation page would be something like:
  `Not provided (Irish traveller)` without giving you a way to clear it.

### Changes proposed in this pull request
Set `ethnic_background` and `additional_ethnic_background` to `nil` when `ethnic_group` is not provided

### Guidance to review

