### PR TITLE
[2304] Course dates for routes which should refer to itt dates for itt trainees

### DIFF
--- a/app/components/apply_applications/confirm_course/view.rb
+++ b/app/components/apply_applications/confirm_course/view.rb
@@ -34,7 +34,7 @@ module ApplyApplications
           { key: subject_key, value: subject_names },
           { key: t(".level"), value: level },
           { key: t(".age_range"), value: age_range },
-          { key: t(".start_date"), value: start_date },
+          { key: t(".#{itt_route? ? 'itt' : 'course'}_start_date"), value: start_date },
           { key: t(".duration"), value: duration },
         ]
       end
@@ -69,6 +69,10 @@ module ApplyApplications
       end
 
     private
+
+      def itt_route?
+        trainee.itt_route?
+      end
 
       def subject_key
         course.subjects.count > 1 ? t(".multiple_subjects") : t(".subject")

--- a/app/components/confirm_publish_course/view.rb
+++ b/app/components/confirm_publish_course/view.rb
@@ -36,7 +36,7 @@ module ConfirmPublishCourse
         { key: subject_key, value: subject_names },
         { key: t(".level"), value: level },
         { key: t(".age_range"), value: age_range },
-        { key: t(".start_date"), value: start_date },
+        { key: t(".#{itt_route? ? 'itt' : 'course'}_start_date"), value: start_date },
         { key: t(".duration"), value: duration },
       ]
     end
@@ -71,6 +71,10 @@ module ConfirmPublishCourse
     end
 
   private
+
+    def itt_route?
+      trainee.itt_route?
+    end
 
     def subject_key
       course.subjects.count > 1 ? t(".multiple_subjects") : t(".subject")

--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -26,8 +26,8 @@ module CourseDetails
         ({ key: t("components.course_detail.type_of_course"), value: course_type } if require_course_type?),
         ({ key: t("components.course_detail.subject"), value: subject, action: action_link("subject") } if require_subject?),
         ({ key: t("components.course_detail.age_range"), value: course_age_range, action: action_link("age range") } if require_age_range?),
-        { key: t("components.course_detail.course_start_date"), value: course_start_date, action: action_link("course start date") },
-        { key: t("components.course_detail.course_end_date"), value: course_end_date, action: action_link("course end date") },
+        { key: t("components.course_detail.#{itt_route? ? 'itt' : 'course'}_start_date"), value: course_start_date, action: action_link("course start date") },
+        { key: t("components.course_detail.#{itt_route? ? 'itt' : 'course'}_end_date"), value: course_end_date, action: action_link("course end date") },
       ].compact.tap do |collection|
         if show_publish_courses?(trainee)
           collection.unshift({
@@ -40,6 +40,10 @@ module CourseDetails
     end
 
   private
+
+    def itt_route?
+      trainee.itt_route?
+    end
 
     def require_subject?
       !trainee.early_years_route?

--- a/app/controllers/trainees/course_details_controller.rb
+++ b/app/controllers/trainees/course_details_controller.rb
@@ -4,13 +4,13 @@ module Trainees
   class CourseDetailsController < ApplicationController
     before_action :authorize_trainee
 
-    COURSE_DATE_CONVERSION = {
-      "course_start_date(3i)" => "start_day",
-      "course_start_date(2i)" => "start_month",
-      "course_start_date(1i)" => "start_year",
-      "course_end_date(3i)" => "end_day",
-      "course_end_date(2i)" => "end_month",
-      "course_end_date(1i)" => "end_year",
+    DATE_CONVERSION = {
+      "_start_date(3i)" => "start_day",
+      "_start_date(2i)" => "start_month",
+      "_start_date(1i)" => "start_year",
+      "_end_date(3i)" => "end_day",
+      "_end_date(2i)" => "end_month",
+      "_end_date(1i)" => "end_year",
     }.freeze
 
     def edit
@@ -39,6 +39,12 @@ module Trainees
       @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
+    def date_conversion
+      @date_conversion ||= DATE_CONVERSION.transform_keys do |key|
+        "#{trainee.itt_route? ? 'itt' : 'course'}#{key}"
+      end
+    end
+
     def course_details_params
       params.require(:course_details_form).permit(*CourseDetailsForm::FIELDS)
     end
@@ -46,8 +52,8 @@ module Trainees
     def course_date_params
       params.require(:course_details_form).except(
         *CourseDetailsForm::FIELDS,
-      ).permit(*COURSE_DATE_CONVERSION.keys)
-      .transform_keys { |key| COURSE_DATE_CONVERSION[key] }
+      ).permit(*date_conversion.keys)
+      .transform_keys { |key| date_conversion[key] }
     end
 
     def redirect_to_confirm

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -32,6 +32,9 @@ class CourseDetailsForm < TraineeForm
 
   attr_accessor(*FIELDS)
 
+  alias_attribute :itt_start_date, :course_start_date
+  alias_attribute :itt_end_date, :course_end_date
+
   before_validation :sanitise_course_dates
   before_validation :sanitise_subjects
 
@@ -166,33 +169,33 @@ private
 
   def course_start_date_valid
     if [start_day, start_month, start_year].all?(&:blank?)
-      errors.add(:course_start_date, :blank)
+      errors.add(course_start_date_attribute_name, :blank)
     elsif start_year.to_i > next_year
-      errors.add(:course_start_date, :future)
+      errors.add(course_start_date_attribute_name, :future)
     elsif !course_start_date.is_a?(Date)
-      errors.add(:course_start_date, :invalid)
+      errors.add(course_start_date_attribute_name, :invalid)
     elsif course_start_date < 10.years.ago
-      errors.add(:course_start_date, :too_old)
+      errors.add(course_start_date_attribute_name, :too_old)
     end
   end
 
   def course_end_date_valid
     if [end_day, end_month, end_year].all?(&:blank?)
-      errors.add(:course_end_date, :blank)
+      errors.add(course_end_date_attribute_name, :blank)
     elsif end_year.to_i > max_years
-      errors.add(:course_end_date, :future)
+      errors.add(course_end_date_attribute_name, :future)
     elsif !course_end_date.is_a?(Date)
-      errors.add(:course_end_date, :invalid)
+      errors.add(course_end_date_attribute_name, :invalid)
     elsif course_end_date < 10.years.ago
-      errors.add(:course_end_date, :too_old)
+      errors.add(course_end_date_attribute_name, :too_old)
     end
 
     additional_validation = errors.attribute_names.none? do |attribute_name|
-      %i[course_start_date course_end_date].include?(attribute_name)
+      [course_start_date_attribute_name, course_end_date_attribute_name].include?(attribute_name)
     end
 
     if additional_validation && course_start_date >= course_end_date
-      errors.add(:course_end_date, :before_or_same_as_start_date)
+      errors.add(course_end_date_attribute_name, :before_or_same_as_start_date)
     end
   end
 

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -34,7 +34,23 @@ class TraineeForm
     valid? && store.set(id, form_store_key, fields.except(*fields_to_ignore_before_stash_or_save))
   end
 
+  def course_start_date_attribute_name
+    "#{course_date_attribute_name_prefix}_start_date".to_sym
+  end
+
+  def course_end_date_attribute_name
+    "#{course_date_attribute_name_prefix}_end_date".to_sym
+  end
+
 private
+
+  def course_date_attribute_name_prefix
+    itt_route? ? :itt : :course
+  end
+
+  def itt_route?
+    trainee.itt_route?
+  end
 
   def compute_fields
     raise NotImplementedError

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -30,7 +30,7 @@ class TrainingRouteManager
   end
 
   def itt_route?
-    ITT_TRAINING_ROUTES.keys.any? { |training_route_enums_key| enabled?(training_route_enums_key) }
+    ITT_TRAINING_ROUTES.keys.any? { |training_route_enums_key| training_route == TRAINING_ROUTE_ENUMS[training_route_enums_key.to_sym] }
   end
 
 private

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -29,6 +29,10 @@ class TrainingRouteManager
     training_route.to_s.starts_with?("early_years")
   end
 
+  def itt_route?
+    ITT_TRAINING_ROUTES.keys.any? { |training_route_enums_key| enabled?(training_route_enums_key) }
+  end
+
 private
 
   attr_reader :trainee
@@ -36,6 +40,6 @@ private
   delegate :training_route, to: :trainee
 
   def enabled?(training_route_enums_key)
-    FeatureService.enabled?("routes.#{training_route_enums_key}") && training_route == TRAINING_ROUTE_ENUMS[training_route_enums_key]
+    FeatureService.enabled?("routes.#{training_route_enums_key}") && training_route == TRAINING_ROUTE_ENUMS[training_route_enums_key.to_sym]
   end
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -17,7 +17,7 @@ class Trainee < ApplicationRecord
   attribute :progress, Progress.to_type
 
   delegate :award_type, :requires_placement_details?, :requires_schools?,
-           :requires_employing_school?, :early_years_route?, :requires_itt_start_date?, to: :training_route_manager
+           :requires_employing_school?, :early_years_route?, :requires_itt_start_date?, :itt_route?, to: :training_route_manager
 
   delegate :update_training_route!, to: :route_data_manager
 

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -59,12 +59,12 @@
       <%= f.govuk_date_field(f.object.course_start_date_attribute_name,
                              date_of_birth: false,
                              legend: { text: CourseDetailsForm.human_attribute_name(f.object.course_start_date_attribute_name), size: "s" },
-                             hint: { text: I18n.t("activemodel.errors.models.course_details_form.attributes.#{f.object.course_start_date_attribute_name}.hint_html", year: Time.zone.now.year) }) %>
+                             hint: { text: t("activemodel.errors.models.course_details_form.attributes.#{f.object.course_start_date_attribute_name}.hint_html", year: Time.zone.now.year) }) %>
 
        <%= f.govuk_date_field(f.object.course_end_date_attribute_name,
                               date_of_birth: false,
                               legend: { text: CourseDetailsForm.human_attribute_name(f.object.course_end_date_attribute_name), size: "s" },
-                              hint: { text: I18n.t("activemodel.errors.models.course_details_form.attributes.#{f.object.course_end_date_attribute_name}.hint_html", year: Time.zone.now.next_year.year) }) %>
+                              hint: { text: t("activemodel.errors.models.course_details_form.attributes.#{f.object.course_end_date_attribute_name}.hint_html", year: Time.zone.now.next_year.year) }) %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -56,15 +56,15 @@
         <% end %>
       <% end %>
 
-      <%= f.govuk_date_field(:course_start_date,
+      <%= f.govuk_date_field(f.object.course_start_date_attribute_name,
                              date_of_birth: false,
-                             legend: { text: "Course start date", size: "s" },
-                             hint: { text: I18n.t("activemodel.errors.models.course_details_form.attributes.course_start_date.hint_html", year: Time.zone.now.year) }) %>
+                             legend: { text: CourseDetailsForm.human_attribute_name(f.object.course_start_date_attribute_name), size: "s" },
+                             hint: { text: I18n.t("activemodel.errors.models.course_details_form.attributes.#{f.object.course_start_date_attribute_name}.hint_html", year: Time.zone.now.year) }) %>
 
-       <%= f.govuk_date_field(:course_end_date,
+       <%= f.govuk_date_field(f.object.course_end_date_attribute_name,
                               date_of_birth: false,
-                              legend: { text: "Course end date", size: "s" },
-                              hint: { text: I18n.t("activemodel.errors.models.course_details_form.attributes.course_end_date.hint_html", year: Time.zone.now.next_year.year) }) %>
+                              legend: { text: CourseDetailsForm.human_attribute_name(f.object.course_end_date_attribute_name), size: "s" },
+                              hint: { text: I18n.t("activemodel.errors.models.course_details_form.attributes.#{f.object.course_end_date_attribute_name}.hint_html", year: Time.zone.now.next_year.year) }) %>
 
       <%= f.govuk_submit %>
     <% end %>
@@ -72,3 +72,5 @@
 </div>
 
 <%= render(CancelLink::View.new(@trainee)) %>
+
+

--- a/app/views/trainees/itt_start_dates/edit.html.erb
+++ b/app/views/trainees/itt_start_dates/edit.html.erb
@@ -15,15 +15,10 @@
                            url: trainee_course_details_itt_start_date_path(@trainee), 
                            local: true) do |f| %>
       <%= f.govuk_error_summary %>
-        <%= f.govuk_fieldset(legend: { text: text, tag: "h1", size: "l" }) do %>
-            <%= f.govuk_date_field :date, legend: { text: "" }, 
-            hint: -> do %>
-              <p class="govuk-body govuk-hint"> <%= t("components.itt_start_date.hint") %> </p>
-              <p class="govuk-body govuk-hint"> <%= "#{t('views.forms.common.for_example')}, 26 7 2021" %> </p>
-            <% end %>
-          <div>
-        <% end %>
-
+      <%= f.govuk_date_field :date, legend: { text: text, tag: "h1", size: "l" }, hint: -> do %>
+        <p class="govuk-body govuk-hint"><%= t("components.itt_start_date.hint") %></p>
+        <p class="govuk-body govuk-hint"><%= "#{t('views.forms.common.for_example')}, 26 7 2021" %></p>
+      <% end %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -54,6 +54,10 @@ TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|
   TRAINING_ROUTE_ENUMS.values_at(:provider_led_postgrad, :school_direct_tuition_fee, :school_direct_salaried, :pg_teaching_apprenticeship).include? training_route
 }.freeze
 
+ITT_TRAINING_ROUTES = TRAINING_ROUTES.select { |training_route|
+  TRAINING_ROUTE_ENUMS.values_at(:early_years_undergrad, :pg_teaching_apprenticeship, :provider_led_undergrad, :opt_in_undergrad).include? training_route
+}.freeze
+
 TRAINING_ROUTE_FEATURE_FLAGS = TRAINING_ROUTE_ENUMS.keys.reject { |training_route|
   %i[assessment_only].include? training_route
 }.freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -926,27 +926,27 @@ en:
               blank: Select an age range
             course_start_date:
               blank: Enter a course start date
-              future: Enter a course start date that is not as far in the future
+              future: Enter a course start date closer to today
               invalid: Enter a valid course start date
               too_old: Enter a valid course start date
               hint_html: For example, 11 3 %{year}
             course_end_date:
               blank: Enter a course end date
-              future: Enter a course end date that is not as far in the future
+              future: Enter a course end date closer to today
               invalid: Enter a valid course end date
               too_old: Enter a valid course end date
               before_or_same_as_start_date: The course end date must be after the start date
               hint_html: For example, 11 3 %{year}
             itt_start_date:
               blank: Enter an ITT start date
-              future: Enter an ITT start date that is not as far in the future
+              future: Enter an ITT start date closer to today
               invalid: Enter a valid ITT start date
               too_old: Enter a valid ITT start date
               hint_html: <p class="govuk-body govuk-hint">The start date of the Initial Teacher Training portion of their course.</p>
                <p class="govuk-body govuk-hint">For example, 11 3 %{year}</p>
             itt_end_date:
               blank: Enter an ITT end date
-              future: Enter an ITT end date that is not as far in the future
+              future: Enter an ITT end date closer to today
               invalid: Enter a valid ITT end date
               too_old: Enter a valid ITT end date
               before_or_same_as_start_date: The ITT end date must be after the start date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -588,7 +588,8 @@ en:
       multiple_subjects: Subjects
       level: Level
       age_range: Age range
-      start_date: Start date
+      itt_start_date: ITT start date
+      itt_end_date: ITT end date
       course_start_date: Course start date
       course_end_date: Course end date
       duration: Duration
@@ -617,7 +618,8 @@ en:
         multiple_subjects: Subjects
         level: Level
         age_range: Age range
-        start_date: Start date
+        itt_start_date: ITT start date
+        itt_end_date: ITT end date
         course_start_date: Course start date
         course_end_date: Course end date
         duration: Duration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,7 +114,9 @@ en:
       subject: Subject
       age_range: Age range
       course_start_date: Course start date
+      itt_start_date: ITT start date
       course_end_date: Course end date
+      itt_end_date: ITT end date
       course_details: Course details
       details_not_on_publish: Details not on Publish
     school_details:
@@ -778,6 +780,12 @@ en:
               invalid: Enter a DTTP ID in the correct format, like 6a61d94f-5060-4d57-8676-bdb265a5b949
               taken: Enter a unique DTTP ID
   activemodel:
+    attributes:
+      course_details_form:
+        course_start_date: Course start date
+        itt_start_date: ITT start date
+        course_end_date: Course end date
+        itt_end_date: ITT end date
     errors:
       validators:
         postcode:
@@ -928,6 +936,19 @@ en:
               invalid: Enter a valid course end date
               too_old: Enter a valid course end date
               before_or_same_as_start_date: The course end date must be after the start date
+              hint_html: For example, 11 3 %{year}
+            itt_start_date:
+              blank: Enter an ITT start date
+              future: Enter an ITT start date that is not as far in the future
+              invalid: Enter a valid ITT start date
+              too_old: Enter a valid ITT start date
+              hint_html: For example, 11 3 %{year}
+            itt_end_date:
+              blank: Enter an ITT end date
+              future: Enter an ITT end date that is not as far in the future
+              invalid: Enter a valid ITT end date
+              too_old: Enter a valid ITT end date
+              before_or_same_as_start_date: The ITT end date must be after the start date
               hint_html: For example, 11 3 %{year}
         publish_course_details_form:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -942,14 +942,16 @@ en:
               future: Enter an ITT start date that is not as far in the future
               invalid: Enter a valid ITT start date
               too_old: Enter a valid ITT start date
-              hint_html: For example, 11 3 %{year}
+              hint_html: <p class="govuk-body govuk-hint">The start date of the Initial Teacher Training portion of their course.</p>
+               <p class="govuk-body govuk-hint">For example, 11 3 %{year}</p>
             itt_end_date:
               blank: Enter an ITT end date
               future: Enter an ITT end date that is not as far in the future
               invalid: Enter a valid ITT end date
               too_old: Enter a valid ITT end date
               before_or_same_as_start_date: The ITT end date must be after the start date
-              hint_html: For example, 11 3 %{year}
+              hint_html: <p class="govuk-body govuk-hint">The end date of the Initial Teacher Training portion of their course.</p>
+               <p class="govuk-body govuk-hint">For example, 11 3 %{year}</p>
         publish_course_details_form:
           attributes:
             code:

--- a/spec/components/course_details/view_preview.rb
+++ b/spec/components/course_details/view_preview.rb
@@ -4,38 +4,49 @@ require "govuk/components"
 
 module CourseDetails
   class ViewPreview < ViewComponent::Preview
-    def default
-      render(View.new(data_model: mock_trainee))
-    end
+    %i[assessment_only
+       early_years_undergrad
+       pg_teaching_apprenticeship].each do |training_route_enums_key|
+      define_method "#{training_route_enums_key}_default" do
+        render(View.new(data_model: mock_trainee(training_route_enums_key: training_route_enums_key)))
+      end
 
-    def with_no_data
-      render(View.new(data_model: Trainee.new(id: 2, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])))
-    end
+      define_method "#{training_route_enums_key}_with_no_data" do
+        render(View.new(data_model: mock_trainee_with_no_data(training_route_enums_key: training_route_enums_key)))
+      end
 
-    def with_multiple_subjects
-      render(View.new(data_model: mock_trainee_with_multiple_subjects))
+      define_method "#{training_route_enums_key}_with_multiple_subjects" do
+        render(View.new(data_model: mock_trainee_with_multiple_subjects(training_route_enums_key: training_route_enums_key)))
+      end
     end
 
   private
 
-    def mock_trainee
+    def mock_trainee_with_no_data(training_route_enums_key:)
+      @mock_trainee ||= Trainee.new(id: 1,
+                                    provider: Provider.new, training_route: TRAINING_ROUTE_ENUMS[training_route_enums_key])
+    end
+
+    def mock_trainee(training_route_enums_key:)
       @mock_trainee ||= Trainee.new(
         id: 1,
+        provider: Provider.new,
         course_subject_one: "Primary",
         course_age_range: [3, 11],
         course_start_date: Date.new(2020, 1, 28),
-        training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+        training_route: TRAINING_ROUTE_ENUMS[training_route_enums_key],
       )
     end
 
-    def mock_trainee_with_multiple_subjects
+    def mock_trainee_with_multiple_subjects(training_route_enums_key:)
       Trainee.new(
         id: 1,
+        provider: Provider.new,
         course_subject_one: "Primary",
         course_subject_two: "Science",
         course_age_range: [3, 11],
         course_start_date: Date.new(2020, 1, 28),
-        training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+        training_route: TRAINING_ROUTE_ENUMS[training_route_enums_key],
       )
     end
   end

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -25,9 +25,31 @@ module Pages
             @form.validate
             render template: template, locals: { "@trainee": @trainee, "@form": @form }
           end
+
+          define_method "#{sections}_itt" do
+            @trainee = itt_trainee(sections)
+
+            @form = TrnSubmissionForm.new(trainee: @trainee)
+            render template: template, locals: { "@trainee": @trainee, "@form": @form }
+          end
+
+          define_method "#{sections}_itt_validated" do
+            @trainee = itt_trainee(sections)
+
+            @form = TrnSubmissionForm.new(trainee: @trainee)
+            @form.validate
+            render template: template, locals: { "@trainee": @trainee, "@form": @form }
+          end
         end
 
       private
+
+        def itt_trainee(section)
+          return trainee_with_all_sections_incomplete(training_route_enums_key: :pg_teaching_apprenticeship) if section == :start_sections
+          return trainee_with_all_sections_in_progress(training_route_enums_key: :pg_teaching_apprenticeship) if section == :continue_sections
+
+          trainee_with_all_sections_completed(training_route_enums_key: :pg_teaching_apprenticeship)
+        end
 
         def trainee(section)
           return trainee_with_all_sections_incomplete if section == :start_sections
@@ -36,11 +58,11 @@ module Pages
           trainee_with_all_sections_completed
         end
 
-        def trainee_with_all_sections_incomplete
-          Trainee.new(id: 1000, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
+        def trainee_with_all_sections_incomplete(training_route_enums_key: :assessment_only)
+          Trainee.new(id: 1000, training_route: TRAINING_ROUTE_ENUMS[training_route_enums_key])
         end
 
-        def trainee_with_all_sections_in_progress
+        def trainee_with_all_sections_in_progress(training_route_enums_key: :assessment_only)
           Trainee.new(id: 1000, trainee_id: "trainee_id",
                       first_names: "first_names",
                       last_name: "last_name",
@@ -53,20 +75,20 @@ module Pages
                       international_address: "international_address",
                       ethnic_background: "ethnic_background",
                       additional_ethnic_background: "additional_ethnic_background",
-                      training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+                      training_route: TRAINING_ROUTE_ENUMS[training_route_enums_key],
                       course_subject_one: "subject",
                       degrees: [Degree.new(id: 1)],
                       training_initiative: ROUTE_INITIATIVES_ENUMS[:transition_to_teach],
                       applying_for_bursary: true)
         end
 
-        def trainee_with_all_sections_completed
+        def trainee_with_all_sections_completed(training_route_enums_key: :assessment_only)
           nationalities = [Nationality.first || Nationality.new(id: 1)]
 
           Trainee.new(id: 1000, trainee_id: "trainee_id",
                       first_names: "first_names",
                       last_name: "last_name",
-                      training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+                      training_route: TRAINING_ROUTE_ENUMS[training_route_enums_key],
                       address_line_one: "address_line_one",
                       address_line_two: "address_line_two",
                       town_city: "town_city",
@@ -98,7 +120,8 @@ module Pages
                       degrees: [Degree.new(id: 1, locale_code: 1, subject: "subject")],
                       commencement_date: Time.zone.now,
                       training_initiative: ROUTE_INITIATIVES_ENUMS[:transition_to_teach],
-                      applying_for_bursary: true)
+                      applying_for_bursary: true,
+                      provider: Provider.new)
         end
 
         def template

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -3,72 +3,84 @@
 require "rails_helper"
 
 describe TrainingRouteManager do
-  let(:training_route_manager) { described_class.new(trainee) }
+  subject { described_class.new(trainee) }
 
-  shared_context "route checks" do |method_name, training_route_enums_key, other_training_route|
-    describe "##{method_name}" do
-      subject do
-        training_route_manager.public_send(method_name)
-      end
-
-      context "trainee on a #{training_route_enums_key} training route" do
-        let(:trainee) { build(:trainee, training_route: training_route_enums_key) }
+  describe "#requires_placement_details?" do
+    context "with the :routes_provider_led_postgrad feature flag enabled", "feature_routes.provider_led_postgrad": true do
+      context "with a provider-led trainee" do
+        let(:trainee) { build(:trainee, :provider_led_postgrad) }
 
         it "returns true" do
-          expect(subject).to be true
+          expect(subject.requires_placement_details?).to be true
         end
       end
 
-      context "trainee on a non #{training_route_enums_key} training route " do
-        let(:trainee) { build(:trainee, other_training_route || :assessment_only) }
+      context "with a non provider-led trainee" do
+        let(:trainee) { build(:trainee) }
 
         it "returns false" do
-          expect(subject).to be false
+          expect(subject.requires_placement_details?).to be false
+        end
+      end
+    end
+
+    context "with the :routes_provider_led_postgrad feature flag disabled", "feature.routes_provider_led_postgrad": false do
+      let(:trainee) { build(:trainee, :provider_led_postgrad) }
+
+      it "returns false" do
+        expect(subject.requires_placement_details?).to be false
+      end
+    end
+  end
+
+  describe "#requires_schools?" do
+    %w[school_direct_tuition_fee school_direct_salaried].each do |route|
+      context "with the :routes_#{route} feature flag enabled", "feature_routes.#{route}": true do
+        context "with a school direct trainee" do
+          let(:trainee) { build(:trainee, route.to_sym) }
+
+          it "returns true" do
+            expect(subject.requires_schools?).to be true
+          end
+        end
+
+        context "with the :routes_#{route} feature flag disabled", "feature_routes.#{route}": false do
+          context "with a non school direct trainee" do
+            let(:trainee) { build(:trainee) }
+
+            it "returns false" do
+              expect(subject.requires_schools?).to be false
+            end
+          end
         end
       end
     end
   end
 
-  shared_examples "enabled? checks" do |method_name, training_route_enums_key, other_training_route|
-    describe "##{method_name}" do
-      subject do
-        training_route_manager.public_send(method_name)
-      end
+  describe "#requires_employing_school?" do
+    context "with the :routes_school_direct_salaried feature flag enabled", "feature_routes.school_direct_salaried": true do
+      context "with a school direct salaried trainee" do
+        let(:trainee) { build(:trainee, :school_direct_salaried) }
 
-      context "with the :routes_#{training_route_enums_key} feature flag enabled", "feature_routes.#{training_route_enums_key}": true do
-        context "trainee on a #{training_route_enums_key} training route" do
-          let(:trainee) { build(:trainee, training_route: training_route_enums_key) }
-
-          it "returns true" do
-            expect(subject).to be true
-          end
-        end
-
-        context "trainee on a non #{training_route_enums_key} training route " do
-          let(:trainee) { build(:trainee, other_training_route || :assessment_only) }
-
-          it "returns false" do
-            expect(subject).to be false
-          end
+        it "returns true" do
+          expect(subject.requires_employing_school?).to be true
         end
       end
 
-      context "with the :routes_#{training_route_enums_key} feature flag disabled", "feature_routes.#{training_route_enums_key}": false do
-        context "trainee on a #{training_route_enums_key} training route" do
-          let(:trainee) { build(:trainee, training_route: training_route_enums_key) }
+      context "with a non school direct trainee" do
+        let(:trainee) { build(:trainee) }
 
-          it "returns false" do
-            expect(subject).to be false
-          end
+        it "returns false" do
+          expect(subject.requires_employing_school?).to be false
         end
+      end
+    end
 
-        context "trainee on a non #{training_route_enums_key} training route " do
-          let(:trainee) { build(:trainee, other_training_route || :assessment_only) }
+    context "with the :routes_school_direct_salaried feature flag disabled", "feature_routes.school_direct_salaried": false do
+      let(:trainee) { build(:trainee) }
 
-          it "returns false" do
-            expect(subject).to be false
-          end
-        end
+      it "returns false" do
+        expect(subject.requires_employing_school?).to be false
       end
     end
   end
@@ -111,23 +123,25 @@ describe TrainingRouteManager do
     end
   end
 
-  include_examples "enabled? checks", "requires_placement_details?", "provider_led_postgrad"
-  include_examples "enabled? checks", "requires_schools?", "school_direct_salaried"
-  include_examples "enabled? checks", "requires_schools?", "school_direct_tuition_fee"
-  include_examples "enabled? checks", "requires_schools?", "pg_teaching_apprenticeship"
-  include_examples "enabled? checks", "requires_employing_school?", "school_direct_salaried"
-  include_examples "enabled? checks", "requires_employing_school?",
-                   "pg_teaching_apprenticeship"
+  describe "#itt_route?" do
+    %i[early_years_undergrad pg_teaching_apprenticeship].each do |route|
+      context "with an itt trainee" do
+        let(:trainee) { build(:trainee, route) }
 
-  include_examples "route checks", "early_years_route?", "early_years_assessment_only"
-  include_examples "route checks", "early_years_route?", "early_years_postgrad"
-  include_examples "route checks", "early_years_route?", "early_years_salaried"
-  include_examples "route checks", "early_years_route?", "early_years_undergrad"
+        it "returns true" do
+          expect(subject.itt_route?).to be true
+        end
+      end
 
-  include_examples "route checks", "itt_route?", "early_years_undergrad"
-  include_examples "route checks", "itt_route?", "pg_teaching_apprenticeship"
+      context "with the :routes_#{route} feature flag disabled", "feature_routes.#{route}": false do
+        context "with a non itt trainee" do
+          let(:trainee) { build(:trainee) }
 
-  # NOTE: `no op`, these routes are not available in the database yet.
-  # include_examples "enabled? checks", "itt_route?", "provider_led_undergrad"
-  # include_examples "enabled? checks", "itt_route?", "opt_in_undergrad"
+          it "returns false" do
+            expect(subject.itt_route?).to be false
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -3,84 +3,72 @@
 require "rails_helper"
 
 describe TrainingRouteManager do
-  subject { described_class.new(trainee) }
+  let(:training_route_manager) { described_class.new(trainee) }
 
-  describe "#requires_placement_details?" do
-    context "with the :routes_provider_led_postgrad feature flag enabled", "feature_routes.provider_led_postgrad": true do
-      context "with a provider-led trainee" do
-        let(:trainee) { build(:trainee, :provider_led_postgrad) }
+  shared_context "route checks" do |method_name, training_route_enums_key, other_training_route|
+    describe "##{method_name}" do
+      subject do
+        training_route_manager.public_send(method_name)
+      end
+
+      context "trainee on a #{training_route_enums_key} training route" do
+        let(:trainee) { build(:trainee, training_route: training_route_enums_key) }
 
         it "returns true" do
-          expect(subject.requires_placement_details?).to be true
+          expect(subject).to be true
         end
       end
 
-      context "with a non provider-led trainee" do
-        let(:trainee) { build(:trainee) }
+      context "trainee on a non #{training_route_enums_key} training route " do
+        let(:trainee) { build(:trainee, other_training_route || :assessment_only) }
 
         it "returns false" do
-          expect(subject.requires_placement_details?).to be false
+          expect(subject).to be false
         end
-      end
-    end
-
-    context "with the :routes_provider_led_postgrad feature flag disabled", "feature.routes_provider_led_postgrad": false do
-      let(:trainee) { build(:trainee, :provider_led_postgrad) }
-
-      it "returns false" do
-        expect(subject.requires_placement_details?).to be false
       end
     end
   end
 
-  describe "#requires_schools?" do
-    %w[school_direct_tuition_fee school_direct_salaried].each do |route|
-      context "with the :routes_#{route} feature flag enabled", "feature_routes.#{route}": true do
-        context "with a school direct trainee" do
-          let(:trainee) { build(:trainee, route.to_sym) }
+  shared_examples "enabled? checks" do |method_name, training_route_enums_key, other_training_route|
+    describe "##{method_name}" do
+      subject do
+        training_route_manager.public_send(method_name)
+      end
+
+      context "with the :routes_#{training_route_enums_key} feature flag enabled", "feature_routes.#{training_route_enums_key}": true do
+        context "trainee on a #{training_route_enums_key} training route" do
+          let(:trainee) { build(:trainee, training_route: training_route_enums_key) }
 
           it "returns true" do
-            expect(subject.requires_schools?).to be true
+            expect(subject).to be true
           end
         end
 
-        context "with the :routes_#{route} feature flag disabled", "feature_routes.#{route}": false do
-          context "with a non school direct trainee" do
-            let(:trainee) { build(:trainee) }
+        context "trainee on a non #{training_route_enums_key} training route " do
+          let(:trainee) { build(:trainee, other_training_route || :assessment_only) }
 
-            it "returns false" do
-              expect(subject.requires_schools?).to be false
-            end
+          it "returns false" do
+            expect(subject).to be false
           end
         end
       end
-    end
-  end
 
-  describe "#requires_employing_school?" do
-    context "with the :routes_school_direct_salaried feature flag enabled", "feature_routes.school_direct_salaried": true do
-      context "with a school direct salaried trainee" do
-        let(:trainee) { build(:trainee, :school_direct_salaried) }
+      context "with the :routes_#{training_route_enums_key} feature flag disabled", "feature_routes.#{training_route_enums_key}": false do
+        context "trainee on a #{training_route_enums_key} training route" do
+          let(:trainee) { build(:trainee, training_route: training_route_enums_key) }
 
-        it "returns true" do
-          expect(subject.requires_employing_school?).to be true
+          it "returns false" do
+            expect(subject).to be false
+          end
         end
-      end
 
-      context "with a non school direct trainee" do
-        let(:trainee) { build(:trainee) }
+        context "trainee on a non #{training_route_enums_key} training route " do
+          let(:trainee) { build(:trainee, other_training_route || :assessment_only) }
 
-        it "returns false" do
-          expect(subject.requires_employing_school?).to be false
+          it "returns false" do
+            expect(subject).to be false
+          end
         end
-      end
-    end
-
-    context "with the :routes_school_direct_salaried feature flag disabled", "feature_routes.school_direct_salaried": false do
-      let(:trainee) { build(:trainee) }
-
-      it "returns false" do
-        expect(subject.requires_employing_school?).to be false
       end
     end
   end
@@ -122,4 +110,24 @@ describe TrainingRouteManager do
       end
     end
   end
+
+  include_examples "enabled? checks", "requires_placement_details?", "provider_led_postgrad"
+  include_examples "enabled? checks", "requires_schools?", "school_direct_salaried"
+  include_examples "enabled? checks", "requires_schools?", "school_direct_tuition_fee"
+  include_examples "enabled? checks", "requires_schools?", "pg_teaching_apprenticeship"
+  include_examples "enabled? checks", "requires_employing_school?", "school_direct_salaried"
+  include_examples "enabled? checks", "requires_employing_school?",
+                   "pg_teaching_apprenticeship"
+
+  include_examples "route checks", "early_years_route?", "early_years_assessment_only"
+  include_examples "route checks", "early_years_route?", "early_years_postgrad"
+  include_examples "route checks", "early_years_route?", "early_years_salaried"
+  include_examples "route checks", "early_years_route?", "early_years_undergrad"
+
+  include_examples "route checks", "itt_route?", "early_years_undergrad"
+  include_examples "route checks", "itt_route?", "pg_teaching_apprenticeship"
+
+  # NOTE: `no op`, these routes are not available in the database yet.
+  # include_examples "enabled? checks", "itt_route?", "provider_led_undergrad"
+  # include_examples "enabled? checks", "itt_route?", "opt_in_undergrad"
 end

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -48,14 +48,26 @@ module Features
     end
 
     def and_the_course_date_fields_are_completed
-      course_details_page.set_date_fields("course_start_date", "11/3/2021")
-      course_details_page.set_date_fields("course_end_date", "11/3/2022")
+      course_details_page.set_date_fields(start_date, "11/3/2021")
+      course_details_page.set_date_fields(end_date, "11/3/2022")
     end
 
     def and_the_course_details_are_submitted
       course_details_page.submit_button.click
       confirm_details_page.confirm.click
       confirm_details_page.continue_button.click
+    end
+
+  private
+
+    def start_date
+      trainee = trainee_from_url
+      trainee.itt_route? ? "itt_start_date" : "course_start_date"
+    end
+
+    def end_date
+      trainee = trainee_from_url
+      trainee.itt_route? ? "itt_end_date" : "course_end_date"
     end
   end
 end

--- a/spec/support/page_objects/trainees/course_details.rb
+++ b/spec/support/page_objects/trainees/course_details.rb
@@ -17,6 +17,14 @@ module PageObjects
       element :course_end_date_month, "#course_details_form_course_end_date_2i"
       element :course_end_date_year, "#course_details_form_course_end_date_1i"
 
+      element :itt_start_date_day, "#course_details_form_itt_start_date_3i"
+      element :itt_start_date_month, "#course_details_form_itt_start_date_2i"
+      element :itt_start_date_year, "#course_details_form_itt_start_date_1i"
+
+      element :itt_end_date_day, "#course_details_form_itt_end_date_3i"
+      element :itt_end_date_month, "#course_details_form_itt_end_date_2i"
+      element :itt_end_date_year, "#course_details_form_itt_end_date_1i"
+
       element :main_age_range_3_to_11, "#course-details-form-main-age-range-3-to-11-field"
       element :main_age_range_5_to_11, "#course-details-form-main-age-range-5-to-11-field"
       element :main_age_range_11_to_16, "#course-details-form-main-age-range-11-to-16-field"


### PR DESCRIPTION
### Context

ITT vs non ITT start and end dates

### Changes proposed in this pull request
`Teaching apprenticeship (postgrad)` route, everything should say `ITT start date` or `ITT end date`

### Guidance to review
Go thro the `Teaching apprenticeship (postgrad)` route, everything should say `ITT start date` or `ITT end date`


https://register-pr-1195.london.cloudapps.digital/trainees/SSLModxSnzXHQKSSTMVdMnuJ


![image](https://user-images.githubusercontent.com/470137/127313676-a2f37f3a-11b1-4943-a0da-b68b09c3e022.png)

https://register-pr-1195.london.cloudapps.digital/trainees/A3NqSjdZ34bzS8bb5Y5TmFRk/course-details/edit

![image](https://user-images.githubusercontent.com/470137/127313952-5b3a6d1f-50fd-4e68-91a8-cb7a06e54961.png)

https://register-pr-1195.london.cloudapps.digital/trainees/A3NqSjdZ34bzS8bb5Y5TmFRk/check-details
![image](https://user-images.githubusercontent.com/470137/127314074-d5271a42-e44e-4b48-ab51-28ccc45b251f.png)

https://register-pr-1195.london.cloudapps.digital/trainees/A3NqSjdZ34bzS8bb5Y5TmFRk/course-details/confirm

![image](https://user-images.githubusercontent.com/470137/127314225-9429f68c-4fa8-4a05-96c5-ad2cd134ee57.png)


This should provisional work for the other routes 
- `early_years_undergrad`, 
- `provider_led_undergrad`, 
- `opt_in_undergrad`
