### PR TITLE
[2621] Remove degree section for undergrad routes

### DIFF
--- a/app/components/apply_applications/trainee_data/view.html.erb
+++ b/app/components/apply_applications/trainee_data/view.html.erb
@@ -9,8 +9,10 @@
 
 <%= render Sections::View.new(trainee: trainee, form: form, section: :diversity) %>
 
-<h2 class="govuk-heading-m">
-  <%= t("education") %>
-</h2>
+<% if trainee.requires_degree? %>
+  <h2 class="govuk-heading-m">
+    <%= t("education") %>
+  </h2>
 
-<%= render Sections::View.new(trainee: trainee, form: form, section: :degrees) %>
+  <%= render Sections::View.new(trainee: trainee, form: form, section: :degrees) %>
+<% end %>

--- a/app/components/review_draft/draft/view.html.erb
+++ b/app/components/review_draft/draft/view.html.erb
@@ -4,38 +4,43 @@
 
     <%= render RouteIndicator::View.new(trainee: @trainee) %>
 
-    <h2 class="govuk-heading-m"><%= t("components.heading.draft.personal_details_and_education") %></h2>
+    <h2 class="govuk-heading-m">
+      <%= t("components.heading.draft.#{@trainee.requires_degree? ? "personal_details_and_education" : "personal_details"}") %>
+    </h2>
 
-      <%= render TaskList::View.new do |component|
-            component.row(**row_helper(@trainee, :personal_details))
-            component.row(**row_helper(@trainee, :contact_details))
-            component.row(**row_helper(@trainee, :diversity_information))
-            component.row(**row_helper(@trainee, :degree))
-          end %>
+    <%= render TaskList::View.new do |component|
+      component.row(**row_helper(@trainee, :personal_details))
+      component.row(**row_helper(@trainee, :contact_details))
+      component.row(**row_helper(@trainee, :diversity_information))
+
+      if @trainee.requires_degree?
+        component.row(**row_helper(@trainee, :degree))
+      end
+    end %>
 
     <h2 class="govuk-heading-m"><%= t("components.heading.draft.about_their_teaching_training") %></h2>
 
     <%= render TaskList::View.new(classes: "record-setup") do |component|
-          if show_publish_courses?(@trainee)
-            component.row(**row_helper(@trainee, :publish_course_details))
-          else
-            component.row(**row_helper(@trainee, :course_details))
-          end
+      if show_publish_courses?(@trainee)
+        component.row(**row_helper(@trainee, :publish_course_details))
+      else
+        component.row(**row_helper(@trainee, :course_details))
+      end
 
-          component.row(**row_helper(@trainee, :training_details).except(:hint_text))
+      component.row(**row_helper(@trainee, :training_details).except(:hint_text))
 
-          if @trainee.requires_schools?
-            component.row(**row_helper(@trainee, :school_details))
-          end
+      if @trainee.requires_schools?
+        component.row(**row_helper(@trainee, :school_details))
+      end
 
-          if FeatureService.enabled?(:show_funding)
-            component.row(**row_helper(@trainee, funding_options(@trainee)))
-          end
+      if FeatureService.enabled?(:show_funding)
+        component.row(**row_helper(@trainee, funding_options(@trainee)))
+      end
 
-          # This will be uncommented once the form is built
-          # if @trainee.requires_placement_details?
-          #   component.row(**row_helper(@trainee, :placement_details))
-          # end
-        end %>
+      # This will be uncommented once the form is built
+      # if @trainee.requires_placement_details?
+      #   component.row(**row_helper(@trainee, :placement_details))
+      # end
+    end %>
   </div>
 </div>

--- a/app/forms/trn_submission_form.rb
+++ b/app/forms/trn_submission_form.rb
@@ -14,15 +14,14 @@ class TrnSubmissionForm
   trn_validator :personal_details, form: "PersonalDetailsForm", unless: :apply_application?
   trn_validator :contact_details, form: "ContactDetailsForm", unless: :apply_application?
   trn_validator :diversity, form: "Diversities::FormValidator", unless: :apply_application?
-  trn_validator :degrees, form: "DegreesForm", unless: :apply_application?
+  trn_validator :degrees, form: "DegreesForm", if: :validate_degree?
   trn_validator :course_details, form: "CourseDetailsForm"
   trn_validator :training_details, form: "TrainingDetailsForm"
   trn_validator :trainee_data, form: "ApplyApplications::TraineeDataForm", if: :apply_application?
   trn_validator :schools, form: "Schools::FormValidator", if: :requires_schools?
   trn_validator :funding, form: "Funding::FormValidator", if: :funding_details_collected?
 
-  delegate :requires_schools?, to: :trainee
-  delegate :apply_application?, to: :trainee
+  delegate :requires_schools?, :requires_degree?, :apply_application?, to: :trainee
 
   validate :submission_ready
 
@@ -47,6 +46,10 @@ class TrnSubmissionForm
 
   def funding_details_collected?
     FeatureService.enabled?(:show_funding)
+  end
+
+  def validate_degree?
+    !apply_application? && requires_degree?
   end
 
 private

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -9,6 +9,10 @@ class TrainingRouteManager
     FeatureService.enabled?("placements") && enabled?(:provider_led_postgrad)
   end
 
+  def requires_degree?
+    !undergrad_route?
+  end
+
   def requires_schools?
     %i[school_direct_salaried school_direct_tuition_fee pg_teaching_apprenticeship].any? { |training_route_enums_key| enabled?(training_route_enums_key) }
   end
@@ -49,6 +53,10 @@ private
   attr_reader :trainee
 
   delegate :training_route, to: :trainee
+
+  def undergrad_route?
+    %w[early_years_undergrad provider_led_undergrad opt_in_undergrad].include?(training_route)
+  end
 
   def enabled?(training_route_enums_key)
     FeatureService.enabled?("routes.#{training_route_enums_key}") && training_route == TRAINING_ROUTE_ENUMS[training_route_enums_key.to_sym]

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -24,6 +24,7 @@ class Trainee < ApplicationRecord
            :requires_itt_start_date?,
            :itt_route?,
            :requires_study_mode?,
+           :requires_degree?,
            to: :training_route_manager
 
   delegate :update_training_route!, to: :route_data_manager

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -12,7 +12,7 @@
 
   <%= render TabNavigation::View.new(items: [
     { name: "About their teacher training", url: trainee_path(@trainee) },
-    { name: "Personal details and education", url: trainee_personal_details_path(@trainee) },
+    { name: @trainee.requires_degree? ? "Personal details and education" : "Personal details", url: trainee_personal_details_path(@trainee) },
     { name: "Timeline", url: trainee_timeline_path(@trainee) },
   ]) %>
 

--- a/app/views/trainees/check_details/_draft_trainee_check_details.html.erb
+++ b/app/views/trainees/check_details/_draft_trainee_check_details.html.erb
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m">
-  Personal details and education
+  <%= t("components.heading.draft.#{@trainee.requires_degree? ? "personal_details_and_education" : "personal_details"}") %>
 </h2>
 
 <%= render Sections::View.new(trainee: @trainee, form: @form, section: :personal_details) %>
@@ -8,7 +8,9 @@
 
 <%= render Sections::View.new(trainee: @trainee, form: @form, section: :diversity) %>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :degrees) %>
+<% if @trainee.requires_degree? %>
+  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :degrees) %>
+<% end %>
 
 <h2 class="govuk-heading-m">
   About their teacher training

--- a/app/views/trainees/personal_details/show.html.erb
+++ b/app/views/trainees/personal_details/show.html.erb
@@ -10,10 +10,12 @@
   <%= render Diversity::View.new(data_model: @trainee) %>
 </div>
 
-<% if @trainee.degrees.any? %>
-  <div class="degree-details">
-    <%= render Degrees::View.new(data_model: @trainee, show_delete_button: true) %>
-  </div>
-<% else %>
-  <%= render CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), has_errors: false) %>
+<% if @trainee.requires_degree? %>
+  <% if @trainee.degrees.any? %>
+    <div class="degree-details">
+      <%= render Degrees::View.new(data_model: @trainee, show_delete_button: true) %>
+    </div>
+  <% else %>
+    <%= render CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), has_errors: false) %>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
       apply_draft:
         registration_data_from_apply: Registration data from Apply
       draft:
+        personal_details: Personal details
         personal_details_and_education: Personal details and education
         about_their_teaching_training: About their teacher training
     application_record_card:

--- a/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "provider-led end-to-end journey", feature_show_funding: true, type: :feature do
+feature "provider-led (postgrad) end-to-end journey", feature_show_funding: true, type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.provider_led_postgrad": true, feature_publish_course_details: true do

--- a/spec/features/end_to_end/provider_led_undergrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_undergrad_journey_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "provider-led (undergrad) end-to-end journey", feature_show_funding: true, type: :feature do
+  background { given_i_am_authenticated }
+
+  scenario "submit for TRN", "feature_routes.provider_led_undergrad": true do
+    given_i_have_created_a_provider_led_undergrad_trainee
+    and_the_personal_details_is_complete
+    and_the_contact_details_is_complete
+    and_the_diversity_information_is_complete
+    and_the_course_details_is_complete
+    and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_is_complete
+    and_the_draft_record_has_been_reviewed
+    and_all_sections_are_complete
+    when_i_submit_for_trn
+    then_i_am_redirected_to_the_trn_success_page
+  end
+end

--- a/spec/support/features/training_route_steps.rb
+++ b/spec/support/features/training_route_steps.rb
@@ -6,6 +6,10 @@ module Features
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
     end
 
+    def given_i_have_created_a_provider_led_undergrad_trainee
+      choose_training_route_for(TRAINING_ROUTE_ENUMS[:provider_led_undergrad])
+    end
+
     def given_i_have_created_an_assessment_only_trainee
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:assessment_only])
     end

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -9,6 +9,7 @@ module PageObjects
 
       element :assessment_only, "#trainee-training-route-assessment-only-field"
       element :provider_led_postgrad, "#trainee-training-route-provider-led-postgrad-field"
+      element :provider_led_undergrad, "#trainee-training-route-provider-led-undergrad-field"
       element :early_years_undergrad, "#trainee-training-route-early-years-undergrad-field"
 
       element :early_years_assessment_only, "#trainee-training-route-early-years-assessment-only-field"


### PR DESCRIPTION
### Context

https://trello.com/c/wxGQZ20K/2621-s-provider-led-ug-dont-show-degree-section

### Changes proposed in this pull request

- Adds a new method to the `TrainingRouteManager` -> `requires_degree?`
- Removes the degree section (and all related validations) for trainees on an undergrad route (Early years, Opt-in and Provider-led)
- Changes section titles from 'Personal details and education' -> 'Personal details'
- Adds an end-to-end test for Provider-led (undergrad) trainees

### Guidance to review
- Create a trainee on an undergrad route
- Check that there is no section to add a degree on the '/review-draft' page and the section title is 'Personal details' (not 'Personal details and education')
- Complete the trainee and press 'Check this record'
- Check that there is no section to add a degree on the `/check-details` page and no banner telling you that "This record is not complete"
- Submit the trainee for TRN - this shouldn't error / require a degree
- Go to view your completed trainee, check that the second tab reads 'Personal details' (not 'Personal details and education')
- Click into the 'Personal details' tab and check that there is no degree section