### PR TITLE
[2673] Fix "mark_as_review" text

### DIFF
--- a/app/views/trainees/apply_applications/confirm_courses/show.html.erb
+++ b/app/views/trainees/apply_applications/confirm_courses/show.html.erb
@@ -15,7 +15,7 @@
                            local: true) do |f| %>
       <%= f.hidden_field :code, value: course_code %>
 
-      <%= f.govuk_check_boxes_fieldset :mark_as_reviewed, multiple: false, legend: { text: "" } do %>
+      <%= f.govuk_check_boxes_fieldset :mark_as_reviewed, multiple: false, legend: nil do %>
         <%= f.govuk_check_box :mark_as_reviewed, 1, 0, multiple: false, link_errors: true, label: { text: t(".mark_as_reviewed") } %>
       <% end %>
 

--- a/app/views/trainees/apply_applications/trainee_data/edit.html.erb
+++ b/app/views/trainees/apply_applications/trainee_data/edit.html.erb
@@ -33,7 +33,7 @@
                            url: trainee_apply_applications_trainee_data_path(@trainee),
                            method: :put,
                            local: true) do |f| %>
-        <%= f.govuk_check_boxes_fieldset :mark_as_reviewed, multiple: false, legend: { text: "" } do %>
+        <%= f.govuk_check_boxes_fieldset :mark_as_reviewed, multiple: false, legend: nil do %>
           <%= f.govuk_check_box :mark_as_reviewed, 1, 0, multiple: false, link_errors: true,
                                 label: { text: t("mark_as_reviewed") } %>
         <% end %>

--- a/app/views/trainees/confirm_details/_form.html.erb
+++ b/app/views/trainees/confirm_details/_form.html.erb
@@ -6,7 +6,7 @@
 
     <%= register_form_with(model: confirm_detail_form, url: resource_confirm_update_path, method: :put, local: true) do |f| %>
       <% if @trainee.draft? %>
-        <%= f.govuk_check_boxes_fieldset :mark_as_completed, multiple: false, legend: { text: "" } do %>
+        <%= f.govuk_check_boxes_fieldset :mark_as_completed, multiple: false, legend: nil do %>
           <%= f.govuk_check_box :mark_as_completed, 1, 0, multiple: false, link_errors: true, label: { text: checkbox_text(trainee_section_key, trainee) } %>
         <% end %>
       <% end %>


### PR DESCRIPTION
### Context

Remove `mark_as_review` and `mark_as_completed` text.

### Changes proposed in this pull request

- Remove legend text by making it nil.

### Guidance to review

**First check**

- On the homepage, click on: `View draft trainees imported from Apply`
- Select a trainee and click on `Trainee data`
- Scroll down and look at the checkbox, it should match the prototype and there should be no legend text above it.


![image](https://user-images.githubusercontent.com/50492247/132007408-c7d685e3-7db1-4490-be28-c403d4c9c654.png)


**Second check**

- On the homepage, click on: `View draft trainees imported from Apply`
- Select a trainee and click on `Course details`
- Look at the checkbox, it should match the prototype and there should be no legend text above it.


![image](https://user-images.githubusercontent.com/50492247/132007362-c73ab2fa-5e70-472b-9be0-021d23f7d6d0.png)

**Third check**

- Navigate to a non apply AO trainee
- Click on `Course details`
- Look at the checkbox, it should match the prototype and there should be no legend text above it.

![image](https://user-images.githubusercontent.com/50492247/132023283-3eaa99e2-67ed-476f-9541-4c06ca1bdfbb.png)
