### PR TITLE
[2417] Handle missing data for funding confirm page

### DIFF
--- a/app/components/funding/view.html.erb
+++ b/app/components/funding/view.html.erb
@@ -2,5 +2,5 @@
   trainee: trainee,
   title: title,
   heading_level: 2,
-  rows: rows,
+  rows: funding_detail_rows,
 ) %>

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -43,7 +43,7 @@ module Trainees
       when "schools"
         Schools::FormValidator
       when "funding"
-        ::Funding::TrainingInitiativesForm
+        ::Funding::FormValidator
       else
         "#{trainee_section_key.underscore.camelcase}Form".constantize
       end

--- a/app/forms/funding/form_validator.rb
+++ b/app/forms/funding/form_validator.rb
@@ -21,7 +21,21 @@ module Funding
       @fields = bursary_form_fields.merge(training_initiatives_form_fields)
     end
 
+    def missing_fields
+      bursary_forms.flat_map do |form|
+        form.valid?
+        form.errors.attribute_names
+      end
+    end
+
   private
+
+    def bursary_forms
+      [
+        training_initiatives_form,
+        (bursary_form if trainee.can_apply_for_bursary?),
+      ].compact
+    end
 
     def validate_bursary
       errors.add(:applying_for_bursary, :inclusion) unless bursary_form.valid?

--- a/app/view_objects/mappable_field_row.rb
+++ b/app/view_objects/mappable_field_row.rb
@@ -31,7 +31,7 @@ private
   end
 
   def action_attribute
-    return {} if field_value.nil?
+    return {} if field_value.nil? || action_url.nil?
 
     html = %(Change <span class="govuk-visually-hidden">#{field_label.downcase}</span>).html_safe
     { action: govuk_link_to(html, action_url) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,18 @@ en:
     view:
       address: &address Address
       email: &email_address Email address
+  funding:
+    view:
+      title: Funding
+      training_initiative: &training_initiative Training initiative
+      bursary_funding: &bursary_funding Bursary funding
+      bursary_applied_for: Bursary applied for
+      no_bursary_applied_for: Not bursary funded
+      no_bursary_available: No bursaries available for this course
+      tiered_bursary_applied_for:
+        tier_one: Applied for Tier 1
+        tier_two: Applied for Tier 2
+        tier_three: Applied for Tier 3
   components:
     heading:
       apply_draft:
@@ -413,6 +425,8 @@ en:
         main_age_range: *course_age_range
         itt_start_date: *itt_start_date
         itt_end_date: *itt_end_date
+        training_initiative: *training_initiative
+        applying_for_bursary: *bursary_funding
     trainees:
       index:
         no_records: Your trainee records will appear here. You do not have any records yet.
@@ -670,18 +684,6 @@ en:
       summary_title: Schools
       lead_school: Lead school
       employing_school: Employing school
-  funding:
-    view:
-      title: Funding
-      training_initiative: Training initiative
-      bursary_funding: Bursary funding
-      bursary_applied_for: Bursary applied for
-      no_bursary_applied_for: Not bursary funded
-      no_bursary_available: No bursaries available for this course
-      tiered_bursary_applied_for:
-        tier_one: Applied for Tier 1
-        tier_two: Applied for Tier 2
-        tier_three: Applied for Tier 3
   trainees:
     not_supported_route:
       heading: Other routes not supported

--- a/spec/forms/funding/form_validator_spec.rb
+++ b/spec/forms/funding/form_validator_spec.rb
@@ -129,5 +129,29 @@ module Funding
         end
       end
     end
+
+    describe "#missing_fields" do
+      let(:trainee) { build(:trainee) }
+
+      subject { described_class.new(trainee).missing_fields }
+
+      context "when valid" do
+        let(:trainee) { build(:trainee, :with_funding, applying_for_bursary: false) }
+
+        it { is_expected.to eq([]) }
+      end
+
+      context "with invalid TrainingInitiativesForm form" do
+        it { is_expected.to eq([:training_initiative]) }
+      end
+
+      context "with invalid TrainingInitiativesForm and Bursary form" do
+        before do
+          allow(trainee).to receive(:bursary_amount).and_return(1)
+        end
+
+        it { is_expected.to eq(%i[training_initiative applying_for_bursary]) }
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/7yY51giW/2417-s-missing-information-ui-funding-section

### Changes proposed in this pull request

Handles missing data for the bursary sections.

If you can't apply for a bursary and come to this page:

<img width="1120" alt="Screenshot 2021-08-09 at 15 39 18" src="https://user-images.githubusercontent.com/616080/128725113-4c691b2e-2822-4c8a-bef5-74c07614c2dc.png">

If you can apply for a bursary and come to this page:

<img width="1196" alt="Screenshot 2021-08-09 at 15 44 30" src="https://user-images.githubusercontent.com/616080/128725611-f44830a3-b85e-4934-a46b-3bb482ecb647.png">

If you can apply for a bursary but have only completed the first part and then arrived on this page:

<img width="1138" alt="Screenshot 2021-08-09 at 15 39 56" src="https://user-images.githubusercontent.com/616080/128725229-40a02c19-ec4c-4c15-95cc-e405e1c2b03d.png">

### Guidance to review

