### PR TITLE
[2210] Suppress confirmation page when editing apply draft sections

### DIFF
--- a/app/controllers/trainees/contact_details_controller.rb
+++ b/app/controllers/trainees/contact_details_controller.rb
@@ -14,7 +14,7 @@ module Trainees
       save_strategy = trainee.draft? ? :save! : :stash
 
       if @contact_details_form.public_send(save_strategy)
-        redirect_to trainee_contact_details_confirm_path(trainee)
+        redirect_to relevant_redirect_path
       else
         render :edit
       end
@@ -39,6 +39,10 @@ module Trainees
 
     def authorize_trainee
       authorize(trainee)
+    end
+
+    def relevant_redirect_path
+      trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_contact_details_confirm_path(trainee)
     end
   end
 end

--- a/app/controllers/trainees/course_details_controller.rb
+++ b/app/controllers/trainees/course_details_controller.rb
@@ -27,7 +27,7 @@ module Trainees
       save_strategy = trainee.draft? ? :save! : :stash
 
       if @course_details_form.public_send(save_strategy)
-        redirect_to trainee_course_details_confirm_path(trainee)
+        redirect_to relevant_redirect_path
       else
         render :edit
       end
@@ -56,6 +56,10 @@ module Trainees
 
     def authorize_trainee
       authorize(trainee)
+    end
+
+    def relevant_redirect_path
+      trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_course_details_confirm_path(trainee)
     end
   end
 end

--- a/app/controllers/trainees/degrees_controller.rb
+++ b/app/controllers/trainees/degrees_controller.rb
@@ -29,7 +29,7 @@ module Trainees
       @degree_form.assign_attributes(autocomplete_params)
 
       if @degree_form.save_or_stash
-        redirect_to trainee_degrees_confirm_path(trainee)
+        redirect_to relevant_redirect_path
       else
         render :edit
       end
@@ -65,6 +65,10 @@ module Trainees
 
     def set_degrees_form
       @degrees_form = DegreesForm.new(trainee)
+    end
+
+    def relevant_redirect_path
+      trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_degrees_confirm_path(trainee)
     end
   end
 end

--- a/app/controllers/trainees/diversity/disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disclosures_controller.rb
@@ -37,7 +37,7 @@ module Trainees
         if @disclosure_form.diversity_disclosed?
           redirect_to(edit_trainee_diversity_ethnic_group_path(trainee))
         else
-          redirect_to(trainee_diversity_confirm_path(trainee))
+          trainee.apply_application? ? redirect_to(page_tracker.last_origin_page_path) : redirect_to(trainee_diversity_confirm_path(trainee))
         end
       end
 

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -32,7 +32,7 @@ module Trainees
       save_strategy = trainee.draft? ? :save! : :stash
 
       if personal_detail.public_send(save_strategy)
-        redirect_to trainee_personal_details_confirm_path(personal_detail.trainee)
+        redirect_to relevant_redirect_path
       else
         @personal_detail_form = personal_detail
         render :edit
@@ -69,6 +69,10 @@ module Trainees
 
     def authorize_trainee
       authorize(trainee)
+    end
+
+    def relevant_redirect_path
+      trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_personal_details_confirm_path(trainee)
     end
   end
 end

--- a/app/controllers/trainees/training_details_controller.rb
+++ b/app/controllers/trainees/training_details_controller.rb
@@ -18,7 +18,7 @@ module Trainees
       @training_details_form = TrainingDetailsForm.new(trainee, params: trainee_params, user: current_user)
 
       if @training_details_form.save
-        redirect_to trainee_training_details_confirm_path(trainee)
+        redirect_to relevant_redirect_path
       else
         render :edit
       end
@@ -39,6 +39,10 @@ module Trainees
 
     def authorize_trainee
       authorize(trainee)
+    end
+
+    def relevant_redirect_path
+      trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_training_details_confirm_path(trainee)
     end
   end
 end

--- a/spec/controllers/trainees/personal_details_controller_spec.rb
+++ b/spec/controllers/trainees/personal_details_controller_spec.rb
@@ -30,4 +30,20 @@ describe Trainees::PersonalDetailsController do
       end
     end
   end
+
+  describe "#update" do
+    context "with an apply draft trainee" do
+      let(:trainee) { create(:trainee, :draft, :with_apply_application, provider: user.provider) }
+
+      before do
+        allow(PersonalDetailsForm).to receive(:new).and_return(double(save!: true))
+        allow(controller).to receive(:page_tracker).and_return(double(last_origin_page_path: "/trainees/#{trainee.slug}/relevant-redirect", save!: nil))
+        allow(controller).to receive(:personal_details_params).and_return(nil)
+      end
+
+      it "redirects to /relevant-redirect after update" do
+        expect(put(:update, params: { trainee_id: trainee.slug })).to redirect_to("/trainees/#{trainee.slug}/relevant-redirect")
+      end
+    end
+  end
 end

--- a/spec/controllers/trainees/training_details_controller_spec.rb
+++ b/spec/controllers/trainees/training_details_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Trainees::TrainingDetailsController do
+  let(:user) { create(:user) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#update" do
+    context "with an apply draft trainee" do
+      let(:trainee) { create(:trainee, :draft, :with_apply_application, provider: user.provider) }
+
+      before do
+        allow(TrainingDetailsForm).to receive(:new).and_return(double(save: true))
+        allow(controller).to receive(:page_tracker).and_return(double(last_origin_page_path: "/trainees/#{trainee.slug}/relevant-redirect", save!: nil))
+        allow(controller).to receive(:trainee_params).and_return(nil)
+      end
+
+      it "redirects to /relevant-redirect after update" do
+        expect(put(:update, params: { trainee_id: trainee.slug })).to redirect_to("/trainees/#{trainee.slug}/relevant-redirect")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/P706ICz2/2210-s-suppress-confirmation-page-when-editing-apply-draft-sections)

### Changes proposed in this pull request

- All form redirects now check if the trainee is from an apply application. 
- If they are, they will use the `last_page_origin_path` instead of redirecting them to the confirm page. 

### Guidance to review

- Create an apply trainee
- Go to their check-details page (or any section that isnt the confirm page) and try and change their details. On updating the form, you will be redirected to the previous page you were on. 

