### PR TITLE
[2440] Reduce field width of subject fields

### DIFF
--- a/app/components/form_components/autocomplete/style.scss
+++ b/app/components/form_components/autocomplete/style.scss
@@ -1,5 +1,51 @@
 @import "../../base.scss";
 
+@mixin autocomplete-set-width($max-width) {
+  // Explicitly set font size on container so ex units work
+  // Assumes all autocompletes are default size.
+  // This matches govuk fixed width inputs which scale with
+  // font size.
+  @include govuk-font(19);
+
+  // Set on govuk-selects and autocompletes (clear and non-clear)
+  // There is no one selector currently we can target, so we target
+  // both, then unset where we don't need.
+  .govuk-select,
+  .autocomplete__wrapper,
+  .autocomplete-select-with-clear {
+    max-width: $max-width !important;
+  }
+
+  // Unset on autocompletes clear button is used
+  // Easier to unset than to have more complex selector above
+  .autocomplete-select-with-clear .autocomplete__wrapper {
+    max-width: inherit !important;
+  }
+}
+
+// Custom width overrides so inputs can be fixed width regardless of resolution.
+@include govuk-media-query($from: tablet) {
+  .app-\!-autocomplete--max-width-three-quarters {
+    @include autocomplete-set-width(50ex);
+  }
+
+  .app-\!-autocomplete--max-width-two-thirds {
+    @include autocomplete-set-width(44ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-half {
+    @include autocomplete-set-width(33ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-third {
+    @include autocomplete-set-width(22ex);
+  }
+
+  .app-\!-autocomplete--max-width-one-quarter {
+    @include autocomplete-set-width(17ex);
+  }
+}
+
 .autocomplete__wrapper {
   @include govuk-typography-common();
   position: relative;

--- a/app/components/form_components/autocomplete/view.rb
+++ b/app/components/form_components/autocomplete/view.rb
@@ -16,7 +16,7 @@ module FormComponents
     private
 
       def default_classes
-        %w[]
+        %w[app-!-autocomplete--max-width-two-thirds]
       end
 
       def default_html_attributes


### PR DESCRIPTION
### Context
https://trello.com/c/GX9OzgHH/2440-s-general-snagging-field-width-for-course-details-subject

### Changes proposed in this pull request
- Change width of surrounding container using a exisiting ulility class

### Before
<img width="599" alt="Screenshot 2021-08-11 at 16 48 46" src="https://user-images.githubusercontent.com/28728/129061481-bfc07b6a-79db-489e-b26d-4db5064cfdc0.png">


### After
<img width="600" alt="Screenshot 2021-08-11 at 16 47 45" src="https://user-images.githubusercontent.com/28728/129061359-bbd0c922-7520-4c66-a10e-3283eb9ebfff.png">