### PR TITLE
[2288] Don't send non-ao trainees to DTTP until after clockover

### DIFF
--- a/app/jobs/dttp/retrieve_trn_job.rb
+++ b/app/jobs/dttp/retrieve_trn_job.rb
@@ -5,12 +5,18 @@ module Dttp
     queue_as :default
     retry_on Client::HttpError
     include NotifyOnTimeout
+    include ClockoverDependent
 
     class TraineeAttributeError < StandardError; end
 
     def perform(trainee, timeout_after = nil)
       @timeout_after = timeout_after
       @trainee = trainee
+
+      if before_clockover?
+        requeue_after_clockover
+        return
+      end
 
       if @timeout_after.nil?
         self.class.perform_later(trainee, trainee.submitted_for_trn_at + Settings.jobs.max_poll_duration_days.days)
@@ -49,6 +55,10 @@ module Dttp
 
     def requeue
       self.class.set(wait: Settings.jobs.poll_delay_hours.hours).perform_later(trainee, timeout_after)
+    end
+
+    def requeue_after_clockover
+      self.class.set(wait_until: clockover_date).perform_later(trainee, clockover_date + Settings.jobs.max_poll_duration_days.days)
     end
   end
 end

--- a/app/lib/clockover_dependent.rb
+++ b/app/lib/clockover_dependent.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ClockoverDependent
+  def before_clockover?
+    Time.zone.now < clockover_date
+  end
+
+  def clockover_date
+    Time.zone.parse(Settings.clockover_date)
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -109,3 +109,5 @@ google_tag_manager:
   tracking_id: GTM-PD8MFNL
   auth_id: O3Y_kHqIkzLf5m0xGNafIA
   env_id: 11
+
+clockover_date: "01/08/2021"

--- a/spec/jobs/dttp/register_for_trn_job_spec.rb
+++ b/spec/jobs/dttp/register_for_trn_job_spec.rb
@@ -8,11 +8,18 @@ module Dttp
     let(:dttp_id) { SecureRandom.uuid }
     let(:placement_assignment_dttp_id) { SecureRandom.uuid }
     let(:creator_dttp_id) { SecureRandom.uuid }
+    let(:run_date) { "01/08/2021" }
 
     before do
       enable_features(:persist_to_dttp)
 
       allow(RegisterForTrn).to receive(:call)
+    end
+
+    around do |example|
+      Timecop.freeze(run_date) do
+        example.run
+      end
     end
 
     describe "#perform_now" do
@@ -37,6 +44,29 @@ module Dttp
           DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED,
           UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
         )
+      end
+
+      context "for non-AO trainees" do
+        let(:clockover_date) { "01/08/2021" }
+
+        before do
+          allow(Settings).to receive(:clockover_date).and_return(clockover_date)
+        end
+
+        context "before clockover" do
+          let(:run_date) { "31/07/2021" }
+
+          it "requeues the job for after clockover" do
+            expect(RegisterForTrnJob).to receive(:set).with(wait_until: Time.zone.parse(clockover_date)).and_return(job = double)
+            expect(job).to receive(:perform_later).with(trainee, creator_dttp_id)
+            subject
+          end
+
+          it "does not make the request to DTTP" do
+            expect(RegisterForTrn).not_to receive(:call)
+            subject
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

DTTP does not accept new registrations for this year until after a process called clockover which happens on 1/8/2021. We don't want to submit any trainees until after that otherwise they'll be registered in the wrong year.

### Changes proposed in this pull request

Update the `RegisterForTrnJob` (and the related `RetreiveTrnJob`) to requeue themselves to after clockover if they are called before the clockover date.

### Guidance to review

