### PR TITLE
[2180] Course level filter

### DIFF
--- a/app/components/filters/view.html.erb
+++ b/app/components/filters/view.html.erb
@@ -11,7 +11,6 @@
 
       <!-- Div made focusable to 'catch' focus from filters. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640 -->
       <div class="moj-filter__content" tabindex="-1">
-
         <% if filters %>
           <div class="moj-filter__selected">
             <div class="moj-filter__selected-heading">

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -91,7 +91,7 @@ private
   end
 
   def filter_params
-    params.permit(:subject, :text_search, :sort_by, training_route: [], state: [])
+    params.permit(:subject, :text_search, :sort_by, level: [], training_route: [], state: [])
   end
 
   def save_filter

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -22,8 +22,20 @@ private
 
   def merged_filters
     @merged_filters ||= text_search.merge(
-      **training_route, **state, **subject, **text_search,
+      **level, **training_route, **state, **subject, **text_search,
     ).with_indifferent_access
+  end
+
+  def level
+    return {} unless level_options.any?
+
+    { "level" => level_options }
+  end
+
+  def level_options
+    COURSE_LEVELS.keys.map(&:to_s).each_with_object([]) do |option, arr|
+      arr << option if params[:level]&.include?(option)
+    end
   end
 
   def training_route

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -21,6 +21,12 @@ module Trainees
 
     def level(trainees, levels)
       return trainees if levels.blank?
+
+      age_ranges = levels.flat_map { |level| COURSE_LEVELS[level.to_sym] }.uniq
+
+      query = Array.new(age_ranges.length, "(course_min_age = ? AND course_max_age = ?)").join("OR")
+
+      trainees.where(query, *age_ranges.flatten)
     end
 
     def training_route(trainees, training_route)

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -19,6 +19,10 @@ module Trainees
 
     attr_reader :trainees, :filters
 
+    def level(trainees, levels)
+      return trainees if levels.blank?
+    end
+
     def training_route(trainees, training_route)
       return trainees if training_route.blank?
 
@@ -58,6 +62,7 @@ module Trainees
       filtered_trainees = state(filtered_trainees, filters[:state])
       filtered_trainees = subject(filtered_trainees, filters[:subject])
       filtered_trainees = text_search(filtered_trainees, filters[:text_search])
+      filtered_trainees = level(filtered_trainees, filters[:level])
       filtered_trainees
     end
   end

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -53,8 +53,26 @@
 
   <% component.filter_option do %>
     <div class="govuk-form-group">
-      <%= label_tag "text_search", "Search records", class: "govuk-label govuk-label--s" %>
+      <%= label_tag "text_search", t("views.trainees.index.filters.search"), class: "govuk-label govuk-label--s" %>
       <%= text_field_tag "text_search", (@filters[:text_search] if @filters), spellcheck: false, class: "govuk-input" %>
+    </div>
+  <% end %>
+
+  <% component.filter_option do %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          <%= t("views.trainees.index.filters.level") %>
+        </legend>
+        <div class="govuk-checkboxes govuk-checkboxes--small">
+          <% %w[early_years primary secondary].map do |level| %>
+            <div class="govuk-checkboxes__item">
+              <%= check_box_tag "level[]", level, checked?(@filters, :level, level), id: "level-#{level}", class: "govuk-checkboxes__input" %>
+              <%= label_tag "level-#{level}", label_for("level", level), class: "govuk-label govuk-checkboxes__label" %>
+            </div>
+          <% end %>
+        </div>
+      </fieldset>
     </div>
   <% end %>
 
@@ -63,7 +81,7 @@
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-            Type of training
+            <%= t("views.trainees.index.filters.type_of_training") %>
           </legend>
           <div class="govuk-checkboxes govuk-checkboxes--small">
             <% @training_routes.map do |training_route, _| %>
@@ -82,7 +100,7 @@
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-          Status
+          <%= t("views.trainees.index.filters.status") %>
         </legend>
         <div class="govuk-checkboxes govuk-checkboxes--small">
           <% TraineeFilter::STATES.map do |state, _| %>
@@ -98,7 +116,7 @@
 
   <% component.filter_option do %>
     <div class="govuk-form-group">
-      <%= label_tag "subject", "Subject", class: "govuk-label govuk-label--s" %>
+      <%= label_tag "subject", t("views.trainees.index.filters.subject"), class: "govuk-label govuk-label--s" %>
       <%= select_tag :subject, options_from_collection_for_select(
         filter_course_subjects_options,
         :value,

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -65,9 +65,9 @@
           <%= t("views.trainees.index.filters.level") %>
         </legend>
         <div class="govuk-checkboxes govuk-checkboxes--small">
-          <% %w[early_years primary secondary].map do |level| %>
+          <% COURSE_LEVELS.keys.map do |level| %>
             <div class="govuk-checkboxes__item">
-              <%= check_box_tag "level[]", level, checked?(@filters, :level, level), id: "level-#{level}", class: "govuk-checkboxes__input" %>
+              <%= check_box_tag "level[]", level, checked?(@filters, :level, level.to_s), id: "level-#{level}", class: "govuk-checkboxes__input" %>
               <%= label_tag "level-#{level}", label_for("level", level), class: "govuk-label govuk-checkboxes__label" %>
             </div>
           <% end %>

--- a/config/initializers/course_levels.rb
+++ b/config/initializers/course_levels.rb
@@ -19,6 +19,11 @@ COURSE_LEVELS = {
     AgeRange::NINE_TO_SIXTEEN,
   ],
   secondary: [
+    AgeRange::FIVE_TO_FOURTEEN,
+    AgeRange::SEVEN_TO_FOURTEEN,
+    AgeRange::SEVEN_TO_SIXTEEN,
+    AgeRange::NINE_TO_FOURTEEN,
+    AgeRange::NINE_TO_SIXTEEN,
     AgeRange::FOURTEEN_TO_NINETEEN,
   ],
 }.freeze

--- a/config/initializers/course_levels.rb
+++ b/config/initializers/course_levels.rb
@@ -2,7 +2,7 @@
 
 COURSE_LEVELS = {
   early_years: [
-    AgeRange::ZERO_TO_FIVE
+    AgeRange::ZERO_TO_FIVE,
   ],
   primary: [
     AgeRange::THREE_TO_ELEVEN,
@@ -19,6 +19,6 @@ COURSE_LEVELS = {
     AgeRange::NINE_TO_SIXTEEN,
   ],
   secondary: [
-    AgeRange::FOURTEEN_TO_NINETEEN
-  ]
+    AgeRange::FOURTEEN_TO_NINETEEN,
+  ],
 }.freeze

--- a/config/initializers/course_levels.rb
+++ b/config/initializers/course_levels.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+COURSE_LEVELS = {
+  early_years: [
+    AgeRange::ZERO_TO_FIVE
+  ],
+  primary: [
+    AgeRange::THREE_TO_ELEVEN,
+    AgeRange::FIVE_TO_ELEVEN,
+    AgeRange::THREE_TO_SEVEN,
+    AgeRange::THREE_TO_EIGHT,
+    AgeRange::THREE_TO_NINE,
+    AgeRange::FIVE_TO_NINE,
+    AgeRange::FIVE_TO_FOURTEEN,
+    AgeRange::SEVEN_TO_ELEVEN,
+    AgeRange::SEVEN_TO_FOURTEEN,
+    AgeRange::SEVEN_TO_SIXTEEN,
+    AgeRange::NINE_TO_FOURTEEN,
+    AgeRange::NINE_TO_SIXTEEN,
+  ],
+  secondary: [
+    AgeRange::FOURTEEN_TO_NINETEEN
+  ]
+}.freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,6 +242,7 @@ en:
         search_hint: Search for a school by it’s unique reference number (URN), name or postcode
         search_button: Search again
     filter:
+      level: Course level
       training_route: Training route
       state: Status
       subject: Subject
@@ -317,6 +318,12 @@ en:
       index:
         no_records: Your trainee records will appear here. You do not have any records yet.
         export: Export these records
+        filters:
+          level: Course level
+          search: Search records
+          status: Status
+          subject: Subject
+          type_of_training: Type of training
       edit:
         defer: Defer
         withdraw: withdraw
@@ -613,6 +620,10 @@ en:
           maths_physics_chairs_programme_researchers_in_schools: Maths and physics chairs programme / Researchers in schools
           future_teaching_scholars: Future teaching scholars
           no_initiative: Not on a training initiative
+        levels:
+          early_years: Early years
+          primary: Primary
+          secondary: Secondary
     errors:
       models:
         trainee:

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -167,6 +167,8 @@ FactoryBot.define do
 
     trait :early_years_undergrad do
       training_route { TRAINING_ROUTE_ENUMS[:early_years_undergrad] }
+      course_subject_one { Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING }
+      course_age_range { AgeRange::ZERO_TO_FIVE }
     end
 
     trait :school_direct_tuition_fee do

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -27,6 +27,11 @@ RSpec.feature "Filtering trainees" do
     then_only_the_draft_trainee_is_visible
   end
 
+  scenario "can filter by level" do
+    when_i_filter_by_early_years_level
+    then_only_the_early_years_trainee_is_visible
+  end
+
   scenario "can filter by training route" do
     when_i_filter_by_assessment_only
     then_only_assessment_only_trainee_is_visible
@@ -97,6 +102,8 @@ private
     @searchable_trainee ||= create(:trainee, trn: "123")
     @draft_trainee ||= create(:trainee, :draft)
     @withdrawn_trainee ||= create(:trainee, :withdrawn)
+    @early_years_trainee ||= create(:trainee, :early_years_undergrad)
+    @primary_trainee ||= create(:trainee, course_age_range: AgeRange::THREE_TO_EIGHT)
     Trainee.update_all(provider_id: @current_user.provider.id)
   end
 
@@ -126,6 +133,11 @@ private
 
   def when_i_filter_by_subject(value)
     trainee_index_page.subject.select(value)
+    trainee_index_page.apply_filters.click
+  end
+
+  def when_i_filter_by_early_years_level
+    trainee_index_page.early_years_checkbox.click
     trainee_index_page.apply_filters.click
   end
 
@@ -190,6 +202,11 @@ private
   def then_only_assessment_only_trainee_is_visible
     expect(trainee_index_page).to have_text(full_name(@assessment_only_trainee))
     expect(trainee_index_page).not_to have_text(full_name(@provider_led_postgrad_trainee))
+  end
+
+  def then_only_the_early_years_trainee_is_visible
+    expect(trainee_index_page).to have_text(full_name(@early_years_trainee))
+    expect(trainee_index_page).not_to have_text(full_name(@primary_trainee))
   end
 
   def then_the_tag_is_visible_for(*values)

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -19,6 +19,16 @@ module Trainees
       it { is_expected.to eq([provider_led_postgrad_trainee]) }
     end
 
+    context "with level filter" do
+      let!(:early_years_trainee) { create(:trainee, :early_years_undergrad) }
+      let!(:primary_trainee) { create(:trainee, course_age_range: AgeRange::FIVE_TO_ELEVEN) }
+      let!(:primary_and_secondary_trainee) { create(:trainee, course_age_range: AgeRange::SEVEN_TO_SIXTEEN) }
+      let!(:secondary_trainee) { create(:trainee, course_age_range: AgeRange::FOURTEEN_TO_NINETEEN) }
+      let(:filters) { { level: %w[primary] } }
+
+      it { is_expected.to eq([primary_trainee, primary_and_secondary_trainee]) }
+    end
+
     context "with state filter" do
       let!(:submitted_for_trn_trainee) { create(:trainee, :submitted_for_trn) }
       let!(:qts_awarded_trainee) { create(:trainee, :qts_awarded) }

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -20,6 +20,7 @@ module PageObjects
       element :apply_filters, "input[type='submit'][value='Apply filters']"
 
       element :text_search, "#text_search"
+      element :early_years_checkbox, "#level-early_years"
       element :assessment_only_checkbox, "#training_route-assessment_only"
       element :draft_checkbox, "#state-draft"
       element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"


### PR DESCRIPTION
### Context

https://trello.com/c/lDX2m93K/2180-add-filter-by-course-level-on-traineeindex-view

### Changes proposed in this pull request

- Adds a new filter to the trainee list view for 'Course level'
- Adds a mapping so that we can determine which age ranges fall into each of 'Early years', 'Primary' and 'Secondary'

<img width="587" alt="Screenshot 2021-07-14 at 17 18 49" src="https://user-images.githubusercontent.com/18436946/125656799-2609b9e4-57b6-4b42-b36c-d3e59d116a15.png">

Note: before this PR EY trainees won't have age ranges: https://github.com/DFE-Digital/register-trainee-teachers/pull/1144, so won't come up in the filter.

### Guidance to review

- Filter some trainees!