### PR TITLE
[2693] Only import apply applications where the provider has apply sync enabled

### DIFF
--- a/app/jobs/trainees/create_from_apply_job.rb
+++ b/app/jobs/trainees/create_from_apply_job.rb
@@ -7,7 +7,7 @@ module Trainees
     def perform
       return unless FeatureService.enabled?("import_applications_from_apply")
 
-      ApplyApplication.joins(:provider).importable.each do |application|
+      ApplyApplication.joins(:provider).where(providers: { apply_sync_enabled: true }).importable.each do |application|
         CreateFromApply.call(application: application)
       end
     end

--- a/spec/jobs/trainees/create_trainees_from_apply_job_spec.rb
+++ b/spec/jobs/trainees/create_trainees_from_apply_job_spec.rb
@@ -5,20 +5,33 @@ require "rails_helper"
 module Trainees
   describe CreateFromApplyJob do
     include ActiveJob::TestHelper
+    let(:state) { :importable }
+    let(:provider_code) { create(:provider, apply_sync_enabled: apply_sync_enabled) }
+    let(:apply_application) { create(:apply_application, accredited_body_code: provider_code.code, state: state) }
 
     describe "#perform", feature_import_applications_from_apply: true do
-      context "apply application is importable" do
-        let(:apply_application) { create(:apply_application, :importable) }
+      context "provider has opted in to import applications from Apply" do
+        let(:apply_sync_enabled) { true }
 
         it "creates a trainee" do
           expect(CreateFromApply).to receive(:call).with(application: apply_application)
 
           described_class.perform_now
         end
+
+        context "apply application is not importable" do
+          let(:state) { :imported }
+
+          it "does not create a trainee" do
+            expect(CreateFromApply).not_to receive(:call).with(application: apply_application)
+
+            described_class.perform_now
+          end
+        end
       end
 
-      context "apply application is not importable" do
-        let(:apply_application) { create(:apply_application) }
+      context "provider has opted out to import applications from Apply" do
+        let(:apply_sync_enabled) { false }
 
         it "does not create a trainee" do
           expect(CreateFromApply).not_to receive(:call).with(application: apply_application)


### PR DESCRIPTION
### Context
https://trello.com/c/ueZhqVy9/2653-test-apply-integration-with-real-data-final-snag

### Changes proposed in this pull request
- Update `Trainees::CreateFromApplyJob` to only consider providers that have apply sync enabled

