### PR TITLE
[2446] Send academic year based on start date

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -82,7 +82,7 @@ RSpec/MessageSpies:
 # Offense count: 159
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:
-  Max: 22
+  Max: 24
 
 # Offense count: 513
 # Configuration parameters: IgnoreSharedExamples.

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -6,6 +6,9 @@ module Dttp
       include Mappable
 
       ACADEMIC_YEAR_2020_2021 = "76bcaeca-2bd1-e711-80df-005056ac45bb"
+      ACADEMIC_YEAR_2021_2022 = "21196925-17b9-e911-a863-000d3ab0dc71"
+      ACADEMIC_YEAR_2022_2023 = "ed0db9f4-eff5-eb11-94ef-000d3ab1e900"
+
       COURSE_LEVEL_PG = 12
       COURSE_LEVEL_UG = 20
       ITT_QUALIFICATION_AIM_QTS = "68cbae32-7389-e711-80d8-005056ac45bb"
@@ -39,7 +42,7 @@ module Dttp
           "dfe_programmeenddate" => trainee.course_end_date.in_time_zone.iso8601,
           "dfe_commencementdate" => trainee.commencement_date.in_time_zone.iso8601,
           "dfe_traineeid" => trainee.trainee_id || "NOTPROVIDED",
-          "dfe_AcademicYearId@odata.bind" => "/dfe_academicyears(#{ACADEMIC_YEAR_2020_2021})",
+          "dfe_AcademicYearId@odata.bind" => "/dfe_academicyears(#{academic_year})",
           "dfe_courselevel" => course_level,
           "dfe_sendforregistration" => true,
           "dfe_ProviderId@odata.bind" => "/accounts(#{trainee.provider.dttp_id})",
@@ -117,6 +120,12 @@ module Dttp
 
       def send_funding_to_dttp?
         FeatureService.enabled?(:show_funding) && FeatureService.enabled?(:send_funding_to_dttp)
+      end
+
+      def academic_year
+        return ACADEMIC_YEAR_2020_2021 if trainee.course_start_date.between?(Date.parse("1/8/2020"), Date.parse("31/7/2021"))
+        return ACADEMIC_YEAR_2021_2022 if trainee.course_start_date.between?(Date.parse("1/8/2021"), Date.parse("31/7/2022"))
+        return ACADEMIC_YEAR_2022_2023 if trainee.course_start_date.between?(Date.parse("1/8/2022"), Date.parse("31/7/2023"))
       end
     end
   end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -9,7 +9,7 @@ module Dttp
       let(:degree) { build(:degree, :uk_degree_with_details) }
       let(:provider) { create(:provider, dttp_id: dttp_provider_id) }
       let(:trainee) do
-        create(:trainee, :with_course_details, :with_start_date, dttp_id: dttp_contact_id, provider: provider)
+        create(:trainee, :with_course_details, :with_start_date, course_start_date: Date.parse("10/10/2020"), dttp_id: dttp_contact_id, provider: provider)
       end
 
       let(:contact_change_set_id) { SecureRandom.uuid }
@@ -49,6 +49,63 @@ module Dttp
       subject { described_class.new(trainee, contact_change_set_id).params }
 
       describe "#params" do
+        describe "academic year" do
+          let(:trainee) { create(:trainee, :with_course_details, :with_start_date, course_start_date: Date.parse(start_date)) }
+          let(:expected_value) { "/dfe_academicyears(#{expected_year})" }
+
+          subject do
+            super()["dfe_AcademicYearId@odata.bind"]
+          end
+
+          context "trainee with course in 20/21" do
+            let(:expected_year) { Dttp::Params::PlacementAssignment::ACADEMIC_YEAR_2020_2021 }
+
+            context "1/8/2020" do
+              let(:start_date) { "1/8/2020" }
+
+              it { is_expected.to eq(expected_value) }
+            end
+
+            context "31/7/2021" do
+              let(:start_date) { "31/7/2021" }
+
+              it { is_expected.to eq(expected_value) }
+            end
+          end
+
+          context "trainee with course in 21/22" do
+            let(:expected_year) { Dttp::Params::PlacementAssignment::ACADEMIC_YEAR_2021_2022 }
+
+            context "1/8/2021" do
+              let(:start_date) { "1/8/2021" }
+
+              it { is_expected.to eq(expected_value) }
+            end
+
+            context "31/7/2022" do
+              let(:start_date) { "31/7/2022" }
+
+              it { is_expected.to eq(expected_value) }
+            end
+          end
+
+          context "trainee with course in 22/23" do
+            let(:expected_year) { Dttp::Params::PlacementAssignment::ACADEMIC_YEAR_2022_2023 }
+
+            context "1/8/2022" do
+              let(:start_date) { "1/8/2022" }
+
+              it { is_expected.to eq(expected_value) }
+            end
+
+            context "31/7/2023" do
+              let(:start_date) { "31/7/2023" }
+
+              it { is_expected.to eq(expected_value) }
+            end
+          end
+        end
+
         context "degrees" do
           before do
             stub_const(


### PR DESCRIPTION
### Context

Academic years run 1/8/year -> 31/7/(year + 1).

Up until now we were sending a hardcoded value but we are in a new year now so need new things.

### Changes proposed in this pull request

Send the correct academic year based on the course start date to DTTP.

### Guidance to review

It would be useful to get a check that the correct GUIDs are set. This is an issue in production at the moment so I realise that we could probably move the constants out of params and into a mapping but it would be good to get this deployed this afternoon and we can revisit.

