### PR TITLE
[XXX] Allow assessment only before clockover

### DIFF
--- a/app/jobs/dttp/register_for_trn_job.rb
+++ b/app/jobs/dttp/register_for_trn_job.rb
@@ -13,7 +13,7 @@ module Dttp
 
       return unless FeatureService.enabled?(:persist_to_dttp)
 
-      if before_clockover?
+      if before_clockover? && trainee_is_not_assessment_only?
         requeue_after_clockover
         return
       end
@@ -39,6 +39,10 @@ module Dttp
 
     def requeue_after_clockover
       self.class.set(wait_until: clockover_date).perform_later(trainee, created_by_dttp_id)
+    end
+
+    def trainee_is_not_assessment_only?
+      !(trainee.assessment_only? || trainee.early_years_assessment_only?)
     end
   end
 end

--- a/app/jobs/dttp/retrieve_trn_job.rb
+++ b/app/jobs/dttp/retrieve_trn_job.rb
@@ -13,7 +13,7 @@ module Dttp
       @timeout_after = timeout_after
       @trainee = trainee
 
-      if before_clockover?
+      if before_clockover? && trainee_is_not_assessment_only?
         requeue_after_clockover
         return
       end
@@ -59,6 +59,10 @@ module Dttp
 
     def requeue_after_clockover
       self.class.set(wait_until: clockover_date).perform_later(trainee, clockover_date + Settings.jobs.max_poll_duration_days.days)
+    end
+
+    def trainee_is_not_assessment_only?
+      !(trainee.assessment_only? || trainee.early_years_assessment_only?)
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -111,4 +111,4 @@ google_tag_manager:
   auth_id: O3Y_kHqIkzLf5m0xGNafIA
   env_id: 11
 
-clockover_date: "01/08/2021"
+clockover_date: "03/08/2021"

--- a/spec/jobs/dttp/register_for_trn_job_spec.rb
+++ b/spec/jobs/dttp/register_for_trn_job_spec.rb
@@ -56,15 +56,32 @@ module Dttp
         context "before clockover" do
           let(:run_date) { "31/07/2021" }
 
-          it "requeues the job for after clockover" do
-            expect(RegisterForTrnJob).to receive(:set).with(wait_until: Time.zone.parse(clockover_date)).and_return(job = double)
-            expect(job).to receive(:perform_later).with(trainee, creator_dttp_id)
-            subject
+          context "the trainee is assessment only" do
+            before do
+              trainee.early_years_assessment_only!
+            end
+
+            it "runs the job" do
+              expect(RegisterForTrn).to receive(:call).with(trainee: trainee, created_by_dttp_id: creator_dttp_id)
+              subject
+            end
           end
 
-          it "does not make the request to DTTP" do
-            expect(RegisterForTrn).not_to receive(:call)
-            subject
+          context "the trainee is not assessment only" do
+            before do
+              trainee.provider_led_postgrad!
+            end
+
+            it "requeues the job for after clockover" do
+              expect(RegisterForTrnJob).to receive(:set).with(wait_until: Time.zone.parse(clockover_date)).and_return(job = double)
+              expect(job).to receive(:perform_later).with(trainee, creator_dttp_id)
+              subject
+            end
+
+            it "does not make the request to DTTP" do
+              expect(RegisterForTrn).not_to receive(:call)
+              subject
+            end
           end
         end
       end


### PR DESCRIPTION
### Context

We are holding back submissions to DTTP until after clockover. This shouldn't include assessment only.

### Changes proposed in this pull request

* Allow assessment only and early years assessment only to be processed now.
* Update the clockover date. Clockover will be on the morning of 2/8 so hold back requests until 3/8

### Guidance to review

