### PR TITLE
[2181] Update trainee start date question

### DIFF
--- a/app/controllers/trainees/training_details_controller.rb
+++ b/app/controllers/trainees/training_details_controller.rb
@@ -31,7 +31,7 @@ module Trainees
     end
 
     def trainee_params
-      params.require(:training_details_form).permit(:trainee_id, :commencement_date, *PARAM_CONVERSION.keys)
+      params.require(:training_details_form).permit(:trainee_id, :commencement_date, :commencement_date_radio_option, *PARAM_CONVERSION.keys)
             .transform_keys do |key|
         PARAM_CONVERSION.keys.include?(key) ? PARAM_CONVERSION[key] : key
       end

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -4,9 +4,15 @@
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
-<%= register_form_with model: @trainee_start_date_form, url: trainee_start_date_path, local: true do |f| %>
-  <%= f.govuk_date_field :commencement_date, legend: { text: t("views.forms.training_details.commencement_date.label"), size: "l", tag: "h1" } %>
-  <%= f.govuk_submit "Continue" %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with model: @trainee_start_date_form, url: trainee_start_date_path, local: true do |f| %>
+      <%= f.govuk_date_field :commencement_date, legend: {
+        text: t("views.forms.start_dates.commencement_date.label"), size: "l", tag: "h1"
+      }, hint: { text: t("views.forms.start_dates.commencement_date.hint") } %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
 
-<p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee)) %></p>
+    <p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee)) %></p>
+  </div>
+</div>

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: t("views.forms.training_details.title")) %>
+<%= render PageTitle::View.new(text: t("views.forms.training_details.title"), has_errors: @training_details_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -12,9 +12,20 @@
 
       <h1 class="govuk-heading-l"><%= t("views.forms.training_details.title") %></h1>
 
-      <%= f.govuk_date_field :commencement_date, legend: {
-        text: t("views.forms.training_details.commencement_date.label"), size: "s"
-      }, hint: { text: t("views.forms.training_details.commencement_date.hint_html", year: Time.zone.now.year) } %>
+      <% if @training_details_form.course_start_date %>
+        <%= f.govuk_radio_buttons_fieldset(:commencement_date_radio_option, legend: { text: t("views.forms.training_details.commencement_date_radio_option.label"), size: "s" }, hint: { text: t("views.forms.training_details.commencement_date_radio_option.hint", year: Time.zone.now.year) }) do %>
+          <%= f.govuk_radio_button :commencement_date_radio_option, TrainingDetailsForm::COMMENCEMENT_DATE_RADIO_OPTION_COURSE, checked: (@training_details_form.commencement_date_radio_option == TrainingDetailsForm::COMMENCEMENT_DATE_RADIO_OPTION_COURSE), value: true, link_errors: true, label: { text: t("views.forms.training_details.commencement_date_radio_option.course", date: @training_details_form.course_start_date.strftime("%e %B %Y")) } %>
+          <%= f.govuk_radio_button :commencement_date_radio_option, TrainingDetailsForm::COMMENCEMENT_DATE_RADIO_OPTION_MANUAL, checked: (@training_details_form.commencement_date_radio_option == TrainingDetailsForm::COMMENCEMENT_DATE_RADIO_OPTION_MANUAL), link_errors: true, label: { text: t("views.forms.training_details.commencement_date_radio_option.manual") } do %>
+            <%= f.govuk_date_field :commencement_date, legend: {
+              text: t("views.forms.training_details.commencement_date_manual.label"), size: "s"
+            }, hint: { text: t("views.forms.training_details.commencement_date_manual.hint", year: Time.zone.now.year) } %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= f.govuk_date_field :commencement_date, legend: {
+          text: t("views.forms.training_details.commencement_date.label"), size: "s"
+        }, hint: { text: t("views.forms.training_details.commencement_date.hint", year: Time.zone.now.year).html_safe } %>
+      <% end %>
 
       <%= f.govuk_text_field :trainee_id, label: {
         text: t("views.forms.training_details.trainee_id.label"), size: "s"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -393,16 +393,28 @@ en:
           <<: *withdrawal_reasons
       training_details:
         title: Trainee start date and ID
+        commencement_date_radio_option:
+          label: What is the trainee’s start date?
+          hint: This is the date the trainee starts on the course. This can be different from the course start date.
+          course: Use the course start date – %{date}
+          manual: Enter another date
         commencement_date:
           label: What is the trainee’s start date?
-          hint_html:
-            When the trainee started the course. This may be different to your overall course start date.<br><br>
-            For example, 9 2 %{year}
+          hint:
+            This is the date the trainee starts on the course. This can be different from the course start date.<br>
+            For example, 9 7 %{year}
+        commencement_date_manual:
+          label: Trainee start date
+          hint: For example, 9 7 %{year}
         trainee_id:
           label: Assign a trainee ID
           hint:
             This will help you to identify them and search for them in your trainee records.
             We may also use it if we need to get in touch with you about this trainee.
+      start_dates:
+        commencement_date:
+          label: What is the trainee’s start date?
+          hint: This is the date the trainee starts on the course. This can be different from the course start date.
       publish_course_details:
         route_message: "Your %{route} courses in the Publish service"
         route_titles:
@@ -860,6 +872,8 @@ en:
             trainee_id:
               blank: Enter a trainee ID
               max_char_exceeded: Your entry must not exceed 100 characters
+            commencement_date_radio_option:
+              inclusion: Choose a start date
         schools_form:
           attributes:
             query:

--- a/spec/features/form_sections/teacher_training_data/edit_training_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_training_details_spec.rb
@@ -18,6 +18,25 @@ feature "edit training details" do
     and_the_training_details_are_updated
   end
 
+  context "edit with course details" do
+    scenario "choose course start date" do
+      given_a_trainee_exists(:with_course_details)
+      when_i_visit_the_training_details_page
+      and_i_choose_course_start_date
+      then_i_am_redirected_to_the_confirm_training_details_page
+      and_the_training_details_are_updated_with_course_start_date
+    end
+
+    scenario "choose custom date" do
+      given_a_trainee_exists(:with_course_details)
+      when_i_visit_the_training_details_page
+      and_i_update_the_training_details
+      and_i_choose_manual_start_date
+      then_i_am_redirected_to_the_confirm_training_details_page
+      and_the_training_details_are_updated
+    end
+  end
+
   def when_i_visit_the_training_details_page
     training_details_page.load(id: trainee.slug)
   end
@@ -28,9 +47,27 @@ feature "edit training details" do
     training_details_page.submit_button.click
   end
 
+  def and_i_choose_course_start_date
+    training_details_page.trainee_id.set(new_trainee_id)
+    training_details_page.commencement_date_radio_option_course.choose
+    training_details_page.submit_button.click
+  end
+
+  def and_i_choose_manual_start_date
+    training_details_page.trainee_id.set(new_trainee_id)
+    training_details_page.commencement_date_radio_option_manual.choose
+    training_details_page.set_date_fields(:commencement_date, new_start_date.strftime("%d/%m/%Y"))
+    training_details_page.submit_button.click
+  end
+
   def and_the_training_details_are_updated
     expect(confirm_training_details_page).to have_text(new_trainee_id)
     expect(confirm_training_details_page).to have_text(date_for_summary_view(new_start_date))
+  end
+
+  def and_the_training_details_are_updated_with_course_start_date
+    expect(confirm_training_details_page).to have_text(new_trainee_id)
+    expect(confirm_training_details_page).to have_text(date_for_summary_view(Trainee.last.course_start_date))
   end
 
   def then_i_am_redirected_to_the_confirm_training_details_page

--- a/spec/forms/training_details_form_spec.rb
+++ b/spec/forms/training_details_form_spec.rb
@@ -50,7 +50,7 @@ describe TrainingDetailsForm, type: :model do
 
     context "commencement date" do
       context "not present" do
-        let(:params) { { day: "", month: "", year: "" } }
+        let(:params) { { commencement_date_radio_option: "manual", day: "", month: "", year: "" } }
 
         it "returns a blank error message" do
           expect(subject.errors[:commencement_date]).to include(
@@ -60,7 +60,7 @@ describe TrainingDetailsForm, type: :model do
       end
 
       context "invalid date" do
-        let(:params) { { day: "2", month: "14", year: "" } }
+        let(:params) { { commencement_date_radio_option: "manual", day: "2", month: "14", year: "" } }
 
         it "returns an invalid date error message" do
           expect(subject.errors[:commencement_date]).to include(

--- a/spec/support/features/training_details_steps.rb
+++ b/spec/support/features/training_details_steps.rb
@@ -12,6 +12,7 @@ module Features
 
     def and_i_fill_in_the_training_details_form
       training_details_page.trainee_id.set("123")
+      training_details_page.commencement_date_radio_option_manual&.choose
       training_details_page.set_date_fields(:commencement_date, Date.tomorrow.strftime("%d/%m/%Y"))
       training_details_page.submit_button.click
     end

--- a/spec/support/page_objects/trainees/training_details.rb
+++ b/spec/support/page_objects/trainees/training_details.rb
@@ -12,6 +12,9 @@ module PageObjects
       element :commencement_date_month, "#training_details_form_commencement_date_2i"
       element :commencement_date_year, "#training_details_form_commencement_date_1i"
 
+      element :commencement_date_radio_option_course, "input[name='training_details_form[commencement_date_radio_option]'][value='course']"
+      element :commencement_date_radio_option_manual, "input[name='training_details_form[commencement_date_radio_option]'][value='manual']"
+
       element :submit_button, "button[type='submit']"
     end
   end

--- a/spec/support/shared_examples/rendering_the_funding_section.rb
+++ b/spec/support/shared_examples/rendering_the_funding_section.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples "rendering the funding section" do
       end
 
       context "and has entered their course details" do
-        before { trainee.update!(course_subject_one: "subject") }
+        before { trainee.course_subject_one = "subject" }
 
         it "renders the funding section as 'not started'" do
           render_inline(described_class.new(trainee: trainee))


### PR DESCRIPTION
### Context

https://trello.com/c/4eHJSmEg/2181-update-trainee-start-date-question

### Changes proposed in this pull request

* When course start date is set, an extra question is asked on training details form, to use the course start date or the enter a start date manually
* Option is not shown if no course start date is set

### Guidance to review

* Add new trainee, complete course section, go to "Trainee start date and ID" section
* Add new trainee, go to "Trainee start date and ID", you should not get option
