### PR TITLE
[2413] Add missing information UI for diversity section

### DIFF
--- a/app/forms/diversities/ethnic_background_form.rb
+++ b/app/forms/diversities/ethnic_background_form.rb
@@ -11,7 +11,7 @@ module Diversities
 
     delegate :ethnic_group, to: :ethnic_group_form
 
-    validates :ethnic_background, presence: true, if: -> { disclosure_form.diversity_disclosed? }
+    validates :ethnic_background, presence: true, if: :requires_ethnic_background?
 
     def initialize(trainee, **kwargs)
       @disclosure_form = DisclosureForm.new(trainee)
@@ -22,6 +22,10 @@ module Diversities
   private
 
     attr_reader :disclosure_form, :ethnic_group_form
+
+    def requires_ethnic_background?
+      disclosure_form.diversity_disclosed? && !ethnic_group_form.not_provided_ethnic_group?
+    end
 
     def compute_fields
       trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)

--- a/app/forms/diversity_form.rb
+++ b/app/forms/diversity_form.rb
@@ -72,4 +72,11 @@ class DiversityForm
   def save!
     diversity_forms.each(&:save!)
   end
+
+  def missing_fields
+    diversity_forms.flat_map do |diversity_form|
+      diversity_form.valid?
+      diversity_form.errors.attribute_names
+    end
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,10 +61,12 @@ en:
         training_initiative:
           title: Training initiative
       diversity:
+        diversity_disclosure_title: &diversity_information Diversity information
         diversity_disclosure:
           diversity_disclosed: Information disclosed
           diversity_not_disclosed: Not shared
-          diversity_not_provided: Not provided
+        ethnicity_title: &ethnicity Ethnicity
+        disability_title: &disability Disability
         ethnic_groups: &ethnic_groups_labels
           asian_ethnic_group: Asian or Asian British
           black_ethnic_group: Black, African, Black British or Caribbean
@@ -316,7 +318,7 @@ en:
       titles:
         personal_details: Personal details
         contact_details: Contact details
-        diversity: Diversity information
+        diversity: *diversity_information
         degrees: Degree details
         course_details: Course details
         training_details: Training details
@@ -372,6 +374,11 @@ en:
         nationality_names: *nationality
         locale_code: *address
         email: *email_address
+        ethnic_background: *ethnicity
+        ethnic_group: *ethnicity
+        diversity_disclosure: *diversity_information
+        disability_disclosure: *disability
+        disability_ids: *disability
     trainees:
       index:
         no_records: Your trainee records will appear here. You do not have any records yet.

--- a/spec/components/diversity/view_spec.rb
+++ b/spec/components/diversity/view_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Diversity::View do
     end
 
     context "when trainee has shared their diversity information " do
-      let(:trainee) { build(:trainee, :diversity_disclosed) }
+      let(:trainee) { create(:trainee, :with_diversity_information) }
 
       it "renders with one line to say the trainee has shared data" do
         expect(rendered_component).to have_text("Information disclosed")
@@ -38,35 +38,39 @@ RSpec.describe Diversity::View do
   end
 
   describe "ethnic selection" do
-    let(:trainee) { build(:trainee, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:asian]) }
-    let(:expected_locale_key) { t("components.confirmation.diversity.ethnic_groups.asian_ethnic_group") }
+    let(:trainee) { build(:trainee, :diversity_disclosed, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:asian]) }
+    let(:locale_key) { t("components.confirmation.diversity.ethnic_groups.asian_ethnic_group") }
 
-    subject { Diversity::View.new(data_model: trainee) }
+    it "returns ethnicity is missing" do
+      expect(rendered_component).to have_text("Ethnicity is missing")
+      expect(rendered_component).not_to have_text(locale_key)
+    end
 
-    it "returns the ethnic_group if the ethnic_background is not provided" do
-      expect(subject.ethnic_group_content).to eq(expected_locale_key)
+    context "when ethnic_background is not provided" do
+      let(:trainee) { build(:trainee, :diversity_disclosed, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:asian], ethnic_background: Diversities::NOT_PROVIDED) }
+
+      it "returns the ethnic_group" do
+        expect(rendered_component).to have_text(locale_key)
+      end
     end
 
     context "ethnic background" do
       let(:ethnic_background) { Diversities::ANOTHER_ETHNIC_BACKGROUND }
-      let(:trainee) { build(:trainee, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:other], ethnic_background: ethnic_background) }
-      let(:expected_locale_key) { t("components.confirmation.diversity.ethnic_groups.other_ethnic_group") }
+      let(:trainee) { build(:trainee, :diversity_disclosed, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:other], ethnic_background: ethnic_background) }
+      let(:locale_key) { t("components.confirmation.diversity.ethnic_groups.other_ethnic_group") }
 
       context "when ethnic_background provided" do
         it "returns the ethnic_background alongside the ethnic_group" do
-          expect(subject.ethnic_group_content).to eq("#{expected_locale_key} (#{ethnic_background})")
+          expect(rendered_component).to have_text("#{locale_key} (#{ethnic_background})")
         end
       end
 
       context "when additional_ethnic_background provided" do
         let(:additional_background) { "some additional background" }
-
-        before do
-          trainee.additional_ethnic_background = additional_background
-        end
+        let(:trainee) { build(:trainee, :diversity_disclosed, ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:other], ethnic_background: ethnic_background, additional_ethnic_background: additional_background) }
 
         it "returns the additional_ethnic_background alongside the ethnic_group" do
-          expect(subject.ethnic_group_content).to eq("#{expected_locale_key} (#{additional_background})")
+          expect(rendered_component).to have_text("#{locale_key} (#{additional_background})")
         end
       end
     end
@@ -74,19 +78,18 @@ RSpec.describe Diversity::View do
 
   describe "#disability_selection" do
     let(:disability_disclosure) { nil }
-    let(:trainee) { build(:trainee, disability_disclosure: disability_disclosure) }
+    let(:trainee) { build(:trainee, :diversity_disclosed, disability_disclosure: disability_disclosure) }
 
-    let(:rendered_component) { Diversity::View.new(data_model: trainee) }
-
-    it "returns answer missing" do
-      expect(rendered_component.disability_selection).to eq("Answer missing")
+    it "returns disability is missing" do
+      expect(rendered_component).to have_text("Disability is missing")
     end
 
     context "disabled" do
       let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled] }
+      let(:trainee) { create(:trainee, :diversity_disclosed, :disabled_with_disabilites_disclosed, disability_disclosure: disability_disclosure) }
 
       it "returns a message stating the user is disabled" do
-        expect(rendered_component.disability_selection).to eq("They shared that they’re disabled")
+        expect(rendered_component).to have_text("They shared that they’re disabled")
       end
     end
 
@@ -94,7 +97,7 @@ RSpec.describe Diversity::View do
       let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability] }
 
       it "returns a message stating the user is not disabled" do
-        expect(rendered_component.disability_selection).to eq("They shared that they’re not disabled")
+        expect(rendered_component).to have_text("They shared that they’re not disabled")
       end
     end
 
@@ -102,31 +105,26 @@ RSpec.describe Diversity::View do
       let(:disability_disclosure) { Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] }
 
       it "returns a message stating the user did not provide details" do
-        expect(rendered_component.disability_selection).to eq("Not provided")
+        expect(rendered_component).to have_text("Not provided")
       end
     end
   end
 
   describe "selected disability options" do
-    let(:trainee) { build(:trainee) }
-    let(:rendered_component) { Diversity::View.new(data_model: trainee) }
+    let(:trainee) { create(:trainee, :diversity_disclosed, :disabled) }
 
     context "when there are no disabilities" do
-      it "returns a empty string if no disabilities" do
-        expect(rendered_component.selected_disability_options).to be_empty
+      it "returns disability is missing" do
+        expect(rendered_component).to have_text("Disability is missing")
       end
     end
 
     context "when there are disabilities" do
-      let(:disabilities_stub) { [double(name: "some disability")] }
-
-      before do
-        allow(trainee).to receive(:disabilities).and_return(disabilities_stub)
-      end
+      let(:trainee) { create(:trainee, :diversity_disclosed, :disabled_with_disabilites_disclosed) }
 
       it "renders the disability names" do
         trainee.disabilities.each do |disability|
-          expect(rendered_component.selected_disability_options).to include(disability.name)
+          expect(rendered_component).to have_text(disability.name)
         end
       end
     end
@@ -134,11 +132,11 @@ RSpec.describe Diversity::View do
     context "when additional disability has been provided" do
       let(:disability) { build(:disability, name: Diversities::OTHER) }
       let(:trainee_disability) { build(:trainee_disability, additional_disability: "some additional disability", disability: disability) }
-      let(:trainee) { create(:trainee, trainee_disabilities: [trainee_disability]) }
+      let(:trainee) { create(:trainee, :diversity_disclosed, :disabled, trainee_disabilities: [trainee_disability]) }
 
       it "renders the additional disability" do
         expected_text = "#{disability.name.downcase} (#{trainee_disability.additional_disability})"
-        expect(rendered_component.selected_disability_options).to include(expected_text)
+        expect(rendered_component).to have_text(expected_text)
       end
     end
   end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -138,12 +138,8 @@ FactoryBot.define do
       disability_disclosure { Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled] }
     end
 
-    trait :with_diversity_information do
-      diversity_disclosed
-      with_ethnic_group
-      with_ethnic_background
+    trait :disabled_with_disabilites_disclosed do
       disabled
-
       transient do
         disabilities_count { 1 }
       end
@@ -151,6 +147,13 @@ FactoryBot.define do
       after(:create) do |trainee, evaluator|
         create_list(:trainee_disability, evaluator.disabilities_count, trainee: trainee)
       end
+    end
+
+    trait :with_diversity_information do
+      diversity_disclosed
+      with_ethnic_group
+      with_ethnic_background
+      disabled_with_disabilites_disclosed
     end
 
     trait :with_placement_assignment do

--- a/spec/forms/diversities/ethnic_background_form_spec.rb
+++ b/spec/forms/diversities/ethnic_background_form_spec.rb
@@ -16,6 +16,18 @@ module Diversities
 
     describe "validations" do
       it { is_expected.to validate_presence_of(:ethnic_background) }
+
+      context "when diversity is not disclosed" do
+        let(:trainee) { build(:trainee) }
+
+        it { is_expected.not_to validate_presence_of(:ethnic_background) }
+      end
+
+      context "when enthic group is not provided" do
+        let(:trainee) { build(:trainee, :diversity_disclosed, ethnic_group: Trainee.ethnic_groups[:not_provided_ethnic_group]) }
+
+        it { is_expected.not_to validate_presence_of(:ethnic_background) }
+      end
     end
 
     describe "#stash" do

--- a/spec/forms/diversity_form_spec.rb
+++ b/spec/forms/diversity_form_spec.rb
@@ -85,4 +85,22 @@ describe DiversityForm, type: :model do
       subject.save!
     end
   end
+
+  describe "#missing_fields" do
+    subject { described_class.new(trainee).missing_fields }
+
+    it { is_expected.to eq([]) }
+
+    context "with invalid diversity forms" do
+      let(:trainee) { build(:trainee, diversity_disclosure: nil) }
+
+      it { is_expected.to eq([:diversity_disclosure]) }
+    end
+
+    context "with multiple invalid diversity forms" do
+      let(:trainee) { build(:trainee, :diversity_disclosed, :disabled) }
+
+      it { is_expected.to eq(%i[ethnic_background ethnic_group disability_ids]) }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,8 @@ RSpec.configure do |config|
     config.default_formatter = "doc"
   end
 
+  config.filter_run_when_matching :focus
+
   config.profile_examples = 3
 
   config.order = :random


### PR DESCRIPTION
### Context

#### With missing ethnicity
![image](https://user-images.githubusercontent.com/910019/128716841-315f97be-9a40-4070-ac19-eced12f46fc5.png)
#### With disclosure, but missing ethnicity and diversity information

![image](https://user-images.githubusercontent.com/910019/128716767-135521df-74b0-4776-b7e0-5ea37ea15bb7.png)

### Changes proposed in this pull request

### Guidance to review
Add a trainee, and try out various combinations of diversitiy information.

