### PR TITLE
[2219] Apply draft confirm page invalid data validation

### DIFF
--- a/app/components/apply_applications/review_summary/view.html.erb
+++ b/app/components/apply_applications/review_summary/view.html.erb
@@ -1,4 +1,4 @@
-<%= render summary_component.new(renderable: invalid_data_view.invalid_data?) do |component| %>
+<%= render summary_component.new(renderable: render?) do |component| %>
   <% component.header  do %>
     <%= invalid_data_view.summary_content %>
   <% end %>

--- a/app/components/apply_applications/review_summary/view.html.erb
+++ b/app/components/apply_applications/review_summary/view.html.erb
@@ -1,0 +1,7 @@
+<%= render summary_component.new(renderable: invalid_data_view.invalid_data?) do |component| %>
+  <% component.header  do %>
+    <%= invalid_data_view.summary_content %>
+  <% end %>
+
+  <%= invalid_data_view.summary_items_content %>
+<% end %>

--- a/app/components/apply_applications/review_summary/view.rb
+++ b/app/components/apply_applications/review_summary/view.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ApplyApplications
+  module ReviewSummary
+    class View < GovukComponent::Base
+      renders_one :header
+
+      def initialize(has_errors:, trainee:)
+        @has_errors = has_errors
+        @invalid_data_view = ApplyInvalidDataView.new(trainee.apply_application)
+      end
+
+      def render?
+        invalid_data_view.invalid_data?
+      end
+
+      def summary_component
+        @summary_component ||= has_errors ? ErrorSummary::View : InformationSummary::View
+      end
+
+    private
+
+      attr_reader :invalid_data_view, :has_errors
+    end
+  end
+end

--- a/app/components/apply_applications/review_summary/view.rb
+++ b/app/components/apply_applications/review_summary/view.rb
@@ -5,22 +5,36 @@ module ApplyApplications
     class View < GovukComponent::Base
       renders_one :header
 
-      def initialize(has_errors:, trainee:)
-        @has_errors = has_errors
+      def initialize(form:, trainee:)
+        @has_errors = form.errors.any?
+        @form = form
+        @trainee = trainee
         @invalid_data_view = ApplyInvalidDataView.new(trainee.apply_application)
       end
 
       def render?
-        invalid_data_view.invalid_data?
+        errors_captured? || invalid_data_exists?
       end
 
       def summary_component
-        @summary_component ||= has_errors ? ErrorSummary::View : InformationSummary::View
+        @summary_component ||= errors_captured? ? ErrorSummary::View : InformationSummary::View
       end
 
     private
 
-      attr_reader :invalid_data_view, :has_errors
+      def invalid_data_exists?
+        form_is_valid = form.valid?
+
+        form.errors.clear unless errors_captured?
+
+        !form_is_valid && invalid_data_view.invalid_data?
+      end
+
+      def errors_captured?
+        @has_errors
+      end
+
+      attr_reader :invalid_data_view, :form
     end
   end
 end

--- a/app/components/apply_applications/trainee_data/view.html.erb
+++ b/app/components/apply_applications/trainee_data/view.html.erb
@@ -14,7 +14,7 @@
   <div class="govuk-grid-column-full">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
-        <%= render ApplyApplications::ReviewSummary::View.new(has_errors: form.errors.any?, trainee: @trainee) %>
+        <%= render ApplyApplications::ReviewSummary::View.new(form: @form, trainee: @trainee) %>
         <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
           <span class="govuk-caption-l">
             <% if trainee_name(@trainee).present? %>

--- a/app/components/apply_applications/trainee_data/view.html.erb
+++ b/app/components/apply_applications/trainee_data/view.html.erb
@@ -14,10 +14,12 @@
   <div class="govuk-grid-column-full">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
-        <%= render ErrorSummary::View.new(has_errors: @form.errors.any?) do %>
-          <% @form.errors.messages.map do |_, messages| %>
-            <%= tag.li(messages.first) %>
+        <%= render ErrorSummary::View.new(has_errors: @form.errors.any?) do |component| %>
+          <% component.header  do %>
+            <%= @apply_invalid_data_view.summary_content %>
           <% end %>
+
+          <%= @apply_invalid_data_view.summary_items_content %>
         <% end %>
 
         <%= render InformationSummary::View.new(renderable: @form.errors.empty?) do |component| %>

--- a/app/components/apply_applications/trainee_data/view.html.erb
+++ b/app/components/apply_applications/trainee_data/view.html.erb
@@ -14,22 +14,7 @@
   <div class="govuk-grid-column-full">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
-        <%= render ErrorSummary::View.new(has_errors: @form.errors.any?) do |component| %>
-          <% component.header  do %>
-            <%= @apply_invalid_data_view.summary_content %>
-          <% end %>
-
-          <%= @apply_invalid_data_view.summary_items_content %>
-        <% end %>
-
-        <%= render InformationSummary::View.new(renderable: @form.errors.empty?) do |component| %>
-          <% component.header  do %>
-            <%= @apply_invalid_data_view.summary_content %>
-          <% end %>
-
-          <%= @apply_invalid_data_view.summary_items_content %>
-        <% end %>
-
+        <%= render ApplyApplications::ReviewSummary::View.new(has_errors: form.errors.any?, trainee: @trainee) %>
         <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
           <span class="govuk-caption-l">
             <% if trainee_name(@trainee).present? %>

--- a/app/components/apply_applications/trainee_data/view.rb
+++ b/app/components/apply_applications/trainee_data/view.rb
@@ -11,7 +11,6 @@ module ApplyApplications
       def initialize(trainee, form)
         @trainee = trainee
         @form = form
-        @apply_invalid_data_view = ApplyInvalidDataView.new(trainee.apply_application)
       end
     end
   end

--- a/app/components/collapsed_section/style.scss
+++ b/app/components/collapsed_section/style.scss
@@ -25,9 +25,16 @@ $govuk-border-width-narrow: 5px;
 
 .app-inset-text--error {
   border-color: $govuk-error-colour;
+  margin: govuk-spacing(0) auto govuk-spacing(4);
 
   .app-inset-text__title {
     color: $govuk-error-colour;
+  }
+
+  &.app-inset-text--no_padding {
+    padding-top: 0;
+    padding-right: 0;
+    padding-bottom: 0;
   }
 }
 

--- a/app/components/collapsed_section/view.html.erb
+++ b/app/components/collapsed_section/view.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--<%= @error ? "error" : "important" %>">
+<div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--<%= @has_errors ? "error" : "important" %>">
   <p class="app-inset-text__title"><%= title %></p>
   <% if url.present? %>
     <%= govuk_link_to link_text, url %>

--- a/app/components/collapsed_section/view.rb
+++ b/app/components/collapsed_section/view.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class CollapsedSection::View < ViewComponent::Base
-  attr_accessor :title, :url, :link_text, :hint_text, :error
+  attr_accessor :title, :url, :link_text, :hint_text, :has_errors
 
-  def initialize(title:, link_text: nil, url: nil, hint_text: nil, error: false)
+  def initialize(title:, link_text: nil, url: nil, hint_text: nil, has_errors: false)
     @url = url
     @link_text = link_text
     @title = title
     @hint_text = hint_text
-    @error = error
+    @has_errors = has_errors
   end
 end

--- a/app/components/contact_details/view.rb
+++ b/app/components/contact_details/view.rb
@@ -4,12 +4,10 @@ module ContactDetails
   class View < GovukComponent::Base
     include SanitizeHelper
 
-    attr_accessor :data_model, :error
-
-    def initialize(data_model:, error: false)
+    def initialize(data_model:, has_errors: false)
       @data_model = data_model
       @not_provided_copy = I18n.t("components.confirmation.not_provided")
-      @error = error
+      @has_errors = has_errors
     end
 
     def trainee
@@ -33,6 +31,8 @@ module ContactDetails
     end
 
   private
+
+    attr_accessor :data_model, :has_errors
 
     def uk_address
       [

--- a/app/components/contact_details/view.rb
+++ b/app/components/contact_details/view.rb
@@ -4,11 +4,12 @@ module ContactDetails
   class View < GovukComponent::Base
     include SanitizeHelper
 
-    attr_accessor :data_model
+    attr_accessor :data_model, :error
 
-    def initialize(data_model:)
+    def initialize(data_model:, error: false)
       @data_model = data_model
       @not_provided_copy = I18n.t("components.confirmation.not_provided")
+      @error = error
     end
 
     def trainee

--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -6,10 +6,9 @@ module CourseDetails
     include CourseDetailsHelper
     include TraineeHelper
 
-    attr_accessor :data_model
-
-    def initialize(data_model:)
+    def initialize(data_model:, error: false)
       @data_model = data_model
+      @error = error
       @not_provided_copy = t("components.confirmation.not_provided")
     end
 
@@ -40,6 +39,8 @@ module CourseDetails
     end
 
   private
+
+    attr_accessor :data_model, :error
 
     def itt_route?
       trainee.itt_route?

--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -6,9 +6,9 @@ module CourseDetails
     include CourseDetailsHelper
     include TraineeHelper
 
-    def initialize(data_model:, error: false)
+    def initialize(data_model:, has_errors: false)
       @data_model = data_model
-      @error = error
+      @has_errors = has_errors
       @not_provided_copy = t("components.confirmation.not_provided")
     end
 
@@ -40,7 +40,7 @@ module CourseDetails
 
   private
 
-    attr_accessor :data_model, :error
+    attr_accessor :data_model, :has_errors
 
     def itt_route?
       trainee.itt_route?

--- a/app/components/degrees/view.rb
+++ b/app/components/degrees/view.rb
@@ -4,12 +4,12 @@ module Degrees
   class View < GovukComponent::Base
     include ApplicationHelper
 
-    def initialize(data_model:, show_add_another_degree_button: true, show_delete_button: true, error: false)
+    def initialize(data_model:, show_add_another_degree_button: true, show_delete_button: true, has_errors: false)
       @data_model = data_model
       @degrees = @data_model.degrees
       @show_add_another_degree_button = show_add_another_degree_button
       @show_delete_button = show_delete_button
-      @error = error
+      @has_errors = has_errors
     end
 
     def trainee
@@ -63,7 +63,7 @@ module Degrees
 
   private
 
-    attr_accessor :degrees, :data_model, :show_add_another_degree_button, :show_delete_button, :error
+    attr_accessor :degrees, :data_model, :show_add_another_degree_button, :show_delete_button, :has_errors
 
     def non_uk_degree_type(degree)
       degree.non_uk_degree == NON_ENIC ? "UK ENIC not provided" : degree.non_uk_degree
@@ -82,7 +82,7 @@ module Degrees
                            field_value: field_value || degree.public_send(field_name),
                            field_label: field_label,
                            action_url: edit_trainee_degree_path(trainee, degree),
-                           error: error).to_h
+                           has_errors: has_errors).to_h
     end
   end
 end

--- a/app/components/degrees/view.rb
+++ b/app/components/degrees/view.rb
@@ -3,13 +3,13 @@
 module Degrees
   class View < GovukComponent::Base
     include ApplicationHelper
-    attr_accessor :degrees, :data_model, :show_add_another_degree_button, :show_delete_button
 
-    def initialize(data_model:, show_add_another_degree_button: true, show_delete_button: true)
+    def initialize(data_model:, show_add_another_degree_button: true, show_delete_button: true, error: false)
       @data_model = data_model
       @degrees = @data_model.degrees
       @show_add_another_degree_button = show_add_another_degree_button
       @show_delete_button = show_delete_button
+      @error = error
     end
 
     def trainee
@@ -63,6 +63,8 @@ module Degrees
 
   private
 
+    attr_accessor :degrees, :data_model, :show_add_another_degree_button, :show_delete_button, :error
+
     def non_uk_degree_type(degree)
       degree.non_uk_degree == NON_ENIC ? "UK ENIC not provided" : degree.non_uk_degree
     end
@@ -79,7 +81,8 @@ module Degrees
                            field_name: field_name,
                            field_value: field_value || degree.public_send(field_name),
                            field_label: field_label,
-                           action_url: edit_trainee_degree_path(trainee, degree)).to_h
+                           action_url: edit_trainee_degree_path(trainee, degree),
+                           error: error).to_h
     end
   end
 end

--- a/app/components/diversity/view.rb
+++ b/app/components/diversity/view.rb
@@ -4,9 +4,9 @@ module Diversity
   class View < GovukComponent::Base
     include SanitizeHelper
 
-    def initialize(data_model:, error: false)
+    def initialize(data_model:, has_errors: false)
       @data_model = data_model
-      @error = error
+      @has_errors = has_errors
     end
 
     def trainee
@@ -73,7 +73,7 @@ module Diversity
 
   private
 
-    attr_accessor :data_model, :error
+    attr_accessor :data_model, :has_errors
 
     def render_disabilities
       data_model.disabilities.each do |disability|

--- a/app/components/diversity/view.rb
+++ b/app/components/diversity/view.rb
@@ -4,10 +4,9 @@ module Diversity
   class View < GovukComponent::Base
     include SanitizeHelper
 
-    attr_accessor :data_model
-
-    def initialize(data_model:)
+    def initialize(data_model:, error: false)
       @data_model = data_model
+      @error = error
     end
 
     def trainee
@@ -73,6 +72,8 @@ module Diversity
     end
 
   private
+
+    attr_accessor :data_model, :error
 
     def render_disabilities
       data_model.disabilities.each do |disability|

--- a/app/components/error_summary/view.html.erb
+++ b/app/components/error_summary/view.html.erb
@@ -3,6 +3,7 @@
     <%= t(".heading") %>
   </h2>
   <div class="govuk-error-summary__body">
+    <p class="govuk-body"><%= header %></p>
     <ul class="govuk-list govuk-error-summary__list">
       <%= content %>
     </ul>

--- a/app/components/error_summary/view.rb
+++ b/app/components/error_summary/view.rb
@@ -3,15 +3,15 @@
 class ErrorSummary::View < GovukComponent::Base
   renders_one :header
 
-  def initialize(has_errors: false)
-    @has_errors = has_errors
+  def initialize(renderable: false)
+    @renderable = renderable
   end
 
   def render?
-    has_errors
+    renderable
   end
 
 private
 
-  attr_reader :has_errors
+  attr_reader :renderable
 end

--- a/app/components/error_summary/view.rb
+++ b/app/components/error_summary/view.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ErrorSummary::View < GovukComponent::Base
+  renders_one :header
+
   def initialize(has_errors: false)
     @has_errors = has_errors
   end

--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -5,9 +5,9 @@ module Funding
     include SanitizeHelper
     include FundingHelper
 
-    def initialize(data_model:, error: false)
+    def initialize(data_model:, has_errors: false)
       @data_model = data_model
-      @error = error
+      @has_errors = has_errors
     end
 
     def trainee
@@ -40,7 +40,7 @@ module Funding
 
   private
 
-    attr_accessor :data_model, :error
+    attr_accessor :data_model, :has_errors
 
     def course_subject_one
       trainee.course_subject_one

--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -5,10 +5,9 @@ module Funding
     include SanitizeHelper
     include FundingHelper
 
-    attr_accessor :data_model
-
-    def initialize(data_model:)
+    def initialize(data_model:, error: false)
       @data_model = data_model
+      @error = error
     end
 
     def trainee
@@ -40,6 +39,8 @@ module Funding
     end
 
   private
+
+    attr_accessor :data_model, :error
 
     def course_subject_one
       trainee.course_subject_one

--- a/app/components/personal_details/view.rb
+++ b/app/components/personal_details/view.rb
@@ -4,12 +4,13 @@ module PersonalDetails
   class View < GovukComponent::Base
     include SanitizeHelper
 
-    attr_accessor :data_model, :nationalities
+    attr_accessor :data_model, :nationalities, :error
 
-    def initialize(data_model:)
+    def initialize(data_model:, error: false)
       @data_model = data_model
       @nationalities = Nationality.where(id: data_model.nationality_ids)
       @not_provided_copy = I18n.t("components.confirmation.not_provided")
+      @error = error
     end
 
     def trainee
@@ -38,7 +39,8 @@ module PersonalDetails
       MappableFieldRow.new(field_value: nationality,
                            field_label: "Nationality",
                            text: t("components.confirmation.missing"),
-                           action_url: edit_trainee_personal_details_path(trainee)).to_h
+                           action_url: edit_trainee_personal_details_path(trainee),
+                           error: error).to_h
     end
 
   private

--- a/app/components/personal_details/view.rb
+++ b/app/components/personal_details/view.rb
@@ -4,13 +4,11 @@ module PersonalDetails
   class View < GovukComponent::Base
     include SanitizeHelper
 
-    attr_accessor :data_model, :nationalities, :error
-
-    def initialize(data_model:, error: false)
+    def initialize(data_model:, has_errors: false)
       @data_model = data_model
       @nationalities = Nationality.where(id: data_model.nationality_ids)
       @not_provided_copy = I18n.t("components.confirmation.not_provided")
-      @error = error
+      @has_errors = has_errors
     end
 
     def trainee
@@ -40,10 +38,12 @@ module PersonalDetails
                            field_label: "Nationality",
                            text: t("components.confirmation.missing"),
                            action_url: edit_trainee_personal_details_path(trainee),
-                           error: error).to_h
+                           has_errors: has_errors).to_h
     end
 
   private
+
+    attr_accessor :data_model, :nationalities, :has_errors
 
     def nationality
       return if nationalities.blank?

--- a/app/components/schools/view.rb
+++ b/app/components/schools/view.rb
@@ -5,9 +5,9 @@ module Schools
     include SummaryHelper
     include SchoolHelper
 
-    def initialize(data_model:, error: false)
+    def initialize(data_model:, has_errors: false)
       @data_model = data_model
-      @error = error
+      @has_errors = has_errors
       @lead_school = trainee.lead_school
       @employing_school = trainee.employing_school
     end

--- a/app/components/schools/view.rb
+++ b/app/components/schools/view.rb
@@ -5,10 +5,9 @@ module Schools
     include SummaryHelper
     include SchoolHelper
 
-    attr_accessor :data_model, :lead_school, :employing_school
-
-    def initialize(data_model:)
+    def initialize(data_model:, error: false)
       @data_model = data_model
+      @error = error
       @lead_school = trainee.lead_school
       @employing_school = trainee.employing_school
     end
@@ -18,6 +17,8 @@ module Schools
     end
 
   private
+
+    attr_accessor :data_model, :lead_school, :employing_school
 
     def change_paths(school_type)
       {

--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -23,7 +23,7 @@ module Sections
     delegate :funding_options, to: :helpers
 
     def confirmation_view_args
-      confirmation_view_args = { data_model: form_klass.new(trainee), error: error }
+      confirmation_view_args = { data_model: form_klass.new(trainee), has_errors: form_has_errors? }
 
       if section == :degrees
         confirmation_view_args.merge!(show_add_another_degree_button: true, show_delete_button: true)
@@ -32,14 +32,14 @@ module Sections
     end
 
     def collapsed_funding_inactive_section_args
-      { title: I18n.t("components.sections.titles.funding_inactive"), hint_text: I18n.t("components.sections.link_texts.funding_inactive"), error: error }
+      { title: I18n.t("components.sections.titles.funding_inactive"), hint_text: I18n.t("components.sections.link_texts.funding_inactive"), has_errors: form_has_errors? }
     end
 
     def collapsed_section_args
       if section == :funding && funding_options(trainee) == :funding_inactive
         collapsed_funding_inactive_section_args
       else
-        { title: title, link_text: link_text, url: url, error: error }
+        { title: title, link_text: link_text, url: url, has_errors: form_has_errors? }
       end
     end
 
@@ -128,8 +128,8 @@ module Sections
       }[section][progress_status]
     end
 
-    def error
-      @error ||= form.errors.present?
+    def form_has_errors?
+      @form_has_errors ||= form.errors.present?
     end
 
     def progress_status

--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -23,7 +23,7 @@ module Sections
     delegate :funding_options, to: :helpers
 
     def confirmation_view_args
-      confirmation_view_args = { data_model: form_klass.new(trainee) }
+      confirmation_view_args = { data_model: form_klass.new(trainee), error: error }
 
       if section == :degrees
         confirmation_view_args.merge!(show_add_another_degree_button: true, show_delete_button: true)

--- a/app/components/training_details/view.rb
+++ b/app/components/training_details/view.rb
@@ -4,10 +4,9 @@ module TrainingDetails
   class View < GovukComponent::Base
     include SummaryHelper
 
-    attr_accessor :data_model, :not_provided_copy
-
-    def initialize(data_model:)
+    def initialize(data_model:, error: false)
       @data_model = data_model
+      @error = error
       @not_provided_copy = I18n.t("components.confirmation.not_provided")
     end
 
@@ -22,5 +21,9 @@ module TrainingDetails
     def trainee_start_date
       trainee.commencement_date.present? ? date_for_summary_view(trainee.commencement_date) : not_provided_copy
     end
+
+  private
+
+    attr_accessor :data_model, :not_provided_copy, :error
   end
 end

--- a/app/components/training_details/view.rb
+++ b/app/components/training_details/view.rb
@@ -4,9 +4,9 @@ module TrainingDetails
   class View < GovukComponent::Base
     include SummaryHelper
 
-    def initialize(data_model:, error: false)
+    def initialize(data_model:, has_errors: false)
       @data_model = data_model
-      @error = error
+      @has_errors = has_errors
       @not_provided_copy = I18n.t("components.confirmation.not_provided")
     end
 
@@ -24,6 +24,6 @@ module TrainingDetails
 
   private
 
-    attr_accessor :data_model, :not_provided_copy, :error
+    attr_accessor :data_model, :not_provided_copy, :has_errors
   end
 end

--- a/app/controllers/trainees/apply_applications/trainee_data_controller.rb
+++ b/app/controllers/trainees/apply_applications/trainee_data_controller.rb
@@ -4,6 +4,7 @@ module Trainees
   module ApplyApplications
     class TraineeDataController < ApplicationController
       before_action :authorize_trainee
+      before_action :require_review_acknowledgement, only: :update
 
       def edit
         page_tracker.save_as_origin!
@@ -11,14 +12,12 @@ module Trainees
       end
 
       def update
-        if params[:apply_applications_trainee_data_form][:mark_as_reviewed] == "1"
-          @trainee_data_form = ::ApplyApplications::TraineeDataForm.new(trainee)
+        @trainee_data_form = ::ApplyApplications::TraineeDataForm.new(trainee)
 
-          if @trainee_data_form.save
-            redirect_to trainee_path(trainee)
-          else
-            render :edit
-          end
+        if @trainee_data_form.save
+          redirect_to trainee_path(trainee)
+        else
+          render :edit
         end
       end
 
@@ -30,6 +29,14 @@ module Trainees
 
       def authorize_trainee
         authorize(trainee)
+      end
+
+      def require_review_acknowledgement
+        redirect_to review_draft_trainee_path(trainee) unless marked_as_reviewed?
+      end
+
+      def marked_as_reviewed?
+        params[:apply_applications_trainee_data_form][:mark_as_reviewed] == "1"
       end
     end
   end

--- a/app/controllers/trainees/contact_details_controller.rb
+++ b/app/controllers/trainees/contact_details_controller.rb
@@ -30,13 +30,6 @@ module Trainees
       params.require(:contact_details_form).permit(*ContactDetailsForm::FIELDS)
     end
 
-    def section_completed?
-      ProgressService.call(
-        validator: ContactDetailsForm.new(trainee),
-        progress_value: trainee.progress.contact_details,
-      ).completed?
-    end
-
     def authorize_trainee
       authorize(trainee)
     end

--- a/app/controllers/trainees/degrees/confirm_details_controller.rb
+++ b/app/controllers/trainees/degrees/confirm_details_controller.rb
@@ -15,7 +15,7 @@ module Trainees
         data_model = trainee.draft? ? trainee : degrees_form
 
         @confirmation_component = if trainee.degrees.empty?
-                                    CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), error: false)
+                                    CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), has_errors: false)
                                   else
                                     ::Degrees::View.new(data_model: data_model)
                                   end

--- a/app/forms/apply_applications/trainee_data_form.rb
+++ b/app/forms/apply_applications/trainee_data_form.rb
@@ -19,6 +19,8 @@ module ApplyApplications
 
     delegate :apply_application?, to: :trainee
 
+    validate :submission_ready
+
     attr_accessor :mark_as_reviewed
 
     def initialize(trainee)
@@ -26,19 +28,13 @@ module ApplyApplications
     end
 
     def save
-      return unless all_forms_valid?
+      return unless valid?
 
       trainee.progress.personal_details = true
       trainee.progress.contact_details = true
       trainee.progress.diversity = true
       trainee.progress.degrees = true
       trainee.save!
-    end
-
-    def all_forms_valid?
-      form_validators.keys.all? do |section|
-        validator(section).new(trainee).valid?
-      end
     end
 
     def progress_status(progress_key)
@@ -66,6 +62,16 @@ module ApplyApplications
     end
 
   private
+
+    def all_forms_valid?
+      form_validators.keys.all? do |section|
+        validator(section).new(trainee).valid?
+      end
+    end
+
+    def submission_ready
+      errors.add(:trainee, :incomplete) unless all_forms_valid?
+    end
 
     def progress_service(progress_key)
       validator = validator(progress_key).new(trainee)

--- a/app/forms/degrees_form.rb
+++ b/app/forms/degrees_form.rb
@@ -6,6 +6,7 @@ class DegreesForm
   attr_accessor :trainee, :degree_ids
 
   validate :degrees_cannot_be_empty
+  validate :degrees_cannot_be_invalid
 
   def initialize(trainee, store = FormStore)
     @trainee = trainee
@@ -83,5 +84,15 @@ private
 
   def degrees_cannot_be_empty
     errors.add(:degree_ids, :empty_degrees) if trainee.degrees.empty?
+  end
+
+  def degrees_cannot_be_invalid
+    errors.add(:degree_ids, :invalid) unless all_degrees_are_valid?
+  end
+
+  def all_degrees_are_valid?
+    trainee.degrees.all? do |degree|
+      DegreeForm.new(degrees_form: self, degree: degree).valid?
+    end
   end
 end

--- a/app/view_objects/apply_invalid_data_view.rb
+++ b/app/view_objects/apply_invalid_data_view.rb
@@ -27,6 +27,10 @@ class ApplyInvalidDataView
     )
   end
 
+  def invalid_data?
+    invalid_fields.size.positive?
+  end
+
 private
 
   attr_reader :apply_application, :invalid_fields

--- a/app/view_objects/mappable_field_row.rb
+++ b/app/view_objects/mappable_field_row.rb
@@ -11,6 +11,7 @@ class MappableFieldRow
     @field_value = options[:field_value]
     @field_label = options[:field_label]
     @action_url = options[:action_url]
+    @error = options[:error]
     @text = options[:text] || "not recognised"
   end
 
@@ -20,7 +21,7 @@ class MappableFieldRow
 
 private
 
-  attr_accessor :invalid_data, :record_id, :field_name, :field_value, :field_label, :text, :action_url
+  attr_accessor :invalid_data, :record_id, :field_name, :field_value, :field_label, :text, :action_url, :error
 
   def value_attribute
     return { value: unmapped_value.html_safe } if field_value.nil?
@@ -37,7 +38,7 @@ private
 
   def unmapped_value
     <<~HTML
-      <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--important app-inset-text--no_padding">
+      <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--#{@error ? 'error' : 'important'} app-inset-text--no_padding">
         <p class="app-inset-text__title govuk-!-margin-bottom-2">#{field_label} is #{text}</p>
         #{original_value_html}
         <div>

--- a/app/view_objects/mappable_field_row.rb
+++ b/app/view_objects/mappable_field_row.rb
@@ -11,7 +11,7 @@ class MappableFieldRow
     @field_value = options[:field_value]
     @field_label = options[:field_label]
     @action_url = options[:action_url]
-    @error = options[:error]
+    @has_errors = options[:has_errors]
     @text = options[:text] || "not recognised"
   end
 
@@ -21,7 +21,7 @@ class MappableFieldRow
 
 private
 
-  attr_accessor :invalid_data, :record_id, :field_name, :field_value, :field_label, :text, :action_url, :error
+  attr_accessor :invalid_data, :record_id, :field_name, :field_value, :field_label, :text, :action_url, :has_errors
 
   def value_attribute
     return { value: unmapped_value.html_safe } if field_value.nil?
@@ -38,7 +38,7 @@ private
 
   def unmapped_value
     <<~HTML
-      <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--#{@error ? 'error' : 'important'} app-inset-text--no_padding">
+      <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--#{has_errors ? 'error' : 'important'} app-inset-text--no_padding">
         <p class="app-inset-text__title govuk-!-margin-bottom-2">#{field_label} is #{text}</p>
         #{original_value_html}
         <div>

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -14,7 +14,7 @@
   <div class="govuk-grid-column-full">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
-        <%= render ErrorSummary::View.new(has_errors: @form.errors.any?) do %>
+        <%= render ErrorSummary::View.new(renderable: @form.errors.any?) do %>
           <% @form.errors.messages.map do |_, messages| %>
             <%= tag.li(messages.first) %>
           <% end %>

--- a/app/views/trainees/personal_details/show.html.erb
+++ b/app/views/trainees/personal_details/show.html.erb
@@ -15,5 +15,5 @@
     <%= render Degrees::View.new(data_model: @trainee, show_delete_button: true) %>
   </div>
 <% else %>
-  <%= render CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), error: false) %>
+  <%= render CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), has_errors: false) %>
 <% end %>

--- a/spec/components/apply_applications/review_summary/view_spec.rb
+++ b/spec/components/apply_applications/review_summary/view_spec.rb
@@ -7,20 +7,26 @@ module ApplyApplications
     describe View, type: :component do
       let(:invalid_data_view) { instance_double(ApplyInvalidDataView, summary_content: "Some header content", summary_items_content: "", invalid_data?: true) }
       let(:trainee) { build(:trainee, :with_apply_application) }
-      let(:described_component) { described_class.new(has_errors: true, trainee: trainee) }
+      let(:form) { instance_double(ApplyApplications::TraineeDataForm, errors: ["bad data"], valid?: false) }
+      let(:described_component) { described_class.new(form: form, trainee: trainee) }
 
       before do
         allow(ApplyInvalidDataView).to receive(:new).with(trainee.apply_application).and_return(invalid_data_view)
       end
 
-      context "with has_errors set to true" do
+      context "with an invalid form having errors initialised" do
         it "renders the given content in a ErrorSummary::View component" do
           expect(described_component.summary_component).to eq(ErrorSummary::View)
         end
       end
 
-      context "with has_errors set to false" do
-        let(:described_component) { described_class.new(has_errors: false, trainee: trainee) }
+      context "with an invalid form, but without errors initialised" do
+        let(:form) { instance_double(ApplyApplications::TraineeDataForm, errors: [], valid?: false) }
+
+        it "renders the component" do
+          render_inline(described_component)
+          expect(rendered_component).to have_text("Some header content")
+        end
 
         it "renders the given content in a InformationSummary::View component" do
           expect(described_component.summary_component).to eq(InformationSummary::View)
@@ -34,6 +40,18 @@ module ApplyApplications
 
         it "renders the given content from the block" do
           expect(rendered_component).to have_selector("p", text: invalid_data_view.summary_content)
+        end
+      end
+
+      context "when the form is valid" do
+        let(:form) { instance_double(ApplyApplications::TraineeDataForm, errors: [], valid?: true) }
+
+        before do
+          render_inline(described_component)
+        end
+
+        it "does not render" do
+          expect(rendered_component).not_to have_text("Some header content")
         end
       end
     end

--- a/spec/components/apply_applications/review_summary/view_spec.rb
+++ b/spec/components/apply_applications/review_summary/view_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ApplyApplications
+  module ReviewSummary
+    describe View, type: :component do
+      let(:invalid_data_view) { instance_double(ApplyInvalidDataView, summary_content: "Some header content", summary_items_content: "", invalid_data?: true) }
+      let(:trainee) { build(:trainee, :with_apply_application) }
+      let(:described_component) { described_class.new(has_errors: true, trainee: trainee) }
+
+      before do
+        allow(ApplyInvalidDataView).to receive(:new).with(trainee.apply_application).and_return(invalid_data_view)
+      end
+
+      context "with has_errors set to true" do
+        it "renders the given content in a ErrorSummary::View component" do
+          expect(described_component.summary_component).to eq(ErrorSummary::View)
+        end
+      end
+
+      context "with has_errors set to false" do
+        let(:described_component) { described_class.new(has_errors: false, trainee: trainee) }
+
+        it "renders the given content in a InformationSummary::View component" do
+          expect(described_component.summary_component).to eq(InformationSummary::View)
+        end
+      end
+
+      context "with header content" do
+        before do
+          render_inline(described_component)
+        end
+
+        it "renders the given content from the block" do
+          expect(rendered_component).to have_selector("p", text: invalid_data_view.summary_content)
+        end
+      end
+    end
+  end
+end

--- a/spec/components/collapsed_section/view_preview.rb
+++ b/spec/components/collapsed_section/view_preview.rb
@@ -7,7 +7,7 @@ module CollapsedSection
     end
 
     def error_with_link_only
-      render CollapsedSection::View.new(title: "title", link_text: "link_text", url: "url", error: true)
+      render CollapsedSection::View.new(title: "title", link_text: "link_text", url: "url", has_errors: true)
     end
 
     def default_with_hint_text_only
@@ -15,7 +15,7 @@ module CollapsedSection
     end
 
     def error_with_hint_text_only
-      render CollapsedSection::View.new(title: "title", hint_text: "hint_text", error: true)
+      render CollapsedSection::View.new(title: "title", hint_text: "hint_text", has_errors: true)
     end
 
     def default_with_link_and_hint_text
@@ -23,7 +23,7 @@ module CollapsedSection
     end
 
     def error_with_link_and_hint_text
-      render CollapsedSection::View.new(title: "title", link_text: "link_text", url: "url", hint_text: "hint_text", error: true)
+      render CollapsedSection::View.new(title: "title", link_text: "link_text", url: "url", hint_text: "hint_text", has_errors: true)
     end
   end
 end

--- a/spec/components/collapsed_section/view_spec.rb
+++ b/spec/components/collapsed_section/view_spec.rb
@@ -34,10 +34,10 @@ module CollapsedSection
       end
     end
 
-    context "error" do
+    context "has_errors" do
       before do
         render_inline(
-          described_class.new(title: title, link_text: link_text, url: url, error: true),
+          described_class.new(title: title, link_text: link_text, url: url, has_errors: true),
         )
       end
 

--- a/spec/components/error_summary/view_preview.rb
+++ b/spec/components/error_summary/view_preview.rb
@@ -3,7 +3,7 @@
 module ErrorSummary
   class ViewPreview < ViewComponent::Preview
     def default
-      render(View.new(has_errors: true)) do
+      render(View.new(renderable: true)) do
         "<li>This is an error item</li>".html_safe
       end
     end

--- a/spec/components/error_summary/view_spec.rb
+++ b/spec/components/error_summary/view_spec.rb
@@ -8,7 +8,7 @@ module ErrorSummary
       let(:error_markup) {  "<li>This is an error item</li>".html_safe }
 
       before do
-        render_inline(described_class.new(has_errors: true)) do
+        render_inline(described_class.new(renderable: true)) do
           error_markup
         end
       end
@@ -20,7 +20,7 @@ module ErrorSummary
 
     context "when has_errors is false" do
       before do
-        render_inline(described_class.new(has_errors: false))
+        render_inline(described_class.new(renderable: false))
       end
 
       it "does not render" do

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -77,7 +77,7 @@ module Pages
                       additional_ethnic_background: "additional_ethnic_background",
                       training_route: TRAINING_ROUTE_ENUMS[training_route_enums_key],
                       course_subject_one: "subject",
-                      degrees: [Degree.new(id: 1)],
+                      degrees: [Degree.new(id: 1, locale_code: :uk)],
                       training_initiative: ROUTE_INITIATIVES_ENUMS[:transition_to_teach],
                       applying_for_bursary: true)
         end

--- a/spec/components/sections/view_preview.rb
+++ b/spec/components/sections/view_preview.rb
@@ -58,7 +58,7 @@ module Sections
         course_subject_one: "subject",
         training_route: TRAINING_ROUTE_ENUMS[training_route(section)],
         lead_school: School.new(id: 1),
-        degrees: [Degree.new(id: 1)],
+        degrees: [Degree.new(id: 1, locale_code: :uk)],
         training_initiative: ROUTE_INITIATIVES_ENUMS[:transition_to_teach],
         applying_for_bursary: true
       )

--- a/spec/factories/apply_applications.rb
+++ b/spec/factories/apply_applications.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     application { ApiStubs::ApplyApi.application }
     invalid_data { {} }
     provider
+
+    trait :with_invalid_data do
+      invalid_data { { "degrees" => { "BUpwce1Qe9RDM3A9AmgsmaNT" => { "subject" => "Master's Degree" } } } }
+    end
   end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -316,6 +316,10 @@ FactoryBot.define do
       apply_application
     end
 
+    trait :with_invalid_apply_application do
+      association :apply_application, :with_invalid_data
+    end
+
     trait :with_funding do
       training_initiative { ROUTE_INITIATIVES_ENUMS.keys.sample }
       applying_for_bursary { Faker::Boolean.boolean }

--- a/spec/features/form_sections/personal_and_education_details/reviewing_apply_trainee_data_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/reviewing_apply_trainee_data_spec.rb
@@ -17,6 +17,13 @@ feature "edit training details" do
     and_the_relevant_sections_are_completed
   end
 
+  scenario "reviewing with invalid data" do
+    given_a_trainee_with_invalid_data_from_apply_exist
+    when_i_visit_the_apply_trainee_data_page
+    and_i_review_the_trainee_data
+    then_i_see_error_messages
+  end
+
   scenario "changing an attribute" do
     given_a_trainee_with_degrees_exist
     when_i_visit_the_apply_trainee_data_page
@@ -34,6 +41,10 @@ feature "edit training details" do
     )
   end
 
+  def given_a_trainee_with_invalid_data_from_apply_exist
+    given_a_trainee_exists(:with_invalid_apply_application)
+  end
+
   def when_i_visit_the_apply_trainee_data_page
     apply_trainee_data_page.load(id: trainee.slug)
   end
@@ -49,6 +60,10 @@ feature "edit training details" do
 
   def and_the_relevant_sections_are_completed
     expect(review_draft_page.apply_trainee_data.status.text).to eq("Status completed")
+  end
+
+  def then_i_see_error_messages
+    expect(apply_trainee_data_page).to have_content(I18n.t("views.apply_invalid_data_view.invalid_answers_summary", count: 1))
   end
 
   def and_i_click_to_change_the_trainee_full_name

--- a/spec/forms/apply_applications/apply_trainee_data_form_spec.rb
+++ b/spec/forms/apply_applications/apply_trainee_data_form_spec.rb
@@ -10,9 +10,13 @@ module ApplyApplications
       context "when one or more of the forms is invalid" do
         let(:trainee) { create(:trainee, :with_apply_application) }
 
+        before do
+          subject.valid?
+        end
+
         it "returns the entire form as invalid" do
           expect(subject.progress).to eq false
-          expect(subject.all_forms_valid?).to eq false
+          expect(subject.errors).not_to be_empty
         end
       end
 
@@ -21,7 +25,7 @@ module ApplyApplications
 
         it "returns the entire form as invalid" do
           expect(subject.progress).to eq true
-          expect(subject.all_forms_valid?).to eq true
+          expect(subject.errors).to be_empty
         end
       end
     end

--- a/spec/forms/degrees_form_spec.rb
+++ b/spec/forms/degrees_form_spec.rb
@@ -16,10 +16,18 @@ describe DegreesForm, type: :model do
 
       context "with degrees" do
         before do
-          trainee.degrees << build(:degree)
+          trainee.degrees << build(:degree, :uk_degree_with_details)
         end
 
         it { is_expected.to be_valid }
+      end
+
+      context "with invalid degrees" do
+        before do
+          trainee.degrees << create(:degree, subject: "")
+        end
+
+        it { is_expected.not_to be_valid }
       end
 
       context "with no degrees" do

--- a/spec/view_objects/apply_invalid_data_view_spec.rb
+++ b/spec/view_objects/apply_invalid_data_view_spec.rb
@@ -35,6 +35,22 @@ describe ApplyInvalidDataView do
     end
   end
 
+  describe "#invalid_data?" do
+    subject { described_class.new(application).invalid_data? }
+
+    it { is_expected.to be_truthy }
+
+    context "when there are no invalid data" do
+      let(:application) do
+        instance_double(ApplyApplication, invalid_data: {
+          "degrees" => { "BUpwce1Qe9RDM3A9AmgsmaNT" => {} },
+        })
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe "#summary_items_content" do
     it "returns the invalid answer summary items" do
       expected_markup = "<li><a class=\"govuk-notification-banner__link\" href=\"#subject\">Subject is not recognised</a></li>"

--- a/spec/view_objects/mappable_field_row_spec.rb
+++ b/spec/view_objects/mappable_field_row_spec.rb
@@ -8,6 +8,7 @@ describe MappableFieldRow do
     let(:field_name) { :subject }
     let(:field_label) { "Subject" }
     let(:field_value) { nil }
+    let(:error) { nil }
     let(:action_url) { "/abc" }
     let(:apply_subject_value) { "Master's Degree" }
 
@@ -17,7 +18,8 @@ describe MappableFieldRow do
                           field_name: field_name,
                           field_value: field_value,
                           field_label: field_label,
-                          action_url: action_url).to_h
+                          action_url: action_url,
+                          error: error).to_h
     end
 
     context "field value matches error value" do
@@ -43,6 +45,14 @@ describe MappableFieldRow do
 
       it "doesn't set the action key" do
         expect(subject).not_to have_key(:action)
+      end
+
+      context "when error is set to true" do
+        let(:error) { true }
+
+        it "uses the app-inset-text--error class" do
+          expect(subject[:value]).to include("app-inset-text--error")
+        end
       end
     end
 

--- a/spec/view_objects/mappable_field_row_spec.rb
+++ b/spec/view_objects/mappable_field_row_spec.rb
@@ -8,7 +8,7 @@ describe MappableFieldRow do
     let(:field_name) { :subject }
     let(:field_label) { "Subject" }
     let(:field_value) { nil }
-    let(:error) { nil }
+    let(:has_errors) { nil }
     let(:action_url) { "/abc" }
     let(:apply_subject_value) { "Master's Degree" }
 
@@ -19,7 +19,7 @@ describe MappableFieldRow do
                           field_value: field_value,
                           field_label: field_label,
                           action_url: action_url,
-                          error: error).to_h
+                          has_errors: has_errors).to_h
     end
 
     context "field value matches error value" do
@@ -47,8 +47,8 @@ describe MappableFieldRow do
         expect(subject).not_to have_key(:action)
       end
 
-      context "when error is set to true" do
-        let(:error) { true }
+      context "when has_errors is set to true" do
+        let(:has_errors) { true }
 
         it "uses the app-inset-text--error class" do
           expect(subject[:value]).to include("app-inset-text--error")
@@ -71,7 +71,7 @@ describe MappableFieldRow do
       end
     end
 
-    context "no error but value missing" do
+    context "no has_errors but value missing" do
       subject do
         described_class.new(field_value: nil,
                             field_label: field_label,


### PR DESCRIPTION
### Context
Validate and display error styled components when a provider attempts to mark an apply draft trainee as reviewed, when they still have invalid data items that need to be adressed. 

##### Information Summary
![image](https://user-images.githubusercontent.com/910019/127528816-a4280ab2-bc95-420c-ab13-67fbbd92bec1.png)
##### Error Summary
![image](https://user-images.githubusercontent.com/910019/127528766-b375b51d-6e54-4d01-a48a-3d7855ac4a4e.png)


### Changes proposed in this pull request
Add a new component `ReviewSummary::View` which chooses to show either the InformationSummary or ErrorSummary depending on the error state.
Ensure that the error state is trickled down to various components, which will enable them to have an error/info class.

### Guidance to review
1. Given that an apply draft trainee exists, with invalid data, visit the Trainee Data page
2. Expect to see the summary, and a small inset against the invalid section.
3. Without changing any of the invalid entries, tick the "I have reviewed this section" checkbox and click Continue
4. Expect to see the same summary as earlier, but styled in an error summary component. 
