### PR TITLE
[2131] Increase timeout on build turnstyle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,11 @@ jobs:
         name: Wait for other inprogress deployment runs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          initial-wait-seconds: 12
+          poll-interval-seconds: 20
+          abort-after-seconds: 1800
+          same-branch-only: true
 
   deploy:
     name: ${{ matrix.environment }} Deployment


### PR DESCRIPTION
### Context
The pipeline failed after 14min as it was abruptly killed by github
actions while waiting for another deployment to finish.

### Changes proposed in this pull request
We now add a 30min timeout to give it enough time.
The poll time is reduced to 20s from default 60s to get out faster.

### Guidance to review

