### PR TITLE
[2542] Ensure invalid country selection is persisted across form reloads

### DIFF
--- a/app/components/form_components/autocomplete/view.rb
+++ b/app/components/form_components/autocomplete/view.rb
@@ -7,9 +7,8 @@ module FormComponents
         @raw_attribute_value = form.object.send("#{attribute_name}_raw")
         @attribute_value = form.object.send(attribute_name)
         @attribute_name = attribute_name
-        super(classes: classes, html_attributes: default_html_attributes.merge(html_attributes))
-
         @form_field = form_field
+        super(classes: classes, html_attributes: default_html_attributes.merge(html_attributes))
       end
 
     private

--- a/app/components/form_components/country_autocomplete/script.js
+++ b/app/components/form_components/country_autocomplete/script.js
@@ -6,6 +6,7 @@ const defaultValueOption = component => component.getAttribute('data-default-val
 
 nodeListForEach($allCountryAutoCompleteElements, (component) => {
   const selectEl = component.querySelector('select')
+  const inError = component.querySelector('div.govuk-form-group').className.includes('error')
   const inputValue = defaultValueOption(component)
 
   // We add a name which we base off the name for the select element and add "raw" to it, eg
@@ -15,9 +16,13 @@ nodeListForEach($allCountryAutoCompleteElements, (component) => {
   const rawFieldName = `${matches[1]}[${matches[2]}_raw]`
 
   openregisterLocationPicker({
-    defaultValue: inputValue,
-    selectElement: component.querySelector('select'),
+    defaultValue: inError ? '' : inputValue,
+    selectElement: selectEl,
     name: rawFieldName,
     url: '/location-autocomplete-graph.json'
   })
+
+  if (inError) {
+    component.querySelector('input').value = inputValue
+  }
 })

--- a/app/components/form_components/country_autocomplete/script.js
+++ b/app/components/form_components/country_autocomplete/script.js
@@ -2,10 +2,22 @@ import { nodeListForEach } from 'govuk-frontend/govuk/common'
 import openregisterLocationPicker from 'govuk-country-and-territory-autocomplete'
 
 const $allCountryAutoCompleteElements = document.querySelectorAll('[data-module="app-country-autocomplete"]')
+const defaultValueOption = component => component.getAttribute('data-default-value') || ''
 
 nodeListForEach($allCountryAutoCompleteElements, (component) => {
+  const selectEl = component.querySelector('select')
+  const inputValue = defaultValueOption(component)
+
+  // We add a name which we base off the name for the select element and add "raw" to it, eg
+  // if there is a select input called "course_details[subject]" we add a name to the text input
+  // as "course_details[subject_raw]"
+  const matches = /(\w+)\[(\w+)\]/.exec(selectEl.name)
+  const rawFieldName = `${matches[1]}[${matches[2]}_raw]`
+
   openregisterLocationPicker({
+    defaultValue: inputValue,
     selectElement: component.querySelector('select'),
+    name: rawFieldName,
     url: '/location-autocomplete-graph.json'
   })
 })

--- a/app/components/form_components/country_autocomplete/view.rb
+++ b/app/components/form_components/country_autocomplete/view.rb
@@ -2,16 +2,8 @@
 
 module FormComponents
   module CountryAutocomplete
-    class View < GovukComponent::Base
-      def initialize(attribute_name:, form_field:, classes: [], html_attributes: {})
-        @attribute_name = attribute_name
-        @form_field = form_field
-        super(classes: classes, html_attributes: default_html_attributes.merge(html_attributes))
-      end
-
+    class View < Autocomplete::View
     private
-
-      attr_accessor :form_field, :attribute_name
 
       def default_classes
         %w[]
@@ -21,6 +13,7 @@ module FormComponents
         {
           id: attribute_name.to_s,
           "data-module" => "app-country-autocomplete",
+          "data-default-value" => (@raw_attribute_value || @attribute_value).to_s,
         }
       end
     end

--- a/app/forms/degree_form.rb
+++ b/app/forms/degree_form.rb
@@ -22,11 +22,13 @@ class DegreeForm
     uk_degree_raw
     subject_raw
     institution_raw
+    country_raw
   ].freeze
 
   attr_accessor(*FIELDS, *AUTOCOMPLETE_FIELDS, :degrees_form, :degree)
 
   validates :subject, :institution, autocomplete: true, allow_nil: true
+  validates :country, autocomplete: true, allow_nil: true
   validate :validate_with_degree_model
 
   validates :institution, inclusion: { in: Degree::INSTITUTIONS }, allow_nil: true

--- a/app/views/trainees/degrees/_non_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_non_uk_degree_form.html.erb
@@ -10,6 +10,7 @@
   <h1 class="govuk-heading-l">Non-UK degree details</h1>
 
   <%= render FormComponents::CountryAutocomplete::View.new(
+    f,
     attribute_name: :country,
     form_field: f.govuk_collection_select(:country, 
                                           countries_options,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -894,6 +894,7 @@ en:
         email:
           invalid: Enter an email address in the correct format, like name@example.com
         autocomplete:
+          country: Select a country from the list - your entry is not recognised
           subject: &subject Select a subject from the list - your entry is not recognised
           course_subject_one: *subject
           course_subject_two: *subject

--- a/spec/features/form_sections/personal_and_education_details/degrees/adding_degree_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/degrees/adding_degree_spec.rb
@@ -109,8 +109,10 @@ RSpec.feature "Adding a degree" do
     scenario "the user submits partially entered autocompletes", js: true do
       given_i_have_selected_the_non_uk_route
       and_i_am_on_the_degree_details_page
+      and_i_fill_in_country_without_selecting_a_value(with: "mongoose")
       and_i_fill_in_subject_without_selecting_a_value(with: "moose")
       and_i_click_continue
+      then_country_is_populated(with: "mongoose")
       then_subject_is_populated(with: "moose")
       then_i_see_error_messages_for_partially_submitted_fields(:subject)
     end
@@ -213,8 +215,16 @@ private
     degree_details_page.subject_raw.fill_in with: with
   end
 
+  def and_i_fill_in_country_without_selecting_a_value(with:)
+    degree_details_page.country_raw.fill_in with: with
+  end
+
   def then_subject_is_populated(with:)
     expect(degree_details_page.subject_raw.value).to eq(with)
+  end
+
+  def then_country_is_populated(with:)
+    expect(degree_details_page.country_raw.value).to eq(with)
   end
 
   def and_i_fill_in_degree_without_selecting_a_value(with:)

--- a/spec/support/page_objects/trainees/new_degree_details.rb
+++ b/spec/support/page_objects/trainees/new_degree_details.rb
@@ -24,6 +24,7 @@ module PageObjects
       element :other_grade, "#degree-other-grade-field"
 
       element :country, "#degree-country-field"
+      element :country_raw, "input[data-nameoriginal='degree[country_raw]']"
 
       element :error_summary, ".govuk-error-summary"
       element :continue, "button[type='submit']"


### PR DESCRIPTION
### Context
Fixes [this bug](https://trello.com/c/VWaQIEwy/2542-bug-previous-valid-answers-persist-in-forms-if-you-change-them-to-invalid-answers-and-try-to-submit)

### Changes proposed in this pull request
Ensure that country autocomplete retains the invalid value across a form reload.
Picked up a bit of the standard autocomplete code and added it to the countries autocomplete to ensure that they both behave in a similar manner.

### Guidance to review
From the bug report:
1. Go to make a trainee
2. Go to the degrees section and add a degree
3. click non uk degree
4. on country, select sweden (for example)
5. try to submit the form
6. Youre met with errors, but sweden is valid and stays in the input box
7. change sweden to "something invalid" or any invalid answer
8. try to submit the form
9. ~sweden persists, when it shouldnt~ country input shows "something invalid"
