### PR TITLE
[2323] Add validation to date forms requiring 4 numbers

### DIFF
--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -26,6 +26,7 @@ class PersonalDetailsForm < TraineeForm
   validates :date_of_birth, presence: true
   validate :date_of_birth_valid
   validate :date_of_birth_not_in_future
+  validate :date_of_birth_year_is_four_digits
   validates :gender, presence: true, inclusion: { in: Trainee.genders.keys }
   validate :check_raw_values
   validates :other_nationality1, :other_nationality2, :other_nationality3, autocomplete: true, allow_nil: true
@@ -129,6 +130,10 @@ private
 
   def date_of_birth_not_in_future
     errors.add(:date_of_birth, :future) if date_of_birth.is_a?(Date) && date_of_birth > Time.zone.today
+  end
+
+  def date_of_birth_year_is_four_digits
+    errors.add(:date_of_birth, :invalid_year) if date_of_birth.is_a?(Date) && date_of_birth.year.digits.length != 4
   end
 
   def calculate_other

--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -12,6 +12,7 @@ class TrainingDetailsForm < TraineeForm
 
   validates :commencement_date_radio_option, inclusion: { in: [COMMENCEMENT_DATE_RADIO_OPTION_COURSE, COMMENCEMENT_DATE_RADIO_OPTION_MANUAL] }, if: :course_start_date
   validate :commencement_date_valid
+  validate :commencement_date_year_is_four_digits
   validates :trainee_id, presence: true,
                          length: {
                            maximum: 100,
@@ -66,6 +67,10 @@ private
     elsif date_before_course_start_date?(commencement_date, trainee.course_start_date)
       errors.add(:commencement_date, :not_before_course_start_date)
     end
+  end
+
+  def commencement_date_year_is_four_digits
+    errors.add(:commencement_date, :invalid_year) if commencement_date.is_a?(Date) && commencement_date.year.digits.length != 4
   end
 
   def valid_date?(date_args)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -875,6 +875,7 @@ en:
             date_of_birth:
               blank: Enter a date of birth
               invalid: Enter a valid date
+              invalid_year: The year must include 4 numbers
               future: Enter a date of birth that is in the past, for example 31 3 1980
               hint_html: For example, 31 3 %{year}
             gender:
@@ -960,6 +961,7 @@ en:
             commencement_date:
               blank: Enter a start date
               invalid: Enter a valid start date
+              invalid_year: The year must include 4 numbers
               not_before_course_start_date: *not_before_course_start_date
             trainee_id:
               blank: Enter a trainee ID

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -94,6 +94,20 @@ describe PersonalDetailsForm, type: :model do
         end
       end
 
+      context "invalid date year" do
+        let(:params) { { day: 1, month: 4, year: 21 } }
+
+        before do
+          subject.validate
+        end
+
+        it "returns an invalid year error message" do
+          expect(subject.errors[:date_of_birth]).to include(
+            I18n.t("activemodel.errors.models.personal_details_form.attributes.date_of_birth.invalid_year"),
+          )
+        end
+      end
+
       context "future date" do
         let(:params) { { day: 1, month: 2, year: 2021 } }
 

--- a/spec/forms/training_details_form_spec.rb
+++ b/spec/forms/training_details_form_spec.rb
@@ -70,6 +70,16 @@ describe TrainingDetailsForm, type: :model do
         end
       end
 
+      context "invalid date year" do
+        let(:params) { { commencement_date_radio_options: "manual", day: "1", month: "4", year: "21" } }
+
+        it "returns an invalid year error message" do
+          expect(subject.errors[:commencement_date]).to include(
+            I18n.t("#{error_attr}.commencement_date.invalid_year"),
+          )
+        end
+      end
+
       context "date is before the course start date" do
         let(:trainee) do
           build(:trainee, course_start_date: Time.zone.today, commencement_date: 1.day.ago)


### PR DESCRIPTION
### Context

Validating the year field in date forms to avoid `21` be saved as `0021`, for example.

`Note:` I haven't added this validation to the other date fields because they have another form of validation which I think would prevent this issue surfacing?

### Changes proposed in this pull request

- Add year validation to `personal details form` ensuring the year is 4 digits.
- Add year validation to `training details form` ensuring the year is 4 digits.

### Guidance to review

- Navigate to a traine in `Draft` 
- Click on personal details and change the date to something like `1-4-21`
- Ensure the validation kicks in and prevents the date from persisting 
- Ensure the new error message is displayed
- Repeat for the date in the `Trainee start date and ID` section