### PR TITLE
[xxx] Add EY(AO) and EY(PG) qualification aims

### DIFF
--- a/app/lib/dttp/code_sets/qualification_aims.rb
+++ b/app/lib/dttp/code_sets/qualification_aims.rb
@@ -12,6 +12,8 @@ module Dttp
         TRAINING_ROUTE_ENUMS[:early_years_undergrad] => { entity_id: "d446cd4b-4d9c-e711-80d9-005056ac45bb" },
         TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => { entity_id: "68cbae32-7389-e711-80d8-005056ac45bb" },
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => { entity_id: "68cbae32-7389-e711-80d8-005056ac45bb" },
+        TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => { entity_id: "e0113eff-141e-e711-80c8-0050568902d3" },
+        TRAINING_ROUTE_ENUMS[:early_years_postgrad] => { entity_id: "d446cd4b-4d9c-e711-80d9-005056ac45bb" },
       }.freeze
     end
   end


### PR DESCRIPTION
### Context

We have added two new routes... Early years assessment only and early years postgrad. 

### Changes proposed in this pull request

Add the ITT qualification aims mapping to enable them to be sent to DTTP.

### Guidance to review

You could check the GUIDs against the DTTP back office 🤷 

https://dttp-ppad.crm4.dynamics.com.mcas.ms/main.aspx?app=d365default&forceUCI=1&pagetype=entitylist&etn=dfe_ittqualificationaim&viewid=692516a9-7ae2-4c8c-8cd6-a20f8c66fbd6&viewType=1039

