### PR TITLE
[2415] Missing information UI (Course details section)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -355,6 +355,30 @@ en:
             tuition: Lead school
             salaried: Lead and employing schools
             pg_teaching_apprenticeship: Lead and employing schools
+  apply_applications:
+    trainee_data:
+      view:
+        heading_1_name: "Draft record for %{name}"
+        heading_1_no_name: "Draft record"
+        heading_2: "Trainee Data"
+    confirm_course:
+      view:
+        change: Change
+        change_course: Change course
+        heading: Confirm trainee’s course details
+        summary_title: Course details
+        route: Route
+        type_of_course: Subject
+        subject: &course_subject Subject
+        multiple_subjects: Subjects
+        level: Level
+        age_range: &course_age_range Age range
+        itt_start_date: &itt_start_date ITT start date
+        itt_end_date: &itt_end_date ITT end date
+        course_start_date: &course_start_date Course start date
+        course_end_date: &course_end_date Course end date
+        duration: Duration
+        course_details: Course details
   views:
     all_records: All records
     apply_invalid_data_view:
@@ -383,6 +407,12 @@ en:
         diversity_disclosure: *diversity_information
         disability_disclosure: *disability
         disability_ids: *disability
+        course_subject_one: *course_subject
+        course_start_date: *course_start_date
+        course_end_date: *course_end_date
+        main_age_range: *course_age_range
+        itt_start_date: *itt_start_date
+        itt_end_date: *itt_end_date
     trainees:
       index:
         no_records: Your trainee records will appear here. You do not have any records yet.
@@ -630,30 +660,6 @@ en:
 
 
         If the details are wrong for this trainee only, you can edit them here.
-  apply_applications:
-    trainee_data:
-      view:
-        heading_1_name: "Draft record for %{name}"
-        heading_1_no_name: "Draft record"
-        heading_2: "Trainee Data"
-    confirm_course:
-      view:
-        change: Change
-        change_course: Change course
-        heading: Confirm trainee’s course details
-        summary_title: Course details
-        route: Route
-        type_of_course: Subject
-        subject: Subject
-        multiple_subjects: Subjects
-        level: Level
-        age_range: Age range
-        itt_start_date: ITT start date
-        itt_end_date: ITT end date
-        course_start_date: Course start date
-        course_end_date: Course end date
-        duration: Duration
-        course_details: Course details
   course_details:
     view:
       subject:

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -21,9 +21,28 @@ module CourseDetails
         render_inline(View.new(data_model: trainee))
       end
 
-      it "tells the user that no data has been entered for course details, course type, subject, age range, course start date and course end date" do
+      it "renders 6 rows" do
         expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 6)
-        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: t("components.confirmation.not_provided"), count: 6)
+      end
+
+      it "renders course details as no provided" do
+        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: t("components.confirmation.not_provided"))
+      end
+
+      it "renders missing hint for subject" do
+        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: "Subject is missing")
+      end
+
+      it "renders missing hint for age range" do
+        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: "Age range is missing")
+      end
+
+      it "renders missing hint for course start date" do
+        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: "Course start date is missing")
+      end
+
+      it "renders missing hint for course end date" do
+        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: "Course end date is missing")
       end
     end
 
@@ -37,27 +56,27 @@ module CourseDetails
           render_inline(View.new(data_model: trainee))
         end
 
-        it "renderendered_rs the course details" do
+        it "renders the course details" do
           expect(rendered_component)
             .to have_text("#{course.name} (#{course.code})")
         end
 
-        it "renderendered_rs the course type" do
+        it "renders the course type" do
           expect(rendered_component)
             .to have_text(t("activerecord.attributes.trainee.training_routes.#{trainee.training_route}"))
         end
 
-        it "rendrendered_ers the subject" do
+        it "renders the subject" do
           expect(rendered_component)
             .to have_text(trainee.course_subject_one.upcase_first)
         end
 
-        it "renderendered_rs the course age range" do
+        it "renders the course age range" do
           expect(rendered_component)
             .to have_text(age_range_for_summary_view(trainee.course_age_range))
         end
 
-        it "renderendered_rs the course start date" do
+        it "renders the course start date" do
           expect(rendered_component)
             .to have_text(date_for_summary_view(trainee.course_start_date))
         end


### PR DESCRIPTION
### Context
https://trello.com/c/z0IzOjMd/2415-s-missing-information-ui-course-details-section

### Changes proposed in this pull request
<img width="898" alt="Screenshot 2021-08-05 at 16 51 23" src="https://user-images.githubusercontent.com/28728/128381218-8444def9-027b-4531-8bb7-9a75387464be.png">

### Guidance to review
- Create new trainee
- Visit `http://localhost:3000/trainees/<slug>/course-details/confirm`
