### PR TITLE
[2212] update filter toggle to be able to filter on apply drafts

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -16,7 +16,7 @@ class TraineesController < ApplicationController
     @draft_trainees = paginated_trainees.select(&:draft?)
     @completed_trainees = paginated_trainees.reject(&:draft?)
     @training_routes = policy_scope(Trainee).group(:training_route).count.keys
-    @trainees_imported_from_apply = policy_scope(Trainee).with_apply_application
+    @trainees_imported_from_apply_count = policy_scope(Trainee).with_apply_application.count
 
     respond_to do |format|
       format.html

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -15,6 +15,7 @@ class TraineesController < ApplicationController
     # clause, removing Kaminari's pagination. Hence the use of `#select`.
     @draft_trainees = paginated_trainees.select(&:draft?)
     @completed_trainees = paginated_trainees.reject(&:draft?)
+    @apply_draft_trainees = policy_scope(Trainee).draft_with_apply_application
     @training_routes = policy_scope(Trainee).group(:training_route).count.keys
 
     respond_to do |format|

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -16,7 +16,7 @@ class TraineesController < ApplicationController
     @draft_trainees = paginated_trainees.select(&:draft?)
     @completed_trainees = paginated_trainees.reject(&:draft?)
     @training_routes = policy_scope(Trainee).group(:training_route).count.keys
-    @trainees_imported_from_apply_count = policy_scope(Trainee).with_apply_application.count
+    @trainees_imported_from_apply_count = policy_scope(Trainee.with_apply_application).count
 
     respond_to do |format|
       format.html

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -15,8 +15,8 @@ class TraineesController < ApplicationController
     # clause, removing Kaminari's pagination. Hence the use of `#select`.
     @draft_trainees = paginated_trainees.select(&:draft?)
     @completed_trainees = paginated_trainees.reject(&:draft?)
-    @apply_draft_trainees = policy_scope(Trainee).draft_with_apply_application
     @training_routes = policy_scope(Trainee).group(:training_route).count.keys
+    @trainees_imported_from_apply = policy_scope(Trainee).with_apply_application
 
     respond_to do |format|
       format.html
@@ -92,7 +92,7 @@ private
   end
 
   def filter_params
-    params.permit(:subject, :text_search, :sort_by, level: [], training_route: [], state: [])
+    params.permit(:subject, :text_search, :sort_by, level: [], training_route: [], state: [], record_source: [])
   end
 
   def save_filter

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -139,7 +139,7 @@ class Trainee < ApplicationRecord
     )
   }
 
-  scope :draft_with_apply_application, -> { where("apply_application_id is not null and state=0") }
+  scope :with_apply_application, -> { where("apply_application_id is not null") }
 
   audited associated_with: :provider
   has_associated_audits

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -139,6 +139,7 @@ class Trainee < ApplicationRecord
     )
   }
 
+  scope :with_manual_application, -> { where(apply_application: nil) }
   scope :with_apply_application, -> { where.not(apply_application: nil) }
 
   audited associated_with: :provider

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -139,6 +139,8 @@ class Trainee < ApplicationRecord
     )
   }
 
+  scope :draft_with_apply_application, -> { where("apply_application_id is not null and state=0") }
+
   audited associated_with: :provider
   has_associated_audits
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -139,7 +139,7 @@ class Trainee < ApplicationRecord
     )
   }
 
-  scope :with_apply_application, -> { where("apply_application_id is not null") }
+  scope :with_apply_application, -> { where.not(apply_application: nil) }
 
   audited associated_with: :provider
   has_associated_audits

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -4,6 +4,8 @@ class TraineeFilter
   AWARD_STATES = %w[qts_recommended qts_awarded eyts_recommended eyts_awarded].freeze
   STATES = Trainee.states.keys.excluding("recommended_for_award", "awarded") + AWARD_STATES
 
+  RECORD_SOURCES = %w[apply manual].freeze
+
   def initialize(params:)
     @params = params
   end
@@ -51,7 +53,7 @@ private
   end
 
   def record_source_options
-    params[:record_source] ? ["imported_from_apply"] : []
+    (params[:record_source].presence || []) & RECORD_SOURCES
   end
 
   def training_route_options

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class TraineeFilter
+  APPLY_DRAFT_STATE = %w[apply_draft].freeze
   AWARD_STATES = %w[qts_recommended qts_awarded eyts_recommended eyts_awarded].freeze
-  STATES = Trainee.states.keys.excluding("recommended_for_award", "awarded") + AWARD_STATES
+  STATES = Trainee.states.keys.excluding("recommended_for_award", "awarded") + AWARD_STATES + APPLY_DRAFT_STATE
 
   def initialize(params:)
     @params = params

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class TraineeFilter
-  APPLY_DRAFT_STATE = %w[apply_draft].freeze
   AWARD_STATES = %w[qts_recommended qts_awarded eyts_recommended eyts_awarded].freeze
-  STATES = Trainee.states.keys.excluding("recommended_for_award", "awarded") + AWARD_STATES + APPLY_DRAFT_STATE
+  STATES = Trainee.states.keys.excluding("recommended_for_award", "awarded") + AWARD_STATES
 
   def initialize(params:)
     @params = params
@@ -23,7 +22,7 @@ private
 
   def merged_filters
     @merged_filters ||= text_search.merge(
-      **level, **training_route, **state, **subject, **text_search,
+      **level, **training_route, **state, **subject, **text_search, **record_source,
     ).with_indifferent_access
   end
 
@@ -43,6 +42,16 @@ private
     return {} unless training_route_options.any?
 
     { "training_route" => training_route_options }
+  end
+
+  def record_source
+    return {} unless record_source_options.any?
+
+    { "record_source" => record_source_options }
+  end
+
+  def record_source_options
+    params[:record_source] ? ["imported_from_apply"] : []
   end
 
   def training_route_options

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -40,12 +40,21 @@ module Trainees
 
       non_award_states = states.dup
 
+      apply_draft_state = false
+
       award_states = []
       states.each do |state|
         award_states << non_award_states.delete(state) if TraineeFilter::AWARD_STATES.include? state
+
+        apply_draft_state = non_award_states.delete(state) if state == "apply_draft"
       end
 
-      trainees.where(state: non_award_states).or(trainees.with_award_states(*award_states))
+      case apply_draft_state
+      when "apply_draft"
+        trainees.where(state: non_award_states).or(trainees.with_award_states(*award_states)).or(trainees.draft_with_apply_application)
+      else
+        trainees.where(state: non_award_states).or(trainees.with_award_states(*award_states))
+      end
     end
 
     def subject(trainees, subject)

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -30,7 +30,9 @@ module Trainees
     end
 
     def record_source(trainees, record_source)
-      return trainees if record_source.blank?
+      return trainees if record_source.blank? || record_source.size > 1
+
+      return trainees.with_manual_application if record_source.include? "manual"
 
       trainees.with_apply_application
     end

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -96,7 +96,7 @@
     <% end %>
   <% end %>
 
-  <% if FeatureService.enabled?(:imported_from_apply_filter) && @trainees_imported_from_apply_count.positive? %>
+  <% if FeatureService.enabled?(:imported_from_apply_filter) && multiple_record_sources? %>
     <% component.filter_option do %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -96,6 +96,26 @@
     <% end %>
   <% end %>
 
+  <% if FeatureService.enabled?(:imported_from_apply_filter) && @trainees_imported_from_apply.present? %>
+    <% component.filter_option do %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            Record source
+          </legend>
+          <div class="govuk-checkboxes govuk-checkboxes--small">
+            
+              <div class="govuk-checkboxes__item">
+                <%= check_box_tag "record_source[]", "imported_from_apply", checked?(@filters, :record_source, "imported_from_apply"), id: "record_source-imported_from_apply", class: "govuk-checkboxes__input" %>
+                <%= label_tag "record_source-imported_from_apply", label_for("record_source", "imported_from_apply"), class: "govuk-label govuk-checkboxes__label" %>
+              </div>
+            
+          </div>
+        </fieldset>
+      </div>
+    <% end %>
+  <% end %>
+
   <% component.filter_option do %>
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">
@@ -104,7 +124,6 @@
         </legend>
         <div class="govuk-checkboxes govuk-checkboxes--small">
           <% TraineeFilter::STATES.each do |state, _| %>
-            <% next if state == "apply_draft" && @apply_draft_trainees.blank? %>
             <div class="govuk-checkboxes__item">
               <%= check_box_tag "state[]", state, checked?(@filters, :state, state), id: "state-#{state}", class: "govuk-checkboxes__input" %>
               <%= label_tag "state-#{state}", label_for("state", state), class: "govuk-label govuk-checkboxes__label" %>

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -103,7 +103,8 @@
           <%= t("views.trainees.index.filters.status") %>
         </legend>
         <div class="govuk-checkboxes govuk-checkboxes--small">
-          <% TraineeFilter::STATES.map do |state, _| %>
+          <% TraineeFilter::STATES.each do |state, _| %>
+            <% next if state == "apply_draft" && @apply_draft_trainees.blank? %>
             <div class="govuk-checkboxes__item">
               <%= check_box_tag "state[]", state, checked?(@filters, :state, state), id: "state-#{state}", class: "govuk-checkboxes__input" %>
               <%= label_tag "state-#{state}", label_for("state", state), class: "govuk-label govuk-checkboxes__label" %>

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -106,8 +106,13 @@
           <div class="govuk-checkboxes govuk-checkboxes--small">
             
               <div class="govuk-checkboxes__item">
-                <%= check_box_tag "record_source[]", "imported_from_apply", checked?(@filters, :record_source, "imported_from_apply"), id: "record_source-imported_from_apply", class: "govuk-checkboxes__input" %>
-                <%= label_tag "record_source-imported_from_apply", label_for("record_source", "imported_from_apply"), class: "govuk-label govuk-checkboxes__label" %>
+                <%= check_box_tag "record_source[]", "apply", checked?(@filters, :record_source, "apply"), id: "record_source-apply", class: "govuk-checkboxes__input" %>
+                <%= label_tag "record_source-apply", label_for("record_source", "apply"), class: "govuk-label govuk-checkboxes__label" %>
+              </div>
+
+              <div class="govuk-checkboxes__item">
+                <%= check_box_tag "record_source[]", "manual", checked?(@filters, :record_source, "manual"), id: "record_source-manual", class: "govuk-checkboxes__input" %>
+                <%= label_tag "record_source-manual", label_for("record_source", "manual"), class: "govuk-label govuk-checkboxes__label" %>
               </div>
             
           </div>

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -96,7 +96,7 @@
     <% end %>
   <% end %>
 
-  <% if FeatureService.enabled?(:imported_from_apply_filter) && @trainees_imported_from_apply.present? %>
+  <% if FeatureService.enabled?(:imported_from_apply_filter) && @trainees_imported_from_apply_count.positive? %>
     <% component.filter_option do %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -637,6 +637,7 @@ en:
           pg_teaching_apprenticeship: Teaching apprenticeship (postgrad)
         states:
           draft: Draft
+          apply_draft: Apply Draft
           submitted_for_trn: Pending TRN
           trn_received: TRN received
           recommended_for_award: Qualification recommended

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -244,6 +244,7 @@ en:
     filter:
       level: Course level
       training_route: Training route
+      record_source: Record source
       state: Status
       subject: Subject
       text_search: Text search
@@ -624,6 +625,8 @@ en:
   activerecord:
     attributes:
       trainee:
+        record_sources:
+          imported_from_apply: Imported from Apply
         trainee_id: Trainee ID
         training_routes:
           assessment_only: Assessment only

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -626,7 +626,8 @@ en:
     attributes:
       trainee:
         record_sources:
-          imported_from_apply: Imported from Apply
+          apply: Imported from Apply
+          manual: Added manually
         trainee_id: Trainee ID
         training_routes:
           assessment_only: Assessment only

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,6 +41,7 @@ features:
   persist_to_dttp: false
   show_funding: false
   send_funding_to_dttp: false
+  imported_from_apply_filter: false
   routes:
     early_years_assessment_only: false
     early_years_salaried: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,6 +7,7 @@ features:
   import_courses_from_ttapi: true
   publish_course_details: true
   show_funding: true
+  imported_from_apply_filter: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -12,6 +12,7 @@ features:
   import_courses_from_ttapi: true
   publish_course_details: true
   show_funding: true
+  imported_from_apply_filter: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -5,6 +5,7 @@ features:
   publish_course_details: true
   show_funding: true
   persist_to_dttp: false
+  imported_from_apply_filter: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -22,6 +22,11 @@ RSpec.feature "Filtering trainees" do
     then_all_trainees_are_visible
   end
 
+  scenario "can filter by apply_drafts" do
+    when_i_filter_by_apply_draft_status
+    then_only_the_apply_draft_trainee_is_visible
+  end
+
   scenario "can filter by status" do
     when_i_filter_by_draft_status
     then_only_the_draft_trainee_is_visible
@@ -104,6 +109,7 @@ private
     @withdrawn_trainee ||= create(:trainee, :withdrawn)
     @early_years_trainee ||= create(:trainee, :early_years_undergrad)
     @primary_trainee ||= create(:trainee, course_age_range: AgeRange::THREE_TO_EIGHT)
+    @apply_draft_trainee ||= create(:trainee, :with_apply_application)
     Trainee.update_all(provider_id: @current_user.provider.id)
   end
 
@@ -123,6 +129,11 @@ private
 
   def when_i_filter_by_draft_status
     trainee_index_page.draft_checkbox.click
+    trainee_index_page.apply_filters.click
+  end
+
+  def when_i_filter_by_apply_draft_status
+    trainee_index_page.apply_draft_checkbox.click
     trainee_index_page.apply_filters.click
   end
 
@@ -192,6 +203,11 @@ private
     ].each do |trainee|
       expect(trainee_index_page).not_to have_text(full_name(trainee))
     end
+  end
+
+  def then_only_the_apply_draft_trainee_is_visible
+    expect(trainee_index_page).to have_text(full_name(@apply_draft_trainee))
+    expect(trainee_index_page).not_to have_text(full_name(@draft_trainee))
   end
 
   def then_only_the_draft_trainee_is_visible

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -27,6 +27,12 @@ RSpec.feature "Filtering trainees" do
     then_only_the_apply_draft_trainee_is_visible
   end
 
+  scenario "when all trainees are from a single source", feature_imported_from_apply_filter: true do
+    given_all_trainees_are_from_a_single_source
+    when_i_visit_the_trainee_index_page
+    then_the_record_source_filter_is_not_visible
+  end
+
   scenario "can filter by status" do
     when_i_filter_by_draft_status
     then_only_the_draft_trainee_is_visible
@@ -111,6 +117,14 @@ private
     @primary_trainee ||= create(:trainee, course_age_range: AgeRange::THREE_TO_EIGHT)
     @apply_draft_trainee ||= create(:trainee, :with_apply_application)
     Trainee.update_all(provider_id: @current_user.provider.id)
+  end
+
+  def given_all_trainees_are_from_a_single_source
+    Trainee.with_apply_application.destroy_all
+  end
+
+  def then_the_record_source_filter_is_not_visible
+    expect(trainee_index_page).not_to have_text("Record source")
   end
 
   def given_a_subject_specialism_is_available_for_selection

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Filtering trainees" do
     then_all_trainees_are_visible
   end
 
-  scenario "can filter by apply_drafts" do
+  scenario "can filter by apply_drafts", feature_imported_from_apply_filter: true do
     when_i_filter_by_apply_draft_status
     then_only_the_apply_draft_trainee_is_visible
   end
@@ -133,7 +133,7 @@ private
   end
 
   def when_i_filter_by_apply_draft_status
-    trainee_index_page.apply_draft_checkbox.click
+    trainee_index_page.imported_from_apply_checkbox.click
     trainee_index_page.apply_filters.click
   end
 

--- a/spec/models/trainee_filter_spec.rb
+++ b/spec/models/trainee_filter_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe TraineeFilter do
   let(:permitted_params) do
     ActionController::Parameters.new(params)
-    .permit(:subject, :text_search, training_route: [], state: [])
+    .permit(:subject, :text_search, training_route: [], state: [], record_source: [])
   end
 
   subject { TraineeFilter.new(params: permitted_params) }
@@ -45,6 +45,12 @@ describe TraineeFilter do
 
     context "with 'All subjects'" do
       let(:params) { { subject: "All subjects" } }
+
+      include_examples returns_nil
+    end
+
+    context "with invalid record_source" do
+      let(:params) { { record_source: %w[hackerman] } }
 
       include_examples returns_nil
     end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -70,13 +70,31 @@ describe Trainee do
 
   context "scopes" do
     describe "with_award_states" do
-      it "returns tainees with the correct training route and state" do
+      it "returns trainees with the correct training route and state" do
         create(:trainee, :trn_received)
         qts_awarded = create(:trainee, :qts_awarded)
         eyts_recommended = create(:trainee, :eyts_recommended)
         create(:trainee, :eyts_awarded)
 
         expect(Trainee.with_award_states(:qts_awarded, :eyts_recommended)).to contain_exactly(qts_awarded, eyts_recommended)
+      end
+    end
+
+    describe ".with_apply_application" do
+      let!(:manual_trainee) { create(:trainee) }
+      let!(:apply_trainee) { create(:trainee, :with_apply_application) }
+
+      it "returns trainees from apply" do
+        expect(described_class.with_apply_application).to contain_exactly(apply_trainee)
+      end
+    end
+
+    describe ".with_manual_application" do
+      let!(:manual_trainee) { create(:trainee) }
+      let!(:apply_trainee) { create(:trainee, :with_apply_application) }
+
+      it "returns trainees from apply" do
+        expect(described_class.with_manual_application).to contain_exactly(manual_trainee)
       end
     end
   end

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -7,6 +7,7 @@ module Trainees
     subject { described_class.call(trainees: trainees, filters: filters) }
 
     let!(:generic_trainee) { create(:trainee) }
+    let!(:apply_draft_trainee) { create(:trainee, :with_apply_application) }
     let(:filters) { nil }
     let(:trainees) { Trainee.all }
 
@@ -32,14 +33,13 @@ module Trainees
     context "with state filter" do
       let!(:draft_trainee) { create(:trainee, :draft) }
       let!(:submitted_for_trn_trainee) { create(:trainee, :submitted_for_trn) }
-      let!(:apply_draft_trainee) { create(:trainee, :with_apply_application) }
       let!(:qts_awarded_trainee) { create(:trainee, :qts_awarded) }
       let!(:eyts_awarded_trainee) { create(:trainee, :eyts_awarded) }
 
-      context "with trn_submitted, qts_awarded and apply_draft trainees" do
-        let(:filters) { { state: %w[submitted_for_trn qts_awarded apply_draft] } }
+      context "with trn_submitted, qts_awarded" do
+        let(:filters) { { state: %w[submitted_for_trn qts_awarded] } }
 
-        it { is_expected.to contain_exactly(submitted_for_trn_trainee, qts_awarded_trainee, apply_draft_trainee) }
+        it { is_expected.to contain_exactly(submitted_for_trn_trainee, qts_awarded_trainee) }
       end
 
       context "with only draft trainees" do
@@ -62,6 +62,12 @@ module Trainees
       let(:filters) { { text_search: "Boaty" } }
 
       it { is_expected.to eq([named_trainee]) }
+    end
+
+    context "with record_source filter" do
+      let(:filters) { { record_source: %w[imported_from_apply] } }
+
+      it { is_expected.to contain_exactly(apply_draft_trainee) }
     end
   end
 end

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -6,7 +6,7 @@ module Trainees
   describe Filter do
     subject { described_class.call(trainees: trainees, filters: filters) }
 
-    let!(:generic_trainee) { create(:trainee) }
+    let!(:draft_trainee) { create(:trainee, :draft) }
     let!(:apply_draft_trainee) { create(:trainee, :with_apply_application) }
     let(:filters) { nil }
     let(:trainees) { Trainee.all }
@@ -31,7 +31,6 @@ module Trainees
     end
 
     context "with state filter" do
-      let!(:draft_trainee) { create(:trainee, :draft) }
       let!(:submitted_for_trn_trainee) { create(:trainee, :submitted_for_trn) }
       let!(:qts_awarded_trainee) { create(:trainee, :qts_awarded) }
       let!(:eyts_awarded_trainee) { create(:trainee, :eyts_awarded) }
@@ -45,7 +44,7 @@ module Trainees
       context "with only draft trainees" do
         let(:filters) { { state: %w[draft] } }
 
-        it { is_expected.to contain_exactly(draft_trainee, apply_draft_trainee, generic_trainee) }
+        it { is_expected.to contain_exactly(draft_trainee, apply_draft_trainee) }
       end
     end
 
@@ -64,10 +63,22 @@ module Trainees
       it { is_expected.to eq([named_trainee]) }
     end
 
-    context "with record_source filter" do
-      let(:filters) { { record_source: %w[imported_from_apply] } }
+    context "with record_source filter set to apply" do
+      let(:filters) { { record_source: %w[apply] } }
 
       it { is_expected.to contain_exactly(apply_draft_trainee) }
+    end
+
+    context "with record_source filter set to manual" do
+      let(:filters) { { record_source: %w[manual] } }
+
+      it { is_expected.to contain_exactly(draft_trainee) }
+    end
+
+    context "with record_source filter set to both manual and apply" do
+      let(:filters) { { record_source: %w[apply manual] } }
+
+      it { is_expected.to contain_exactly(apply_draft_trainee, draft_trainee) }
     end
   end
 end

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -30,12 +30,23 @@ module Trainees
     end
 
     context "with state filter" do
+      let!(:draft_trainee) { create(:trainee, :draft) }
       let!(:submitted_for_trn_trainee) { create(:trainee, :submitted_for_trn) }
+      let!(:apply_draft_trainee) { create(:trainee, :with_apply_application) }
       let!(:qts_awarded_trainee) { create(:trainee, :qts_awarded) }
       let!(:eyts_awarded_trainee) { create(:trainee, :eyts_awarded) }
-      let(:filters) { { state: %w[submitted_for_trn qts_awarded] } }
 
-      it { is_expected.to contain_exactly(submitted_for_trn_trainee, qts_awarded_trainee) }
+      context "with trn_submitted, qts_awarded and apply_draft trainees" do
+        let(:filters) { { state: %w[submitted_for_trn qts_awarded apply_draft] } }
+
+        it { is_expected.to contain_exactly(submitted_for_trn_trainee, qts_awarded_trainee, apply_draft_trainee) }
+      end
+
+      context "with only draft trainees" do
+        let(:filters) { { state: %w[draft] } }
+
+        it { is_expected.to contain_exactly(draft_trainee, apply_draft_trainee, generic_trainee) }
+      end
     end
 
     context "with subject filter" do

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -23,7 +23,7 @@ module PageObjects
       element :early_years_checkbox, "#level-early_years"
       element :assessment_only_checkbox, "#training_route-assessment_only"
       element :draft_checkbox, "#state-draft"
-      element :apply_draft_checkbox, "#state-apply_draft"
+      element :imported_from_apply_checkbox, "#record_source-imported_from_apply"
       element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"
       element :subject, "#subject"
 

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -23,7 +23,7 @@ module PageObjects
       element :early_years_checkbox, "#level-early_years"
       element :assessment_only_checkbox, "#training_route-assessment_only"
       element :draft_checkbox, "#state-draft"
-      element :imported_from_apply_checkbox, "#record_source-imported_from_apply"
+      element :imported_from_apply_checkbox, "#record_source-apply"
       element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"
       element :subject, "#subject"
 

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -23,6 +23,7 @@ module PageObjects
       element :early_years_checkbox, "#level-early_years"
       element :assessment_only_checkbox, "#training_route-assessment_only"
       element :draft_checkbox, "#state-draft"
+      element :apply_draft_checkbox, "#state-apply_draft"
       element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"
       element :subject, "#subject"
 


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/unyTXiWR/2212-m-update-filter-toggle-to-be-able-to-filter-on-apply-drafts)

### Changes proposed in this pull request

- Added an imported from apply filter
- The imported from apply filter does not show, if there are no trainees imported from apply
- This is feature flagged

### Guidance to review

- Make sure to have apply draft trainees on your system 
- Go to the trainees index page. Click on the imported from apply checkbox. 
- Select `filter`
- You will only see apply draft trainees
- If you go on an account that has no apply draft trainees, you will not see the filter

