### PR TITLE
[2499] Change fake TRN number

### DIFF
--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -221,7 +221,7 @@ FactoryBot.define do
 
     trait :trn_received do
       submitted_for_trn
-      trn { SecureRandom.uuid }
+      trn { Faker::Number.number(digits: 7) }
       state { "trn_received" }
     end
 


### PR DESCRIPTION
### Context
https://trello.com/c/7E2HQu90/2499-fake-trns-arent-realistic
Example data was using factory to generate fake trn number. Factory had a uuid instead of ~~9~~ 7 digit number. 

### Changes proposed in this pull request
Changed factory trait to make trn a ~~9~~ 7 digit number as requested in ticket

### Guidance to review
<img width="732" alt="Screenshot 2021-08-23 at 17 17 33" src="https://user-images.githubusercontent.com/58793682/130481963-3cc38949-c8da-4e8c-8ca6-3da7857bf8d6.png">


