### PR TITLE
[xxx] EY(salaried) funding mapping

### DIFF
--- a/app/lib/dttp/code_sets/bursary_details.rb
+++ b/app/lib/dttp/code_sets/bursary_details.rb
@@ -10,8 +10,8 @@ module Dttp
         # Undergraduate bursary
         TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => { entity_id: "96756cc6-6041-e811-80f2-005056ac45bb" },
         TRAINING_ROUTE_ENUMS[:opt_in_undergrad] => { entity_id: "96756cc6-6041-e811-80f2-005056ac45bb" },
-        # EYITT-GEB
-        TRAINING_ROUTE_ENUMS[:early_years_salaried] => { entity_id: "6292647b-91e2-e811-8136-5065f38bc341" },
+        # EYITT-GEB this is actually a salary but is stored in the bursary section in DTTP
+        TRAINING_ROUTE_ENUMS[:early_years_salaried] => { entity_id: "fd403c13-3e07-ec11-94ef-000d3adda801" },
         # Tier one
         BURSARY_TIER_ENUMS[:tier_one] => { entity_id: "001bf834-33ff-eb11-94ef-00224899ca99" },
         # Tier two


### PR DESCRIPTION
### Context

A bursary detail record has now been added for EY(salaried) in DTTP. This route actually has a salary so our funding content is currently incorrect. We'll address that in future work.

### Changes proposed in this pull request

Add correct mapping for the DTTP bursary details entity for this route.

### Guidance to review

This should map to the 'Early years salaried' bursary detail entity in DTTP.

