### PR TITLE
[2279] Enable EY AO and postgrad routes in staging

### DIFF
--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -19,6 +19,8 @@ features:
   publish_course_details: true
   persist_to_dttp: true
   routes:
+    early_years_assessment_only: true
+    early_years_postgrad: true
     provider_led_postgrad: true
     school_direct_salaried: true
     school_direct_tuition_fee: true


### PR DESCRIPTION
### Context

https://trello.com/c/Zl3oYt8W/2279-enable-eyts-routes-in-staging-for-testing

### Changes proposed in this pull request

Enables Early years (assessment only) and Early years (postgrad) routes in staging for testing.

### Guidance to review

🚢 