### PR TITLE
Fix translation bug

### DIFF
--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -141,7 +141,7 @@ module TaskListHelper
           task_name: "Funding",
           path: nil,
           confirm_path: nil,
-          status: "cannot start yet",
+          status: "cannot_start_yet",
           classes: "funding",
           hint_text: "Complete course details first",
           active: false,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
   return_to_draft_later: Return to this draft record later
   answer_missing: Answer missing
   incomplete: incomplete
+  cannot_start_yet: cannot start yet
   in_progress_valid: in progress
   in_progress_invalid: in progress
   review: review


### PR DESCRIPTION
### Context
Fix missing translation on review draft page

### Guidance to review

- Navigate to a trainee on the `provider-led (postgrad)`
- On the review draft scroll down to the funding section
- The translation should be fixed. 
- Compare with QA/Staging for the broken version

### Before screenshot 

![image](https://user-images.githubusercontent.com/50492247/127639902-8c50bd2c-c760-42f0-9947-fa45c89b5cc4.png)

### After screenshot 

![image](https://user-images.githubusercontent.com/50492247/127639924-824c3e39-9f5d-4e6a-b30f-a97e700374d3.png)

