### PR TITLE
[2605] Fix flakey test

### DIFF
--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -337,11 +337,11 @@ FactoryBot.define do
       applying_for_bursary { Faker::Boolean.boolean }
     end
 
-    trait :with_bursary do
+    trait :with_provider_led_bursary do
       applying_for_bursary { true }
 
       after(:create) do |trainee, _|
-        bursary = create(:bursary, :with_bursary_subjects)
+        bursary = create(:bursary, :with_bursary_subjects, training_route: :provider_led_postgrad)
         trainee.course_subject_one = bursary.allocation_subjects.first.name
         trainee.training_route = bursary.training_route
       end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -377,10 +377,9 @@ module Dttp
               let(:trainee) do
                 create(
                   :trainee,
-                  :provider_led_postgrad,
                   :with_course_details,
                   :with_start_date,
-                  :with_bursary,
+                  :with_provider_led_bursary,
                   dttp_id: dttp_contact_id,
                 )
               end


### PR DESCRIPTION
### Context

https://trello.com/c/Es1CJDlC/2605-fix-flakey-placement-params-test

### Changes proposed in this pull request

The trait `:with_bursary` was sometimes setting the trainee to have a schools route, but the trainee had no lead school. Hence creating the placement params would error.

This explicitly sets the trainee and bursary to be a provider-led bursary.

### Guidance to review
