### PR TITLE
[2634] Fix markup snag

### DIFF
--- a/app/components/invalid_data_text/view.rb
+++ b/app/components/invalid_data_text/view.rb
@@ -13,6 +13,7 @@ class InvalidDataText::View < GovukComponent::Base
   def content
     return hint if data_text.blank?
     return hint if form_section_valid?
+    return tag.div(data_text, class: text_class) if hint.nil?
 
     hint << tag.div(data_text, class: text_class)
   end
@@ -22,6 +23,8 @@ private
   attr_reader :hint_text, :data_text, :degree_form, :form_section
 
   def hint
+    return nil if hint_text.blank?
+
     tag.div(hint_text, class: "govuk-hint")
   end
 

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -66,7 +66,7 @@
         width: "one-quarter",
         form_group: { class: invalid_data_message("graduation_year", @degree_form.degree) ? "govuk-form-group govuk-inset-text app-inset-text--narrow-border app-inset-text--important" : "govuk-form-group", id: :graduation_year },
         label: { text: "Graduation year", size: "s" } do
-          render InvalidDataText::View.new(form_section: :graduation_year, hint: "", degree_form: @degree_form)
+          render InvalidDataText::View.new(form_section: :graduation_year, degree_form: @degree_form)
         end %>
 
   <%= f.govuk_submit %>

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -4,30 +4,36 @@
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
-<%= register_form_with(model: @publish_course_details_form,
-                       url: trainee_publish_course_details_path(@trainee),
-                       method: :put,
-                       local: true) do |f| %>
-  <%= f.govuk_error_summary %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+  
+    <%= register_form_with(model: @publish_course_details_form,
+                          url: trainee_publish_course_details_path(@trainee),
+                          method: :put,
+                          local: true) do |f| %>
+      <%= f.govuk_error_summary %>
 
-  <div class="govuk-form-group">
-    <%= f.govuk_radio_buttons_fieldset :code,
-                                       legend: { text: t(".heading"), tag: "h1", size: "l" },
-                                       hint: { text: courses_fieldset_text_for(@trainee) },
-                                       classes: "published-courses" do %>
-      <% @courses.each do |course| %>
-        <%= f.govuk_radio_button :code, course.code,
-          label: { text: "#{course.name} (#{course.code})" },
-          hint: { text: course_summary_text_for(@trainee, course) },
-          link_errors: true %>
-      <% end %>
+      <div class="govuk-form-group">
+        <%= f.govuk_radio_buttons_fieldset :code,
+                                          legend: { text: t(".heading"), tag: "h1", size: "l" },
+                                          hint: { text: courses_fieldset_text_for(@trainee) },
+                                          classes: "published-courses" do %>
+          <% @courses.each do |course| %>
+            <%= f.govuk_radio_button :code, course.code,
+              label: { text: "#{course.name} (#{course.code})" },
+              hint: { text: course_summary_text_for(@trainee, course) },
+              link_errors: true %>
+          <% end %>
 
-      <div class="govuk-radios__divider">or</div>
+          <div class="govuk-radios__divider">or</div>
 
-      <%= f.govuk_radio_button :code, PublishCourseDetailsForm::NOT_LISTED,
-        label: { text: t(".course_not_listed") } %>
+          <%= f.govuk_radio_button :code, PublishCourseDetailsForm::NOT_LISTED,
+            label: { text: t(".course_not_listed") } %>
+        <% end %>
+      </div>
+
+      <%= f.govuk_submit %>
     <% end %>
   </div>
+</div>
 
-  <%= f.govuk_submit %>
-<% end %>

--- a/spec/components/invalid_data_text/view_spec.rb
+++ b/spec/components/invalid_data_text/view_spec.rb
@@ -25,8 +25,8 @@ module InvalidDataText
       let(:trainee) { create(:trainee, :with_apply_application) }
       let(:form_section) { :subject }
 
-      it "renders the correct css" do
-        expect(rendered_component).to have_css(".govuk-hint")
+      it "does not render the inset css" do
+        expect(rendered_component).not_to have_css(".app-inset-text__title")
         expect(rendered_component).to have_text(nil)
       end
     end


### PR DESCRIPTION
### Context
https://trello.com/c/W7ioWhlB/2634-snag-fix-markup

### Changes proposed in this pull request
* Add row + column to subject specialism selection
* Remove empty hint div on degree partials when there is no hint. Slight refactor of invalid data text component needed. 

### Guidance to review
Check both normal draft trainee and Apply draft trainee with invalid data to verify correct behaviour of degree partials 
