### PR TITLE
Use make commands in ci workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,7 @@ jobs:
       name: Checkout
 
     - name: Set environment variables
-      run: |
-        GIT_SHA_SHORT=$(echo ${GITHUB_SHA} | cut -c 1-7)
-        echo "GIT_SHA_SHORT=$GIT_SHA_SHORT" >> $GITHUB_ENV
-        echo "SHA_TAG=$GIT_SHA_SHORT" >> $GITHUB_ENV
+      run: echo "SHA_TAG=${{ github.sha }}" >> $GITHUB_ENV
 
     - name: Login to DockerHub
       if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
       with:
         workflow: 'Deploy to PaaS'
         token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}
-        inputs: '{"qa": "true", "staging": "true", "production": "true", "sandbox": "true", "rollover": "true", "sha": "${{ env.SHA_TAG }}"}'
+        inputs: '{"qa": "true", "staging": "true", "production": "true", "sandbox": "true", "sha": "${{ env.SHA_TAG }}"}'
 
     - name: Check for Failure
       if: ${{ failure() && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -37,10 +37,8 @@ jobs:
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           TF_STATE_FILE=pr-$PR_NUMBER.tfstate
-          echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          echo "APP_NAME=$PR_NUMBER" >> $GITHUB_ENV
           echo "DEPLOY_ENV=review" >> $GITHUB_ENV
-          echo "TF_VAR_paas_web_app_hostname=$PR_NUMBER" >> $GITHUB_ENV
           echo "TF_STATE_FILE=$TF_STATE_FILE" >> $GITHUB_ENV
 
           pr_state_file=$(az storage blob list -c review-app-tfstate \
@@ -54,7 +52,6 @@ jobs:
           echo "TF_VAR_key_vault_app_secret_name=$TF_VAR_key_vault_app_secret_name" >> $GITHUB_ENV
           echo "TF_VAR_key_vault_infra_secret_name=$TF_VAR_key_vault_infra_secret_name" >> $GITHUB_ENV
         env:
-          DOCKER_IMAGE: ${{ format('dfedigital/register-trainee-teachers:paas-{0}', github.sha) }}
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_REVIEW }}
 
       - uses: azure/login@v1
@@ -73,13 +70,10 @@ jobs:
 
       - name: Terraform destroy
         if: env.TF_STATE_EXISTS == 'true'
-        working-directory: terraform
-        run: |
-            terraform init -backend-config workspace-variables/review_backend.tfvars -backend-config=key=${{ env.TF_STATE_FILE }}
-            terraform destroy -var-file workspace-variables/review.tfvars -auto-approve
+        run: make review ci destroy
         env:
           ARM_ACCESS_KEY:               ${{ secrets.ARM_ACCESS_KEY_REVIEW }}
-          TF_VAR_paas_app_docker_image: ${{ env.DOCKER_IMAGE }}
+          IMAGE_TAG:                    ${{ github.sha }}
           TF_VAR_azure_credentials:     ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
 
       - name: Delete tf state file

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,14 +19,6 @@ on:
         description: Deploy to sandbox?
         default: 'false'
         required: true
-      rollover:
-        description: Deploy to rollover?
-        default: 'false'
-        required: true
-      pen:
-        description: Deploy to pen test?
-        default: 'false'
-        required: true
       pr:
         description: PR number for the review app
         required: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,12 +68,11 @@ jobs:
         run: |
           echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
 
-          if [ ! -z "${{ github.event.inputs.pr }}" ]; then
+          if [ -n "${{ github.event.inputs.pr }}" ]; then
             PR_NUMBER=${{ github.event.inputs.pr }}
             echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+            echo "APP_NAME=$PR_NUMBER" >> $GITHUB_ENV
             echo "DEPLOY_ENV=review" >> $GITHUB_ENV
-            echo "BACKEND_KEY=-backend-config=key=pr-$PR_NUMBER.tfstate" >> $GITHUB_ENV
-            echo "TF_VAR_paas_web_app_hostname=$PR_NUMBER" >> $GITHUB_ENV
             echo "DEPLOY_URL=https://register-pr-$PR_NUMBER.london.cloudapps.digital" >> $GITHUB_ENV
             . terraform/workspace-variables/review.sh
           else
@@ -85,7 +84,6 @@ jobs:
           echo "TF_VAR_key_vault_app_secret_name=$TF_VAR_key_vault_app_secret_name" >> $GITHUB_ENV
           echo "TF_VAR_key_vault_infra_secret_name=$TF_VAR_key_vault_infra_secret_name" >> $GITHUB_ENV
         env:
-          DOCKER_IMAGE: ${{ format('dfedigital/register-trainee-teachers:{0}', github.event.inputs.sha) }}
           DEPLOY_ENV: ${{ matrix.environment }}
 
       - name: Start ${{ matrix.environment }} Deployment
@@ -108,22 +106,18 @@ jobs:
           ${{ env.TF_VAR_key_vault_app_secret_name }}
           ${{ env.TF_VAR_key_vault_infra_secret_name }}
 
-
       - name: Pin Terraform version
         uses: hashicorp/setup-terraform@v1.2.1
         with:
           terraform_version: 0.13.5
 
       - name: Terraform init, Terraform Plan and Apply
-        run: |
-          terraform init -backend-config=workspace-variables/${{ env.DEPLOY_ENV }}_backend.tfvars $BACKEND_KEY
-          terraform plan -var-file=workspace-variables/${{ env.DEPLOY_ENV }}.tfvars
-          terraform apply -var-file=workspace-variables/${{ env.DEPLOY_ENV }}.tfvars -auto-approve
-        working-directory: terraform
+        run: make ${{ env.DEPLOY_ENV }} ci deploy
         env:
-          ARM_ACCESS_KEY: ${{ secrets[format('ARM_ACCESS_KEY_{0}', env.DEPLOY_ENV)] }}
-          TF_VAR_paas_app_docker_image: ${{env.DOCKER_IMAGE}}
-          TF_VAR_azure_credentials:     ${{ secrets[format('AZURE_CREDENTIALS_{0}', env.DEPLOY_ENV)] }}
+          ARM_ACCESS_KEY:           ${{ secrets[format('ARM_ACCESS_KEY_{0}', env.DEPLOY_ENV)] }}
+          TF_VAR_azure_credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', env.DEPLOY_ENV)] }}
+          IMAGE_TAG:                ${{ github.event.inputs.sha }}
+          CONFIRM_PRODUCTION:       yes
 
       - name: Trigger ${{ env.DEPLOY_ENV }} Smoke Tests
         uses: benc-uk/workflow-dispatch@v1.1

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ yarn-debug.log*
 tfplan
 *.tfplan
 *.plan
-**/tokens
+**/*token*
 *secret*.tfvars
 !terraform/**/app_config.yml
 terraform/**/*.yml

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,6 @@ staging:
 	$(eval space=bat-staging)
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-test)
 
-pen:
-	$(eval env=pen)
-	$(eval env_config=pen)
-	$(eval space=bat-staging)
-	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-test)
-
 production:
 	$(if $(CONFIRM_PRODUCTION), , $(error Can only run with CONFIRM_PRODUCTION))
 	$(eval env=production)
@@ -69,12 +63,6 @@ sandbox:
 	$(eval env_config=sandbox)
 	$(eval space=bat-prod)
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-production)
-
-rollover:
-	$(eval env=rollover)
-	$(eval env_config=rollover)
-	$(eval space=bat-staging)
-	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-test)
 
 install-fetch-config:
 	[ ! -f bin/fetch_config.rb ] \

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -22,10 +22,10 @@ terraform {
 
 provider cloudfoundry {
   api_url           = local.paas_api_url
-  user              = try(local.infra_secrets.CF_USER, null)
-  password          = try(local.infra_secrets.CF_PASSWORD, null)
-  sso_passcode      = var.paas_sso_passcode
-  store_tokens_path = "tokens"
+  user              = var.paas_sso_passcode == "" ? local.infra_secrets.CF_USER : null
+  password          = var.paas_sso_passcode == "" ? local.infra_secrets.CF_PASSWORD : null
+  sso_passcode      = var.paas_sso_passcode != "" ? var.paas_sso_passcode : null
+  store_tokens_path = var.paas_sso_passcode != "" ? ".cftoken" : null
   version           = "~> 0.12"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,4 @@
-variable paas_sso_passcode { default = null }
+variable paas_sso_passcode { default = "" }
 
 variable paas_app_environment {}
 


### PR DESCRIPTION
### Context

Keep Makefile commands and ci workflow scripts consistent.

### Changes proposed in this pull request

Update build to tag image with full commit sha.
Use passcode to authenticate with cf when running from non ci environments.
Update ci pipeline to use make commands to deploy the application.

