### PR TITLE
[2141] Add bursary tier field on trainee

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -29,6 +29,8 @@ class Trainee < ApplicationRecord
 
   enum training_initiative: ROUTE_INITIATIVES
 
+  enum bursary_tier: BURSARY_TIERS
+
   enum locale_code: { uk: 0, non_uk: 1 }
 
   enum gender: {

--- a/config/initializers/bursary_tiers.rb
+++ b/config/initializers/bursary_tiers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+BURSARY_TIER_ENUMS = {
+  tier_one: "tier_one",
+  tier_two: "tier_two",
+  tier_three: "tier_three",
+}.freeze
+
+BURSARY_TIERS = {
+  BURSARY_TIER_ENUMS[:tier_one] => 0,
+  BURSARY_TIER_ENUMS[:tier_two] => 1,
+  BURSARY_TIER_ENUMS[:tier_three] => 2,
+}.freeze

--- a/db/migrate/20210702093832_add_bursary_tier_to_trainees.rb
+++ b/db/migrate/20210702093832_add_bursary_tier_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBursaryTierToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :bursary_tier, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_22_120839) do
+ActiveRecord::Schema.define(version: 2021_07_02_093832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -304,8 +304,9 @@ ActiveRecord::Schema.define(version: 2021_06_22_120839) do
     t.text "course_subject_two"
     t.text "course_subject_three"
     t.datetime "awarded_at"
-    t.integer "training_initiative"
     t.boolean "applying_for_bursary"
+    t.integer "training_initiative"
+    t.integer "bursary_tier"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -297,5 +297,10 @@ FactoryBot.define do
       training_initiative { ROUTE_INITIATIVES_ENUMS.keys.sample }
       applying_for_bursary { Faker::Boolean.boolean }
     end
+
+    trait :with_tiered_bursary do
+      applying_for_bursary { true }
+      bursary_tier { BURSARY_TIER_ENUMS[:tier_one] }
+    end
   end
 end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -57,6 +57,14 @@ describe Trainee do
         Diversities::ETHNIC_GROUP_ENUMS[:not_provided] => 5,
       )
     end
+
+    it do
+      expect(subject).to define_enum_for(:bursary_tier).with_values(
+        BURSARY_TIER_ENUMS[:tier_one] => 0,
+        BURSARY_TIER_ENUMS[:tier_two] => 1,
+        BURSARY_TIER_ENUMS[:tier_three] => 2,
+      )
+    end
   end
 
   context "scopes" do


### PR DESCRIPTION
### Context

- https://trello.com/c/6nAStKL7/2141-bursaries-new-bursarytier-field-on-trainee

### Changes proposed in this pull request

- Adds `bursary_tier` column on the `trainees` table

### Guidance to review

- Run migrations, assert new field on the `trainees` table

