### PR TITLE
[1982] Client side autocomplete - handling punctuation

### DIFF
--- a/app/components/form_components/autocomplete/sort.js
+++ b/app/components/form_components/autocomplete/sort.js
@@ -3,7 +3,7 @@ const matchPositions = (string, regexes) => regexes.map(regex => string.search(r
 
 // Returns a lowercase string with some common punctation removed / replaced
 // by whitespace.
-const clean = s => s.trim().replace(/'/g, '').replace(/[.,"/#!$%^&*;:{}=\-_`~()]/g, ' ').toLowerCase()
+const clean = s => s.trim().replace(/['’]/g, '').replace(/[.,"/#!$%^&*;:{}=\-_`~()]/g, ' ').toLowerCase()
 
 // Determines how closely a query matches either an option's name/synonyms.
 // Returns an integer ranging from 0 (no match) to 100 (exact name match).

--- a/app/components/form_components/autocomplete/sort.js
+++ b/app/components/form_components/autocomplete/sort.js
@@ -1,8 +1,9 @@
 // Returns an array of integers representing the position of each regex match.
 const matchPositions = (string, regexes) => regexes.map(regex => string.search(regex)).filter(i => i >= 0)
 
-// Returns a lowercase string with some common punctation removed.
-const clean = s => s.trim().replace(/[.,'"/#!$%^&*;:{}=\-_`~()]/g, '').toLowerCase()
+// Returns a lowercase string with some common punctation removed / replaced
+// by whitespace.
+const clean = s => s.trim().replace(/'/g, '').replace(/[.,"/#!$%^&*;:{}=\-_`~()]/g, ' ').toLowerCase()
 
 // Determines how closely a query matches either an option's name/synonyms.
 // Returns an integer ranging from 0 (no match) to 100 (exact name match).

--- a/app/webpacker/scripts/autocomplete_sort.spec.js
+++ b/app/webpacker/scripts/autocomplete_sort.spec.js
@@ -78,15 +78,16 @@ describe('sort', () => {
       { name: 'plants' }
     ]
     expect(sort("plant's", options)).toEqual(['plants'])
-    expect(sort("'plant'", options)).toEqual(['plants'])
-    expect(sort('plant(s)', options)).toEqual(['plants'])
+    expect(sort("(plants)", options)).toEqual(['plants'])
   })
 
   it('can handle query with missing punctuation', () => {
     const options = [
       { name: "plant's leaf" },
-      { name: 'flower', synonyms: ["plant's leaf"] }
+      { name: 'flower', synonyms: ["plant's leaf"] },
+      { name: 'flower/rose' }
     ]
     expect(sort('plants leaf', options)).toEqual(["plant's leaf", 'flower'])
+    expect(sort('flower rose', options)).toEqual(['flower/rose'])
   })
 })

--- a/app/webpacker/scripts/autocomplete_sort.spec.js
+++ b/app/webpacker/scripts/autocomplete_sort.spec.js
@@ -77,7 +77,7 @@ describe('sort', () => {
     const options = [
       { name: 'plants' }
     ]
-    expect(sort("plant's", options)).toEqual(['plants'])
+    expect(sort('plant’s', options)).toEqual(['plants'])
     expect(sort('(plants)', options)).toEqual(['plants'])
   })
 

--- a/app/webpacker/scripts/autocomplete_sort.spec.js
+++ b/app/webpacker/scripts/autocomplete_sort.spec.js
@@ -78,7 +78,7 @@ describe('sort', () => {
       { name: 'plants' }
     ]
     expect(sort("plant's", options)).toEqual(['plants'])
-    expect(sort("(plants)", options)).toEqual(['plants'])
+    expect(sort('(plants)', options)).toEqual(['plants'])
   })
 
   it('can handle query with missing punctuation', () => {


### PR DESCRIPTION
### Context

https://trello.com/c/shC2CPc3/1982-autocompletes-handling-punctuation

### Changes proposed in this pull request

Rather than stripping punctuation from both the user's query and the option's name/synonyms, this PR replaces the punctuation with whitespace (except for `'` which we still strip).

This means that things like searching for "ba education" will return a result "ba/education":

**Before**

<img width="534" alt="Screenshot 2021-07-15 at 15 30 38" src="https://user-images.githubusercontent.com/18436946/125805582-0dc0d511-2bc1-4044-8b28-7805e9574a4e.png">

**After**

<img width="518" alt="Screenshot 2021-07-15 at 15 29 21" src="https://user-images.githubusercontent.com/18436946/125805656-8e900e14-f128-4f23-99b8-25489b36bb53.png">

### Guidance to review

Search for some things with/without punctuation and check whether it returns you the expected results.