### PR TITLE
[2120] Clear bursary info when changing publish course

### DIFF
--- a/app/forms/concerns/course_form_helpers.rb
+++ b/app/forms/concerns/course_form_helpers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module CourseFormHelpers
+  def clear_bursary_information
+    trainee.progress.funding = false
+
+    trainee.assign_attributes({
+      applying_for_bursary: nil,
+    })
+  end
+
+  def course_subjects_changed?
+    trainee.course_subject_one_changed? || trainee.course_subject_two_changed? || trainee.course_subject_three_changed?
+  end
+end

--- a/app/forms/confirm_publish_course_form.rb
+++ b/app/forms/confirm_publish_course_form.rb
@@ -4,6 +4,7 @@ class ConfirmPublishCourseForm
   include ActiveModel::Model
   include ActiveModel::AttributeAssignment
   include ActiveModel::Validations::Callbacks
+  include CourseFormHelpers
 
   FIELDS = %i[
     code
@@ -24,6 +25,8 @@ class ConfirmPublishCourseForm
     return false unless valid?
 
     update_trainee_attributes
+
+    clear_bursary_information if course_subjects_changed?
     trainee.save!
   end
 

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CourseDetailsForm < TraineeForm
+  include CourseFormHelpers
+
   FIELDS = %i[
     course_subject_one
     course_subject_one_raw
@@ -112,18 +114,6 @@ private
       course_start_date: course_start_date,
       course_end_date: course_end_date,
     })
-  end
-
-  def clear_bursary_information
-    trainee.progress.funding = false
-
-    trainee.assign_attributes({
-      applying_for_bursary: nil,
-    })
-  end
-
-  def course_subjects_changed?
-    trainee.course_subject_one_changed? || trainee.course_subject_two_changed? || trainee.course_subject_three_changed?
   end
 
   def compute_attributes_from_trainee

--- a/spec/forms/confirm_publish_course_form_spec.rb
+++ b/spec/forms/confirm_publish_course_form_spec.rb
@@ -53,6 +53,19 @@ describe ConfirmPublishCourseForm, type: :model do
           .and change { trainee.course_end_date }
           .from(nil).to((course.start_date + course.duration_in_years.years).to_date.prev_day)
       end
+
+      context "when the course_subject has changed" do
+        let(:progress) { Progress.new(course_details: true, funding: true, personal_details: true) }
+        let(:trainee) { build(:trainee, applying_for_bursary: true, progress: progress) }
+
+        it "nullifies the bursary information and resets funding section progress" do
+          expect { subject.save }
+          .to change { trainee.applying_for_bursary }
+          .from(true).to(nil)
+          .and change { trainee.progress.funding }
+          .from(true).to(false)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION


### Context

https://trello.com/c/T2SmfktI/2120-bug-bursary-info-not-clearing-when-you-change-publish-course-subject

The bursary info can change if your course changes. We previously added
this to the course details form, but your course can also change in the
confirm publish course form.

### Changes proposed in this pull request

Clear bursary info in publish course subject form, extract common methods into concern

### Guidance to review

