### PR TITLE
Deploy review app only if labelled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
     - master
+    types: [opened, reopened, synchronize, labeled]
 
 jobs:
   build:
@@ -18,6 +19,7 @@ jobs:
       DB_HOSTNAME: localhost
 
     steps:
+
     - uses: actions/checkout@v2
       name: Checkout
 
@@ -61,7 +63,7 @@ jobs:
         docker push ${{env.DOCKER_REPO}}:master || true
 
     - name: Trigger Review App Deployment
-      if: ${{ success() && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+      if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
       uses: benc-uk/workflow-dispatch@v1.1
       with:
         workflow: 'Deploy to PaaS'
@@ -98,7 +100,7 @@ jobs:
 
     - name: Wait for review app deployment
       id: wait_for_review_app_deployment
-      if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+      if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - name: Wait for Deploy App Workflow for review
         id: wait_for_deployment
+        if: contains(github.event.pull_request.labels.*.name, 'deploy')
         uses: fountainhead/action-wait-for-check@v1.0.0
         with:
          token: ${{ secrets.GITHUB_TOKEN }}
@@ -21,7 +22,7 @@ jobs:
          timeoutSeconds: 1800
 
       - name: Exit whole workflow if wait was not successful
-        if: steps.wait_for_deployment.outputs.conclusion != 'success'
+        if: ${{ steps.wait_for_deployment.outputs.conclusion != '' && steps.wait_for_deployment.outputs.conclusion != 'success' }}
         run: exit 1
 
       - name: Checkout


### PR DESCRIPTION
### Context

To avoid unnecessary review app deployments and to keep costs down, it is decided to deploy the review app
on if it is required.

### Changes proposed in this pull request

Review app will be deployed only if the `deploy` label is added to the PR.


