### PR TITLE
Activate sentry performance monitoring

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,5 +6,7 @@ Sentry.init do |config|
     filter.filter(event.to_hash)
   end
 
+  config.traces_sample_rate = 0.5
+
   config.release = ENV["COMMIT_SHA"]
 end


### PR DESCRIPTION
### Context

Sentry will start analysing performance once a sample rate has been set in the [initialiser](https://docs.sentry.io/platforms/ruby/guides/rails/performance/) `config.traces_sample_rate`. This may need to be tweaked after a while to find the right level of reporting.

### Changes proposed in this pull request

Enables this fancy dashboard:

<img width="2342" alt="Screenshot 2021-08-18 at 16 15 20" src="https://user-images.githubusercontent.com/616080/129924517-60036978-6b10-465e-bc37-28247b75933d.png">


### Guidance to review

