### PR TITLE
[xxx] Feature flag placements

### DIFF
--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -6,7 +6,7 @@ class TrainingRouteManager
   end
 
   def requires_placement_details?
-    enabled? :provider_led_postgrad
+    FeatureService.enabled?("placements") && enabled?(:provider_led_postgrad)
   end
 
   def requires_schools?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,7 @@ features:
   show_funding: false
   send_funding_to_dttp: false
   imported_from_apply_filter: false
+  placements: false
   routes:
     early_years_assessment_only: false
     early_years_salaried: false

--- a/spec/components/review_draft/apply_draft/view_spec.rb
+++ b/spec/components/review_draft/apply_draft/view_spec.rb
@@ -11,17 +11,33 @@ RSpec.describe ReviewDraft::ApplyDraft::View do
     end
 
     context "when the trainee is on the provider-led route", "feature_routes.provider_led_postgrad": true do
-      let(:trainee) { create(:trainee, :provider_led_postgrad, :with_placement_assignment, :with_apply_application) }
+      context "placements enabled", feature_placements: true do
+        let(:trainee) { create(:trainee, :provider_led_postgrad, :with_placement_assignment, :with_apply_application) }
 
-      it "renders the correct provider-led sections" do
-        expect(rendered_component).to have_text("Course details")
-        expect(rendered_component).to have_text("Trainee data")
-        expect(rendered_component).to have_text("Placement details")
-        expect(rendered_component).to have_text("Training details")
+        it "renders the correct provider-led sections" do
+          expect(rendered_component).to have_text("Course details")
+          expect(rendered_component).to have_text("Trainee data")
+          expect(rendered_component).to have_text("Placement details")
+          expect(rendered_component).to have_text("Training details")
+        end
+
+        it "does not render non provider-led sections" do
+          expect(rendered_component).not_to have_text(I18n.t("components.review_draft.draft.schools.titles.tuition"))
+        end
       end
 
-      it "does not render non provider-led sections" do
-        expect(rendered_component).not_to have_text(I18n.t("components.review_draft.draft.schools.titles.tuition"))
+      context "placements disabled", feature_placements: false do
+        let(:trainee) { create(:trainee, :provider_led_postgrad, :with_placement_assignment, :with_apply_application) }
+
+        it "renders the correct provider-led sections" do
+          expect(rendered_component).to have_text("Course details")
+          expect(rendered_component).to have_text("Trainee data")
+          expect(rendered_component).to have_text("Training details")
+        end
+
+        it "does not render non provider-led sections" do
+          expect(rendered_component).not_to have_text(I18n.t("components.review_draft.draft.schools.titles.tuition"))
+        end
       end
     end
 

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -7,19 +7,39 @@ describe TrainingRouteManager do
 
   describe "#requires_placement_details?" do
     context "with the :routes_provider_led_postgrad feature flag enabled", "feature_routes.provider_led_postgrad": true do
-      context "with a provider-led trainee" do
-        let(:trainee) { build(:trainee, :provider_led_postgrad) }
+      context "with placement feature enabled", feature_placements: true do
+        context "with a provider-led trainee" do
+          let(:trainee) { build(:trainee, :provider_led_postgrad) }
 
-        it "returns true" do
-          expect(subject.requires_placement_details?).to be true
+          it "returns true" do
+            expect(subject.requires_placement_details?).to be true
+          end
+        end
+
+        context "with a non provider-led trainee" do
+          let(:trainee) { build(:trainee) }
+
+          it "returns false" do
+            expect(subject.requires_placement_details?).to be false
+          end
         end
       end
 
-      context "with a non provider-led trainee" do
-        let(:trainee) { build(:trainee) }
+      context "with placement feature disabled", feature_placements: false do
+        context "with a provider-led trainee" do
+          let(:trainee) { build(:trainee, :provider_led_postgrad) }
 
-        it "returns false" do
-          expect(subject.requires_placement_details?).to be false
+          it "returns false" do
+            expect(subject.requires_placement_details?).to be false
+          end
+        end
+
+        context "with a non provider-led trainee" do
+          let(:trainee) { build(:trainee) }
+
+          it "returns false" do
+            expect(subject.requires_placement_details?).to be false
+          end
         end
       end
     end

--- a/spec/views/trainees/show.html.erb_spec.rb
+++ b/spec/views/trainees/show.html.erb_spec.rb
@@ -5,41 +5,60 @@ require "rails_helper"
 describe "trainees/show.html.erb", "feature_routes.provider_led_postgrad": true do
   before do
     assign(:trainee, trainee)
-    render
   end
 
-  context "with an Assessment only trainee" do
-    let(:trainee) { create(:trainee, :submitted_for_trn) }
+  context "placements enabled", feature_placements: true do
+    before do
+      render
+    end
 
-    it "does not render the placement details component" do
-      expect(rendered).not_to have_text("Placement details")
+    context "with an Assessment only trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn) }
+
+      it "does not render the placement details component" do
+        expect(rendered).not_to have_text("Placement details")
+      end
+    end
+
+    context "with a Provider-led (postgrad) trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn, :provider_led_postgrad) }
+
+      it "renders the placement details component" do
+        expect(rendered).to have_text("Placement details")
+      end
+    end
+
+    context "with non early year trainees that have status trn_received" do
+      let(:non_early_year_trainees) { TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :school_direct_tuition_fee, :school_direct_salaried) }
+      let(:trainee) { create(:trainee, :trn_received, non_early_year_trainees.sample) }
+
+      it "renders the correct text on the button" do
+        expect(rendered).to have_text("Recommend trainee for QTS")
+      end
+    end
+
+    context "with early year trainees that have status trn_received" do
+      let(:early_years_trainees) { TRAINING_ROUTE_ENUMS.values_at(:early_years_assessment_only, :early_years_postgrad, :early_years_salaried, :early_years_undergrad) }
+
+      let(:trainee) { create(:trainee, :trn_received, early_years_trainees.sample) }
+
+      it "renders the correct text on the button" do
+        expect(rendered).to have_text("Recommend trainee for EYTS")
+      end
     end
   end
 
-  context "with a Provider-led (postgrad) trainee" do
-    let(:trainee) { create(:trainee, :submitted_for_trn, :provider_led_postgrad) }
-
-    it "renders the placement details component" do
-      expect(rendered).to have_text("Placement details")
+  context "placements disabled", feature_placements: false do
+    before do
+      render
     end
-  end
 
-  context "with non early year trainees that have status trn_received" do
-    let(:non_early_year_trainees) { TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :school_direct_tuition_fee, :school_direct_salaried) }
-    let(:trainee) { create(:trainee, :trn_received, non_early_year_trainees.sample) }
+    context "with a Provider-led (postgrad) trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn, :provider_led_postgrad) }
 
-    it "renders the correct text on the button" do
-      expect(rendered).to have_text("Recommend trainee for QTS")
-    end
-  end
-
-  context "with early year trainees that have status trn_received" do
-    let(:early_years_trainees) { TRAINING_ROUTE_ENUMS.values_at(:early_years_assessment_only, :early_years_postgrad, :early_years_salaried, :early_years_undergrad) }
-
-    let(:trainee) { create(:trainee, :trn_received, early_years_trainees.sample) }
-
-    it "renders the correct text on the button" do
-      expect(rendered).to have_text("Recommend trainee for EYTS")
+      it "doesn't render the placement details component" do
+        expect(rendered).not_to have_text("Placement details")
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

We aren't collecting placement info yet. Provider led postgrad was
displaying the placement section in a couple of places with 'Not
required' in the text.

### Changes proposed in this pull request

Add a feature flag, set to false, for placement information.

### Guidance to review

View a the trainee show page or review apply page for a provider led postgrad trainee. No placement details section should be visible.

