### PR TITLE
[2451] Backlink bug fixes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,6 +76,10 @@ private
     end
   end
 
+  def unregister_page_from_tracker
+    page_tracker.unregister_current_page
+  end
+
   def clear_form_stash(trainee)
     FormStore.clear_all(trainee.id)
   end

--- a/app/controllers/trainees/diversity/disability_details_controller.rb
+++ b/app/controllers/trainees/diversity/disability_details_controller.rb
@@ -5,6 +5,7 @@ module Trainees
     class DisabilityDetailsController < ApplicationController
       before_action :authorize_trainee
       before_action :load_disabilities
+      before_action :unregister_page_from_tracker
 
       def edit
         @disability_detail_form = Diversities::DisabilityDetailForm.new(trainee)

--- a/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
@@ -4,6 +4,7 @@ module Trainees
   module Diversity
     class EthnicBackgroundsController < ApplicationController
       before_action :authorize_trainee
+      before_action :unregister_page_from_tracker
 
       def edit
         @ethnic_background_form = Diversities::EthnicBackgroundForm.new(trainee)

--- a/app/lib/page_tracker.rb
+++ b/app/lib/page_tracker.rb
@@ -41,6 +41,10 @@ class PageTracker
     origin_pages.reject { |path| path.include?("confirm") }.last
   end
 
+  def unregister_current_page
+    history.delete(request.fullpath)
+  end
+
 private
 
   attr_reader :session, :request, :history_session_key, :origin_pages_session_key

--- a/app/lib/wizards/diversities_step_wizard.rb
+++ b/app/lib/wizards/diversities_step_wizard.rb
@@ -18,6 +18,11 @@ module Wizards
     end
 
     def start_point
+      # As this is essentially a redirect, we want to remove the page
+      # from the page tracker, to give the illusion it was never
+      # visited at all
+      page_tracker&.unregister_current_page
+
       return unless any_form_incomplete?
       return edit_trainee_diversity_disclosure_path(trainee) unless ::Diversities::DisclosureForm.new(trainee).valid?
       return edit_trainee_diversity_ethnic_group_path(trainee) unless ::Diversities::EthnicGroupForm.new(trainee).valid?


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/sd4RgFyX/2451-back-links-can-get-stuck-in-an-infinite-loop)

### Changes proposed in this pull request

- Pages that are the second half of two part questions are removed from page tracker history. This is because they are the issue of the loop, as they have static backlinks to the question before (which in essence have dynamic backlinks, linking the user to the place they were just at)

### Guidance to review