### PR TITLE
[2293] Handle date before course start date validation for other trainee date forms

### DIFF
--- a/app/forms/multi_date_form.rb
+++ b/app/forms/multi_date_form.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class MultiDateForm < TraineeForm
+  include TrainingDatesHelper
+
   attr_accessor :day, :month, :year, :date_string
 
   validate :date_valid
@@ -85,6 +87,8 @@ private
       errors.add(:date, :blank)
     elsif !date.is_a?(Date)
       errors.add(:date, :invalid)
+    elsif date_before_course_start_date?(date, trainee.course_start_date)
+      errors.add(:date, :not_before_course_start_date)
     end
   end
 end

--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TraineeStartDateForm < TraineeForm
-  include TrainingDetailsHelper
+  include TrainingDatesHelper
 
   attr_accessor :day, :month, :year
 

--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TrainingDetailsForm < TraineeForm
-  include TrainingDetailsHelper
+  include TrainingDatesHelper
 
   COMMENCEMENT_DATE_RADIO_OPTION_COURSE = "course"
   COMMENCEMENT_DATE_RADIO_OPTION_MANUAL = "manual"

--- a/app/helpers/training_dates_helper.rb
+++ b/app/helpers/training_dates_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module TrainingDetailsHelper
+module TrainingDatesHelper
   def date_before_course_start_date?(commencement_date, course_start_date)
     return false if course_start_date.blank?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -755,6 +755,7 @@ en:
             date:
               blank: Enter a deferral date
               invalid: Enter a valid deferral date
+              not_before_course_start_date: &not_before_course_start_date The date must not be before the course start date
         degrees_form:
           attributes:
             degree_ids:
@@ -808,6 +809,7 @@ en:
             date:
               blank: Enter an outcome date
               invalid: Enter a valid outcome date
+              not_before_course_start_date: *not_before_course_start_date
         personal_details_form:
           attributes:
             first_names:
@@ -862,6 +864,7 @@ en:
               blank: Enter a date of return
               invalid: Enter a valid date of return
               hint_html: For example, 15 6 %{year}
+              not_before_course_start_date: *not_before_course_start_date
         trn_submission_form:
           attributes:
             trainee:
@@ -873,6 +876,7 @@ en:
             date:
               blank: Enter a withdrawal date
               invalid: Enter a valid withdrawal date
+              not_before_course_start_date: *not_before_course_start_date
             additional_withdraw_reason:
               blank: Enter a reason
             withdraw_reason:
@@ -887,7 +891,7 @@ en:
             commencement_date:
                 blank: Enter a start date
                 invalid: Enter a valid start date
-                not_before_course_start_date: &not_before_course_start_date The date must not be before the course start date
+                not_before_course_start_date: *not_before_course_start_date
         training_details_form:
           attributes:
             commencement_date:

--- a/spec/forms/deferral_form_spec.rb
+++ b/spec/forms/deferral_form_spec.rb
@@ -9,14 +9,14 @@ describe DeferralForm, type: :model do
 
   let(:params) do
     {
-      "year" => "1963",
-      "month" => "11",
-      "day" => "11",
-      "date_string" => "other",
+      year: trainee.course_start_date.year,
+      month: trainee.course_start_date.month,
+      day: trainee.course_start_date.day,
+      date_string: "other",
     }
   end
 
-  subject { described_class.new(trainee, params: params, store: form_store) }
+  subject { described_class.new(trainee, params: params.stringify_keys, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)
@@ -53,17 +53,14 @@ describe DeferralForm, type: :model do
           )
         end
       end
+
+      include_examples "date is not before course start date", :deferral_form
     end
   end
 
   describe "#fields" do
     it "combines the data from params with the existing trainee data" do
-      expect(subject.fields).to match({
-        date_string: "other",
-        day: "11",
-        month: "11",
-        year: "1963",
-      })
+      expect(subject.fields).to match(params)
     end
   end
 

--- a/spec/forms/outcome_date_form_spec.rb
+++ b/spec/forms/outcome_date_form_spec.rb
@@ -8,14 +8,14 @@ describe OutcomeDateForm, type: :model do
 
   let(:params) do
     {
-      "year" => "1963",
-      "month" => "11",
-      "day" => "11",
-      "date_string" => "other",
+      year: trainee.course_start_date.year,
+      month: trainee.course_start_date.month,
+      day: trainee.course_start_date.day,
+      date_string: "other",
     }
   end
 
-  subject { described_class.new(trainee, params: params, store: form_store) }
+  subject { described_class.new(trainee, params: params.stringify_keys, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)
@@ -52,17 +52,14 @@ describe OutcomeDateForm, type: :model do
           )
         end
       end
+
+      include_examples "date is not before course start date", :outcome_date_form
     end
   end
 
   describe "#fields" do
     it "combines the data from params with the existing trainee data" do
-      expect(subject.fields).to match({
-        date_string: "other",
-        day: "11",
-        month: "11",
-        year: "1963",
-      })
+      expect(subject.fields).to match(params)
     end
   end
 

--- a/spec/forms/reinstatement_form_spec.rb
+++ b/spec/forms/reinstatement_form_spec.rb
@@ -8,14 +8,14 @@ describe ReinstatementForm, type: :model do
 
   let(:params) do
     {
-      "year" => "1963",
-      "month" => "11",
-      "day" => "11",
-      "date_string" => "other",
+      year: trainee.course_start_date.year,
+      month: trainee.course_start_date.month,
+      day: trainee.course_start_date.day,
+      date_string: "other",
     }
   end
 
-  subject { described_class.new(trainee, params: params, store: form_store) }
+  subject { described_class.new(trainee, params: params.stringify_keys, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)
@@ -52,17 +52,14 @@ describe ReinstatementForm, type: :model do
           )
         end
       end
+
+      include_examples "date is not before course start date", :reinstatement_form
     end
   end
 
   describe "#fields" do
     it "combines the data from params with the existing trainee data" do
-      expect(subject.fields).to match({
-        date_string: "other",
-        day: "11",
-        month: "11",
-        year: "1963",
-      })
+      expect(subject.fields).to match(params)
     end
   end
 

--- a/spec/forms/withdrawal_form_spec.rb
+++ b/spec/forms/withdrawal_form_spec.rb
@@ -7,7 +7,7 @@ describe WithdrawalForm, type: :model do
   let(:trainee) { create(:trainee, :withdrawn, :withdrawn_for_another_reason) }
   let(:form_store) { class_double(FormStore) }
 
-  subject { described_class.new(trainee, params: params, store: form_store) }
+  subject { described_class.new(trainee, params: params.stringify_keys, store: form_store) }
 
   before do
     allow(form_store).to receive(:get).and_return(nil)
@@ -44,6 +44,8 @@ describe WithdrawalForm, type: :model do
           )
         end
       end
+
+      include_examples "date is not before course start date", :withdrawal_form
     end
   end
 
@@ -51,24 +53,17 @@ describe WithdrawalForm, type: :model do
     context "with params" do
       let(:params) do
         {
-          "day" => "11",
-          "month" => "11",
-          "year" => "1963",
-          "date_string" => "other",
-          "withdraw_reason" => WithdrawalReasons::HEALTH_REASONS,
-          "additional_withdraw_reason" => "",
+          year: trainee.course_start_date.year,
+          month: trainee.course_start_date.month,
+          day: trainee.course_start_date.day,
+          date_string: "other",
+          withdraw_reason: WithdrawalReasons::HEALTH_REASONS,
+          additional_withdraw_reason: "",
         }
       end
 
       it "combines the data from params with the existing trainee data" do
-        expect(subject.fields).to match({
-          date_string: "other",
-          day: "11",
-          month: "11",
-          year: "1963",
-          withdraw_reason: WithdrawalReasons::HEALTH_REASONS,
-          additional_withdraw_reason: "",
-        })
+        expect(subject.fields).to match(params)
       end
     end
 

--- a/spec/support/shared_examples/date_not_before_course_start_date.rb
+++ b/spec/support/shared_examples/date_not_before_course_start_date.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "date is not before course start date" do |form|
+  context "date is before the course start date" do
+    before do
+      subject.year = trainee.course_start_date.year - 1
+      subject.validate
+    end
+
+    it "is invalid" do
+      expect(subject.errors[:date]).to include(I18n.t("activemodel.errors.models.#{form}.attributes.date.not_before_course_start_date"))
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/DImGqgwX/2293-validate-outcome-date-form-is-not-before-the-course-start-date

### Changes proposed in this pull request

<img width="1080" alt="Screenshot 2021-07-21 at 14 03 07" src="https://user-images.githubusercontent.com/616080/126517227-e16a4861-a11d-47bd-a15b-27d100a68e26.png">
<img width="1055" alt="Screenshot 2021-07-21 at 14 05 38" src="https://user-images.githubusercontent.com/616080/126517233-47a398da-ea5e-4ad8-b24e-7f787d9fc180.png">
<img width="1084" alt="Screenshot 2021-07-21 at 14 06 18" src="https://user-images.githubusercontent.com/616080/126517235-89868ac6-5fdf-402f-9284-2bffebafdff3.png">
<img width="1120" alt="Screenshot 2021-07-21 at 16 02 36" src="https://user-images.githubusercontent.com/616080/126517238-5c21b773-6b48-4196-b7e5-a6b9e370c35d.png">


### Guidance to review

Play about with a few trainees post trn received status by setting the dates for either (outcome, withdrawal, reinstatement, deferral) to be before the course start date.
