### PR TITLE
[2263] Show funding in QA

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -11,10 +11,12 @@ features:
   use_dfe_sign_in: false
   import_courses_from_ttapi: true
   publish_course_details: true
+  show_funding: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true
     early_years_postgrad: true
+    early_years_salaried: true
     school_direct_salaried: true
     school_direct_tuition_fee: true
 


### PR DESCRIPTION
### Context

https://trello.com/c/uoRKQl1a/2264-funding-switch-on-funding-info-collection-in-qa

### Changes proposed in this pull request

Show funding in QA, plus the EY salaried route to check the alternative bursary page content.

### Guidance to review