### PR TITLE
[2524] Bugs with publish study mode

### DIFF
--- a/app/controllers/concerns/publish_course_next_path.rb
+++ b/app/controllers/concerns/publish_course_next_path.rb
@@ -4,7 +4,13 @@ module PublishCourseNextPath
   def publish_course_next_path
     if trainee.requires_itt_start_date?
       edit_trainee_course_details_itt_start_date_path(trainee)
-    elsif requires_study_mode?
+    else
+      study_mode_or_confirmation_path
+    end
+  end
+
+  def study_mode_or_confirmation_path
+    if requires_study_mode?
       edit_trainee_course_details_study_mode_path(trainee)
     else
       course_confirmation_path

--- a/app/controllers/trainees/itt_start_dates_controller.rb
+++ b/app/controllers/trainees/itt_start_dates_controller.rb
@@ -14,7 +14,7 @@ module Trainees
       @itt_start_date_form = IttStartDateForm.new(trainee, params: trainee_params, user: current_user)
 
       if @itt_start_date_form.stash
-        redirect_to course_confirmation_path
+        redirect_to study_mode_or_confirmation_path
       else
         render :edit
       end
@@ -28,6 +28,10 @@ module Trainees
         .transform_keys do |key|
           MultiDateForm::PARAM_CONVERSION.fetch(key, key)
         end.merge({ date_string: :other })
+    end
+
+    def course_code
+      publish_course_details_form.code
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/study_modes_controller.rb
+++ b/app/controllers/trainees/study_modes_controller.rb
@@ -7,7 +7,7 @@ module Trainees
     before_action :authorize_trainee
 
     def edit
-      @study_mode_form = StudyModesForm.new(trainee)
+      @study_mode_form = StudyModesForm.new(trainee, params: { study_mode: nil })
     end
 
     def update

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -39,7 +39,6 @@ class TrainingRouteManager
 
     [
       TRAINING_ROUTE_ENUMS[:assessment_only],
-      TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
       TRAINING_ROUTE_ENUMS[:opt_in_undergrad],
       TRAINING_ROUTE_ENUMS[:hpitt_postgrad],
     ].exclude?(training_route)

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -22,15 +22,19 @@ FactoryBot.define do
     end
 
     factory :course_with_subjects do
-      study_mode { "full_time" }
       transient do
         subjects_count { 1 }
         subject_names { [] }
+        study_mode { "full_time" }
       end
 
       before(:create) do |course, evaluator|
         if evaluator.subject_names.any?
           course.name = evaluator.subject_names.join(" and ")
+        end
+
+        if evaluator.study_mode.present?
+          course.study_mode = evaluator.study_mode
         end
       end
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -302,13 +302,15 @@ FactoryBot.define do
       transient do
         courses_count { 5 }
         subject_names { [] }
+        study_mode { "full_time" }
       end
 
       after(:create) do |trainee, evaluator|
         create_list(:course_with_subjects, evaluator.courses_count,
                     subject_names: evaluator.subject_names,
                     accredited_body_code: trainee.provider.code,
-                    route: trainee.training_route)
+                    route: trainee.training_route,
+                    study_mode: evaluator.study_mode)
 
         trainee.reload
       end

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -7,6 +7,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
 
   let(:subjects) { [] }
   let(:training_route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
+  let(:study_mode) { "full_time" }
 
   background do
     given_i_am_authenticated
@@ -162,7 +163,30 @@ feature "publish course details", type: :feature, feature_publish_course_details
           then_i_see_the_confirm_publish_course_page
         end
 
-        scenario "with invalid itt start date" do
+        context "course study_mode is full_time_or_part_time" do
+          let(:study_mode) { "full_time_or_part_time" }
+          let(:with_valid_itt_start_date) { "with valid itt start date" }
+
+          context "with study_mode off", feature_course_study_mode: false do
+            scenario :with_valid_itt_start_date do
+              then_i_see_the_itt_start_date_edit_page
+              and_i_set_itt_start_date("1/01/2020")
+              and_i_continue
+              then_i_see_the_confirm_publish_course_page
+            end
+          end
+
+          context "with study_mode on", feature_course_study_mode: true do
+            scenario :with_valid_itt_start_date do
+              then_i_see_the_itt_start_date_edit_page
+              and_i_set_itt_start_date("9/09/2020")
+              and_i_continue
+              then_i_see_the_study_mode_edit_page
+            end
+          end
+        end
+
+        scenario :with_valid_itt_start_date do
           then_i_see_the_itt_start_date_edit_page
           and_i_set_itt_start_date("32/01/2020")
           and_i_continue
@@ -222,7 +246,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
   end
 
   def given_a_trainee_exists_with_some_courses(with_subjects: [], with_training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
-    given_a_trainee_exists(:with_related_courses, subject_names: with_subjects, training_route: with_training_route)
+    given_a_trainee_exists(:with_related_courses, subject_names: with_subjects, training_route: with_training_route, study_mode: study_mode)
     @matching_courses = trainee.provider.courses.where(route: trainee.training_route)
   end
 
@@ -353,6 +377,10 @@ feature "publish course details", type: :feature, feature_publish_course_details
 
   def then_i_see_the_confirm_publish_course_page
     expect(confirm_publish_course_page).to be_displayed(trainee_id: trainee.slug)
+  end
+
+  def then_i_see_the_study_mode_edit_page
+    expect(study_mode_edit_page).to be_displayed(trainee_id: trainee.slug)
   end
 
   def then_i_see_the_itt_start_date_edit_page

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -173,13 +173,13 @@ describe TrainingRouteManager do
         early_years_postgrad: false,
         early_years_salaried: false,
         early_years_undergrad: false,
-        pg_teaching_apprenticeship: false,
         opt_in_undergrad: false,
 
         provider_led_postgrad: true,
         school_direct_tuition_fee: true,
         school_direct_salaried: true,
         provider_led_undergrad: true,
+        pg_teaching_apprenticeship: true,
         hpitt_postgrad: false,
       }.each do |route, return_val|
         context "route #{route}" do

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -162,6 +162,10 @@ module Features
       @itt_start_date_page ||= PageObjects::Trainees::EditIttStartDate.new
     end
 
+    def study_mode_edit_page
+      @study_mode_edit_page ||= PageObjects::Trainees::EditStudyMode.new
+    end
+
     def trainee_id_edit_page
       @trainee_id_edit_page ||= PageObjects::Trainees::EditTraineeId.new
     end

--- a/spec/support/page_objects/trainees/edit_study_mode.rb
+++ b/spec/support/page_objects/trainees/edit_study_mode.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class EditStudyMode < PageObjects::Base
+      include PageObjects::Helpers
+      set_url "/trainees/{trainee_id}/course-details/study-mode/edit"
+    end
+  end
+end


### PR DESCRIPTION
### Context

Fixing a couple of bugs in the Publish study mode flow as outlined below. 

### Changes proposed in this pull request

- Remove `pg_teaching_apprenticeship` from the training routes which are excluded from `requires_study_mode?`
- Make `study_mode` `nil` in the edit action to prevent the answer from saving

### Guidance to review

#### For issue number 1

- Create a new trainee on the `Teaching apprenticeship (postgrad)` route
- Click on `Course details`
- Select a course which is `full_time_or_part_time` and click `Continue`
- Choose any specialism and click `Continue`
- Enter a `ITT start date` and submit
- Ensure that the `study_mode` question is asked on the next page
- Ensure you can complete the journey. 

#### For issue number 2

- Create a new trainee on a `Provider-led (postgrad)` route
- Click on `Course details`
- Select a course which is `full_time_or_part_time` and click `Continue`
- Select any `specialism` and click `Continue`
- Select `Part time` and click `Continue`
- When you get to the confirm page, click `Change course`
- Follow the journey through again selecting a different `full_time_or_part_time` course
- When you get to the `study_mode` question ensure that `Full time` or `Part time` has not already been pre selected.
