### PR TITLE
[2287] Collect ITT start date for PGTA publish courses

### DIFF
--- a/app/components/apply_applications/confirm_course/view.rb
+++ b/app/components/apply_applications/confirm_course/view.rb
@@ -6,12 +6,13 @@ module ApplyApplications
       include SummaryHelper
       include CourseDetailsHelper
 
-      attr_accessor :trainee, :course, :specialisms
+      attr_accessor :trainee, :course, :specialisms, :itt_start_date
 
-      def initialize(trainee:, course:, specialisms:)
+      def initialize(trainee:, course:, specialisms:, itt_start_date:)
         @trainee = trainee
         @course = course
         @specialisms = specialisms
+        @itt_start_date = itt_start_date
       end
 
       def heading
@@ -60,7 +61,7 @@ module ApplyApplications
       end
 
       def start_date
-        date_for_summary_view(course.start_date)
+        date_for_summary_view(itt_start_date || course.start_date)
       end
 
       def duration

--- a/app/components/confirm_publish_course/view.rb
+++ b/app/components/confirm_publish_course/view.rb
@@ -5,12 +5,13 @@ module ConfirmPublishCourse
     include SummaryHelper
     include CourseDetailsHelper
 
-    attr_accessor :trainee, :course, :specialisms
+    attr_accessor :trainee, :course, :specialisms, :itt_start_date
 
-    def initialize(trainee:, course:, specialisms:)
+    def initialize(trainee:, course:, specialisms:, itt_start_date:)
       @trainee = trainee
       @course = course
       @specialisms = specialisms
+      @itt_start_date = itt_start_date
     end
 
     def heading
@@ -62,7 +63,7 @@ module ConfirmPublishCourse
     end
 
     def start_date
-      date_for_summary_view(course.start_date)
+      date_for_summary_view(itt_start_date || course.start_date)
     end
 
     def duration

--- a/app/controllers/concerns/publish_course_next_path.rb
+++ b/app/controllers/concerns/publish_course_next_path.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Enforces HTTP Basic Auth
+module PublishCourseNextPath
+  def publish_course_next_path
+    if trainee.requires_itt_start_date?
+      edit_trainee_course_details_itt_start_date_path(trainee)
+    else
+      course_confirmation_path
+    end
+  end
+
+  def course_confirmation_path
+    if trainee.apply_application?
+      trainee_apply_applications_confirm_courses_path(trainee)
+    else
+      edit_trainee_confirm_publish_course_path(@trainee)
+    end
+  end
+end

--- a/app/controllers/concerns/publish_course_next_path.rb
+++ b/app/controllers/concerns/publish_course_next_path.rb
@@ -14,7 +14,7 @@ module PublishCourseNextPath
     if trainee.apply_application?
       trainee_apply_applications_confirm_courses_path(trainee)
     else
-      edit_trainee_confirm_publish_course_path(@trainee)
+      edit_trainee_confirm_publish_course_path(trainee)
     end
   end
 end

--- a/app/controllers/trainees/apply_applications/confirm_courses_controller.rb
+++ b/app/controllers/trainees/apply_applications/confirm_courses_controller.rb
@@ -7,14 +7,15 @@ module Trainees
       before_action :set_course
       before_action :set_specialisms
       helper_method :course_code
+      before_action :set_itt_start_date
 
       def show
         page_tracker.save_as_origin!
-        @confirm_course_form = ::ApplyApplications::ConfirmCourseForm.new(trainee, @specialisms)
+        @confirm_course_form = ::ApplyApplications::ConfirmCourseForm.new(trainee, @specialisms, @itt_start_date)
       end
 
       def update
-        @confirm_course_form = ::ApplyApplications::ConfirmCourseForm.new(trainee, @specialisms, course_params)
+        @confirm_course_form = ::ApplyApplications::ConfirmCourseForm.new(trainee, @specialisms, @itt_start_date, course_params)
 
         if @confirm_course_form.save
           clear_form_stash(trainee)
@@ -32,6 +33,12 @@ module Trainees
 
       def set_course
         @course = trainee.available_courses.find_by!(code: course_code)
+      end
+
+      def set_itt_start_date
+        @itt_start_date = if @trainee.requires_itt_start_date?
+                            IttStartDateForm.new(@trainee).date
+                          end
       end
 
       def set_specialisms

--- a/app/controllers/trainees/confirm_publish_course_controller.rb
+++ b/app/controllers/trainees/confirm_publish_course_controller.rb
@@ -6,14 +6,15 @@ module Trainees
     before_action :authorize_trainee
     before_action :set_course
     before_action :set_specialisms
+    before_action :set_itt_start_date
 
     def edit
       page_tracker.save_as_origin!
-      @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee, @specialisms)
+      @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee, @specialisms, @course_start_date)
     end
 
     def update
-      @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee, @specialisms, course_params)
+      @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee, @specialisms, @course_start_date, course_params)
       if @confirm_publish_course_form.save
         clear_form_stash(@trainee)
         redirect_to review_draft_trainee_path(@trainee)
@@ -23,6 +24,12 @@ module Trainees
     end
 
   private
+
+    def set_itt_start_date
+      @itt_start_date = if @trainee.requires_itt_start_date?
+                          IttStartDateForm.new(@trainee).date
+                        end
+    end
 
     def set_specialisms
       specialism_form_type = PublishCourseDetailsForm.new(@trainee).specialism_form&.to_sym

--- a/app/controllers/trainees/confirm_publish_course_controller.rb
+++ b/app/controllers/trainees/confirm_publish_course_controller.rb
@@ -10,11 +10,11 @@ module Trainees
 
     def edit
       page_tracker.save_as_origin!
-      @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee, @specialisms, @course_start_date)
+      @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee, @specialisms, @itt_start_date)
     end
 
     def update
-      @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee, @specialisms, @course_start_date, course_params)
+      @confirm_publish_course_form = ConfirmPublishCourseForm.new(@trainee, @specialisms, @itt_start_date, course_params)
       if @confirm_publish_course_form.save
         clear_form_stash(@trainee)
         redirect_to review_draft_trainee_path(@trainee)

--- a/app/controllers/trainees/itt_start_dates_controller.rb
+++ b/app/controllers/trainees/itt_start_dates_controller.rb
@@ -12,7 +12,7 @@ module Trainees
       @itt_start_date_form = IttStartDateForm.new(trainee, params: trainee_params, user: current_user)
 
       if @itt_start_date_form.stash
-        redirect_to edit_trainee_confirm_publish_course_path(trainee_id: @trainee.slug)
+        redirect_to edit_trainee_confirm_publish_course_path(trainee.slug)
       else
         render :edit
       end

--- a/app/controllers/trainees/itt_start_dates_controller.rb
+++ b/app/controllers/trainees/itt_start_dates_controller.rb
@@ -5,13 +5,13 @@ module Trainees
     before_action :authorize_trainee
 
     def edit
-      @start_form = IttStartDateForm.new(trainee)
+      @itt_start_date_form = IttStartDateForm.new(trainee)
     end
 
     def update
-      @start_form = IttStartDateForm.new(trainee, params: trainee_params, user: current_user)
+      @itt_start_date_form = IttStartDateForm.new(trainee, params: trainee_params, user: current_user)
 
-      if @start_form.stash
+      if @itt_start_date_form.stash
         redirect_to edit_trainee_confirm_publish_course_path(trainee_id: @trainee.slug)
       else
         render :edit

--- a/app/controllers/trainees/itt_start_dates_controller.rb
+++ b/app/controllers/trainees/itt_start_dates_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Trainees
+  class IttStartDatesController < ApplicationController
+    before_action :authorize_trainee
+
+    def edit
+      @start_form = IttStartDateForm.new(trainee)
+    end
+
+    def update
+      @start_form = IttStartDateForm.new(trainee, params: trainee_params, user: current_user)
+
+      if @start_form.stash
+        redirect_to edit_trainee_confirm_publish_course_path(trainee_id: @trainee.slug)
+      else
+        render :edit
+      end
+    end
+
+  private
+
+    def trainee
+      @trainee ||= Trainee.from_param(params[:trainee_id])
+    end
+
+    def trainee_params
+      params.require(:itt_start_date_form)
+        .permit(:date_string, *MultiDateForm::PARAM_CONVERSION.keys)
+        .transform_keys do |key|
+          MultiDateForm::PARAM_CONVERSION.fetch(key, key)
+        end.merge({ date_string: :other })
+    end
+
+    def authorize_trainee
+      authorize(trainee, :requires_itt_start_date?)
+    end
+  end
+end

--- a/app/controllers/trainees/language_specialisms_controller.rb
+++ b/app/controllers/trainees/language_specialisms_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class LanguageSpecialismsController < ApplicationController
+    include PublishCourseNextPath
+
     before_action :authorize_trainee
     before_action :load_language_specialisms
 
@@ -22,11 +24,7 @@ module Trainees
   private
 
     def next_step_path
-      if trainee.apply_application?
-        trainee_apply_applications_confirm_courses_path(trainee)
-      else
-        edit_trainee_confirm_publish_course_path(trainee_id: trainee.slug)
-      end
+      publish_course_next_path
     end
 
     def trainee

--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class PublishCourseDetailsController < ApplicationController
+    include PublishCourseNextPath
+
     before_action :authorize_trainee
 
     def edit
@@ -49,17 +51,18 @@ module Trainees
     def clear_form_stashes
       FormStore.set(@trainee.id, :subject_specialism, nil)
       FormStore.set(@trainee.id, :language_specialisms, nil)
+      FormStore.set(@trainee.id, :itt_start_date, nil)
     end
 
     def next_step_path
       if @publish_course_details_form.manual_entry_chosen?
         edit_trainee_course_details_path(@trainee)
       elsif course_has_one_specialism?
-        course_confirmation_path
+        publish_course_next_path
       elsif specialism_type == :language
-        edit_trainee_language_specialisms_path(@trainee)
+        edit_trainee_language_specialisms_path(trainee)
       else
-        edit_trainee_subject_specialism_path(@trainee, 1)
+        edit_trainee_subject_specialism_path(trainee, 1)
       end
     end
 
@@ -87,14 +90,6 @@ module Trainees
 
     def authorize_trainee
       authorize(trainee)
-    end
-
-    def course_confirmation_path
-      if trainee.apply_application?
-        trainee_apply_applications_confirm_courses_path(trainee)
-      else
-        edit_trainee_confirm_publish_course_path(@trainee)
-      end
     end
   end
 end

--- a/app/controllers/trainees/subject_specialisms_controller.rb
+++ b/app/controllers/trainees/subject_specialisms_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class SubjectSpecialismsController < ApplicationController
+    include PublishCourseNextPath
+
     before_action :authorize_trainee
     helper_method :position
 
@@ -77,10 +79,8 @@ module Trainees
       next_position = position + 1
       if specialisms[:"course_subject_#{to_word(next_position)}"].present?
         edit_trainee_subject_specialism_path(trainee, next_position)
-      elsif trainee.apply_application?
-        trainee_apply_applications_confirm_courses_path(trainee)
       else
-        edit_trainee_confirm_publish_course_path(trainee)
+        publish_course_next_path
       end
     end
 

--- a/app/forms/apply_applications/confirm_course_form.rb
+++ b/app/forms/apply_applications/confirm_course_form.rb
@@ -10,13 +10,15 @@ module ApplyApplications
       mark_as_reviewed
     ].freeze
 
-    attr_accessor(*FIELDS, :trainee, :specialisms, :params)
+    attr_accessor(*FIELDS, :trainee, :specialisms, :itt_start_date, :params)
 
     delegate :id, :persisted?, to: :trainee
 
-    def initialize(trainee, specialisms, params = {})
+    def initialize(trainee, specialisms, itt_start_date, params = {})
       @trainee = trainee
       @specialisms = specialisms
+      @itt_start_date = itt_start_date
+
       assign_attributes({ mark_as_reviewed: trainee.progress.course_details }.merge(params))
     end
 
@@ -36,7 +38,7 @@ module ApplyApplications
         training_route: course&.route,
         course_code: course.code,
         course_age_range: course.age_range,
-        course_start_date: course.start_date,
+        course_start_date: itt_start_date || course.start_date,
         course_end_date: course.end_date,
         course_subject_one: course_subject_one,
         course_subject_two: course_subject_two,

--- a/app/forms/confirm_publish_course_form.rb
+++ b/app/forms/confirm_publish_course_form.rb
@@ -10,15 +10,16 @@ class ConfirmPublishCourseForm
     code
   ].freeze
 
-  attr_accessor(*FIELDS, :trainee)
+  attr_accessor(*FIELDS, :trainee, :specialisms, :itt_start_date)
 
   delegate :id, :persisted?, to: :trainee
 
   validates :code, presence: true
 
-  def initialize(trainee, specialisms, params = {})
+  def initialize(trainee, specialisms, itt_start_date, params = {})
     @trainee = trainee
     @specialisms = specialisms
+    @itt_start_date = itt_start_date
     super(params)
   end
 
@@ -34,7 +35,7 @@ class ConfirmPublishCourseForm
 private
 
   def update_trainee_attributes
-    specialism1, specialism2, specialism3 = *@specialisms
+    specialism1, specialism2, specialism3 = *specialisms
     trainee.progress.course_details = true
     trainee.assign_attributes({
       course_subject_one: specialism1,
@@ -42,7 +43,7 @@ private
       course_subject_three: specialism3,
       course_code: course.code,
       course_age_range: course.age_range,
-      course_start_date: course.start_date,
+      course_start_date: itt_start_date || course.start_date,
       course_end_date: course.end_date,
     })
   end

--- a/app/forms/itt_start_date_form.rb
+++ b/app/forms/itt_start_date_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class IttStartDateForm < MultiDateForm
+private
+
+  def date_field
+    @date_field ||= :course_start_date
+  end
+end

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -17,6 +17,10 @@ class TrainingRouteManager
     %i[school_direct_salaried pg_teaching_apprenticeship].any? { |training_route_enums_key| enabled?(training_route_enums_key) }
   end
 
+  def requires_itt_start_date?
+    enabled? :pg_teaching_apprenticeship
+  end
+
   def award_type
     TRAINING_ROUTE_AWARD_TYPE[training_route&.to_sym]
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -17,7 +17,7 @@ class Trainee < ApplicationRecord
   attribute :progress, Progress.to_type
 
   delegate :award_type, :requires_placement_details?, :requires_schools?,
-           :requires_employing_school?, :early_years_route?, to: :training_route_manager
+           :requires_employing_school?, :early_years_route?, :requires_itt_start_date?, to: :training_route_manager
 
   delegate :update_training_route!, to: :route_data_manager
 

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -16,7 +16,7 @@ class TraineePolicy
 
   attr_reader :user, :trainee, :training_router_manager
 
-  delegate :requires_schools?, :requires_employing_school?, to: :training_router_manager
+  delegate :requires_schools?, :requires_employing_school?, :requires_itt_start_date?, to: :training_router_manager
 
   def initialize(user, trainee)
     @user = user

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -28,6 +28,7 @@ class FormStore
     bursary
     language_specialisms
     subject_specialism
+    itt_start_date
   ].freeze
 
   class << self

--- a/app/views/trainees/apply_applications/confirm_courses/show.html.erb
+++ b/app/views/trainees/apply_applications/confirm_courses/show.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render ApplyApplications::ConfirmCourse::View.new(trainee: @trainee, course: @course, specialisms: @specialisms) %>
+    <%= render ApplyApplications::ConfirmCourse::View.new(trainee: @trainee, course: @course, specialisms: @specialisms, itt_start_date: @itt_start_date) %>
 
     <%= register_form_with(model: @confirm_course_form,
                            url: trainee_apply_applications_confirm_courses_path(@trainee),

--- a/app/views/trainees/confirm_publish_course/edit.html.erb
+++ b/app/views/trainees/confirm_publish_course/edit.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render ConfirmPublishCourse::View.new(trainee: @trainee, course: @course, specialisms: @specialisms) %>
+    <%= render ConfirmPublishCourse::View.new(trainee: @trainee, course: @course, specialisms: @specialisms, itt_start_date: @itt_start_date) %>
 
     <%= register_form_with(model: @confirm_publish_course_form, url: trainee_confirm_publish_course_path(@trainee, @course.code), method: :put, local: true) do |f| %>
       <%= f.hidden_field :code, value: @course.code %>

--- a/app/views/trainees/itt_start_dates/edit.html.erb
+++ b/app/views/trainees/itt_start_dates/edit.html.erb
@@ -1,6 +1,6 @@
 <% text = I18n.t("components.page_titles.trainees.itt_start_date.edit") %>
 
-<%= render PageTitle::View.new(text: text, has_errors: @start_form.errors.present?) %>
+<%= render PageTitle::View.new(text: text, has_errors: @itt_start_date_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @start_form, 
+    <%= register_form_with(model: @itt_start_date_form, 
                            url: trainee_course_details_itt_start_date_path(@trainee), 
                            local: true) do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/trainees/itt_start_dates/edit.html.erb
+++ b/app/views/trainees/itt_start_dates/edit.html.erb
@@ -1,0 +1,25 @@
+<% text = I18n.t("components.page_titles.trainees.start_date.edit") %>
+
+<%= render PageTitle::View.new(text: text, has_errors: @start_form.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLink.new(
+    text: "Back",
+    href: trainee_path(@trainee),
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: @start_form, url: trainee_course_details_itt_start_date_path(@trainee), local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+        <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: text, tag: "h1", size: "l" }, classes: "start-date", hint: {text: "The start date of the Initial Teacher Training portion of their course. "}) do %>
+            <%= f.govuk_date_field :date, legend: { text: "" }, 
+            hint: { text: "#{t('views.forms.common.for_example')}, 3 12 2020" } %>
+          <div>
+        <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/trainees/itt_start_dates/edit.html.erb
+++ b/app/views/trainees/itt_start_dates/edit.html.erb
@@ -1,4 +1,4 @@
-<% text = I18n.t("components.page_titles.trainees.start_date.edit") %>
+<% text = I18n.t("components.page_titles.trainees.itt_start_date.edit") %>
 
 <%= render PageTitle::View.new(text: text, has_errors: @start_form.errors.present?) %>
 
@@ -11,11 +11,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @start_form, url: trainee_course_details_itt_start_date_path(@trainee), local: true) do |f| %>
+    <%= register_form_with(model: @start_form, 
+                           url: trainee_course_details_itt_start_date_path(@trainee), 
+                           local: true) do |f| %>
       <%= f.govuk_error_summary %>
-        <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: text, tag: "h1", size: "l" }, classes: "start-date", hint: {text: "The start date of the Initial Teacher Training portion of their course. "}) do %>
+        <%= f.govuk_fieldset(legend: { text: text, tag: "h1", size: "l" }) do %>
             <%= f.govuk_date_field :date, legend: { text: "" }, 
-            hint: { text: "#{t('views.forms.common.for_example')}, 3 12 2020" } %>
+            hint: -> do %>
+              <p class="govuk-body govuk-hint"> <%= t("components.itt_start_date.hint") %> </p>
+              <p class="govuk-body govuk-hint"> <%= "#{t('views.forms.common.for_example')}, 26 7 2021" %> </p>
+            <% end %>
           <div>
         <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,8 @@ en:
       status_date_prefix:
         deferred: "Deferral date: "
         withdrawn: "Withdrawal date: "
+    itt_start_date:
+      hint: The start date of the Initial Teacher Training portion of their course.
     page_titles:
       personas: Personas
       pages:
@@ -191,7 +193,7 @@ en:
           edit: What type of training are they doing?
         course_details:
           edit: Course details
-        start_date:
+        itt_start_date:
           edit: ITT start date
         withdrawal:
           show: Withdraw trainee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,6 +191,8 @@ en:
           edit: What type of training are they doing?
         course_details:
           edit: Course details
+        start_date:
+          edit: ITT start date
         withdrawal:
           show: Withdraw trainee
         confirm_withdrawal:
@@ -862,6 +864,13 @@ en:
               empty_nationalities: Select at least one nationality
             other_nationality1:
               blank: If you have an additional nationality, select it from the list
+        itt_start_date_form:
+          attributes:
+            date_string:
+              blank: Enter an ITT start date
+            date:
+              blank: Enter an ITT start date
+              invalid: Enter a valid ITT start date
         course_details_form:
           attributes:
             course_subject_one:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,11 @@ Rails.application.routes.draw do
       resource :publish_course_details, only: %i[edit update], path: "/publish-course-details"
       resource :confirm_publish_course, only: %i[edit update], path: "confirm-publish-course", controller: "/trainees/confirm_publish_course"
 
-      resource :course_details, concerns: :confirmable, only: %i[edit update], path: "/course-details"
+      resource :course_details, only: %i[edit update], path: "/course-details" do
+        concerns :confirmable
+        resource :itt_start_date, only: %i[edit update], path: "/start-date"
+      end
+
       resource :schools, concerns: :confirmable, only: %i[edit update], path: "/schools"
       resource :contact_details, concerns: :confirmable, only: %i[edit update], path: "/contact-details"
       resource :trainee_id, concerns: :confirmable, only: %i[edit update], path: "/trainee-id"

--- a/spec/components/apply_applications/confirm_course/view_preview.rb
+++ b/spec/components/apply_applications/confirm_course/view_preview.rb
@@ -6,19 +6,23 @@ module ApplyApplications
   module ConfirmCourse
     class ViewPreview < ViewComponent::Preview
       def default
-        render(View.new(trainee: mock_trainee, course: build_course, specialisms: build_specialisms))
+        render(View.new(trainee: mock_trainee, course: build_course, specialisms: build_specialisms, itt_start_date: nil))
+      end
+
+      def default_with_itt_start_date
+        render(View.new(trainee: mock_trainee, course: build_course, specialisms: build_specialisms, itt_start_date: Time.zone.today))
       end
 
       def with_two_subjects
         course = build_course(subject_names: ["Subject 2"])
         specialisms = build_specialisms << "Specialism 2"
-        render(View.new(trainee: mock_trainee, course: course, specialisms: specialisms))
+        render(View.new(trainee: mock_trainee, course: course, specialisms: specialisms, itt_start_date: nil))
       end
 
       def with_three_subjects
         course = build_course(subject_names: ["Subject 2", "Subject 3"])
         specialisms = build_specialisms.concat(["Specialism 2", "Specialism 3"])
-        render(View.new(trainee: mock_trainee, course: course, specialisms: specialisms))
+        render(View.new(trainee: mock_trainee, course: course, specialisms: specialisms, itt_start_date: nil))
       end
 
     private

--- a/spec/components/confirm_publish_course/view_preview.rb
+++ b/spec/components/confirm_publish_course/view_preview.rb
@@ -5,7 +5,11 @@ require "govuk/components"
 module ConfirmPublishCourse
   class ViewPreview < ViewComponent::Preview
     def default
-      render(View.new(trainee: mock_trainee, course: build_course, specialisms: build_specialisms))
+      render(View.new(trainee: mock_trainee, course: build_course, specialisms: build_specialisms, itt_start_date: nil))
+    end
+
+    def default_with_itt_start_date
+      render(View.new(trainee: mock_trainee, course: build_course, specialisms: build_specialisms, itt_start_date: Time.zone.today))
     end
 
     def with_two_subjects
@@ -13,7 +17,7 @@ module ConfirmPublishCourse
       course.subjects << Subject.new(name: "Subject 2")
       specialisms = build_specialisms
       specialisms << "Specialism 2"
-      render(View.new(trainee: mock_trainee, course: course, specialisms: specialisms))
+      render(View.new(trainee: mock_trainee, course: course, specialisms: specialisms, itt_start_date: nil))
     end
 
     def with_three_subjects
@@ -23,7 +27,7 @@ module ConfirmPublishCourse
       specialisms = build_specialisms
       specialisms << "Specialism 2"
       specialisms << "Specialism 3"
-      render(View.new(trainee: mock_trainee, course: course, specialisms: specialisms))
+      render(View.new(trainee: mock_trainee, course: course, specialisms: specialisms, itt_start_date: nil))
     end
 
   private

--- a/spec/forms/confirm_publish_course_form_spec.rb
+++ b/spec/forms/confirm_publish_course_form_spec.rb
@@ -6,16 +6,15 @@ describe ConfirmPublishCourseForm, type: :model do
   let(:params) { {} }
   let(:trainee) { build(:trainee) }
   let(:specialisms) { [] }
+  let(:itt_start_date) { nil }
 
-  subject { described_class.new(trainee, specialisms, params) }
+  subject { described_class.new(trainee, specialisms, itt_start_date, params) }
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:code) }
   end
 
   context "with valid params" do
-    subject { described_class.new(trainee, specialisms, params) }
-
     let(:course) { create(:course_with_subjects, subject_names: subjects) }
     let(:params) { { code: course.code } }
     let(:subjects) { ["Subject 1", "Subject 2", "Subject 3"] }
@@ -48,6 +47,28 @@ describe ConfirmPublishCourseForm, type: :model do
           .from(nil).to(course.start_date)
           .and change { trainee.course_end_date }
           .from(nil).to((course.start_date + course.duration_in_years.years).to_date.prev_day)
+      end
+
+      context "with itt_start_date set" do
+        let(:itt_start_date) { Time.zone.today }
+
+        it "updates all the course related attributes and itt_start_date" do
+          expect { subject.save }
+            .to change { trainee.course_subject_one }
+            .from(nil).to(subject_specialism_one)
+            .and change { trainee.course_subject_two }
+            .from(nil).to(subject_specialism_two)
+            .and change { trainee.course_subject_three }
+            .from(nil).to(subject_specialism_three)
+            .and change { trainee.course_min_age }
+            .from(nil).to(course.min_age)
+            .and change { trainee.course_max_age }
+            .from(nil).to(course.max_age)
+            .and change { trainee.course_start_date }
+            .from(nil).to(itt_start_date)
+            .and change { trainee.course_end_date }
+            .from(nil).to((course.start_date + course.duration_in_years.years).to_date.prev_day)
+        end
       end
 
       context "when the course_subject has changed" do

--- a/spec/forms/confirm_publish_course_form_spec.rb
+++ b/spec/forms/confirm_publish_course_form_spec.rb
@@ -54,20 +54,8 @@ describe ConfirmPublishCourseForm, type: :model do
 
         it "updates all the course related attributes and itt_start_date" do
           expect { subject.save }
-            .to change { trainee.course_subject_one }
-            .from(nil).to(subject_specialism_one)
-            .and change { trainee.course_subject_two }
-            .from(nil).to(subject_specialism_two)
-            .and change { trainee.course_subject_three }
-            .from(nil).to(subject_specialism_three)
-            .and change { trainee.course_min_age }
-            .from(nil).to(course.min_age)
-            .and change { trainee.course_max_age }
-            .from(nil).to(course.max_age)
-            .and change { trainee.course_start_date }
+            .to change { trainee.course_start_date }
             .from(nil).to(itt_start_date)
-            .and change { trainee.course_end_date }
-            .from(nil).to((course.start_date + course.duration_in_years.years).to_date.prev_day)
         end
       end
 

--- a/spec/forms/itt_start_date_form_spec.rb
+++ b/spec/forms/itt_start_date_form_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe IttStartDateForm, type: :model do
+  let(:trainee) { create(:trainee, :pg_teaching_apprenticeship) }
+  let(:form_store) { class_double(FormStore) }
+
+  let(:params) do
+    {
+      year: "1963",
+      month: "11",
+      day: "11",
+      date_string: "other",
+    }
+  end
+
+  subject { described_class.new(trainee, params: params.stringify_keys, store: form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    context "date" do
+      context "empty date" do
+        before do
+          subject.date_string = nil
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date_string]).to include(
+            I18n.t(
+              "activemodel.errors.models.itt_start_date_form.attributes.date_string.blank",
+            ),
+          )
+        end
+      end
+
+      context "invalid date" do
+        before do
+          subject.month = nil
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date]).to include(
+            I18n.t(
+              "activemodel.errors.models.itt_start_date_form.attributes.date.invalid",
+            ),
+          )
+        end
+      end
+    end
+  end
+
+  describe "#fields" do
+    it "combines the data from params with the existing trainee data" do
+      expect(subject.fields).to match(params)
+    end
+  end
+
+  describe "#stash" do
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and itt start date" do
+      expect(form_store).to receive(:set).with(trainee.id, :itt_start_date, subject.fields)
+
+      subject.stash
+    end
+  end
+end

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -85,6 +85,26 @@ describe TrainingRouteManager do
     end
   end
 
+  describe "#requires_itt_start_date?" do
+    context "with the :routes_pg_teaching_apprenticeship feature flag enabled", "feature_routes.pg_teaching_apprenticeship": true do
+      context "with a pg teaching apprenticeship trainee" do
+        let(:trainee) { build(:trainee, :pg_teaching_apprenticeship) }
+
+        it "returns true" do
+          expect(subject.requires_itt_start_date?).to be true
+        end
+      end
+
+      context "with a non pg teaching apprenticeship trainee" do
+        let(:trainee) { build(:trainee) }
+
+        it "returns false" do
+          expect(subject.requires_itt_start_date?).to be false
+        end
+      end
+    end
+  end
+
   describe "#early_years_route?" do
     context "non early years route" do
       let(:trainee) { build(:trainee, :school_direct_salaried) }

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -158,6 +158,10 @@ module Features
       @confirm_publish_course_page ||= PageObjects::Trainees::ConfirmPublishCourse.new
     end
 
+    def itt_start_date_edit_page
+      @itt_start_date_page ||= PageObjects::Trainees::EditIttStartDate.new
+    end
+
     def trainee_id_edit_page
       @trainee_id_edit_page ||= PageObjects::Trainees::EditTraineeId.new
     end

--- a/spec/support/page_objects/trainees/edit_itt_start_date.rb
+++ b/spec/support/page_objects/trainees/edit_itt_start_date.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class EditIttStartDate < PageObjects::Base
+      include PageObjects::Helpers
+      set_url "/trainees/{trainee_id}/course-details/start-date/edit"
+
+      element :itt_start_date_radios, ".govuk-radios.itt_start-date"
+
+      element :itt_start_date_day, "#itt_start_date_form_date_3i"
+      element :itt_start_date_month, "#itt_start_date_form_date_2i"
+      element :itt_start_date_year, "#itt_start_date_form_date_1i"
+
+      element :continue, "button[type='submit']"
+    end
+  end
+end

--- a/spec/support/shared_examples/rendering_course_confirmation.rb
+++ b/spec/support/shared_examples/rendering_course_confirmation.rb
@@ -2,13 +2,14 @@
 
 RSpec.shared_examples "rendering course confirmation" do
   let(:trainee) { build(:trainee) }
+  let(:itt_start_date) { nil }
 
   context "default behaviour" do
     let(:course) { build(:course, duration_in_years: 2) }
     let(:specialisms) { ["Specialism 1"] }
 
     before do
-      render_inline(described_class.new(trainee: trainee, course: course, specialisms: specialisms))
+      render_inline(described_class.new(trainee: trainee, course: course, specialisms: specialisms, itt_start_date: itt_start_date))
     end
 
     it "renders the course details" do
@@ -30,13 +31,21 @@ RSpec.shared_examples "rendering course confirmation" do
     it "renders the duration" do
       expect(rendered_component).to have_text("#{course.duration_in_years} years")
     end
+
+    context "with itt_start_date set" do
+      let(:itt_start_date) { Time.zone.now }
+
+      it "renders the itt start date" do
+        expect(rendered_component).to have_text(date_for_summary_view(course.start_date))
+      end
+    end
   end
 
   context "course subjects" do
     let(:course) { create(:course_with_subjects, subjects_count: subject_count) }
 
     before do
-      render_inline(described_class.new(trainee: trainee, course: course, specialisms: specialisms))
+      render_inline(described_class.new(trainee: trainee, course: course, specialisms: specialisms, itt_start_date: itt_start_date))
     end
 
     context "with one subject" do


### PR DESCRIPTION
### Context
Collect ITT start date for PGTA publish courses

### Changes proposed in this pull request
Collect ITT start date for PGTA publish courses

Given a trainee and they are on the  PG teaching apprentice route
When they have selected a publish course to use as template
Then the user is asked for the ITT start date

Trainee
- even if they are from `Apply` & they are on the  PG teaching apprentice route

ITT start date 
- uses trainee's course start date for the itt start date :shrug: 
- after subject specialism selection

### Guidance to review

There will be a follow up PR to clean address content changes as well

Only applicable if selecting from `teaching apprenticeship postgrad courses in the Publish service`

![image](https://user-images.githubusercontent.com/470137/126657260-261fc26c-db1a-4b64-be70-422ba1d87892.png)

![image](https://user-images.githubusercontent.com/470137/126657297-e8448933-edba-4255-8b77-5636bb51447a.png)

