### PR TITLE
Add missing data summary to all confirm pages (personal details)

### DIFF
--- a/app/components/degrees/view.rb
+++ b/app/components/degrees/view.rb
@@ -76,13 +76,16 @@ module Degrees
     end
 
     def mappable_field_row(degree, field_name, field_label, field_value = nil)
-      MappableFieldRow.new(invalid_data: trainee.apply_application&.degrees_invalid_data,
-                           record_id: degree.to_param,
-                           field_name: field_name,
-                           field_value: field_value || degree.public_send(field_name),
-                           field_label: field_label,
-                           action_url: edit_trainee_degree_path(trainee, degree),
-                           has_errors: has_errors).to_h
+      MappableFieldRow.new(
+        invalid_data: trainee.apply_application&.degrees_invalid_data,
+        record_id: degree.to_param,
+        field_name: field_name,
+        field_value: field_value || degree.public_send(field_name),
+        field_label: field_label,
+        action_url: edit_trainee_degree_path(trainee, degree),
+        has_errors: has_errors,
+        apply_draft: trainee.apply_application?,
+      ).to_h
     end
   end
 end

--- a/app/components/personal_details/view.html.erb
+++ b/app/components/personal_details/view.html.erb
@@ -1,23 +1,5 @@
-<%= render SummaryCard::View.new(trainee: trainee, title: "Personal details",
-                                 heading_level: 2,
-                                 rows: [
-      {
-        key: t("components.confirmation.personal_detail.full_name"),
-        value: full_name,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> full name</span>'.html_safe,
-                              edit_trainee_personal_details_path(trainee)),
-      },
-      {
-        key: t("components.confirmation.personal_detail.date_of_birth"),
-        value: date_of_birth,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> date of birth</span>'.html_safe,
-                              edit_trainee_personal_details_path(trainee)),
-      },
-      {
-        key: t("components.confirmation.personal_detail.gender"),
-        value: gender,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> gender</span>'.html_safe,
-                              edit_trainee_personal_details_path(trainee)),
-      },
-      nationality_row
-    ]) %>
+<%= render SummaryCard::View.new(
+  trainee: trainee, title: "Personal details",
+  heading_level: 2,
+  rows: personal_detail_rows
+) %>

--- a/app/components/personal_details/view.rb
+++ b/app/components/personal_details/view.rb
@@ -7,43 +7,52 @@ module PersonalDetails
     def initialize(data_model:, has_errors: false)
       @data_model = data_model
       @nationalities = Nationality.where(id: data_model.nationality_ids)
-      @not_provided_copy = I18n.t("components.confirmation.not_provided")
       @has_errors = has_errors
     end
 
-    def trainee
-      data_model.is_a?(Trainee) ? data_model : data_model.trainee
-    end
-
-    def full_name
-      return @not_provided_copy unless data_model.first_names && data_model.last_name
-
-      "#{data_model.first_names} #{data_model.middle_names} #{data_model.last_name}"
-    end
-
-    def date_of_birth
-      return @not_provided_copy unless data_model.date_of_birth.is_a?(Date)
-
-      data_model.date_of_birth.strftime("%-d %B %Y")
-    end
-
-    def gender
-      return @not_provided_copy unless data_model.gender
-
-      I18n.t("components.confirmation.personal_detail.genders.#{data_model.gender}")
-    end
-
-    def nationality_row
-      MappableFieldRow.new(field_value: nationality,
-                           field_label: "Nationality",
-                           text: t("components.confirmation.missing"),
-                           action_url: edit_trainee_personal_details_path(trainee),
-                           has_errors: has_errors).to_h
+    def personal_detail_rows
+      [
+        full_name_row,
+        date_of_birth_row,
+        gender_row,
+        nationality_row,
+      ].compact
     end
 
   private
 
     attr_accessor :data_model, :nationalities, :has_errors
+
+    def trainee
+      data_model.is_a?(Trainee) ? data_model : data_model.trainee
+    end
+
+    def full_name_row
+      name = "#{data_model.first_names} #{data_model.middle_names} #{data_model.last_name}"
+
+      mappable_field(
+        [data_model.first_names, data_model.last_name].any?(&:nil?) ? nil : name,
+        t("components.confirmation.personal_detail.full_name"),
+      )
+    end
+
+    def date_of_birth_row
+      mappable_field(
+        data_model.date_of_birth.is_a?(Date) ? data_model.date_of_birth.strftime("%-d %B %Y") : nil,
+        t("components.confirmation.personal_detail.date_of_birth"),
+      )
+    end
+
+    def gender_row
+      mappable_field(
+        data_model.gender ? I18n.t("components.confirmation.personal_detail.genders.#{data_model.gender}") : nil,
+        t("components.confirmation.personal_detail.gender"),
+      )
+    end
+
+    def nationality_row
+      mappable_field(nationality, t("components.confirmation.personal_detail.nationality"))
+    end
 
     def nationality
       return if nationalities.blank?
@@ -69,6 +78,17 @@ module PersonalDetails
       found = array.delete(nationality)
       array.unshift(nationality) if found
       array
+    end
+
+    def mappable_field(field_value, field_label)
+      MappableFieldRow.new(
+        field_value: field_value,
+        field_label: field_label,
+        text: t("components.confirmation.missing"),
+        action_url: edit_trainee_personal_details_path(trainee),
+        has_errors: has_errors,
+        apply_draft: trainee.apply_application?,
+      ).to_h
     end
   end
 end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -12,6 +12,7 @@ module Trainees
 
       if trainee.draft?
         @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.public_send(trainee_section_key))
+        @missing_data_view = MissingDataView.new(form_klass.new(trainee))
       end
 
       @confirmation_component = component_klass.new(data_model: trainee.draft? ? trainee : form_klass.new(trainee))
@@ -41,6 +42,8 @@ module Trainees
       case trainee_section_key
       when "schools"
         Schools::FormValidator
+      when "funding"
+        ::Funding::TrainingInitiativesForm
       else
         "#{trainee_section_key.underscore.camelcase}Form".constantize
       end

--- a/app/controllers/trainees/degrees/confirm_details_controller.rb
+++ b/app/controllers/trainees/degrees/confirm_details_controller.rb
@@ -10,12 +10,18 @@ module Trainees
 
         if trainee.draft?
           @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.degrees)
+          @missing_data_view = MissingDataView.new(degrees_form)
         end
 
         data_model = trainee.draft? ? trainee : degrees_form
 
         @confirmation_component = if trainee.degrees.empty?
-                                    CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), has_errors: false)
+                                    CollapsedSection::View.new(
+                                      title: t("components.incomplete_section.degree_details_not_provided"),
+                                      link_text: t("components.incomplete_section.add_degree_details"),
+                                      url: trainee_degrees_new_type_path(@trainee),
+                                      has_errors: false,
+                                    )
                                   else
                                     ::Degrees::View.new(data_model: data_model)
                                   end

--- a/app/controllers/trainees/diversity/confirm_details_controller.rb
+++ b/app/controllers/trainees/diversity/confirm_details_controller.rb
@@ -10,6 +10,7 @@ module Trainees
 
         if trainee.draft?
           @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.diversity)
+          @missing_data_view = MissingDataView.new(diversity_form)
         end
 
         data_model = trainee.draft? ? trainee : diversity_form

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -81,6 +81,12 @@ class PersonalDetailsForm < TraineeForm
       end
   end
 
+  def missing_fields
+    return [] if valid?
+
+    errors.attribute_names
+  end
+
 private
 
   def compute_fields

--- a/app/view_objects/mappable_field_row.rb
+++ b/app/view_objects/mappable_field_row.rb
@@ -13,6 +13,7 @@ class MappableFieldRow
     @action_url = options[:action_url]
     @has_errors = options[:has_errors]
     @text = options[:text] || "not recognised"
+    @apply_draft = options[:apply_draft] || false
   end
 
   def to_h
@@ -21,7 +22,7 @@ class MappableFieldRow
 
 private
 
-  attr_accessor :invalid_data, :record_id, :field_name, :field_value, :field_label, :text, :action_url, :has_errors
+  attr_accessor :invalid_data, :record_id, :field_name, :field_value, :field_label, :text, :action_url, :has_errors, :apply_draft
 
   def value_attribute
     return { value: unmapped_value.html_safe } if field_value.nil?
@@ -43,7 +44,7 @@ private
         #{original_value_html}
         <div>
           <a class="govuk-link govuk-link--no-visited-state app-summary-list__link--invalid" href="#{action_url}">
-            Review the trainee’s answer<span class="govuk-visually-hidden"> for #{field_label.downcase}</span>
+            #{field_hint_text(field_label)}
           </a>
         </div>
       </div>
@@ -56,5 +57,11 @@ private
 
   def original_value
     invalid_data&.dig(record_id, field_name.to_s)
+  end
+
+  def field_hint_text(field_label)
+    return I18n.t("views.mappable_field_row.default_hint_text_html", field_label: field_label.downcase) unless apply_draft
+
+    I18n.t("views.mappable_field_row.apply_field_hint_text_html", field_label: field_label.downcase)
   end
 end

--- a/app/view_objects/missing_data_view.rb
+++ b/app/view_objects/missing_data_view.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class MissingDataView
+  include ActionView::Helpers::UrlHelper
+  include ActionView::Helpers::TagHelper
+
+  def initialize(form_instance)
+    @form_instance = form_instance
+    @missing_fields = populate_missing_fields
+  end
+
+  def summary_content
+    I18n.t("views.missing_data_view.missing_fields_summary", count: missing_fields.size)
+  end
+
+  def missing_items_content
+    @missing_items_content ||= safe_join(
+      missing_fields.map do |field|
+        tag.li(
+          link_to(
+            I18n.t("views.missing_data_view.missing_field_text", missing_field: get_display_name(field)),
+            "##{get_display_name(field).parameterize}",
+            class: "govuk-notification-banner__link",
+          ),
+        )
+      end.uniq,
+    )
+  end
+
+  def missing_data?
+    missing_fields.size.positive?
+  end
+
+private
+
+  attr_reader :form_instance, :missing_fields
+
+  def get_display_name(field)
+    I18n.t("views.missing_data_view.missing_fields_mapping.#{field}")
+  end
+
+  def populate_missing_fields
+    form_instance.respond_to?(:missing_fields) ? form_instance.missing_fields : []
+  end
+end

--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -4,6 +4,15 @@
   <%= render DynamicBackLink::View.new(@trainee) %>
 <% end %>
 
+<%= render InformationSummary::View.new(renderable: @missing_data_view&.missing_data?) do |component| %>
+  <% component.header  do %>
+    <%= @missing_data_view.summary_content %>
+  <% end %>
+
+  <%= @missing_data_view.missing_items_content %>
+<% end %>
+
+
 <%= render(
   partial: "form",
   locals: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -353,7 +353,7 @@ en:
         other: "This application contains %{count} answers that you need to amend. This is because they were entered in a free text format."
       unrecognised_field_text: "%{invalid_field} is not recognised"
     mappable_field_row:
-      default_hint_text_html: 'Enter an answer %{field_label} <span class="govuk-visually-hidden"> for %{field_label}</span>'
+      default_hint_text_html: 'Enter an answer <span class="govuk-visually-hidden"> for %{field_label}</span>'
       apply_field_hint_text_html: 'Review the trainee’s answer<span class="govuk-visually-hidden"> for %{field_label}</span>'
     missing_data_view:
       missing_fields_summary:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,14 +73,15 @@ en:
           no_disability: They shared that they’re not disabled
           disability_not_provided: Not provided
       personal_detail:
-        full_name: Full name
-        date_of_birth: Date of birth
-        gender: Gender
+        full_name: &full_name Full name
+        date_of_birth: &date_of_birth Date of birth
+        gender: &gender Gender
         genders:
           male: Male
           female: Female
           other: Other
           gender_not_provided: Not provided
+        nationality: &nationality Nationality
       reinstatement_details:
         reinstate_date_label: Date of return
         summary_title: Reinstatement details
@@ -351,6 +352,20 @@ en:
         one: "This application contains 1 answer that you need to amend. This is because it was entered in a free text format."
         other: "This application contains %{count} answers that you need to amend. This is because they were entered in a free text format."
       unrecognised_field_text: "%{invalid_field} is not recognised"
+    mappable_field_row:
+      default_hint_text_html: 'Enter an answer %{field_label} <span class="govuk-visually-hidden"> for %{field_label}</span>'
+      apply_field_hint_text_html: 'Review the trainee’s answer<span class="govuk-visually-hidden"> for %{field_label}</span>'
+    missing_data_view:
+      missing_fields_summary:
+        one: "This section contains 1 question that you need to complete."
+        other: "This section contains questions which you need to complete."
+      missing_field_text: "%{missing_field} is missing"
+      missing_fields_mapping:
+        first_names: *full_name
+        last_name: *full_name
+        date_of_birth: *date_of_birth
+        gender: *gender
+        nationality_names: *nationality
     trainees:
       index:
         no_records: Your trainee records will appear here. You do not have any records yet.

--- a/spec/components/personal_details/view_spec.rb
+++ b/spec/components/personal_details/view_spec.rb
@@ -19,9 +19,11 @@ module PersonalDetails
         expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 4)
       end
 
-      it "tells the user that no data has been entered" do
-        expect(rendered_component).to have_selector(".govuk-summary-list__value",
-                                                    text: t("components.confirmation.not_provided"), count: 3)
+      it "tells the user that the data is missing" do
+        expect(rendered_component).to have_selector(
+          ".govuk-summary-list__value",
+          text: t("components.confirmation.missing"), count: 4,
+        )
       end
     end
 

--- a/spec/view_objects/mappable_field_row_spec.rb
+++ b/spec/view_objects/mappable_field_row_spec.rb
@@ -13,13 +13,16 @@ describe MappableFieldRow do
     let(:apply_subject_value) { "Master's Degree" }
 
     subject do
-      described_class.new(invalid_data: invalid_data,
-                          record_id: record_id,
-                          field_name: field_name,
-                          field_value: field_value,
-                          field_label: field_label,
-                          action_url: action_url,
-                          has_errors: has_errors).to_h
+      described_class.new(
+        invalid_data: invalid_data,
+        record_id: record_id,
+        field_name: field_name,
+        field_value: field_value,
+        field_label: field_label,
+        action_url: action_url,
+        has_errors: has_errors,
+        apply_draft: true,
+      ).to_h
     end
 
     context "field value matches error value" do
@@ -73,10 +76,13 @@ describe MappableFieldRow do
 
     context "no has_errors but value missing" do
       subject do
-        described_class.new(field_value: nil,
-                            field_label: field_label,
-                            text: "missing",
-                            action_url: action_url).to_h
+        described_class.new(
+          field_value: nil,
+          field_label: field_label,
+          text: "missing",
+          action_url: action_url,
+          apply_draft: true,
+        ).to_h
       end
 
       let(:expected_html) do


### PR DESCRIPTION
### Context

- https://trello.com/c/yxJ5Aw4Z/2366-l-missing-information-ui

### Changes proposed in this pull request

This PR implements an approach around handling missing data for confirm pages (this is for the personal details to begin with). The following changes are proposed:

- Form object implements a `missing_fields` validation context
- The method above can be extracted into a module which is included in every form object. Will return keys corresponding to the missing fields (based on existing validation rules)
- The `MissingDataView` then gets the form instance and iterate over these missing fields, looking up the correct display value used by the summary component render the field name correctly (and anchor to it's row correctly)
- The look up display names are re-referenced from other yaml keys in the translation files so they're all change-able from one place.

<img width="1127" alt="Screenshot 2021-08-02 at 18 52 44" src="https://user-images.githubusercontent.com/616080/127978006-fd0a2733-807a-4040-ad0d-e6ab2d25e576.png">


### Guidance to review

https://register-pr-1219.london.cloudapps.digital/trainees/NwzJsDTzfHVncTerTGomu7LH/personal-details/confirm

Select Provider A
