### PR TITLE
[2140] Add new EY salaried bursary and add to seeds/data migration

### DIFF
--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -76,32 +76,57 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 24_000,
-    allocation_subjects: %w[Chemistry Computing Mathematics Physics],
+    allocation_subjects: [
+      Dttp::CodeSets::AllocationSubjects::CHEMISTRY,
+      Dttp::CodeSets::AllocationSubjects::COMPUTING,
+      Dttp::CodeSets::AllocationSubjects::MATHEMATICS,
+      Dttp::CodeSets::AllocationSubjects::PHYSICS,
+    ],
   ),
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 10_000,
-    allocation_subjects: ["Modern languages", "Classics"],
+    allocation_subjects: [
+      Dttp::CodeSets::AllocationSubjects::MODERN_LANGUAGES,
+      Dttp::CodeSets::AllocationSubjects::CLASSICS,
+    ],
   ),
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 7_000,
-    allocation_subjects: %w[Biology],
+    allocation_subjects: [
+      Dttp::CodeSets::AllocationSubjects::BIOLOGY,
+    ],
   ),
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 24_000,
-    allocation_subjects: %w[Chemistry Computing Mathematics Physics],
+    allocation_subjects: [
+      Dttp::CodeSets::AllocationSubjects::CHEMISTRY,
+      Dttp::CodeSets::AllocationSubjects::COMPUTING,
+      Dttp::CodeSets::AllocationSubjects::MATHEMATICS,
+      Dttp::CodeSets::AllocationSubjects::PHYSICS,
+    ],
   ),
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 10_000,
-    allocation_subjects: ["Modern languages", "Classics"],
+    allocation_subjects: [
+      Dttp::CodeSets::AllocationSubjects::MODERN_LANGUAGES,
+      Dttp::CodeSets::AllocationSubjects::CLASSICS,
+    ],
   ),
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 7_000,
-    allocation_subjects: %w[Biology],
+    allocation_subjects: [
+      Dttp::CodeSets::AllocationSubjects::BIOLOGY,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:early_years_salaried],
+    amount: 14_000,
+    allocation_subjects: [Dttp::CodeSets::AllocationSubjects::EARLY_YEARS_ITT],
   ),
 ].freeze
 

--- a/db/data/20210702132811_create_bursaries.rb
+++ b/db/data/20210702132811_create_bursaries.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateBursaries < ActiveRecord::Migration[6.1]
+  def up
+    SEED_BURSARIES.each do |b|
+      bursary = Bursary.find_or_create_by!(training_route: b.training_route, amount: b.amount)
+      b.allocation_subjects.map do |subject|
+        allocation_subject = AllocationSubject.find_by!(name: subject)
+        bursary.bursary_subjects.find_or_create_by!(allocation_subject: allocation_subject)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-DataMigrate::Data.define(version: 20_210_607_164_459)
+DataMigrate::Data.define(version: 20210702132811)


### PR DESCRIPTION
### Context

https://trello.com/c/sMdbp3ai/2140-bursaries-create-new-early-years-salaried-bursary

### Changes proposed in this pull request

- Adds new EY salaried bursary to our DB seeds
- Adds data migration to add all bursaries in prod
- Updates our seed to use the `AllocationSubjects` constants now defined.

### Note
This is related to this ticket: https://trello.com/c/ZOJSkkUx/2139-save-the-early-years-teaching-subject-directly-onto-the-ey-trainees

If anyone has any Early years (salaried) trainees, and this card is merged before the above, then their funding sections for these trainees will be labelled 'Cannot start yet'. This is because there will be a bursary in the DB but the trainee's subject isn't completed.

This shouldn't be a problem at the moment, since in settings: `early_years_salaried: false` and `show_funding: false`