### PR TITLE
[2273] Add ability to search for allocation subject in filter

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -9,7 +9,7 @@ class TraineesController < ApplicationController
   def index
     return redirect_to trainees_path(filter_params) if current_page_exceeds_total_pages?
 
-    @total_trainees_count = filtered_trainees.count
+    @total_trainees_count = filtered_trainees.length
 
     # We can't use `#draft` to find @draft_trainees since that applies a `WHERE`
     # clause, removing Kaminari's pagination. Hence the use of `#select`.

--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -8,7 +8,7 @@ module CourseDetailsHelper
   end
 
   def filter_course_subjects_options
-    to_options(course_subjects, first_value: "All subjects")
+    to_options(all_subjects, first_value: "All subjects")
   end
 
   def main_age_ranges_options
@@ -67,5 +67,10 @@ private
 
   def course_subjects
     @course_subjects ||= SubjectSpecialism.order_by_name.pluck(:name)
+  end
+
+  def all_subjects
+    @all_subjects ||= (SubjectSpecialism.pluck(:name) + AllocationSubject.pluck(:name))
+      .map(&:downcase).uniq.sort
   end
 end

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -59,7 +59,7 @@ module Trainees
     def subject(trainees, subject)
       return trainees if subject.blank?
 
-      trainees.with_subject(subject)
+      trainees.with_subject_or_allocation_subject(subject)
     end
 
     def text_search(trainees, text_search)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -193,8 +193,8 @@ ActiveRecord::Schema.define(version: 2021_07_02_093832) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.string "code"
     t.boolean "apply_sync_enabled", default: false
+    t.string "code"
     t.string "ukprn"
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -78,6 +78,13 @@ namespace :example_data do
               )
             end
 
+            if route.to_s.include?("early_years")
+              attrs.merge!(
+                course_subject_one: Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING,
+                course_age_range: AgeRange::ZERO_TO_FIVE,
+              )
+            end
+
             trainee = FactoryBot.create(:trainee, route, state, attrs)
 
             # Add an extra nationality 20% of the time

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -165,14 +165,29 @@ FactoryBot.define do
       training_route { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
     end
 
+    trait :with_early_years_course_details do
+      course_subject_one { Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING }
+      course_age_range { AgeRange::ZERO_TO_FIVE }
+    end
+
+    trait :early_years_assessment_only do
+      training_route { TRAINING_ROUTE_ENUMS[:early_years_assessment_only] }
+      with_early_years_course_details
+    end
+
+    trait :early_years_salaried do
+      training_route { TRAINING_ROUTE_ENUMS[:early_years_salaried] }
+      with_early_years_course_details
+    end
+
     trait :early_years_postgrad do
       training_route { TRAINING_ROUTE_ENUMS[:early_years_postgrad] }
+      with_early_years_course_details
     end
 
     trait :early_years_undergrad do
       training_route { TRAINING_ROUTE_ENUMS[:early_years_undergrad] }
-      course_subject_one { Dttp::CodeSets::CourseSubjects::EARLY_YEARS_TEACHING }
-      course_age_range { AgeRange::ZERO_TO_FIVE }
+      with_early_years_course_details
     end
 
     trait :school_direct_tuition_fee do

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -364,11 +364,11 @@ describe Trainee do
     end
   end
 
-  describe "#with_subject" do
+  describe "#with_subject_or_allocation_subject" do
     let!(:trainee_with_subject) { create(:trainee, course_subject_one: Dttp::CodeSets::CourseSubjects::BIOLOGY) }
     let!(:trainee_without_subject) { create(:trainee, course_subject_one: Dttp::CodeSets::CourseSubjects::MATHEMATICS) }
 
-    subject { described_class.with_subject(Dttp::CodeSets::CourseSubjects::BIOLOGY) }
+    subject { described_class.with_subject_or_allocation_subject(Dttp::CodeSets::CourseSubjects::BIOLOGY) }
 
     it { is_expected.to eq([trainee_with_subject]) }
 
@@ -393,6 +393,15 @@ describe Trainee do
       end
 
       it { is_expected.to match_array([trainee_with_subject, trainee_with_subject_two, trainee_with_subject_three]) }
+    end
+
+    context "with allocation subject" do
+      let(:subject_specialism) { create(:subject_specialism) }
+      let!(:trainee_with_subject) { create(:trainee, course_subject_one: subject_specialism.name) }
+
+      subject { described_class.with_subject_or_allocation_subject(subject_specialism.allocation_subject.name) }
+
+      it { is_expected.to eq([trainee_with_subject]) }
     end
   end
 


### PR DESCRIPTION
### Context

https://trello.com/c/XYBwAlCO/2273-m-dev-include-allocations-subjects-in-subject-filters

### Changes proposed in this pull request

- Increases the scope of `:with_subject` on trainee such that it includes the allocation subject for each of the three possible subjects recorded on a trainee.
- Renames `:with_subject` to `:with_subject_or_allocation_subject` to better reflect the returned trainees

### Guidance to review

- Check that you can search by allocation subject e.g. search for Modern Languages, and 'French language' etc is returned