### PR TITLE
[2102] subject specialism form

### DIFF
--- a/app/controllers/trainees/subject_specialisms_controller.rb
+++ b/app/controllers/trainees/subject_specialisms_controller.rb
@@ -56,7 +56,7 @@ module Trainees
     end
 
     def specialism_params
-      return {} unless params[:subject_specialism_form].present?
+      return {} if params[:subject_specialism_form].blank?
 
       params.require(:subject_specialism_form).permit(:"specialism#{position}")
     end

--- a/app/controllers/trainees/subject_specialisms_controller.rb
+++ b/app/controllers/trainees/subject_specialisms_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Trainees
+  class SubjectSpecialismsController < ApplicationController
+    before_action :authorize_trainee
+    helper_method :position
+
+    def edit
+      # PITA
+      course = Course.find(10)
+      @subject = course.subjects[position - 1].name
+      @specialisms = CalculateSubjectSpecialisms.call(subjects: course.subjects.map(&:name))[:"course_subject_#{position_in_words}"]
+      @select_specialism_form = SelectSpecialismForm.new(trainee, position)
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def position
+      params[:position].to_i
+    end
+
+    def position_in_words
+      @_piw ||= to_word(position)
+    end
+
+    def to_word(number)
+      case number
+      when 1
+        "one"
+      when 2
+        "two"
+      when
+        "three"
+      end
+    end
+
+    def authorize_trainee
+      authorize(trainee)
+    end
+  end
+end

--- a/app/controllers/trainees/subject_specialisms_controller.rb
+++ b/app/controllers/trainees/subject_specialisms_controller.rb
@@ -56,6 +56,8 @@ module Trainees
     end
 
     def specialism_params
+      return {} unless params[:subject_specialism_form].present?
+
       params.require(:subject_specialism_form).permit(:"specialism#{position}")
     end
 

--- a/app/forms/subject_specialism_form.rb
+++ b/app/forms/subject_specialism_form.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+class SubjectSpecialismForm < TraineeForm
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations::Callbacks
+
+  FIELDS = %i[
+    specialism_1
+    specialism_2
+    specialism_3
+    course_subject_one
+    course_subject_two
+    course_subject_three
+  ].freeze
+
+  ERROR_TRANSLATION_KEY =
+    "activemodel.errors.models.subject_specialism_form.attributes.specialism.blank".freeze
+
+  validate :specialism_is_present
+
+  attr_accessor(*FIELDS)
+
+  def initialize(trainee, position, params: {}, user: nil, store: FormStore)
+    @position = position
+    @trainee = trainee
+    super(trainee, params: params, user: user, store: store)
+  end
+
+  def save!
+    if valid?
+      update_trainee_attributes
+      trainee.save!
+      store.set(trainee.id, :subject_specialism, nil)
+    else
+      false
+    end
+  end
+
+  private
+
+  def update_trainee_attributes
+    (1..3).each do |i|
+      trainee.send("#{subject_attribute(i)}=", fields[:"specialism_#{i}"])
+    end
+  end
+
+  def compute_fields
+    trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+  end
+
+  def subject_attribute(position = @position)
+    "course_subject_#{to_word(position)}"
+  end
+
+  def specialism_attribute
+    @_specialism_attribute ||= "specialism_#{@position}"
+  end
+
+  def to_word(number)
+    case number
+    when 1
+      "one"
+    when 2
+      "two"
+    when 3
+      "three"
+    end
+  end
+
+  def specialism_is_present
+    if @position && send(specialism_attribute).blank?
+      errors.add(specialism_attribute, I18n.t(ERROR_TRANSLATION_KEY))
+    end
+  end
+
+  def form_store_key
+    :subject_specialism
+  end
+end
+
+
+#/subject_specialism/3
+#
+#specialism_3
+#specialisms[:course_subject_3]
+#
+#
+#if save?
+#  if current_position < 3 && specialisms(course_subject#{position+1}.present?
+#
+#end

--- a/app/forms/subject_specialism_form.rb
+++ b/app/forms/subject_specialism_form.rb
@@ -6,16 +6,16 @@ class SubjectSpecialismForm < TraineeForm
   include ActiveModel::Validations::Callbacks
 
   FIELDS = %i[
-    specialism_1
-    specialism_2
-    specialism_3
+    specialism1
+    specialism2
+    specialism3
     course_subject_one
     course_subject_two
     course_subject_three
   ].freeze
 
   ERROR_TRANSLATION_KEY =
-    "activemodel.errors.models.subject_specialism_form.attributes.specialism.blank".freeze
+    "activemodel.errors.models.subject_specialism_form.attributes.specialism.blank"
 
   validate :specialism_is_present
 
@@ -37,11 +37,11 @@ class SubjectSpecialismForm < TraineeForm
     end
   end
 
-  private
+private
 
   def update_trainee_attributes
     (1..3).each do |i|
-      trainee.send("#{subject_attribute(i)}=", fields[:"specialism_#{i}"])
+      trainee.send("#{subject_attribute(i)}=", fields[:"specialism#{i}"])
     end
   end
 
@@ -54,7 +54,7 @@ class SubjectSpecialismForm < TraineeForm
   end
 
   def specialism_attribute
-    @_specialism_attribute ||= "specialism_#{@position}"
+    @_specialism_attribute ||= "specialism#{@position}"
   end
 
   def to_word(number)
@@ -78,15 +78,3 @@ class SubjectSpecialismForm < TraineeForm
     :subject_specialism
   end
 end
-
-
-#/subject_specialism/3
-#
-#specialism_3
-#specialisms[:course_subject_3]
-#
-#
-#if save?
-#  if current_position < 3 && specialisms(course_subject#{position+1}.present?
-#
-#end

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -27,6 +27,7 @@ class FormStore
     training_initiative
     bursary
     language_specialisms
+    subject_specialism
   ].freeze
 
   class << self

--- a/app/views/trainees/subject_specialisms/edit.html.erb
+++ b/app/views/trainees/subject_specialisms/edit.html.erb
@@ -1,0 +1,32 @@
+<%= render PageTitle::View.new(i18n_key: "trainees.course_details.edit", has_errors: @select_specialism_form.errors.present?) %>
+<%= content_for(:breadcrumbs) do %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+<% end %>
+<%= register_form_with(model: @select_specialism_form, url: trainee_subject_specialism_path(@trainee), method: :put, local: true) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <div class="govuk-form-group">
+
+    <%= f.govuk_radio_buttons_fieldset :"specialism_#{position}",
+                                      legend: { text: t(".heading", subject: @subject), tag: "h1", size: "l" } do %>
+
+      <div class="govuk-hint">
+        <p class="govuk-body govuk-hint">
+        <%= t(".hint") %>
+        </p>
+      <div>
+
+      <% @specialisms.each_with_index do |subject, index| %>
+        <%= f.govuk_radio_button(
+            :"specialism_#{position}",
+            subject,
+            multiple: true,
+            link_errors: index.zero?,
+            label: { text: subject },
+          ) %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/trainees/subject_specialisms/edit.html.erb
+++ b/app/views/trainees/subject_specialisms/edit.html.erb
@@ -2,7 +2,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
-<%= register_form_with(model: @select_specialism_form, url: trainee_subject_specialism_path(@trainee, position), method: :put, local: true) do |f| %>
+<%= register_form_with(model: @subject_specialism_form, url: trainee_subject_specialism_path(@trainee, position), method: :put, local: true) do |f| %>
   <%= f.govuk_error_summary %>
 
   <div class="govuk-form-group">

--- a/app/views/trainees/subject_specialisms/edit.html.erb
+++ b/app/views/trainees/subject_specialisms/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.course_details.edit", has_errors: @select_specialism_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.subject_specialisms.edit", has_errors: @subject_specialism_form.errors.present?) %>
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>

--- a/app/views/trainees/subject_specialisms/edit.html.erb
+++ b/app/views/trainees/subject_specialisms/edit.html.erb
@@ -2,12 +2,12 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
-<%= register_form_with(model: @select_specialism_form, url: trainee_subject_specialism_path(@trainee), method: :put, local: true) do |f| %>
+<%= register_form_with(model: @select_specialism_form, url: trainee_subject_specialism_path(@trainee, position), method: :put, local: true) do |f| %>
   <%= f.govuk_error_summary %>
 
   <div class="govuk-form-group">
 
-    <%= f.govuk_radio_buttons_fieldset :"specialism_#{position}",
+    <%= f.govuk_radio_buttons_fieldset :"specialism#{position}",
                                       legend: { text: t(".heading", subject: @subject), tag: "h1", size: "l" } do %>
 
       <div class="govuk-hint">
@@ -18,7 +18,7 @@
 
       <% @specialisms.each_with_index do |subject, index| %>
         <%= f.govuk_radio_button(
-            :"specialism_#{position}",
+            :"specialism#{position}",
             subject,
             multiple: true,
             link_errors: index.zero?,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -572,6 +572,10 @@ en:
       edit:
         heading: Employing school
         hint: Search for a school by its unique reference number (URN), name or postcode
+    subject_specialisms:
+      edit:
+        heading: Which %{subject} specialism has the trainee chosen to study?
+        hint: This specialism is what is recorded on the trainee's QTS award
 
   activerecord:
     attributes:
@@ -838,6 +842,10 @@ en:
               length:
                 one: "Enter at least one character"
                 other: "Enter at least %{count} characters"
+        subject_specialism_form:
+          attributes:
+            specialism:
+              blank: Select a specialism
         schools/lead_school_form:
           attributes:
             lead_school_id:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,8 @@ en:
             edit: Bursary funding
         language_specialisms:
           edit: Choose subject specialisms
+        subject_specialisms:
+          edit: Which specialism has the trainee chosen to study?
       providers:
         index: Providers
         new: Add a provider

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,8 @@ Rails.application.routes.draw do
       resource :apply_trainee_data, only: %i[update edit], path: "/apply-trainee-data"
 
       resource :timeline, only: :show
+
+      resource :subject_specialism, only: %i[edit update], path: "/subject-specialism/:position"
     end
 
     member do

--- a/spec/controllers/trainees/subject_specialisms_controller_spec.rb
+++ b/spec/controllers/trainees/subject_specialisms_controller_spec.rb
@@ -13,6 +13,7 @@ describe Trainees::SubjectSpecialismsController do
   describe "#update" do
     context "with empty form params" do
       let!(:course) { create(:course_with_subjects, subjects_count: 1) }
+
       it "rerenders the page" do
         put(:update, params: { trainee_id: trainee, position: 1 })
         expect(response.code).to eq("200")

--- a/spec/controllers/trainees/subject_specialisms_controller_spec.rb
+++ b/spec/controllers/trainees/subject_specialisms_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Trainees::SubjectSpecialismsController do
+  let(:user) { create(:user) }
+  let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.provider) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#update" do
+    context "there are more specialisms to choose" do
+      let!(:course) { create(:course_with_subjects, subjects_count: 2) }
+
+      it "does nice things" do
+        put(:update, params: { trainee_id: trainee, position: 1, subject_specialism_form: { specialism1: "moose" } })
+        expect(response).to redirect_to(
+          edit_trainee_subject_specialism_path(trainee, 2),
+        )
+      end
+    end
+
+    context "there are no more specialisms to choose" do
+      let!(:course) { create(:course_with_subjects, subjects_count: 1) }
+
+      # TODO: update this when  the confirm page exists
+      it "redirects to the confirm page" do
+        put(:update, params: { trainee_id: trainee, position: 1, subject_specialism_form: { specialism1: "moose" } })
+        expect(response).to redirect_to(
+          "www.example.com",
+        )
+      end
+    end
+  end
+end

--- a/spec/controllers/trainees/subject_specialisms_controller_spec.rb
+++ b/spec/controllers/trainees/subject_specialisms_controller_spec.rb
@@ -11,6 +11,14 @@ describe Trainees::SubjectSpecialismsController do
   end
 
   describe "#update" do
+    context "with empty form params" do
+      let!(:course) { create(:course_with_subjects, subjects_count: 1) }
+      it "rerenders the page" do
+        put(:update, params: { trainee_id: trainee, position: 1 })
+        expect(response.code).to eq("200")
+      end
+    end
+
     context "there are more specialisms to choose" do
       let!(:course) { create(:course_with_subjects, subjects_count: 2) }
 

--- a/spec/forms/subject_specialism_form_spec.rb
+++ b/spec/forms/subject_specialism_form_spec.rb
@@ -16,15 +16,15 @@ describe SubjectSpecialismForm, type: :model do
   describe "validations" do
     let(:position) { 1 }
 
-    it "validates the presence of the course subject matching the position"  do
+    it "validates the presence of the course subject matching the position" do
       expect(subject.valid?).to eq false
-      expect(subject.errors[:specialism_1]).to contain_exactly("Select a specialism")
+      expect(subject.errors[:specialism1]).to contain_exactly("Select a specialism")
     end
   end
 
   describe "#stash" do
     let(:position) { 1 }
-    let(:params) { { specialism_1: "special" } }
+    let(:params) { { specialism1: "special" } }
 
     it "uses FormStore to temporarily save the fields under a key combination of trainee ID and subject_specialism" do
       expect(form_store).to receive(:set).with(trainee.id, :subject_specialism,  subject.fields)
@@ -36,8 +36,8 @@ describe SubjectSpecialismForm, type: :model do
     let(:position) { nil }
     let(:stashed_fields) do
       {
-        specialism_1: "pizza",
-        specialism_2: "oragami",
+        specialism1: "pizza",
+        specialism2: "oragami",
       }
     end
 

--- a/spec/forms/subject_specialism_form_spec.rb
+++ b/spec/forms/subject_specialism_form_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SubjectSpecialismForm, type: :model do
+  let(:params) { {} }
+  let(:trainee) { build(:trainee, id: 123456) }
+  let(:form_store) { class_double(FormStore) }
+
+  subject { described_class.new(trainee, position, params: params, store: form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    let(:position) { 1 }
+
+    it "validates the presence of the course subject matching the position"  do
+      expect(subject.valid?).to eq false
+      expect(subject.errors[:specialism_1]).to contain_exactly("Select a specialism")
+    end
+  end
+
+  describe "#stash" do
+    let(:position) { 1 }
+    let(:params) { { specialism_1: "special" } }
+
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and subject_specialism" do
+      expect(form_store).to receive(:set).with(trainee.id, :subject_specialism,  subject.fields)
+      subject.stash
+    end
+  end
+
+  describe "#save!" do
+    let(:position) { nil }
+    let(:stashed_fields) do
+      {
+        specialism_1: "pizza",
+        specialism_2: "oragami",
+      }
+    end
+
+    before do
+      allow(form_store).to receive(:get).and_return(stashed_fields)
+      allow(form_store).to receive(:set).with(trainee.id, :subject_specialism, nil)
+    end
+
+    it "takes any data from the form store and saves it to the database" do
+      expect { subject.save! }.to change(trainee, :course_subject_one).to("pizza")
+        .and change(trainee, :course_subject_two).to("oragami")
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/uMJ3U4dm/2102-l-subjects-allow-users-to-choose-un-mappable-subjects-general

### Changes proposed in this pull request

Adds subject specialism form and controller, not wired up to the rest of the section yet as the confirm page isn't ready. Will connect this together in https://trello.com/c/ymhhRNpG/2105-l-subjects-refactor-of-current-publish-course-forms-flow

### Guidance to review

