### PR TITLE
[xxx] Fix flakey specialism spec

### DIFF
--- a/spec/controllers/trainees/subject_specialisms_controller_spec.rb
+++ b/spec/controllers/trainees/subject_specialisms_controller_spec.rb
@@ -15,8 +15,7 @@ describe Trainees::SubjectSpecialismsController do
     context "with empty form params" do
       let!(:course) do
         create(
-          :course_with_subjects,
-          subjects_count: 1,
+          :course_with_unmappable_subject,
           accredited_body_code: trainee.provider.code,
           route: trainee.training_route,
         )

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -21,6 +21,25 @@ FactoryBot.define do
       [qualifications, study_mode].join(" ")
     end
 
+    factory :course_with_unmappable_subject do
+      transient do
+        subjects_count { 1 }
+        subject_names { ["Crosby, Stills & Nash studies"] }
+        study_mode { "full_time" }
+      end
+
+      before(:create) do |course, evaluator|
+        course.name = "Unmappable subject course"
+        course.study_mode = evaluator.study_mode
+      end
+
+      after(:create) do |course, evaluator|
+        evaluator.subject_names.each do |subject_name|
+          course.subjects << create(:subject, name: subject_name)
+        end
+      end
+    end
+
     factory :course_with_subjects do
       transient do
         subjects_count { 1 }


### PR DESCRIPTION

### Context

This spec is flakey

### Changes proposed in this pull request

* Add a factory that creates a subject with an unmappable course and use that for the invalid branch of the spec.

The setup for the course in this spec was indeterminately adding a mappable subject in the `course_with_subjects` factory (I think) and was failing as the `SubjectSpecialismForm` would then end up with a subject already set and be valid.

### Guidance to review

