### PR TITLE
[2624] Update Course level -> Education phase in filters

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,7 +318,7 @@ en:
     filter:
       title: Filters
       selected_title: Selected filters
-      level: Course level
+      level: Education phase
       training_route: Training route
       record_source: Record source
       state: Status
@@ -478,7 +478,7 @@ en:
         no_records: Your trainee records will appear here. You do not have any records yet.
         export: Export these records
         filters:
-          level: Course level
+          level: Education phase
           search: Search records
           status: Status
           subject: Subject


### PR DESCRIPTION
### Context

https://trello.com/c/6wci02Mt/2624-s-change-label-of-course-level-filter-to-education-phase

### Changes proposed in this pull request

What it says on the tin.

### Guidance to review
- Check the filter heading and the 'selected filters' label say 'Education phase'
