### PR TITLE
[2498] Map "Not Provided" gender to "Other" in DTTP

### DIFF
--- a/app/lib/dttp/params/contact.rb
+++ b/app/lib/dttp/params/contact.rb
@@ -5,11 +5,13 @@ module Dttp
     class Contact
       include Mappable
 
+      OTHER_GENDER_CODE = 389_040_000
+
       GENDER_CODES = {
         male: 1,
         female: 2,
-        other: 389_040_000,
-        gender_not_provided: nil,
+        other: OTHER_GENDER_CODE,
+        gender_not_provided: OTHER_GENDER_CODE,
       }.freeze
 
       TRAINEE_CONTACT_TYPE_DTTP_ID = "faba11c7-07d9-e711-80e1-005056ac45bb"

--- a/spec/lib/dttp/params/contact_spec.rb
+++ b/spec/lib/dttp/params/contact_spec.rb
@@ -72,6 +72,16 @@ module Dttp
           end
         end
 
+        context "when gender is gender_not_provided" do
+          let(:trainee) { create(:trainee, :completed, gender: "gender_not_provided", provider: provider) }
+
+          it "maps gender to other" do
+            expect(subject).to include({
+              "gendercode" => Dttp::Params::Contact::GENDER_CODES[:other],
+            })
+          end
+        end
+
         context "diversity information" do
           let(:dttp_ethnicity_entity_id) { Dttp::CodeSets::Ethnicities::MAPPING[ethnic_background][:entity_id] }
           let(:dttp_disability_entity_id) { Dttp::CodeSets::Disabilities::MAPPING[dttp_disability][:entity_id] }


### PR DESCRIPTION
### Context
Use "Other" instead of "Not Provided" when sending trainee info over to DTTP.

### Changes proposed in this pull request
Use the same DTTP value for other and not provided.


