### PR TITLE
[2619] Alphabetise 'Type of training filter'

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -16,7 +16,11 @@ class TraineesController < ApplicationController
     # clause, removing Kaminari's pagination. Hence the use of `#select`.
     @draft_trainees = paginated_trainees.select(&:draft?)
     @completed_trainees = paginated_trainees.reject(&:draft?)
-    @training_routes = policy_scope(Trainee).group(:training_route).count.keys
+
+    # sort_by is to enable alphabetization in line with translations, which is named different to the hash.
+    @training_routes = policy_scope(Trainee)
+                         .group(:training_route)
+                         .count.keys.sort_by(&TRAINING_ROUTE_ENUMS.values.method(:index))
 
     respond_to do |format|
       format.html

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -6,13 +6,13 @@ TRAINING_ROUTE_ENUMS = {
   early_years_postgrad: "early_years_postgrad",
   early_years_salaried: "early_years_salaried",
   early_years_undergrad: "early_years_undergrad",
+  opt_in_undergrad: "opt_in_undergrad",
   provider_led_postgrad: "provider_led_postgrad",
   provider_led_undergrad: "provider_led_undergrad",
   school_direct_salaried: "school_direct_salaried",
   school_direct_tuition_fee: "school_direct_tuition_fee",
-  opt_in_undergrad: "opt_in_undergrad",
-  hpitt_postgrad: "hpitt_postgrad",
   pg_teaching_apprenticeship: "pg_teaching_apprenticeship",
+  hpitt_postgrad: "hpitt_postgrad",
 }.freeze
 
 ROUTE_INITIATIVES_ENUMS = {


### PR DESCRIPTION
### Context

Alphabetise  the `Type of training filter`.

### Guidance to review

- Navigate to the `Trainee records` page .
- Check that the `Type of training` checkboxes are in alphabetical order.

### Screenshot

![image](https://user-images.githubusercontent.com/50492247/132054689-1d24f524-0441-43b3-83d4-083d1b2d83ed.png)