### PR TITLE
[2535] Fix slow loading of trainees index page

### DIFF
--- a/app/services/find_empty_trainees.rb
+++ b/app/services/find_empty_trainees.rb
@@ -1,19 +1,34 @@
 # frozen_string_literal: true
 
+# This service is used to find all draft trainees that do not have any valid data for their forms and are considered to be empty.
 class FindEmptyTrainees
   include ServicePattern
+
+  EXCLUDED_FIELDS = %w[
+    created_at
+    updated_at
+    dttp_update_sha
+    progress
+    slug
+    training_route
+    id
+    provider_id
+  ].freeze
+
+  class FieldsDoNotExistError < StandardError; end
 
   attr_reader :trainees, :ids_only, :forms
 
   def initialize(trainees: Trainee.all, ids_only: false)
+    raise FieldsDoNotExistError unless exluded_fields_exist?
+
     @trainees = trainees
     @ids_only = ids_only
-    @forms = compile_progress_validation_forms
   end
 
   def call
-    trainees.draft.filter_map do |trainee|
-      if trainee_empty?(trainee)
+    draft_trainees.filter_map do |trainee|
+      if no_form_data_for?(trainee)
         ids_only ? trainee.id : trainee
       end
     end
@@ -21,14 +36,39 @@ class FindEmptyTrainees
 
 private
 
-  def trainee_empty?(trainee)
-    forms.all? do |progress_type, form|
-      progress_value = trainee.progress.public_send(progress_type)
-      ProgressService.call(validator: form.new(trainee), progress_value: progress_value).not_started?
+  def exluded_fields_exist?
+    EXCLUDED_FIELDS.all? do |field|
+      Trainee.column_names.include?(field)
     end
   end
 
-  def compile_progress_validation_forms
-    TrnSubmissionForm.form_validators.transform_values { |form_details| form_details[:form].constantize }
+  def draft_trainees
+    # Finds all the draft trainees that do not have any degrees, disabilities and nationalities.
+    trainees
+      .draft
+      .includes(:degrees, :disabilities, :nationalities)
+      .where(degrees: { id: nil }, disabilities: { id: nil }, nationalities: { id: nil })
+  end
+
+  def no_form_data_for?(trainee)
+    # Build a digest of the trainee's current form data, excluding non form related fields
+    trainee_values = trainee.serializable_hash.reject { |k, _v| EXCLUDED_FIELDS.include?(k) }.values.compact.join(",")
+
+    trainee.early_years_route? ? check_for_early_years_initial_data(trainee_values) : check_for_initial_draft_data(trainee_values)
+  end
+
+  def check_for_initial_draft_data(values)
+    # If the trainee has form related fields set, the value digest will be a long string containing all the current values
+    # otherwise we just expect it to match the state field, which would just be the value "draft"
+    values == "draft"
+  end
+
+  def check_for_early_years_initial_data(values)
+    # For an early years trainee, we expect the values to just match the initial data set when the route is selected otherwise
+    # it would have additional form data set.
+    min_age = AgeRange::ZERO_TO_FIVE.first
+    max_age = AgeRange::ZERO_TO_FIVE.last
+
+    values == "#{CourseSubjects::EARLY_YEARS_TEACHING},draft,#{min_age},#{max_age}"
   end
 end

--- a/app/services/trainees/create_timeline.rb
+++ b/app/services/trainees/create_timeline.rb
@@ -40,7 +40,7 @@ module Trainees
     # created e.g. when a user saves more than one disability for a trainee.
     # For now, just show one 'create' timeline entry.
     def grouped_audits
-      audits.group_by(&:request_uuid).map { |_, audits| audits.first }
+      audits.includes(:user).group_by(&:request_uuid).map { |_, audits| audits.first }
     end
 
     def audits

--- a/spec/services/find_empty_trainees_spec.rb
+++ b/spec/services/find_empty_trainees_spec.rb
@@ -24,4 +24,24 @@ describe FindEmptyTrainees do
 
     it { is_expected.to match_array([draft_trainee_with_no_data.id]) }
   end
+
+  context "if excluded fields have changed" do
+    before do
+      stub_const("FindEmptyTrainees::EXCLUDED_FIELDS", ["random_field"])
+    end
+
+    it "raises an error" do
+      expect { described_class.call }.to raise_error(FindEmptyTrainees::FieldsDoNotExistError)
+    end
+  end
+
+  context "for early year routes" do
+    let!(:draft_trainee_with_no_data) do
+      create(:trainee, :incomplete, :early_years_salaried)
+    end
+
+    subject { described_class.call }
+
+    it { is_expected.to match_array(draft_trainee_with_no_data) }
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/DYRiMEkl/2535-investigate-and-fix-slow-loading-of-trainees-page

### Changes proposed in this pull request

#### Issue

Our filtering logic contains a call to a service `FindEmptyTrainees` which attempts to find empty trainees (so they can be filtered out). It does this by running every form object against the progress validator to see whether it's been started or not. Some of these form objects may contain SQL calls to check some associated data (eg personal details/nationalities). Because the service loops over every trainee, the SQL call is repeated for every trainee in the set.

This is evident by the Skylight report:

<img width="1396" alt="Screenshot 2021-08-19 at 12 45 42" src="https://user-images.githubusercontent.com/616080/130063825-84f97d2b-e123-4bfb-a844-2d0f7206f8c9.png">

And the logs:

<img width="2552" alt="Screenshot 2021-08-19 at 12 53 46" src="https://user-images.githubusercontent.com/616080/130064169-600b667e-df22-42d4-ab98-d8204ce58fb8.png">

#### Suggestion

I think we can just do one SQL look up for draft trainees to find all of the drafts who have empty associated data (degrees, nationalities and disabilities) then check these trainees using a new method `new_and_empty?`. This method taps into a technique we have already which returns a digest containing all the values for section related fields concatenated. If no section has been filled out the digest will just return "draft" but if a section has been filled out, the digest will be longer (the trainee would actually be filtered out from the earlier SQL call).

This seems to still filter out draft trainees in the UI as normal and the logs now show this generated SQL:

<img width="2560" alt="Screenshot 2021-08-19 at 12 38 52" src="https://user-images.githubusercontent.com/616080/130063848-32b045b0-164b-4de2-84b2-2fb26b0cbf07.png">

### Guidance to review

Have a play with the filtering page, create some empty trainees and check that they're still being excluded by the filter
