### PR TITLE
[xxx] Stop trying to retrieve TRN in no-DTTP envs

### DIFF
--- a/app/jobs/dttp/retrieve_trn_job.rb
+++ b/app/jobs/dttp/retrieve_trn_job.rb
@@ -9,6 +9,8 @@ module Dttp
     class TraineeAttributeError < StandardError; end
 
     def perform(trainee, timeout_after = nil)
+      return unless FeatureService.enabled?(:persist_to_dttp)
+
       @timeout_after = timeout_after
       @trainee = trainee
 

--- a/spec/jobs/dttp/retrieve_trn_job_spec.rb
+++ b/spec/jobs/dttp/retrieve_trn_job_spec.rb
@@ -13,6 +13,8 @@ module Dttp
     let(:timeout_date) { configured_poll_timeout_days.days.from_now }
 
     before do
+      enable_features(:persist_to_dttp)
+
       allow(RetrieveTrn).to receive(:call).with(trainee: trainee).and_return(trn)
       allow(Settings.jobs).to receive(:poll_delay_hours).and_return(configured_delay)
       allow(Settings.jobs).to receive(:max_poll_duration_days).and_return(configured_poll_timeout_days)


### PR DESCRIPTION
### Context

We're getting a lot of Sentry errors for failed `RetrieveTrnJob`s in review apps and QA.

### Changes proposed in this pull request

This PR adds a guard to `RetrieveTrnJob` the same as our other DTTP-related jobs (see `RegisterForTrnJob` as an example).

### Guidance to review