### PR TITLE
[2483] Set correct env var to use as the host in the production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST") }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
### Context

Set correct env var to use as the host in the production.rb