### PR TITLE
Reload Trainee cache when chaining db setup/seed commands

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "faker"
-require "factory_bot"
 require Rails.root.join("spec/support/api_stubs/apply_api")
 
 # Course names are not all that important here because it's for marketing
@@ -56,6 +54,10 @@ namespace :example_data do
       puts "Noop as DB already contains data"
       exit
     end
+
+    # Running `bundle exec rails db:migrate db:seed example_data:generate` can sometimes use cached column information.
+    # This forces rails to reload column information before attempting to generate factories
+    Trainee.reset_column_information
 
     Faker::Config.locale = "en-GB"
 


### PR DESCRIPTION
### Context
Running `bundle exec rails db:migrate db:seed example_data:generate`
can sometimes use cached column information. This seems to be blowing up when creating review apps.
This PR forces rails to reload column information before attempting to generate factories.

Fixes https://sentry.io/organizations/dfe-bat/issues/2587744130/

### Changes proposed in this pull request
1. remove [extra](https://github.com/DFE-Digital/register-trainee-teachers/blob/bbe99ebdb27aa34608a7c23e945bdee7684dccd7/Gemfile#L157-L160) require calls to faker/factorybot
2. Ensure trainees table column information is reloaded before running this example data generator.

### Guidance to review
:warning: This will destroy your test database.
- Run `bundle exec rails db:drop db:create db:migrate db:seed example_data:generate RAILS_ENV=test` 
 on master, and expect it to blow up with `undefined method `course_start_date' for #<FactoryBot::SyntaxRunner`
- Run the same on this branch, and it should run and exit successfully. 

