### PR TITLE
[xxx] Temporary mapping for 11-18

### DIFF
--- a/config/initializers/age_ranges.rb
+++ b/config/initializers/age_ranges.rb
@@ -4,6 +4,7 @@ module AgeRange
   THREE_TO_ELEVEN = [3, 11].freeze
   FIVE_TO_ELEVEN = [5, 11].freeze
   ELEVEN_TO_SIXTEEN = [11, 16].freeze
+  ELEVEN_TO_NINETEEN = [11, 18].freeze # there isn't currently an 11-18 in DTTP. Update when there is
   ELEVEN_TO_NINETEEN = [11, 19].freeze
   ZERO_TO_FIVE = [0, 5].freeze
   THREE_TO_SEVEN = [3, 7].freeze


### PR DESCRIPTION
### Context

DTTP doesn't currently have an 11-18 age range but a user has asked to
enter it. 

### Changes proposed in this pull request

Map it to 11-19 in DTTP for now so as the update jobs don't fail for this trainee.

### Guidance to review

