### PR TITLE
[2443] Change add-nationality-button to type="button"

### DIFF
--- a/app/webpacker/scripts/global/nationality_select.js
+++ b/app/webpacker/scripts/global/nationality_select.js
@@ -86,6 +86,7 @@ const prepareNationalitySelect = () => {
     addNationalityButton = document.createElement('button')
     addNationalityButton.innerHTML = 'Add another nationality'
     addNationalityButton.id = 'add-nationality-button'
+    addNationalityButton.type = 'button'
     addNationalityButton.classList.add(
       'govuk-button',
       'govuk-button--secondary'

--- a/app/webpacker/scripts/global/nationality_select.spec.js
+++ b/app/webpacker/scripts/global/nationality_select.spec.js
@@ -1,0 +1,28 @@
+const templateHTML = `
+<form id="personal-details-form-other-1-conditional">
+  <div class="govuk-form-group">
+    <label for="personal-details-form-other-nationality1-field">Nationality 1</label>
+    <input type="text" id="personal-details-form-other-nationality1-field">
+  </div>
+  <div class="govuk-form-group">
+    <label for="personal-details-form-other-nationality2-field">Nationality 2</label>
+    <input type="text" id="personal-details-form-other-nationality2-field">
+  </div>
+  <div class="govuk-form-group">
+    <label for="personal-details-form-other-nationality3-field">Nationality 3</label>
+    <input type="text" id="personal-details-form-other-nationality3-field">
+  </div>
+</form>`
+
+describe('Add nationality button', () => {
+  beforeAll(() => {
+    document.body.innerHTML = templateHTML
+    require('./nationality_select')
+  })
+
+  it('adds an add nationality button of type button', () => {
+    const addNationalityButton = document.body.querySelector('#add-nationality-button')
+    expect(addNationalityButton.innerHTML).toEqual('Add another nationality')
+    expect(addNationalityButton.type).toEqual('button')
+  })
+})


### PR DESCRIPTION
### Context
Due to a missing type attribute on the add-nationality button
browsers are assigning it as the [default button](https://html.spec.whatwg.org/#implicit-submission)

This was causing the button action, (in this case adding an extra
nationality input) to be triggered on pressing enter on any of the form inputs.
This change fixes the issue and ensures that the default (submit) button
would be the "Continue" button at the bottom of the page

### Guidance to review
1. Visit personal details page, and under "nationality" choose "Other"
2. In the newly visible input, add a nationality, and press Enter. Current behaviour is that a new empty input gets added.
3. Verify that a new input does not render automatically by pressing enter on the input.


