### PR TITLE
Add entity ids for school routes

### DIFF
--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -7,6 +7,8 @@ module Dttp
         TRAINING_ROUTE_ENUMS[:assessment_only] => { entity_id: "99f435d5-a626-e711-80c8-0050568902d3" },
         TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => { entity_id: "6189922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:early_years_undergrad] => { entity_id: "6b89922e-acc2-e611-80be-00155d010316" },
+        TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => { entity_id: "6f89922e-acc2-e611-80be-00155d010316" },
+        TRAINING_ROUTE_ENUMS[:school_direct_salaried] => { entity_id: "7789922e-acc2-e611-80be-00155d010316" },
       }.freeze
     end
   end


### PR DESCRIPTION
Adds the missing entity ids for the school routes so the dttp jobs don't blow up.
