### PR TITLE
[2705] Funding content changes

### DIFF
--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -21,7 +21,7 @@ module Funding
     def funding_detail_rows
       [
         training_initiative_row,
-        bursary_funding_row,
+        funding_method_row,
       ].compact
     end
 
@@ -33,12 +33,12 @@ module Funding
       mappable_field(training_initiative, t(".training_initiative"), edit_trainee_funding_training_initiative_path(trainee))
     end
 
-    def bursary_funding_row
+    def funding_method_row
       return unless show_bursary_funding?
 
       mappable_field(
-        bursary_funding,
-        t(".bursary_funding"),
+        funding_method,
+        t(".funding_method"),
         (edit_trainee_funding_bursary_path(trainee) if trainee.can_apply_for_bursary?),
       )
     end
@@ -65,10 +65,10 @@ module Funding
       t("activerecord.attributes.trainee.training_initiatives.#{data_model.training_initiative}")
     end
 
-    def bursary_funding
+    def funding_method
       return if trainee.can_apply_for_bursary? && data_model.applying_for_bursary.nil?
 
-      return t(".no_bursary_available") if !trainee.can_apply_for_bursary?
+      return t(".no_funding_available") if !trainee.can_apply_for_bursary?
 
       return "#{t(".tiered_bursary_applied_for.#{data_model.bursary_tier}")}#{bursary_funding_hint}".html_safe if data_model.bursary_tier.present?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,10 +32,10 @@ en:
     view:
       title: Funding
       training_initiative: &training_initiative Training initiative
-      bursary_funding: &bursary_funding Bursary funding
+      funding_method: &funding_method Funding method
       bursary_applied_for: Bursary applied for
-      no_bursary_applied_for: Not bursary funded
-      no_bursary_available: No bursaries available for this course
+      no_bursary_applied_for: Not funded
+      no_funding_available: Not applicable
       tiered_bursary_applied_for:
         tier_one: Applied for Tier 1
         tier_two: Applied for Tier 2
@@ -377,8 +377,8 @@ en:
         lead_school: School details
         trainee_data: Trainee data
         schools: Schools
-        funding: Funding
-        funding_inactive: Funding cannot be started yet
+        funding: Funding details
+        funding_inactive: Funding details cannot be started yet
       statuses:
         not_provided: not provided
         incomplete: not started
@@ -391,7 +391,7 @@ en:
         in_progress_valid: Continue section
         in_progress_invalid: Continue section
         review: Review their data
-        funding_inactive:  Complete course details first
+        funding_inactive: Complete course details first
     school_result_notice:
       result_text: "1 more school matches your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."
       multiple_result_text: "%{remaining_search_count} more schools match your search for ‘%{search_query}’. Try narrowing down your search if the school you’re looking for is not listed."
@@ -463,7 +463,7 @@ en:
         itt_start_date: *itt_start_date
         itt_end_date: *itt_end_date
         training_initiative: *training_initiative
-        applying_for_bursary: *bursary_funding
+        applying_for_bursary: *funding_method
         institution: *institution
         subject: *subject
         uk_degree: *degree_type
@@ -622,7 +622,7 @@ en:
           title: Are you applying for a bursary for this trainee?
           true: Yes, apply for a bursary
           false: No, do not apply for a bursary
-          false_hint: For example, the trainee is not eligible or has applied for a scholarship
+          false_hint: For example, the trainee is not eligible or is self-funded.
   pages:
     request_an_account:
       inviting_limited_itt: We are only inviting a limited amount of initial teacher training providers to use Register,

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -85,7 +85,7 @@ module Funding
             let(:state) { :trn_received }
 
             it "renders bursary not available" do
-              expect(rendered_component).to have_text("No bursaries available for this course")
+              expect(rendered_component).to have_text("Not applicable")
             end
           end
         end
@@ -121,7 +121,7 @@ module Funding
             end
 
             it "renders" do
-              expect(rendered_component).to have_text("Not bursary funded")
+              expect(rendered_component).to have_text("Not funded")
               expect(rendered_component).not_to have_text("£24,000 estimated bursary")
             end
 


### PR DESCRIPTION
### Context

https://trello.com/c/FY5CvZj1/2705-s-funding-content-changes-for-all-trainees

### Changes proposed in this pull request

A couple of small content changes for the funding section applicable to all trainees (i.e. regardless of whether they're on a scholarship).

### Guidance to review

**On the bursary form:**
- Hint text for the 'No bursary applied for' radio button should read "For example the trainee is not eligible or is self-funded"

**On the funding summary card:**
- Label on the bursary row should read "Funding method" (rather than "Bursary details")
- When there is a possible bursary, but the user has chosen "Not applying", the row should read "Not funded" (rather than "Not bursary funded")
- For **registered** trainees: When no bursary is applicable, the row should read "Not applicable" (rather than "No bursaries available for this course")

**On the check-details page:**
- When funding cannot be started yet, the text in blue should read "Funding details cannot be started yet"
- When funding is incomplete, the text in blue should read "Funding details not marked as complete"