### PR TITLE
[2492] Switch on funding section in prod

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -29,6 +29,7 @@ features:
   persist_to_dttp: true
   import_courses_from_ttapi: true
   publish_course_details: true
+  show_funding: true
   routes:
     early_years_assessment_only: true
     early_years_postgrad: true


### PR DESCRIPTION
### Context

https://trello.com/c/ldWoOSnZ/2492-turn-on-funding-in-prod

### Changes proposed in this pull request

Switch on showing the funding section in production, collecting the data from users on Register.

**This does not switch on sending funding to DTTP** - the work for this is still outstanding. When the work is completed, we can switch on the separate flag `send_funding_to_dttp`.

At that point we will have to re-sync any trainees for which we have collected funding information with DTTP.

### Guidance to review

🚢 