### PR TITLE
[2544] Tighten start date validation

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -192,7 +192,7 @@ private
       errors.add(course_start_date_attribute_name, :future)
     elsif !course_start_date.is_a?(Date)
       errors.add(course_start_date_attribute_name, :invalid)
-    elsif course_start_date < 10.years.ago
+    elsif course_start_date < earliest_valid_start_date
       errors.add(course_start_date_attribute_name, :too_old)
     end
   end
@@ -235,6 +235,10 @@ private
 
   def max_years
     next_year + MAX_END_YEARS
+  end
+
+  def earliest_valid_start_date
+    Date.parse("1/8/2020")
   end
 
   def sanitise_subjects

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1028,7 +1028,7 @@ en:
               blank: Enter a course start date
               future: Enter a course start date closer to today
               invalid: Enter a valid course start date
-              too_old: Enter a valid course start date
+              too_old: The course start date must be after 31 July 2020
               hint_html: For example, 11 3 %{year}
             course_end_date:
               blank: Enter a course end date

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :abstract_trainee, class: "Trainee" do
     transient do
-      potential_course_start_date { course_start_date || Faker::Date.between(from: 10.years.ago, to: Time.zone.today) }
+      potential_course_start_date { course_start_date || Faker::Date.between(from: 1.year.ago, to: Time.zone.today) }
     end
 
     sequence :trainee_id do |n|
@@ -115,7 +115,7 @@ FactoryBot.define do
       course_subject_one { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
       course_code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
       course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.reject { |_k, v| v[:option] == :main }.keys.sample }
-      course_start_date { Faker::Date.between(from: 10.years.ago, to: 2.days.ago) }
+      course_start_date { Faker::Date.between(from: 1.year.ago, to: 2.days.ago) }
       course_end_date { Faker::Date.between(from: course_start_date + 1.day, to: Time.zone.today) }
     end
 

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -319,7 +319,7 @@ describe CourseDetailsForm, type: :model do
 
   context "valid trainee" do
     let(:valid_start_date) do
-      Faker::Date.between(from: 10.years.ago, to: 2.days.ago)
+      Faker::Date.between(from: 1.year.ago, to: 2.days.ago)
     end
 
     let(:valid_end_date) do


### PR DESCRIPTION
### Context
https://trello.com/c/xAaSIkyJ/2544-tighten-up-coursestartdate-validation
Course start dates could be up to ten years ago.
### Changes proposed in this pull request
* Change so that the earliest course start date allowed is 01/08/2020
### Guidance to review
Test the form so that validations are triggered (or not) on the correct inputted date
