### PR TITLE
[2411] Future Teaching Scholars DTTP mapping

### DIFF
--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -12,6 +12,8 @@ module Dttp
         TRAINING_ROUTE_ENUMS[:early_years_postgrad] => { entity_id: "6789922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => { entity_id: "6589922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => { entity_id: "cf9154ee-5678-e811-80f6-005056ac45bb" },
+        # DTTP recognise future_teaching_scholars as a route not an initiative, hence this 'odd' mapping.
+        ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars] => { entity_id: "e7b6efbc-8d96-ea11-a811-000d3ab55801" },
       }.freeze
     end
   end

--- a/app/lib/dttp/code_sets/training_initiatives.rb
+++ b/app/lib/dttp/code_sets/training_initiatives.rb
@@ -3,11 +3,12 @@
 module Dttp
   module CodeSets
     module TrainingInitiatives
+      # DTTP recognise future_teaching_scholars as a route not an initiative,
+      # hence there is no mapping. See Dttp::CodeSets::Routes.
       MAPPING = {
         ROUTE_INITIATIVES_ENUMS[:transition_to_teach] => { entity_id: "544a6435-e2af-ea11-a812-000d3ab55801" },
         ROUTE_INITIATIVES_ENUMS[:now_teach] => { entity_id: "04516b48-e2af-ea11-a812-000d3ab55801" },
         ROUTE_INITIATIVES_ENUMS[:maths_physics_chairs_programme_researchers_in_schools] => { entity_id: "6a08fd3f-276e-e711-80d2-005056ac45bb" },
-        ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars] => { entity_id: "" },
       }.freeze
     end
   end

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -136,9 +136,10 @@ module Dttp
 
       def dttp_recognised_initiative?
         [
-          ROUTE_INITIATIVES_ENUMS[:no_initiative],
-          ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars],
-        ].exclude?(trainee.training_initiative)
+          ROUTE_INITIATIVES_ENUMS[:transition_to_teach],
+          ROUTE_INITIATIVES_ENUMS[:now_teach],
+          ROUTE_INITIATIVES_ENUMS[:maths_physics_chairs_programme_researchers_in_schools],
+        ].include?(trainee.training_initiative)
       end
     end
   end

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -23,7 +23,7 @@ module Dttp
         if contact_change_set_id
           @params.merge!({
             "dfe_ContactId@odata.bind" => "$#{contact_change_set_id}",
-            "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id(trainee.training_route)})",
+            "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id(training_route)})",
           })
         end
       end
@@ -54,7 +54,7 @@ module Dttp
         .merge(qualifying_degree.uk? ? uk_specific_params : non_uk_specific_params)
         .merge(school_params)
         .merge(subject_params)
-        .merge(funding_params)
+        .merge(training_initiative_param)
       end
 
       def course_level
@@ -110,8 +110,8 @@ module Dttp
         { "dfe_ITTSubject3Id@odata.bind" => "/dfe_subjects(#{course_subject_id(trainee.course_subject_three)})" }
       end
 
-      def funding_params
-        return {} unless send_funding_to_dttp? && trainee.training_initiative != ROUTE_INITIATIVES_ENUMS[:no_initiative]
+      def training_initiative_param
+        return {} unless send_funding_to_dttp? && dttp_recognised_initiative?
 
         {
           "dfe_initiative1id_value" => "/dfe_initiatives(#{training_initiative_id(trainee.training_initiative)})",
@@ -126,6 +126,19 @@ module Dttp
         return ACADEMIC_YEAR_2020_2021 if trainee.course_start_date.between?(Date.parse("1/8/2020"), Date.parse("31/7/2021"))
         return ACADEMIC_YEAR_2021_2022 if trainee.course_start_date.between?(Date.parse("1/8/2021"), Date.parse("31/7/2022"))
         return ACADEMIC_YEAR_2022_2023 if trainee.course_start_date.between?(Date.parse("1/8/2022"), Date.parse("31/7/2023"))
+      end
+
+      def training_route
+        return trainee.training_initiative if trainee.future_teaching_scholars?
+
+        trainee.training_route
+      end
+
+      def dttp_recognised_initiative?
+        [
+          ROUTE_INITIATIVES_ENUMS[:no_initiative],
+          ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars],
+        ].exclude?(trainee.training_initiative)
       end
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/sT9mKfas/2411-m-funding-add-future-teaching-scholars-initiative-dttp-mapping

### Changes proposed in this pull request

DTTP recognise Future Teaching Scholars as a route, but we want to continue collecting it from users as a training initiative.

This PR does two things to allow this to happen. If a trainee is on Future Teaching Scholars initiative:
1.  Does not attempt to send to DTTP as a training initiative (there is nothing to map it to).
2. Sends the trainees training route as future_teaching_scholars regardless of what actual route they are on.

### Guidance to review