### PR TITLE
[2507] & [2432] - A few niggles

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -2,6 +2,7 @@
 
 class CourseDetailsForm < TraineeForm
   include CourseFormHelpers
+  include DatesHelper
 
   FIELDS = %i[
     course_subject_one
@@ -171,7 +172,7 @@ private
 
   def new_date(date_hash)
     date_args = date_hash.values.map(&:to_i)
-    Date.valid_date?(*date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+    valid_date?(date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
   end
 
   def age_range_valid

--- a/app/forms/multi_date_form.rb
+++ b/app/forms/multi_date_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MultiDateForm < TraineeForm
-  include TrainingDatesHelper
+  include DatesHelper
 
   attr_accessor :day, :month, :year, :date_string
 
@@ -77,7 +77,7 @@ private
     date_hash = { year: year, month: month, day: day }
     date_args = date_hash.values.map(&:to_i)
 
-    Date.valid_date?(*date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+    valid_date?(date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
   end
 
   def date_valid

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PersonalDetailsForm < TraineeForm
+  include DatesHelper
+
   FIELDS = %i[
     first_names
     middle_names
@@ -37,7 +39,7 @@ class PersonalDetailsForm < TraineeForm
     date_hash = { year: year, month: month, day: day }
     date_args = date_hash.values.map(&:to_i)
 
-    Date.valid_date?(*date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+    valid_date?(date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
   end
 
   def save!

--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TraineeStartDateForm < TraineeForm
-  include TrainingDatesHelper
+  include DatesHelper
 
   attr_accessor :day, :month, :year
 
@@ -46,10 +46,6 @@ private
     elsif date_before_course_start_date?(commencement_date, trainee.course_start_date)
       errors.add(:commencement_date, :not_before_course_start_date)
     end
-  end
-
-  def valid_date?(date_args)
-    Date.valid_date?(*date_args) && date_args.all?(&:positive?)
   end
 
   def fields_from_store

--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TrainingDetailsForm < TraineeForm
-  include TrainingDatesHelper
+  include DatesHelper
 
   COMMENCEMENT_DATE_RADIO_OPTION_COURSE = "course"
   COMMENCEMENT_DATE_RADIO_OPTION_MANUAL = "manual"
@@ -71,9 +71,5 @@ private
 
   def commencement_date_year_is_four_digits
     errors.add(:commencement_date, :invalid_year) if commencement_date.is_a?(Date) && commencement_date.year.digits.length != 4
-  end
-
-  def valid_date?(date_args)
-    Date.valid_date?(*date_args) && date_args.all?(&:positive?)
   end
 end

--- a/app/helpers/dates_helper.rb
+++ b/app/helpers/dates_helper.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-module TrainingDatesHelper
+module DatesHelper
   def date_before_course_start_date?(commencement_date, course_start_date)
     return false if course_start_date.blank?
 
     commencement_date < course_start_date
+  end
+
+  def valid_date?(date_args)
+    Date.valid_date?(*date_args) && date_args.all?(&:positive?)
   end
 end

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.trainee_start_date.edit") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.trainee_start_date.edit", has_errors: @trainee_start_date_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -6,7 +6,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with model: @trainee_start_date_form, url: trainee_start_date_path, local: true do |f| %>
+    <%= register_form_with(model: @trainee_start_date_form, url: trainee_start_date_path, local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
       <%= f.govuk_date_field :commencement_date, legend: {
         text: t("views.forms.start_dates.commencement_date.label"), size: "l", tag: "h1"
       }, hint: { text: t("views.forms.start_dates.commencement_date.hint") } %>

--- a/app/views/trainees/trainee_ids/edit.html.erb
+++ b/app/views/trainees/trainee_ids/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.trainee_ids.edit") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.trainee_ids.edit", has_errors: @trainee_id_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -6,7 +6,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with model: @trainee_id_form, url: trainee_trainee_id_path, local: true do |f| %>
+    <%= register_form_with(model: @trainee_id_form, url: trainee_trainee_id_path, local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
       <%= f.govuk_text_field :trainee_id,
                              label: { text: "Trainee ID", tag: "h1", size: "l" },
                              width: 20,


### PR DESCRIPTION
### Context

- https://trello.com/c/FkfxElIY/2507-form-pages-missing-error-summaries
- https://trello.com/c/aWpvIPuC/2432-if-you-leave-the-year-field-blank-when-it-errors-the-field-is-filled-with-0

### Changes proposed in this pull request

- Fixes a few issues outlined in the tickets above

### Guidance to review

Trainee ID & Start date forms

- View an existing non draft trainee, enter an invalid value for one of those forms and assert the error summary is shown (and the title reflects)

Dates

- Submit a personal details form for a non draft trainee with an empty year
- Assert the year field is still empty post validation

