### PR TITLE
[xxx] Sandbox routes == production routes

### DIFF
--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -14,6 +14,20 @@ dfe_sign_in:
 
 features:
   basic_auth: false
+  enable_feedback_link: false
+  sync_from_dttp: true
+  send_emails: false
+  persist_to_dttp: false
+  import_courses_from_ttapi: true
+  publish_course_details: true
+  show_funding: true
+  routes:
+    early_years_assessment_only: true
+    early_years_postgrad: true
+    pg_teaching_apprenticeship: true
+    provider_led_postgrad: true
+    school_direct_salaried: true
+    school_direct_tuition_fee: true
 
 environment:
   name: sandbox


### PR DESCRIPTION
### Context

We have a sandbox environment where we can try things out in a production like environment with stable data.

### Changes proposed in this pull request

Update the feature flags for sandbox to enable the same routes as production.

### Guidance to review

Check the feature flags against `production.yml`. I've changed a couple of the non-route ones as we don't want things like email or DTTP persistence.

