### PR TITLE
[2633] Fix publish course options for apply draft

### DIFF
--- a/app/helpers/publish_courses_helper.rb
+++ b/app/helpers/publish_courses_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module PublishCoursesHelper
+  def course_summary_text_for(trainee, course)
+    summary_with_route = t(".summary_with_route", summary: course.summary, route: t("activerecord.attributes.trainee.training_routes.#{course.route}"))
+    trainee.apply_application? ? summary_with_route : course.summary
+  end
+end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -214,6 +214,8 @@ class Trainee < ApplicationRecord
   end
 
   def available_courses
+    return provider.courses if apply_application?
+
     provider.courses.where(route: training_route) if TRAINING_ROUTES_FOR_COURSE.keys.include?(training_route)
   end
 

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -18,7 +18,7 @@
       <% @courses.each do |course| %>
         <%= f.govuk_radio_button :code, course.code,
           label: { text: "#{course.name} (#{course.code})" },
-          hint: { text: course.summary },
+          hint: { text: course_summary_text_for(@trainee, course) },
           link_errors: true %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -742,6 +742,8 @@ en:
       edit:
         heading: What course are they doing?
         course_not_listed: Another course not listed
+        enter_course_details: Enter course details
+        summary_with_route: "%{summary}, %{route}"
     language_specialisms:
       edit:
         heading: Which language specialisms has the trainee chosen to study?


### PR DESCRIPTION
### Context

- https://trello.com/c/3rB5pGzY/2633-snag-show-correct-list-of-courses-on-courses-page-for-apply-draft

### Changes proposed in this pull request

If a provider decides to change the publish course for an apply draft, they should see all their courses for all routes. The course summary hints should also show route (only for apply drafts)

<img width="738" alt="Screenshot 2021-08-25 at 16 24 27" src="https://user-images.githubusercontent.com/616080/130821205-44890b40-8183-44a7-90b7-ab2be23142c8.png">

### Guidance to review


