### PR TITLE
[2617] Include 'Study mode' question for Early years (salaried) trainees

### DIFF
--- a/app/lib/route_data_manager.rb
+++ b/app/lib/route_data_manager.rb
@@ -30,6 +30,7 @@ private
       course_age_range: nil,
       course_start_date: nil,
       course_end_date: nil,
+      study_mode: nil,
     }
   end
 

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -39,12 +39,10 @@ class TrainingRouteManager
 
   def requires_study_mode?
     return false unless FeatureService.enabled?("course_study_mode")
-    return false if early_years_route?
 
     [
       TRAINING_ROUTE_ENUMS[:assessment_only],
-      TRAINING_ROUTE_ENUMS[:opt_in_undergrad],
-      TRAINING_ROUTE_ENUMS[:hpitt_postgrad],
+      TRAINING_ROUTE_ENUMS[:early_years_assessment_only],
     ].exclude?(training_route)
   end
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -8,11 +8,13 @@ features:
   publish_course_details: true
   imported_from_apply_filter: true
   enable_teach_first_provider: true
+  course_study_mode: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true
     early_years_postgrad: true
     early_years_undergrad: true
+    early_years_salaried: true
     school_direct_salaried: true
     school_direct_tuition_fee: true
     pg_teaching_apprenticeship: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -10,6 +10,7 @@ features:
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true
+    early_years_salaried: true
     early_years_postgrad: true
     early_years_undergrad: true
     early_years_salaried: true

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -223,7 +223,7 @@ module CourseDetails
       end
 
       context "route without study_mode" do
-        let(:trainee) { create(:trainee, :early_years_undergrad, study_mode: nil) }
+        let(:trainee) { create(:trainee, :assessment_only, study_mode: nil) }
 
         before do
           render_inline(View.new(data_model: trainee))

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -119,6 +119,11 @@ FactoryBot.define do
       course_end_date { Faker::Date.between(from: course_start_date + 1.day, to: Time.zone.today) }
     end
 
+    trait :with_course_details_and_study_mode do
+      with_course_details
+      study_mode { COURSE_STUDY_MODES[:full_time] }
+    end
+
     trait :with_start_date do
       commencement_date { Faker::Date.between(from: 6.months.from_now, to: Time.zone.today) }
     end

--- a/spec/features/end_to_end/early_years_salaried_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_salaried_journey_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "early_years_salaried end-to-end journey", feature_show_funding: true, feature_course_study_mode: true, type: :feature do
+  background { given_i_am_authenticated }
+
+  scenario "submit for TRN", "feature_routes.early_years_salaried": true do
+    given_i_have_created_an_early_years_salaried_trainee
+    and_the_personal_details_is_complete
+    and_the_contact_details_is_complete
+    and_the_diversity_information_is_complete
+    and_the_degree_details_is_complete
+    and_the_ey_course_details_is_complete(requires_study_mode: true)
+    and_the_trainee_start_date_and_id_is_complete
+    and_the_funding_details_is_complete
+    and_the_draft_record_has_been_reviewed
+    and_all_sections_are_complete
+    when_i_submit_for_trn
+    then_i_am_redirected_to_the_trn_success_page
+  end
+end

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -302,7 +302,7 @@ describe CourseDetailsForm, type: :model do
       end
 
       context "not required route" do
-        let(:trainee) { create(:trainee, :early_years_undergrad, study_mode: nil) }
+        let(:trainee) { create(:trainee, :assessment_only, study_mode: nil) }
 
         before do
           subject.valid?

--- a/spec/forms/study_modes_form_spec.rb
+++ b/spec/forms/study_modes_form_spec.rb
@@ -30,7 +30,7 @@ describe StudyModesForm, type: :model, feature_course_study_mode: true do
   end
 
   context "not required route" do
-    let(:trainee) { create(:trainee, :early_years_undergrad) }
+    let(:trainee) { create(:trainee, :assessment_only) }
 
     before do
       subject.valid?

--- a/spec/lib/route_data_manager_spec.rb
+++ b/spec/lib/route_data_manager_spec.rb
@@ -20,7 +20,7 @@ describe RouteDataManager do
       end
 
       context "when a trainee has course details" do
-        let(:trainee) { create(:trainee, :assessment_only, :with_course_details, progress: progress) }
+        let(:trainee) { create(:trainee, :assessment_only, :with_course_details_and_study_mode, progress: progress) }
 
         it "wipes the course details" do
           expect { subject }
@@ -34,6 +34,8 @@ describe RouteDataManager do
             .from(trainee.course_start_date).to(nil)
             .and change { trainee.course_end_date }
             .from(trainee.course_end_date).to(nil)
+            .and change { trainee.study_mode }
+            .from(trainee.study_mode).to(nil)
         end
 
         it "resets the course details progress" do

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -185,28 +185,36 @@ describe TrainingRouteManager do
     end
   end
 
-  context "with the :course_study_mode feature flag enabled", feature_course_study_mode: true do
-    describe "#requires_study_mode?" do
-      {
-        assessment_only: false,
-        early_years_assessment_only: false,
-        early_years_postgrad: false,
-        early_years_salaried: false,
-        early_years_undergrad: false,
-        opt_in_undergrad: false,
-
-        provider_led_postgrad: true,
-        school_direct_tuition_fee: true,
-        school_direct_salaried: true,
-        provider_led_undergrad: true,
-        pg_teaching_apprenticeship: true,
-        hpitt_postgrad: false,
-      }.each do |route, return_val|
-        context "route #{route}" do
+  describe "#requires_study_mode?" do
+    context "with the :course_study_mode feature flag enabled", feature_course_study_mode: true do
+      (TRAINING_ROUTES.keys - %w[early_years_assessment_only assessment_only]).each do |route|
+        context "for route #{route}" do
           let(:trainee) { Struct.new(:training_route).new(route.to_s) }
 
-          it "returns #{return_val}" do
-            expect(subject.requires_study_mode?).to be(return_val)
+          it "returns true" do
+            expect(subject.requires_study_mode?).to be true
+          end
+        end
+      end
+
+      %w[early_years_assessment_only assessment_only].each do |route|
+        context "for route #{route}" do
+          let(:trainee) { create(:trainee, route) }
+
+          it "returns false" do
+            expect(subject.requires_study_mode?).to be false
+          end
+        end
+      end
+    end
+
+    context "with the :course_study_mode feature flag disabled" do
+      TRAINING_ROUTES.each_key do |route|
+        context "for route #{route}" do
+          let(:trainee) { Struct.new(:training_route).new(route.to_s) }
+
+          it "returns false" do
+            expect(subject.requires_study_mode?).to be false
           end
         end
       end

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -25,8 +25,11 @@ module Features
       and_the_course_details_is_marked_completed
     end
 
-    def and_the_ey_course_details_is_complete
+    def and_the_ey_course_details_is_complete(requires_study_mode: false)
       course_details_page.load(id: trainee_from_url.slug)
+      if requires_study_mode
+        and_the_course_study_mode_field_is_completed
+      end
       and_the_course_date_fields_are_completed
       and_the_course_details_are_submitted
       and_the_course_details_is_marked_completed

--- a/spec/support/features/training_route_steps.rb
+++ b/spec/support/features/training_route_steps.rb
@@ -34,6 +34,10 @@ module Features
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:early_years_postgrad])
     end
 
+    def given_i_have_created_an_early_years_salaried_trainee
+      choose_training_route_for(TRAINING_ROUTE_ENUMS[:early_years_salaried])
+    end
+
     def given_i_have_created_a_pg_teaching_apprenticeship_trainee
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship])
     end

--- a/spec/support/page_objects/trainees/new.rb
+++ b/spec/support/page_objects/trainees/new.rb
@@ -11,9 +11,8 @@ module PageObjects
       element :provider_led_postgrad, "#trainee-training-route-provider-led-postgrad-field"
       element :provider_led_undergrad, "#trainee-training-route-provider-led-undergrad-field"
       element :early_years_undergrad, "#trainee-training-route-early-years-undergrad-field"
-
+      element :early_years_salaried, "#trainee-training-route-early-years-salaried-field"
       element :early_years_assessment_only, "#trainee-training-route-early-years-assessment-only-field"
-      element :early_years_salaried, "#trainee-training-route-early-years-graduate-placement-based-field"
       element :early_years_postgrad, "#trainee-training-route-early-years-postgrad-field"
       element :school_direct_salaried, "#trainee-training-route-school-direct-salaried-field"
       element :school_direct_tuition_fee, "#trainee-training-route-school-direct-tuition-fee-field"


### PR DESCRIPTION
### Context

https://trello.com/c/1WEo4EWI/2617-s-ey-salaried-include-study-mode-question

### Changes proposed in this pull request

- Updates the logic in method `requires_study_mode?` to reflect the fact that _only_ Assessment only trainees do not require study mode.
- Switches on the `early_years_salaried` route in dev and review

### Guidance to review
- Create an Early years (salaried) trainee and check that you are asked for the Study mode in the Course details section.
- Create an Assessment only trainee and check that you are not asked for the same.
- All other trainees should be asked the Study mode question.
