### PR TITLE
[2529] Fixed publish course issue due to duplicate course codes

### DIFF
--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -130,7 +130,7 @@ module CourseDetails
     end
 
     def course
-      @course ||= Course.find_by(code: data_model.course_code)
+      @course ||= trainee.available_courses.find_by(code: data_model.course_code)
     end
 
     def mappable_field(field_value, field_label)

--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -78,7 +78,7 @@ module Trainees
     end
 
     def course_subjects
-      @course_subjects ||= Course.find_by_code(@publish_course_details_form.code).subjects.map(&:name)
+      @course_subjects ||= trainee.available_courses.find_by(code: @publish_course_details_form.code).subjects.map(&:name)
     end
 
     def course_params

--- a/app/forms/confirm_publish_course_form.rb
+++ b/app/forms/confirm_publish_course_form.rb
@@ -58,6 +58,6 @@ private
   end
 
   def course
-    @course ||= Course.find_by(code: code)
+    @course ||= trainee.available_courses.find_by(code: code)
   end
 end

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -61,7 +61,7 @@ module CourseDetails
           render_inline(View.new(data_model: trainee))
         end
 
-        it "renders the incorrect course details" do
+        it "doesn't render the incorrect course details" do
           expect(rendered_component)
           .not_to have_text("#{unrelated_course.name} (#{unrelated_course.code})")
         end

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -48,15 +48,25 @@ module CourseDetails
 
     context "when data has been provided" do
       context "with a publish course", feature_publish_course_details: true do
-        let(:trainee) { create(:trainee, :with_course_details, :with_related_courses, courses_count: 1) }
-        let(:course) { instance_double("course", name: "some_name", code: "some_code") }
+        let(:trainee) { create(:trainee, :with_course_details, training_route: training_route) }
+        let(:training_route) { TRAINING_ROUTES_FOR_COURSE.keys.sample }
+
+        let(:course) { create(:course_with_subjects, code: trainee.course_code, accredited_body_code: trainee.provider.code, route: training_route) }
+
+        let(:unrelated_course) { create(:course_with_subjects, code: trainee.course_code) }
 
         before do
-          allow(Course).to receive(:find_by).with(code: trainee.course_code).and_return(course)
+          unrelated_course
+          course
           render_inline(View.new(data_model: trainee))
         end
 
-        it "renders the course details" do
+        it "renders the incorrect course details" do
+          expect(rendered_component)
+          .not_to have_text("#{unrelated_course.name} (#{unrelated_course.code})")
+        end
+
+        it "renders the correct course details" do
           expect(rendered_component)
             .to have_text("#{course.name} (#{course.code})")
         end

--- a/spec/forms/confirm_publish_course_form_spec.rb
+++ b/spec/forms/confirm_publish_course_form_spec.rb
@@ -4,10 +4,15 @@ require "rails_helper"
 
 describe ConfirmPublishCourseForm, type: :model do
   let(:params) { {} }
-  let(:trainee) { build(:trainee) }
+  let(:trainee) { create(:trainee, training_route: training_route, applying_for_bursary: true, progress: progress) }
+  let(:training_route) {
+    TRAINING_ROUTES_FOR_COURSE.keys.sample
+  }
   let(:specialisms) { [] }
   let(:itt_start_date) { nil }
   let(:course_study_mode) { nil }
+  let(:progress) { Progress.new }
+  let(:applying_for_bursary) { nil }
 
   subject { described_class.new(trainee, specialisms, itt_start_date, course_study_mode, params) }
 
@@ -16,7 +21,8 @@ describe ConfirmPublishCourseForm, type: :model do
   end
 
   context "with valid params" do
-    let(:course) { create(:course_with_subjects, subject_names: subjects) }
+    let(:course) { create(:course_with_subjects, subject_names: subjects, accredited_body_code: trainee.provider.code, route: training_route) }
+
     let(:params) { { code: course.code } }
     let(:subjects) { ["Subject 1", "Subject 2", "Subject 3"] }
 
@@ -32,9 +38,35 @@ describe ConfirmPublishCourseForm, type: :model do
     end
 
     describe "#save" do
+      context "unrelated course" do
+        let(:unrelated_subjects) { ["Subject 4", "Subject 5", "Subject 6"] }
+
+        let(:unrelated_course) do
+          create(:course_with_subjects, code: course.code, subject_names: unrelated_subjects, route: training_route,
+                                        min_age: 5,
+                                        max_age: 9,
+                                        start_date: course.start_date - 1.day)
+        end
+
+        before do
+          unrelated_course
+        end
+
+        it "does not use unrelated course" do
+          subject.save
+          expect(trainee.course_min_age).not_to eq(unrelated_course.min_age)
+          expect(trainee.course_max_age).not_to eq(unrelated_course.max_age)
+          expect(trainee.course_start_date).not_to eq(unrelated_course.start_date)
+          expect(trainee.course_end_date).not_to eq((unrelated_course.start_date + unrelated_course.duration_in_years.years).to_date.prev_day)
+          expect(trainee.course_subjects).not_to include(unrelated_subjects)
+        end
+      end
+
       it "updates all the course related attributes" do
         expect { subject.save }
-          .to change { trainee.course_subject_one }
+          .to change { trainee.course_code }
+          .from(nil).to(course.code)
+          .and change { trainee.course_subject_one }
           .from(nil).to(subject_specialism_one)
           .and change { trainee.course_subject_two }
           .from(nil).to(subject_specialism_two)
@@ -60,34 +92,38 @@ describe ConfirmPublishCourseForm, type: :model do
         end
       end
 
-      context "course study mode feature enabled", feature_course_study_mode: true do
-        context "with study_mode set" do
-          let(:trainee) { build(:trainee, :provider_led_postgrad, study_mode: nil) }
-          let(:course_study_mode) { "full_time" }
+      context "course study mode training route" do
+        let(:training_route) {
+          (TRAINING_ROUTES_FOR_COURSE.keys - ["pg_teaching_apprenticeship"]).sample
+        }
 
-          it "updates all the course related attributes and study_mode" do
-            expect { subject.save }
-              .to change { trainee.study_mode }
-              .from(nil).to(course_study_mode)
+        context "course study mode feature enabled", feature_course_study_mode: true do
+          context "with study_mode set" do
+            let(:course_study_mode) { "full_time" }
+
+            it "updates all the course related attributes and study_mode" do
+              expect { subject.save }
+                .to change { trainee.study_mode }
+                .from(nil).to(course_study_mode)
+            end
           end
         end
-      end
 
-      context "course study mode feature disabled", feature_course_study_mode: false do
-        context "with study_mode set" do
-          let(:trainee) { build(:trainee, :provider_led_postgrad, study_mode: nil) }
-          let(:course_study_mode) { "full_time" }
+        context "course study mode feature disabled", feature_course_study_mode: false do
+          context "with study_mode set" do
+            let(:course_study_mode) { "full_time" }
 
-          it "does not update study_mode" do
-            expect { subject.save }
-              .not_to(change { trainee.study_mode })
+            it "does not update study_mode" do
+              expect { subject.save }
+                .not_to(change { trainee.study_mode })
+            end
           end
         end
       end
 
       context "when the course_subject has changed" do
         let(:progress) { Progress.new(course_details: true, funding: true, personal_details: true) }
-        let(:trainee) { build(:trainee, applying_for_bursary: true, progress: progress) }
+        let(:applying_for_bursary) { true }
 
         it "nullifies the bursary information and resets funding section progress" do
           expect { subject.save }


### PR DESCRIPTION
### Context

Duplicate course codes

Course uniqueness is defined by course code and provider code

### Changes proposed in this pull request

Fixed saving non presented unrelated course onto trainee
Fixed displaying unrelated course to user when confirming the course details
Fixed specialisms unrelated course issue


### Guidance to review


As per user  journey 

1. user is shown __related__ course details
2. user confirms on the __related__ course details
3. system [saves](https://github.com/DFE-Digital/register-trainee-teacher-data/blob/2529-publish-course-issue-with-duplicate-course-codes/app/forms/confirm_publish_course_form.rb#L53-L56) the __unrelated__ course details
4. user is then shown the __unrelated__ course details along their user journey
5. Shows the user the __unrelated__ course name with all other details from __related__ course details
6. User can click change and be in the same loop
7. __unrelated__ course subjects is used to decipher specialisms.
 


Given 2 or more course with the same course code.
It will be at the database server __SOLE DISCRETION__ of returning from  __ANY ORDER__ in a __NON REPRODUCIBLE__  manner, 

ie, 1 __related__ and upto 3 __unrelated__ courses maybe in play.

![image](https://user-images.githubusercontent.com/470137/130100007-0aecf813-1476-4c9c-888c-78a5a0bf094f.png)

