### PR TITLE
[xxx] Don't reset review app DB

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -52,6 +52,11 @@ namespace :example_data do
   task generate: :environment do
     raise "THIS TASK CANNOT BE RUN IN PRODUCTION" if Rails.env.production?
 
+    if Trainee.any?
+      puts "Noop as DB already contains data"
+      exit
+    end
+
     Faker::Config.locale = "en-GB"
 
     # Base our example data on the currently switched-on feature flags

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -41,7 +41,7 @@ locals {
   app_environment = merge(var.app_config_variable, var.app_secrets_variable, {
     SETTINGS__BLAZER_DATABASE_URL = cloudfoundry_service_key.postgres-blazer-key.credentials.uri
   })
-  review_app_start_command = "bundle exec rake db:schema:load db:seed example_data:generate && bundle exec rails server -b 0.0.0.0"
+  review_app_start_command = "bundle exec rake db:migrate db:seed example_data:generate && bundle exec rails server -b 0.0.0.0"
   web_app_start_command    = var.app_environment == "review" ? local.review_app_start_command : "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "register-worker-${local.app_name_suffix}"


### PR DESCRIPTION
### Context

We want review app data to persist across app restarts.

### Changes proposed in this pull request

* Run db:migrate instead of schema_load
* Make example_data:generate noop if there is already data in the DB.

### Guidance to review

