### PR TITLE
[2300] Scope provider users to kept

### DIFF
--- a/app/components/provider_card/view.html.erb
+++ b/app/components/provider_card/view.html.erb
@@ -3,6 +3,6 @@
     <%= govuk_link_to provider.name, provider_path(provider) %>
   </h2>
   <p class="govuk-body govuk-hint">
-    <%= pluralize(provider.users.count, "user") %>
+    <%= pluralize(provider.users.kept.count, "user") %>
   </p>
 </div>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ private
   end
 
   def current_user
-    @current_user ||= User.find_by("LOWER(email) = ?", dfe_sign_in_user&.email)
+    @current_user ||= User.kept.find_by("LOWER(email) = ?", dfe_sign_in_user&.email)
   end
 
   def authenticated?

--- a/app/view_objects/system_admin/users_view.rb
+++ b/app/view_objects/system_admin/users_view.rb
@@ -7,7 +7,7 @@ module SystemAdmin
     end
 
     def registered
-      @registered ||= provider.users.order(:last_name)
+      @registered ||= provider.users.kept.order(:last_name)
     end
 
     def not_registered

--- a/app/views/system_admin/dttp_providers/show.html.erb
+++ b/app/views/system_admin/dttp_providers/show.html.erb
@@ -14,11 +14,11 @@
 ) %>
 </p>
 
-<% if @provider.users.any? %>
+<% if @provider.users.kept.any? %>
   <div class="govuk-!-margin-bottom-8">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <h2 class="govuk-heading-m"><%= pluralize(@provider.users.count, "user") %> </h2>
+        <h2 class="govuk-heading-m"><%= pluralize(@provider.users.kept.count, "user") %> </h2>
       </div>
     </div>
     <%= render UserCard::View.with_collection(@users) %>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -46,5 +46,18 @@ describe ApplicationController, type: :controller do
         expect(response.body).to include "current user is nil!"
       end
     end
+
+    context "there is a user but they have been deleted" do
+      let(:dfe_sign_in_email) { user.email }
+
+      before do
+        user.discard!
+      end
+
+      it "returns nil" do
+        get :index
+        expect(response.body).to include "current user is nil!"
+      end
+    end
   end
 end

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -27,7 +27,7 @@ module Trainees
       let!(:secondary_trainee) { create(:trainee, course_age_range: AgeRange::FOURTEEN_TO_NINETEEN) }
       let(:filters) { { level: %w[primary] } }
 
-      it { is_expected.to eq([primary_trainee, primary_and_secondary_trainee]) }
+      it { is_expected.to contain_exactly(primary_trainee, primary_and_secondary_trainee) }
     end
 
     context "with state filter" do

--- a/spec/view_objects/system_admin/users_view_spec.rb
+++ b/spec/view_objects/system_admin/users_view_spec.rb
@@ -19,6 +19,17 @@ describe SystemAdmin::UsersView do
       expect(subject.registered.count).to eq 1
       expect(subject.registered.first).to eq user
     end
+
+    context "soft deleted" do
+      before do
+        user.update(discarded_at: Faker::Time.backward(days: 1).utc)
+      end
+
+      it "doesnt return users" do
+        expect(subject.registered.count).not_to eq 1
+        expect(subject.registered.first).not_to eq user
+      end
+    end
   end
 
   describe "#not_registered" do


### PR DESCRIPTION
### Context
We are now discarding / soft-deleting users using the discard gem.

### Changes proposed in this pull request

* Only show `kept` users scoped to providers
* Don't allow deleted users to login
* Exclude discarded users from user counts

### Guidance to review

One mildly controversial bit of this PR is the way we've used discard. In TTAPI we have set the `kept` scope as a default scope on `user` and `course` associations. I've added it explicitly where required here as I think that makes it more obvious where it is used and leaves the default association returning all users as you would expect when you call it. This is inconsistent between the apps now. Discussion welcomed if anybody disagrees.

Run `discard` against a user

`User.find(97).discard`

Navigate to provider and the user should no longer be listed

`/system-admin/providers/16`

Test the login by enabling DfE signin and discarding your own user in the console. You should no longer have access to the app.
