### PR TITLE
Fix flaky spec in edit_course_details_spec

### DIFF
--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -114,7 +114,7 @@ FactoryBot.define do
     trait :with_course_details do
       course_subject_one { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
       course_code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
-      course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.reject { |_k, v| v[:option] == :additional }.keys.sample }
+      course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.reject { |_k, v| v[:option] == :main }.keys.sample }
       course_start_date { Faker::Date.between(from: 10.years.ago, to: 2.days.ago) }
       course_end_date { Faker::Date.between(from: course_start_date + 1.day, to: Time.zone.today) }
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -114,7 +114,7 @@ FactoryBot.define do
     trait :with_course_details do
       course_subject_one { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
       course_code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
-      course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.keys.sample }
+      course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.reject { |_k, v| v[:option] == :additional }.keys.sample }
       course_start_date { Faker::Date.between(from: 10.years.ago, to: 2.days.ago) }
       course_end_date { Faker::Date.between(from: course_start_date + 1.day, to: Time.zone.today) }
     end


### PR DESCRIPTION
### Context
Flaky spec gets triggered at `rspec ./spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb:49`

### Changes proposed in this pull request
Added two commits, one to reproduce the failure consistently, and the second to fix the flake.

### Guidance to review

