### PR TITLE
[xxx] Disable consistency checks

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -26,7 +26,6 @@ features:
   enable_feedback_link: true
   sync_from_dttp: true
   send_emails: true
-  run_consistency_check_job: true
   persist_to_dttp: true
   import_courses_from_ttapi: true
   publish_course_details: true


### PR DESCRIPTION
### Context

We have a consistency check to alert us if a record is updated directly in DTTP. Due to a bug in DTTP the records appear to be updated quite regularly when they haven't so these are currently useless and noisy.

### Changes proposed in this pull request

Disable them until the bug is fixed.

### Guidance to review

