### PR TITLE
[2274] Handle validation for commence date before course start date

### DIFF
--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TraineeStartDateForm < TraineeForm
+  include TrainingDetailsHelper
+
   attr_accessor :day, :month, :year
 
   validate :commencement_date_valid
@@ -41,6 +43,8 @@ private
       errors.add(:commencement_date, :blank)
     elsif !commencement_date.is_a?(Date)
       errors.add(:commencement_date, :invalid)
+    elsif date_before_course_start_date?(commencement_date, trainee.course_start_date)
+      errors.add(:commencement_date, :not_before_course_start_date)
     end
   end
 

--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TrainingDetailsForm < TraineeForm
+  include TrainingDetailsHelper
+
   COMMENCEMENT_DATE_RADIO_OPTION_COURSE = "course"
   COMMENCEMENT_DATE_RADIO_OPTION_MANUAL = "manual"
 
@@ -61,6 +63,8 @@ private
       errors.add(:commencement_date, :blank)
     elsif !commencement_date.is_a?(Date)
       errors.add(:commencement_date, :invalid)
+    elsif date_before_course_start_date?(commencement_date, trainee.course_start_date)
+      errors.add(:commencement_date, :not_before_course_start_date)
     end
   end
 

--- a/app/helpers/training_details_helper.rb
+++ b/app/helpers/training_details_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module TrainingDetailsHelper
+  def date_before_course_start_date?(commencement_date, course_start_date)
+    return false if course_start_date.blank?
+
+    commencement_date < course_start_date
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -879,11 +879,13 @@ en:
             commencement_date:
                 blank: Enter a start date
                 invalid: Enter a valid start date
+                not_before_course_start_date: &not_before_course_start_date The date must not be before the course start date
         training_details_form:
           attributes:
             commencement_date:
               blank: Enter a start date
               invalid: Enter a valid start date
+              not_before_course_start_date: *not_before_course_start_date
             trainee_id:
               blank: Enter a trainee ID
               max_char_exceeded: Your entry must not exceed 100 characters

--- a/spec/forms/trainee_start_date_form_spec.rb
+++ b/spec/forms/trainee_start_date_form_spec.rb
@@ -6,7 +6,7 @@ describe TraineeStartDateForm, type: :model do
   let(:params) { { year: "2020", month: "12", day: "20" } }
   let(:trainee) { build(:trainee, :not_started) }
   let(:form_store) { class_double(FormStore) }
-  let(:error_attr) { "activemodel.errors.models.training_details_form.attributes.commencement_date" }
+  let(:error_attr) { "activemodel.errors.models.trainee_start_date_form.attributes.commencement_date" }
 
   subject { described_class.new(trainee, params: params, store: form_store) }
 
@@ -30,6 +30,16 @@ describe TraineeStartDateForm, type: :model do
 
       it "is invalid" do
         expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.blank"))
+      end
+    end
+
+    context "date is before the course start date" do
+      let(:trainee) do
+        build(:trainee, course_start_date: Time.zone.today, commencement_date: 1.day.ago)
+      end
+
+      it "is invalid" do
+        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.not_before_course_start_date"))
       end
     end
   end

--- a/spec/forms/training_details_form_spec.rb
+++ b/spec/forms/training_details_form_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe TrainingDetailsForm, type: :model do
   let(:params) { {} }
   let(:trainee) { build(:trainee) }
+  let(:error_attr) { "activemodel.errors.models.training_details_form.attributes" }
 
   subject { described_class.new(trainee, params: params) }
 
@@ -23,7 +24,7 @@ describe TrainingDetailsForm, type: :model do
 
         it "returns a blank error message" do
           expect(subject.errors[:trainee_id]).to include(
-            I18n.t("activemodel.errors.models.training_details_form.attributes.trainee_id.blank"),
+            I18n.t("#{error_attr}.trainee_id.blank"),
           )
         end
       end
@@ -34,7 +35,7 @@ describe TrainingDetailsForm, type: :model do
         it "returns a max character exceeded message" do
           expect(subject).not_to be_valid
           expect(subject.errors[:trainee_id]).to include(
-            I18n.t("activemodel.errors.models.training_details_form.attributes.trainee_id.max_char_exceeded"),
+            I18n.t("#{error_attr}.trainee_id.max_char_exceeded"),
           )
         end
       end
@@ -54,7 +55,7 @@ describe TrainingDetailsForm, type: :model do
 
         it "returns a blank error message" do
           expect(subject.errors[:commencement_date]).to include(
-            I18n.t("activemodel.errors.models.training_details_form.attributes.commencement_date.blank"),
+            I18n.t("#{error_attr}.commencement_date.blank"),
           )
         end
       end
@@ -64,8 +65,18 @@ describe TrainingDetailsForm, type: :model do
 
         it "returns an invalid date error message" do
           expect(subject.errors[:commencement_date]).to include(
-            I18n.t("activemodel.errors.models.training_details_form.attributes.commencement_date.invalid"),
+            I18n.t("#{error_attr}.commencement_date.invalid"),
           )
+        end
+      end
+
+      context "date is before the course start date" do
+        let(:trainee) do
+          build(:trainee, course_start_date: Time.zone.today, commencement_date: 1.day.ago)
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.commencement_date.not_before_course_start_date"))
         end
       end
     end


### PR DESCRIPTION
### Context

- https://trello.com/c/KQ9bKnc1/2274-add-validation-for-programme-date-and-start-date

### Changes proposed in this pull request

Prior to this PR you could set the `commencement_date` before the course start date and it'll result in a trainee not being able to receive an award. This PR enforces a validation only if the course information has been filled out (assuming you may edit this section before the course details one).

**Training Details Form**

<img width="1131" alt="Screenshot 2021-07-19 at 18 25 37" src="https://user-images.githubusercontent.com/616080/126299150-02b613ee-58cc-4c41-bebc-4facab7530af.png">

**Trainee Start Date Form (From record page)**

<img width="988" alt="Screenshot 2021-07-19 at 17 51 14" src="https://user-images.githubusercontent.com/616080/126299163-f5736678-5e73-4fbf-8bb9-a20fcf583636.png">

### Guidance to review

- Create a new trainee, fill out the course details
- Head to the training details section and enter a date before the course start date

