### PR TITLE
[2636] Added dynamic backlink to the confirm courses page

### DIFF
--- a/app/views/trainees/apply_applications/confirm_courses/show.html.erb
+++ b/app/views/trainees/apply_applications/confirm_courses/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(i18n_key: "trainees.apply_applications.confirm_course.show") %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLink.new(text: t(:back), href: trainee_apply_applications_course_details_path(@trainee)) %>
+  <%= render DynamicBackLink::View.new(@trainee) %>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/tqZ5cnU3/2636-snag-back-link-on-confirm-course-details-page-behaving-weirdly)

### Changes proposed in this pull request

- Added a standard `DynamicBacklink` to the `confirm course details` show page. This shows up as `Back to draft record`

### Guidance to review

- Go to an apply draft trainee. 
- Click on course details
- See and use the backlink at the top of the page

