### PR TITLE
[2232] Send pgta to dttp

### DIFF
--- a/app/lib/dttp/code_sets/qualification_aims.rb
+++ b/app/lib/dttp/code_sets/qualification_aims.rb
@@ -14,6 +14,7 @@ module Dttp
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => { entity_id: "68cbae32-7389-e711-80d8-005056ac45bb" },
         TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => { entity_id: "e0113eff-141e-e711-80c8-0050568902d3" },
         TRAINING_ROUTE_ENUMS[:early_years_postgrad] => { entity_id: "d446cd4b-4d9c-e711-80d9-005056ac45bb" },
+        TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => { entity_id: "d4113eff-141e-e711-80c8-0050568902d3" },
       }.freeze
     end
   end

--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -11,6 +11,7 @@ module Dttp
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => { entity_id: "7789922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:early_years_postgrad] => { entity_id: "6789922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => { entity_id: "6589922e-acc2-e611-80be-00155d010316" },
+        TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => { entity_id: "cf9154ee-5678-e811-80f6-005056ac45bb" },
       }.freeze
     end
   end


### PR DESCRIPTION
### Context

We have a Postgraduate Teaching Apprenticeship route. This PR adds the ITT qualification aims and routes mapping to enable them to be sent to DTTP.

### Changes proposed in this pull request

- Add route entity id to params
- Add qualification aims entity id to params

### Guidance to review

- You could check the qualification aim on the Trello ticket comment and the route in the back office 
