### PR TITLE
[2207] Review create from Apply service

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,24 @@ To create the lead schools csv, there is a spreadsheet in google drive: https://
 
 The second tab: "MASTER LIST_All Lead Schools" must be exported as a csv.
 
+## Running Apply application import against example data
+
+Add the following to your `development.local.yml`:
+```yml
+features:
+  import_applications_from_apply: true
+
+apply_api:
+  base_url: "https://sandbox.apply-for-teacher-training.service.gov.uk/register-api"
+  auth_token: <request token from Apply team>
+```
+Running the following script:
+```
+ApplyApi::ImportApplication.class_eval do
+  def provider
+    Provider.all.sample
+  end
+end
+ApplyApplicationSyncRequest.delete_all
+ApplyApi::ImportApplicationsJob.perform_now
+```

--- a/app/services/apply_api/retrieve_applications.rb
+++ b/app/services/apply_api/retrieve_applications.rb
@@ -27,7 +27,7 @@ module ApplyApi
     def query
       {
         recruitment_cycle_year: Settings.current_recruitment_cycle_year,
-        changed_since: changed_since,
+        changed_since: changed_since&.utc&.iso8601,
       }.compact.to_query
     end
   end

--- a/spec/services/apply_api/retrieve_applications_spec.rb
+++ b/spec/services/apply_api/retrieve_applications_spec.rb
@@ -42,7 +42,7 @@ module ApplyApi
 
         context "when a 'changed_at' is provided" do
           let(:changed_since) { Time.zone.now }
-          let(:expected_query) { { recruitment_cycle_year: 2021, changed_since: changed_since }.to_query }
+          let(:expected_query) { { recruitment_cycle_year: 2021, changed_since: changed_since.utc.iso8601 }.to_query }
           let(:expected_path) { "/applications?#{expected_query}" }
 
           it "includes the changed_at param in the request" do


### PR DESCRIPTION
### Context
https://trello.com/c/j9axMbki/2207-review-createfromapply-service

### Changes proposed in this pull request
- Update `ApplyApi::RetrieveApplications` to send `changed_since` param in ISO8601 format
- Update `README` with instructions to run the Apply application import job against example data

### Guidance to review
- Add the following to your `development.local.yml`
```yml
apply_api:
  base_url: "https://sandbox.apply-for-teacher-training.service.gov.uk/register-api"
  auth_token: <key available on request>
```
- Follow the instructions in the `README` and confirm it works.

