### PR TITLE
[2482] Send GTM event to track failed autocomplete searches

### DIFF
--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -2,6 +2,7 @@ import './style.scss'
 import accessibleAutocomplete from 'accessible-autocomplete'
 import { nodeListForEach } from 'govuk-frontend/govuk/common'
 import sort from './sort.js'
+import tracker from '../tracker.js'
 
 const $allAutocompleteElements = document.querySelectorAll('[data-module="app-autocomplete"]')
 const defaultValueOption = component => component.getAttribute('data-default-value') || ''
@@ -40,11 +41,17 @@ const setupAutoComplete = (component) => {
     selectElement: selectEl,
     minLength: 2,
     source: (query, populateResults) => {
+      tracker.trackSearch(query)
       populateResults(sort(query, options))
     },
     autoselect: true,
     templates: { suggestion: (value) => suggestion(value, options) },
-    name: rawFieldName
+    name: rawFieldName,
+    onConfirm: (val) => {
+      tracker.sendTrackingEvent(val, selectEl.name)
+      const selectedOption = [].filter.call(selectOptions, option => (option.textContent || option.innerText) === val)[0]
+      if (selectedOption) selectedOption.selected = true
+    }
   })
 
   if (inError) {

--- a/app/components/form_components/schools_autocomplete/script.js
+++ b/app/components/form_components/schools_autocomplete/script.js
@@ -1,5 +1,6 @@
 import accessibleAutocomplete from 'accessible-autocomplete'
 import { nodeListForEach } from 'govuk-frontend/govuk/common'
+import tracker from '../tracker.js'
 
 const $allAutocompleteElements = document.querySelectorAll('[data-module="app-schools-autocomplete"]')
 const idElement = document.getElementById('school-id')
@@ -82,6 +83,7 @@ const setupAutoComplete = (form) => {
         defaultValue: defaultValueOption,
         name: fieldName,
         source: (query, populateResults) => {
+          tracker.trackSearch(query)
           return findSchools({
             query,
             populateResults,
@@ -89,7 +91,10 @@ const setupAutoComplete = (form) => {
           })
         },
         templates: renderTemplate,
-        onConfirm: setSchoolHiddenField,
+        onConfirm: (value) => {
+          tracker.sendTrackingEvent(value, fieldName)
+          setSchoolHiddenField(value)
+        },
         tNoResults: () => statusMessage
       })
 

--- a/app/components/form_components/tracker.js
+++ b/app/components/form_components/tracker.js
@@ -1,0 +1,48 @@
+function Tracker () {
+  this.searches = []
+  this.startTime = false
+
+  this.trackSearch = (query) => {
+    if (!this.startTime) { this.startTime = Date.now() }
+    this.searches.push(query)
+  }
+
+  // Push an 'autocomplete-search' event to the dataLayer with the searches and
+  // the final choice (if present).
+  this.sendTrackingEvent = (val, fieldName) => {
+    let successfulSearch
+    let timeTaken
+    const filteredSearches = this.searches.filter(s => !this._containsStringStartingWith(s))
+
+    // Record the time taken from first search to selection (or giving up).
+    if (this.startTime) { timeTaken = Date.now() - this.startTime }
+
+    // If the user selected something i.e. val !== nil, then the last tracked
+    // search counts as successful. Remove this.
+    if (val) { successfulSearch = filteredSearches.pop() }
+
+    if (filteredSearches.length > 0) {
+      window.dataLayer.push({
+        event: 'autocomplete-search',
+        fieldName: fieldName,
+        failedSearches: filteredSearches,
+        successfulSearch: successfulSearch,
+        match: val,
+        timeTaken: timeTaken
+      })
+    }
+    // Empty out the searches array.
+    this.searches.splice(0, this.searches.length)
+    this.startTime = false
+  }
+
+  // Returns true/false if any string in the array starts with the item (excluding)
+  // the item itself.
+  this._containsStringStartingWith = (item) => {
+    const newArray = [...this.searches]
+    newArray.splice(this.searches.indexOf(item), 1)
+    return newArray.some(a => a.search(item) === 0)
+  }
+}
+
+export default new Tracker()

--- a/app/webpacker/scripts/tracker.spec.js
+++ b/app/webpacker/scripts/tracker.spec.js
@@ -1,9 +1,8 @@
 import tracker from '../../components/form_components/tracker.js'
 
 describe('tracker', () => {
-
   beforeAll(() => {
-    jest.spyOn(Date, 'now').mockImplementation(() => Date.now());
+    jest.spyOn(Date, 'now').mockImplementation(() => Date.now())
   })
 
   afterAll(() => { jest.restoreAllMocks() })

--- a/app/webpacker/scripts/tracker.spec.js
+++ b/app/webpacker/scripts/tracker.spec.js
@@ -1,0 +1,74 @@
+import tracker from '../../components/form_components/tracker.js'
+
+describe('tracker', () => {
+
+  beforeAll(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => Date.now());
+  })
+
+  afterAll(() => { jest.restoreAllMocks() })
+
+  describe('trackSearch', () => {
+    it('pushes a search into the searches array', () => {
+      tracker.trackSearch('flower')
+      expect(tracker.searches).toEqual(['flower'])
+    })
+  })
+
+  describe('sendTrackingEvent', () => {
+    let mockedPush
+
+    beforeEach(() => {
+      mockedPush = jest.fn()
+      jest.spyOn(global, 'window', 'get')
+        .mockImplementation(() => ({
+          dataLayer: { push: mockedPush }
+        }))
+    })
+
+    describe('when no match is selected', () => {
+      it('sends the autocomplete-search event with the correct params', () => {
+        tracker.searches = ['fl', 'flo', 'flow', 'flowe', 'flower']
+        tracker.sendTrackingEvent(undefined, 'flower_search')
+
+        expect(mockedPush).toBeCalledWith({
+          event: 'autocomplete-search',
+          fieldName: 'flower_search',
+          failedSearches: ['flower'],
+          successfulSearch: undefined,
+          match: undefined,
+          timeTaken: undefined
+        })
+      })
+    })
+
+    describe('when a match is selected and there were previously failed searches', () => {
+      it('excludes the successful search from failedSearches, sends the successfulSearch and the match', () => {
+        tracker.searches = ['fl', 'flo', 'flow', 'flowe', 'flower', 'ro']
+        tracker.sendTrackingEvent('rose', 'flower_search')
+
+        expect(mockedPush).toBeCalledWith({
+          event: 'autocomplete-search',
+          fieldName: 'flower_search',
+          failedSearches: ['flower'],
+          successfulSearch: 'ro',
+          match: 'rose'
+        })
+      })
+    })
+
+    describe('when a match is selected and no search was failed', () => {
+      it('does not send an event', () => {
+        tracker.searches = ['fl', 'flo', 'flow', 'flowe', 'flower']
+        tracker.sendTrackingEvent('flower', 'flower_search')
+        expect(mockedPush).not.toBeCalled()
+      })
+    })
+
+    it('empties searches array', () => {
+      tracker.searches = ['fl', 'flo', 'flow', 'flowe', 'flower']
+      tracker.sendTrackingEvent('flower', 'flower_search')
+      expect(tracker.searches).toEqual([])
+    })
+  })
+})

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -25,5 +25,5 @@ environment:
 # Temporary for testing
 google_tag_manager:
   tracking_id: GTM-PD8MFNL
-  auth_id: 4QOTj7cE_XE50Z4O4MijqA
-  env_id: 47
+  auth_id: PvVHYhH8SvtYf_faEjvFXQ
+  env_id: 51

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -21,3 +21,9 @@ pagination:
 
 environment:
   name: review
+
+# Temporary for testing
+google_tag_manager:
+  tracking_id: GTM-PD8MFNL
+  auth_id: 4QOTj7cE_XE50Z4O4MijqA
+  env_id: 47


### PR DESCRIPTION
### Context

https://trello.com/c/PvHGADBh/2482-l-tracking-autocompletes-send-custom-event-to-gtm

For initial testing and write up of SPIKE see:
https://github.com/DFE-Digital/register-trainee-teachers/pull/1224

### Changes proposed in this pull request

Adds a `Tracker` with two functions that can be called from autocompletes:
- `trackSearch`, called with the user's search query. Adds the query to an array
- `sendTrackingEvent`, called with the user's final selection (if present) and the name of the field. This function:
  - Trims down the array of queries (we don't want to send every key press)
  - Pushes the data to the `dataLayer`, triggering an event `autocomplete-search` in GTM
  - Empties the array of searches

### Guidance to review

Check out the guidance in https://github.com/DFE-Digital/register-trainee-teachers/pull/1224 for getting this to run locally. With the new features in this PR you'll need two more data layer variables. In total you should have:

- `fieldName` (the name of the form field)
- `failedSearches` (searches that didn't result in a selection)
- `successfulSearch` (the search that did results in a selection)
- `match` (the selection)
- `timeTaken` (the time the user takes to select something or give up in ms from first entry)

You'll also need a Custom Event Trigger called `autocomplete-search`.