### PR TITLE
[xxx] Fix missing translation

### DIFF
--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -101,7 +101,7 @@ module RecordDetails
     def progress_date
       return unless trainee_progress_date
 
-      I18n.t(".progress_date_prefix.#{trainee.state}") + date_for_summary_view(trainee_progress_date)
+      I18n.t("record_details.view.progress_date_prefix.#{trainee.state}") + date_for_summary_view(trainee_progress_date)
     end
 
     def status_date


### PR DESCRIPTION
### Context
Currently on prod:

<img width="1027" alt="Screenshot 2021-08-20 at 16 30 03" src="https://user-images.githubusercontent.com/5216/130257146-e6d5e20e-cac9-4eb6-9079-3373b87f3ca4.png">

### Changes proposed in this pull request

Translation was incorrectly referenced so was being rendered as a missing translation. Fixed.

### Guidance to review

