### PR TITLE
[xxx] Fix duplicate persona creation

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -77,18 +77,16 @@ namespace :example_data do
     # For each persona...
     PERSONAS.each do |persona_attributes|
       # Create the persona
-      persona = Persona.find_or_create_by!(first_name: persona_attributes[:first_name],
-                                           last_name: persona_attributes[:last_name],
-                                           email: persona_attributes[:email],
-                                           dttp_id: SecureRandom.uuid,
-                                           system_admin: persona_attributes[:system_admin])
+      persona = Persona.create_with(dttp_id: SecureRandom.uuid).find_or_create_by!(first_name: persona_attributes[:first_name],
+                                                                                   last_name: persona_attributes[:last_name],
+                                                                                   email: persona_attributes[:email],
+                                                                                   system_admin: persona_attributes[:system_admin])
 
       next unless persona_attributes[:provider]
 
       # Create the provider for that persona
-      provider = Provider.find_or_create_by!(
+      provider = Provider.create_with(dttp_id: SecureRandom.uuid).find_or_create_by!(
         name: persona_attributes[:provider],
-        dttp_id: SecureRandom.uuid,
         code: persona_attributes[:provider_code].presence || Faker::Alphanumeric.alphanumeric(number: 3).upcase,
       )
 


### PR DESCRIPTION
### Context

Review apps are getting duplicate personas over time.

### Changes proposed in this pull request

* add `dttp_id` as a `create_with` argument

When creating a persona don't include the `SecureRandom.uuid` in the `find_or_create_by` as that will cause it to always create.

### Guidance to review

There is already a guard clause to prevent the example data script running on a DB with data already present. I'm not sure how this issue is arising, possibly a race condition between the worker instance and the app instance on the review apps. This looks like a likely cause though and is only run on review apps and QA.

