### PR TITLE
[2376] Don’t send degree date obtained as part of degree payload to dttp

### DIFF
--- a/app/lib/dttp/params/degree_qualification.rb
+++ b/app/lib/dttp/params/degree_qualification.rb
@@ -25,7 +25,6 @@ module Dttp
           "dfe_ContactId@odata.bind" => "$#{contact_change_set_id}",
           "dfe_TrainingRecordId@odata.bind" => "$#{placement_assignment_change_set_id}",
           "dfe_DegreeSubjectId@odata.bind" => "/dfe_jacses(#{degree_subject_id(degree.subject)})",
-          "dfe_undergraddegreedateobtained" => "#{degree.graduation_year}-01-01",
         }.merge(degree.uk? ? uk_specific_params : non_uk_specific_params)
       end
 

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -46,7 +46,7 @@ module Dttp
           "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{dttp_qualification_aim_id(trainee.training_route)})",
           "dfe_programmeyear" => 1, # TODO: this will need to be derived for other routes. It's n of x year course e.g. 1 of 2
           "dfe_programmelength" => 1, # TODO: this will change for other routes as above. So these two are course_year of course_length
-          "dfe_undergraddegreedateobtained" => "#{qualifying_degree.graduation_year}-01-01",
+          "dfe_undergraddegreedateobtained" => Date.parse("01-01-#{trainee.degrees.first.graduation_year}").to_datetime.iso8601,
         }
         .merge(qualifying_degree.uk? ? uk_specific_params : non_uk_specific_params)
         .merge(school_params)

--- a/spec/lib/dttp/params/degree_qualification_spec.rb
+++ b/spec/lib/dttp/params/degree_qualification_spec.rb
@@ -43,7 +43,6 @@ module Dttp
               "dfe_DegreeSubjectId@odata.bind" => "/dfe_jacses(#{dttp_degree_subject_entity_id})",
               "dfe_DegreeTypeId@odata.bind" => "/dfe_degreetypes(#{dttp_degree_type_id})",
               "dfe_AwardingInstitutionId@odata.bind" => "/accounts(#{dttp_degree_institution_entity_id})",
-              "dfe_undergraddegreedateobtained" => "#{degree.graduation_year}-01-01",
             })
           end
         end
@@ -60,7 +59,6 @@ module Dttp
               "dfe_DegreeSubjectId@odata.bind" => "/dfe_jacses(#{dttp_degree_subject_entity_id})",
               "dfe_DegreeTypeId@odata.bind" => "/dfe_degreetypes(#{dttp_degree_type_id})",
               "dfe_DegreeCountryId@odata.bind" => "/dfe_countries(#{dttp_country_entity_id})",
-              "dfe_undergraddegreedateobtained" => "#{degree.graduation_year}-01-01",
             })
           end
         end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -78,7 +78,7 @@ module Dttp
                 "dfe_programmeyear" => 1,
                 "dfe_programmelength" => 1,
                 "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id})",
-                "dfe_undergraddegreedateobtained" => "#{degree.graduation_year}-01-01",
+                "dfe_undergraddegreedateobtained" => Date.parse("01-01-#{degree.graduation_year}").to_datetime.iso8601,
               })
             end
           end
@@ -105,7 +105,7 @@ module Dttp
                 "dfe_programmeyear" => 1,
                 "dfe_programmelength" => 1,
                 "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id})",
-                "dfe_undergraddegreedateobtained" => "#{degree.graduation_year}-01-01",
+                "dfe_undergraddegreedateobtained" => Date.parse("01-01-#{degree.graduation_year}").to_datetime.iso8601,
               })
             end
           end


### PR DESCRIPTION
### Context

https://trello.com/c/dBc9YoLt/2376-bug-dttpclienterror-when-attempting-to-register-trn

### Changes proposed in this pull request

This field doesn’t exist, and is causing a 400 error when we try to 
send it to dttp. The degree qualifications model only has a degree
end date as a possible value rather than the graduation date, but it 
seems to be null all the time. The degree date obtained is still set
on the placement assignment

### Guidance to review

It is quite painful to set up the communication with DTTP locally and get a trainee in a valid enough state to run the job manually in the console. It is probably easier if I screen share to demonstrate