### PR TITLE
[2626] Fix review label

### DIFF
--- a/app/services/progress_service.rb
+++ b/app/services/progress_service.rb
@@ -38,7 +38,7 @@ class ProgressService
   end
 
   def review?
-    (in_progress_valid? || in_progress_invalid?) && is_apply_application?
+    (in_progress_valid? || in_progress_invalid? || not_started?) && is_apply_application?
   end
 
   def completed?


### PR DESCRIPTION
### Context

- https://trello.com/c/akLLFVKo/2626-snag-fix-review-label-for-apply-draft-course-details-section

### Changes proposed in this pull request

- Update progress service to return review for a section which may not have been started but is an `apply_application?`

### Guidance to review

