### PR TITLE
[2708] Consider 'new' schools active

### DIFF
--- a/app/models/dttp/school.rb
+++ b/app/models/dttp/school.rb
@@ -15,6 +15,8 @@ module Dttp
       proposed_to_open: 300000008,
     }.freeze
 
-    scope :active, -> { where(status_code: STATUS_CODES[:active]) }
+    ACTIVE_STATUS_CODES = [STATUS_CODES[:active], STATUS_CODES[:new]].freeze
+
+    scope :active, -> { where(status_code: ACTIVE_STATUS_CODES) }
   end
 end

--- a/spec/factories/dttp/schools.rb
+++ b/spec/factories/dttp/schools.rb
@@ -11,5 +11,13 @@ FactoryBot.define do
     trait :active do
       status_code { Dttp::School::STATUS_CODES[:active] }
     end
+
+    trait :new do
+      status_code { Dttp::School::STATUS_CODES[:new] }
+    end
+
+    trait :inactive do
+      status_code { Dttp::School::STATUS_CODES[:inactive] }
+    end
   end
 end

--- a/spec/models/dttp/school_spec.rb
+++ b/spec/models/dttp/school_spec.rb
@@ -9,18 +9,30 @@ module Dttp
     it { is_expected.to have_db_index(:dttp_id) }
 
     describe ".active" do
-      let(:active_dttp_school) { create(:dttp_school, :active) }
-
       subject { described_class.active }
 
-      before do
-        active_dttp_school
-        create(:dttp_school)
+      context "when a school is active" do
+        let(:school) { create(:dttp_school, :active) }
+
+        it "is returned" do
+          expect(subject).to include(school)
+        end
       end
 
-      it "returns only active schools" do
-        expect(subject.count).to eq(1)
-        expect(subject).to include(active_dttp_school)
+      context "when a school is new" do
+        let(:school) { create(:dttp_school, :new) }
+
+        it "is returned" do
+          expect(subject).to include(school)
+        end
+      end
+
+      context "when a school is neither" do
+        let(:school) { create(:dttp_school, :inactive) }
+
+        it "is not returned" do
+          expect(subject).not_to include(school)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

We match our schools to a list of schools from DTTP. DTTP has a weird and wonderful bunch of statuses for these schools but we only match on 'active' when we look them up. There is a production issue where a user has selected a 'new' school in the lead school dropdown for a couple of trainees. It seems like we should include 'new' as a slightly colourful version of 'active'.

### Changes proposed in this pull request

Match DTTP schools in status 'active' and 'new' when looking up the DTTP mapping.

New schools can be selected as lead/employing school so we need to be able to map them.

### Guidance to review

