### PR TITLE
[xxx] Add early years to routes codeset

### DIFF
--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -9,6 +9,8 @@ module Dttp
         TRAINING_ROUTE_ENUMS[:early_years_undergrad] => { entity_id: "6b89922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => { entity_id: "6f89922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => { entity_id: "7789922e-acc2-e611-80be-00155d010316" },
+        TRAINING_ROUTE_ENUMS[:early_years_postgrad] => { entity_id: "6789922e-acc2-e611-80be-00155d010316" },
+        TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => { entity_id: "6589922e-acc2-e611-80be-00155d010316" },
       }.freeze
     end
   end


### PR DESCRIPTION
### Context

We have added early years postgrad and assessment only routes.

### Changes proposed in this pull request

Add the mappings to the codeset.

### Guidance to review

DTTP entries -> https://dttp-ppad.crm4.dynamics.com.mcas.ms/main.aspx?app=d365default&forceUCI=1&pagetype=entitylist&etn=dfe_route&viewid=b564da9c-6717-414b-a679-c6ac2230a222&viewType=1039

