### PR TITLE
[xxx] Fix bug in tiered bursary form

### DIFF
--- a/app/forms/funding/bursary_form.rb
+++ b/app/forms/funding/bursary_form.rb
@@ -23,7 +23,26 @@ module Funding
       @applying_for_bursary = ActiveModel::Type::Boolean.new.cast(value)
     end
 
+    def save!
+      if valid?
+        update_trainee_attributes
+        trainee.save!
+        clear_stash
+      else
+        false
+      end
+    end
+
   private
+
+    def update_trainee_attributes
+      # Need to save the applying_for_bursary attribute
+      trainee.assign_attributes(
+        fields
+          .merge(applying_for_bursary: applying_for_bursary)
+          .except(*fields_to_ignore_before_stash_or_save),
+      )
+    end
 
     def set_applying_for_bursary
       self.applying_for_bursary = true if bursary_tier.present?

--- a/spec/forms/funding/bursary_form_spec.rb
+++ b/spec/forms/funding/bursary_form_spec.rb
@@ -28,6 +28,8 @@ module Funding
       end
 
       context "when bursary_tier is set" do
+        let(:trainee) { create(:trainee, applying_for_bursary: nil) }
+
         let(:params) do
           {
             "bursary_tier" => "tier_one",
@@ -35,11 +37,14 @@ module Funding
           }
         end
 
+        before do
+          allow(form_store).to receive(:set).with(trainee.id, :bursary, nil)
+        end
+
         it { is_expected.to validate_inclusion_of(:bursary_tier).in_array(Trainee.bursary_tiers.keys) }
 
         it "sets applying_for_bursary to true" do
-          subject.valid?
-          expect(subject.applying_for_bursary).to eq(true)
+          expect { subject.save! }.to change(trainee, :applying_for_bursary).to true
         end
       end
     end


### PR DESCRIPTION
### Context

When a tiered bursary was selected for an Early years (postgrad), `applying_for_bursary` was not being set to true :(

### Changes proposed in this pull request

Make sure `applying_for_bursary` is actually saved on the trainee, not just set on the form object.

### Guidance to review