### PR TITLE
[2157] TRN Submissions page and route updated

### DIFF
--- a/app/views/trn_submissions/show.html.erb
+++ b/app/views/trn_submissions/show.html.erb
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <div class="govuk-panel govuk-panel--confirmation trn-submission-success-panel govuk-!-margin-bottom-6">
       <h1 class="govuk-panel__title">
-        Record submitted for <%= trainee_name(@trainee) %>
+        <%= trainee_name(@trainee) %> is registered
       </h1>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,7 +119,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :trn_submissions, only: %i[create show], param: :trainee_id
+  resources :trn_submissions, only: %i[create show], param: :trainee_id, path: "trainee-registrations"
 
   root to: "pages#start"
 end

--- a/spec/features/trainee_actions/submit_for_trn_spec.rb
+++ b/spec/features/trainee_actions/submit_for_trn_spec.rb
@@ -118,7 +118,7 @@ feature "submit for TRN" do
   end
 
   def with_the_correct_content
-    expect(trn_success_page).to have_text("Record submitted for #{trainee_name(trainee)}")
+    expect(trn_success_page).to have_text("#{trainee_name(trainee)} is registered")
     expect(trn_success_page).to have_link("view #{trainee_name(trainee)}", href: trainee_path(trainee))
     expect(trn_success_page).to have_link("add a new trainee", href: new_trainee_path)
     expect(trn_success_page).to have_link("view all your records", href: trainees_path)

--- a/spec/support/page_objects/trainees/trn_success.rb
+++ b/spec/support/page_objects/trainees/trn_success.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Trainees
     class TrnSuccess < Base
-      set_url "/trn_submissions/{trainee_id}"
+      set_url "/trainee-registrations/{trainee_id}"
     end
   end
 end


### PR DESCRIPTION
### Context

-[This trello ticket](https://trello.com/c/WmZdvggX/2157-general-snagging-submitted-for-trn-page)

### Changes proposed in this pull request

- TRN submission route changed. You can find it now at `/trainee-registrations/{trainee_slug}`
- Content now says `{trainee name} is registered`

### Guidance to review

- Go to `/trainee-registrations/{trainee_slug}` to see the content changes. 

