### PR TITLE
[2103] bursaries new tiered bursary form

### DIFF
--- a/app/controllers/trainees/funding/bursaries_controller.rb
+++ b/app/controllers/trainees/funding/bursaries_controller.rb
@@ -32,9 +32,7 @@ module Trainees
       def bursary_params
         return { applying_for_bursary: nil } if params[:funding_bursary_form].blank?
 
-        params.require(:funding_bursary_form).permit(:applying_for_bursary).transform_values do |v|
-          ActiveModel::Type::Boolean.new.cast(v)
-        end
+        params.require(:funding_bursary_form).permit(:applying_for_bursary, :bursary_tier)
       end
 
       def authorize_trainee

--- a/app/controllers/trainees/funding/bursaries_controller.rb
+++ b/app/controllers/trainees/funding/bursaries_controller.rb
@@ -32,7 +32,7 @@ module Trainees
       def bursary_params
         return { applying_for_bursary: nil } if params[:funding_bursary_form].blank?
 
-        params.require(:funding_bursary_form).permit(:applying_for_bursary, :bursary_tier)
+        params.require(:funding_bursary_form).permit(:applying_for_bursary, :bursary_tier, :tiered_bursary_form)
       end
 
       def authorize_trainee

--- a/app/controllers/trainees/funding/training_initiatives_controller.rb
+++ b/app/controllers/trainees/funding/training_initiatives_controller.rb
@@ -15,7 +15,7 @@ module Trainees
         save_strategy = trainee.draft? ? :save! : :stash
 
         if @training_initiatives_form.public_send(save_strategy)
-          if trainee.bursary_amount.present?
+          if trainee.can_apply_for_bursary?
             redirect_to edit_trainee_funding_bursary_path(trainee)
           else
             trainee.update!(applying_for_bursary: false)

--- a/app/forms/funding/bursary_form.rb
+++ b/app/forms/funding/bursary_form.rb
@@ -4,13 +4,25 @@ module Funding
   class BursaryForm < TraineeForm
     FIELDS = %i[
       applying_for_bursary
+      bursary_tier
     ].freeze
 
     attr_accessor(*FIELDS)
 
+    before_validation :set_applying_for_bursary
+
     validates :applying_for_bursary, inclusion: { in: [true, false] }
+    validates :bursary_tier, inclusion: { in: Trainee.bursary_tiers.keys }, allow_blank: true
+
+    def applying_for_bursary=(value)
+      @applying_for_bursary = ActiveModel::Type::Boolean.new.cast(value)
+    end
 
   private
+
+    def set_applying_for_bursary
+      self.applying_for_bursary = true if bursary_tier.present?
+    end
 
     def compute_fields
       trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)

--- a/app/forms/funding/bursary_form.rb
+++ b/app/forms/funding/bursary_form.rb
@@ -5,6 +5,11 @@ module Funding
     FIELDS = %i[
       applying_for_bursary
       bursary_tier
+      tiered_bursary_form
+    ].freeze
+
+    NON_TRAINEE_FIELDS = %i[
+      tiered_bursary_form
     ].freeze
 
     attr_accessor(*FIELDS)
@@ -12,7 +17,7 @@ module Funding
     before_validation :set_applying_for_bursary
 
     validates :applying_for_bursary, inclusion: { in: [true, false] }
-    validates :bursary_tier, inclusion: { in: Trainee.bursary_tiers.keys }, allow_blank: true
+    validates :bursary_tier, inclusion: { in: Trainee.bursary_tiers.keys }, if: :requires_bursary_tier?
 
     def applying_for_bursary=(value)
       @applying_for_bursary = ActiveModel::Type::Boolean.new.cast(value)
@@ -30,6 +35,18 @@ module Funding
 
     def form_store_key
       :bursary
+    end
+
+    def requires_bursary_tier?
+      bursary_tier.present? || tier_not_selected?
+    end
+
+    def tier_not_selected?
+      tiered_bursary_form.present? && bursary_tier.nil?
+    end
+
+    def fields_to_ignore_before_stash_or_save
+      NON_TRAINEE_FIELDS
     end
   end
 end

--- a/app/lib/route_data_manager.rb
+++ b/app/lib/route_data_manager.rb
@@ -37,6 +37,7 @@ private
     {
       training_initiative: nil,
       applying_for_bursary: nil,
+      bursary_tier: nil,
     }
   end
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -238,4 +238,8 @@ class Trainee < ApplicationRecord
       self.course_subject_one = Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING
     end
   end
+
+  def can_apply_for_bursary?
+    training_route == TRAINING_ROUTE_ENUMS[:early_years_postgrad] || bursary_amount.present?
+  end
 end

--- a/app/services/calculate_bursary.rb
+++ b/app/services/calculate_bursary.rb
@@ -1,12 +1,22 @@
 # frozen_string_literal: true
 
 class CalculateBursary
+  TIER_AMOUNTS = {
+    tier_one: 5000,
+    tier_two: 4000,
+    tier_three: 2000,
+  }.freeze
+
   class << self
     # Returns true/false if there are any bursaries available for a given route.
     def available_for_route?(route)
       raise_if_route_not_recognised!(route)
 
       Bursary.find_by(training_route: route)&.bursary_subjects.present?
+    end
+
+    def for_tier(tier)
+      TIER_AMOUNTS[tier.to_sym]
     end
 
     # Returns the amount in pounds of bursary available for a given route/subject combo.

--- a/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
@@ -9,10 +9,9 @@
       subject: @subject,
       training_route: t("activerecord.attributes.trainee.training_routes.#{@trainee.training_route}")
     ) %>
-    </br>
-    </br>
-    <%= t("views.forms.funding.bursaries.guidance_html") %>
   </p>
+  <p class="govuk-body"><%= t("views.forms.funding.bursaries.guidance_html") %></p>
+
 
   <%= f.govuk_radio_buttons_fieldset(:applying_for_bursary, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
       <%= f.govuk_radio_button(

--- a/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
@@ -1,0 +1,33 @@
+<%= register_form_with(model: @bursary_form, url: trainee_funding_bursary_path(@trainee), method: :put, local: true) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %></h1>
+  <p class="govuk-body">
+    <%= t(
+      (@trainee.early_years_route? ? "views.forms.funding.bursaries.non_tiered.early_years_description" : "views.forms.funding.bursaries.non_tiered.description"),
+      amount: format_currency(@amount),
+      subject: @subject,
+      training_route: t("activerecord.attributes.trainee.training_routes.#{@trainee.training_route}")
+    ) %>
+    </br>
+    </br>
+    <%= t("views.forms.funding.bursaries.guidance_html") %>
+  </p>
+
+  <%= f.govuk_radio_buttons_fieldset(:applying_for_bursary, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
+      <%= f.govuk_radio_button(
+        :applying_for_bursary,
+        "true",
+        label: { text: t("views.forms.funding.bursaries.true") },
+        link_errors: true,
+      ) %>
+
+      <%= f.govuk_radio_button(
+        :applying_for_bursary,
+        "false",
+        hint: { text: t("views.forms.funding.bursaries.false_hint") },
+        label: { text: t("views.forms.funding.bursaries.false") },
+      ) %>
+  <% end %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
@@ -8,6 +8,7 @@
   <%= f.govuk_radio_buttons_fieldset(:bursary_tier, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
 
     <%= f.hidden_field :applying_for_bursary, value: false %>
+    <%= f.hidden_field :tiered_bursary_form, value: true %>
 
     <% BURSARY_TIERS.each do |tier_key, _tier_value| %>
       <%= f.govuk_radio_button(

--- a/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
@@ -2,12 +2,8 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %><h1>
-  <p class="govuk-body">
-    <%= t("views.forms.funding.bursaries.tiered.description") %>
-    </br>
-    </br>
-    <%= t("views.forms.funding.bursaries.guidance_html") %>
-  </p>
+  <p class="govuk-body"><%= t("views.forms.funding.bursaries.tiered.description") %></p>
+  <p class="govuk-body"><%= t("views.forms.funding.bursaries.guidance_html") %></p>
 
   <%= f.govuk_radio_buttons_fieldset(:bursary_tier, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
 
@@ -25,12 +21,14 @@
 
     <%= f.govuk_radio_divider %>
 
-      <%= f.govuk_radio_button(
-        :bursary_tier,
-        "",
+    <%= f.govuk_radio_button(
+      :bursary_tier,
+      "",
+      {
         hint: { text: t("views.forms.funding.bursaries.false_hint") },
         label: { text: t("views.forms.funding.bursaries.false") },
-      ) %>
+      }.merge(@trainee.applying_for_bursary.nil? ? { checked: false } : {} )
+    ) %>
   <% end %>
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
@@ -1,0 +1,36 @@
+<%= register_form_with(model: @bursary_form, url: trainee_funding_bursary_path(@trainee), method: :put, local: true) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %><h1>
+  <p class="govuk-body">
+    <%= t("views.forms.funding.bursaries.tiered.description") %>
+    </br>
+    </br>
+    <%= t("views.forms.funding.bursaries.guidance_html") %>
+  </p>
+
+  <%= f.govuk_radio_buttons_fieldset(:bursary_tier, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
+
+    <%= f.hidden_field :applying_for_bursary, value: false %>
+
+    <% BURSARY_TIERS.each do |tier_key, _tier_value| %>
+      <%= f.govuk_radio_button(
+        :bursary_tier,
+        tier_key,
+        label: { text: t("views.forms.funding.bursaries.tiered.#{tier_key}.label") },
+        hint: { text: t("views.forms.funding.bursaries.tiered.#{tier_key}.hint") },
+        link_errors: true,
+      ) %>
+    <% end %>
+
+    <%= f.govuk_radio_divider %>
+
+      <%= f.govuk_radio_button(
+        :bursary_tier,
+        "",
+        hint: { text: t("views.forms.funding.bursaries.false_hint") },
+        label: { text: t("views.forms.funding.bursaries.false") },
+      ) %>
+  <% end %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/trainees/funding/bursaries/edit.html.erb
+++ b/app/views/trainees/funding/bursaries/edit.html.erb
@@ -6,35 +6,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @bursary_form, url: trainee_funding_bursary_path(@trainee), method: :put, local: true) do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %></h1>
-      <p class="govuk-body">
-        <%= t(
-          (@trainee.early_years_route? ? "views.forms.funding.bursaries.early_years_description_html" : "views.forms.funding.bursaries.description_html"),
-          amount: format_currency(@amount),
-          subject: @subject,
-          training_route: t("activerecord.attributes.trainee.training_routes.#{@trainee.training_route}"),
-        ) %>
-      </p>
-
-        <%= f.govuk_radio_buttons_fieldset(:applying_for_bursary, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
-            <%= f.govuk_radio_button(
-              :applying_for_bursary,
-              "true",
-              label: { text: t("views.forms.funding.bursaries.true") },
-              link_errors: true,
-            ) %>
-
-            <%= f.govuk_radio_button(
-              :applying_for_bursary,
-              "false",
-              hint: { text: t("views.forms.funding.bursaries.false_hint") },
-              label: { text: t("views.forms.funding.bursaries.false") },
-            ) %>
-        <% end %>
-      <%= f.govuk_submit %>
-    <% end %>
+    <%= @trainee.early_years_postgrad? ? (render "tiered_bursary_form") : (render "non_tiered_bursary_form") %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -550,8 +550,8 @@ en:
       title: Funding
       training_initiative: Training initiative
       bursary_funding: Bursary funding
-      bursury_applied_for: Bursary applied for
-      no_bursury_applied_for: Not bursary funded
+      bursary_applied_for: Bursary applied for
+      no_bursary_applied_for: Not bursary funded
       tiered_bursary_applied_for:
         tier_one: Applied for Tier 1
         tier_two: Applied for Tier 2
@@ -763,7 +763,9 @@ en:
         funding/bursary_form:
           attributes:
             applying_for_bursary:
-              inclusion: Select if you are applying for a bursary for this trainee
+              inclusion: &bursary_selection_required Select if you are applying for a bursary for this trainee
+            bursary_tier:
+              inclusion: *bursary_selection_required
         outcome_date_form:
           attributes:
             date_string:
@@ -899,7 +901,9 @@ en:
               training_initiative:
                 blank: Select if the trainee is on a training initiative
               applying_for_bursary:
-                inclusion: Select if you are applying for a bursary for this trainee
+                inclusion: *bursary_selection_required
+              bursary_tier:
+                inclusion: *bursary_selection_required
   page_headings:
     start_page: Register trainee teachers
   system_admin:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,8 +418,21 @@ en:
             They provide incentives and support for people training to teach.<br><br>
             If you’re not sure if the trainee is on an initiative you could check with a colleague or ask the trainee directly.
         bursaries:
-          description_html: The course you have selected has a bursary available of %{amount} for %{subject}. You need to check if the trainee is eligible for this bursary </br></br> <a target="_blank" href="https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-fu[…]er-training-bursaries-funding-manual-2021-to-2022-academic-year">DfE bursary guidance for the academic year 2021 to 2022 (opens in new tab)</a>
-          early_years_description_html: "%{training_route} has a bursary available of %{amount}. You need to check if the trainee is eligible for this bursary.<br/><br/> <a target=\"_blank\" href=\"https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-fu[…]er-training-bursaries-funding-manual-2021-to-2022-academic-year\">DfE bursary guidance for the academic year 2021 to 2022 (opens in new tab)</a>"
+          non_tiered:
+            description: The course you have selected has a bursary available of %{amount} for %{subject}. You need to check if the trainee is eligible for this bursary.
+            early_years_description: "%{training_route} has a bursary available of %{amount}. You need to check if the trainee is eligible for this bursary."
+          tiered:
+            description: Early years (postgrad) has a bursary available. You need to check if the trainee is eligible for this bursary.
+            tier_one:
+              label: Yes - Tier 1 (£5,000)
+              hint: First-class honours degree, doctoral degree, medical masters (distinction)
+            tier_two:
+              label: Yes - Tier 2 (£4,000)
+              hint: 2:1 honours degree, master’s degree
+            tier_three:
+              label: Yes - Tier 3 (£2,000)
+              hint: 2:2 honours degree
+          guidance_html: <a target="_blank" href="https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-funding-manual/initial-teacher-training-bursaries-funding-manual-2021-to-2022-academic-year#training-bursary-award-and-eligibility">DfE bursary guidance for the academic year 2021 to 2022 (opens in new tab)</a>
           title: Are you applying for a bursary for this trainee?
           true: Yes, apply for a bursary
           false: No, do not apply for a bursary
@@ -539,6 +552,10 @@ en:
       bursary_funding: Bursary funding
       bursury_applied_for: Bursary applied for
       no_bursury_applied_for: Not bursary funded
+      tiered_bursary_applied_for:
+        tier_one: Applied for Tier 1
+        tier_two: Applied for Tier 2
+        tier_three: Applied for Tier 3
   trainees:
     not_supported_route:
       heading: Other routes not supported

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -8,6 +8,15 @@ module Funding
       render_inline(View.new(data_model: trainee))
     end
 
+    context "with tieried bursary" do
+      let(:trainee) { build(:trainee, :early_years_postgrad, applying_for_bursary: true, bursary_tier: BURSARY_TIERS.keys.first) }
+
+      it "renders tiered bursary text" do
+        expect(rendered_component).to have_text("Applied for Tier 1")
+        expect(rendered_component).to have_text("£5,000 estimated bursary")
+      end
+    end
+
     context "assessment only route" do
       let(:trainee) { build(:trainee, training_initiative: training_initiative) }
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -165,6 +165,10 @@ FactoryBot.define do
       training_route { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
     end
 
+    trait :early_years_postgrad do
+      training_route { TRAINING_ROUTE_ENUMS[:early_years_postgrad] }
+    end
+
     trait :early_years_undergrad do
       training_route { TRAINING_ROUTE_ENUMS[:early_years_undergrad] }
     end

--- a/spec/features/form_sections/teacher_training_data/edit_bursary_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_bursary_spec.rb
@@ -7,22 +7,31 @@ feature "edit bursary", type: :feature do
 
   let(:course_subject) { Dttp::CodeSets::CourseSubjects::LAW }
 
-  before do
+  scenario "edit with valid parameters" do
     given_a_trainee_exists(:provider_led_postgrad, course_subject_one: course_subject)
     and_a_bursary_exists_for_their_subject
     when_i_visit_the_bursary_page
-  end
-
-  scenario "edit with valid parameters" do
-    and_i_update_the_bursary
+    and_i_choose_applying_for_bursary
 
     and_i_submit_the_form
     then_i_am_redirected_to_the_funding_confirmation_page
   end
 
   scenario "submitting with invalid parameters" do
+    given_a_trainee_exists(:provider_led_postgrad, course_subject_one: course_subject)
+    and_a_bursary_exists_for_their_subject
+    when_i_visit_the_bursary_page
     and_i_submit_the_form
     then_i_see_error_messages
+  end
+
+  scenario "edit with valid parameters for tiered bursary" do
+    given_a_trainee_exists(:early_years_postgrad)
+    when_i_visit_the_bursary_page
+    and_i_choose_the_applicable_bursary_tier
+
+    and_i_submit_the_form
+    then_i_am_redirected_to_the_funding_confirmation_page
   end
 
 private
@@ -31,8 +40,12 @@ private
     bursary_page.load(id: trainee.slug)
   end
 
-  def and_i_update_the_bursary
+  def and_i_choose_applying_for_bursary
     bursary_page.applying_for_bursary.click
+  end
+
+  def and_i_choose_the_applicable_bursary_tier
+    bursary_page.bursary_tier.click
   end
 
   def and_i_submit_the_form

--- a/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
@@ -24,6 +24,14 @@ feature "edit training initiative", type: :feature do
     then_i_am_redirected_to_the_funding_confirmation_page
   end
 
+  scenario "edit with valid parameters on the early_years_postgrad route" do
+    given_a_trainee_exists(:early_years_postgrad)
+    when_i_visit_the_training_initiative_page
+    and_i_update_the_training_initiative
+    and_i_submit_the_form
+    then_i_am_redirected_to_the_bursary_page
+  end
+
   scenario "submitting with invalid parameters" do
     given_a_trainee_exists
     when_i_visit_the_training_initiative_page

--- a/spec/forms/funding/bursary_form_spec.rb
+++ b/spec/forms/funding/bursary_form_spec.rb
@@ -16,6 +16,24 @@ module Funding
 
     describe "validations" do
       it { is_expected.to validate_inclusion_of(:applying_for_bursary).in_array([true, false]) }
+      it { is_expected.to validate_inclusion_of(:bursary_tier).in_array(Trainee.bursary_tiers.keys) }
+
+      context "when bursary_tier is set" do
+        let(:params) do
+          {
+            "bursary_tier" => "tier_one",
+            "applying_for_bursary" => "false",
+          }
+        end
+
+        before do
+          subject.valid?
+        end
+
+        it "sets applying_for_bursary to true" do
+          expect(subject.applying_for_bursary).to eq(true)
+        end
+      end
     end
 
     describe "#stash" do

--- a/spec/forms/funding/bursary_form_spec.rb
+++ b/spec/forms/funding/bursary_form_spec.rb
@@ -16,7 +16,16 @@ module Funding
 
     describe "validations" do
       it { is_expected.to validate_inclusion_of(:applying_for_bursary).in_array([true, false]) }
-      it { is_expected.to validate_inclusion_of(:bursary_tier).in_array(Trainee.bursary_tiers.keys) }
+
+      context "with tiered_bursary_form" do
+        let(:params) do
+          {
+            "tiered_bursary_form" => "true",
+          }
+        end
+
+        it { is_expected.to validate_inclusion_of(:bursary_tier).in_array(Trainee.bursary_tiers.keys) }
+      end
 
       context "when bursary_tier is set" do
         let(:params) do
@@ -26,11 +35,10 @@ module Funding
           }
         end
 
-        before do
-          subject.valid?
-        end
+        it { is_expected.to validate_inclusion_of(:bursary_tier).in_array(Trainee.bursary_tiers.keys) }
 
         it "sets applying_for_bursary to true" do
+          subject.valid?
           expect(subject.applying_for_bursary).to eq(true)
         end
       end

--- a/spec/lib/route_data_manager_spec.rb
+++ b/spec/lib/route_data_manager_spec.rb
@@ -50,7 +50,7 @@ describe RouteDataManager do
       end
 
       context "when the trainee has funding" do
-        let(:trainee) { create(:trainee, :assessment_only, :with_funding, progress: progress) }
+        let(:trainee) { create(:trainee, :assessment_only, :with_funding, :with_tiered_bursary, progress: progress) }
 
         it "wipes initiative details" do
           expect { subject }
@@ -64,6 +64,8 @@ describe RouteDataManager do
           expect { subject }
             .to change { trainee.applying_for_bursary }
             .from(trainee.applying_for_bursary).to(nil)
+            .and change { trainee.bursary_tier }
+            .from(trainee.bursary_tier).to(nil)
         end
 
         it "resets the funding progress" do

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -235,6 +235,26 @@ describe Trainee do
     end
   end
 
+  describe "#can_apply_for_bursary?" do
+    let(:trainee) { create(:trainee) }
+
+    subject { trainee.can_apply_for_bursary? }
+
+    it { is_expected.to be_falsey }
+
+    context "when the trainee is on the early_years_postgrad route" do
+      let(:trainee) { create(:trainee, :early_years_postgrad) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when the bursary amount is calculated on the selected route and subject" do
+      before { allow(CalculateBursary).to receive(:for_route_and_subject).and_return(1000) }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
   describe "#with_name_trainee_id_or_trn_like" do
     let(:other_trainee) { create(:trainee) }
     let(:matching_trainee) do

--- a/spec/services/calculate_bursary_spec.rb
+++ b/spec/services/calculate_bursary_spec.rb
@@ -37,6 +37,13 @@ describe CalculateBursary do
     end
   end
 
+  describe "#for_tier" do
+    it { expect(described_class.for_tier("invalid")).to be_nil }
+    it { expect(described_class.for_tier(BURSARY_TIERS.keys.first)).to eq 5000 }
+    it { expect(described_class.for_tier(BURSARY_TIERS.keys.second)).to eq 4000 }
+    it { expect(described_class.for_tier(BURSARY_TIERS.keys.third)).to eq 2000 }
+  end
+
   describe "#for_route_and_subject" do
     let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
     let(:subject_specialism) { create(:subject_specialism) }

--- a/spec/support/page_objects/trainees/funding/bursary.rb
+++ b/spec/support/page_objects/trainees/funding/bursary.rb
@@ -7,6 +7,7 @@ module PageObjects
         set_url "/trainees/{id}/funding/bursary/edit"
 
         element :applying_for_bursary, "#funding-bursary-form-applying-for-bursary-true-field"
+        element :bursary_tier, "#funding-bursary-form-bursary-tier-tier-one-field"
         element :not_applying_for_bursary, "#funding-bursary-form-applying-for-bursary-false-field"
 
         element :submit_button, "button[type='submit']"


### PR DESCRIPTION
### Context
For a trainee on the Early years (postgrad) route, we show them a different bursary choice form, listing the possible tiers available, plus an option for "Not applying for bursary"

### Changes proposed in this pull request
Split the bursary section into two forms, one for tiered bursaries, applicable on the EY postgrad route, and the standard bursary form for all other routes where bursaries are applicable.

### Guidance to review
1. For a draft trainee on the early years (postgrad) route, visit the funding section, and complete the initiative section, and press continue.
2. A tiered bursary form should be now seen, allowing the user to choose between tiers one, two, three, or do not apply
3. Select an option and expect to see the chosen tier in the confirmation page.
