### PR TITLE
[2716] Add training route indicator to check details page

### DIFF
--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -37,6 +37,7 @@
           </div>
         <% end %>
 
+        <%= render RouteIndicator::View.new(trainee: @trainee) %>
       </div>
     </div>
 


### PR DESCRIPTION
### Context

https://trello.com/c/elY9hBK2/2716-add-training-route-indicator-to-check-details-page

### Changes proposed in this pull request

Adds the training route indicator to the 'check-details' page.

It looks like this: ✨ 

<img width="886" alt="Screenshot 2021-09-09 at 15 19 32" src="https://user-images.githubusercontent.com/18436946/132703316-833de198-0a21-4800-874a-8e048631abff.png">


### Guidance to review

:shipit: 
