### PR TITLE
[2267] Set age range on EY trainees

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -40,7 +40,7 @@ class TraineesController < ApplicationController
       redirect_to trainees_not_supported_route_path
     else
       authorize @trainee = Trainee.new(trainee_params.merge(provider_id: current_user.provider_id))
-      trainee.set_early_years_course_subject
+      trainee.set_early_years_course_details
       if trainee.save
         redirect_to review_draft_trainee_path(trainee)
       else

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -107,7 +107,6 @@ private
   def update_trainee_attributes
     attributes = {
       course_code: course_code,
-      course_age_range: course_age_range,
       course_start_date: course_start_date,
       course_end_date: course_end_date,
     }
@@ -117,6 +116,7 @@ private
         course_subject_one: course_subject_one,
         course_subject_two: course_subject_two,
         course_subject_three: course_subject_three,
+        course_age_range: course_age_range,
       })
     end
 
@@ -143,7 +143,7 @@ private
 
     age_range = Dttp::CodeSets::AgeRanges::MAPPING[trainee.course_age_range]
 
-    if age_range.present?
+    if age_range.present? && !trainee.early_years_route?
       attributes["#{age_range[:option]}_age_range".to_sym] = trainee.course_age_range.join(" to ")
       attributes[:main_age_range] = :other if age_range[:option] == :additional
     end

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -9,7 +9,6 @@ module Dttp
       COURSE_LEVEL_PG = 12
       COURSE_LEVEL_UG = 20
       ITT_QUALIFICATION_AIM_QTS = "68cbae32-7389-e711-80d8-005056ac45bb"
-      EARLY_YEARS_AGE_RANGE = AgeRange::ZERO_TO_FIVE
 
       attr_reader :trainee, :qualifying_degree, :params
 
@@ -34,7 +33,7 @@ module Dttp
 
       def build_params
         {
-          "dfe_CoursePhaseId@odata.bind" => "/dfe_coursephases(#{course_phase_id(course_age_range)})",
+          "dfe_CoursePhaseId@odata.bind" => "/dfe_coursephases(#{course_phase_id(trainee.course_age_range)})",
           "dfe_SubjectofUGDegreeId@odata.bind" => "/dfe_jacses(#{degree_subject_id(qualifying_degree.subject)})",
           "dfe_programmestartdate" => trainee.course_start_date.in_time_zone.iso8601,
           "dfe_programmeenddate" => trainee.course_end_date.in_time_zone.iso8601,
@@ -54,20 +53,12 @@ module Dttp
         .merge(funding_params)
       end
 
-      def course_age_range
-        trainee.early_years_route? ? EARLY_YEARS_AGE_RANGE : trainee.course_age_range
-      end
-
       def course_level
         if trainee.training_route == "early_years_undergrad"
           COURSE_LEVEL_UG
         else
           COURSE_LEVEL_PG
         end
-      end
-
-      def subject_entity_id
-        course_subject_id(trainee.course_subject_one)
       end
 
       def uk_specific_params
@@ -100,7 +91,7 @@ module Dttp
       end
 
       def first_subject
-        { "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{subject_entity_id})" }
+        { "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{course_subject_id(trainee.course_subject_one)})" }
       end
 
       def second_subject

--- a/app/lib/route_data_manager.rb
+++ b/app/lib/route_data_manager.rb
@@ -8,7 +8,7 @@ class RouteDataManager
   def update_training_route!(route)
     trainee.training_route = route
     reset_trainee_details if trainee.training_route_changed?
-    trainee.set_early_years_course_subject
+    trainee.set_early_years_course_details
     trainee.save!
   end
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -233,9 +233,10 @@ class Trainee < ApplicationRecord
     CalculateBursary.for_route_and_subject(training_route.to_sym, course_subject_one)
   end
 
-  def set_early_years_course_subject
+  def set_early_years_course_details
     if early_years_route?
       self.course_subject_one = Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING
+      self.course_age_range = AgeRange::ZERO_TO_FIVE
     end
   end
 

--- a/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
@@ -132,5 +132,6 @@ private
 
   def and_trainee_course_subject_one_set_to_early_years_teaching
     expect(Trainee.last.course_subject_one).to eq(Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING)
+    expect(Trainee.last.course_age_range).to eq(AgeRange::ZERO_TO_FIVE)
   end
 end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -167,24 +167,12 @@ module Dttp
 
           before do
             stub_const("Dttp::CodeSets::AgeRanges::MAPPING", { AgeRange::ZERO_TO_FIVE => { entity_id: dttp_ey_age_range_entity_id } })
-            trainee.set_early_years_course_subject
+            trainee.set_early_years_course_details
           end
 
           it "returns a hash including the undergrad course level" do
             expect(subject).to include(
               { "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_UG },
-            )
-          end
-
-          it "returns a hash including the Early years 0 to 5 age range" do
-            expect(subject).to include(
-              { "dfe_CoursePhaseId@odata.bind" => "/dfe_coursephases(#{dttp_ey_age_range_entity_id})" },
-            )
-          end
-
-          it "returns a hash containing the Early years subject" do
-            expect(subject).to include(
-              { "dfe_ITTSubject1Id@odata.bind" => "/dfe_subjects(#{CodeSets::CourseSubjects::MAPPING[Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING][:entity_id]})" },
             )
           end
         end

--- a/spec/lib/route_data_manager_spec.rb
+++ b/spec/lib/route_data_manager_spec.rb
@@ -83,11 +83,12 @@ describe RouteDataManager do
         described_class.new(trainee: trainee).update_training_route!("early_years_undergrad")
       end
 
-      it "trainee course_subject_one set to early years teaching" do
+      it "sets course_subject_one to early years teaching and age_range to 0-5" do
         expect { subject }
           .to change { trainee.training_route }
           .from(trainee.training_route).to("early_years_undergrad")
         expect(trainee.course_subject_one).to eq(Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING)
+        expect(trainee.course_age_range).to eq(AgeRange::ZERO_TO_FIVE)
       end
     end
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -386,9 +386,10 @@ describe Trainee do
   describe "#set_early_years_course_subject" do
     let(:trainee) { build(:trainee, :early_years_undergrad) }
 
-    it "sets course_subject_one to early years teaching" do
-      trainee.set_early_years_course_subject
+    it "sets course_subject_one to early years teaching and age range to 0-5" do
+      trainee.set_early_years_course_details
       expect(trainee.course_subject_one).to eq(Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING)
+      expect(trainee.course_age_range).to eq(AgeRange::ZERO_TO_FIVE)
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/lxXrDheO/2267-save-ey-age-range-directly-onto-trainee

### Changes proposed in this pull request

This builds on this PR https://github.com/DFE-Digital/register-trainee-teachers/pull/1096 where we started saving EY trainees' subject directly on the model instead of deducing it when we send to DTTP.

This PR does the same but for age_range.

This is needed to make the filtering on age_range easier (currently in progress https://trello.com/c/lDX2m93K/2180-add-filter-by-course-level-on-traineeindex-view). It also makes the DTTP code simpler.

### Guidance to review

- Create and update some EY trainees and check in your DB that the age range is set to 0-5.
- Update an EY trainee to be on a non-EY route e.g. Assessment only and check that their age range is cleared.