### PR TITLE
[2320] Update status card layout and css

### DIFF
--- a/app/components/badges/view.html.erb
+++ b/app/components/badges/view.html.erb
@@ -1,15 +1,13 @@
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
-  <% full_width_states.map do |state, count| %>
-    <div class="govuk-grid-column-one-third">
-      <%= render TraineeStatusCard::View.new(state: state, count: count, target: trainees_path("state[]": state)) %>
-    </div>
-  <% end %>
-</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="app-home-statuses">
+        <% full_width_states.map do |state, count| %>
+            <%= render TraineeStatusCard::View.new(state: state, count: count, target: trainees_path("state[]": state)) %>
+        <% end %>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-6">
-  <% narrow_states.map do |state, count| %>
-    <div class="govuk-grid-column-one-quarter">
-      <%= render TraineeStatusCard::View.new(state: state, count: count, target: trainees_path("state[]": state)) %>
+        <% narrow_states.map do |state, count| %>
+            <%= render TraineeStatusCard::View.new(state: state, count: count, target: trainees_path("state[]": state)) %>
+        <% end %>
     </div>
-  <% end %>
+  </div>
 </div>

--- a/app/components/status_card/style.scss
+++ b/app/components/status_card/style.scss
@@ -8,13 +8,11 @@
   @include govuk-media-query($from: desktop) {
     padding: govuk-spacing(4);
   }
- 
-  margin-bottom: govuk-spacing(3);
 
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(0);
   }
-  
+
   outline: 2px solid transparent;
   outline-offset: -2px;
 
@@ -46,13 +44,23 @@
   text-decoration: underline;
   overflow-wrap: break-word;
   word-wrap: break-word;
-  hyphens: auto;
+  hyphens: none;
+}
+
+.app-home-statuses {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    @include govuk-media-query($from: tablet) {
+      grid-template-columns: 1fr 1fr 1fr 1fr
+    }
+    gap: govuk-spacing(4);
+    grid-auto-rows: 1fr;
 }
 
 .app-status-card--grey {
   &, &:link, &:visited {
     color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
-    background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90); 
+    background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
   }
   &:hover {
     background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 80);


### PR DESCRIPTION
### Context

Status card squares have new markup, they are now all the same height and width, and we do not break mid-word.

### Changes proposed in this pull request

- Remove hyphens from word breaks
- Make boxes consistent sizes
- Add grid layout (4x2 desktop, 2x4 mobile)

### Guidance to review

- Navigate to the home page and checkout the status cards. 

### Screenshot

![image](https://user-images.githubusercontent.com/50492247/127399085-6f76518e-36d9-480e-9d2b-0cc4eccb6070.png)