### PR TITLE
[2419] Add back homepage squares for missing states, remove academic year heading

### DIFF
--- a/app/components/badges/view.rb
+++ b/app/components/badges/view.rb
@@ -4,8 +4,21 @@ module Badges
   class View < GovukComponent::Base
     attr_reader :state_counts
 
+    INCLUDED_STATES = %w[
+      submitted_for_trn
+      trn_received
+      recommended_for_award
+      awarded
+      eyts_recommended
+      eyts_awarded
+      qts_recommended
+      qts_awarded
+      deferred
+      withdrawn
+    ].freeze
+
     def initialize(state_counts)
-      @state_counts = state_counts
+      @state_counts = state_counts.slice(*INCLUDED_STATES)
     end
 
     def map_state_to_filter_params(state)

--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -5,9 +5,6 @@ class HomeView
                                     eyts_recommended withdrawn deferred qts_awarded
                                     eyts_awarded].freeze
 
-  REGISTERED_STATES = %w[submitted_for_trn trn_received recommended_for_award
-                         awarded deferred withdrawn].freeze
-
   def initialize(trainees)
     @trainees = trainees
     populate_state_counts!
@@ -16,7 +13,7 @@ class HomeView
   attr_reader :state_counts
 
   def registered_state_counts
-    @registered_state_counts ||= state_counts.slice(*REGISTERED_STATES)
+    @registered_state_counts ||= state_counts.except("draft")
   end
 
   def registered_trainees_count

--- a/app/views/pages/_badges.html.erb
+++ b/app/views/pages/_badges.html.erb
@@ -1,6 +1,1 @@
-<h2 class="govuk-heading-m">
-  <%= t(".heading", start_year: 2020, end_year: 2021) %>
-<%# TODO:  Make this dynamic once we have a concept of academic years %>
-</h2>
-
-<%= render Badges::View.new(@home_view.registered_state_counts) %>
+<%= render Badges::View.new(@home_view.state_counts) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -531,8 +531,6 @@ en:
         4: recommend your trainees for qualified teacher status (QTS) or early years teacher status (EYTS)
     cookie_policy:
       heading: Cookies on Register trainee teachers
-    badges:
-      heading: "%{start_year} to %{end_year} trainees"
     accessibility:
       heading: Accessibility statement for Register trainee teachers
     guidance:


### PR DESCRIPTION
### Context

https://trello.com/c/0HVNdmrq/2419-bug-fix-missing-homepage-squares

### Changes proposed in this pull request

- Fix bug whereby recommended for award and awarded homepage squares weren't appearing for users with only QTS or only EYTS trainees
- Remove heading which related to academic years

### Guidance to review

Screenshot of Registered trainees section for a user with no EYTS trainees:

<img width="990" alt="Screenshot 2021-08-02 at 17 37 54" src="https://user-images.githubusercontent.com/18436946/127895013-3e63e367-13aa-4926-8b50-9dcbc19ed33b.png">
