### PR TITLE
[2213] Handle degree deletion on apply draft page

### DIFF
--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -65,6 +65,7 @@ module Sections
           in_progress: "trainee_diversity_confirm_path",
         },
         degrees: {
+          not_provided: "trainee_degrees_new_type_path",
           not_started: "trainee_degrees_new_type_path",
           in_progress: "trainee_degrees_confirm_path",
         },

--- a/app/controllers/trainees/degrees_controller.rb
+++ b/app/controllers/trainees/degrees_controller.rb
@@ -13,7 +13,7 @@ module Trainees
       @degree_form = @degrees_form.build_degree(degree_params, autocomplete_params)
 
       if @degree_form.save_or_stash
-        redirect_to trainee_degrees_confirm_path(trainee)
+        trainee.apply_application? ? (redirect_to edit_trainee_apply_trainee_data_path(trainee)) : (redirect_to trainee_degrees_confirm_path(trainee))
       else
         render :new
       end

--- a/app/forms/apply_trainee_data_form.rb
+++ b/app/forms/apply_trainee_data_form.rb
@@ -31,12 +31,14 @@ class ApplyTraineeDataForm
   end
 
   def progress_status(progress_key)
+    return :not_provided if trainee.apply_application? && !progress_service(progress_key).started?
+
     progress_service(progress_key).status.parameterize(separator: "_").to_sym
   end
 
   def display_type(section_key)
     if section_key == :degrees
-      progress_status(section_key) == :not_started ? :collapsed : :expanded
+      progress_status(section_key) == :not_provided ? :collapsed : :expanded
     else
       :expanded
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,9 +297,11 @@ en:
         schools: Schools
         funding: Funding
       statuses:
+        not_provided: not provided
         not_started: not started
         in_progress: not marked as complete
       link_texts:
+        not_provided: Add degree details
         not_started: Start section
         in_progress: Continue section
     school_result_notice:

--- a/spec/components/apply_trainee_data/view_spec.rb
+++ b/spec/components/apply_trainee_data/view_spec.rb
@@ -20,11 +20,12 @@ module ApplyTraineeData
       end
     end
 
-    context "trainee without degrees" do
-      let(:trainee) { create(:trainee, nationalities: [build(:nationality)], degrees: []) }
+    context "draft apply trainee without degrees" do
+      let(:apply_application) { create(:apply_application) }
+      let(:trainee) { create(:trainee, nationalities: [build(:nationality)], degrees: [], apply_application: apply_application) }
 
       it "has a collapsed degrees section" do
-        expect(component).to have_text("Degree details not started")
+        expect(component).to have_text("Degree details not provided")
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/L0l8PA38/2213-m-handle-degree-deletion-on-apply-draft-page

### Changes proposed in this pull request
* For apply draft trainee with no degrees, `sections` component is rendered with different copy to non apply draft trainee
* Redirects back to trainee data edit page instead of confirmation page if degree added

### Guidance to review
Create an apply draft trainee with a degree, navigate to review trainee data section and delete a degree 
<img width="1306" alt="Screenshot 2021-07-13 at 12 52 48" src="https://user-images.githubusercontent.com/58793682/125447141-326464fe-e13b-4818-9636-16db993ff27a.png">
