### PR TITLE
[2317] Extract error summary partial into a component

### DIFF
--- a/app/components/apply_applications/trainee_data/view.html.erb
+++ b/app/components/apply_applications/trainee_data/view.html.erb
@@ -16,7 +16,7 @@
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <%= render ErrorSummary::View.new(has_errors: @form.errors.any?) do %>
           <% @form.errors.messages.map do |_, messages| %>
-            <li><%= messages.first %></li>
+            <%= tag.li(messages.first) %>
           <% end %>
         <% end %>
 

--- a/app/components/apply_applications/trainee_data/view.html.erb
+++ b/app/components/apply_applications/trainee_data/view.html.erb
@@ -12,13 +12,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-
-    <% if @form.errors.any? %>
-      <%= render "trainees/check_details/error_summary" %>
-    <% end %>
-
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
+        <%= render ErrorSummary::View.new(has_errors: @form.errors.any?) do %>
+          <% @form.errors.messages.map do |_, messages| %>
+            <li><%= messages.first %></li>
+          <% end %>
+        <% end %>
+
         <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
           <span class="govuk-caption-l">
             <% if trainee_name(@trainee).present? %>

--- a/app/components/error_summary/view.html.erb
+++ b/app/components/error_summary/view.html.erb
@@ -1,12 +1,10 @@
 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
-    There is a problem
+    <%= t(".heading") %>
   </h2>
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">
-      <% @form.errors.messages.map do |_, messages| %>
-        <li><%= messages.first %></li>
-      <% end %>
+      <%= content %>
     </ul>
   </div>
 </div>

--- a/app/components/error_summary/view.rb
+++ b/app/components/error_summary/view.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ErrorSummary::View < GovukComponent::Base
+  def initialize(has_errors: false)
+    @has_errors = has_errors
+  end
+
+  def render?
+    has_errors
+  end
+
+private
+
+  attr_reader :has_errors
+end

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -16,7 +16,7 @@
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <%= render ErrorSummary::View.new(has_errors: @form.errors.any?) do %>
           <% @form.errors.messages.map do |_, messages| %>
-            <li><%= messages.first %></li>
+            <%= tag.li(messages.first) %>
           <% end %>
         <% end %>
       

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -12,13 +12,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-
-    <% if @form.errors.any? %>
-      <%= render "trainees/check_details/error_summary" %>
-    <% end %>
-
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
+        <%= render ErrorSummary::View.new(has_errors: @form.errors.any?) do %>
+          <% @form.errors.messages.map do |_, messages| %>
+            <li><%= messages.first %></li>
+          <% end %>
+        <% end %>
+      
         <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
           <span class="govuk-caption-l">
             Draft record <%= "for #{trainee_name(@trainee)}" if trainee_name(@trainee).present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -542,6 +542,9 @@ en:
     view:
       display_text: "Trainee on the %{training_route_link} route."
       apply_display_text: "Trainee enrolled on %{course_with_code}, %{training_route}."
+  error_summary:
+    view:
+      heading: There is a problem
   confirm_publish_course:
     view:
       change: Change

--- a/spec/components/error_summary/view_preview.rb
+++ b/spec/components/error_summary/view_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ErrorSummary
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render(View.new(has_errors: true)) do
+        "<li>This is an error item</li>".html_safe
+      end
+    end
+  end
+end

--- a/spec/components/error_summary/view_spec.rb
+++ b/spec/components/error_summary/view_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ErrorSummary
+  describe View, type: :component do
+    context "when there are errors" do
+      let(:error_markup) {  "<li>This is an error item</li>".html_safe }
+
+      before do
+        render_inline(described_class.new(has_errors: true)) do
+          error_markup
+        end
+      end
+
+      it "renders the given content from the block" do
+        expect(rendered_component).to have_selector("li", count: 1)
+      end
+    end
+
+    context "when has_errors is false" do
+      before do
+        render_inline(described_class.new(has_errors: false))
+      end
+
+      it "does not render" do
+        expect(rendered_component).not_to have_css(".govuk-error-summary")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/d512BVIB/2317-s-componentise-the-error-summary

### Changes proposed in this pull request

- Extracts the error summary partial into a component to be a little more flexible/re-usable
- Initial work to validating the apply draft confirm pages

### Guidance to review

