### PR TITLE
[2265] Added funding inactive section

### DIFF
--- a/app/components/collapsed_section/view.html.erb
+++ b/app/components/collapsed_section/view.html.erb
@@ -1,4 +1,10 @@
 <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--<%= @error ? "error" : "important" %>">
   <p class="app-inset-text__title"><%= title %></p>
-  <%= govuk_link_to link_text, url %>
+  <% if url.present? %>
+    <%= govuk_link_to link_text, url %>
+  <% else %>
+    <span class="govuk-hint">
+      <%= link_text %>
+    </span>
+  <% end %>
 </div>

--- a/app/components/collapsed_section/view.html.erb
+++ b/app/components/collapsed_section/view.html.erb
@@ -2,9 +2,10 @@
   <p class="app-inset-text__title"><%= title %></p>
   <% if url.present? %>
     <%= govuk_link_to link_text, url %>
-  <% else %>
+  <% end %>
+  <% if hint_text.present? %>
     <span class="govuk-hint">
-      <%= link_text %>
+      <%= hint_text %>
     </span>
   <% end %>
 </div>

--- a/app/components/collapsed_section/view.rb
+++ b/app/components/collapsed_section/view.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class CollapsedSection::View < ViewComponent::Base
-  attr_accessor :title, :url, :link_text, :error
+  attr_accessor :title, :url, :link_text, :hint_text, :error
 
-  def initialize(title:, link_text:, url:, error: false)
+  def initialize(title:, link_text: nil, url: nil, hint_text: nil, error: false)
     @url = url
     @link_text = link_text
     @title = title
+    @hint_text = hint_text
     @error = error
   end
 end

--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -12,19 +12,36 @@ module Sections
 
     def component
       if display_type == :expanded
-        confirmation_view_args = { data_model: form_klass.new(trainee) }
-
-        if section == :degrees
-          confirmation_view_args.merge!(show_add_another_degree_button: false, show_delete_button: true)
-        end
-
         confirmation_view.new(**confirmation_view_args)
       else
-        CollapsedSection::View.new(title: title, link_text: link_text, url: url, error: error)
+        CollapsedSection::View.new(**collapsed_section_args)
       end
     end
 
   private
+
+    delegate :funding_options, to: :helpers
+
+    def confirmation_view_args
+      confirmation_view_args = { data_model: form_klass.new(trainee) }
+
+      if section == :degrees
+        confirmation_view_args.merge!(show_add_another_degree_button: false, show_delete_button: true)
+      end
+      confirmation_view_args
+    end
+
+    def collapsed_funding_inactive_section_args
+      { title: I18n.t("components.sections.titles.funding_inactive"), link_text: I18n.t("components.sections.link_texts.funding_inactive"), url: nil, error: error }
+    end
+
+    def collapsed_section_args
+      if section == :funding && funding_options(trainee) == :funding_inactive
+        collapsed_funding_inactive_section_args
+      else
+        { title: title, link_text: link_text, url: url, error: error }
+      end
+    end
 
     def form_klass
       case section

--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -32,7 +32,7 @@ module Sections
     end
 
     def collapsed_funding_inactive_section_args
-      { title: I18n.t("components.sections.titles.funding_inactive"), link_text: I18n.t("components.sections.link_texts.funding_inactive"), url: nil, error: error }
+      { title: I18n.t("components.sections.titles.funding_inactive"), hint_text: I18n.t("components.sections.link_texts.funding_inactive"), error: error }
     end
 
     def collapsed_section_args

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,6 +304,7 @@ en:
         trainee_data: Trainee data
         schools: Schools
         funding: Funding
+        funding_inactive: Funding section cannot be started yet
       statuses:
         not_provided: not provided
         not_started: not started
@@ -314,6 +315,7 @@ en:
         not_started: Start section
         in_progress: Continue section
         review: Review their data
+        funding_inactive:  Complete course details first
     school_result_notice:
       result_text: "1 more school matches your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."
       multiple_result_text: "%{remaining_search_count} more schools match your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,7 +304,7 @@ en:
         trainee_data: Trainee data
         schools: Schools
         funding: Funding
-        funding_inactive: Funding section cannot be started yet
+        funding_inactive: Funding cannot be started yet
       statuses:
         not_provided: not provided
         not_started: not started

--- a/spec/components/collapsed_section/view_preview.rb
+++ b/spec/components/collapsed_section/view_preview.rb
@@ -2,12 +2,28 @@
 
 module CollapsedSection
   class ViewPreview < ViewComponent::Preview
-    def default
+    def default_with_link_only
       render CollapsedSection::View.new(title: "title", link_text: "link_text", url: "url")
     end
 
-    def error
+    def error_with_link_only
       render CollapsedSection::View.new(title: "title", link_text: "link_text", url: "url", error: true)
+    end
+
+    def default_with_hint_text_only
+      render CollapsedSection::View.new(title: "title", hint_text: "hint_text")
+    end
+
+    def error_with_hint_text_only
+      render CollapsedSection::View.new(title: "title", hint_text: "hint_text", error: true)
+    end
+
+    def default_with_link_and_hint_text
+      render CollapsedSection::View.new(title: "title", link_text: "link_text", url: "url", hint_text: "hint_text")
+    end
+
+    def error_with_link_and_hint_text
+      render CollapsedSection::View.new(title: "title", link_text: "link_text", url: "url", hint_text: "hint_text", error: true)
     end
   end
 end

--- a/spec/components/collapsed_section/view_spec.rb
+++ b/spec/components/collapsed_section/view_spec.rb
@@ -7,12 +7,13 @@ module CollapsedSection
     alias_method :component, :page
     let(:title) { "title" }
     let(:link_text) { "link_text" }
+    let(:hint_text) { "hint_text" }
     let(:url) { "url" }
 
     context "default" do
       before do
         render_inline(
-          described_class.new(title: title, link_text: link_text, url: url),
+          described_class.new(title: title, link_text: link_text, hint_text: hint_text, url: url),
         )
       end
 
@@ -22,6 +23,10 @@ module CollapsedSection
 
       it "renders the link" do
         expect(component).to have_link(link_text, href: url)
+      end
+
+      it "renders the hint text" do
+        expect(component).to have_css(".govuk-hint", text: hint_text)
       end
 
       it "renders the correct css classes" do


### PR DESCRIPTION
### Context
Funding inactive section

### Changes proposed in this pull request
Funding section should not be clickable unless the course details has been prefilled as it relies on course data to drive the funding options, applicable to provider-led and school direct fee

### Guidance to review
#### Before 
![image](https://user-images.githubusercontent.com/470137/125786493-834c204c-c78b-45b4-b7ab-979056552d02.png)
![image](https://user-images.githubusercontent.com/470137/125786533-a1fd20eb-4c29-4ae3-9794-130d42ed05a5.png)


#### After
![image](https://user-images.githubusercontent.com/470137/125785862-cb6c3860-9ee1-4c50-9f45-3b67bcfdf262.png)
![image](https://user-images.githubusercontent.com/470137/125785971-56f5db5b-87ea-446a-bff1-712bca6e3fa9.png)

