### PR TITLE
[2494] Handle missing data for trainee progress card

### DIFF
--- a/app/components/record_details/view.html.erb
+++ b/app/components/record_details/view.html.erb
@@ -1,26 +1,6 @@
-<%= render SummaryCard::View.new(trainee: trainee,
-                                 title: "Trainee progress",
-                                 heading_level: 2,
-                                 rows: [
-    {
-      key: "Trainee ID",
-      value: trainee_id,
-      action: govuk_link_to('Change<span class="govuk-visually-hidden"> trainee ID</span>'.html_safe, edit_trainee_trainee_id_path(trainee)),
-    },
-    trn_row,
-    trainee_progress_row,
-    trainee_status_row,
-    {
-      key: "Last updated",
-      value: last_updated_date,
-    },
-    {
-      key: "Record created",
-      value: date_for_summary_view(trainee.created_at),
-    },
-    {
-      key: "Trainee start date",
-      value: trainee_start_date,
-      action: govuk_link_to('Change<span class="govuk-visually-hidden"> start date</span>'.html_safe, edit_trainee_start_date_path(trainee)),
-    },
-  ].compact) %>
+<%= render SummaryCard::View.new(
+  trainee: trainee,
+  title: "Trainee progress",
+  heading_level: 2,
+  rows: record_detail_rows
+) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,21 @@ en:
       summary_title: Schools
       lead_school: &lead_school Lead school
       employing_school: &employing_school Employing school
+  record_details:
+    view:
+      trainee_id: Trainee ID
+      submitted_for_trn: Submitted for TRN
+      trainee_status: Trainee status
+      last_updated: Last updated
+      record_created: Record created
+      trainee_start_date: Trainee start date
+      trn: TRN
+      progress_date_prefix:
+        recommended_for_award: "Recommended: "
+        awarded: "Awarded: "
+      status_date_prefix:
+        deferred: "Deferral date: "
+        withdrawn: "Withdrawal date: "
   components:
     heading:
       apply_draft:
@@ -164,13 +179,6 @@ en:
     incomplete_section:
       degree_details_not_provided: Degree details not provided
       add_degree_details: Add degree details
-    record_details:
-      progress_date_prefix:
-        recommended_for_award: "Recommended: "
-        awarded: "Awarded: "
-      status_date_prefix:
-        deferred: "Deferral date: "
-        withdrawn: "Withdrawal date: "
     itt_start_date:
       hint: The start date of the Initial Teacher Training part of their course.
     page_titles:

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -19,8 +19,8 @@ module RecordDetails
         render_inline(View.new(trainee: trainee, last_updated_event: timeline_event))
       end
 
-      it "tells the user that no data has been entered for trainee ID" do
-        expect(rendered_component).to have_text(t("components.confirmation.not_provided"))
+      it "tells the user that the data is missing" do
+        expect(rendered_component).to have_text(t("components.confirmation.missing"))
       end
     end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/VJMp2jqa/2416-s-missing-information-ui-training-details-section

### Changes proposed in this pull request

Applies missing data pattern for non draft summary card (Trainee progress).

<img width="1182" alt="Screenshot 2021-08-12 at 14 10 08" src="https://user-images.githubusercontent.com/616080/129204049-ce8be20b-9e22-4483-b5e0-9485557ee2ee.png">

### Guidance to review

https://register-pr-1264.london.cloudapps.digital/trainees/sxgt2p3Mv7qjkv18qHhnxaT4 (select Provider A)