### PR TITLE
[2208] [Spike] CreateFromApply: handling invalid data by storing errors

### DIFF
--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -19,11 +19,11 @@ module DegreesHelper
   end
 
   def institutions_options
-    to_options(institutions)
+    to_options(Degree::INSTITUTIONS)
   end
 
   def subjects_options
-    to_options(subjects)
+    to_options(Degree::SUBJECTS)
   end
 
   def countries_options
@@ -35,14 +35,6 @@ module DegreesHelper
   end
 
 private
-
-  def institutions
-    Dttp::CodeSets::Institutions::MAPPING.keys
-  end
-
-  def subjects
-    Dttp::CodeSets::DegreeSubjects::MAPPING.keys
-  end
 
   def countries
     Dttp::CodeSets::Countries::MAPPING.keys

--- a/app/models/apply_application.rb
+++ b/app/models/apply_application.rb
@@ -2,6 +2,7 @@
 
 class ApplyApplication < ApplicationRecord
   belongs_to :provider
+  has_one :trainee
 
   validates :application, presence: true
 end

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -3,6 +3,9 @@
 class Degree < ApplicationRecord
   include Sluggable
 
+  INSTITUTIONS = Dttp::CodeSets::Institutions::MAPPING.keys
+  SUBJECTS = Dttp::CodeSets::DegreeSubjects::MAPPING.keys
+
   validates :locale_code, presence: true
   validates :institution, presence: true, on: :uk
   validates :country, presence: true, on: :non_uk
@@ -12,6 +15,8 @@ class Degree < ApplicationRecord
   validates :grade, presence: true, on: :uk
   validates :graduation_year, presence: true, on: %i[uk non_uk]
   validate :graduation_year_valid, if: -> { graduation_year.present? }
+  validates :institution, inclusion: { in: INSTITUTIONS }, allow_nil: true
+  validates :subject, inclusion: { in: SUBJECTS }, allow_nil: true
 
   belongs_to :trainee
 

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -9,7 +9,8 @@ module Trainees
     end
 
     def call
-      trainee.save!
+      validate_and_capture_invalid_info
+      trainee.save! && application.save!
       trainee
     end
 
@@ -134,6 +135,20 @@ module Trainees
 
     def raw_degrees
       @raw_degrees ||= attributes["qualifications"]["degrees"]
+    end
+
+    def validate_and_capture_invalid_info
+      trainee.valid?
+      errors = { degrees: [] }
+
+      trainee.degrees.each_with_index do |degree, index|
+        degree.errors.each do |error|
+          errors[:degrees][index] = { error.attribute.to_sym => degree.send(error.attribute) }
+          degree.send("#{error.attribute}=", nil)
+        end
+      end
+
+      application.invalid_data = errors
     end
   end
 end

--- a/db/migrate/20210715074856_add_invalid_data_to_apply_application.rb
+++ b/db/migrate/20210715074856_add_invalid_data_to_apply_application.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddInvalidDataToApplyApplication < ActiveRecord::Migration[6.1]
+  def change
+    add_column :apply_applications, :invalid_data, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_02_093832) do
+ActiveRecord::Schema.define(version: 2021_07_15_074856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2021_07_02_093832) do
     t.bigint "provider_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.jsonb "invalid_data"
     t.index ["apply_id"], name: "index_apply_applications_on_apply_id", unique: true
     t.index ["provider_id"], name: "index_apply_applications_on_provider_id"
   end

--- a/spec/helpers/degree_helper_spec.rb
+++ b/spec/helpers/degree_helper_spec.rb
@@ -34,7 +34,7 @@ describe DegreesHelper do
 
   describe "#institutions_options" do
     before do
-      allow(self).to receive(:institutions).and_return(%w[institution])
+      stub_const("Degree::INSTITUTIONS", %w[institution])
     end
 
     it "iterates over array and prints out correct institutions values" do
@@ -47,7 +47,7 @@ describe DegreesHelper do
 
   describe "#subjects_options" do
     before do
-      allow(self).to receive(:subjects).and_return(%w[subject])
+      stub_const("Degree::SUBJECTS", %w[subject])
     end
 
     it "iterates over array and prints out correct subjects values" do

--- a/spec/models/apply_application_spec.rb
+++ b/spec/models/apply_application_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe ApplyApplication do
   describe "associations" do
     it { is_expected.to belong_to(:provider) }
+    it { is_expected.to have_one(:trainee) }
   end
 
   describe "validations" do


### PR DESCRIPTION
### Context
https://trello.com/c/JCGni6pb/2208-create-from-apply-service-handles-invalid-data

[See also PR for Option 1](https://github.com/DFE-Digital/register-trainee-teachers/pull/1149)

Spike for Option 2 of handling invalid data:
We'd have a column which clearly lists all of the invalid fields and their values which we can pass around to other classes (like components) to act on this information.

```
trainee.apply_application.invalid_data.whatever
```

or potentially pass it to a component like:

```
SomeViewComponent.new(trainee.apply_application.invalid_data)
```

### Changes proposed in this pull request
1. Defined the reverse relationship between trainee and apply application
2. I've had to move some of the validations over to the Degree model so that we can validate against the model rather than initialising a DegreeForm. The reason for doing that is since some of the fields are autocomplete related, and in this version, we are using the standard rails inclusion validator, as opposed to comparing two values submitted via an enhanced autocomplete.
3. Added a migration for a new column `invalid_data` on `apply_applications` table.
4. In the `Trainees::CreateFromApply` service, added a bit of code to 
- validate, so that the errors are identified,
- capture the errors, and nullify them
- store the errors on the ApplyApplication record.


### Guidance to review
In a `rails console`, ensuring you have an `ApplyApplication` record available, run the following commands
```ruby
application = ApplyApplication.last
Trainees::CreateFromApply.call(application: application)`
```
Then to see the stored invalid data against the  `application`, run
```ruby
application.invalid_data
# => {"degrees"=>[{"institution"=>"University of Warwick"}]}
```



