### PR TITLE
[2314] Fix contact update error

### DIFF
--- a/app/services/dttp/contact_update.rb
+++ b/app/services/dttp/contact_update.rb
@@ -5,6 +5,8 @@ module Dttp
     include ServicePattern
 
     def initialize(trainee:)
+      return unless FeatureService.enabled?(:persist_to_dttp)
+
       @trainee = trainee
       @contact_payload = Params::Contact.new(trainee)
       @placement_assignment_payload = Params::PlacementAssignment.new(trainee)

--- a/spec/services/dttp/contact_update_spec.rb
+++ b/spec/services/dttp/contact_update_spec.rb
@@ -57,6 +57,28 @@ module Dttp
         let(:contact_response) { http_response }
         let(:placement_response) { http_response }
       end
+
+      context "when the trainee doesn't have a lead school" do
+        let(:contact_response) { { status: 204 } }
+        let(:placement_response) { { status: 204 } }
+        let(:trainee) { create(:trainee, lead_school_id: nil) }
+
+        context "and persist_to_dttp is enabled" do
+          it "raises an error" do
+            expect { subject }.to raise_error(NoMethodError)
+          end
+        end
+
+        context "and persist_to_dttp is disabled" do
+          before do
+            disable_features(:persist_to_dttp, "routes.school_direct_salaried", "routes.school_direct_tuition_fee", "routes.pg_teaching_apprenticeship", :show_funding, :send_funding_to_dttp)
+          end
+
+          it "doesn't raise an error" do
+            expect { subject }.not_to raise_error
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION

### Context
https://trello.com/c/v4CKJpyo/2314-error-in-review-environments-for-contactupdate-when-trainee-doesnt-have-a-lead-school

https://sentry.io/organizations/dfe-bat/issues/2512893263/?project=5552118&query=is%3Aunresolved

### Changes proposed in this pull request
We already have a feature flag to disable this job in the review 
environment because the generated trainees don’t have complete data.

There is an error occurring in the initialiser for this service despite
It being disabled, so add another check in the initializer to short
circuit even earlier.


### Guidance to review

