### PR TITLE
[2608] Configure bursaries subjects for opt in

### DIFF
--- a/app/components/review_draft/draft/view.html.erb
+++ b/app/components/review_draft/draft/view.html.erb
@@ -4,38 +4,43 @@
 
     <%= render RouteIndicator::View.new(trainee: @trainee) %>
 
-    <h2 class="govuk-heading-m"><%= t("components.heading.draft.personal_details_and_education") %></h2>
+    <h2 class="govuk-heading-m">
+      <%= t("components.heading.draft.#{@trainee.requires_degree? ? "personal_details_and_education" : "personal_details"}") %>
+    </h2>
 
-      <%= render TaskList::View.new do |component|
-            component.row(**row_helper(@trainee, :personal_details))
-            component.row(**row_helper(@trainee, :contact_details))
-            component.row(**row_helper(@trainee, :diversity_information))
-            component.row(**row_helper(@trainee, :degree))
-          end %>
+    <%= render TaskList::View.new do |component|
+      component.row(**row_helper(@trainee, :personal_details))
+      component.row(**row_helper(@trainee, :contact_details))
+      component.row(**row_helper(@trainee, :diversity_information))
+
+      if @trainee.requires_degree?
+        component.row(**row_helper(@trainee, :degree))
+      end
+    end %>
 
     <h2 class="govuk-heading-m"><%= t("components.heading.draft.about_their_teaching_training") %></h2>
 
     <%= render TaskList::View.new(classes: "record-setup") do |component|
-          if show_publish_courses?(@trainee)
-            component.row(**row_helper(@trainee, :publish_course_details))
-          else
-            component.row(**row_helper(@trainee, :course_details))
-          end
+      if show_publish_courses?(@trainee)
+        component.row(**row_helper(@trainee, :publish_course_details))
+      else
+        component.row(**row_helper(@trainee, :course_details))
+      end
 
-          component.row(**row_helper(@trainee, :training_details).except(:hint_text))
+      component.row(**row_helper(@trainee, :training_details).except(:hint_text))
 
-          if @trainee.requires_schools?
-            component.row(**row_helper(@trainee, :school_details))
-          end
+      if @trainee.requires_schools?
+        component.row(**row_helper(@trainee, :school_details))
+      end
 
-          if FeatureService.enabled?(:show_funding)
-            component.row(**row_helper(@trainee, funding_options(@trainee)))
-          end
+      if FeatureService.enabled?(:show_funding)
+        component.row(**row_helper(@trainee, funding_options(@trainee)))
+      end
 
-          # This will be uncommented once the form is built
-          # if @trainee.requires_placement_details?
-          #   component.row(**row_helper(@trainee, :placement_details))
-          # end
-        end %>
+      # This will be uncommented once the form is built
+      # if @trainee.requires_placement_details?
+      #   component.row(**row_helper(@trainee, :placement_details))
+      # end
+    end %>
   </div>
 </div>

--- a/app/forms/trn_submission_form.rb
+++ b/app/forms/trn_submission_form.rb
@@ -14,15 +14,14 @@ class TrnSubmissionForm
   trn_validator :personal_details, form: "PersonalDetailsForm", unless: :apply_application?
   trn_validator :contact_details, form: "ContactDetailsForm", unless: :apply_application?
   trn_validator :diversity, form: "Diversities::FormValidator", unless: :apply_application?
-  trn_validator :degrees, form: "DegreesForm", unless: :apply_application?
+  trn_validator :degrees, form: "DegreesForm", if: :should_validate_degree?
   trn_validator :course_details, form: "CourseDetailsForm"
   trn_validator :training_details, form: "TrainingDetailsForm"
   trn_validator :trainee_data, form: "ApplyApplications::TraineeDataForm", if: :apply_application?
   trn_validator :schools, form: "Schools::FormValidator", if: :requires_schools?
   trn_validator :funding, form: "Funding::FormValidator", if: :funding_details_collected?
 
-  delegate :requires_schools?, to: :trainee
-  delegate :apply_application?, to: :trainee
+  delegate :requires_schools?, :requires_degree?, :apply_application?, to: :trainee
 
   validate :submission_ready
 
@@ -47,6 +46,10 @@ class TrnSubmissionForm
 
   def funding_details_collected?
     FeatureService.enabled?(:show_funding)
+  end
+
+  def should_validate_degree?
+    !apply_application? && requires_degree?
   end
 
 private

--- a/app/forms/trn_submission_form.rb
+++ b/app/forms/trn_submission_form.rb
@@ -14,7 +14,7 @@ class TrnSubmissionForm
   trn_validator :personal_details, form: "PersonalDetailsForm", unless: :apply_application?
   trn_validator :contact_details, form: "ContactDetailsForm", unless: :apply_application?
   trn_validator :diversity, form: "Diversities::FormValidator", unless: :apply_application?
-  trn_validator :degrees, form: "DegreesForm", if: :should_validate_degree?
+  trn_validator :degrees, form: "DegreesForm", if: :validate_degree?
   trn_validator :course_details, form: "CourseDetailsForm"
   trn_validator :training_details, form: "TrainingDetailsForm"
   trn_validator :trainee_data, form: "ApplyApplications::TraineeDataForm", if: :apply_application?
@@ -48,7 +48,7 @@ class TrnSubmissionForm
     FeatureService.enabled?(:show_funding)
   end
 
-  def should_validate_degree?
+  def validate_degree?
     !apply_application? && requires_degree?
   end
 

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -63,7 +63,7 @@ module Dttp
       end
 
       def course_level
-        if trainee.training_route == "early_years_undergrad"
+        if %w[early_years_undergrad opt_in_undergrad].include? trainee.training_route
           COURSE_LEVEL_UG
         else
           COURSE_LEVEL_PG

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -9,6 +9,10 @@ class TrainingRouteManager
     FeatureService.enabled?("placements") && enabled?(:provider_led_postgrad)
   end
 
+  def requires_degree?
+    !undergrad_route?
+  end
+
   def requires_schools?
     %i[school_direct_salaried school_direct_tuition_fee pg_teaching_apprenticeship].any? { |training_route_enums_key| enabled?(training_route_enums_key) }
   end
@@ -49,6 +53,10 @@ private
   attr_reader :trainee
 
   delegate :training_route, to: :trainee
+
+  def undergrad_route?
+    %w[early_years_undergrad provider_led_undergrad opt_in_undergrad].include?(training_route)
+  end
 
   def enabled?(training_route_enums_key)
     FeatureService.enabled?("routes.#{training_route_enums_key}") && training_route == TRAINING_ROUTE_ENUMS[training_route_enums_key.to_sym]

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -36,7 +36,7 @@ class Trainee < ApplicationRecord
   validates :training_route, inclusion: { in: [TRAINING_ROUTE_ENUMS[:hpitt_postgrad]] }, if: :hpitt_provider?
   validates :training_route, exclusion: { in: [TRAINING_ROUTE_ENUMS[:hpitt_postgrad]] }, unless: :hpitt_provider?
 
-  enum training_route: TRAINING_ROUTES_FOR_TRAINEE
+  enum training_route: TRAINING_ROUTES
 
   enum training_initiative: ROUTE_INITIATIVES
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -24,6 +24,7 @@ class Trainee < ApplicationRecord
            :requires_itt_start_date?,
            :itt_route?,
            :requires_study_mode?,
+           :requires_degree?,
            to: :training_route_manager
 
   delegate :update_training_route!, to: :route_data_manager

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -12,7 +12,7 @@
 
   <%= render TabNavigation::View.new(items: [
     { name: "About their teacher training", url: trainee_path(@trainee) },
-    { name: "Personal details and education", url: trainee_personal_details_path(@trainee) },
+    { name: @trainee.requires_degree? ? "Personal details and education" : "Personal details", url: trainee_personal_details_path(@trainee) },
     { name: "Timeline", url: trainee_timeline_path(@trainee) },
   ]) %>
 

--- a/app/views/trainees/check_details/_draft_trainee_check_details.html.erb
+++ b/app/views/trainees/check_details/_draft_trainee_check_details.html.erb
@@ -1,5 +1,8 @@
 <h2 class="govuk-heading-m">
-  Personal details and education
+  Personal details
+  <% if @trainee.requires_degree? %>
+     and education
+  <% end %>
 </h2>
 
 <%= render Sections::View.new(trainee: @trainee, form: @form, section: :personal_details) %>
@@ -8,7 +11,9 @@
 
 <%= render Sections::View.new(trainee: @trainee, form: @form, section: :diversity) %>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :degrees) %>
+<% if @trainee.requires_degree? %>
+  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :degrees) %>
+<% end %>
 
 <h2 class="govuk-heading-m">
   About their teacher training

--- a/app/views/trainees/check_details/_draft_trainee_check_details.html.erb
+++ b/app/views/trainees/check_details/_draft_trainee_check_details.html.erb
@@ -1,8 +1,5 @@
 <h2 class="govuk-heading-m">
-  Personal details
-  <% if @trainee.requires_degree? %>
-     and education
-  <% end %>
+  <%= t("components.heading.draft.#{@trainee.requires_degree? ? "personal_details_and_education" : "personal_details"}") %>
 </h2>
 
 <%= render Sections::View.new(trainee: @trainee, form: @form, section: :personal_details) %>

--- a/app/views/trainees/personal_details/show.html.erb
+++ b/app/views/trainees/personal_details/show.html.erb
@@ -10,10 +10,12 @@
   <%= render Diversity::View.new(data_model: @trainee) %>
 </div>
 
-<% if @trainee.degrees.any? %>
-  <div class="degree-details">
-    <%= render Degrees::View.new(data_model: @trainee, show_delete_button: true) %>
-  </div>
-<% else %>
-  <%= render CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), has_errors: false) %>
+<% if @trainee.requires_degree? %>
+  <% if @trainee.degrees.any? %>
+    <div class="degree-details">
+      <%= render Degrees::View.new(data_model: @trainee, show_delete_button: true) %>
+    </div>
+  <% else %>
+    <%= render CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), has_errors: false) %>
+  <% end %>
 <% end %>

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -137,6 +137,16 @@ SEED_BURSARIES = [
     amount: 14_000,
     allocation_subjects: [AllocationSubjects::EARLY_YEARS_ITT],
   ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:opt_in_undergrad],
+    amount: 9_000,
+    allocation_subjects: [
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MODERN_LANGUAGES,
+    ],
+  ),
 ].freeze
 
 TRAINING_ROUTE_INITIATIVES = {

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -46,11 +46,6 @@ ROUTE_INITIATIVES = {
   ROUTE_INITIATIVES_ENUMS[:no_initiative] => 4,
 }.freeze
 
-TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|
-  TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :early_years_undergrad, :school_direct_tuition_fee, :school_direct_salaried, :early_years_assessment_only,
-                                 :early_years_salaried, :early_years_postgrad, :pg_teaching_apprenticeship, :hpitt_postgrad, :opt_in_undergrad, :provider_led_undergrad).include? training_route
-}.freeze
-
 TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|
   TRAINING_ROUTE_ENUMS.values_at(:provider_led_postgrad, :school_direct_tuition_fee, :school_direct_salaried, :pg_teaching_apprenticeship).include? training_route
 }.freeze

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -47,7 +47,8 @@ ROUTE_INITIATIVES = {
 }.freeze
 
 TRAINING_ROUTES_FOR_TRAINEE = TRAINING_ROUTES.select { |training_route|
-  TRAINING_ROUTE_ENUMS.values_at(:opt_in_undergrad).exclude? training_route
+  TRAINING_ROUTE_ENUMS.values_at(:assessment_only, :provider_led_postgrad, :early_years_undergrad, :school_direct_tuition_fee, :school_direct_salaried, :early_years_assessment_only,
+                                 :early_years_salaried, :early_years_postgrad, :pg_teaching_apprenticeship, :hpitt_postgrad, :opt_in_undergrad, :provider_led_undergrad).include? training_route
 }.freeze
 
 TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -811,6 +811,7 @@ en:
           school_direct_tuition_fee: School direct (tuition fee)
           pg_teaching_apprenticeship: Teaching apprenticeship (postgrad)
           hpitt_postgrad: Teach First
+          opt_in_undergrad: Opt-in (undergrad)
         states:
           draft: Draft
           apply_draft: Apply Draft

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
       apply_draft:
         registration_data_from_apply: Registration data from Apply
       draft:
+        personal_details: Personal details
         personal_details_and_education: Personal details and education
         about_their_teaching_training: About their teacher training
     application_record_card:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -16,6 +16,7 @@ features:
     school_direct_tuition_fee: true
     pg_teaching_apprenticeship: true
     provider_led_undergrad: true
+    opt_in_undergrad: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -15,6 +15,7 @@ features:
     school_direct_tuition_fee: true
     pg_teaching_apprenticeship: true
     provider_led_undergrad: true
+    opt_in_undergrad: true
 
 pagination:
   records_per_page: 30

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -17,6 +17,21 @@ module Funding
       end
     end
 
+    # context "on opt-in (undergrad) route" do
+    #   let(:state) { :draft }
+    #   let(:training_initiative) { TRAINING_ROUTE_INITIATIVES["opt_in_undergrad"].first }
+    #   let(:degree) { AllocationSubjects::MATHEMATICS }
+    #   let(:trainee) { build(:trainee, state, training_initiative: training_initiative, training_route: "opt_in_undergrad", degree: degree) }
+
+    #   it "renders if the trainee selects mathematics" do
+    #     expect(rendered_component).to have_text("£24,000 estimated bursary")
+    #   end
+
+    #   it "doesnt render if the trainee selects drama" do
+    #     expect(rendered_component).to have_text("No bursaries available for this course")
+    #   end
+    # end
+
     context "assessment only route" do
       let(:state) { :draft }
       let(:trainee) { build(:trainee, state, training_initiative: training_initiative) }

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -17,20 +17,41 @@ module Funding
       end
     end
 
-    # context "on opt-in (undergrad) route" do
-    #   let(:state) { :draft }
-    #   let(:training_initiative) { TRAINING_ROUTE_INITIATIVES["opt_in_undergrad"].first }
-    #   let(:degree) { AllocationSubjects::MATHEMATICS }
-    #   let(:trainee) { build(:trainee, state, training_initiative: training_initiative, training_route: "opt_in_undergrad", degree: degree) }
+    context "on opt-in (undergrad) route" do
+      let(:state) { :draft }
+      let(:training_initiative) { TRAINING_ROUTE_INITIATIVES["opt_in_undergrad"].first }
+      let(:degree) { create(:degree, subject: AllocationSubjects::MATHEMATICS) }
+      let(:trainee) { build(:trainee, state, training_initiative: training_initiative, training_route: "opt_in_undergrad", degrees: [degree]) }
 
-    #   it "renders if the trainee selects mathematics" do
-    #     expect(rendered_component).to have_text("£24,000 estimated bursary")
-    #   end
+      context "when there is a bursary available" do
+        before do
+          allow(CalculateBursary).to receive(:for_route_and_subject).with(
+            trainee.training_route.to_sym,
+            trainee.course_subject_one,
+          ).and_return(9_000)
+          allow(trainee).to receive(:applying_for_bursary).and_return(true)
+          render_inline(View.new(data_model: trainee))
+        end
 
-    #   it "doesnt render if the trainee selects drama" do
-    #     expect(rendered_component).to have_text("No bursaries available for this course")
-    #   end
-    # end
+        it "renders if the trainee selects mathematics" do
+          expect(rendered_component).to have_text("£9,000 estimated bursary")
+        end
+      end
+
+      context "when there is no bursary available" do
+        before do
+          allow(CalculateBursary).to receive(:for_route_and_subject).with(
+            trainee.training_route.to_sym,
+            trainee.course_subject_one,
+          ).and_return(nil)
+          render_inline(View.new(data_model: trainee))
+        end
+
+        it "doesnt render if the trainee selects drama" do
+          expect(rendered_component).not_to have_text("Bursary applied for")
+        end
+      end
+    end
 
     context "assessment only route" do
       let(:state) { :draft }

--- a/spec/factories/bursaries.rb
+++ b/spec/factories/bursaries.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :bursary do
-    training_route { TRAINING_ROUTES_FOR_TRAINEE.keys.sample }
+    training_route { TRAINING_ROUTES.keys.sample }
     amount { Faker::Number.number(digits: 5) }
 
     trait :with_bursary_subjects do

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -209,6 +209,10 @@ FactoryBot.define do
       study_mode { COURSE_STUDY_MODES[:full_time] }
     end
 
+    trait :opt_in_undergrad do
+      training_route { TRAINING_ROUTE_ENUMS[:opt_in_undergrad] }
+    end
+
     trait :draft do
       state { "draft" }
     end

--- a/spec/features/end_to_end/opt_in_undergrad_spec.rb
+++ b/spec/features/end_to_end/opt_in_undergrad_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "opt-in-undergrad end-to-end journey", feature_show_funding: true, type: :feature do
+  background { given_i_am_authenticated }
+
+  scenario "submit for TRN", "feature_routes.opt_in_undergrad": true do
+    given_i_have_created_an_opt_in_undergrad_trainee
+    and_the_personal_details_is_complete
+    and_the_contact_details_is_complete
+    and_the_diversity_information_is_complete
+    and_the_course_details_is_complete
+    and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_is_complete
+    and_the_draft_record_has_been_reviewed
+    and_all_sections_are_complete
+    when_i_submit_for_trn
+    then_i_am_redirected_to_the_trn_success_page
+  end
+end

--- a/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "provider-led end-to-end journey", feature_show_funding: true, type: :feature do
+feature "provider-led (postgrad) end-to-end journey", feature_show_funding: true, type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.provider_led_postgrad": true, feature_publish_course_details: true do

--- a/spec/features/end_to_end/provider_led_undergrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_undergrad_journey_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "provider-led (undergrad) end-to-end journey", feature_show_funding: true, type: :feature do
+  background { given_i_am_authenticated }
+
+  scenario "submit for TRN", "feature_routes.provider_led_undergrad": true do
+    given_i_have_created_a_provider_led_undergrad_trainee
+    and_the_personal_details_is_complete
+    and_the_contact_details_is_complete
+    and_the_diversity_information_is_complete
+    and_the_course_details_is_complete
+    and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_is_complete
+    and_the_draft_record_has_been_reviewed
+    and_all_sections_are_complete
+    when_i_submit_for_trn
+    then_i_am_redirected_to_the_trn_success_page
+  end
+end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -258,6 +258,21 @@ module Dttp
           end
         end
 
+        context "Opt in undergrad" do
+          let(:trainee) do
+            create(:trainee, :opt_in_undergrad, :with_course_details, :with_start_date,
+                   dttp_id: dttp_contact_id, provider: provider)
+          end
+
+          subject { described_class.new(trainee).params }
+
+          it "returns a hash including the undergrad course level" do
+            expect(subject).to include(
+              { "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_UG },
+            )
+          end
+        end
+
         context "school direct (tuition fee)" do
           let(:trainee) do
             create(:trainee,

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -18,6 +18,7 @@ describe Trainee do
         TRAINING_ROUTE_ENUMS[:early_years_salaried] => 7,
         TRAINING_ROUTE_ENUMS[:early_years_postgrad] => 8,
         TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => 9,
+        TRAINING_ROUTE_ENUMS[:opt_in_undergrad] => 10,
         TRAINING_ROUTE_ENUMS[:hpitt_postgrad] => 11,
       )
     end

--- a/spec/support/features/training_route_steps.rb
+++ b/spec/support/features/training_route_steps.rb
@@ -6,6 +6,10 @@ module Features
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
     end
 
+    def given_i_have_created_a_provider_led_undergrad_trainee
+      choose_training_route_for(TRAINING_ROUTE_ENUMS[:provider_led_undergrad])
+    end
+
     def given_i_have_created_an_assessment_only_trainee
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:assessment_only])
     end

--- a/spec/support/features/training_route_steps.rb
+++ b/spec/support/features/training_route_steps.rb
@@ -38,6 +38,10 @@ module Features
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship])
     end
 
+    def given_i_have_created_an_opt_in_undergrad_trainee
+      choose_training_route_for(TRAINING_ROUTE_ENUMS[:opt_in_undergrad])
+    end
+
   private
 
     def choose_training_route_for(route)

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -9,6 +9,7 @@ module PageObjects
 
       element :assessment_only, "#trainee-training-route-assessment-only-field"
       element :provider_led_postgrad, "#trainee-training-route-provider-led-postgrad-field"
+      element :provider_led_undergrad, "#trainee-training-route-provider-led-undergrad-field"
       element :early_years_undergrad, "#trainee-training-route-early-years-undergrad-field"
 
       element :early_years_assessment_only, "#trainee-training-route-early-years-assessment-only-field"

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -19,6 +19,7 @@ module PageObjects
       element :school_direct_tuition_fee, "#trainee-training-route-school-direct-tuition-fee-field"
       element :pg_teaching_apprenticeship, "#trainee-training-route-pg-teaching-apprenticeship-field"
       element :hpitt_postgrad, "#trainee-training-route-hpitt-postgrad-field"
+      element :opt_in_undergrad, "#trainee-training-route-opt-in-undergrad-field"
 
       element :other, "#trainee-training-route-other-field"
 


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/cjQgZ7Th/2608-s-configure-bursaries-subjects-for-opt-in)

### Changes proposed in this pull request

- Added a 9k bursary for Mathematics, Physics and Languages subjects for trainees on the opt-in undergrad route

### Guidance to review

Head to https://register-pr-1362.london.cloudapps.digital/

Create trainee on the opt in undergrad route
in the course details, select one of the above subjects elegible for a bursary
Go to funding section and click on either of the top two choices
You will see a busary page, mentioning a 9k bursary that is eligible for the trainee