### PR TITLE
Run Dttp::RetrieveTrnJob only when sync_from_dttp feature is enabled

### DIFF
--- a/app/jobs/dttp/retrieve_trn_job.rb
+++ b/app/jobs/dttp/retrieve_trn_job.rb
@@ -9,6 +9,8 @@ module Dttp
     class TraineeAttributeError < StandardError; end
 
     def perform(trainee, timeout_after = nil)
+      return unless FeatureService.enabled?(:sync_from_dttp)
+
       @timeout_after = timeout_after
       @trainee = trainee
 

--- a/spec/jobs/dttp/retrieve_trn_job_spec.rb
+++ b/spec/jobs/dttp/retrieve_trn_job_spec.rb
@@ -13,6 +13,8 @@ module Dttp
     let(:timeout_date) { configured_poll_timeout_days.days.from_now }
 
     before do
+      enable_features(:sync_from_dttp)
+
       allow(RetrieveTrn).to receive(:call).with(trainee: trainee).and_return(trn)
       allow(Settings.jobs).to receive(:poll_delay_hours).and_return(configured_delay)
       allow(Settings.jobs).to receive(:max_poll_duration_days).and_return(configured_poll_timeout_days)


### PR DESCRIPTION
### Context
Fixes https://sentry.io/organizations/dfe-bat/issues/2516275833/?project=5552118&query=is%3Aunresolved

### Changes proposed in this pull request
Return early if `sync_from_dttp` is not enabled in any environment.

### Guidance to review

