### PR TITLE
[2217] Apply draft confirm page invalid data row notice

### DIFF
--- a/app/components/collapsed_section/style.scss
+++ b/app/components/collapsed_section/style.scss
@@ -15,6 +15,12 @@ $govuk-border-width-narrow: 5px;
   .app-inset-text__title {
     color: govuk-colour("blue");
   }
+
+  &.app-inset-text--no_padding {
+    padding-top: 0;
+    padding-right: 0;
+    padding-bottom: 0;
+  }
 }
 
 .app-inset-text--error {

--- a/app/components/degrees/view.rb
+++ b/app/components/degrees/view.rb
@@ -27,49 +27,27 @@ module Degrees
     def get_degree_rows(degree)
       if degree.uk?
         [
-          {
-            key: "Institution",
-            value: degree.institution,
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> institution</span>'.html_safe, edit_trainee_degree_path(trainee, degree)),
-          },
-          {
-            key: "Subject",
-            value: degree.subject,
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> subject</span>'.html_safe, edit_trainee_degree_path(trainee, degree)),
-          },
-          {
-            key: "Degree type",
-            value: degree.uk_degree,
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> degree type</span>'.html_safe, edit_trainee_degree_path(trainee, degree)),
-          },
+          mappable_field_row(degree, :institution, "Institution"),
+          mappable_field_row(degree, :subject, "Subject"),
+          mappable_field_row(degree, :uk_degree, "Degree type"),
           {
             key: "Grade",
             value: grade_for(degree),
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> grade</span>'.html_safe, edit_trainee_degree_path(trainee, degree)),
+            action: govuk_link_to('Change<span class="govuk-visually-hidden"> grade</span>'.html_safe,
+                                  edit_trainee_degree_path(trainee, degree)),
           },
           {
             key: "Graduation year",
             value: degree.graduation_year,
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> graduation year</span>'.html_safe, edit_trainee_degree_path(trainee, degree)),
+            action: govuk_link_to('Change<span class="govuk-visually-hidden"> graduation year</span>'.html_safe,
+                                  edit_trainee_degree_path(trainee, degree)),
           },
         ]
       else
         [
-          {
-            key: "Country",
-            value: degree.country,
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> country</span>'.html_safe, edit_trainee_degree_path(trainee, degree)),
-          },
-          {
-            key: "Subject",
-            value: degree.subject,
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> subject</span>'.html_safe, edit_trainee_degree_path(trainee, degree)),
-          },
-          {
-            key: "Degree type",
-            value: degree.non_uk_degree == NON_ENIC ? "UK ENIC not provided" : degree.non_uk_degree,
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> degree type</span>'.html_safe, edit_trainee_degree_path(trainee, degree)),
-          },
+          mappable_field_row(degree, :country, "Country"),
+          mappable_field_row(degree, :subject, "Subject"),
+          mappable_field_row(degree, :non_uk_degree, "Degree type", non_uk_degree_type(degree)),
           {
             key: "Graduation year",
             value: degree.graduation_year,
@@ -85,10 +63,23 @@ module Degrees
 
   private
 
+    def non_uk_degree_type(degree)
+      degree.non_uk_degree == NON_ENIC ? "UK ENIC not provided" : degree.non_uk_degree
+    end
+
     def grade_for(degree)
       return degree.grade += " (#{degree.other_grade})" if degree.other_grade.present?
 
       degree.grade
+    end
+
+    def mappable_field_row(degree, field_name, field_label, field_value = nil)
+      MappableFieldRow.new(invalid_data: trainee.apply_application&.degrees_invalid_data,
+                           record_id: degree.to_param,
+                           field_name: field_name,
+                           field_value: field_value || degree.public_send(field_name),
+                           field_label: field_label,
+                           action_url: edit_trainee_degree_path(trainee, degree)).to_h
     end
   end
 end

--- a/app/components/personal_details/view.html.erb
+++ b/app/components/personal_details/view.html.erb
@@ -2,27 +2,22 @@
                                  heading_level: 2,
                                  rows: [
       {
-        key: "Full name",
+        key: t("components.confirmation.personal_detail.full_name"),
         value: full_name,
         action: govuk_link_to('Change<span class="govuk-visually-hidden"> full name</span>'.html_safe,
                               edit_trainee_personal_details_path(trainee)),
       },
       {
-        key: "Date of birth",
+        key: t("components.confirmation.personal_detail.date_of_birth"),
         value: date_of_birth,
         action: govuk_link_to('Change<span class="govuk-visually-hidden"> date of birth</span>'.html_safe,
                               edit_trainee_personal_details_path(trainee)),
       },
       {
-        key: "Gender",
+        key: t("components.confirmation.personal_detail.gender"),
         value: gender,
         action: govuk_link_to('Change<span class="govuk-visually-hidden"> gender</span>'.html_safe,
                               edit_trainee_personal_details_path(trainee)),
       },
-      {
-        key: "Nationality",
-        value: nationality,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> nationality</span>'.html_safe,
-                              edit_trainee_personal_details_path(trainee)),
-      },
+      nationality_row
     ]) %>

--- a/app/components/personal_details/view.rb
+++ b/app/components/personal_details/view.rb
@@ -31,11 +31,20 @@ module PersonalDetails
     def gender
       return @not_provided_copy unless data_model.gender
 
-      I18n.t("components.confirmation.personal_detail.gender.#{data_model.gender}")
+      I18n.t("components.confirmation.personal_detail.genders.#{data_model.gender}")
     end
 
+    def nationality_row
+      MappableFieldRow.new(field_value: nationality,
+                           field_label: "Nationality",
+                           text: t("components.confirmation.missing"),
+                           action_url: edit_trainee_personal_details_path(trainee)).to_h
+    end
+
+  private
+
     def nationality
-      return @not_provided_copy if nationalities.blank?
+      return if nationalities.blank?
 
       if nationalities.size == 1
         nationalities.first.name.titleize

--- a/app/view_objects/mappable_field_row.rb
+++ b/app/view_objects/mappable_field_row.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class MappableFieldRow
+  include GovukLinkHelper
+  include ActionView::Helpers::UrlHelper
+
+  def initialize(options = {})
+    @invalid_data = options[:invalid_data]
+    @record_id = options[:record_id]
+    @field_name = options[:field_name]
+    @field_value = options[:field_value]
+    @field_label = options[:field_label]
+    @action_url = options[:action_url]
+    @text = options[:text] || "not recognised"
+  end
+
+  def to_h
+    { key: field_label }.merge(value_attribute).merge(action_attribute)
+  end
+
+private
+
+  attr_accessor :invalid_data, :record_id, :field_name, :field_value, :field_label, :text, :action_url
+
+  def value_attribute
+    return { value: unmapped_value.html_safe } if field_value.nil?
+
+    { value: field_value }
+  end
+
+  def action_attribute
+    return {} if field_value.nil?
+
+    html = %(Change <span class="govuk-visually-hidden">#{field_label.downcase}</span>).html_safe
+    { action: govuk_link_to(html, action_url) }
+  end
+
+  def unmapped_value
+    <<~HTML
+      <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--important app-inset-text--no_padding">
+        <p class="app-inset-text__title govuk-!-margin-bottom-2">#{field_label} is #{text}</p>
+        #{original_value_html}
+        <div>
+          <a class="govuk-link govuk-link--no-visited-state app-summary-list__link--invalid" href="#{action_url}">
+            Review the trainee’s answer<span class="govuk-visually-hidden"> for #{field_label.downcase}</span>
+          </a>
+        </div>
+      </div>
+    HTML
+  end
+
+  def original_value_html
+    %(<div class="govuk-!-margin-bottom-1">#{original_value}</div>) if original_value
+  end
+
+  def original_value
+    invalid_data&.dig(record_id, field_name.to_s)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       trainee_name:
         blank: "Draft record"
     confirmation:
+      missing: missing
       not_provided: Not provided
       heading: "Confirm trainee’s %{section_title}"
       cancel_and_return: Cancel and return to record
@@ -66,7 +67,10 @@ en:
           no_disability: They shared that they’re not disabled
           disability_not_provided: Not provided
       personal_detail:
-        gender:
+        full_name: Full name
+        date_of_birth: Date of birth
+        gender: Gender
+        genders:
           male: Male
           female: Female
           other: Other

--- a/spec/components/personal_details/view_spec.rb
+++ b/spec/components/personal_details/view_spec.rb
@@ -20,7 +20,8 @@ module PersonalDetails
       end
 
       it "tells the user that no data has been entered" do
-        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: t("components.confirmation.not_provided"), count: 4)
+        expect(rendered_component).to have_selector(".govuk-summary-list__value",
+                                                    text: t("components.confirmation.not_provided"), count: 3)
       end
     end
 
@@ -46,7 +47,7 @@ module PersonalDetails
       it "renders the gender" do
         expect(rendered_component)
           .to have_text(
-            I18n.t("components.confirmation.personal_detail.gender.#{trainee.gender}"),
+            I18n.t("components.confirmation.personal_detail.genders.#{trainee.gender}"),
           )
       end
 

--- a/spec/view_objects/mappable_field_row_spec.rb
+++ b/spec/view_objects/mappable_field_row_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe MappableFieldRow do
+  describe "#to_h" do
+    let(:record_id) { "WUtHPtyT4JmACiTQGh8YywDn" }
+    let(:field_name) { :subject }
+    let(:field_label) { "Subject" }
+    let(:field_value) { nil }
+    let(:action_url) { "/abc" }
+    let(:apply_subject_value) { "Master's Degree" }
+
+    subject do
+      described_class.new(invalid_data: invalid_data,
+                          record_id: record_id,
+                          field_name: field_name,
+                          field_value: field_value,
+                          field_label: field_label,
+                          action_url: action_url).to_h
+    end
+
+    context "field value matches error value" do
+      let(:invalid_data) { { record_id => { "subject" => apply_subject_value } } }
+
+      let(:expected_html) do
+        <<~HTML
+          <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--important app-inset-text--no_padding">
+            <p class="app-inset-text__title govuk-!-margin-bottom-2">#{field_label} is not recognised</p>
+            <div class="govuk-!-margin-bottom-1">#{apply_subject_value}</div>
+            <div>
+              <a class="govuk-link govuk-link--no-visited-state app-summary-list__link--invalid" href="#{action_url}">
+                Review the trainee’s answer<span class="govuk-visually-hidden"> for #{field_label.downcase}</span>
+              </a>
+            </div>
+          </div>
+        HTML
+      end
+
+      it "returns HTML to inform user that field value is not recognised and needs changing" do
+        expect(subject[:value]).to eq(expected_html)
+      end
+
+      it "doesn't set the action key" do
+        expect(subject).not_to have_key(:action)
+      end
+    end
+
+    context "field value is not listed in the errors" do
+      let(:invalid_data) { {} }
+      let(:field_value) { "History" }
+
+      it "returns field value" do
+        expect(subject[:value]).to eq(field_value)
+      end
+
+      it "sets the action key" do
+        expect(subject[:action]).to eq(
+          %(<a class="govuk-link" href="/abc">Change <span class="govuk-visually-hidden">#{field_label.downcase}</span></a>),
+        )
+      end
+    end
+
+    context "no error but value missing" do
+      subject do
+        described_class.new(field_value: nil,
+                            field_label: field_label,
+                            text: "missing",
+                            action_url: action_url).to_h
+      end
+
+      let(:expected_html) do
+        <<~HTML
+          <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--important app-inset-text--no_padding">
+            <p class="app-inset-text__title govuk-!-margin-bottom-2">#{field_label} is missing</p>
+            #{''}
+            <div>
+              <a class="govuk-link govuk-link--no-visited-state app-summary-list__link--invalid" href="#{action_url}">
+                Review the trainee’s answer<span class="govuk-visually-hidden"> for #{field_label.downcase}</span>
+              </a>
+            </div>
+          </div>
+        HTML
+      end
+
+      it "returns HTML excluding information about error value since it's not available" do
+        expect(subject[:value]).to eq(expected_html)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/ZAn3b2cO/2217-l-apply-draft-confirm-page-invalid-data-row-notice

### Changes proposed in this pull request
- Create new view object `MappableFieldRow` that can deal with 2 scenarios within summary components:
  - Scenario 1: Field value is nil, but there is invalid information about the field
  - Scenario 2: Field value is nil and there's no invalid information
- Update personal details and degree components to use `MappableFieldRow` on those particular attributes that can be in an unmapped state

#### Scenario 1: Field value is nil, but there is invalid information about the field
<img width="965" alt="Screenshot 2021-07-22 at 14 20 41" src="https://user-images.githubusercontent.com/28728/126645716-83a42a09-e8cd-452f-80d9-704794749cd7.png">

#### Scenario 2: Field value is nil and there's no invalid information
<img width="874" alt="Screenshot 2021-07-23 at 16 06 11" src="https://user-images.githubusercontent.com/28728/126801954-8b8f30df-8a1e-42fa-88a2-4a028edd2635.png">

### Guidance to review
#### Nationality
- Select a trainee imported from Apply
- If a nationality is not provided, it should be displayed as missing
- Click on link to choose nationality
- Missing information should no longer appear

#### Degrees
- Select a trainee imported from Apply and make sure it has a degree
- Open rails console and run the follow:
```ruby
trainee = Trainee.find_by(slug: "<slug>")
degree = trainee.degrees.first
degree.update(subject: nil)
trainee.apply_application.update(invalid_data: { 'degrees' => { degree.to_param => { "subject" => "Master's Degree" } } })
```
- Refresh page and the subject field should display blue notice that it's not recognised
