### PR TITLE
[2159] schools snagging nonjs form

### DIFF
--- a/app/views/trainees/employing_schools/_results.html.erb
+++ b/app/views/trainees/employing_schools/_results.html.erb
@@ -1,18 +1,10 @@
 <%= f.govuk_error_summary %>
 
-<h1 class="govuk-heading-l govuk-!-margin-bottom-1">
-  <%= t("components.page_titles.trainees.employing_schools.index") %>
-</h1>
-
-<% if query.present? %>
-  <div class="govuk-hint">
-    <%= t("components.page_titles.search_schools.sub_text_results") %> ‘<%= query %>’
-  </div>
-<% end %>
-
 <%= f.hidden_field :employing_school_id, value: nil %>
 
-<%= f.govuk_radio_buttons_fieldset :employing_school_id, legend: nil do %>
+<%= f.govuk_radio_buttons_fieldset :employing_school_id, 
+  legend: { text: t("components.page_titles.trainees.employing_schools.index"), tag: "h1", size: "l" },
+  hint: { text: "#{t('components.page_titles.search_schools.sub_text_results')} ‘#{query}’" } do %>
   <%= f.hidden_field :school_value, value: "true" %>
 
     <% @school_search.schools.each_with_index do |school, index| %>

--- a/app/views/trainees/lead_schools/_results.html.erb
+++ b/app/views/trainees/lead_schools/_results.html.erb
@@ -1,18 +1,10 @@
 <%= f.govuk_error_summary %>
 
-<h1 class="govuk-heading-l govuk-!-margin-bottom-1">
-  <%= t("components.page_titles.trainees.lead_schools.index") %>
-</h1>
-
-<% if query.present? %>
-  <div class="govuk-hint">
-    <%= t("components.page_titles.search_schools.sub_text_results") %> ‘<%= query %>’
-  </div>
-<% end %>
-
 <%= f.hidden_field :lead_school_id, value: nil %>
 
-<%= f.govuk_radio_buttons_fieldset :lead_school_id, legend: nil do %>
+<%= f.govuk_radio_buttons_fieldset :lead_school_id, 
+  legend: { text: t("components.page_titles.trainees.lead_schools.index"), tag: "h1", size: "l" }, 
+  hint: { text: "#{t('components.page_titles.search_schools.sub_text_results')} ‘#{query}’" } do %>
   <%= f.hidden_field :school_value, value: "true" %>
 
     <% @school_search.schools.each_with_index do |school, index| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -851,7 +851,7 @@ en:
         schools/lead_school_form:
           attributes:
             lead_school_id:
-              blank: Enter a school unique reference number (URN), name or postcode
+              blank: Select a lead school or search again
             results_search_again_query:
               blank: Enter a school unique reference number (URN), name or postcode
             no_results_search_again_query:
@@ -859,7 +859,7 @@ en:
         schools/employing_school_form:
           attributes:
             employing_school_id:
-              blank: Enter a school unique reference number (URN), name or postcode
+              blank: Select an employing school or search again
             results_search_again_query:
               blank: Enter a school unique reference number (URN), name or postcode
             no_results_search_again_query:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
       training_details:
         title: Trainee start date and ID
         start_date:
-          title: Trainee's start date
+          title: Trainee’s start date
       funding:
         title: Funding
         training_initiative:
@@ -394,7 +394,7 @@ en:
       training_details:
         title: Trainee start date and ID
         commencement_date:
-          label: What is the trainee's start date?
+          label: What is the trainee’s start date?
           hint_html:
             When the trainee started the course. This may be different to your overall course start date.<br><br>
             For example, 9 2 %{year}

--- a/spec/support/shared_examples/school_form_validations.rb
+++ b/spec/support/shared_examples/school_form_validations.rb
@@ -20,10 +20,13 @@ RSpec.shared_examples "school form validations" do |school_id_key|
   end
 
   context "with no school chosen and no query provided" do
+    let(:form_name) { school_id_key.sub("id", "form") }
     let(:params) { { "results_search_again_query" => "", school_id_key => "" } }
 
     it "returns an error" do
-      expect(subject.errors[school_id_key]).to include(I18n.t("activemodel.errors.models.schools/employing_school_form.attributes.employing_school_id.blank"))
+      expect(subject.errors[school_id_key]).to include(
+        I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.#{school_id_key}.blank"),
+      )
     end
   end
 end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/aQw0KyVw/2159-schools-snagging-nonjs-form)

### Changes proposed in this pull request

- Changed the error message if a user does not select any radio button on the Lead and Employing school NonJS form
- Fixed the `_results` partial to use the `legend` and `hint` functionalities in the `govuk_radio_buttons_fieldset` in both Lead and Employing school forms

### Guidance to review

- Make a trainee on school direct salaried
- Turn off JS and input at least 3 valid chars.
- On the radio button and NonJS page, dont select anything. You will see a custom error message saying `Select an lead/employing school or search again` (lead/employing dependent on which form you are on)

