### PR TITLE
[2512] Remove redundant property from schools validator fields

### DIFF
--- a/app/forms/schools/form_validator.rb
+++ b/app/forms/schools/form_validator.rb
@@ -18,7 +18,7 @@ module Schools
       @trainee = trainee
       @lead_school_form = LeadSchoolForm.new(trainee, params: { non_search_validation: non_search_validation })
       @employing_school_form = EmployingSchoolForm.new(trainee, params: { non_search_validation: non_search_validation })
-      @fields = lead_school_form_fields.merge(employing_school_form_fields)
+      @fields = lead_school_form_fields.merge(employing_school_form_fields).except(:non_search_validation)
     end
 
     def missing_fields


### PR DESCRIPTION
### Context

- https://trello.com/c/5WhjBOXP/2512-snaggy-snags-school-routes-new-draft-trainee-shows-school-section-in-progress

### Changes proposed in this pull request

- Fixes a small regression where schools section status would say `in progress` for a new empty draft trainee.

### Guidance to review

- Fire up a new schools trainee, assert status is `incomplete`

