### PR TITLE
[2208] [Spike] CreateFromApply: add accessor methods to ApplyApplication model

### DIFF
--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -19,11 +19,11 @@ module DegreesHelper
   end
 
   def institutions_options
-    to_options(institutions)
+    to_options(Degree::INSTITUTIONS)
   end
 
   def subjects_options
-    to_options(subjects)
+    to_options(Degree::SUBJECTS)
   end
 
   def countries_options
@@ -35,14 +35,6 @@ module DegreesHelper
   end
 
 private
-
-  def institutions
-    Dttp::CodeSets::Institutions::MAPPING.keys
-  end
-
-  def subjects
-    Dttp::CodeSets::DegreeSubjects::MAPPING.keys
-  end
 
   def countries
     Dttp::CodeSets::Countries::MAPPING.keys

--- a/app/models/apply_application.rb
+++ b/app/models/apply_application.rb
@@ -5,4 +5,22 @@ class ApplyApplication < ApplicationRecord
   has_one :trainee
 
   validates :application, presence: true
+
+  def application_attributes
+    parsed_application["attributes"]
+  end
+
+  def degrees
+    raw_degrees.map { |degree| Degrees::MapFromApply.call(attributes: degree) }
+  end
+
+private
+
+  def parsed_application
+    @parsed_application ||= JSON.parse(application)
+  end
+
+  def raw_degrees
+    application_attributes["qualifications"]["degrees"]
+  end
 end

--- a/app/models/apply_application.rb
+++ b/app/models/apply_application.rb
@@ -2,6 +2,7 @@
 
 class ApplyApplication < ApplicationRecord
   belongs_to :provider
+  has_one :trainee
 
   validates :application, presence: true
 end

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -3,6 +3,9 @@
 class Degree < ApplicationRecord
   include Sluggable
 
+  INSTITUTIONS = Dttp::CodeSets::Institutions::MAPPING.keys
+  SUBJECTS = Dttp::CodeSets::DegreeSubjects::MAPPING.keys
+
   validates :locale_code, presence: true
   validates :institution, presence: true, on: :uk
   validates :country, presence: true, on: :non_uk
@@ -12,6 +15,8 @@ class Degree < ApplicationRecord
   validates :grade, presence: true, on: :uk
   validates :graduation_year, presence: true, on: %i[uk non_uk]
   validate :graduation_year_valid, if: -> { graduation_year.present? }
+  validates :institution, inclusion: { in: INSTITUTIONS }, allow_nil: true
+  validates :subject, inclusion: { in: SUBJECTS }, allow_nil: true
 
   belongs_to :trainee
 

--- a/app/services/degrees/map_from_apply.rb
+++ b/app/services/degrees/map_from_apply.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Degrees
-  class CreateFromApply
+  class MapFromApply
     include ServicePattern
 
     def initialize(attributes:)
@@ -9,20 +9,12 @@ module Degrees
     end
 
     def call
-      degree
+      common_params.merge(degree_params)
     end
 
   private
 
     attr_reader :attributes
-
-    def degree
-      Degree.new(params)
-    end
-
-    def params
-      @params ||= common_params.merge(degree_params)
-    end
 
     def degree_params
       uk_degree? ? uk_degree_params : non_uk_degree_params

--- a/spec/helpers/degree_helper_spec.rb
+++ b/spec/helpers/degree_helper_spec.rb
@@ -34,7 +34,7 @@ describe DegreesHelper do
 
   describe "#institutions_options" do
     before do
-      allow(self).to receive(:institutions).and_return(%w[institution])
+      stub_const("Degree::INSTITUTIONS", %w[institution])
     end
 
     it "iterates over array and prints out correct institutions values" do
@@ -47,7 +47,7 @@ describe DegreesHelper do
 
   describe "#subjects_options" do
     before do
-      allow(self).to receive(:subjects).and_return(%w[subject])
+      stub_const("Degree::SUBJECTS", %w[subject])
     end
 
     it "iterates over array and prints out correct subjects values" do

--- a/spec/models/apply_application_spec.rb
+++ b/spec/models/apply_application_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe ApplyApplication do
   describe "associations" do
     it { is_expected.to belong_to(:provider) }
+    it { is_expected.to have_one(:trainee) }
   end
 
   describe "validations" do

--- a/spec/services/degrees/map_from_apply_spec.rb
+++ b/spec/services/degrees/map_from_apply_spec.rb
@@ -3,20 +3,20 @@
 require "rails_helper"
 
 module Degrees
-  describe CreateFromApply do
+  describe MapFromApply do
     let(:apply_application) { create(:apply_application) }
     let(:degree_attributes) { ApiStubs::ApplyApi.uk_degree.as_json }
 
     let(:common_attributes) do
       {
         subject: degree_attributes["subject"],
-        graduation_year: degree_attributes["award_year"].to_i,
+        graduation_year: degree_attributes["award_year"],
       }
     end
 
     let(:uk_degree_attributes) do
       {
-        locale_code: "uk",
+        locale_code: Trainee.locale_codes[:uk],
         uk_degree: degree_attributes["qualification_type"],
         institution: degree_attributes["institution_details"],
         grade: degree_attributes["grade"],
@@ -25,7 +25,7 @@ module Degrees
 
     let(:non_uk_degree_attributes) do
       {
-        locale_code: "non_uk",
+        locale_code: Trainee.locale_codes[:non_uk],
         non_uk_degree: degree_attributes["comparable_uk_degree"],
         country: "St Kitts and Nevis",
       }
@@ -33,17 +33,17 @@ module Degrees
 
     subject { described_class.call(attributes: degree_attributes) }
 
-    it { is_expected.to be_a_new(Degree) }
-    it { is_expected.to have_attributes(common_attributes) }
+    it { is_expected.to be_a(Hash) }
+    it { is_expected.to include(common_attributes) }
 
     context "with a uk degree" do
-      it { is_expected.to have_attributes(uk_degree_attributes) }
+      it { is_expected.to include(uk_degree_attributes) }
     end
 
     context "with a non-uk degree" do
       let(:degree_attributes) { ApiStubs::ApplyApi.non_uk_degree.as_json }
 
-      it { is_expected.to have_attributes(non_uk_degree_attributes) }
+      it { is_expected.to include(non_uk_degree_attributes) }
     end
   end
 end

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -66,6 +66,12 @@ module Trainees
       }.to change(Trainee.draft, :count).by(1)
     end
 
+    it "creates a degree" do
+      expect {
+        create_trainee_from_apply
+      }.to change(Degree, :count).by(1)
+    end
+
     it { is_expected.to have_attributes(trainee_attributes) }
 
     it "associates the created trainee against the apply_application and provider" do


### PR DESCRIPTION
### Context
https://trello.com/c/JCGni6pb/2208-create-from-apply-service-handles-invalid-data

[see also PR for Option 2](https://github.com/DFE-Digital/register-trainee-teachers/pull/1147)

Spike for Option 1 of handling invalid data:
Introducing methods on the ApplyApplication object attached to a trainee for all fields which could have unmappable values eg:

trainee.apply_application.institution this would return the invalid data from the jsonb column if the value wasn't initially saved on the trainee

### Changes proposed in this pull request
1. Defined the reverse relationship between trainee and apply application
2. I've had to move some of the validations over to the Degree model so that we can validate against the model rather than initialising a DegreeForm. The reason for doing that is since some of the fields are autocomplete related, and in this version, we are using the standard rails inclusion validator, as opposed to comparing two values submitted via an enhanced autocomplete.
3. Rename `Degrees::CreateFromApply` to `Degrees::MapFromApply`, since this service has changed its output to a hash now.
4. A method called `degrees` added to `ApplyApplication`, along with a few other reader methods.
5. In the `Trainees::CreateFromApply` service, added a bit of code to validate and blank out erroring fields


### Guidance to review
In a `rails console`, ensuring you have an `ApplyApplication` record available, run the following commands
```ruby
application = ApplyApplication.last
Trainees::CreateFromApply.call(application: application)
```
A trainee should be created as per usual.
The difference between this option and [option 2](https://github.com/DFE-Digital/register-trainee-teachers/pull/1147) is that in this option, we do not explicitly store any error data against the `ApplyApplication`. All of the application json would be potentially made into reader methods depending on the need.
To view the degree attributes run the following (Note that in this case, these reader methods exist independent to a trainee creation)
```ruby

trainee.apply_application.degrees
# or if you want to check the contents before creating a trainee
ApplyApplication.last.degrees
# => [{:subject=>"Religious Studies", :graduation_year=>"2020", :locale_code=>0, :uk_degree=>"BA", :institution=>"University of Warwick", :grade=>"First class honours"}]
```



