### PR TITLE
Add apply drafts to example data script

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -2,16 +2,16 @@
 
 require "faker"
 require "factory_bot"
+require Rails.root.join("spec/support/api_stubs/apply_api")
 
 namespace :example_data do
   desc "Create personas, their providers and a selection of trainees"
   task generate: :environment do
+    include FactoryBot::Syntax::Methods
+
     raise "THIS TASK CANNOT BE RUN IN PRODUCTION" if Rails.env.production?
 
     Faker::Config.locale = "en-GB"
-
-    FactoryBot.create_list(:school, 50)
-    FactoryBot.create_list(:school, 50, lead_school: true)
 
     # Base our example data on the currently switched-on feature flags
     enabled_routes = TRAINING_ROUTE_FEATURE_FLAGS.select { |flag| FeatureService.enabled?("routes.#{flag}") }
@@ -20,11 +20,11 @@ namespace :example_data do
     enabled_course_routes = enabled_routes & TRAINING_ROUTES_FOR_COURSE.keys.map(&:to_sym)
 
     # Create some schools
-    employing_schools = FactoryBot.create_list(:school, 50)
-    lead_schools = FactoryBot.create_list(:school, 50, lead_school: true)
+    employing_schools = create_list(:school, 50)
+    lead_schools = create_list(:school, 50, lead_school: true)
 
     # Create some subjects
-    subjects = FactoryBot.create_list(:subject, 20)
+    subjects = create_list(:subject, 20)
 
     # For each persona...
     PERSONAS.each do |persona_attributes|
@@ -49,7 +49,7 @@ namespace :example_data do
       # For each of the course routes enabled...
       enabled_course_routes.each do |route|
         # Create some courses for that provider with some subjects
-        courses = FactoryBot.build_list(:course, rand(10..70), accredited_body_code: provider.code, route: route) do |course|
+        courses = build_list(:course, rand(10..70), accredited_body_code: provider.code, route: route) do |course|
           course.subjects = subjects.sample(rand(1..3))
         end
         courses.each(&:save!)
@@ -60,7 +60,9 @@ namespace :example_data do
         # And for all possible trainee states...
         Trainee.states.keys.map(&:to_sym).each do |state|
           # Create small number of trainees
-          rand(1...4).times do
+          sample_size = rand(1...4)
+
+          sample_size.times do |sample_index|
             attrs = { created_at: Faker::Date.between(from: 100.days.ago, to: 50.days.ago) }
             attrs.merge!(provider: provider) if provider
 
@@ -69,7 +71,16 @@ namespace :example_data do
             attrs.merge!(employing_school: employing_schools.sample) if route == :school_direct_salaried
             attrs.merge!(course_code: courses.sample.code) unless state == :draft
 
-            trainee = FactoryBot.create(:trainee, route, state, attrs)
+            # Make *roughly* half of draft trainees apply drafts
+            if state == :draft && sample_index < sample_size / 2
+              attrs.merge!(
+                attributes_for(:trainee, :with_course_details, course_code: nil)
+                  .slice(:course_subject_one, :course_code, :course_age_range, :course_start_date, :course_end_date),
+                apply_application: create(:apply_application, provider: provider),
+              )
+            end
+
+            trainee = create(:trainee, route, state, attrs)
 
             # Add an extra nationality 20% of the time
             trainee.nationalities << Nationality.all.sample if rand(10) < 2


### PR DESCRIPTION
It's a bit of a faf to get test apply draft trainees working with the integration locally so this PR updates the example data script to seed some apply drafts for easier local dev.

### Changes proposed in this pull request

<img width="912" alt="Screenshot 2021-07-12 at 18 46 41" src="https://user-images.githubusercontent.com/616080/125333076-b7258180-e341-11eb-820b-263302413629.png">

### Guidance to review

This will make roughly half of the total trainees created for each route an apply draft.

To use one of these in dev you still need to go into the console and do something like: `Trainee.where("apply_application_id is not null and state = 0").sample` then use their slug to `/trainees/{slug}` until we implement the filter to filter these out from the trainee records page.