### PR TITLE
[2049] Activate end to end tests for funding

### DIFF
--- a/spec/features/end_to_end/assessment_only_journey_spec.rb
+++ b/spec/features/end_to_end/assessment_only_journey_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "assessment-only end-to-end journey", type: :feature do
+feature "assessment-only end-to-end journey", feature_show_funding: true, type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN" do
@@ -13,6 +13,7 @@ feature "assessment-only end-to-end journey", type: :feature do
     and_the_degree_details_is_complete
     and_the_course_details_is_complete
     and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_is_complete
     and_the_draft_record_has_been_reviewed
     and_all_sections_are_complete
     when_i_submit_for_trn

--- a/spec/features/end_to_end/early_years_assessment_only_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_assessment_only_journey_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "early_years_assessment_only end-to-end journey", type: :feature do
+feature "early_years_assessment_only end-to-end journey", feature_show_funding: true, type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.early_years_assessment_only": true do
@@ -13,6 +13,7 @@ feature "early_years_assessment_only end-to-end journey", type: :feature do
     and_the_degree_details_is_complete
     and_the_ey_course_details_is_complete
     and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_is_complete
     and_the_draft_record_has_been_reviewed
     and_all_sections_are_complete
     when_i_submit_for_trn

--- a/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "early_years_postgrad end-to-end journey", type: :feature do
+feature "early_years_postgrad end-to-end journey", feature_show_funding: true, type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.early_years_postgrad": true do
@@ -13,6 +13,7 @@ feature "early_years_postgrad end-to-end journey", type: :feature do
     and_the_degree_details_is_complete
     and_the_ey_course_details_is_complete
     and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_with_bursary_is_complete
     and_the_draft_record_has_been_reviewed
     and_all_sections_are_complete
     when_i_submit_for_trn

--- a/spec/features/end_to_end/provider_led_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_journey_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "provider-led end-to-end journey", type: :feature do
+feature "provider-led end-to-end journey", feature_show_funding: true, type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.provider_led_postgrad": true, feature_publish_course_details: true do
@@ -13,6 +13,7 @@ feature "provider-led end-to-end journey", type: :feature do
     and_the_degree_details_is_complete
     and_the_publish_course_details_is_complete
     and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_is_complete
     and_the_draft_record_has_been_reviewed
     and_all_sections_are_complete
     when_i_submit_for_trn

--- a/spec/features/end_to_end/school_direct_salaried_journey_spec.rb
+++ b/spec/features/end_to_end/school_direct_salaried_journey_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "school-direct-salaried end-to-end journey", type: :feature do
+feature "school-direct-salaried end-to-end journey", feature_show_funding: true, type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.school_direct_salaried": true do
@@ -13,6 +13,7 @@ feature "school-direct-salaried end-to-end journey", type: :feature do
     and_the_degree_details_is_complete
     and_the_course_details_is_complete
     and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_is_complete
     and_the_lead_and_employing_schools_section_is_complete
     and_the_draft_record_has_been_reviewed
     and_all_sections_are_complete

--- a/spec/features/end_to_end/school_direct_tuition_fee_journey_spec.rb
+++ b/spec/features/end_to_end/school_direct_tuition_fee_journey_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "school-direct-tuition-fee end-to-end journey", type: :feature do
+feature "school-direct-tuition-fee end-to-end journey", feature_show_funding: true, type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.school_direct_tuition_fee": true do
@@ -13,6 +13,7 @@ feature "school-direct-tuition-fee end-to-end journey", type: :feature do
     and_the_degree_details_is_complete
     and_the_course_details_is_complete
     and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_is_complete
     and_the_lead_school_section_is_complete
     and_the_draft_record_has_been_reviewed
     and_all_sections_are_complete

--- a/spec/support/features/funding_details_steps.rb
+++ b/spec/support/features/funding_details_steps.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Features
+  module FundingDetailsSteps
+    def and_the_funding_details_is_complete
+      review_draft_page.funding_section.link.click
+      edit_funding_page.training_initiative_radios.choose("funding-training-initiatives-form-training-initiative-now-teach-field")
+      edit_funding_page.continue_button.click
+      confirm_funding_page.confirm.check
+      confirm_funding_page.continue.click
+    end
+
+    def and_the_funding_details_with_bursary_is_complete
+      review_draft_page.funding_section.link.click
+      edit_funding_page.training_initiative_radios.choose("funding-training-initiatives-form-training-initiative-now-teach-field")
+      edit_funding_page.continue_button.click
+      bursary_page.choose("funding-bursary-form-bursary-tier-tier-one-field")
+      bursary_page.submit_button.click
+      confirm_funding_page.confirm.check
+      confirm_funding_page.continue.click
+    end
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -226,6 +226,10 @@ module Features
       @bursary_page ||= PageObjects::Trainees::Funding::Bursary.new
     end
 
+    def edit_funding_page
+      @edit_funding_page ||= PageObjects::Trainees::EditTraineeFunding.new
+    end
+
     def confirm_funding_page
       @confirm_funding_page ||= PageObjects::Trainees::ConfirmFunding.new
     end

--- a/spec/support/page_objects/sections/funding_details.rb
+++ b/spec/support/page_objects/sections/funding_details.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class Funding < PageObjects::Sections::Base
+      element :link, ".govuk-link"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/confirm_funding.rb
+++ b/spec/support/page_objects/trainees/confirm_funding.rb
@@ -5,6 +5,7 @@ module PageObjects
     class ConfirmFunding < PageObjects::Base
       set_url "/trainees/{id}/funding/confirm"
 
+      element :confirm, "input[name='confirm_detail_form[mark_as_completed]']"
       element :continue, "button[type='submit']"
     end
   end

--- a/spec/support/page_objects/trainees/edit_trainee_funding.rb
+++ b/spec/support/page_objects/trainees/edit_trainee_funding.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class EditTraineeFunding < PageObjects::Base
+      set_url "/trainees/{trainee_id}/funding/training-initiative/edit"
+
+      element :training_initiative_radios, ".govuk-radios"
+      element :continue_button, 'button.govuk-button[type="submit"]'
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/review_draft.rb
+++ b/spec/support/page_objects/trainees/review_draft.rb
@@ -16,6 +16,7 @@ module PageObjects
       section :degree_details, PageObjects::Sections::DegreeDetails, ".degree-details"
       section :course_details, PageObjects::Sections::CourseDetails, ".app-task-list__item.course-details"
       section :training_details, PageObjects::Sections::TrainingDetails, ".training-details"
+      section :funding_section, PageObjects::Sections::Funding, ".app-task-list__item.funding"
       section :lead_and_employing_schools_section, PageObjects::Sections::SchoolsDetails, ".app-task-list__item.school-details"
 
       element :review_this_record_link, "#check-details"


### PR DESCRIPTION
### Context

We are switching on the funding feature flags for our existing end to end tests.

### Changes proposed in this pull request

- Switch on the funding feature flags for the existing end to end feature tests.
- Make the failing end to end feature tests pass by completing the funding section.

### Guidance to review

- Run the tests and hopefully watch them pass.