### PR TITLE
[2412] Handle missing information data for contact details confirm

### DIFF
--- a/app/components/contact_details/view.html.erb
+++ b/app/components/contact_details/view.html.erb
@@ -1,16 +1,5 @@
-<%= render SummaryCard::View.new(trainee: trainee, title: "Contact details",
-                                 heading_level: 2,
-                                 rows: [
-      {
-        key: "Address",
-        value: address,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> address</span>'.html_safe,
-                              edit_trainee_contact_details_path(trainee)),
-      },
-      {
-        key: "Email address",
-        value: email,
-        action: govuk_link_to('Change<span class="govuk-visually-hidden"> email address</span>'.html_safe,
-                              edit_trainee_contact_details_path(trainee)),
-      },
-    ]) %>
+<%= render SummaryCard::View.new(
+  trainee: trainee, title: "Contact details",
+  heading_level: 2,
+  rows: contact_detail_rows
+) %>

--- a/app/components/contact_details/view.rb
+++ b/app/components/contact_details/view.rb
@@ -6,33 +6,33 @@ module ContactDetails
 
     def initialize(data_model:, has_errors: false)
       @data_model = data_model
-      @not_provided_copy = I18n.t("components.confirmation.not_provided")
       @has_errors = has_errors
     end
 
-    def trainee
-      data_model.is_a?(Trainee) ? data_model : data_model.trainee
-    end
-
-    def address
-      return @not_provided_copy if data_model.locale_code.nil? || (uk_address.blank? && international_address.blank?)
-
-      address = (data_model.uk? ? uk_address : international_address).reject(&:blank?)
-                                                                      .map { |item| html_escape(item) }
-                                                                      .join(tag.br)
-
-      sanitize(address)
-    end
-
-    def email
-      return @not_provided_copy if data_model.email.blank?
-
-      data_model.email
+    def contact_detail_rows
+      [
+        address_row,
+        email_row,
+      ].compact
     end
 
   private
 
     attr_accessor :data_model, :has_errors
+
+    def trainee
+      data_model.is_a?(Trainee) ? data_model : data_model.trainee
+    end
+
+    def address_row
+      is_invalid_address = data_model.locale_code.nil? || (uk_address.blank? && international_address.blank?)
+
+      mappable_field(is_invalid_address ? nil : formatted_address, t(".address"))
+    end
+
+    def email_row
+      mappable_field(data_model.email.presence, t(".email"))
+    end
 
     def uk_address
       [
@@ -45,6 +45,26 @@ module ContactDetails
 
     def international_address
       data_model.international_address.split(/\r\n+/)
+    end
+
+    def formatted_address
+      address = (data_model.uk? ? uk_address : international_address)
+        .reject(&:blank?)
+        .map { |item| html_escape(item) }
+        .join(tag.br)
+
+      sanitize(address)
+    end
+
+    def mappable_field(field_value, field_label)
+      MappableFieldRow.new(
+        field_value: field_value,
+        field_label: field_label,
+        text: t("components.confirmation.missing"),
+        action_url: edit_trainee_contact_details_path(trainee),
+        has_errors: has_errors,
+        apply_draft: trainee.apply_application?,
+      ).to_h
     end
   end
 end

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -82,12 +82,6 @@ class PersonalDetailsForm < TraineeForm
       end
   end
 
-  def missing_fields
-    return [] if valid?
-
-    errors.attribute_names
-  end
-
 private
 
   def new_attributes

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -42,6 +42,12 @@ class TraineeForm
     "#{course_date_attribute_name_prefix}_end_date".to_sym
   end
 
+  def missing_fields
+    return [] if valid?
+
+    errors.attribute_names
+  end
+
 private
 
   def course_date_attribute_name_prefix

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,10 @@ en:
     items:
       sign_out: Sign out
       system_admin: System admin
+  contact_details:
+    view:
+      address: &address Address
+      email: &email_address Email address
   components:
     heading:
       apply_draft:
@@ -366,6 +370,8 @@ en:
         date_of_birth: *date_of_birth
         gender: *gender
         nationality_names: *nationality
+        locale_code: *address
+        email: *email_address
     trainees:
       index:
         no_records: Your trainee records will appear here. You do not have any records yet.

--- a/spec/components/contact_details/view_spec.rb
+++ b/spec/components/contact_details/view_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe ContactDetails::View do
       expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 2)
     end
 
-    it "tells the user that no data has been entered" do
-      expect(rendered_component).to have_selector(".govuk-summary-list__value", text: "Not provided", count: 2)
+    it "tells the user that the data is missing" do
+      expect(rendered_component).to have_selector(".govuk-summary-list__value", text: t("components.confirmation.missing"), count: 2)
     end
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/lX1qKKj1/2412-s-missing-information-ui-contact-details

### Changes proposed in this pull request

<img width="1216" alt="Screenshot 2021-08-03 at 15 24 14" src="https://user-images.githubusercontent.com/616080/128151437-6198e4c1-2178-4a9c-8f65-c3c904525634.png">

Based on https://github.com/DFE-Digital/register-trainee-teachers/pull/1219. Handles missing data for the contact details confirm page.

### Guidance to review
