### PR TITLE
[2364] Added validation for ITT start date

### DIFF
--- a/app/forms/itt_start_date_form.rb
+++ b/app/forms/itt_start_date_form.rb
@@ -6,4 +6,22 @@ private
   def date_field
     @date_field ||= :course_start_date
   end
+
+  def date_valid
+    if date_string.nil?
+      errors.add(:date_string, :blank)
+    elsif date_string == "other" && [day, month, year].all?(&:blank?)
+      errors.add(:date, :blank)
+    elsif year.to_i > next_year
+      errors.add(:date, :future)
+    elsif !date.is_a?(Date)
+      errors.add(:date, :invalid)
+    elsif date < 10.years.ago
+      errors.add(:date, :too_old)
+    end
+  end
+
+  def next_year
+    Time.zone.now.year.next
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -889,7 +889,7 @@ en:
               blank: Enter an ITT start date
             date:
               blank: Enter an ITT start date
-              future: Enter an ITT start date that is not as far in the future
+              future: Enter an ITT start date closer to today
               invalid: Enter a valid ITT start date
               too_old: Enter a valid ITT start date
         course_details_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -889,7 +889,9 @@ en:
               blank: Enter an ITT start date
             date:
               blank: Enter an ITT start date
+              future: Enter an ITT start date that is not as far in the future
               invalid: Enter a valid ITT start date
+              too_old: Enter a valid ITT start date
         course_details_form:
           attributes:
             course_subject_one:

--- a/spec/forms/itt_start_date_form_spec.rb
+++ b/spec/forms/itt_start_date_form_spec.rb
@@ -7,10 +7,11 @@ describe IttStartDateForm, type: :model do
   let(:form_store) { class_double(FormStore) }
 
   let(:params) do
+    date = Faker::Date.between(from: 10.years.ago, to: 2.days.ago)
     {
-      year: "1963",
-      month: "11",
-      day: "11",
+      year: date.year.to_s,
+      month: date.month.to_s,
+      day: date.day.to_s,
       date_string: "other",
     }
   end
@@ -48,6 +49,38 @@ describe IttStartDateForm, type: :model do
           expect(subject.errors[:date]).to include(
             I18n.t(
               "activemodel.errors.models.itt_start_date_form.attributes.date.invalid",
+            ),
+          )
+        end
+      end
+
+      context "future date" do
+        before do
+          subject.year = "2099"
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date]).to include(
+            I18n.t(
+              "activemodel.errors.models.itt_start_date_form.attributes.date.future",
+            ),
+          )
+        end
+      end
+
+      context "too old date" do
+        before do
+          subject.day = "12"
+          subject.month = "11"
+          subject.year = "2000"
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date]).to include(
+            I18n.t(
+              "activemodel.errors.models.itt_start_date_form.attributes.date.too_old",
             ),
           )
         end


### PR DESCRIPTION
### Context
ITT start date Validation

### Changes proposed in this pull request
ITT start date validation needs to be same as course start date

### Guidance to review
date rules
- blank
- invalid
- in the future (1 year)
- in the past (10 years)

Should be the same as `course_start_date`
