### PR TITLE
[2369] Hide and remove (periodically) empty trainees

### DIFF
--- a/app/jobs/delete_empty_trainees_job.rb
+++ b/app/jobs/delete_empty_trainees_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DeleteEmptyTraineesJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    FindEmptyTrainees.call.map(&:destroy)
+  end
+end

--- a/app/services/find_empty_trainees.rb
+++ b/app/services/find_empty_trainees.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class FindEmptyTrainees
+  include ServicePattern
+
+  attr_reader :trainees, :ids_only, :forms
+
+  def initialize(trainees: Trainee.all, ids_only: false)
+    @trainees = trainees
+    @ids_only = ids_only
+    @forms = compile_progress_validation_forms
+  end
+
+  def call
+    trainees.draft.filter_map do |trainee|
+      if trainee_empty?(trainee)
+        ids_only ? trainee.id : trainee
+      end
+    end
+  end
+
+private
+
+  def trainee_empty?(trainee)
+    forms.all? do |progress_type, form|
+      progress_value = trainee.progress.public_send(progress_type)
+      ProgressService.call(validator: form.new(trainee), progress_value: progress_value).not_started?
+    end
+  end
+
+  def compile_progress_validation_forms
+    TrnSubmissionForm.form_validators.transform_values { |form_details| form_details[:form].constantize }
+  end
+end

--- a/app/services/progress_service.rb
+++ b/app/services/progress_service.rb
@@ -25,6 +25,10 @@ class ProgressService
     @validator.fields.values.flatten.compact.any?
   end
 
+  def not_started?
+    !started?
+  end
+
   def in_progress_valid?
     started? && @validator.valid? && !completed?
   end

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -5,7 +5,7 @@ module Trainees
     include ServicePattern
 
     def initialize(trainees:, filters:)
-      @trainees = trainees
+      @trainees = remove_empty_trainees(trainees)
       @filters = filters
     end
 
@@ -18,6 +18,10 @@ module Trainees
   private
 
     attr_reader :trainees, :filters
+
+    def remove_empty_trainees(trainees)
+      trainees.where.not(id: FindEmptyTrainees.call(trainees: trainees, ids_only: true))
+    end
 
     def level(trainees, levels)
       return trainees if levels.blank?
@@ -77,8 +81,8 @@ module Trainees
       filtered_trainees = subject(filtered_trainees, filters[:subject])
       filtered_trainees = text_search(filtered_trainees, filters[:text_search])
       filtered_trainees = level(filtered_trainees, filters[:level])
-      filtered_trainees = record_source(filtered_trainees, filters[:record_source])
-      filtered_trainees
+
+      record_source(filtered_trainees, filters[:record_source])
     end
   end
 end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -34,3 +34,7 @@ import_users_from_dttp:
   cron: "0 4 * * *"
   class: "Dttp::SyncUsersJob"
   queue: dttp
+delete_empty_trainees:
+  cron: "0 0 * * *"
+  class: "DeleteEmptyTraineesJob"
+  queue: default

--- a/spec/jobs/delete_empty_trainees_job_spec.rb
+++ b/spec/jobs/delete_empty_trainees_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DeleteEmptyTraineesJob do
+  include ActiveJob::TestHelper
+
+  let(:provider) { create(:provider) }
+
+  before do
+    Trainee.create(provider: provider, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
+  end
+
+  it "enqueues job" do
+    expect {
+      described_class.perform_later
+    }.to have_enqueued_job
+  end
+
+  it "deletes empty trainee records" do
+    expect { described_class.perform_now }.to change { Trainee.count }.from(1).to(0)
+  end
+end

--- a/spec/services/find_empty_trainees_spec.rb
+++ b/spec/services/find_empty_trainees_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe FindEmptyTrainees do
+  let(:provider) { create(:provider) }
+
+  let!(:draft_trainee_with_no_data) do
+    Trainee.create(provider: provider, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
+  end
+
+  subject { described_class.call }
+
+  before do
+    create(:trainee, :draft, provider: provider)
+  end
+
+  it "returns only trainees that have no data" do
+    expect(subject).to match_array(draft_trainee_with_no_data)
+  end
+
+  context "returning trainee ID's only" do
+    subject { described_class.call(ids_only: true) }
+
+    it { is_expected.to match_array([draft_trainee_with_no_data.id]) }
+  end
+end

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -11,7 +11,16 @@ module Trainees
     let(:filters) { nil }
     let(:trainees) { Trainee.all }
 
-    it { is_expected.to eq(trainees) }
+    it { is_expected.to match_array(trainees) }
+
+    context "empty trainee exists" do
+      let!(:empty_trainee) do
+        Trainee.create(provider_id: draft_trainee.provider.id,
+                       training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
+      end
+
+      it { is_expected.not_to include(empty_trainee) }
+    end
 
     context "with training_route filter" do
       let!(:provider_led_postgrad_trainee) { create(:trainee, :provider_led_postgrad) }


### PR DESCRIPTION
### Context
https://trello.com/c/e74UiITG/2369-spike-work-out-what-to-do-with-empty-drafts

This solution is the outcome of a conversation with @edwardhorsford where we agreed to keep things simple and just hide trainees that don't have any information other than the training route. This means that if the user creates a new trainee but then decideds to abandon it (which ususally happens when providers login to try out the app but don't intend to complete all the sections just yet), we don't bother showing it on the index page. If they want to create trainee with all the details later on, they can create another one.

### Changes proposed in this pull request
- New service `FindEmptyTrainees`
- New job `DeleteEmptyTraineesJob` that uses `FindEmptyTrainees`
- Modify `Trainees::Filter` to use `FindEmptyTrainees` so it doens't show empty trainees on the index page

### Guidance to review
- Create a new trainee
- Visit trainees index page
- It shouldn't be display
