### PR TITLE
[2116] Make `Trainee#sha` less sensitive

### DIFF
--- a/db/data/20210719132235_reset_update_sha.rb
+++ b/db/data/20210719132235_reset_update_sha.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ResetUpdateSha < ActiveRecord::Migration[6.1]
+  def up
+    trainees = Trainee.where("updated_at < ?", 1.day.ago).where("updated_at != created_at")
+    trainees.each do |t|
+      t.update!(dttp_update_sha: t.sha)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

We use `Trainee#sha` to determine when we should update DTTP. With the
current implementation any time the `Trainee` model changed e.g. a
schema change, all trainees would trigger updates as we were including
field names and nil fields.

Before we merge ->

If we deploy this as is all trainees will get updated to DTTP as the sha will change. We could update all trainees in a data migration but will need to consider how to avoid stopping updates that should happen. 

### Changes proposed in this pull request

Update the `digest` -> `value_digest` method to only hash non-nil values
instead of all field names and values.

Also exclude `#progress` as this serializes to an Object key which
changes every time. We only use this internally anyway and it isn't sent
to DTTP.

### Guidance to review



