### PR TITLE
[2518] Pull in all dttp schools but filter on active

### DIFF
--- a/app/lib/dttp/mappable.rb
+++ b/app/lib/dttp/mappable.rb
@@ -59,7 +59,7 @@ module Dttp
     end
 
     def dttp_school_id(urn)
-      Dttp::School.find_by(urn: urn)&.dttp_id
+      Dttp::School.active.find_by!(urn: urn)&.dttp_id
     end
 
     def training_initiative_id(training_initiative)

--- a/app/lib/dttp/parsers/account.rb
+++ b/app/lib/dttp/parsers/account.rb
@@ -20,6 +20,7 @@ module Dttp
               name: school["name"],
               urn: school["dfe_urn"],
               dttp_id: school["accountid"],
+              status_code: school["statuscode"],
             }
           end
         end

--- a/app/models/dttp/school.rb
+++ b/app/models/dttp/school.rb
@@ -3,5 +3,18 @@
 module Dttp
   class School < ApplicationRecord
     self.table_name = "dttp_schools"
+
+    STATUS_CODES = {
+      active: 1,
+      inactive: 2,
+      closed: 300000002,
+      new: 300000007,
+      open_closing: 300000000,
+      notification_to_close: 300000005,
+      pnp_active: 300000003,
+      proposed_to_open: 300000008,
+    }.freeze
+
+    scope :active, -> { where(status_code: STATUS_CODES[:active]) }
   end
 end

--- a/app/services/dttp/retrieve_schools.rb
+++ b/app/services/dttp/retrieve_schools.rb
@@ -5,24 +5,19 @@ module Dttp
     include ServicePattern
     include SyncPattern
 
-    FILTER = {
-      "$filter" => "dfe_provider eq false",
-    }.freeze
-
     SELECT = {
       "$select" => %w[
         name
         dfe_urn
         accountid
+        statuscode
       ].join(","),
     }.freeze
-
-    QUERY = FILTER.merge(SELECT).to_query
 
   private
 
     def default_path
-      @default_path ||= "/accounts?#{QUERY}"
+      @default_path ||= "/accounts?#{SELECT.to_query}"
     end
   end
 end

--- a/db/migrate/20210816104942_add_status_code_to_dttp_schools.rb
+++ b/db/migrate/20210816104942_add_status_code_to_dttp_schools.rb
@@ -1,0 +1,5 @@
+class AddStatusCodeToDttpSchools < ActiveRecord::Migration[6.1]
+  def change
+    add_column :dttp_schools, :status_code, :integer
+  end
+end

--- a/db/migrate/20210816104942_add_status_code_to_dttp_schools.rb
+++ b/db/migrate/20210816104942_add_status_code_to_dttp_schools.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddStatusCodeToDttpSchools < ActiveRecord::Migration[6.1]
   def change
     add_column :dttp_schools, :status_code, :integer

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_09_143338) do
+ActiveRecord::Schema.define(version: 2021_08_16_104942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -215,6 +215,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_143338) do
     t.string "urn"
     t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.integer "status_code"
     t.index ["dttp_id"], name: "index_dttp_schools_on_dttp_id", unique: true
   end
 
@@ -250,8 +251,8 @@ ActiveRecord::Schema.define(version: 2021_08_09_143338) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.string "code"
     t.boolean "apply_sync_enabled", default: false
+    t.string "code"
     t.string "ukprn"
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end

--- a/spec/factories/dttp/schools.rb
+++ b/spec/factories/dttp/schools.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     end
     dttp_id { SecureRandom.uuid }
     urn { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
+
+    trait :active do
+      status_code { Dttp::School::STATUS_CODES[:active] }
+    end
   end
 end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -247,16 +247,29 @@ module Dttp
                    provider: provider)
           end
 
-          before do
-            create(:dttp_school, dttp_id: dttp_lead_school_id, urn: trainee.lead_school.urn)
+          context "with a valid school" do
+            before do
+              create(:dttp_school, :active, dttp_id: dttp_lead_school_id, urn: trainee.lead_school.urn)
+            end
+
+            subject { described_class.new(trainee).params }
+
+            it "sets the lead school DTTP param" do
+              expect(subject).to include({
+                "dfe_LeadSchoolId@odata.bind" => "/accounts(#{dttp_lead_school_id})",
+              })
+            end
           end
 
-          subject { described_class.new(trainee).params }
+          context "with an invalid school" do
+            before do
+              create(:dttp_school)
+            end
 
-          it "sets the lead school DTTP param" do
-            expect(subject).to include({
-              "dfe_LeadSchoolId@odata.bind" => "/accounts(#{dttp_lead_school_id})",
-            })
+            it "raises an active record error" do
+              expect { described_class.new(trainee).params }.to raise_error(ActiveRecord::RecordNotFound)
+            end
+
           end
         end
 
@@ -273,8 +286,8 @@ module Dttp
           end
 
           before do
-            create(:dttp_school, dttp_id: dttp_lead_school_id, urn: trainee.lead_school.urn)
-            create(:dttp_school, dttp_id: dttp_employing_school_id, urn: trainee.employing_school.urn)
+            create(:dttp_school, :active, dttp_id: dttp_lead_school_id, urn: trainee.lead_school.urn)
+            create(:dttp_school, :active, dttp_id: dttp_employing_school_id, urn: trainee.employing_school.urn)
           end
 
           subject { described_class.new(trainee).params }

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -269,7 +269,6 @@ module Dttp
             it "raises an active record error" do
               expect { described_class.new(trainee).params }.to raise_error(ActiveRecord::RecordNotFound)
             end
-
           end
         end
 

--- a/spec/models/dttp/school_spec.rb
+++ b/spec/models/dttp/school_spec.rb
@@ -2,8 +2,26 @@
 
 require "rails_helper"
 
-RSpec.describe Dttp::School, type: :model do
-  subject { create(:dttp_school) }
+module Dttp
+  describe School, type: :model do
+    subject { create(:dttp_school) }
 
-  it { is_expected.to have_db_index(:dttp_id) }
+    it { is_expected.to have_db_index(:dttp_id) }
+
+    describe ".active" do
+      let(:active_dttp_school) { create(:dttp_school, :active) }
+
+      subject { described_class.active }
+
+      before do
+        active_dttp_school
+        create(:dttp_school)
+      end
+
+      it "returns only active schools" do
+        expect(subject.count).to eq(1)
+        expect(subject).to include(active_dttp_school)
+      end
+    end
+  end
 end

--- a/spec/services/dttp/retrieve_schools_spec.rb
+++ b/spec/services/dttp/retrieve_schools_spec.rb
@@ -6,7 +6,7 @@ module Dttp
   describe RetrieveSchools do
     let(:request_uri) { nil }
     let(:expected_path) do
-      "/accounts?%24filter=dfe_provider+eq+false&%24select=name%2Cdfe_urn%2Caccountid"
+      "/accounts?%24select=name%2Cdfe_urn%2Caccountid%2Cstatuscode"
     end
     let(:request_headers) { { headers: { "Prefer" => "odata.maxpagesize=5000" } } }
     let(:http_response) { { status: 200, body: { value: [1, 2, 3], "@odata.nextLink": "https://example.com" }.to_json } }


### PR DESCRIPTION
### Context

https://trello.com/b/BBEuhbHM/publish-register-sprint-board

### Changes proposed in this pull request

In order to reduce some of the Sentry noise related to missing school data, we've decided to pull in the entire list of dttp schools into our look up table.

We're also filtering these on a new field `statuscode` (active) which is used to map the status of the dttp school account . This is to reduce the duplicate URNs.

We've also decided to raise if we can't find a school to use so we can intervene manually.

### Guidance to review

It's quite tricky to test this but you'll have to pull down the dttp school prod data locally using the sidekiq job and interrogate the data. I was able to find a URN for a job that's failing in prod at the moment.
