### PR TITLE
[2272] Bursary row for non-draft trainees

### DIFF
--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -32,7 +32,7 @@ module Funding
         rows << {
           key: t(".bursary_funding"),
           value: bursary_funding,
-          action: action_link("bursary funding", edit_trainee_funding_bursary_path(trainee)),
+          action: (action_link("bursary funding", edit_trainee_funding_bursary_path(trainee)) if trainee.can_apply_for_bursary?),
         }
       end
 
@@ -46,7 +46,7 @@ module Funding
     end
 
     def show_bursary_funding?
-      trainee.can_apply_for_bursary?
+      !trainee.draft? || trainee.can_apply_for_bursary?
     end
 
     def bursary_amount
@@ -66,7 +66,9 @@ module Funding
     end
 
     def bursary_funding
-      return t("components.confirmation.not_provided") if trainee.applying_for_bursary.nil?
+      return t("components.confirmation.not_provided") if trainee.can_apply_for_bursary? && trainee.applying_for_bursary.nil?
+
+      return t(".no_bursary_available") if !trainee.can_apply_for_bursary?
 
       return "#{t(".tiered_bursary_applied_for.#{trainee.bursary_tier}")}#{bursary_funding_hint}".html_safe if trainee.bursary_tier.present?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -574,6 +574,7 @@ en:
       bursary_funding: Bursary funding
       bursary_applied_for: Bursary applied for
       no_bursary_applied_for: Not bursary funded
+      no_bursary_available: No bursaries available for this course
       tiered_bursary_applied_for:
         tier_one: Applied for Tier 1
         tier_two: Applied for Tier 2

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -18,7 +18,8 @@ module Funding
     end
 
     context "assessment only route" do
-      let(:trainee) { build(:trainee, training_initiative: training_initiative) }
+      let(:state) { :draft }
+      let(:trainee) { build(:trainee, state, training_initiative: training_initiative) }
 
       describe "on training initiative" do
         let(:training_initiative) { ROUTE_INITIATIVES.keys.first }
@@ -40,8 +41,16 @@ module Funding
             render_inline(View.new(data_model: trainee))
           end
 
-          it "doesnt not render" do
+          it "doesnt not render bursary row" do
             expect(rendered_component).not_to have_text("Bursary applied for")
+          end
+
+          context "and it non-draft" do
+            let(:state) { :trn_received }
+
+            it "renders bursary not available" do
+              expect(rendered_component).to have_text("No bursaries available for this course")
+            end
           end
         end
 


### PR DESCRIPTION
### Context

https://trello.com/c/3zNJdE4B/2272-funding-snagging-bursary-row-for-non-draft-trainees

### Changes proposed in this pull request

Shows a bursary row for all non-draft trainees in the funding.component. If no bursary was available for their route/subject combo, it says "No bursaries available for this course".

Only renders a 'change' link on that row if there was a bursary available.

### Guidance to review