### PR TITLE
[2514] do not store CSV export url in back link

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -103,6 +103,8 @@ private
   end
 
   def save_filter
+    return if request.format.csv?
+
     FilteredBackLink::Tracker.new(session: session, href: trainees_path).save_path(request.fullpath)
   end
 


### PR DESCRIPTION
### Context

https://trello.com/c/diGvXMBv/2514-trainees-csv-export-action-is-stored-in-back-link

### Changes proposed in this pull request

* If action is CSV, do not save URL for back link

### Guidance to review

* Go to trainees list
* Export CSV
* Click into trainee
* Click back link (does it go back to trainees list or does it run CSV export?)
