### PR TITLE
[2654] Provider-led (undergrad) qualification aim and route to DTTP

### DIFF
--- a/app/lib/dttp/code_sets/qualification_aims.rb
+++ b/app/lib/dttp/code_sets/qualification_aims.rb
@@ -11,6 +11,7 @@ module Dttp
       MAPPING = {
         TRAINING_ROUTE_ENUMS[:assessment_only] => { entity_id: QTS },
         TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => { entity_id: QTS },
+        TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => { entity_id: QTS },
         TRAINING_ROUTE_ENUMS[:early_years_undergrad] => { entity_id: EYTS },
         TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => { entity_id: QTS },
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => { entity_id: QTS },

--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -6,6 +6,7 @@ module Dttp
       MAPPING = {
         TRAINING_ROUTE_ENUMS[:assessment_only] => { entity_id: "99f435d5-a626-e711-80c8-0050568902d3" },
         TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => { entity_id: "6189922e-acc2-e611-80be-00155d010316" },
+        TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => { entity_id: "6189922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:early_years_undergrad] => { entity_id: "6b89922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => { entity_id: "6f89922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => { entity_id: "7789922e-acc2-e611-80be-00155d010316" },


### PR DESCRIPTION
### Context

https://trello.com/c/CQlrH21t/2654-s-provider-led-ug-add-values-to-dttp-codesets

### Changes proposed in this pull request

- Adds the relevant entity ID mapping for route and qualification aim for the Provider-led (undergrad) route.
- Note: the route ID is the same as Provider-led (postgrad), what distinguishes these routes is the course level (UG vs PG)

### Guidance to review
🚢 