### PR TITLE
[2470] Fix data migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /coverage/*
 /db/*.sqlite3
 /db/*.sqlite3-journal
+/db/data_schema.rb
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,5 @@ RUN bundle exec rake assets:precompile && \
 ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
 
-CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && \
-    bundle exec rails data:migrate && \
+CMD bundle exec rails db:migrate:with_data_migrations && \
     bundle exec rails server -b 0.0.0.0

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-DataMigrate::Data.define(version: 20210806100151)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -173,6 +173,9 @@ ActiveRecord::Schema.define(version: 2021_09_01_154843) do
     t.index ["code", "accredited_body_code"], name: "index_courses_on_code_and_accredited_body_code", unique: true
   end
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "degrees", force: :cascade do |t|
     t.integer "locale_code", null: false
     t.string "uk_degree"

--- a/lib/tasks/migrate_with_data.rake
+++ b/lib/tasks/migrate_with_data.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :migrate do
+    desc "Run db:migrate:with_data if environment is staging or production or just db:migrate and ignore ActiveRecord::ConcurrentMigrationError errors"
+    task with_data_migrations: :environment do
+      if %w[staging production].include?(Rails.env)
+        Rake::Task["db:migrate:with_data"].invoke
+      else
+        Rake::Task["db:migrate"].invoke
+      end
+
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -42,7 +42,7 @@ locals {
     SETTINGS__BLAZER_DATABASE_URL = cloudfoundry_service_key.postgres-blazer-key.credentials.uri
   })
   review_app_start_command = "bundle exec rake db:migrate db:seed example_data:generate && bundle exec rails server -b 0.0.0.0"
-  web_app_start_command    = var.app_environment == "review" ? local.review_app_start_command : "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
+  web_app_start_command    = var.app_environment == "review" ? local.review_app_start_command : "bundle exec rails db:migrate:with_data_migrations && bundle exec rails server -b 0.0.0.0"
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "register-worker-${local.app_name_suffix}"
   logging_service_name     = "register-logit-${local.app_name_suffix}"


### PR DESCRIPTION
### Context

- https://trello.com/c/dIEIo0C1/2470-data-migrations-arent-running

The data migrations were out of sync across non dev environments. They've been synced up to match with prod so the data migration task should run the next logical migration and record them correctly in the `data_migrations`  table.

This PR consolidates the task to run migrations so it includes the data ones if we're deploying to staging or prod otherwise it'll just run the normal migrations command. Also ignores `ActiveRecord::ConcurrentMigrationError errors` and updates the command in both the `Dockerfile` and `variables.tf` (which overrides the startup command in Dockerfile)
