### PR TITLE
Fix flaky spec due to trainee#withdraw_date

### DIFF
--- a/spec/components/withdrawal_details/view_spec.rb
+++ b/spec/components/withdrawal_details/view_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe WithdrawalDetails::View do
   include SummaryHelper
 
-  let(:trainee) { build(:trainee, :withdrawn_on_another_day, id: 1) }
+  let(:trainee) { build(:trainee, :with_withdrawal_date, id: 1) }
   let(:withdraw_date) { trainee.withdraw_date }
   let(:withdraw_reason) { nil }
   let(:additional_withdraw_reason) { nil }

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -2,8 +2,12 @@
 
 FactoryBot.define do
   factory :abstract_trainee, class: "Trainee" do
+    transient do
+      potential_course_start_date { course_start_date || Faker::Date.between(from: 10.years.ago, to: Time.zone.today) }
+    end
+
     sequence :trainee_id do |n|
-      year = (course_start_date || Faker::Date.between(from: 10.years.ago, to: Time.zone.today)).strftime("%y").to_i
+      year = potential_course_start_date.strftime("%y").to_i
 
       "#{year}/#{year + 1}-#{n}"
     end
@@ -227,9 +231,13 @@ FactoryBot.define do
       state { "recommended_for_award" }
     end
 
+    trait :with_withdrawal_date do
+      withdraw_date { Faker::Date.between(from: potential_course_start_date, to: potential_course_start_date + 1.year) }
+    end
+
     trait :withdrawn do
       trn_received
-      withdraw_date { Faker::Date.in_date_period }
+      with_withdrawal_date
       state { "withdrawn" }
     end
 
@@ -277,17 +285,13 @@ FactoryBot.define do
       dormancy_dttp_id { SecureRandom.uuid }
     end
 
-    trait :withdrawn_on_another_day do
-      withdraw_date { Faker::Date.in_date_period }
-    end
-
     trait :withdrawn_for_specific_reason do
-      withdraw_date { Time.zone.today }
+      with_withdrawal_date
       withdraw_reason { WithdrawalReasons::SPECIFIC.sample }
     end
 
     trait :withdrawn_for_another_reason do
-      withdraw_date { Faker::Date.in_date_period }
+      with_withdrawal_date
       withdraw_reason { WithdrawalReasons::FOR_ANOTHER_REASON }
       additional_withdraw_reason { Faker::Lorem.paragraph }
     end

--- a/spec/forms/deferral_form_spec.rb
+++ b/spec/forms/deferral_form_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 describe DeferralForm, type: :model do
-  let(:user) { create(:user) }
   let(:trainee) { create(:trainee, :deferred) }
   let(:form_store) { class_double(FormStore) }
 


### PR DESCRIPTION
### Context
This flaky spec occurs (or at least, one of the ways to consistently reproduce it is) when `withdraw_date` is before `course_start_date`, as that fails [this validation](https://github.com/DFE-Digital/register-trainee-teachers/blob/8152172248e9ed672a5965fe7324600069ab6605/app/forms/multi_date_form.rb#L90-L92)

### Changes proposed in this pull request
Ensure that the `withdraw_date` is _always_ after `course_start_date`

### Guidance to review
1. Change [this line](https://github.com/DFE-Digital/register-trainee-teachers/pull/1276/files#diff-d5bf2b27c5376d38d33850883479ee552e995dd83db79df992120055636ce8d3R235) to be a date before course_start_date, eg:
```ruby
withdraw_date { Faker::Date.between(from: potential_course_start_date - 2.years, to: potential_course_start_date) }
```
2. run `bundle exec rspec spec/forms/withdrawal_form_spec.rb` to reproduce a consistent failure.
