### PR TITLE
Ensure deferral/withdrawal dates are picked after course_start_date

### DIFF
--- a/spec/features/trainee_actions/defer_trainee_spec.rb
+++ b/spec/features/trainee_actions/defer_trainee_spec.rb
@@ -86,7 +86,7 @@ feature "Deferring a trainee", type: :feature do
   end
 
   def and_i_enter_a_valid_date
-    @chosen_date = Faker::Date.in_date_period
+    @chosen_date = valid_date_after_course_start_date
     @chosen_date.tap do |defer_date|
       deferral_page.set_date_fields(:defer_date, defer_date.strftime("%d/%m/%Y"))
     end

--- a/spec/features/trainee_actions/recording_training_outcome_spec.rb
+++ b/spec/features/trainee_actions/recording_training_outcome_spec.rb
@@ -69,7 +69,7 @@ feature "Recording a training outcome", type: :feature do
     end
 
     scenario "and filling out a valid date" do
-      when_i_chose_a_specific_date
+      and_i_enter_a_valid_date
       and_i_continue
       then_i_am_redirected_to_the_confirm_outcome_details_page
       and_i_see_my_date(@outcome_date)
@@ -105,8 +105,8 @@ feature "Recording a training outcome", type: :feature do
     confirm_outcome_details_page.record_outcome.click
   end
 
-  def when_i_chose_a_specific_date
-    @outcome_date = Faker::Date.in_date_period
+  def and_i_enter_a_valid_date
+    @outcome_date = valid_date_after_course_start_date
     stub_dttp_placement_assignment_request(outcome_date: @outcome_date, status: 204)
     outcome_date_edit_page.set_date_fields("outcome_date", @outcome_date.strftime("%d/%m/%Y"))
   end

--- a/spec/features/trainee_actions/reinstating_a_trainee_spec.rb
+++ b/spec/features/trainee_actions/reinstating_a_trainee_spec.rb
@@ -86,7 +86,7 @@ feature "Reinstating a trainee", type: :feature do
   end
 
   def and_i_enter_a_valid_date
-    @chosen_date = Faker::Date.in_date_period
+    @chosen_date = valid_date_after_course_start_date
     @chosen_date.tap do |reinstate_date|
       reinstatement_page.set_date_fields(:reinstate_date, reinstate_date.strftime("%d/%m/%Y"))
     end

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -131,7 +131,7 @@ feature "Withdrawing a trainee", type: :feature do
   end
 
   def and_i_enter_a_valid_date
-    @chosen_date = Faker::Date.in_date_period
+    @chosen_date = valid_date_after_course_start_date
     @chosen_date.tap do |withdraw_date|
       withdrawal_page.set_date_fields(:withdraw_date, withdraw_date.strftime("%d/%m/%Y"))
     end

--- a/spec/support/features/training_details_steps.rb
+++ b/spec/support/features/training_details_steps.rb
@@ -16,5 +16,9 @@ module Features
       training_details_page.set_date_fields(:commencement_date, Date.tomorrow.strftime("%d/%m/%Y"))
       training_details_page.submit_button.click
     end
+
+    def valid_date_after_course_start_date
+      Faker::Date.between(from: trainee.course_start_date, to: trainee.course_start_date + 1.year)
+    end
   end
 end


### PR DESCRIPTION
### Context
Like https://github.com/DFE-Digital/register-trainee-teachers/pull/1276, but for a few feature specs.

### Guidance to review
To reproduce consistently, change https://github.com/DFE-Digital/register-trainee-teachers/pull/1279/files#diff-4542f56b4800da01aa2acbfafe87de73f462b66adc0328fac7a013c945267b64R21 line to a date before `course_start_date`, eg
```ruby
trainee.course_start_date - 1.day
```
2. See failures when running the four spec files edited in this PR, as the form expects a date _after_ `course_start_date`

