### PR TITLE
[XXXX] Fix trainee status translation

### DIFF
--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -107,7 +107,7 @@ module RecordDetails
     def status_date
       return unless trainee_status_date
 
-      I18n.t(".status_date_prefix.#{trainee.state}") + date_for_summary_view(trainee_status_date)
+      I18n.t("record_details.view.status_date_prefix.#{trainee.state}") + date_for_summary_view(trainee_status_date)
     end
 
     def trainee_progress_date

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -67,6 +67,10 @@ module RecordDetails
         it "renders the trainee withdrawal date" do
           expect(rendered_component).to have_text(date_for_summary_view(trainee.withdraw_date))
         end
+
+        it "renders the trainee state" do
+          expect(rendered_component).to have_text(I18n.t("record_details.view.status_date_prefix.#{trainee.state}"))
+        end
       end
 
       context "when trainee state is recommended_for_award" do


### PR DESCRIPTION
### Context

Fix trainee status translation

### Guidance to review

- Navigate to a deferred/withdrawn record and click on it 
- Check that the deferral/withdrawal state is displayed by the date

### Before

![image](https://user-images.githubusercontent.com/50492247/129591250-1e1cdf00-322e-4e79-ac98-a7be366793d5.png)


### After

![image](https://user-images.githubusercontent.com/50492247/129591056-17b043bb-9aba-4ad1-b3bf-187bf096d12a.png)


