### PR TITLE
[2158] Schools snagging JS and Non-JS school form

### DIFF
--- a/app/controllers/trainees/employing_schools_controller.rb
+++ b/app/controllers/trainees/employing_schools_controller.rb
@@ -55,7 +55,7 @@ module Trainees
     end
 
     def index_or_edit_page
-      @employing_school_form.index_page_radio_buttons? ? :index : :edit
+      @employing_school_form.search_results_found? ? :index : :edit
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/lead_schools_controller.rb
+++ b/app/controllers/trainees/lead_schools_controller.rb
@@ -3,12 +3,12 @@
 module Trainees
   class LeadSchoolsController < ApplicationController
     before_action :authorize_trainee
-    before_action :load_schools
 
     helper_method :query
 
     def index
       @lead_school_form = Schools::LeadSchoolForm.new(trainee)
+      @school_search = SchoolSearch.call(query: query, lead_schools_only: true)
     end
 
     def edit
@@ -27,6 +27,7 @@ module Trainees
       if @lead_school_form.public_send(save_strategy)
         redirect_to origin_page_or_next_step
       else
+        @school_search = SchoolSearch.call(query: params[:query], lead_schools_only: true)
         render index_or_edit_page
       end
     end
@@ -35,10 +36,6 @@ module Trainees
 
     def redirect_url
       trainee.requires_employing_school? ? edit_trainee_employing_schools_path(trainee) : trainee_schools_confirm_path(trainee)
-    end
-
-    def load_schools
-      @school_search = SchoolSearch.call(query: query, lead_schools_only: true)
     end
 
     def trainee
@@ -68,7 +65,7 @@ module Trainees
     end
 
     def index_or_edit_page
-      @lead_school_form.index_page_radio_buttons? ? :index : :edit
+      @lead_school_form.search_results_found? || @lead_school_form.no_results_searching_again? ? :index : :edit
     end
 
     def authorize_trainee

--- a/app/forms/schools/employing_school_form.rb
+++ b/app/forms/schools/employing_school_form.rb
@@ -8,7 +8,9 @@ module Schools
 
     attr_accessor(*FIELDS)
 
-    validates :employing_school_id, presence: true, unless: -> { school_not_selected? }
+    validates :employing_school_id,
+              presence: true,
+              if: -> { search_results_found? && results_search_again_query.blank? }
 
     alias_method :school_id, :employing_school_id
 

--- a/app/forms/schools/form.rb
+++ b/app/forms/schools/form.rb
@@ -6,19 +6,21 @@ module Schools
       query
       results_search_again_query
       no_results_search_again_query
-      school_value
+      search_results_found
     ].freeze
 
     attr_accessor(*NON_TRAINEE_FIELDS)
 
     validates :query,
+              presence: true,
               length: {
                 minimum: SchoolSearch::MIN_QUERY_LENGTH,
                 message: I18n.t("activemodel.errors.models.schools_form.attributes.query.length"),
               },
-              if: -> { initial_incomplete_search? }
+              if: -> { initial_search? }
 
     validates :results_search_again_query,
+              presence: true,
               length: {
                 minimum: SchoolSearch::MIN_QUERY_LENGTH,
                 message: I18n.t("activemodel.errors.models.schools_form.attributes.query.length"),
@@ -26,37 +28,34 @@ module Schools
               if: -> { results_searching_again? }
 
     validates :no_results_search_again_query,
+              presence: true,
               length: {
                 minimum: SchoolSearch::MIN_QUERY_LENGTH,
                 message: I18n.t("activemodel.errors.models.schools_form.attributes.query.length"),
               },
               if: -> { no_results_searching_again? }
 
-    def searching_again?
-      results_searching_again? || no_results_searching_again?
+    def search_results_found?
+      search_results_found == "true"
     end
 
-    def results_searching_again?
-      school_id == "results_search_again" || results_search_again_query.present?
+    def school_not_selected?
+      school_id.to_i.zero?
     end
 
     def no_results_searching_again?
       school_id == "no_results_search_again"
     end
 
-    def index_page_radio_buttons?
-      school_value == "true"
-    end
-
-    def initial_incomplete_search?
-      query.present? && school_id.blank?
-    end
-
-    def school_not_selected?
-      searching_again? || initial_incomplete_search?
-    end
-
   private
+
+    def initial_search?
+      params.key?("query")
+    end
+
+    def results_searching_again?
+      school_id == "results_search_again"
+    end
 
     def school_id
       raise NotImplementedError

--- a/app/forms/schools/lead_school_form.rb
+++ b/app/forms/schools/lead_school_form.rb
@@ -8,7 +8,9 @@ module Schools
 
     attr_accessor(*FIELDS)
 
-    validates :lead_school_id, presence: true, unless: -> { school_not_selected? }
+    validates :lead_school_id,
+              presence: true,
+              if: -> { search_results_found? && results_search_again_query.blank? }
 
     alias_method :school_id, :lead_school_id
 

--- a/app/views/trainees/employing_schools/_results.html.erb
+++ b/app/views/trainees/employing_schools/_results.html.erb
@@ -1,12 +1,11 @@
 <%= f.govuk_error_summary %>
 
 <%= f.hidden_field :employing_school_id, value: nil %>
+<%= f.hidden_field :search_results_found, value: "true" %>
 
-<%= f.govuk_radio_buttons_fieldset :employing_school_id, 
+<%= f.govuk_radio_buttons_fieldset :employing_school_id,
   legend: { text: t("components.page_titles.trainees.employing_schools.index"), tag: "h1", size: "l" },
   hint: { text: "#{t('components.page_titles.search_schools.sub_text_results')} ‘#{query}’" } do %>
-  <%= f.hidden_field :school_value, value: "true" %>
-
     <% @school_search.schools.each_with_index do |school, index| %>
       <%= f.govuk_radio_button :employing_school_id, school.id,
                               checked: false,

--- a/app/views/trainees/lead_schools/_no_results.html.erb
+++ b/app/views/trainees/lead_schools/_no_results.html.erb
@@ -1,12 +1,14 @@
-<h1 class="govuk-heading-l govuk-!-margin-bottom-1">
-  <%= t("components.page_titles.search_schools.page_title_no_results") %>
-</h1>
+<% if f.object.valid? %>
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
+    <%= t("components.page_titles.search_schools.page_title_no_results") %>
+  </h1>
 
-<div class="govuk-inset-text">
-  <p class="govuk-body"><%= t("components.page_titles.search_schools.sub_text_no_results") %>
-    <span class="govuk-!-font-weight-bold"><%= query %></span>.
-  </p>
-</div>
+  <div class="govuk-inset-text">
+    <p class="govuk-body"><%= t("components.page_titles.search_schools.sub_text_no_results") %>
+      <span class="govuk-!-font-weight-bold"><%= query %></span>.
+    </p>
+  </div>
+<% end %>
 
 <%= f.govuk_error_summary %>
 

--- a/app/views/trainees/lead_schools/_results.html.erb
+++ b/app/views/trainees/lead_schools/_results.html.erb
@@ -1,12 +1,11 @@
 <%= f.govuk_error_summary %>
 
 <%= f.hidden_field :lead_school_id, value: nil %>
+<%= f.hidden_field :search_results_found, value: "true" %>
 
-<%= f.govuk_radio_buttons_fieldset :lead_school_id, 
-  legend: { text: t("components.page_titles.trainees.lead_schools.index"), tag: "h1", size: "l" }, 
+<%= f.govuk_radio_buttons_fieldset :lead_school_id,
+  legend: { text: t("components.page_titles.trainees.lead_schools.index"), tag: "h1", size: "l" },
   hint: { text: "#{t('components.page_titles.search_schools.sub_text_results')} ‘#{query}’" } do %>
-  <%= f.hidden_field :school_value, value: "true" %>
-
     <% @school_search.schools.each_with_index do |school, index| %>
       <%= f.govuk_radio_button :lead_school_id, school.id,
                               checked: false,

--- a/app/views/trainees/lead_schools/edit.html.erb
+++ b/app/views/trainees/lead_schools/edit.html.erb
@@ -6,7 +6,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with model: @lead_school_form, url: trainee_lead_schools_path(@trainee), local: true, html: { data: { module: "app-schools-autocomplete" } } do |f| %>
+    <%= register_form_with model: @lead_school_form, url: trainee_lead_schools_path(@trainee), local: true,
+                           html: { data: { module: "app-schools-autocomplete" } } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field(
@@ -17,7 +18,8 @@
         "data-field" => "schools-autocomplete",
         width: "three-quarters",
       ) %>
-      <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-only-lead-schools=true data-default-value="<%= query %>" data-field-name="schools_lead_school_form[query]"></div>
+      <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-only-lead-schools=true
+           data-default-value="<%= query %>" data-field-name="schools_lead_school_form[query]"></div>
 
       <%= f.hidden_field :lead_school_id, id: "school-id", value: nil %>
       <%= f.govuk_submit t("continue") %>

--- a/config/initializers/publish_subject_mapping.rb
+++ b/config/initializers/publish_subject_mapping.rb
@@ -10,7 +10,7 @@ PUBLISH_SUBJECT_SPECIALISM_MAPPING = Dttp::CodeSets::AllocationSubjects::MAPPING
 end
 
 PUBLISH_LANGUAGE_SUBJECTS = Dttp::CodeSets::AllocationSubjects::MAPPING[
-  Dttp::CodeSets::AllocationSubjects::MODERN_LANGUAGES][:subject_specialisms
-].map { |subject_specialism|
+  Dttp::CodeSets::AllocationSubjects::MODERN_LANGUAGES
+][:subject_specialisms].map { |subject_specialism|
   subject_specialism[:publish_equivalent]
 }.uniq

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -854,6 +854,8 @@ en:
               blank: Select a specialism
         schools/lead_school_form:
           attributes:
+            query:
+              blank: Enter a school unique reference number (URN), name or postcode
             lead_school_id:
               blank: Select a lead school or search again
             results_search_again_query:
@@ -862,6 +864,8 @@ en:
               blank: Enter a school unique reference number (URN), name or postcode
         schools/employing_school_form:
           attributes:
+            query:
+              blank: Enter a school unique reference number (URN), name or postcode
             employing_school_id:
               blank: Select an employing school or search again
             results_search_again_query:

--- a/spec/support/shared_examples/school_form_validations.rb
+++ b/spec/support/shared_examples/school_form_validations.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples "school form validations" do |school_id_key|
   end
 
   context "when searching again" do
-    let(:params) { { "results_search_again_query" => "a" } }
+    let(:params) { { "results_search_again_query" => "a", school_id_key => "results_search_again" } }
 
     it "returns an error against the search again query" do
       expect(subject.errors[:results_search_again_query]).to include(I18n.t("activemodel.errors.models.schools_form.attributes.query.length", count: 2))
@@ -21,7 +21,7 @@ RSpec.shared_examples "school form validations" do |school_id_key|
 
   context "with no school chosen and no query provided" do
     let(:form_name) { school_id_key.sub("id", "form") }
-    let(:params) { { "results_search_again_query" => "", school_id_key => "" } }
+    let(:params) { { "results_search_again_query" => "", school_id_key => "", "search_results_found" => "true" } }
 
     it "returns an error" do
       expect(subject.errors[school_id_key]).to include(


### PR DESCRIPTION
### Context
https://trello.com/c/0B55QgA3/2158-schools-snagging-js-school-form

### Changes proposed in this pull request
#### Scenario 1
- When the user submits an empty search form, the field itself should appear with error styling and the link in the error summary should link to the field

#### Scenario 2
- When search results are rendered and the user submits the form without choosing a school, it renders a message prompting the user to select a school or search again.
- If the user chooses to search again and submits an empty form, it's get the error message about missing query
- If the user searches again using one character, it's get the appropriate message about miniumum length and no other error message

### Guidance to review
- Create a "School direct (salaried)" trainee and visit the schools section
- Play around with the forms and see if you can break it
