### PR TITLE
[2623] Reorder course details error messages to match form

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -41,18 +41,20 @@ class CourseDetailsForm < TraineeForm
   before_validation :sanitise_subjects
 
   validates :course_subject_one, autocomplete: true, presence: true, if: :require_subject?
+
+  validate :course_subject_two_valid, if: :require_subject?
   validates :course_subject_two, autocomplete: true, if: :require_subject?
+
+  validate :course_subject_three_valid, if: :require_subject?
   validates :course_subject_three, autocomplete: true, if: :require_subject?
+
+  validate :age_range_valid, if: :require_age_range?
   validates :additional_age_range, autocomplete: true, if: -> { other_age_range? && require_age_range? }
 
   validates :study_mode, inclusion: { in: TRAINEE_STUDY_MODES.keys }, if: :requires_study_mode?
 
   validate :course_start_date_valid
   validate :course_end_date_valid
-
-  validate :age_range_valid, if: :require_age_range?
-  validate :course_subject_two_valid, if: :require_subject?
-  validate :course_subject_three_valid, if: :require_subject?
 
   delegate :apply_application?, :requires_study_mode?, to: :trainee
 


### PR DESCRIPTION
### Context

https://trello.com/c/0oZTPS4v/2623-s-ordering-of-error-messages-on-course-details-page-is-wrong

### Changes proposed in this pull request

#ronseal

... aka does exactly what it says on the tin.

### Guidance to review

New order 🎵 :

<img width="691" alt="Screenshot 2021-08-27 at 12 09 15" src="https://user-images.githubusercontent.com/18436946/131120330-3b0664e8-c8f6-487d-8707-71150dde7f8c.png">

