### PR TITLE
[2153] Review draft page updated

### DIFF
--- a/app/components/review_draft/apply_draft/view.html.erb
+++ b/app/components/review_draft/apply_draft/view.html.erb
@@ -1,7 +1,4 @@
-<h1 class="govuk-heading-l">
-  <span class="govuk-caption-l"><%= trainee_draft_title(@trainee) %></span>
-  <%= t("components.page_titles.trainees.show.apply_draft") %>
-</h1>
+<%= trainee_draft_title(trainee) %>
 
 <%= render RouteIndicator::View.new(trainee: @trainee) %>
 

--- a/app/components/review_draft/draft/view.html.erb
+++ b/app/components/review_draft/draft/view.html.erb
@@ -1,7 +1,4 @@
-<h1 class="govuk-heading-l">
-  <span class="govuk-caption-l"><%= trainee_draft_title(@trainee) %></span>
-  <%= t("components.page_titles.trainees.show.draft") %>
-</h1>
+<%= trainee_draft_title(trainee) %>
 
 <%= render RouteIndicator::View.new(trainee: @trainee) %>
 

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -40,11 +40,9 @@ module TraineeHelper
   end
 
   def trainee_draft_title(trainee)
-    name = trainee_name(trainee)
-    title_suffix = "#{name.present? ? " for #{name}" : ''} "
-    translation_prefix = t("views.trainees.show.#{trainee.apply_application? ? 'apply_draft' : 'draft'}")
+    draft_or_apply_draft_caption = t("views.trainees.show.#{trainee.apply_application? ? 'apply_draft' : 'draft'}")
 
-    "#{translation_prefix}#{title_suffix}"
+    tag.span(draft_or_apply_draft_caption, class: "govuk-caption-l") + tag.h1(trainee_name(trainee).presence || t("components.page_titles.trainees.show.#{trainee.apply_application? ? 'apply_draft' : 'draft'}"), class: "govuk-heading-l")
   end
 
   def checked?(filters, filter, value)

--- a/spec/views/trainees/review_draft/show.html.erb_spec.rb
+++ b/spec/views/trainees/review_draft/show.html.erb_spec.rb
@@ -33,22 +33,38 @@ describe "trainees/review_draft/show.html.erb" do
 
   describe "trainees/review_draft/show.html.erb", "feature_routes.provider_led_postgrad": true
 
-  context "with an Apply draft trainee" do
+  context "with a named Apply draft trainee" do
     let(:trainee) { create(:trainee, :with_apply_application) }
     let(:trainee_name) { "#{trainee.first_names} #{trainee.middle_names} #{trainee.last_name}" }
 
     it "renders Apply draft text" do
-      expect(rendered).to have_text("Apply draft for #{trainee_name}")
+      expect(rendered).to have_text("Apply draft")
+      expect(rendered).to have_text(trainee_name)
+    end
+  end
+
+  context "with an unnamed Apply draft trainee" do
+    let(:trainee) { create(:trainee, :with_apply_application, first_names: nil, middle_names: nil, last_name: nil) }
+
+    it "renders Apply draft text" do
       expect(rendered).to have_text("Register a trainee")
     end
   end
 
-  context "with an normal draft trainee" do
+  context "with a named normal draft trainee" do
     let(:trainee) { create(:trainee, :draft) }
     let(:trainee_name) { "#{trainee.first_names} #{trainee.middle_names} #{trainee.last_name}" }
 
     it "renders draft record text" do
-      expect(rendered).to have_text("Draft record for #{trainee_name}")
+      expect(rendered).to have_text("Draft record")
+      expect(rendered).to have_text(trainee_name)
+    end
+  end
+
+  context "with an unnamed normal draft trainee" do
+    let(:trainee) { create(:trainee, first_names: nil, middle_names: nil, last_name: nil) }
+
+    it "renders draft record text" do
       expect(rendered).to have_text("Add a trainee")
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/XGbZ0khL/2153-general-snagging-review-draft-page
### Changes proposed in this pull request
* Changed functionality of helper method so that a draft trainee will simply have "Draft record" as caption and "Add a trainee" as the h1 if unnamed. If named, the name will be the h1 instead. 
* Changed for an apply draft trainee too as it would otherwise become tech debt? 
* Updated view spec 
### Guidance to review
Add a trainee and check when named and unnamed
If you want to check apply draft trainee you'd need to create apply application and associate with trainee
Though screenshot below 

<img width="810" alt="Screenshot 2021-07-06 at 15 55 27" src="https://user-images.githubusercontent.com/58793682/124622464-0f0c4600-de73-11eb-81ff-b83ba0d2959d.png">
