### PR TITLE
[2640] Offer manual entry option for apply drafts

### DIFF
--- a/app/controllers/trainees/apply_applications/confirm_courses_controller.rb
+++ b/app/controllers/trainees/apply_applications/confirm_courses_controller.rb
@@ -4,6 +4,7 @@ module Trainees
   module ApplyApplications
     class ConfirmCoursesController < ApplicationController
       before_action :authorize_trainee
+      before_action :redirect_to_manual_confirm_page, if: -> { publish_course_details_form.manual_entry_chosen? }
       before_action :set_course
       before_action :set_specialisms
       helper_method :course_code
@@ -29,6 +30,10 @@ module Trainees
 
       def trainee
         @trainee ||= Trainee.from_param(params[:trainee_id])
+      end
+
+      def redirect_to_manual_confirm_page
+        redirect_to trainee_course_details_confirm_path(trainee)
       end
 
       def set_course

--- a/app/lib/page_tracker.rb
+++ b/app/lib/page_tracker.rb
@@ -34,7 +34,12 @@ class PageTracker
   end
 
   def last_origin_page_path
-    on_confirm_page? ? origin_pages[-2] : origin_pages.last
+    # Edge case scenario of multiple confirm pages
+    # If we have two confirm page paths return to first origin page
+    return origin_pages.first if on_confirm_page? && another_confirm_page_in_history?
+    return origin_pages[-2] if on_confirm_page?
+
+    origin_pages.last
   end
 
   def last_non_confirm_origin_page_path
@@ -85,5 +90,10 @@ private
     edit_page_paths = history.select { |path| path.include?("edit") }
 
     confirm_path.nil? && edit_page_paths.size == 1
+  end
+
+  def another_confirm_page_in_history?
+    confirm_paths = history.select { |path| path.include?("confirm") }
+    confirm_paths.size > 1
   end
 end

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -22,12 +22,10 @@
           link_errors: true %>
       <% end %>
 
-      <% unless @trainee.apply_application? %>
-        <div class="govuk-radios__divider">or</div>
+      <div class="govuk-radios__divider">or</div>
 
-        <%= f.govuk_radio_button :code, PublishCourseDetailsForm::NOT_LISTED,
-          label: { text: t(".course_not_listed") } %>
-      <% end %>
+      <%= f.govuk_radio_button :code, PublishCourseDetailsForm::NOT_LISTED,
+        label: { text: t(".course_not_listed") } %>
     <% end %>
   </div>
 


### PR DESCRIPTION
### Context

- https://trello.com/c/lASJOEPv/2640-snag-allow-manual-option-for-apply-draft-courses-selection

### Changes proposed in this pull request

- Enables the manual entry option when choosing courses for apply drafts
- Deals with an edge case in the page tracker being able to store multiple confirm pages (sep. spike ticket is around to look into this)

### Guidance to review

