### PR TITLE
[2635] snag trainee data summary card not shown even after complete

### DIFF
--- a/app/components/apply_applications/trainee_data/view.html.erb
+++ b/app/components/apply_applications/trainee_data/view.html.erb
@@ -1,60 +1,16 @@
-<%= render PageTitle::View.new(i18n_key: "check_details.show", has_errors: form.errors.present?) %>
 
-<%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(
-    text: t("back_to_draft"),
-    href: review_draft_trainee_path(trainee),
-    html_attributes: {
-      id: "back-to-draft-record",
-    },
-  ) %>
-<% end %>
+<h2 class="govuk-heading-m">
+  <%= t("personal_details") %>
+</h2>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds-from-desktop">
-        <%= render ReviewSummary::View.new(form: form, invalid_data_view: invalid_data_view) %>
-        <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
-          <span class="govuk-caption-l">
-            <% if trainee_name(trainee).present? %>
-              <%= t(".heading_1_name", name: trainee_name(trainee)) %>
-            <% else %>
-              <%= t(".heading_1_no_name") %>
-            <% end %>
-          </span>
-          <%= t(".heading_2") %>
-        </h1>
-      </div>
-    </div>
+<%= render Sections::View.new(trainee: trainee, form: form, section: :personal_details) %>
 
-    <h2 class="govuk-heading-m">
-      <%= t("personal_details") %>
-    </h2>
+<%= render Sections::View.new(trainee: trainee, form: form, section: :contact_details) %>
 
-    <%= render Sections::View.new(trainee: trainee, form: form, section: :personal_details) %>
+<%= render Sections::View.new(trainee: trainee, form: form, section: :diversity) %>
 
-    <%= render Sections::View.new(trainee: trainee, form: form, section: :contact_details) %>
+<h2 class="govuk-heading-m">
+  <%= t("education") %>
+</h2>
 
-    <%= render Sections::View.new(trainee: trainee, form: form, section: :diversity) %>
-
-    <h2 class="govuk-heading-m">
-      <%= t("education") %>
-    </h2>
-
-    <%= render Sections::View.new(trainee: trainee, form: form, section: :degrees) %>
-
-    <%= register_form_with(model: form, builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-                           url: trainee_apply_applications_trainee_data_path(trainee),
-                           method: :put,
-                           local: true) do |f| %>
-        <%= f.govuk_check_boxes_fieldset :mark_as_reviewed, multiple: false, legend: { text: "" } do %>
-          <%= f.govuk_check_box :mark_as_reviewed, 1, 0, multiple: false, link_errors: true,
-                                label: { text: t("mark_as_reviewed") } %>
-        <% end %>
-      <%= f.govuk_submit t("continue") %>
-    <% end %>
-  </div>
-</div>
-
-<p class="govuk-body"><%= govuk_link_to(t("return_to_draft_later"), trainees_path, { id: "return-to-draft-later" }) %></p>
+<%= render Sections::View.new(trainee: trainee, form: form, section: :degrees) %>

--- a/app/components/apply_applications/trainee_data/view.rb
+++ b/app/components/apply_applications/trainee_data/view.rb
@@ -6,12 +6,16 @@ module ApplyApplications
       include ApplicationHelper
       include TraineeHelper
 
-      attr_reader :trainee, :form, :invalid_data_view
+      attr_reader :data_model, :form, :invalid_data_view
 
-      def initialize(trainee, form)
-        @trainee = trainee
-        @form = form
+      def initialize(data_model)
+        @data_model = data_model[:data_model] || data_model
+        @form = TraineeDataForm.new(trainee)
         @invalid_data_view = ApplyInvalidDataView.new(trainee.apply_application)
+      end
+
+      def trainee
+        data_model.is_a?(Trainee) ? data_model : data_model.trainee
       end
     end
   end

--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -66,7 +66,7 @@ module Sections
         training_details: TrainingDetails::View,
         schools: Schools::View,
         funding: Funding::View,
-        trainee_data: ReviewDraft::ApplyDraft::View,
+        trainee_data: ApplyApplications::TraineeData::View,
       }[section]
     end
 

--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -49,6 +49,8 @@ module Sections
         Schools::FormValidator
       when :funding
         Funding::FormValidator
+      when :trainee_data
+        ApplyApplications::TraineeDataForm
       else
         "#{section.to_s.camelcase}Form".constantize
       end

--- a/app/controllers/trainees/apply_applications/trainee_data_controller.rb
+++ b/app/controllers/trainees/apply_applications/trainee_data_controller.rb
@@ -8,11 +8,15 @@ module Trainees
 
       def edit
         page_tracker.save_as_origin!
-        @trainee_data_form = ::ApplyApplications::TraineeDataForm.new(trainee)
+        @trainee = trainee
+        @trainee_data_form = trainee_data_form
+        @invalid_data_view = invalid_data_view
       end
 
       def update
-        @trainee_data_form = ::ApplyApplications::TraineeDataForm.new(trainee)
+        @trainee = trainee
+        @trainee_data_form = trainee_data_form
+        @invalid_data_view = ApplyInvalidDataView.new(trainee.apply_application)
 
         if @trainee_data_form.save
           redirect_to trainee_path(trainee)
@@ -25,6 +29,14 @@ module Trainees
 
       def trainee
         @trainee ||= Trainee.from_param(params[:trainee_id])
+      end
+
+      def trainee_data_form
+        @trainee_data_form ||= ::ApplyApplications::TraineeDataForm.new(trainee)
+      end
+
+      def invalid_data_view
+        @invalid_data_view ||= ApplyInvalidDataView.new(trainee.apply_application)
       end
 
       def authorize_trainee

--- a/app/forms/apply_applications/trainee_data_form.rb
+++ b/app/forms/apply_applications/trainee_data_form.rb
@@ -34,6 +34,7 @@ module ApplyApplications
       trainee.progress.contact_details = true
       trainee.progress.diversity = true
       trainee.progress.degrees = true
+      trainee.progress.trainee_data = true
       trainee.save!
     end
 

--- a/app/forms/apply_applications/trainee_data_form.rb
+++ b/app/forms/apply_applications/trainee_data_form.rb
@@ -21,7 +21,7 @@ module ApplyApplications
 
     validate :submission_ready
 
-    attr_accessor :mark_as_reviewed
+    attr_accessor :mark_as_reviewed, :trainee
 
     def initialize(trainee)
       @trainee = trainee
@@ -83,7 +83,5 @@ module ApplyApplications
     def validator(section)
       form_validators[section][:form].constantize
     end
-
-    attr_reader :trainee
   end
 end

--- a/app/views/trainees/apply_applications/trainee_data/edit.html.erb
+++ b/app/views/trainees/apply_applications/trainee_data/edit.html.erb
@@ -1,1 +1,45 @@
-<%= render ApplyApplications::TraineeData::View.new(@trainee, @trainee_data_form) %>
+<%= render PageTitle::View.new(i18n_key: "check_details.show", has_errors: @trainee_data_form.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLink.new(
+    text: t("back_to_draft"),
+    href: review_draft_trainee_path(@trainee),
+    html_attributes: {
+      id: "back-to-draft-record",
+    },
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <%= render ReviewSummary::View.new(form: @trainee_data_form, invalid_data_view: @invalid_data_view) %>
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-8">
+          <span class="govuk-caption-l">
+            <% if trainee_name(@trainee).present? %>
+              <%= t("apply_applications.trainee_data.view.heading_1_name", name: trainee_name(@trainee)) %>
+            <% else %>
+              <%= t("apply_applications.trainee_data.view.heading_1_no_name") %>
+            <% end %>
+          </span>
+          <%= t("apply_applications.trainee_data.view.heading_2") %>
+        </h1>
+      </div>
+    </div>
+    <%= render ApplyApplications::TraineeData::View.new(@trainee) %>
+
+    <%= register_form_with(model: @trainee_data_form, builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+                           url: trainee_apply_applications_trainee_data_path(@trainee),
+                           method: :put,
+                           local: true) do |f| %>
+        <%= f.govuk_check_boxes_fieldset :mark_as_reviewed, multiple: false, legend: { text: "" } do %>
+          <%= f.govuk_check_box :mark_as_reviewed, 1, 0, multiple: false, link_errors: true,
+                                label: { text: t("mark_as_reviewed") } %>
+        <% end %>
+      <%= f.govuk_submit t("continue") %>
+    <% end %>
+  </div>
+</div>
+
+<p class="govuk-body"><%= govuk_link_to(t("return_to_draft_later"), trainees_path, { id: "return-to-draft-later" }) %></p>

--- a/spec/components/apply_applications/trainee_data/view_preview.rb
+++ b/spec/components/apply_applications/trainee_data/view_preview.rb
@@ -6,11 +6,11 @@ module ApplyApplications
   module TraineeData
     class ViewPreview < ViewComponent::Preview
       def default
-        render(View.new(trainee([degree]), form))
+        render(View.new(trainee([degree])))
       end
 
       def with_no_degrees
-        render(View.new(trainee, form))
+        render(View.new(trainee))
       end
 
     private

--- a/spec/components/apply_applications/trainee_data/view_spec.rb
+++ b/spec/components/apply_applications/trainee_data/view_spec.rb
@@ -10,8 +10,7 @@ module ApplyApplications
       let(:apply_application) { create(:apply_application) }
 
       before do
-        form = ::ApplyApplications::TraineeDataForm.new(trainee)
-        render_inline(View.new(trainee, form))
+        render_inline(View.new(trainee))
       end
 
       context "trainee with degrees" do


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/RdaLgDjk/2635-snag-trainee-data-summary-card-not-shown-even-after-complete)

### Changes proposed in this pull request

- The edit page was rendered entirely inside of the `TraineeData::View` component, even parts that were specific to the edit page.
- I moved the edit page specifics out of the component so we can render the summary cards in the trainee record
- When `I have reviewed this section` has been ticked, `progress_tracker` for `trainee_data` was also updated to true

### Guidance to review

- Make sure an Apply Draft Trainee has their trainee data section completed, and ticked with `I have reviewed this section`
- Then go to the check-details section and you will see the summary card(s) of the trainee data section in that view. 

