### PR TITLE
[2154] Changed start date text to match prototype

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
       training_details:
         title: Trainee start date and ID
         start_date:
-          title: Date trainee started
+          title: Trainee's start date
       funding:
         title: Funding
         training_initiative:
@@ -184,7 +184,7 @@ en:
         trainee_ids:
           edit: Trainee ID
         trainee_start_date:
-          edit: Date trainee started
+          edit: Trainee's start date
         training_details:
           edit: Edit training details
         training_routes:
@@ -394,7 +394,7 @@ en:
       training_details:
         title: Trainee start date and ID
         commencement_date:
-          label: Date trainee started
+          label: What is the trainee's start date?
           hint_html:
             When the trainee started the course. This may be different to your overall course start date.<br><br>
             For example, 9 2 %{year}


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/ie7kfKtc/2154-general-snagging-trainee-start-date-and-id-content-changes)

### Changes proposed in this pull request

- Changed the text from `Date trainee started` to `Trainee's start date`

### Guidance to review

View the `Trainee start date and ID` section from the trainee details page

