### PR TITLE
Remove FactoryBot::Syntax::Methods module from rake task

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -7,8 +7,6 @@ require Rails.root.join("spec/support/api_stubs/apply_api")
 namespace :example_data do
   desc "Create personas, their providers and a selection of trainees"
   task generate: :environment do
-    include FactoryBot::Syntax::Methods
-
     raise "THIS TASK CANNOT BE RUN IN PRODUCTION" if Rails.env.production?
 
     Faker::Config.locale = "en-GB"
@@ -20,11 +18,11 @@ namespace :example_data do
     enabled_course_routes = enabled_routes & TRAINING_ROUTES_FOR_COURSE.keys.map(&:to_sym)
 
     # Create some schools
-    employing_schools = create_list(:school, 50)
-    lead_schools = create_list(:school, 50, lead_school: true)
+    employing_schools = FactoryBot.create_list(:school, 50)
+    lead_schools = FactoryBot.create_list(:school, 50, lead_school: true)
 
     # Create some subjects
-    subjects = create_list(:subject, 20)
+    subjects = FactoryBot.create_list(:subject, 20)
 
     # For each persona...
     PERSONAS.each do |persona_attributes|
@@ -49,7 +47,7 @@ namespace :example_data do
       # For each of the course routes enabled...
       enabled_course_routes.each do |route|
         # Create some courses for that provider with some subjects
-        courses = build_list(:course, rand(10..70), accredited_body_code: provider.code, route: route) do |course|
+        courses = FactoryBot.build_list(:course, rand(10..70), accredited_body_code: provider.code, route: route) do |course|
           course.subjects = subjects.sample(rand(1..3))
         end
         courses.each(&:save!)
@@ -74,13 +72,13 @@ namespace :example_data do
             # Make *roughly* half of draft trainees apply drafts
             if state == :draft && sample_index < sample_size / 2
               attrs.merge!(
-                attributes_for(:trainee, :with_course_details, course_code: nil)
+                FactoryBot.attributes_for(:trainee, :with_course_details, course_code: nil)
                   .slice(:course_subject_one, :course_code, :course_age_range, :course_start_date, :course_end_date),
-                apply_application: create(:apply_application, provider: provider),
+                apply_application: FactoryBot.create(:apply_application, provider: provider),
               )
             end
 
-            trainee = create(:trainee, route, state, attrs)
+            trainee = FactoryBot.create(:trainee, route, state, attrs)
 
             # Add an extra nationality 20% of the time
             trainee.nationalities << Nationality.all.sample if rand(10) < 2


### PR DESCRIPTION
### Context
Including `FactoryBot::Syntax::Methods` does not seem to play nicely with rspec.
Removing it to use the long form, `FactoryBot.create(...` as opposed to `create(...` instead.

### Guidance to review
Run `bundle exec rspec spec/lib/tasks/example_data_spec.rb spec/mailers/welcome_email_mailer_spec.rb --seed 47735`
1. on master, and expect a few failures as factory bot overrides the definition of `.generate`
2. on this branch, and expect the test output to be green.
