### PR TITLE
[2262] Change link and link text for early years bursary

### DIFF
--- a/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
@@ -7,11 +7,10 @@
       (@trainee.early_years_route? ? "views.forms.funding.bursaries.non_tiered.early_years_description" : "views.forms.funding.bursaries.non_tiered.description"),
       amount: format_currency(@amount),
       subject: @subject,
-      training_route: t("activerecord.attributes.trainee.training_routes.#{@trainee.training_route}")
+      training_route: t("activerecord.attributes.trainee.training_routes.#{@trainee.training_route}"),
     ) %>
   </p>
-  <p class="govuk-body"><%= t("views.forms.funding.bursaries.guidance_html") %></p>
-
+  <p class="govuk-body"><%= t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_html' : 'guidance_html'}") %></p>
 
   <%= f.govuk_radio_buttons_fieldset(:applying_for_bursary, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
       <%= f.govuk_radio_button(

--- a/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
@@ -1,9 +1,9 @@
 <%= register_form_with(model: @bursary_form, url: trainee_funding_bursary_path(@trainee), method: :put, local: true) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %><h1>
+  <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %></h1>
   <p class="govuk-body"><%= t("views.forms.funding.bursaries.tiered.description") %></p>
-  <p class="govuk-body"><%= t("views.forms.funding.bursaries.guidance_html") %></p>
+  <p class="govuk-body"><%= t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_html' : 'guidance_html'}") %></p>
 
   <%= f.govuk_radio_buttons_fieldset(:bursary_tier, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -433,6 +433,7 @@ en:
               label: Yes - Tier 3 (£2,000)
               hint: 2:2 honours degree
           guidance_html: <a target="_blank" href="https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-funding-manual/initial-teacher-training-bursaries-funding-manual-2021-to-2022-academic-year#training-bursary-award-and-eligibility">DfE bursary guidance for the academic year 2021 to 2022 (opens in new tab)</a>
+          early_years_guidance_html: "<a target=_blank href=https://www.gov.uk/guidance/early-years-initial-teacher-training-2021-to-2022-funding-guidance>Early years initial teacher training: 2021 to 2022 funding guidance (opens in new tab)</a>"
           title: Are you applying for a bursary for this trainee?
           true: Yes, apply for a bursary
           false: No, do not apply for a bursary


### PR DESCRIPTION
### Context

Changing the link and link text for any bursary applying to an early years route (we have two at the moment).

### Guidance to review

- Add a new trainee on the`Early years (postgrad)`
- Click on the funding section
- Select `Now Teach` and continue
- Check that the correct link and link text appears as per the Trello ticket

- Repeat for a trainee on the `Early years (salaried) route`. 
You may have to add `early_years_salaried: true` locally and run the seeds again.
