### PR TITLE
[2414] Add Missing Information UI for degrees section

### DIFF
--- a/app/components/degrees/view.html.erb
+++ b/app/components/degrees/view.html.erb
@@ -1,6 +1,6 @@
 <% if degrees.present? %>
-  <% degrees.each do |degree| %>
-    <%= render SummaryCard::View.new(trainee: trainee, title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree), id_token: degree.to_param) do |component| %>
+  <% degrees.each.with_index(1) do |degree, index| %>
+    <%= render SummaryCard::View.new(trainee: trainee, title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree), id_suffix: index) do |component| %>
       <% if show_delete_button %>
         <% component.header_actions do %>
           <%= register_form_with model: [trainee, degree], url: trainee_degree_path(trainee, degree), method: :delete, local: true do |f| %>

--- a/app/components/degrees/view.html.erb
+++ b/app/components/degrees/view.html.erb
@@ -1,6 +1,6 @@
 <% if degrees.present? %>
   <% degrees.each do |degree| %>
-    <%= render SummaryCard::View.new(trainee: trainee, title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree)) do |component| %>
+    <%= render SummaryCard::View.new(trainee: trainee, title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree), id_token: degree.to_param) do |component| %>
       <% if show_delete_button %>
         <% component.header_actions do %>
           <%= register_form_with model: [trainee, degree], url: trainee_degree_path(trainee, degree), method: :delete, local: true do |f| %>

--- a/app/components/degrees/view.rb
+++ b/app/components/degrees/view.rb
@@ -20,39 +20,25 @@ module Degrees
       if degree.uk?
         "#{degree.uk_degree}: #{degree.subject&.downcase}"
       else
-        "Non-UK #{degree.non_uk_degree_non_enic? ? 'degree' : degree.non_uk_degree}: #{degree.subject.downcase}"
+        "Non-UK #{degree.non_uk_degree_non_enic? ? 'degree' : degree.non_uk_degree}: #{degree.subject&.downcase}"
       end
     end
 
     def get_degree_rows(degree)
       if degree.uk?
         [
-          mappable_field_row(degree, :institution, "Institution"),
-          mappable_field_row(degree, :subject, "Subject"),
-          mappable_field_row(degree, :uk_degree, "Degree type"),
-          {
-            key: "Grade",
-            value: grade_for(degree),
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> grade</span>'.html_safe,
-                                  edit_trainee_degree_path(trainee, degree)),
-          },
-          {
-            key: "Graduation year",
-            value: degree.graduation_year,
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> graduation year</span>'.html_safe,
-                                  edit_trainee_degree_path(trainee, degree)),
-          },
+          mappable_field_row(degree, :institution, t("components.degrees.institution")),
+          mappable_field_row(degree, :subject, t("components.degrees.subject")),
+          mappable_field_row(degree, :uk_degree, t("components.degrees.degree_type")),
+          mappable_field_row(degree, :grade, t("components.degrees.grade"), grade_for(degree)),
+          mappable_field_row(degree, :graduation_year, t("components.degrees.graduation_year")),
         ]
       else
         [
-          mappable_field_row(degree, :country, "Country"),
-          mappable_field_row(degree, :subject, "Subject"),
-          mappable_field_row(degree, :non_uk_degree, "Degree type", non_uk_degree_type(degree)),
-          {
-            key: "Graduation year",
-            value: degree.graduation_year,
-            action: govuk_link_to('Change<span class="govuk-visually-hidden"> graduation year</span>'.html_safe, edit_trainee_degree_path(trainee, degree)),
-          },
+          mappable_field_row(degree, :country, t("components.degrees.country")),
+          mappable_field_row(degree, :subject, t("components.degrees.subject")),
+          mappable_field_row(degree, :non_uk_degree, t("components.degrees.degree_type"), non_uk_degree_type(degree)),
+          mappable_field_row(degree, :graduation_year, t("components.degrees.graduation_year")),
         ]
       end
     end
@@ -82,6 +68,7 @@ module Degrees
         field_name: field_name,
         field_value: field_value || degree.public_send(field_name),
         field_label: field_label,
+        text: t("components.confirmation.missing"),
         action_url: edit_trainee_degree_path(trainee, degree),
         has_errors: has_errors,
         apply_draft: trainee.apply_application?,

--- a/app/components/summary_card/view.rb
+++ b/app/components/summary_card/view.rb
@@ -5,11 +5,13 @@ class SummaryCard::View < ViewComponent::Base
 
   renders_one :header_actions
 
-  def initialize(trainee:, title:, heading_level: 2, rows:)
+
+  def initialize(trainee:, title:, heading_level: 2, rows:, id_token: nil)
     @trainee = trainee
     @title = title
     @heading_level = heading_level
     @rows = rows
+    @id_token = id_token
   end
 
   def rows
@@ -29,6 +31,8 @@ private
   end
 
   def row_title(key)
-    key.parameterize
+    return key.parameterize if id_token.nil?
+
+    "#{id_token}-#{key.parameterize}"
   end
 end

--- a/app/components/summary_card/view.rb
+++ b/app/components/summary_card/view.rb
@@ -5,8 +5,6 @@ class SummaryCard::View < ViewComponent::Base
 
   renders_one :header_actions
 
-  attr_accessor :trainee, :title, :heading_level
-
   def initialize(trainee:, title:, heading_level: 2, rows:)
     @trainee = trainee
     @title = title
@@ -23,6 +21,8 @@ class SummaryCard::View < ViewComponent::Base
   end
 
 private
+
+  attr_accessor :trainee, :title, :heading_level
 
   def prevent_action?
     trainee.recommended_for_award? || trainee.awarded? || trainee.withdrawn?

--- a/app/components/summary_card/view.rb
+++ b/app/components/summary_card/view.rb
@@ -5,13 +5,12 @@ class SummaryCard::View < ViewComponent::Base
 
   renders_one :header_actions
 
-
-  def initialize(trainee:, title:, heading_level: 2, rows:, id_token: nil)
+  def initialize(trainee:, title:, heading_level: 2, rows:, id_suffix: nil)
     @trainee = trainee
     @title = title
     @heading_level = heading_level
     @rows = rows
-    @id_token = id_token
+    @id_suffix = id_suffix
   end
 
   def rows
@@ -24,15 +23,15 @@ class SummaryCard::View < ViewComponent::Base
 
 private
 
-  attr_accessor :trainee, :title, :heading_level
+  attr_accessor :trainee, :title, :heading_level, :id_suffix
 
   def prevent_action?
     trainee.recommended_for_award? || trainee.awarded? || trainee.withdrawn?
   end
 
   def row_title(key)
-    return key.parameterize if id_token.nil?
+    return key.parameterize if id_suffix.nil?
 
-    "#{id_token}-#{key.parameterize}"
+    "#{key.parameterize}-#{id_suffix}"
   end
 end

--- a/app/controllers/trainees/degrees/confirm_details_controller.rb
+++ b/app/controllers/trainees/degrees/confirm_details_controller.rb
@@ -10,7 +10,7 @@ module Trainees
 
         if trainee.draft?
           @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.degrees)
-          @missing_data_view = MissingDataView.new(degrees_form)
+          @missing_data_view = MissingDataView.new(degrees_form, multiple_records: true)
         end
 
         data_model = trainee.draft? ? trainee : degrees_form

--- a/app/forms/degrees_form.rb
+++ b/app/forms/degrees_form.rb
@@ -73,7 +73,7 @@ class DegreesForm
   def missing_fields
     return [] if valid?
 
-    degree_forms.flat_map do |degree_form|
+    degree_forms.map do |degree_form|
       degree_form.valid?
       degree_form.errors.attribute_names
     end

--- a/app/forms/degrees_form.rb
+++ b/app/forms/degrees_form.rb
@@ -70,6 +70,15 @@ class DegreesForm
     degrees.each(&:save!)
   end
 
+  def missing_fields
+    return [] if valid?
+
+    degree_forms.flat_map do |degree_form|
+      degree_form.valid?
+      degree_form.errors.attribute_names
+    end
+  end
+
 private
 
   attr_reader :store
@@ -90,9 +99,13 @@ private
     errors.add(:degree_ids, :invalid) unless all_degrees_are_valid?
   end
 
-  def all_degrees_are_valid?
-    trainee.degrees.all? do |degree|
-      DegreeForm.new(degrees_form: self, degree: degree).valid?
+  def degree_forms
+    trainee.degrees.map do |degree|
+      DegreeForm.new(degrees_form: self, degree: degree)
     end
+  end
+
+  def all_degrees_are_valid?
+    degree_forms.all?(&:valid?)
   end
 end

--- a/app/forms/diversity_form.rb
+++ b/app/forms/diversity_form.rb
@@ -74,9 +74,11 @@ class DiversityForm
   end
 
   def missing_fields
-    diversity_forms.flat_map do |diversity_form|
-      diversity_form.valid?
-      diversity_form.errors.attribute_names
-    end
+    [
+      diversity_forms.flat_map do |diversity_form|
+        diversity_form.valid?
+        diversity_form.errors.attribute_names
+      end,
+    ]
   end
 end

--- a/app/forms/funding/form_validator.rb
+++ b/app/forms/funding/form_validator.rb
@@ -27,10 +27,12 @@ module Funding
     end
 
     def missing_fields
-      bursary_forms.flat_map do |form|
-        form.valid?
-        form.errors.attribute_names
-      end
+      [
+        bursary_forms.flat_map do |form|
+          form.valid?
+          form.errors.attribute_names
+        end,
+      ]
     end
 
   private

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -45,7 +45,7 @@ class TraineeForm
   def missing_fields
     return [] if valid?
 
-    errors.attribute_names
+    [errors.attribute_names]
   end
 
 private

--- a/app/view_objects/mappable_field_row.rb
+++ b/app/view_objects/mappable_field_row.rb
@@ -12,7 +12,7 @@ class MappableFieldRow
     @field_label = options[:field_label]
     @action_url = options[:action_url]
     @has_errors = options[:has_errors]
-    @text = options[:text] || "not recognised"
+    @text = options[:text]
     @apply_draft = options[:apply_draft] || false
   end
 

--- a/app/view_objects/missing_data_view.rb
+++ b/app/view_objects/missing_data_view.rb
@@ -15,15 +15,17 @@ class MissingDataView
 
   def missing_items_content
     @missing_items_content ||= safe_join(
-      missing_fields.map do |field|
-        tag.li(
-          link_to(
-            I18n.t("views.missing_data_view.missing_field_text", missing_field: get_display_name(field)),
-            "##{get_display_name(field).parameterize}",
-            class: "govuk-notification-banner__link",
-          ),
-        )
-      end.uniq,
+      missing_fields.map.with_index(1) do |fieldset, index|
+        fieldset.map do |field|
+          tag.li(
+            link_to(
+              I18n.t("views.missing_data_view.missing_field_text", missing_field: get_display_name(field)),
+              get_link_anchor(field, index),
+              class: "govuk-notification-banner__link",
+            ),
+          )
+        end.uniq
+      end,
     )
   end
 
@@ -34,6 +36,12 @@ class MissingDataView
 private
 
   attr_reader :form_instance, :missing_fields
+
+  def get_link_anchor(field, index)
+    return "##{get_display_name(field).parameterize}" if missing_fields.size == 1
+
+    "##{get_display_name(field).parameterize}-#{index}"
+  end
 
   def get_display_name(field)
     I18n.t("views.missing_data_view.missing_fields_mapping.#{field}")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,6 +150,12 @@ en:
       title: Placement details
     degrees:
       add_another_degree: Add another degree
+      institution: &institution Institution
+      subject: &subject Subject
+      degree_type: &degree_type Degree type
+      grade: &grade Grade
+      graduation_year: &graduation_year Graduation year
+      country: &country Country
     incomplete_section:
       degree_details_not_provided: Degree details not provided
       add_degree_details: Add degree details
@@ -427,6 +433,13 @@ en:
         itt_end_date: *itt_end_date
         training_initiative: *training_initiative
         applying_for_bursary: *bursary_funding
+        institution: *institution
+        subject: *subject
+        uk_degree: *degree_type
+        non_uk_degree: *degree_type
+        grade: *grade
+        graduation_year: *graduation_year
+        country: *country
     trainees:
       index:
         no_records: Your trainee records will appear here. You do not have any records yet.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -408,10 +408,12 @@ en:
       default_hint_text_html: 'Enter an answer <span class="govuk-visually-hidden"> for %{field_label}</span>'
       apply_field_hint_text_html: 'Review the trainee’s answer<span class="govuk-visually-hidden"> for %{field_label}</span>'
     missing_data_view:
+      degrees_form: degree
       missing_fields_summary:
         one: "This section contains 1 question that you need to complete."
         other: "This section contains questions which you need to complete."
-      missing_field_text: "%{missing_field} is missing"
+      single_missing_field_text_html: '%{missing_field} is missing'
+      multiple_missing_field_text_html: '%{missing_field} is missing<span class="govuk-visually-hidden"> for %{section_label}</span>'
       missing_fields_mapping:
         first_names: *full_name
         last_name: *full_name

--- a/spec/forms/diversity_form_spec.rb
+++ b/spec/forms/diversity_form_spec.rb
@@ -89,18 +89,18 @@ describe DiversityForm, type: :model do
   describe "#missing_fields" do
     subject { described_class.new(trainee).missing_fields }
 
-    it { is_expected.to eq([]) }
+    it { is_expected.to eq([[]]) }
 
     context "with invalid diversity forms" do
       let(:trainee) { build(:trainee, diversity_disclosure: nil) }
 
-      it { is_expected.to eq([:diversity_disclosure]) }
+      it { is_expected.to eq([[:diversity_disclosure]]) }
     end
 
     context "with multiple invalid diversity forms" do
       let(:trainee) { build(:trainee, :diversity_disclosed, :disabled) }
 
-      it { is_expected.to eq(%i[ethnic_background ethnic_group disability_ids]) }
+      it { is_expected.to eq([%i[ethnic_background ethnic_group disability_ids]]) }
     end
   end
 end

--- a/spec/forms/funding/form_validator_spec.rb
+++ b/spec/forms/funding/form_validator_spec.rb
@@ -138,11 +138,11 @@ module Funding
       context "when valid" do
         let(:trainee) { build(:trainee, :with_funding, applying_for_bursary: false) }
 
-        it { is_expected.to eq([]) }
+        it { is_expected.to eq([[]]) }
       end
 
       context "with invalid TrainingInitiativesForm form" do
-        it { is_expected.to eq([:training_initiative]) }
+        it { is_expected.to eq([[:training_initiative]]) }
       end
 
       context "with invalid TrainingInitiativesForm and Bursary form" do
@@ -150,7 +150,7 @@ module Funding
           allow(trainee).to receive(:bursary_amount).and_return(1)
         end
 
-        it { is_expected.to eq(%i[training_initiative applying_for_bursary]) }
+        it { is_expected.to eq([%i[training_initiative applying_for_bursary]]) }
       end
     end
   end

--- a/spec/view_objects/mappable_field_row_spec.rb
+++ b/spec/view_objects/mappable_field_row_spec.rb
@@ -19,6 +19,7 @@ describe MappableFieldRow do
         field_name: field_name,
         field_value: field_value,
         field_label: field_label,
+        text: "not recognised",
         action_url: action_url,
         has_errors: has_errors,
         apply_draft: true,


### PR DESCRIPTION
### Context
Add a missing information summary for the degrees section.

![image](https://user-images.githubusercontent.com/910019/128679061-40162047-22e0-4575-a4f9-5c5cbbf03a2d.png)

A separate followup PR is added https://github.com/DFE-Digital/register-trainee-teachers/pull/1251 to ensure that the links reference the correct section.

### Changes proposed in this pull request

### Guidance to review

