### PR TITLE
[2249] Update ApplyApi::ImportApplicationsJob to create trainees from application data

### DIFF
--- a/app/jobs/apply_api/import_applications_job.rb
+++ b/app/jobs/apply_api/import_applications_job.rb
@@ -7,8 +7,9 @@ module ApplyApi
     def perform
       return unless FeatureService.enabled?("import_applications_from_apply")
 
-      new_applications.each do |application|
-        ImportApplication.call(application: application)
+      new_applications.each do |application_data|
+        application_record = ImportApplication.call(application_data: application_data)
+        Trainees::CreateFromApply.call(application: application_record)
       end
     end
 

--- a/app/services/apply_api/import_application.rb
+++ b/app/services/apply_api/import_application.rb
@@ -4,22 +4,21 @@ module ApplyApi
   class ImportApplication
     include ServicePattern
 
-    def initialize(application:)
-      @raw_application = application
+    def initialize(application_data:)
+      @application_data = application_data
     end
 
     def call
       return unless provider
 
-      application.update!(
-        application: raw_application.to_json,
-        provider: provider,
-      )
+      application.update!(application: application_data.to_json, provider: provider)
+
+      application
     end
 
   private
 
-    attr_reader :raw_application
+    attr_reader :application_data
 
     def provider
       @provider ||= Provider.find_by(code: provider_code)
@@ -32,11 +31,11 @@ module ApplyApi
     end
 
     def provider_code
-      @provider_code ||= raw_application["attributes"]["course"]["training_provider_code"]
+      @provider_code ||= application_data["attributes"]["course"]["training_provider_code"]
     end
 
     def apply_id
-      @apply_id ||= raw_application["id"]
+      @apply_id ||= application_data["id"]
     end
   end
 end

--- a/spec/services/apply_api/import_application_spec.rb
+++ b/spec/services/apply_api/import_application_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 module ApplyApi
   describe ImportApplication do
     describe "#call" do
-      let(:application) { JSON.parse(ApiStubs::ApplyApi.application) }
+      let(:application_data) { JSON.parse(ApiStubs::ApplyApi.application) }
 
-      subject { described_class.call(application: application) }
+      subject { described_class.call(application_data: application_data) }
 
       context "when the provider does not exist in register" do
         let(:provider) { create(:provider) }
@@ -18,17 +18,21 @@ module ApplyApi
       end
 
       context "when the provider exists in register" do
-        let(:provider_code) { application["attributes"]["course"]["training_provider_code"] }
-        let(:provider) { create(:provider, code: provider_code) }
+        let(:provider_code) { application_data["attributes"]["course"]["training_provider_code"] }
+        let!(:provider) { create(:provider, code: provider_code) }
+
+        it "returns the application record" do
+          expect(subject).to be_instance_of(ApplyApplication)
+        end
 
         it "creates the apply_application and associates it with that provider" do
           expect { subject }.to change { provider.apply_applications.count }.by(1)
-          expect(provider.apply_applications.first.application).to eq application.to_json
+          expect(provider.apply_applications.first.application).to eq(application_data.to_json)
         end
 
-        context "and the apply application also exists in register" do
+        context "and the apply application_data also exists in register" do
           before do
-            create(:apply_application, apply_id: application["id"])
+            create(:apply_application, apply_id: application_data["id"])
           end
 
           it "does not create a duplicate" do


### PR DESCRIPTION
### Context
https://trello.com/c/0L9h6P71/2249-s-refactor-applyapiimportapplicationsjob-to-actually-create-the-trainees-too

### Changes proposed in this pull request
- Modify `ApplyApi::ImportApplicationsJob` to create trainee record from apply application import

The ticket mentioned renaming the job name (my suggestion), but after noticing the naming of other import jobs, I think it makes sense to leave it as it is so it remains consistent with other files (happy to discuss this further).

