### PR TITLE
[2173] Use min_alpha in ensure alphanumeric course codes

### DIFF
--- a/spec/controllers/trainees/subject_specialisms_controller_spec.rb
+++ b/spec/controllers/trainees/subject_specialisms_controller_spec.rb
@@ -32,7 +32,7 @@ describe Trainees::SubjectSpecialismsController do
     end
 
     context "there are no more specialisms to choose" do
-      let!(:course) { create(:course_with_subjects, subjects_count: 1) }
+      let!(:course) { create(:course_with_subjects, subjects_count: 1, subject_names: [Dttp::CodeSets::AllocationSubjects::ART_AND_DESIGN]) }
 
       # TODO: update this when  the confirm page exists
       it "redirects to the confirm page" do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :course do
     name { PUBLISH_SUBJECT_SPECIALISM_MAPPING.keys.sample }
-    code { Faker::Alphanumeric.unique.alphanumeric(number: 4).upcase }
+    code { Faker::Alphanumeric.unique.alphanumeric(number: 4, min_alpha: 1).upcase }
     accredited_body_code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     start_date { Time.zone.today }
     level { :primary }

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :subject do
-    sequence(:name) { PUBLISH_SUBJECT_SPECIALISM_MAPPING.keys.sample }
+    name { ["Primary with geography and history", "Primary with modern languages", "Primary with physical education", "Primary with science"].sample }
     code { Faker::Alphanumeric.unique.alphanumeric(number: 2).upcase }
   end
 

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :subject do
-    name { ["Primary with geography and history", "Primary with modern languages", "Primary with physical education", "Primary with science"].sample }
+    name { PUBLISH_SUBJECT_SPECIALISM_MAPPING.keys.sample }
     code { Faker::Alphanumeric.unique.alphanumeric(number: 2).upcase }
   end
 


### PR DESCRIPTION
### Context
This flaky spec can be reproduced consistently by enforcing a fully numeric
code in the factory, eg:

```ruby
Faker::Alphanumeric.unique.alphanumeric(number: 4, min_numeric: 4).upcase
```
which will raise a `NonCaseSwappableValueError` error.

This change will ensure that we have at least one alphabet, and prevent
the exception from being raised randomly in the test suite.


Also fixes https://trello.com/c/rr0UvNtL/2182-flaky-test-traineessubjectspecialismscontrollerupdate:
Made failure consistently reproducible via https://github.com/DFE-Digital/register-trainee-teachers/pull/1109/commits/0d612648163a308d4f09dd4b11f6f25d2657ce66, and fixed via https://github.com/DFE-Digital/register-trainee-teachers/pull/1109/commits/fe2efea34c539732f7f2bc8c9c610d156987af1c


