### PR TITLE
[2663] Update Trainees::CreateFromApply to handle missing course

### DIFF
--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -22,6 +22,8 @@ module Trainees
         return
       end
 
+      return if course.nil? # Courses can be missing in non-prod environments
+
       trainee.save!
       save_personal_details!
       create_degrees!

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -12,11 +12,12 @@ module Trainees
     let(:course_info) { ApiStubs::ApplyApi.course.as_json }
     let(:trainee) { create_trainee_from_apply }
     let(:subject_names) { [] }
+    let(:course_code) { course_info["course_code"] }
 
     let!(:course) do
       create(
         :course_with_subjects,
-        code: course_info["course_code"],
+        code: course_code,
         accredited_body_code: apply_application.provider_code,
         route: :school_direct_tuition_fee,
         subject_names: subject_names,
@@ -78,6 +79,16 @@ module Trainees
         expect {
           create_trainee_from_apply
         }.to change(apply_application, :state).to("non_importable_duplicate")
+      end
+    end
+
+    context "course doesn't exist" do
+      let(:course_code) { "ABC" }
+
+      it "doesn't change the state" do
+        expect {
+          create_trainee_from_apply
+        }.not_to change(apply_application, :state)
       end
     end
 


### PR DESCRIPTION
### Context
Non-prod environments can have missing courses which can cause `Trainees::CreateFromApply` to blow up. Added a guard clause the protect the service from this situtation.