### PR TITLE
[1402] Extend csv export to include all fields

### DIFF
--- a/app/components/status_tag/view.rb
+++ b/app/components/status_tag/view.rb
@@ -6,10 +6,6 @@ class StatusTag::View < GovukComponent::Base
     @trainee = trainee
   end
 
-private
-
-  attr_accessor :trainee
-
   def status
     {
       submitted_for_trn: "pending trn",
@@ -17,6 +13,10 @@ private
       awarded: "#{trainee.award_type} awarded",
     }[trainee.state.to_sym] || trainee.state.gsub("_", " ")
   end
+
+private
+
+  attr_accessor :trainee
 
   def status_colour
     {

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -107,6 +107,6 @@ private
   end
 
   def data_export
-    @data_export ||= Exports::TraineeSearchData.new(filtered_trainees, include_provider: current_user.system_admin?)
+    @data_export ||= Exports::TraineeSearchData.new(filtered_trainees)
   end
 end

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -2,10 +2,10 @@
 
 module Exports
   class TraineeSearchData
-    VULNERABLE_CHARACTERS = ["=", "+", "-", "@"].freeze
+    VULNERABLE_CHARACTERS = %w[= + - @].freeze
 
-    def initialize(trainees, include_provider: false)
-      @data_for_export = format_trainees(trainees, include_provider)
+    def initialize(trainees)
+      @data_for_export = format_trainees(trainees)
     end
 
     def data
@@ -15,7 +15,7 @@ module Exports
         rows << header_row
 
         data_for_export.map(&:values).each do |value|
-          rows << value
+          rows << value.map { |v| sanitise(v) }
         end
       end
     end
@@ -28,34 +28,195 @@ module Exports
 
     attr_reader :data_for_export
 
-    def format_trainees(trainees, include_provider)
+    def format_trainees(trainees)
       trainees.map do |trainee|
+        degree = trainee.degrees.first
+        course = Course.where(code: trainee.course_code).first
         {
-          "First name" => sanitise(trainee.first_names),
-          "Last name" => sanitise(trainee.last_name),
-          "Trainee Id" => sanitise(trainee.trainee_id),
-          "TRN" => trainee.trn,
-          "Status" => status(trainee),
-          "Route" => trainee.training_route,
-          "Subject" => trainee.course_subject_one,
-          "Course start date" => trainee.course_start_date,
-          "Course end date" => trainee.course_end_date,
-          "Created date" => trainee.created_at,
-          "Last updated date" => trainee.updated_at,
-          "TRN Submitted date" => trainee.submitted_for_trn_at,
-          "Award submitted date" => trainee.recommended_for_award_at,
-        }.tap do |fields|
-          fields.merge!("Provider Name" => sanitise(trainee.provider.name)) if include_provider
-        end
+          "register_id" => trainee.slug,
+          "trainee_url" => "#{Settings.base_url}/trainees/#{trainee.slug}",
+          "apply_id" => trainee.apply_application&.apply_id,
+          "provider_training_id" => trainee.trainee_id,
+          "trn" => trainee.trn,
+          "status" => status(trainee),
+          "academic_year" => nil,
+          "updated_at" => trainee.updated_at&.iso8601,
+          "record_created_at" => trainee.created_at&.iso8601,
+          "submitted_for_trn_at" => trainee.submitted_for_trn_at&.iso8601,
+          "provider_name" => trainee.provider&.name,
+          "provider_id" => trainee.provider&.code,
+          "first_names" => trainee.first_names,
+          "middle_names" => trainee.middle_names,
+          "last_names" => trainee.last_name,
+          "date_of_birth" => trainee.date_of_birth&.iso8601,
+          "gender" => gender(trainee),
+          "nationalities" => trainee.nationalities.pluck(:name).map(&:titleize).join(", "),
+          "address_line_1" => trainee.address_line_one,
+          "address_line_2" => trainee.address_line_two,
+          "town_city" => trainee.town_city,
+          "postcode" => trainee.postcode,
+          "international_address" => international_address(trainee),
+          "email_address" => trainee.email,
+          "diversity_disclosure" => diversity_disclosure(trainee),
+          "ethnic_group" => ethnic_group(trainee),
+          "ethnic_background" => trainee.ethnic_background,
+          "ethnic_background_additional" => trainee.additional_ethnic_background,
+          "disability_disclosure" => disability_disclosure(trainee),
+          "disabilities" => disabilities(trainee),
+          "number_of_degrees" => trainee.degrees.count,
+          "degree_1_uk_or_non_uk" => uk_or_non_uk(degree),
+          "degree_1_institution" => degree&.institution,
+          "degree_1_country" => degree&.country,
+          "degree_1_subject" => degree&.subject,
+          "degree_1_type_of_degree" => degree&.uk_degree,
+          "degree_1_non_uk_type" => degree&.non_uk_degree,
+          "degree_1_grade" => degree&.grade,
+          "degree_1_other_grade" => degree&.other_grade,
+          "degree_1_graduation_year" => degree&.graduation_year,
+          "degrees" => degrees(trainee),
+          "course_code" => trainee.course_code,
+          "course_name" => course&.name,
+          "course_route" => course_route(trainee),
+          "course_qualification" => course&.qualification,
+          "course_qualification_type" => nil,
+          "course_level" => course&.level&.capitalize,
+          "course_allocation_subject" => course_allocation_subject(trainee.course_subject_one),
+          "course_itt_subject_1" => trainee.course_subject_one,
+          "course_itt_subject_2" => trainee.course_subject_two,
+          "course_itt_subject_3" => trainee.course_subject_three,
+          "course_min_age" => course&.min_age,
+          "course_max_age" => course&.max_age,
+          "course_study_mode" => course_study_mode(trainee),
+          "course_start_date" => trainee.course_start_date&.iso8601,
+          "course_end_date" => trainee.course_end_date&.iso8601,
+          "course_duration_in_years" => course&.duration_in_years,
+          "course_summary" => course&.summary,
+          "commencement_date" => trainee.commencement_date&.iso8601,
+          "lead_school_name" => trainee.lead_school&.name,
+          "lead_school_urn" => trainee.lead_school&.urn,
+          "employing_school_name" => trainee.employing_school&.name,
+          "employing_school_urn" => trainee.employing_school&.urn,
+          "training_initiative" => training_initiative(trainee),
+          "applying_for_bursary" => trainee.applying_for_bursary.to_s.upcase,
+          "bursary_value" => (trainee.bursary_amount if trainee.applying_for_bursary),
+          "bursary_tier" => bursary_tier(trainee),
+          "award_standards_met_date" => trainee.outcome_date&.iso8601,
+          "award_awarded_at" => trainee.awarded_at&.iso8601,
+          "defer_date" => trainee.defer_date&.iso8601,
+          "reinstate_date" => trainee.reinstate_date&.iso8601,
+          "withdraw_date" => trainee.withdraw_date&.to_date&.iso8601,
+          "withdraw_reason" => trainee.withdraw_reason,
+          "additional_withdraw_reason" => trainee.additional_withdraw_reason,
+        }
       end
     end
 
+    def t(*args)
+      I18n.t(*args)
+    end
+
     def status(trainee)
-      I18n.t("activerecord.attributes.trainee.states.#{trainee.state}", award_type: trainee.award_type)
+      StatusTag::View.new(trainee: trainee).status
+    end
+
+    def gender(trainee)
+      return if trainee.gender.blank?
+
+      t("components.confirmation.personal_detail.genders.#{trainee.gender}")
+    end
+
+    def diversity_disclosure(trainee)
+      {
+        "diversity_disclosed" => "TRUE",
+        "diversity_not_disclosed" => "FALSE",
+      }[trainee.diversity_disclosure]
+    end
+
+    def ethnic_group(trainee)
+      t("components.confirmation.diversity.ethnic_groups.#{trainee.ethnic_group.presence || 'not_provided_ethnic_group'}")
+    end
+
+    def disability_disclosure(trainee)
+      {
+        "disabled" => "TRUE",
+        "no_disability" => "FALSE",
+      }[trainee.disability_disclosure]
+    end
+
+    def disabilities(trainee)
+      trainee.disabilities.map do |disability|
+        if disability.name == Diversities::OTHER
+          trainee.trainee_disabilities.where(disability_id: disability.id).first.additional_disability
+        else
+          disability.name
+        end
+      end.join(", ")
+    end
+
+    def uk_or_non_uk(degree)
+      return unless degree
+
+      {
+        "uk" => "UK",
+        "non_uk" => "non-UK",
+      }[degree.locale_code]
+    end
+
+    def degrees(trainee)
+      trainee.degrees.map do |degree|
+        [
+          uk_or_non_uk(degree),
+          degree.institution,
+          degree.country,
+          degree.subject,
+          degree.uk_degree,
+          degree.non_uk_degree,
+          degree.grade,
+          degree.other_grade,
+          degree.graduation_year,
+        ].map { |d| "\"#{d}\"" }.join(", ")
+      end.join(" | ")
+    end
+
+    def course_route(trainee)
+      t("activerecord.attributes.trainee.training_routes.#{trainee.training_route}")
+    end
+
+    def training_initiative(trainee)
+      return unless trainee.training_initiative
+
+      t("activerecord.attributes.trainee.training_initiatives.#{trainee.training_initiative}")
+    end
+
+    def bursary_tier(trainee)
+      {
+        "tier_one" => "Tier 1",
+        "tier_two" => "Tier 2",
+        "tier_three" => "Tier 3",
+      }[trainee.bursary_tier]
+    end
+
+    def international_address(trainee)
+      trainee.international_address.to_s.split(/[\r\n,]/).select(&:present?).join(", ")
+    end
+
+    def course_allocation_subject(subject)
+      SubjectSpecialism.find_by(name: subject)&.allocation_subject&.name
+    end
+
+    def course_study_mode(trainee)
+      return unless trainee.respond_to?(:study_mode) #  TODO remove after trello card 2326 is merged
+
+      {
+        "full_time" => "Full time",
+        "part_time" => "Part time",
+      }[trainee.study_mode]
     end
 
     def sanitise(value)
-      value&.start_with?(*VULNERABLE_CHARACTERS) ? value.prepend("'") : value
+      return value unless value.is_a?(String)
+
+      value.start_with?(*VULNERABLE_CHARACTERS) ? value.prepend("'") : value
     end
   end
 end

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -5,27 +5,111 @@ require "rails_helper"
 module Exports
   describe TraineeSearchData do
     let(:trainee) do
-      build(:trainee, :with_course_details, :submitted_for_trn, :trn_received, :recommended_for_award, :awarded)
+      create(
+        :trainee,
+        :with_degree,
+        :with_course_details,
+        :submitted_for_trn,
+        :trn_received,
+        :recommended_for_award,
+        :awarded,
+        :with_tiered_bursary,
+        :with_lead_school,
+        :with_employing_school,
+        gender: "male",
+        nationalities: [build(:nationality, name: "British")],
+        diversity_disclosure: "diversity_disclosed",
+        ethnic_group: "asian_ethnic_group",
+        disability_disclosure: "disabled",
+        disabilities: [build(:disability, name: "Blind")],
+        training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+        training_initiative: "transition_to_teach",
+        applying_for_bursary: true,
+        international_address: "Test addr",
+      )
     end
 
     subject { described_class.new([trainee]) }
 
     describe "#data" do
       let(:expected_output) do
+        degree = trainee.degrees.first
+        course = Course.where(code: trainee.course_code).first
         {
-          "First name" => trainee.first_names,
-          "Last name" => trainee.last_name,
-          "Trainee Id" => trainee.trainee_id,
-          "TRN" => trainee.trn,
-          "Status" => t("activerecord.attributes.trainee.states.#{trainee.state}", award_type: trainee.award_type),
-          "Route" => trainee.training_route,
-          "Subject" => trainee.course_subject_one,
-          "Course start date" => trainee.course_start_date,
-          "Course end date" => trainee.course_end_date,
-          "Created date" => trainee.created_at,
-          "Last updated date" => trainee.updated_at,
-          "TRN Submitted date" => trainee.submitted_for_trn_at,
-          "Award submitted date" => trainee.recommended_for_award_at,
+          "register_id" => trainee.slug,
+          "trainee_url" => "#{Settings.base_url}/trainees/#{trainee.slug}",
+          "apply_id" => trainee.apply_application&.apply_id,
+          "provider_training_id" => trainee.trainee_id,
+          "trn" => trainee.trn,
+          "status" => "QTS awarded",
+          "academic_year" => nil,
+          "updated_at" => trainee.updated_at&.iso8601,
+          "record_created_at" => trainee.created_at&.iso8601,
+          "submitted_for_trn_at" => trainee.submitted_for_trn_at&.iso8601,
+          "provider_name" => trainee.provider&.name,
+          "provider_id" => trainee.provider&.code,
+          "first_names" => trainee.first_names,
+          "middle_names" => trainee.middle_names,
+          "last_names" => trainee.last_name,
+          "date_of_birth" => trainee.date_of_birth&.iso8601,
+          "gender" => "Male",
+          "nationalities" => "British",
+          "address_line_1" => trainee.address_line_one,
+          "address_line_2" => trainee.address_line_two,
+          "town_city" => trainee.town_city,
+          "postcode" => trainee.postcode,
+          "international_address" => trainee.international_address,
+          "email_address" => trainee.email,
+          "diversity_disclosure" => "TRUE",
+          "ethnic_group" => "Asian or Asian British",
+          "ethnic_background" => trainee.ethnic_background,
+          "ethnic_background_additional" => trainee.additional_ethnic_background,
+          "disability_disclosure" => "TRUE",
+          "disabilities" => "Blind",
+          "number_of_degrees" => trainee.degrees.count,
+          "degree_1_uk_or_non_uk" => "UK",
+          "degree_1_institution" => degree&.institution,
+          "degree_1_country" => degree&.country,
+          "degree_1_subject" => degree&.subject,
+          "degree_1_type_of_degree" => degree&.uk_degree,
+          "degree_1_non_uk_type" => degree&.non_uk_degree,
+          "degree_1_grade" => degree&.grade,
+          "degree_1_other_grade" => degree&.other_grade,
+          "degree_1_graduation_year" => degree&.graduation_year,
+          "degrees" => "\"#{['UK', degree&.institution, degree&.country, degree&.subject, degree&.uk_degree, degree&.non_uk_degree, degree&.grade, degree&.other_grade, degree&.graduation_year].map { |d| "\"\"#{d}\"\"" }.join(', ')}\"",
+          "course_code" => trainee.course_code,
+          "course_name" => course&.name,
+          "course_route" => "Assessment only",
+          "course_qualification" => course&.qualification,
+          "course_qualification_type" => nil,
+          "course_level" => course&.level&.capitalize,
+          "course_allocation_subject" => nil,
+          "course_itt_subject_1" => trainee.course_subject_one,
+          "course_itt_subject_2" => trainee.course_subject_two,
+          "course_itt_subject_3" => trainee.course_subject_three,
+          "course_min_age" => course&.min_age,
+          "course_max_age" => course&.max_age,
+          "course_study_mode" => nil,
+          "course_start_date" => trainee.course_start_date&.iso8601,
+          "course_end_date" => trainee.course_end_date&.iso8601,
+          "course_duration_in_years" => course&.duration_in_years,
+          "course_summary" => course&.summary,
+          "commencement_date" => trainee.commencement_date&.iso8601,
+          "lead_school_name" => trainee.lead_school&.name,
+          "lead_school_urn" => trainee.lead_school&.urn,
+          "employing_school_name" => trainee.employing_school&.name,
+          "employing_school_urn" => trainee.employing_school&.urn,
+          "training_initiative" => "Transition to teach",
+          "applying_for_bursary" => trainee.applying_for_bursary.to_s.upcase,
+          "bursary_value" => (trainee.bursary_amount if trainee.applying_for_bursary),
+          "bursary_tier" => ("Tier #{BURSARY_TIERS[trainee.bursary_tier] + 1}" if trainee.bursary_tier),
+          "award_standards_met_date" => trainee.outcome_date&.iso8601,
+          "award_awarded_at" => trainee.awarded_at&.iso8601,
+          "defer_date" => trainee.defer_date&.iso8601,
+          "reinstate_date" => trainee.reinstate_date&.iso8601,
+          "withdraw_date" => trainee.withdraw_date&.to_date&.iso8601,
+          "withdraw_reason" => trainee.withdraw_reason,
+          "additional_withdraw_reason" => trainee.additional_withdraw_reason,
         }
       end
 
@@ -39,35 +123,11 @@ module Exports
 
       context "when names contain whitespace or vulnerable characters" do
         before do
-          trainee.update!(first_names: "Christophe", last_name: "=SUM(A1&A2)")
+          trainee.update!(first_names: "Christophe", middle_names: "Malcolm", last_name: "=SUM(A1&A2)")
         end
 
         it "adds an apostrophe before vulnerable characters" do
-          expect(subject.data).to include("Christophe,'=SUM(A1&A2)")
-        end
-      end
-
-      context "with provider option enabled" do
-        subject { described_class.new([trainee], include_provider: true) }
-
-        it "includes the provider name" do
-          expect(subject.data).to include(trainee.provider.name)
-        end
-      end
-
-      context "rendering various states in human readable terms" do
-        shared_examples "state is humanised" do |state|
-          context state do
-            let(:trainee) { build(:trainee, state) }
-
-            specify do
-              expect(subject.data).to include(I18n.t("activerecord.attributes.trainee.states.#{state}"))
-            end
-          end
-        end
-
-        (Trainee.states.keys - %w[recommended_for_award awarded]).each do |state|
-          it_behaves_like "state is humanised", state
+          expect(subject.data).to include("Christophe,Malcolm,'=SUM(A1&A2)")
         end
       end
     end


### PR DESCRIPTION
### Context

https://trello.com/c/kB2QSJ2I/1402-m-extend-csv-export-to-include-all-fields

### Changes proposed in this pull request

* updated export columns to include all from google sheet
* some columns highlighted red on google sheet has been left blank as they are not available for now, can be added in future as they are added.

### Guidance to review

* From trainee list page click "Export these records"

