### PR TITLE
[2215] Check details page needs to show collapsed version of apply draft sections

### DIFF
--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -47,6 +47,7 @@ module Sections
         training_details: TrainingDetails::View,
         schools: Schools::View,
         funding: Funding::View,
+        trainee_data: ReviewDraft::ApplyDraft::View,
       }[section]
     end
 
@@ -55,35 +56,48 @@ module Sections
         personal_details: {
           not_started: "edit_trainee_personal_details_path",
           in_progress: "trainee_personal_details_confirm_path",
+          review: "trainee_personal_details_confirm_path",
         },
         contact_details: {
           not_started: "edit_trainee_contact_details_path",
           in_progress: "trainee_contact_details_confirm_path",
+          review: "trainee_contact_details_confirm_path",
         },
         diversity: {
           not_started: "edit_trainee_diversity_disclosure_path",
           in_progress: "trainee_diversity_confirm_path",
+          review: "trainee_diversity_confirm_path",
         },
         degrees: {
           not_provided: "trainee_degrees_new_type_path",
           not_started: "trainee_degrees_new_type_path",
           in_progress: "trainee_degrees_confirm_path",
+          review: "trainee_degrees_confirm_path",
         },
         course_details: {
           not_started: "edit_trainee_course_details_path",
           in_progress: "trainee_course_details_confirm_path",
+          review: "trainee_course_details_confirm_path",
         },
         training_details: {
           not_started: "edit_trainee_training_details_path",
           in_progress: "trainee_training_details_confirm_path",
+          review: "trainee_training_details_confirm_path",
         },
         schools: {
           not_started: "edit_trainee_lead_schools_path",
           in_progress: "trainee_schools_confirm_path",
+          review: "trainee_schools_confirm_path",
         },
         funding: {
           not_started: "edit_trainee_funding_training_initiative_path",
           in_progress: "trainee_funding_confirm_path",
+          review: "trainee_funding_confirm_path",
+        },
+        trainee_data: {
+          not_started: "edit_trainee_apply_trainee_data_path",
+          in_progress: "edit_trainee_apply_trainee_data_path",
+          review: "edit_trainee_apply_trainee_data_path",
         },
       }[section][progress_status]
     end

--- a/app/controllers/trainees/apply_trainee_data_controller.rb
+++ b/app/controllers/trainees/apply_trainee_data_controller.rb
@@ -6,17 +6,18 @@ module Trainees
 
     def edit
       page_tracker.save_as_origin!
-      @form = ApplyTraineeDataForm.new(trainee: @trainee)
+      @form = ApplyTraineeDataForm.new(@trainee)
     end
 
     def update
       if params[:apply_trainee_data_form][:mark_as_reviewed] == "1"
-        @form = ApplyTraineeDataForm.new(trainee: @trainee)
-        unless @form.save
+        @form = ApplyTraineeDataForm.new(@trainee)
+        if @form.save
+          redirect_to trainee_path(trainee)
+        else
           render :edit
         end
       end
-      redirect_to trainee_path(trainee)
     end
 
   private

--- a/app/forms/apply_trainee_data_form.rb
+++ b/app/forms/apply_trainee_data_form.rb
@@ -16,13 +16,17 @@ class ApplyTraineeDataForm
   validator :diversity, form: "Diversities::FormValidator"
   validator :degrees, form: "DegreesForm"
 
+  delegate :apply_application?, to: :trainee
+
   attr_accessor :mark_as_reviewed
 
-  def initialize(trainee:)
+  def initialize(trainee)
     @trainee = trainee
   end
 
   def save
+    return unless all_forms_valid?
+
     trainee.progress.personal_details = true
     trainee.progress.contact_details = true
     trainee.progress.diversity = true
@@ -30,10 +34,26 @@ class ApplyTraineeDataForm
     trainee.save!
   end
 
+  def all_forms_valid?
+    form_validators.keys.all? do |section|
+      validator(section).new(trainee).valid?
+    end
+  end
+
   def progress_status(progress_key)
     return :not_provided if trainee.apply_application? && !progress_service(progress_key).started?
 
     progress_service(progress_key).status.parameterize(separator: "_").to_sym
+  end
+
+  def progress
+    form_validators.keys.all? { |section_key| trainee.progress.public_send(section_key) }
+  end
+
+  def fields
+    form_validators.keys.map do |section|
+      validator(section).new(trainee).fields
+    end.inject :merge
   end
 
   def display_type(section_key)

--- a/app/forms/trn_submission_form.rb
+++ b/app/forms/trn_submission_form.rb
@@ -11,16 +11,18 @@ class TrnSubmissionForm
     end
   end
 
-  trn_validator :personal_details, form: "PersonalDetailsForm"
-  trn_validator :contact_details, form: "ContactDetailsForm"
-  trn_validator :diversity, form: "Diversities::FormValidator"
-  trn_validator :degrees, form: "DegreesForm"
+  trn_validator :personal_details, form: "PersonalDetailsForm", unless: :apply_application?
+  trn_validator :contact_details, form: "ContactDetailsForm", unless: :apply_application?
+  trn_validator :diversity, form: "Diversities::FormValidator", unless: :apply_application?
+  trn_validator :degrees, form: "DegreesForm", unless: :apply_application?
   trn_validator :course_details, form: "CourseDetailsForm"
   trn_validator :training_details, form: "TrainingDetailsForm"
+  trn_validator :trainee_data, form: "ApplyTraineeDataForm", if: :apply_application?
   trn_validator :schools, form: "Schools::FormValidator", if: :requires_schools?
   trn_validator :funding, form: "Funding::FormValidator", if: :funding_details_collected?
 
   delegate :requires_schools?, to: :trainee
+  delegate :apply_application?, to: :trainee
 
   validate :submission_ready
 

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -70,7 +70,10 @@ module TaskListHelper
           path: edit_trainee_apply_trainee_data_path(trainee),
           confirm_path: edit_trainee_apply_trainee_data_path(trainee),
           classes: "trainee-data",
-          status: "review",
+          status: ProgressService.call(
+            validator: ApplyTraineeDataForm.new(trainee),
+            progress_value: ApplyTraineeDataForm.new(trainee).progress,
+          ).status,
         },
 
       personal_details:

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -17,6 +17,7 @@ class Progress
   attribute :course_details, :boolean, default: false
   attribute :training_details, :boolean, default: false
   attribute :placement_details, :boolean, default: false
+  attribute :trainee_data, :boolean, default: false
   attribute :schools, :boolean, default: false
   attribute :funding, :boolean, default: false
 end

--- a/app/views/trainees/check_details/_apply_draft_trainee_check_details.html.erb
+++ b/app/views/trainees/check_details/_apply_draft_trainee_check_details.html.erb
@@ -1,0 +1,21 @@
+<h2 class="govuk-heading-m">
+  Registration data from Apply
+</h2>
+
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :course_details) %>
+
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :trainee_data) %>
+
+<h2 class="govuk-heading-m">
+  About their teacher training
+</h2>
+
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :training_details) %>
+
+<% if @trainee.requires_schools? %>
+  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :schools) %>
+<% end %>
+
+<% if FeatureService.enabled?(:show_funding) %>
+  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :funding) %>
+<% end %>

--- a/app/views/trainees/check_details/_draft_trainee_check_details.html.erb
+++ b/app/views/trainees/check_details/_draft_trainee_check_details.html.erb
@@ -1,0 +1,27 @@
+<h2 class="govuk-heading-m">
+  Personal details and education
+</h2>
+
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :personal_details) %>
+
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :contact_details) %>
+
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :diversity) %>
+
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :degrees) %>
+
+<h2 class="govuk-heading-m">
+  About their teacher training
+</h2>
+
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :course_details) %>
+
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :training_details) %>
+
+<% if @trainee.requires_schools? %>
+  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :schools) %>
+<% end %>
+
+<% if FeatureService.enabled?(:show_funding) %>
+  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :funding) %>
+<% end %>

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -41,32 +41,10 @@
       </div>
     </div>
 
-    <h2 class="govuk-heading-m">
-      Personal details and education
-    </h2>
-
-    <%= render Sections::View.new(trainee: @trainee, form: @form, section: :personal_details) %>
-
-    <%= render Sections::View.new(trainee: @trainee, form: @form, section: :contact_details) %>
-
-    <%= render Sections::View.new(trainee: @trainee, form: @form, section: :diversity) %>
-
-    <%= render Sections::View.new(trainee: @trainee, form: @form, section: :degrees) %>
-
-    <h2 class="govuk-heading-m">
-      About their teacher training
-    </h2>
-
-    <%= render Sections::View.new(trainee: @trainee, form: @form, section: :course_details) %>
-
-    <%= render Sections::View.new(trainee: @trainee, form: @form, section: :training_details) %>
-
-    <% if @trainee.requires_schools? %>
-      <%= render Sections::View.new(trainee: @trainee, form: @form, section: :schools) %>
-    <% end %>
-
-    <% if FeatureService.enabled?(:show_funding) %>
-      <%= render Sections::View.new(trainee: @trainee, form: @form, section: :funding) %>
+    <% if @trainee.apply_application? %>
+      <%= render "trainees/check_details/apply_draft_trainee_check_details" %>
+    <% else %>
+      <%= render "trainees/check_details/draft_trainee_check_details" %>
     <% end %>
 
     <%= register_form_with(model: @form, url: trn_submissions_path, method: :post, local: true) do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,16 +296,19 @@ en:
         training_details: Training details
         placement_details: Placement details
         lead_school: School details
+        trainee_data: Trainee data
         schools: Schools
         funding: Funding
       statuses:
         not_provided: not provided
         not_started: not started
         in_progress: not marked as complete
+        review: not reviewed
       link_texts:
         not_provided: Add degree details
         not_started: Start section
         in_progress: Continue section
+        review: Review their data
     school_result_notice:
       result_text: "1 more school matches your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."
       multiple_result_text: "%{remaining_search_count} more schools match your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."

--- a/spec/components/apply_trainee_data/view_preview.rb
+++ b/spec/components/apply_trainee_data/view_preview.rb
@@ -55,7 +55,7 @@ module ApplyTraineeData
     end
 
     def form
-      ApplyTraineeDataForm.new(trainee: trainee)
+      ApplyTraineeDataForm.new(trainee)
     end
   end
 end

--- a/spec/components/apply_trainee_data/view_spec.rb
+++ b/spec/components/apply_trainee_data/view_spec.rb
@@ -7,7 +7,7 @@ module ApplyTraineeData
     alias_method :component, :page
 
     before do
-      form = ApplyTraineeDataForm.new(trainee: trainee)
+      form = ApplyTraineeDataForm.new(trainee)
       render_inline(View.new(trainee, form))
     end
 

--- a/spec/features/trainee_actions/submit_for_trn_spec.rb
+++ b/spec/features/trainee_actions/submit_for_trn_spec.rb
@@ -46,6 +46,18 @@ feature "submit for TRN" do
     end
   end
 
+  describe "content" do
+    let(:trainee) { create(:trainee, :with_apply_application, provider: current_user.provider) }
+
+    context "with an apply-draft-trainee" do
+      scenario "has a trainee data section" do
+        given_an_apply_draft_trainee_exists
+        and_i_am_on_the_check_details_page
+        theres_a_trainee_data_section
+      end
+    end
+  end
+
   describe "navigation" do
     context "clicking back to draft record" do
       scenario "returns the user to the summary page" do
@@ -64,6 +76,14 @@ feature "submit for TRN" do
         then_i_am_redirected_to_the_trainee_records_page
       end
     end
+  end
+
+  def given_an_apply_draft_trainee_exists
+    trainee
+  end
+
+  def theres_a_trainee_data_section
+    expect(review_draft_page).to have_text("Trainee data")
   end
 
   def when_i_am_viewing_the_review_draft_page

--- a/spec/forms/apply_trainees/apply_trainee_data_form_spec.rb
+++ b/spec/forms/apply_trainees/apply_trainee_data_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ApplyTraineeDataForm, type: :model do
+  subject { described_class.new(trainee) }
+
+  describe "validations" do
+    context "when one or more of the forms is invalid" do
+      let(:trainee) { create(:trainee, :with_apply_application) }
+
+      it "returns the entire form as invalid" do
+        expect(subject.progress).to eq false
+        expect(subject.all_forms_valid?).to eq false
+      end
+    end
+
+    context "when all of the forms are valid" do
+      let(:trainee) { create(:trainee, :with_apply_application, :completed) }
+
+      it "returns the entire form as invalid" do
+        expect(subject.progress).to eq true
+        expect(subject.all_forms_valid?).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/CP15d6zY/2215-s-check-details-page-needs-to-show-collapsed-version-of-apply-draft-sections)

### Changes proposed in this pull request

- Changed the check-details page to be like prototype; the key difference being that 4 forms (personal, contact, diversity, degrees) are coupled into a new higher-order form called Trainee Data
- I changed this form to behave a little more dynamically, and so it now works with the progress/status/fields that are required for a form to have if it wants to work with the ProgressService among other things. 
- The view for check-details/show is now using partials to render seperate pages, one for normal draft trainees and one for apply draft trainees

### Guidance to review

- Find an Apply Draft Trainee
- Click on the `Check Details` at the bottom of the review draft page
- You will be directed to the check details page. 
- Here, you will see the blue inset text box for the trainee data form with the status text of the form.
