### PR TITLE
ApplyApplication provider relationship should be optional in case provider doesn't exist

### DIFF
--- a/app/models/apply_application.rb
+++ b/app/models/apply_application.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplyApplication < ApplicationRecord
-  belongs_to :provider, foreign_key: :provider_code, primary_key: :code, inverse_of: :apply_applications
+  belongs_to :provider, foreign_key: :provider_code, primary_key: :code, inverse_of: :apply_applications, optional: true
 
   validates :application, presence: true
 

--- a/spec/models/apply_application_spec.rb
+++ b/spec/models/apply_application_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe ApplyApplication do
   describe "associations" do
-    it { is_expected.to belong_to(:provider) }
+    it { is_expected.to belong_to(:provider).optional }
   end
 
   describe "validations" do


### PR DESCRIPTION
Forgot to make provider an optional association in #1368.