### PR TITLE
[2414] Enable multiple missing information items with the same label texts

### DIFF
--- a/app/components/degrees/view.html.erb
+++ b/app/components/degrees/view.html.erb
@@ -1,6 +1,6 @@
 <% if degrees.present? %>
-  <% degrees.each do |degree| %>
-    <%= render SummaryCard::View.new(trainee: trainee, title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree), id_token: degree.to_param) do |component| %>
+  <% degrees.each.with_index(1) do |degree, index| %>
+    <%= render SummaryCard::View.new(trainee: trainee, title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree), id_suffix: index) do |component| %>
       <% if show_delete_button %>
         <% component.header_actions do %>
           <%= register_form_with model: [trainee, degree], url: trainee_degree_path(trainee, degree), method: :delete, local: true do |f| %>

--- a/app/components/degrees/view.html.erb
+++ b/app/components/degrees/view.html.erb
@@ -1,6 +1,6 @@
 <% if degrees.present? %>
   <% degrees.each do |degree| %>
-    <%= render SummaryCard::View.new(trainee: trainee, title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree)) do |component| %>
+    <%= render SummaryCard::View.new(trainee: trainee, title: degree_title(degree), heading_level: 2, rows: get_degree_rows(degree), id_token: degree.to_param) do |component| %>
       <% if show_delete_button %>
         <% component.header_actions do %>
           <%= register_form_with model: [trainee, degree], url: trainee_degree_path(trainee, degree), method: :delete, local: true do |f| %>

--- a/app/components/summary_card/view.rb
+++ b/app/components/summary_card/view.rb
@@ -5,11 +5,13 @@ class SummaryCard::View < ViewComponent::Base
 
   renders_one :header_actions
 
-  def initialize(trainee:, title:, heading_level: 2, rows:)
+
+  def initialize(trainee:, title:, heading_level: 2, rows:, id_token: nil)
     @trainee = trainee
     @title = title
     @heading_level = heading_level
     @rows = rows
+    @id_token = id_token
   end
 
   def rows
@@ -29,6 +31,8 @@ private
   end
 
   def row_title(key)
-    key.parameterize
+    return key.parameterize if id_token.nil?
+
+    "#{id_token}-#{key.parameterize}"
   end
 end

--- a/app/components/summary_card/view.rb
+++ b/app/components/summary_card/view.rb
@@ -5,13 +5,12 @@ class SummaryCard::View < ViewComponent::Base
 
   renders_one :header_actions
 
-
-  def initialize(trainee:, title:, heading_level: 2, rows:, id_token: nil)
+  def initialize(trainee:, title:, heading_level: 2, rows:, id_suffix: nil)
     @trainee = trainee
     @title = title
     @heading_level = heading_level
     @rows = rows
-    @id_token = id_token
+    @id_suffix = id_suffix
   end
 
   def rows
@@ -24,15 +23,15 @@ class SummaryCard::View < ViewComponent::Base
 
 private
 
-  attr_accessor :trainee, :title, :heading_level
+  attr_accessor :trainee, :title, :heading_level, :id_suffix
 
   def prevent_action?
     trainee.recommended_for_award? || trainee.awarded? || trainee.withdrawn?
   end
 
   def row_title(key)
-    return key.parameterize if id_token.nil?
+    return key.parameterize if id_suffix.nil?
 
-    "#{id_token}-#{key.parameterize}"
+    "#{key.parameterize}-#{id_suffix}"
   end
 end

--- a/app/forms/degrees_form.rb
+++ b/app/forms/degrees_form.rb
@@ -73,7 +73,7 @@ class DegreesForm
   def missing_fields
     return [] if valid?
 
-    degree_forms.flat_map do |degree_form|
+    degree_forms.map do |degree_form|
       degree_form.valid?
       degree_form.errors.attribute_names
     end

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -45,7 +45,7 @@ class TraineeForm
   def missing_fields
     return [] if valid?
 
-    errors.attribute_names
+    [errors.attribute_names]
   end
 
 private

--- a/app/view_objects/mappable_field_row.rb
+++ b/app/view_objects/mappable_field_row.rb
@@ -12,7 +12,7 @@ class MappableFieldRow
     @field_label = options[:field_label]
     @action_url = options[:action_url]
     @has_errors = options[:has_errors]
-    @text = options[:text] || "not recognised"
+    @text = options[:text]
     @apply_draft = options[:apply_draft] || false
   end
 

--- a/app/view_objects/missing_data_view.rb
+++ b/app/view_objects/missing_data_view.rb
@@ -15,15 +15,17 @@ class MissingDataView
 
   def missing_items_content
     @missing_items_content ||= safe_join(
-      missing_fields.map do |field|
-        tag.li(
-          link_to(
-            I18n.t("views.missing_data_view.missing_field_text", missing_field: get_display_name(field)),
-            "##{get_display_name(field).parameterize}",
-            class: "govuk-notification-banner__link",
-          ),
-        )
-      end.uniq,
+      missing_fields.map.with_index(1) do |fieldset, index|
+        fieldset.map do |field|
+          tag.li(
+            link_to(
+              I18n.t("views.missing_data_view.missing_field_text", missing_field: get_display_name(field)),
+              get_link_anchor(field, index),
+              class: "govuk-notification-banner__link",
+            ),
+          )
+        end.uniq
+      end,
     )
   end
 
@@ -34,6 +36,12 @@ class MissingDataView
 private
 
   attr_reader :form_instance, :missing_fields
+
+  def get_link_anchor(field, index)
+    return "##{get_display_name(field).parameterize}" if missing_fields.size == 1
+
+    "##{get_display_name(field).parameterize}-#{index}"
+  end
 
   def get_display_name(field)
     I18n.t("views.missing_data_view.missing_fields_mapping.#{field}")

--- a/spec/view_objects/mappable_field_row_spec.rb
+++ b/spec/view_objects/mappable_field_row_spec.rb
@@ -19,6 +19,7 @@ describe MappableFieldRow do
         field_name: field_name,
         field_value: field_value,
         field_label: field_label,
+        text: "not recognised",
         action_url: action_url,
         has_errors: has_errors,
         apply_draft: true,


### PR DESCRIPTION
### Context
Followup to https://github.com/DFE-Digital/register-trainee-teachers/pull/1250
For situations with multiple missing information items, this PR ensures that the links reference the correct section.

![image](https://user-images.githubusercontent.com/910019/128679061-40162047-22e0-4575-a4f9-5c5cbbf03a2d.png)

### Changes proposed in this pull request
1. Add a suffix to each attribute anchor where we have multiple items, eg, in a degrees section.

### Guidance to review

