### PR TITLE
[xxx] Update dttp_id data migration

### DIFF
--- a/db/data/20210806100151_update_dttp_ids.rb
+++ b/db/data/20210806100151_update_dttp_ids.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class UpdateDttpIds < ActiveRecord::Migration[6.1]
+  def up
+    trainee_one = Trainee.from_param("XaGziQXghtBfH6VUhgRrSLMa")
+    if trainee_one.present?
+      ActiveRecord::Base.connection.execute(
+        "UPDATE trainees SET dttp_id = '102f6f17-bb03-eb11-a812-000d3ab5d7e6', placement_assignment_dttp_id = '9f78a844-5df2-eb11-94ee-000d3ab23888' WHERE id = #{trainee_one.id}",
+      )
+    end
+
+    trainee_two = Trainee.from_param("AX7MmPYKKt9R1WLRZ7XXsioe")
+    if trainee_two.present?
+      ActiveRecord::Base.connection.execute(
+        "UPDATE trainees SET dttp_id = '162f6f17-bb03-eb11-a812-000d3ab5d7e6', placement_assignment_dttp_id = '1c8d70a6-5df2-eb11-94ee-000d3ab2366d' WHERE id = #{trainee_two.id}",
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-DataMigrate::Data.define(version: 20210702132811)
+DataMigrate::Data.define(version: 20210806100151)


### PR DESCRIPTION
### Context

Two trainee records have been deleted in DTTP as they already had a duplicate record. We need to update register to point to the record that has been left.

The record register created has been deleted which isn't how we should handle this.

### Changes proposed in this pull request

Data migration to update the DTTP ids. We have made these protected attributes so it has to be done via SQL.

### Guidance to review

Mostly checking the DTTP Ids which will require prod DTTP access. I can pair on the review.


