### PR TITLE
[2439] Amended `Schools` to be `Lead and employing schools`

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,8 +343,8 @@ en:
         schools:
           titles:
             tuition: Lead school
-            salaried: Schools
-            pg_teaching_apprenticeship: Schools
+            salaried: Lead and employing schools
+            pg_teaching_apprenticeship: Lead and employing schools
   views:
     all_records: All records
     apply_invalid_data_view:


### PR DESCRIPTION
### Context
Schools heading in `/review-draft` table

### Changes proposed in this pull request
Amended `Schools` to be `Lead and employing schools`

### Guidance to review

:shipit: 