### PR TITLE
Filter empty drafts from HomeView count

### DIFF
--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -6,7 +6,7 @@ class HomeView
                                     eyts_awarded].freeze
 
   def initialize(trainees)
-    @trainees = trainees
+    @trainees = Trainees::Filter.call(trainees: trainees, filters: {})
     populate_state_counts!
   end
 
@@ -25,14 +25,16 @@ class HomeView
   end
 
   def draft_apply_trainees_count
-    @trainees.draft.with_apply_application.count
+    trainees.draft.with_apply_application.count
   end
 
 private
 
+  attr_reader :trainees
+
   def populate_state_counts!
     defaults = Trainee.states.keys.index_with { 0 }
-    counts = @trainees.group(:state).count.reverse_merge(defaults)
+    counts = trainees.group(:state).count.reverse_merge(defaults)
 
     if eyts_trainees? == qts_trainees?
       counts["awarded"] ||= 0
@@ -55,14 +57,10 @@ private
   end
 
   def eyts_trainees?
-    return @_eyts_trainees if defined?(@_eyts_trainees)
-
-    @_eyts_trainees = @trainees.with_award_states("eyts_recommended", "eyts_awarded").count.positive?
+    @eyts_trainees ||= trainees.with_award_states("eyts_recommended", "eyts_awarded").count.positive?
   end
 
   def qts_trainees?
-    return @_qts_trainees if defined?(@_qts_trainees)
-
-    @_qts_trainees = @trainees.with_award_states("qts_recommended", "qts_awarded").count.positive?
+    @qts_trainees ||= trainees.with_award_states("qts_recommended", "qts_awarded").count.positive?
   end
 end

--- a/spec/view_objects/home_view_spec.rb
+++ b/spec/view_objects/home_view_spec.rb
@@ -3,12 +3,14 @@
 require "rails_helper"
 
 describe HomeView do
+  let(:draft_trainee) { create(:trainee, :draft) }
+
   subject { described_class.new(trainees) }
 
   describe "#state_counts" do
     context "no trainees in award states" do
       let(:trainees) do
-        trainee_id = create(:trainee, :draft).id
+        trainee_id = draft_trainee.id
         Trainee.where(id: trainee_id)
       end
 
@@ -104,7 +106,7 @@ describe HomeView do
   describe "#registered_trainees_count" do
     let(:trainees) do
       trainee_ids = [
-        create(:trainee, :draft).id,
+        draft_trainee.id,
         create(:trainee, :assessment_only, :awarded).id,
         create(:trainee, :early_years_undergrad, :awarded).id,
       ]
@@ -119,7 +121,7 @@ describe HomeView do
   describe "#draft_trainees_count" do
     let(:trainees) do
       trainee_ids = [
-        create(:trainee, :draft).id,
+        draft_trainee.id,
         create(:trainee, :assessment_only, :awarded).id,
         create(:trainee, :early_years_undergrad, :awarded).id,
       ]
@@ -129,12 +131,26 @@ describe HomeView do
     it "returns the number of trainees in draft states" do
       expect(subject.draft_trainees_count).to eq(1)
     end
+
+    context "with empty trainee exists" do
+      let(:trainees) do
+        trainee_ids = [
+          draft_trainee.id,
+          Trainee.create!(provider: draft_trainee.provider, training_route: TRAINING_ROUTE_ENUMS[:assessment_only]).id,
+        ]
+        Trainee.where(id: trainee_ids)
+      end
+
+      it "does not include empty trainees" do
+        expect(subject.draft_trainees_count).to eq(1)
+      end
+    end
   end
 
   describe "#draft_apply_trainees_count" do
     let(:trainees) do
       trainee_ids = [
-        create(:trainee, :draft).id,
+        draft_trainee.id,
         create(:trainee, :draft, :with_apply_application).id,
         create(:trainee, :awarded, :with_apply_application).id,
       ]


### PR DESCRIPTION
### Context
Filter empty drafts on the Home page, to match the count in the trainee listing.
![image](https://user-images.githubusercontent.com/910019/129374394-c125c89b-dc87-4904-b701-a41393984902.png)

### Changes proposed in this pull request
Use the `Trainees::Filter` to ensure that the empty trainee records are filtered out.

### Guidance to review
#### Before this change:
 1. Start a draft, completed a section then changed route (wiped out all data)
 2. Expect that the home page draft count is increased by 1
#### After this change. 
1. Repeat step 1 above
2. Expect that the home page draft count is not changed.



