### PR TITLE
[2517] Fix issues with erroring confirm pages

### DIFF
--- a/app/components/apply_applications/trainee_data/view.html.erb
+++ b/app/components/apply_applications/trainee_data/view.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "check_details.show") %>
+<%= render PageTitle::View.new(i18n_key: "check_details.show", has_errors: form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/view_objects/mappable_field_row.rb
+++ b/app/view_objects/mappable_field_row.rb
@@ -40,7 +40,7 @@ private
   def unmapped_value
     <<~HTML
       <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--#{has_errors ? 'error' : 'important'} app-inset-text--no_padding">
-        <p class="app-inset-text__title govuk-!-margin-bottom-2">#{field_label} is #{text}</p>
+        <p class="app-inset-text__title govuk-!-margin-bottom-2">#{error_message_prefix}#{field_label} is #{text}</p>
         #{original_value_html}
         <div>
           <a class="govuk-link govuk-link--no-visited-state app-summary-list__link--invalid" href="#{action_url}">
@@ -49,6 +49,10 @@ private
         </div>
       </div>
     HTML
+  end
+
+  def error_message_prefix
+    has_errors ? '<span class="govuk-visually-hidden">Error:</span>' : ""
   end
 
   def original_value_html

--- a/app/view_objects/missing_data_view.rb
+++ b/app/view_objects/missing_data_view.rb
@@ -39,7 +39,7 @@ private
   attr_reader :form_instance, :missing_fields
 
   def get_link_anchor(field, index)
-    return "##{get_display_name(field).parameterize}" if missing_fields.flatten.size == 1
+    return "##{get_display_name(field).parameterize}" if missing_fields.size == 1
 
     "##{get_display_name(field).parameterize}-#{index}"
   end

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "check_details.show") %>
+<%= render PageTitle::View.new(i18n_key: "check_details.show", has_errors: @form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLink.new(

--- a/app/views/trainees/confirm_details/show.html.erb
+++ b/app/views/trainees/confirm_details/show.html.erb
@@ -1,10 +1,14 @@
-<%= render PageTitle::View.new(text: t("components.confirmation.heading", section_title: confirm_section_title)) %>
+<%= render PageTitle::View.new(text: t("components.confirmation.heading", section_title: confirm_section_title), has_errors: @form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee) %>
 <% end %>
 
-<%= render ReviewSummary::View.new(form: @form, invalid_data_view: @missing_data_view) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= render ReviewSummary::View.new(form: @form, invalid_data_view: @missing_data_view) %>
+  </div>
+</div>
 
 <%= render(
   partial: "form",

--- a/app/views/trainees/diversity/confirm_details/show.html.erb
+++ b/app/views/trainees/diversity/confirm_details/show.html.erb
@@ -1,10 +1,14 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.diversity.confirm") %>
+<%= render PageTitle::View.new(i18n_key: "trainees.diversity.confirm", has_errors: @form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
-<%= render ReviewSummary::View.new(form: @form, invalid_data_view: @missing_data_view) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= render ReviewSummary::View.new(form: @form, invalid_data_view: @missing_data_view) %>
+  </div>
+</div>
 
 <%= render(
   partial: "trainees/confirm_details/form",

--- a/spec/view_objects/mappable_field_row_spec.rb
+++ b/spec/view_objects/mappable_field_row_spec.rb
@@ -57,6 +57,10 @@ describe MappableFieldRow do
         it "uses the app-inset-text--error class" do
           expect(subject[:value]).to include("app-inset-text--error")
         end
+
+        it "has a visually hidden error prefix" do
+          expect(subject[:value]).to include('<span class="govuk-visually-hidden">Error:</span>')
+        end
       end
     end
 


### PR DESCRIPTION
### Context
- Add Error: prefix to page titles:
- Fix non-working anchors in the error/info summaries
- Add visually hidden Error: against each error inset
- Add govuk-grid-column-two-thirds-from-desktop for
error summaries

### Changes proposed in this pull request

### Guidance to review
Visit confirmation pages manually (to ensure that you are presented with the errors).
Some of the fixes are visually hidden, so they would need to be inspected in the html markup.
