### PR TITLE
[2418] Handle missing data for schools

### DIFF
--- a/app/components/school_details/view.rb
+++ b/app/components/school_details/view.rb
@@ -20,5 +20,14 @@ module SchoolDetails
         employing: edit_trainee_employing_schools_path(trainee),
       }[school_type.to_sym]
     end
+
+    def mappable_field(field_value, field_label, section_url)
+      MappableFieldRow.new(
+        field_value: field_value,
+        field_label: field_label,
+        text: t("components.confirmation.missing"),
+        action_url: section_url,
+      ).to_h
+    end
   end
 end

--- a/app/components/schools/view.rb
+++ b/app/components/schools/view.rb
@@ -8,8 +8,8 @@ module Schools
     def initialize(data_model:, has_errors: false)
       @data_model = data_model
       @has_errors = has_errors
-      @lead_school = trainee.lead_school
-      @employing_school = trainee.employing_school
+      @lead_school = fetch_lead_school
+      @employing_school = fetch_employing_school
     end
 
     def trainee
@@ -18,13 +18,41 @@ module Schools
 
   private
 
-    attr_accessor :data_model, :lead_school, :employing_school
+    attr_accessor :data_model, :lead_school, :employing_school, :has_errors
 
     def change_paths(school_type)
       {
         lead: edit_trainee_lead_schools_path(trainee),
         employing: edit_trainee_employing_schools_path(trainee),
       }[school_type.to_sym]
+    end
+
+    def mappable_field(field_value, field_label, section_url)
+      MappableFieldRow.new(
+        field_value: field_value,
+        field_label: field_label,
+        text: t("components.confirmation.missing"),
+        action_url: section_url,
+        has_errors: has_errors,
+      ).to_h
+    end
+
+    def fetch_lead_school
+      return data_model.lead_school if data_model.respond_to?(:lead_school)
+
+      fetch_school(data_model.lead_school_id)
+    end
+
+    def fetch_employing_school
+      return data_model.employing_school if data_model.respond_to?(:employing_school)
+
+      fetch_school(data_model.employing_school_id)
+    end
+
+    def fetch_school(id)
+      return if id.blank?
+
+      School.find(id)
     end
   end
 end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -2,6 +2,9 @@
 
 module Trainees
   class ConfirmDetailsController < ApplicationController
+    SCHOOLS_KEY = "schools"
+    FUNDING_KEY = "funding"
+
     before_action :authorize_trainee
 
     helper_method :trainee_section_key
@@ -12,7 +15,7 @@ module Trainees
 
       if trainee.draft?
         @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.public_send(trainee_section_key))
-        @missing_data_view = MissingDataView.new(form_klass.new(trainee))
+        @missing_data_view = MissingDataView.new(form_instance)
       end
 
       @confirmation_component = component_klass.new(data_model: trainee.draft? ? trainee : form_klass.new(trainee))
@@ -40,13 +43,17 @@ module Trainees
 
     def form_klass
       case trainee_section_key
-      when "schools"
+      when SCHOOLS_KEY
         Schools::FormValidator
-      when "funding"
+      when FUNDING_KEY
         ::Funding::FormValidator
       else
         "#{trainee_section_key.underscore.camelcase}Form".constantize
       end
+    end
+
+    def form_instance
+      trainee_section_key == SCHOOLS_KEY ? form_klass.new(trainee, non_search_validation: true) : form_klass.new(trainee)
     end
 
     # Returns the route that the confirm path is nested under for each confirm path

--- a/app/forms/schools/form_validator.rb
+++ b/app/forms/schools/form_validator.rb
@@ -21,12 +21,28 @@ module Schools
       @fields = lead_school_form_fields.merge(employing_school_form_fields)
     end
 
+    def missing_fields
+      [
+        school_forms.flat_map do |form|
+          form.valid?
+          form.errors.attribute_names
+        end,
+      ]
+    end
+
     def save!
       lead_school_form.save!
       employing_school_form.save!
     end
 
   private
+
+    def school_forms
+      [
+        (lead_school_form if trainee.requires_schools?),
+        (employing_school_form if trainee.requires_employing_school?),
+      ].compact
+    end
 
     def validate_lead_school
       errors.add(:lead_school_id, :not_valid) unless lead_school_form.valid?

--- a/app/helpers/school_helper.rb
+++ b/app/helpers/school_helper.rb
@@ -6,7 +6,7 @@ module SchoolHelper
   end
 
   def school_detail(school)
-    return t(:answer_missing) unless school
+    return unless school
 
     tag.p(school.name, class: "govuk-body") + tag.span(school_urn_and_location(school), class: "govuk-hint")
   end
@@ -16,24 +16,20 @@ module SchoolHelper
   end
 
   def lead_school_row
-    {
-      key: t("components.school_details.lead_school_key"),
-      value: school_detail(lead_school),
-      action: change_link(:lead),
-    }
+    mappable_field(
+      school_detail(lead_school),
+      t("components.school_details.lead_school_key"),
+      change_paths(:lead),
+    )
   end
 
   def employing_school_row
     return unless trainee.requires_employing_school?
 
-    {
-      key: t("components.school_details.employing_school_key"),
-      value: school_detail(employing_school),
-      action: change_link(:employing),
-    }
-  end
-
-  def change_link(school_type)
-    govuk_link_to("Change<span class='govuk-visually-hidden'> #{school_type} school</span>".html_safe, change_paths(school_type))
+    mappable_field(
+      school_detail(employing_school),
+      t("components.school_details.employing_school_key"),
+      change_paths(:employing),
+    )
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,11 @@ en:
         tier_one: Applied for Tier 1
         tier_two: Applied for Tier 2
         tier_three: Applied for Tier 3
+  schools:
+    view:
+      summary_title: Schools
+      lead_school: &lead_school Lead school
+      employing_school: &employing_school Employing school
   components:
     heading:
       apply_draft:
@@ -442,6 +447,8 @@ en:
         grade: *grade
         graduation_year: *graduation_year
         country: *country
+        lead_school_id: *lead_school
+        employing_school_id: *employing_school
     trainees:
       index:
         no_records: Your trainee records will appear here. You do not have any records yet.
@@ -694,11 +701,6 @@ en:
       subject:
         one: Subject
         other: Subjects
-  schools:
-    view:
-      summary_title: Schools
-      lead_school: Lead school
-      employing_school: Employing school
   trainees:
     not_supported_route:
       heading: Other routes not supported

--- a/spec/components/school_details/view_spec.rb
+++ b/spec/components/school_details/view_spec.rb
@@ -4,28 +4,22 @@ require "rails_helper"
 
 module SchoolDetails
   describe View do
-    alias_method :component, :page
-
     shared_examples("school row") do |field_name|
-      subject do
-        component.find(".govuk-summary-list__row.#{field_name.parameterize}")
-      end
-
       it "renders the school type" do
-        expect(subject).to have_text(field_name.humanize)
+        expect(rendered_component).to have_text(field_name.humanize)
       end
 
       it "renders the school name" do
-        expect(subject).to have_text(school.name)
+        expect(rendered_component).to have_text(school.name)
       end
 
       it "renders the school location" do
         expected_location_format = "URN #{school.urn}, #{school.town}, #{school.postcode}"
-        expect(subject).to have_text(expected_location_format)
+        expect(rendered_component).to have_text(expected_location_format)
       end
 
       it "renders the school change link" do
-        expect(subject).to have_link(t("change"))
+        expect(rendered_component).to have_link(t("change"))
       end
     end
 

--- a/spec/components/schools/view_preview.rb
+++ b/spec/components/schools/view_preview.rb
@@ -8,20 +8,25 @@ module Schools
       render(View.new(data_model: mock_trainee))
     end
 
+    def with_employing_school
+      render(View.new(data_model: mock_trainee(with_employing_school: true, route: TRAINING_ROUTE_ENUMS[:school_direct_salaried])))
+    end
+
     def with_no_data
-      render(View.new(data_model: Trainee.new(id: 2, training_route: TRAINING_ROUTE_ENUMS[:assessment_only], lead_school: mock_school)))
+      render(View.new(data_model: Trainee.new(id: 2, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])))
     end
 
   private
 
-    def mock_trainee
-      @mock_trainee ||= Trainee.new(
+    def mock_trainee(with_employing_school: false, route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee])
+      Trainee.new(
         id: 1,
         course_subject_one: "Primary",
         course_age_range: [3, 11],
         course_start_date: Date.new(2020, 0o1, 28),
-        training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+        training_route: route,
         lead_school: mock_school,
+        employing_school: with_employing_school ? mock_school : nil,
       )
     end
 

--- a/spec/forms/schools/form_validator_spec.rb
+++ b/spec/forms/schools/form_validator_spec.rb
@@ -123,6 +123,56 @@ module Schools
           end
         end
       end
+
+      describe "#missing_fields" do
+        let(:trainee) { build(:trainee, :school_direct_tuition_fee) }
+
+        subject { described_class.new(trainee).missing_fields }
+
+        context "when valid" do
+          it { is_expected.to eq([[]]) }
+        end
+
+        context "with invalid LeadSchoolForm form", "feature_routes.school_direct_tuition_fee": true do
+          let(:lead_school_form) do
+            instance_double(
+              Schools::LeadSchoolForm,
+              fields: nil,
+              lead_school_id: nil,
+              non_search_validation: true,
+              errors: double(attribute_names: [:lead_school_id]),
+            )
+          end
+
+          before do
+            allow(Schools::LeadSchoolForm).to receive(:new).and_return(lead_school_form)
+            allow(lead_school_form).to receive(:valid?).and_return(false)
+          end
+
+          it { is_expected.to include([:lead_school_id]) }
+
+          context "with invalid LeadSchoolForm and EmployingSchoolForm form", "feature_routes.school_direct_tuition_fee": true, "feature_routes.school_direct_salaried": true do
+            let(:employing_school_form) do
+              instance_double(
+                Schools::EmployingSchoolForm,
+                fields: nil,
+                employing_school_id: nil,
+                non_search_validation: true,
+                errors: double(attribute_names: [:employing_school_id]),
+              )
+            end
+
+            let(:trainee) { build(:trainee, :school_direct_salaried) }
+
+            before do
+              allow(Schools::EmployingSchoolForm).to receive(:new).and_return(employing_school_form)
+              allow(employing_school_form).to receive(:valid?).and_return(false)
+            end
+
+            it { is_expected.to include(%i[lead_school_id employing_school_id]) }
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/eVYW7z0X/2418-s-missing-information-ui-schools-section

### Changes proposed in this pull request

- Updates schools view component to handle missing data
- Populate missing fields on the schools validator
- Fix stashing behaviour when updating schools to handle the correct data model

If only lead school is required:

<img width="1152" alt="Screenshot 2021-08-11 at 16 44 55" src="https://user-images.githubusercontent.com/616080/129069375-32218dc1-12c6-492a-b50a-26e47e488c02.png">

If both schools required but only one is filled out:

<img width="1259" alt="Screenshot 2021-08-11 at 16 43 57" src="https://user-images.githubusercontent.com/616080/129069411-f038ed32-f85f-4f50-a1bb-e3809c2e1b62.png">

If both schools are required and both are missing:

<img width="1198" alt="Screenshot 2021-08-11 at 16 44 37" src="https://user-images.githubusercontent.com/616080/129069445-09ed59af-5755-4cbb-92e1-35ada30e7db4.png">

### Guidance to review

