### PR TITLE
[2150] Fix check details inset text spacing

### DIFF
--- a/app/components/collapsed_section/style.scss
+++ b/app/components/collapsed_section/style.scss
@@ -1,11 +1,16 @@
 @import "../base.scss";
 
+$govuk-border-width-narrow: 5px;
+
 .app-inset-text--narrow-border {
   border-left-width: $govuk-border-width-narrow;
 }
 
 .app-inset-text--important {
   border-color: govuk-colour("blue");
+  padding: govuk-spacing(2);
+  padding-left: govuk-spacing(3);
+  margin: govuk-spacing(0) auto govuk-spacing(4);
 
   .app-inset-text__title {
     color: govuk-colour("blue");
@@ -22,5 +27,5 @@
 
 .app-inset-text__title {
   @include govuk-font($size: 19, $weight: "bold");
-  margin-bottom: govuk-spacing(2);
+  margin-bottom: govuk-spacing(0);
 }

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -23,7 +23,7 @@
           <span class="govuk-caption-l">
             Draft record <%= "for #{trainee_name(@trainee)}" if trainee_name(@trainee).present? %>
           </span>
-          Review trainee record
+          Check trainee record
         </h1>
 
         <% unless @form.all_sections_complete? %>


### PR DESCRIPTION
### Context

- https://trello.com/c/0mOfm8kh/2150-general-snagging-check-details-page

### Changes proposed in this pull request

- Fixes spacing on inset text components on `/check-details` to match prototype

<img width="846" alt="Screenshot 2021-07-06 at 16 25 47" src="https://user-images.githubusercontent.com/616080/124626814-ea19d200-de76-11eb-88f5-ac173be687fa.png">

### Guidance to review

