### PR TITLE
Fix some flakes

### DIFF
--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -112,7 +112,7 @@ FactoryBot.define do
     end
 
     trait :with_course_details do
-      course_subject_one { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
+      course_subject_one { ::CourseSubjects::MATHEMATICS }
       course_code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
       course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.reject { |_k, v| v[:option] == :main }.keys.sample }
       course_start_date { Faker::Date.between(from: 1.year.ago, to: 2.days.ago) }
@@ -248,13 +248,13 @@ FactoryBot.define do
 
     trait :deferred do
       trn_received
-      defer_date { Faker::Date.in_date_period }
+      defer_date { potential_course_start_date }
       state { "deferred" }
     end
 
     trait :reinstated do
       completed
-      defer_date { Faker::Date.in_date_period }
+      defer_date { potential_course_start_date }
       reinstate_date { Faker::Date.in_date_period }
       state { "trn_received" }
     end

--- a/spec/forms/deferral_form_spec.rb
+++ b/spec/forms/deferral_form_spec.rb
@@ -72,6 +72,15 @@ describe DeferralForm, type: :model do
   end
 
   describe "#save!" do
+    let(:params) do
+      {
+        year: trainee.course_start_date.year + 1,
+        month: trainee.course_start_date.month,
+        day: trainee.course_start_date.day,
+        date_string: "other",
+      }
+    end
+
     it "takes any data from the form store and saves it to the database and clears the store data" do
       expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
 


### PR DESCRIPTION
### Context

Fixes a couple of flakey tests which were failing due to:

- Course start date validation issues for other dates (withdrawing etc)
- Random selection of `Dttp::CodeSets::CourseSubjects::MAPPING` should be avoided as we transform some of these values in the actual UI (eg the test was asserting that a subject such as `German language` was rendered by a component when in fact it would be shown as `German` in the UI