### PR TITLE
[xxx] Default show_funding to true

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,7 +39,7 @@ features:
   sync_from_dttp: false
   send_emails: false
   persist_to_dttp: false
-  show_funding: false
+  show_funding: true
   send_funding_to_dttp: false
   imported_from_apply_filter: false
   placements: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,7 +6,6 @@ features:
   basic_auth: false
   import_courses_from_ttapi: true
   publish_course_details: true
-  show_funding: true
   imported_from_apply_filter: true
   enable_teach_first_provider: true
   routes:

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -29,7 +29,6 @@ features:
   persist_to_dttp: true
   import_courses_from_ttapi: true
   publish_course_details: true
-  show_funding: true
   routes:
     early_years_assessment_only: true
     early_years_postgrad: true

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -11,7 +11,6 @@ features:
   use_dfe_sign_in: false
   import_courses_from_ttapi: true
   publish_course_details: true
-  show_funding: true
   imported_from_apply_filter: true
   course_study_mode: true
   routes:

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -3,7 +3,6 @@ features:
   use_dfe_sign_in: false
   enable_feedback_link: true
   publish_course_details: true
-  show_funding: true
   persist_to_dttp: false
   imported_from_apply_filter: true
   course_study_mode: true

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -20,7 +20,6 @@ features:
   persist_to_dttp: false
   import_courses_from_ttapi: true
   publish_course_details: true
-  show_funding: true
   routes:
     early_years_assessment_only: true
     early_years_postgrad: true

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -86,6 +86,7 @@ FactoryBot.define do
 
     trait :completed do
       in_progress
+      with_funding
       nationalities { [build(:nationality)] }
       progress do
         Progress.new(

--- a/spec/features/end_to_end/pg_teaching_apprenticeship_journey_spec.rb
+++ b/spec/features/end_to_end/pg_teaching_apprenticeship_journey_spec.rb
@@ -12,6 +12,7 @@ feature "pg_teaching_apprenticeship end-to-end journey", type: :feature do
     and_the_diversity_information_is_complete
     and_the_degree_details_is_complete
     and_the_course_details_is_complete
+    and_the_funding_details_is_complete
     and_the_trainee_start_date_and_id_is_complete
     and_the_lead_and_employing_schools_section_is_complete
     and_the_draft_record_has_been_reviewed

--- a/spec/forms/trn_submission_form_spec.rb
+++ b/spec/forms/trn_submission_form_spec.rb
@@ -3,7 +3,13 @@
 require "rails_helper"
 
 describe TrnSubmissionForm, type: :model do
-  let(:trainee) { create(:trainee, :completed, progress: progress) }
+  let(:trainee) do
+    create(
+      :trainee,
+      :completed,
+      progress: progress,
+    )
+  end
 
   shared_examples "error" do
     it "is invalid and returns an error message" do
@@ -24,6 +30,7 @@ describe TrnSubmissionForm, type: :model do
           personal_details: true,
           course_details: true,
           training_details: true,
+          funding: true,
         }
       end
 
@@ -33,22 +40,14 @@ describe TrnSubmissionForm, type: :model do
       end
 
       context "requires school" do
-        let(:trainee) { create(:trainee, :school_direct_salaried, :with_lead_school, :with_employing_school, :completed, progress: progress.merge(schools: true)) }
-
-        it "is valid" do
-          expect(subject.valid?).to be true
-          expect(subject.errors).to be_empty
-        end
-      end
-
-      context "when the funding flag is on", feature_show_funding: true do
         let(:trainee) do
           create(
             :trainee,
+            :school_direct_salaried,
+            :with_lead_school,
+            :with_employing_school,
             :completed,
-            training_initiative: ROUTE_INITIATIVES_ENUMS[:transition_to_teach],
-            applying_for_bursary: false,
-            progress: progress.merge(funding: true),
+            progress: progress.merge(schools: true),
           )
         end
 
@@ -77,12 +76,6 @@ describe TrnSubmissionForm, type: :model do
 
       context "requires school but incomplete" do
         let(:trainee) { create(:trainee, :school_direct_salaried, :with_lead_school, progress: progress.merge(schools: false)) }
-
-        include_examples "error"
-      end
-
-      context "when the funding flag is on but it's incomplete", feature_show_funding: true do
-        let(:trainee) { create(:trainee, progress: progress.merge(funding: true)) }
 
         include_examples "error"
       end

--- a/spec/support/shared_examples/rendering_the_funding_section.rb
+++ b/spec/support/shared_examples/rendering_the_funding_section.rb
@@ -1,47 +1,37 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "rendering the funding section" do
-  context "when a the funding feature flag is off" do
-    let(:trainee) { create(:trainee) }
+  context "when a trainee on a route with a bursary" do
+    let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
+    let(:trainee) { create(:trainee, :draft, route) }
 
-    it "does not render the funding section" do
-      expect(rendered_component).not_to have_text("Funding")
-    end
-  end
+    before { create(:bursary, :with_bursary_subjects, training_route: route) }
 
-  context "when a the funding feature flag is on", feature_show_funding: true do
-    context "when a trainee on a route with a bursary" do
-      let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
-      let(:trainee) { create(:trainee, :draft, route) }
-
-      before { create(:bursary, :with_bursary_subjects, training_route: route) }
-
-      context "and has not entered their course details" do
-        it "renders the funding section as 'cannot start yet'" do
-          render_inline(described_class.new(trainee: trainee))
-          expect(rendered_component).to have_css "#funding-status", text: "cannot start yet"
-        end
-      end
-
-      context "and has entered their course details" do
-        before { trainee.course_subject_one = "subject" }
-
-        it "renders the funding section as 'incomplete'" do
-          render_inline(described_class.new(trainee: trainee))
-          expect(rendered_component).to have_css "#funding-status", text: "incomplete"
-        end
+    context "and has not entered their course details" do
+      it "renders the funding section as 'cannot start yet'" do
+        render_inline(described_class.new(trainee: trainee))
+        expect(rendered_component).to have_css "#funding-status", text: "cannot start yet"
       end
     end
 
-    context "when a trainee on a route with no bursary" do
-      let(:trainee) { create(:trainee, :draft, TRAINING_ROUTE_ENUMS[:assessment_only]) }
-
-      before { create(:bursary, :with_bursary_subjects, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad]) }
+    context "and has entered their course details" do
+      before { trainee.course_subject_one = "subject" }
 
       it "renders the funding section as 'incomplete'" do
         render_inline(described_class.new(trainee: trainee))
         expect(rendered_component).to have_css "#funding-status", text: "incomplete"
       end
+    end
+  end
+
+  context "when a trainee on a route with no bursary" do
+    let(:trainee) { create(:trainee, :draft, TRAINING_ROUTE_ENUMS[:assessment_only]) }
+
+    before { create(:bursary, :with_bursary_subjects, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad]) }
+
+    it "renders the funding section as 'incomplete'" do
+      render_inline(described_class.new(trainee: trainee))
+      expect(rendered_component).to have_css "#funding-status", text: "incomplete"
     end
   end
 end


### PR DESCRIPTION
### Context

The show_funding feature is on now in production. 

### Changes proposed in this pull request

Set it to default on in the base settings.yml to ensure it is enabled in all environments.

### Guidance to review

This is a bit difficult to test. Check that there aren't any rogue overrides to the default settings.yml. After deployment ensure that the funding section is visible on each env.

