### PR TITLE
[2322] Update check-details page

### DIFF
--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -26,7 +26,7 @@ module Sections
       confirmation_view_args = { data_model: form_klass.new(trainee) }
 
       if section == :degrees
-        confirmation_view_args.merge!(show_add_another_degree_button: false, show_delete_button: true)
+        confirmation_view_args.merge!(show_add_another_degree_button: true, show_delete_button: true)
       end
       confirmation_view_args
     end

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -19,7 +19,7 @@
             <%= tag.li(messages.first) %>
           <% end %>
         <% end %>
-      
+
         <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
           <span class="govuk-caption-l">
             Draft record <%= "for #{trainee_name(@trainee)}" if trainee_name(@trainee).present? %>
@@ -50,7 +50,7 @@
 
     <%= register_form_with(model: @form, url: trn_submissions_path, method: :post, local: true) do |f| %>
       <%= hidden_field_tag :trainee_id, @trainee.slug %>
-      <%= f.govuk_submit "Submit record and request TRN" %>
+      <%= f.govuk_submit "Register trainee and request TRN" %>
     <% end %>
   </div>
 </div>

--- a/spec/support/page_objects/trainees/check_details/show.rb
+++ b/spec/support/page_objects/trainees/check_details/show.rb
@@ -8,7 +8,7 @@ module PageObjects
 
         element :back_to_draft_record, "#back-to-draft-record"
         element :return_to_draft_later, "#return-to-draft-later"
-        element :submit_button, "button[type='submit']", text: "Submit record and request TRN"
+        element :submit_button, "button[type='submit']", text: "Register trainee and request TRN"
       end
     end
   end


### PR DESCRIPTION
### Context
Updating the `check-details` page.

### Changes proposed in this pull request

- Change text on submit button as outlined in the Trello ticket
- Switch on the add another degree button

### Guidance to review

- Navigate to a draft trainee
- Fill out all the details
- Click `Check this record`
- Check that the `Add another degree` button is present on this page
- Check that if you remove all degrees the `Add another degree` button is not present
- Check the updated text on the green button at the bottom of that page (as outlined in Trello)