### PR TITLE
Add synonyms for combined studies

### DIFF
--- a/app/lib/dttp/code_sets/degree_subjects.rb
+++ b/app/lib/dttp/code_sets/degree_subjects.rb
@@ -223,7 +223,7 @@ module Dttp
         "Cognitive Psychology" => { entity_id: "c18470f0-5dce-e911-a985-000d3ab79618" },
         "Colonial And Post-Colonial Literature" => { entity_id: "618570f0-5dce-e911-a985-000d3ab79618" },
         "Colour Chemistry" => { entity_id: "018570f0-5dce-e911-a985-000d3ab79618" },
-        "Combined Studies" => => {
+        "Combined Studies" => {
           entity_id: "298670f0-5dce-e911-a985-000d3ab79618",
           synonyms: ["open degree", "multiple subjects", "several subjects"],
         },


### PR DESCRIPTION
### Context
Not all degrees have subjects, and some degrees have several subjects. Talking with Shaun, the correct option to pick in this case is `Combined Studies`. 

This came up via support with a trainee that had a degree from the Open University where the subject is listed as `open degree`.
