### PR TITLE
[2139] Save the "Early years teaching" subject directly onto the EY t…

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -40,6 +40,7 @@ class TraineesController < ApplicationController
       redirect_to trainees_not_supported_route_path
     else
       authorize @trainee = Trainee.new(trainee_params.merge(provider_id: current_user.provider_id))
+      trainee.set_early_years_course_subject
       if trainee.save
         redirect_to review_draft_trainee_path(trainee)
       else

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -105,22 +105,26 @@ private
   end
 
   def update_trainee_attributes
-    trainee.assign_attributes({
+    attributes = {
       course_code: course_code,
-      course_subject_one: course_subject_one,
-      course_subject_two: course_subject_two,
-      course_subject_three: course_subject_three,
       course_age_range: course_age_range,
       course_start_date: course_start_date,
       course_end_date: course_end_date,
-    })
+    }
+
+    unless trainee.early_years_route?
+      attributes.merge!({
+        course_subject_one: course_subject_one,
+        course_subject_two: course_subject_two,
+        course_subject_three: course_subject_three,
+      })
+    end
+
+    trainee.assign_attributes(attributes)
   end
 
   def compute_attributes_from_trainee
     attributes = {
-      course_subject_one: trainee.course_subject_one,
-      course_subject_two: trainee.course_subject_two,
-      course_subject_three: trainee.course_subject_three,
       start_day: trainee.course_start_date&.day,
       start_month: trainee.course_start_date&.month,
       start_year: trainee.course_start_date&.year,
@@ -128,6 +132,14 @@ private
       end_month: trainee.course_end_date&.month,
       end_year: trainee.course_end_date&.year,
     }
+
+    unless trainee.early_years_route?
+      attributes.merge!({
+        course_subject_one: trainee.course_subject_one,
+        course_subject_two: trainee.course_subject_two,
+        course_subject_three: trainee.course_subject_three,
+      })
+    end
 
     age_range = Dttp::CodeSets::AgeRanges::MAPPING[trainee.course_age_range]
 

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -9,7 +9,6 @@ module Dttp
       COURSE_LEVEL_PG = 12
       COURSE_LEVEL_UG = 20
       ITT_QUALIFICATION_AIM_QTS = "68cbae32-7389-e711-80d8-005056ac45bb"
-      EARLY_YEARS_SUBJECT = "3aa12838-b3cf-e911-a860-000d3ab1da01"
       EARLY_YEARS_AGE_RANGE = AgeRange::ZERO_TO_FIVE
 
       attr_reader :trainee, :qualifying_degree, :params
@@ -68,7 +67,7 @@ module Dttp
       end
 
       def subject_entity_id
-        trainee.early_years_route? ? EARLY_YEARS_SUBJECT : course_subject_id(trainee.course_subject_one)
+        course_subject_id(trainee.course_subject_one)
       end
 
       def uk_specific_params
@@ -101,8 +100,6 @@ module Dttp
       end
 
       def first_subject
-        subject_entity_id = trainee.early_years_route? ? EARLY_YEARS_SUBJECT : course_subject_id(trainee.course_subject_one)
-
         { "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{subject_entity_id})" }
       end
 

--- a/app/lib/route_data_manager.rb
+++ b/app/lib/route_data_manager.rb
@@ -8,6 +8,7 @@ class RouteDataManager
   def update_training_route!(route)
     trainee.training_route = route
     reset_trainee_details if trainee.training_route_changed?
+    trainee.set_early_years_course_subject
     trainee.save!
   end
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -232,4 +232,10 @@ class Trainee < ApplicationRecord
   def bursary_amount
     CalculateBursary.for_route_and_subject(training_route.to_sym, course_subject_one)
   end
+
+  def set_early_years_course_subject
+    if early_years_route?
+      self.course_subject_one = Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING
+    end
+  end
 end

--- a/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
@@ -25,6 +25,7 @@ feature "Create trainee journey" do
     and_i_select_early_years_undergrad_route
     and_i_save_the_form
     then_i_should_see_the_new_trainee_overview
+    and_trainee_course_subject_one_set_to_early_years_teaching
   end
 
   scenario "provider led postgrad radio button not shown when feature set to false", "feature_routes.provider_led_postgrad": false do
@@ -127,5 +128,9 @@ private
 
   def then_i_should_see_a_validation_error
     expect(new_trainee_page).to have_content(I18n.t("activerecord.errors.models.trainee.attributes.training_route"))
+  end
+
+  def and_trainee_course_subject_one_set_to_early_years_teaching
+    expect(Trainee.last.course_subject_one).to eq(Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING)
   end
 end

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -369,4 +369,22 @@ describe CourseDetailsForm, type: :model do
       end
     end
   end
+
+  describe "#compute_fields" do
+    context "non early_years route" do
+      let(:trainee) { build(:trainee) }
+
+      it "include course subject columns" do
+        expect(subject.send(:compute_fields)).to include(:course_subject_one, :course_subject_two, :course_subject_three)
+      end
+    end
+
+    context "early_years route" do
+      let(:trainee) { build(:trainee, :early_years_undergrad) }
+
+      it "shouldnt include course subject columns" do
+        expect(subject.send(:compute_fields)).not_to include(:course_subject_one, :course_subject_two, :course_subject_three)
+      end
+    end
+  end
 end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -167,6 +167,7 @@ module Dttp
 
           before do
             stub_const("Dttp::CodeSets::AgeRanges::MAPPING", { AgeRange::ZERO_TO_FIVE => { entity_id: dttp_ey_age_range_entity_id } })
+            trainee.set_early_years_course_subject
           end
 
           it "returns a hash including the undergrad course level" do
@@ -183,7 +184,7 @@ module Dttp
 
           it "returns a hash containing the Early years subject" do
             expect(subject).to include(
-              { "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{Dttp::Params::PlacementAssignment::EARLY_YEARS_SUBJECT})" },
+              { "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{CodeSets::CourseSubjects::MAPPING[Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING][:entity_id]})" },
             )
           end
         end

--- a/spec/lib/route_data_manager_spec.rb
+++ b/spec/lib/route_data_manager_spec.rb
@@ -74,6 +74,21 @@ describe RouteDataManager do
       end
     end
 
+    context "when a trainee selects early_years_undergrad route" do
+      let(:trainee) { create(:trainee, :assessment_only) }
+
+      subject do
+        described_class.new(trainee: trainee).update_training_route!("early_years_undergrad")
+      end
+
+      it "trainee course_subject_one set to early years teaching" do
+        expect { subject }
+          .to change { trainee.training_route }
+          .from(trainee.training_route).to("early_years_undergrad")
+        expect(trainee.course_subject_one).to eq(Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING)
+      end
+    end
+
     context "when a trainee selects the same route" do
       before do
         subject

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -362,4 +362,13 @@ describe Trainee do
   describe "auditing" do
     it { is_expected.to be_audited.associated_with(:provider) }
   end
+
+  describe "#set_early_years_course_subject" do
+    let(:trainee) { build(:trainee, :early_years_undergrad) }
+
+    it "sets course_subject_one to early years teaching" do
+      trainee.set_early_years_course_subject
+      expect(trainee.course_subject_one).to eq(Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING)
+    end
+  end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/ZOJSkkUx/2139-early-years-save-the-early-years-teaching-subject-directly-onto-the-trainee

### Changes proposed in this pull request

* sets `course_subject_one` on trainee create and when route is changed
* `CourseDetailsForm` updated to not include subject columns so section is not started

### Guidance to review

