### PR TITLE
[2607] Add opt-in undergrad route

### DIFF
--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -63,7 +63,7 @@ module Dttp
       end
 
       def course_level
-        if trainee.training_route == "early_years_undergrad"
+        if %w[early_years_undergrad opt_in_undergrad].include? trainee.training_route
           COURSE_LEVEL_UG
         else
           COURSE_LEVEL_PG

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -36,7 +36,7 @@ class Trainee < ApplicationRecord
   validates :training_route, inclusion: { in: [TRAINING_ROUTE_ENUMS[:hpitt_postgrad]] }, if: :hpitt_provider?
   validates :training_route, exclusion: { in: [TRAINING_ROUTE_ENUMS[:hpitt_postgrad]] }, unless: :hpitt_provider?
 
-  enum training_route: TRAINING_ROUTES_FOR_TRAINEE
+  enum training_route: TRAINING_ROUTES
 
   enum training_initiative: ROUTE_INITIATIVES
 

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -46,21 +46,22 @@ ROUTE_INITIATIVES = {
   ROUTE_INITIATIVES_ENUMS[:no_initiative] => 4,
 }.freeze
 
-TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|
-  TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :early_years_undergrad, :school_direct_tuition_fee, :school_direct_salaried, :early_years_assessment_only,
-                                 :early_years_salaried, :early_years_postgrad, :pg_teaching_apprenticeship, :hpitt_postgrad, :opt_in_undergrad, :provider_led_undergrad).include? training_route
-}.freeze
-
 TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|
-  TRAINING_ROUTE_ENUMS.values_at(:provider_led_postgrad, :school_direct_tuition_fee, :school_direct_salaried, :pg_teaching_apprenticeship).include? training_route
+  TRAINING_ROUTE_ENUMS.values_at(:provider_led_postgrad,
+                                 :school_direct_tuition_fee,
+                                 :school_direct_salaried,
+                                 :pg_teaching_apprenticeship).include?(training_route)
 }.freeze
 
 ITT_TRAINING_ROUTES = TRAINING_ROUTES.select { |training_route|
-  TRAINING_ROUTE_ENUMS.values_at(:early_years_undergrad, :pg_teaching_apprenticeship, :provider_led_undergrad, :opt_in_undergrad).include? training_route
+  TRAINING_ROUTE_ENUMS.values_at(:early_years_undergrad,
+                                 :pg_teaching_apprenticeship,
+                                 :provider_led_undergrad,
+                                 :opt_in_undergrad).include?(training_route)
 }.freeze
 
 TRAINING_ROUTE_FEATURE_FLAGS = TRAINING_ROUTE_ENUMS.keys.reject { |training_route|
-  %i[assessment_only].include? training_route
+  %i[assessment_only].include?(training_route)
 }.freeze
 
 TRAINING_ROUTE_AWARD_TYPE = {

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -47,7 +47,8 @@ ROUTE_INITIATIVES = {
 }.freeze
 
 TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|
-  TRAINING_ROUTE_ENUMS.values_at(:opt_in_undergrad).exclude? training_route
+  TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :early_years_undergrad, :school_direct_tuition_fee, :school_direct_salaried, :early_years_assessment_only,
+                                 :early_years_salaried, :early_years_postgrad, :pg_teaching_apprenticeship, :hpitt_postgrad, :opt_in_undergrad, :provider_led_undergrad).include? training_route
 }.freeze
 
 TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -811,6 +811,7 @@ en:
           school_direct_tuition_fee: School direct (tuition fee)
           pg_teaching_apprenticeship: Teaching apprenticeship (postgrad)
           hpitt_postgrad: Teach First
+          opt_in_undergrad: Opt-in (undergrad)
         states:
           draft: Draft
           apply_draft: Apply Draft

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -16,6 +16,7 @@ features:
     school_direct_tuition_fee: true
     pg_teaching_apprenticeship: true
     provider_led_undergrad: true
+    opt_in_undergrad: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -15,6 +15,7 @@ features:
     school_direct_tuition_fee: true
     pg_teaching_apprenticeship: true
     provider_led_undergrad: true
+    opt_in_undergrad: true
 
 pagination:
   records_per_page: 30

--- a/spec/factories/bursaries.rb
+++ b/spec/factories/bursaries.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :bursary do
-    training_route { TRAINING_ROUTES_FOR_TRAINEE.keys.sample }
+    training_route { TRAINING_ROUTES.keys.sample }
     amount { Faker::Number.number(digits: 5) }
 
     trait :with_bursary_subjects do

--- a/spec/features/end_to_end/opt_in_undergrad_spec.rb
+++ b/spec/features/end_to_end/opt_in_undergrad_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "opt-in-undergrad end-to-end journey", feature_show_funding: true, type: :feature do
+  background { given_i_am_authenticated }
+
+  scenario "submit for TRN", "feature_routes.opt_in_undergrad": true do
+    given_i_have_created_an_opt_in_undergrad_trainee
+    and_the_personal_details_is_complete
+    and_the_contact_details_is_complete
+    and_the_diversity_information_is_complete
+    and_the_course_details_is_complete
+    and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_is_complete
+    and_the_draft_record_has_been_reviewed
+    and_all_sections_are_complete
+    when_i_submit_for_trn
+    then_i_am_redirected_to_the_trn_success_page
+  end
+end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -258,6 +258,21 @@ module Dttp
           end
         end
 
+        context "Opt in undergrad" do
+          let(:trainee) do
+            create(:trainee, :opt_in_undergrad, :with_course_details, :with_start_date,
+                   dttp_id: dttp_contact_id, provider: provider)
+          end
+
+          subject { described_class.new(trainee).params }
+
+          it "returns a hash including the undergrad course level" do
+            expect(subject).to include(
+              { "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_UG },
+            )
+          end
+        end
+
         context "school direct (tuition fee)" do
           let(:trainee) do
             create(:trainee,

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -18,6 +18,7 @@ describe Trainee do
         TRAINING_ROUTE_ENUMS[:early_years_salaried] => 7,
         TRAINING_ROUTE_ENUMS[:early_years_postgrad] => 8,
         TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => 9,
+        TRAINING_ROUTE_ENUMS[:opt_in_undergrad] => 10,
         TRAINING_ROUTE_ENUMS[:hpitt_postgrad] => 11,
       )
     end

--- a/spec/support/features/training_route_steps.rb
+++ b/spec/support/features/training_route_steps.rb
@@ -38,6 +38,10 @@ module Features
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship])
     end
 
+    def given_i_have_created_an_opt_in_undergrad_trainee
+      choose_training_route_for(TRAINING_ROUTE_ENUMS[:opt_in_undergrad])
+    end
+
   private
 
     def choose_training_route_for(route)

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -19,6 +19,7 @@ module PageObjects
       element :school_direct_tuition_fee, "#trainee-training-route-school-direct-tuition-fee-field"
       element :pg_teaching_apprenticeship, "#trainee-training-route-pg-teaching-apprenticeship-field"
       element :hpitt_postgrad, "#trainee-training-route-hpitt-postgrad-field"
+      element :opt_in_undergrad, "#trainee-training-route-opt-in-undergrad-field"
 
       element :other, "#trainee-training-route-other-field"
 


### PR DESCRIPTION
### Context
https://trello.com/c/nMF8cKf0/2607-add-opt-in-undergrad-route

### Changes proposed in this pull request
Add opt in undergrad route
### Guidance to review
Create a new trainee and select the 'Opt in (undergrad)' radio button. Check that degree section is not visible on `/review-draft` page and `check-details` page.
