### PR TITLE
[2397] Qualification awarded/recommended homepage squares have incorrect links

### DIFF
--- a/app/components/badges/view.html.erb
+++ b/app/components/badges/view.html.erb
@@ -2,7 +2,9 @@
   <div class="govuk-grid-column-full">
     <div class="app-home-statuses">
         <% state_counts.map do |state, count| %>
-            <%= render TraineeStatusCard::View.new(state: state, count: count, target: trainees_path("state[]": state)) %>
+            <%= render TraineeStatusCard::View.new(state: state,
+                                                   count: count,
+                                                   target: trainees_path(state: map_state_to_filter_params(state))) %>
         <% end %>
     </div>
   </div>

--- a/app/components/badges/view.rb
+++ b/app/components/badges/view.rb
@@ -7,5 +7,16 @@ module Badges
     def initialize(state_counts)
       @state_counts = state_counts
     end
+
+    def map_state_to_filter_params(state)
+      case state
+      when "awarded"
+        %w[eyts_awarded qts_awarded]
+      when "recommended_for_award"
+        %w[eyts_recommended qts_recommended]
+      else
+        [state]
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/un6waqU9/2397-bug-qualification-recommended-and-qualification-awarded-homepage-squares-have-incorrect-links

### Changes proposed in this pull request
- Fix link urls for the homepage squares "Qualification recommended" and "Qualification awarded"

Before fix "Qualification recommended" pointed to `/trainees?states[]=recommended_for_award`. "recommended_for_award" is not an option in the filters page. It should be pointing to `/trainees?state[]=eyts_recommended&state[]=qts_recommended`. Same goes for "Qualification awarded".

### Guidance to review
Open the home page. Hover over each square and verify that the url matches the example above.
