### PR TITLE
[2622] Change 'Other age range' field from autocomplete to select

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -19,7 +19,6 @@ class CourseDetailsForm < TraineeForm
     end_year
     main_age_range
     additional_age_range
-    additional_age_range_raw
     study_mode
   ].freeze
 
@@ -43,7 +42,7 @@ class CourseDetailsForm < TraineeForm
   validates :course_subject_one, autocomplete: true, presence: true, if: :require_subject?
   validates :course_subject_two, autocomplete: true, if: :require_subject?
   validates :course_subject_three, autocomplete: true, if: :require_subject?
-  validates :additional_age_range, autocomplete: true, if: -> { other_age_range? && require_age_range? }
+  validates :additional_age_range, presence: true, if: -> { other_age_range? && require_age_range? }
 
   validates :study_mode, inclusion: { in: TRAINEE_STUDY_MODES.keys }, if: :requires_study_mode?
 

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -31,7 +31,10 @@
       <% end %>
 
       <% if f.object.require_age_range? %>
-        <%= f.govuk_radio_buttons_fieldset(:main_age_range, legend: { text: "Age range", size: "s" }, classes: "age_range") do %>
+        <%= f.govuk_radio_buttons_fieldset(:main_age_range,
+                                           legend: { text: "Age range", size: "s" },
+                                           classes: "age_range") do %>
+
           <% main_age_ranges_options.each_with_index do |age_range, index| %>
             <%= f.govuk_radio_button(:main_age_range, age_range,
                                      label: { text: age_range },
@@ -43,14 +46,12 @@
           <%= f.govuk_radio_button(:main_age_range,
                                    :other,
                                    label: { text: "Other age range" }) do %>
-            <%= render FormComponents::Autocomplete::View.new(
-              f,
-              attribute_name: :additional_age_range,
-              form_field: f.govuk_collection_select(:additional_age_range, additional_age_ranges_options,
-                                                    :value,
-                                                    :text,
-                                                    label: { text: "Other age range", size: "s" }),
-            ) %>
+
+            <%= f.govuk_collection_select(:additional_age_range,
+                                          additional_age_ranges_options,
+                                          :value,
+                                          :text,
+                                          label: { text: "Select the age range" }) %>
 
           <% end %>
         <% end %>

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -11,7 +11,7 @@
 
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">Course details</h1>
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
       <% if f.object.require_subject? %>
         <%= render FormComponents::Autocomplete::View.new(
@@ -22,7 +22,7 @@
             course_subjects_options,
             :value,
             :text,
-            label: { text: "Subject", size: "s" },
+            label: { text: t(".subject_label"), size: "s" },
             hint: { text: t(".subject_hint") },
           ),
         ) %>
@@ -32,7 +32,7 @@
 
       <% if f.object.require_age_range? %>
         <%= f.govuk_radio_buttons_fieldset(:main_age_range,
-                                           legend: { text: "Age range", size: "s" },
+                                           legend: { text: t(".age_range_label"), size: "s" },
                                            classes: "age_range") do %>
 
           <% main_age_ranges_options.each_with_index do |age_range, index| %>
@@ -45,13 +45,13 @@
 
           <%= f.govuk_radio_button(:main_age_range,
                                    :other,
-                                   label: { text: "Other age range" }) do %>
+                                   label: { text: t(".other_age_range_label") }) do %>
 
             <%= f.govuk_collection_select(:additional_age_range,
                                           additional_age_ranges_options,
                                           :value,
                                           :text,
-                                          label: { text: "Select the age range" }) %>
+                                          label: { text: t(".additional_age_range_label") }) %>
 
           <% end %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -749,6 +749,11 @@ en:
         additional_hint: Choose up to three.
     course_details:
       edit:
+        additional_age_range_label: Select the age range
+        age_range_label: Age range
+        heading: Course details
+        other_age_range_label: Other age range
+        subject_label: Subject
         subject_hint: &subject_hint Search for the closest matching subject
         study_mode_label: Full time or part time?
         study_mode_full_time: Full time
@@ -888,7 +893,6 @@ en:
           course_subject_one: *subject
           course_subject_two: *subject
           course_subject_three: *subject
-          additional_age_range: Select an age range from the list - your entry is not recognised
           institution: Select an institution from the list - your entry is not recognised
           other_nationality1: &nationality Select a nationality from the list - your entry is not recognised
           other_nationality2: *nationality

--- a/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
@@ -49,10 +49,8 @@ feature "course details", type: :feature do
       scenario "submitting with a partial subject/age range", js: true do
         when_i_visit_the_course_details_page
         and_i_fill_in_subject_without_selecting_a_value(with: "moose")
-        and_i_fill_in_additional_age_range_without_selecting_a_value(with: "goose")
         and_i_submit_the_form
         then_subject_is_populated(with: "moose")
-        then_additional_age_range_is_populated(with: "goose")
         then_i_see_error_messages_for_partially_submitted_fields
       end
 
@@ -129,15 +127,6 @@ private
     course_details_page.subject_raw.native.send_key(:backspace)
   end
 
-  def and_i_fill_in_additional_age_range_without_selecting_a_value(with:)
-    choose "Other age range", allow_label_click: true
-    course_details_page.additional_age_range.fill_in with: with
-  end
-
-  def then_additional_age_range_is_populated(with:)
-    expect(course_details_page.additional_age_range_raw.value).to eq(with)
-  end
-
   def then_subject_is_populated(with:)
     expect(course_details_page.subject_raw.value).to eq(with)
   end
@@ -163,9 +152,6 @@ private
   def then_i_see_error_messages_for_partially_submitted_fields
     expect(course_details_page).to have_content(
       I18n.t("activemodel.errors.validators.autocomplete.course_subject_one"),
-    )
-    expect(course_details_page).to have_content(
-      I18n.t("activemodel.errors.validators.autocomplete.additional_age_range"),
     )
   end
 

--- a/spec/support/page_objects/trainees/course_details.rb
+++ b/spec/support/page_objects/trainees/course_details.rb
@@ -35,7 +35,6 @@ module PageObjects
       element :main_age_range_other, "#course-details-form-main-age-range-other-field"
 
       element :additional_age_range, "#course-details-form-additional-age-range-field"
-      element :additional_age_range_raw, "input[data-nameoriginal='course_details_form[additional_age_range_raw]']"
 
       element :submit_button, "button[type='submit']"
     end


### PR DESCRIPTION
### Context

https://trello.com/c/92avoV21/2622-s-change-other-age-range-autocomplete-to-standard-select

### Changes proposed in this pull request

Change 'Other age range' field from autocomplete component to standard select.

### Guidance to review

- Head to a manual course details page for a provider-led trainee, for example
- Select 'Other age range'
- Check that the revealed field is now a standard select rather than an autocomplete
- Select an age range and check that the form still saves correctly