### PR TITLE
[2321] Use govuk_link_to helper for guidance links

### DIFF
--- a/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
@@ -10,7 +10,14 @@
       training_route: t("activerecord.attributes.trainee.training_routes.#{@trainee.training_route}"),
     ) %>
   </p>
-  <p class="govuk-body"><%= t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_html' : 'guidance_html'}") %></p>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(
+      t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_link_text' : 'guidance_link_text'}"),
+      t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_url' : 'guidance_url'}"),
+      { target: "_blank", rel: "noreferrer noopener" }
+    ) %>
+  </p>
 
   <%= f.govuk_radio_buttons_fieldset(:applying_for_bursary, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
       <%= f.govuk_radio_button(

--- a/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
@@ -3,7 +3,14 @@
 
   <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %></h1>
   <p class="govuk-body"><%= t("views.forms.funding.bursaries.tiered.description") %></p>
-  <p class="govuk-body"><%= t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_html' : 'guidance_html'}") %></p>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(
+      t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_link_text' : 'guidance_link_text'}"),
+      t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_url' : 'guidance_url'}"),
+      { target: "_blank", rel: "noreferrer noopener" }
+    ) %>
+  </p>
 
   <%= f.govuk_radio_buttons_fieldset(:bursary_tier, legend: { text: t("views.forms.funding.bursaries.title"), size: "m" }) do %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -466,8 +466,10 @@ en:
             tier_three:
               label: Yes - Tier 3 (£2,000)
               hint: 2:2 honours degree
-          guidance_html: <a target="_blank" href="https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-funding-manual/initial-teacher-training-bursaries-funding-manual-2021-to-2022-academic-year#training-bursary-award-and-eligibility">DfE bursary guidance for the academic year 2021 to 2022 (opens in new tab)</a>
-          early_years_guidance_html: "<a target=_blank href=https://www.gov.uk/guidance/early-years-initial-teacher-training-2021-to-2022-funding-guidance>Early years initial teacher training: 2021 to 2022 funding guidance (opens in new tab)</a>"
+          guidance_link_text: DfE bursary guidance for the academic year 2021 to 2022 (opens in new tab)
+          guidance_url: https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-funding-manual/initial-teacher-training-bursaries-funding-manual-2021-to-2022-academic-year#training-bursary-award-and-eligibility
+          early_years_guidance_link_text: "Early years initial teacher training: 2021 to 2022 funding guidance (opens in new tab)"
+          early_years_guidance_url: https://www.gov.uk/guidance/early-years-initial-teacher-training-2021-to-2022-funding-guidance
           title: Are you applying for a bursary for this trainee?
           true: Yes, apply for a bursary
           false: No, do not apply for a bursary


### PR DESCRIPTION
### Context

https://trello.com/c/yjD1E7ex/2321-s-eyts-snagging-link-to-guidance

### Changes proposed in this pull request

- Use the `govuk_link_to` helper to ensure correct classes are applied
- Adds `rel="noreferrer noopener"` (protect against [reverse tab-nabbing](https://owasp.org/www-community/attacks/Reverse_Tabnabbing))

### Guidance to review

1. Link text is correct blue:

<img width="543" alt="Screenshot 2021-07-27 at 11 26 05" src="https://user-images.githubusercontent.com/18436946/127139506-aeeb20a7-5d5b-44d5-b2c2-d6ec92d8c425.png">

2. Html is correct:

<img width="509" alt="Screenshot 2021-07-27 at 11 26 24" src="https://user-images.githubusercontent.com/18436946/127139575-b4854074-4d0a-41b6-b39a-df7409d938d8.png">
