### PR TITLE
[2551] Add back link to cookies page

### DIFF
--- a/app/views/pages/cookie_policy.html.erb
+++ b/app/views/pages/cookie_policy.html.erb
@@ -1,5 +1,12 @@
 <%= render PageTitle::View.new(i18n_key: "pages.cookie_policy") %>
 
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: t("back"),
+    href: root_path,
+    ) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-9"><%= t(".heading") %></h1>


### PR DESCRIPTION
### Context

Add back link to cookies page, which sends users to the `root_path`.

### Guidance to review

- Navigate to the cookies page in the footer
- Click the back link