### PR TITLE
Use commit sha of base branch as docker tag for PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,16 @@ jobs:
       DB_HOSTNAME: localhost
 
     steps:
-
     - uses: actions/checkout@v2
       name: Checkout
 
-    - name: Set environment variables
-      run: echo "SHA_TAG=${{ github.sha }}" >> $GITHUB_ENV
+    - name: Set environment variables (push)
+      if: github.event_name == 'push'
+      run: echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
+
+    - name: Set environment variables (pull_request)
+      if: github.event_name == 'pull_request'
+      run: echo "IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
     - name: Login to DockerHub
       if: github.actor != 'dependabot[bot]'
@@ -40,23 +44,23 @@ jobs:
     - name: Build Docker Image
       uses: docker/build-push-action@v2
       with:
-        tags: ${{env.DOCKER_REPO}}:${{env.SHA_TAG}}
+        tags: ${{env.DOCKER_REPO}}:${{env.IMAGE_TAG}}
         builder: ${{ steps.buildx.outputs.name }}
         load: true
         cache-to: type=inline
         cache-from: |
           type=registry,ref=${{env.DOCKER_REPO}}:master
-          type=registry,ref=${{env.DOCKER_REPO}}:${{env.SHA_TAG}}
+          type=registry,ref=${{env.DOCKER_REPO}}:${{env.IMAGE_TAG}}
         build-args: COMMIT_SHA=${{ github.sha }}
 
     - name: Tag master image
       if: github.ref == 'refs/heads/master'
-      run: docker tag ${{env.DOCKER_REPO}}:${{env.SHA_TAG}} ${{env.DOCKER_REPO}}:master
+      run: docker tag ${{env.DOCKER_REPO}}:${{env.IMAGE_TAG}} ${{env.DOCKER_REPO}}:master
 
     - name: Push Docker Image
       if: github.actor != 'dependabot[bot]'
       run: |
-        docker push ${{env.DOCKER_REPO}}:${{env.SHA_TAG}}
+        docker push ${{env.DOCKER_REPO}}:${{env.IMAGE_TAG}}
         docker push ${{env.DOCKER_REPO}}:master || true
 
     - name: Trigger Review App Deployment
@@ -66,7 +70,7 @@ jobs:
         workflow: 'Deploy to PaaS'
         ref: ${{ github.head_ref }}
         token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}
-        inputs: '{"pr": "${{ github.event.pull_request.number }}", "sha": "${{ env.SHA_TAG }}"}'
+        inputs: '{"pr": "${{ github.event.pull_request.number }}", "sha": "${{ env.IMAGE_TAG }}"}'
 
     - name: Bring images up
       run: |
@@ -116,7 +120,7 @@ jobs:
       with:
         workflow: 'Deploy to PaaS'
         token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}
-        inputs: '{"qa": "true", "staging": "true", "production": "true", "sandbox": "true", "sha": "${{ env.SHA_TAG }}"}'
+        inputs: '{"qa": "true", "staging": "true", "production": "true", "sandbox": "true", "sha": "${{ env.IMAGE_TAG }}"}'
 
     - name: Check for Failure
       if: ${{ failure() && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       if: github.event_name == 'push'
       run: |
         GIT_BRANCH=${GITHUB_REF##*/}
-        echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
+        echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV # GIT_BRANCH will be master for refs/heads/master
         echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
 
     - name: Set environment variables (pull_request)
@@ -43,17 +43,12 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
 
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1.3.0
-
     - name: Build Docker Image
       uses: docker/build-push-action@v2
       with:
         tags: |
           ${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
           ${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
-        builder: ${{ steps.buildx.outputs.name }}
         load: true
         cache-to: type=inline
         cache-from: |
@@ -62,15 +57,11 @@ jobs:
           type=registry,ref=${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
         build-args: COMMIT_SHA=${{ github.sha }}
 
-    - name: Tag master image
-      if: github.ref == 'refs/heads/master'
-      run: docker tag ${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}} ${{env.DOCKER_IMAGE}}:master
-
     - name: Push Docker Image
       if: github.actor != 'dependabot[bot]'
       run: |
         docker push ${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
-        docker push ${{env.DOCKER_IMAGE}}:master || true
+        docker push ${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
 
     - name: Trigger Review App Deployment
       if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKER_REPO: dfedigital/register-trainee-teachers
+      DOCKER_IMAGE: dfedigital/register-trainee-teachers
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
       DB_HOSTNAME: localhost
@@ -24,11 +24,17 @@ jobs:
 
     - name: Set environment variables (push)
       if: github.event_name == 'push'
-      run: echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
+      run: |
+        GIT_BRANCH=${GITHUB_REF##*/}
+        echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
+        echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
 
     - name: Set environment variables (pull_request)
       if: github.event_name == 'pull_request'
-      run: echo "IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+      run: |
+        GIT_BRANCH=${GITHUB_HEAD_REF##*/}
+        echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
+        echo "IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
     - name: Login to DockerHub
       if: github.actor != 'dependabot[bot]'
@@ -44,24 +50,27 @@ jobs:
     - name: Build Docker Image
       uses: docker/build-push-action@v2
       with:
-        tags: ${{env.DOCKER_REPO}}:${{env.IMAGE_TAG}}
+        tags: |
+          ${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
+          ${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
         builder: ${{ steps.buildx.outputs.name }}
         load: true
         cache-to: type=inline
         cache-from: |
-          type=registry,ref=${{env.DOCKER_REPO}}:master
-          type=registry,ref=${{env.DOCKER_REPO}}:${{env.IMAGE_TAG}}
+          type=registry,ref=${{env.DOCKER_IMAGE}}:master
+          type=registry,ref=${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
+          type=registry,ref=${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
         build-args: COMMIT_SHA=${{ github.sha }}
 
     - name: Tag master image
       if: github.ref == 'refs/heads/master'
-      run: docker tag ${{env.DOCKER_REPO}}:${{env.IMAGE_TAG}} ${{env.DOCKER_REPO}}:master
+      run: docker tag ${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}} ${{env.DOCKER_IMAGE}}:master
 
     - name: Push Docker Image
       if: github.actor != 'dependabot[bot]'
       run: |
-        docker push ${{env.DOCKER_REPO}}:${{env.IMAGE_TAG}}
-        docker push ${{env.DOCKER_REPO}}:master || true
+        docker push ${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
+        docker push ${{env.DOCKER_IMAGE}}:master || true
 
     - name: Trigger Review App Deployment
       if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -74,7 +74,6 @@ jobs:
         run: make review ci destroy
         env:
           ARM_ACCESS_KEY:               ${{ secrets.ARM_ACCESS_KEY_REVIEW }}
-          IMAGE_TAG:                    ${{ github.sha }}
           TF_VAR_azure_credentials:     ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
 
       - name: Delete tf state file

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,14 @@ RUN  yarn install --frozen-lockfile && \
 
 COPY . .
 
-ARG COMMIT_SHA
-ENV COMMIT_SHA=$COMMIT_SHA
 RUN echo export PATH=/usr/local/bin:\$PATH > /root/.ashrc
 ENV ENV="/root/.ashrc"
 
 RUN bundle exec rake assets:precompile && \
     rm -rf node_modules tmp
+
+ARG COMMIT_SHA
+ENV COMMIT_SHA=$COMMIT_SHA
 
 CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && \
     bundle exec rails data:migrate && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     build:
       context: .
       cache_from:
-        - dfedigital/register-trainee-teachers:${SHA_TAG:-master}
-    image: dfedigital/register-trainee-teachers:${SHA_TAG:-master}
+        - dfedigital/register-trainee-teachers:${IMAGE_TAG:-master}
+    image: dfedigital/register-trainee-teachers:${IMAGE_TAG:-master}
     command: ash -c "bundle exec rails server -p 3001 -b '0.0.0.0'"
     ports:
       - 3001:3001
@@ -31,7 +31,7 @@ services:
       - REDIS_URL=redis://redis:6379
 
   bg-jobs:
-    image: dfedigital/register-trainee-teachers:${SHA_TAG:-master}
+    image: dfedigital/register-trainee-teachers:${IMAGE_TAG:-master}
     command: bundle exec sidekiq -c 5 -C config/sidekiq.yml
     depends_on:
       - web


### PR DESCRIPTION
### Context

Improve docker build caching

### Changes proposed in this pull request

Move COMMIT_SHA argument to end of the Dockerfile
Tag docker image with base branch name and base commit sha
Remove buildx cache step and just use inline cache

### Guidance to review

