### PR TITLE
[2329] Study mode for apply trainees

### DIFF
--- a/app/components/apply_applications/confirm_course/view.rb
+++ b/app/components/apply_applications/confirm_course/view.rb
@@ -8,6 +8,8 @@ module ApplyApplications
 
       attr_accessor :trainee, :course, :specialisms, :itt_start_date
 
+      delegate :requires_study_mode?, :itt_route?, to: :trainee
+
       def initialize(trainee:, course:, specialisms:, itt_start_date:)
         @trainee = trainee
         @course = course
@@ -36,7 +38,8 @@ module ApplyApplications
           { key: t(".age_range"), value: age_range },
           { key: t(".#{itt_route? ? 'itt' : 'course'}_start_date"), value: start_date },
           { key: t(".duration"), value: duration },
-        ]
+          ({ key: t(".study_mode"), value: @trainee.study_mode.humanize } if requires_study_mode?),
+        ].compact
       end
 
       def course_details
@@ -69,10 +72,6 @@ module ApplyApplications
       end
 
     private
-
-      def itt_route?
-        trainee.itt_route?
-      end
 
       def subject_key
         course.subjects.count > 1 ? t(".multiple_subjects") : t(".subject")

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -38,6 +38,7 @@ module Trainees
         course_code: course&.code,
         training_route: course&.route,
         disabilities: disabilities,
+        study_mode: study_mode,
       }.merge(address)
     end
 
@@ -137,6 +138,10 @@ module Trainees
 
     def raw_course
       @raw_course ||= application.application_attributes["course"]
+    end
+
+    def study_mode
+      @study_mode ||= TRAINEE_STUDY_MODE_ENUMS[raw_course["study_mode"]]
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,6 +412,7 @@ en:
         course_end_date: &course_end_date Course end date
         duration: Duration
         course_details: Course details
+        study_mode: Full time or part time
   views:
     all_records: All records
     apply_invalid_data_view:

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -103,7 +103,7 @@ namespace :example_data do
         # And for all possible trainee states...
         Trainee.states.keys.map(&:to_sym).each do |state|
           # Create small number of trainees
-          sample_size = rand(1...4)
+          sample_size = rand(4...8)
 
           sample_size.times do |sample_index|
             attrs = { created_at: Faker::Date.between(from: 100.days.ago, to: 50.days.ago) }

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -36,6 +36,7 @@ module Trainees
         email: contact_details["email"],
         training_route: course.route,
         course_code: course.code,
+        study_mode: "full_time",
       }
     end
 

--- a/spec/support/shared_examples/rendering_course_confirmation.rb
+++ b/spec/support/shared_examples/rendering_course_confirmation.rb
@@ -51,15 +51,27 @@ RSpec.shared_examples "rendering course confirmation" do
       expect(rendered_component).to have_text("#{course.duration_in_years} years")
     end
 
-    if described_class == ConfirmPublishCourse::View
-      it "renders study_mode" do
-        expect(rendered_component).to have_selector(".govuk-summary-list__row.full-time-or-part-time .govuk-summary-list__key", text: "Full time or part time")
-      end
+    it "renders study_mode" do
+      expect(rendered_component).to have_selector(".govuk-summary-list__row.full-time-or-part-time .govuk-summary-list__key", text: "Full time or part time")
+    end
 
-      it "renders the selected study_mode" do
-        expect(rendered_component).to have_selector(".govuk-summary-list__row.full-time-or-part-time .govuk-summary-list__value", text: "Full time")
+    it "renders the selected study_mode" do
+      expect(rendered_component).to have_selector(".govuk-summary-list__row.full-time-or-part-time .govuk-summary-list__value", text: "Full time")
+    end
+
+    if described_class == ConfirmPublishCourse::View
+      it "renders 7 rows on the confirmation page" do
+        expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 7)
       end
     else
+      it "renders 8 rows on the confirmation page" do
+        expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 8)
+      end
+    end
+
+    context "non study mode training route" do
+      let(:trainee) { build(:trainee, :assessment_only) }
+
       it "does not render study_mode" do
         expect(rendered_component).not_to have_selector(".govuk-summary-list__row.full-time-or-part-time .govuk-summary-list__key", text: "Full time or part time")
       end
@@ -67,10 +79,16 @@ RSpec.shared_examples "rendering course confirmation" do
       it "does not render the selected study_mode" do
         expect(rendered_component).not_to have_selector(".govuk-summary-list__row.full-time-or-part-time .govuk-summary-list__value", text: "Full time")
       end
-    end
 
-    it "renders 7 rows on the confirmation page" do
-      expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 7)
+      if described_class == ConfirmPublishCourse::View
+        it "renders 6 rows on the confirmation page" do
+          expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 6)
+        end
+      else
+        it "renders 7 rows on the confirmation page" do
+          expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 7)
+        end
+      end
     end
 
     context "with itt_start_date set" do


### PR DESCRIPTION
### Context
Study mode for apply trainees

### Changes proposed in this pull request
When importing an `Apply trainee` also import study mode onto trainee 


### Guidance to review

https://www.apply-for-teacher-training.service.gov.uk/api-docs/reference

![image](https://user-images.githubusercontent.com/470137/129181033-b7edfbc4-c329-46f3-9fb2-0d371659c864.png)

requires https://github.com/DFE-Digital/register-trainee-teachers/pull/1249