### PR TITLE
[2724] Don't update ITT Qualification aim

### DIFF
--- a/app/lib/dttp/params/placement_outcomes/withdrawn.rb
+++ b/app/lib/dttp/params/placement_outcomes/withdrawn.rb
@@ -5,7 +5,6 @@ module Dttp
     module PlacementOutcomes
       class Withdrawn
         include Mappable
-        NO_QUALIFICATION_OBTAINED_ON_EXIT = "eaee7457-9448-e811-80f2-005056ac45bb"
 
         delegate :to_json, to: :params
 
@@ -16,9 +15,7 @@ module Dttp
         def params
           @params ||= {
             "dfe_dateleft" => date_left,
-            "dfe_datestandardsassessmentpassed" => date_standards_assessed,
             "dfe_ReasonforLeavingId@odata.bind" => "/dfe_reasonforleavings(#{dttp_reason_for_leaving_id(trainee.withdraw_reason)})",
-            "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{NO_QUALIFICATION_OBTAINED_ON_EXIT})",
           }
         end
 
@@ -28,10 +25,6 @@ module Dttp
 
         def date_left
           trainee.withdraw_date.in_time_zone.iso8601
-        end
-
-        def date_standards_assessed
-          trainee.outcome_date ? trainee.outcome_date.in_time_zone.iso8601 : nil
         end
       end
     end

--- a/spec/lib/dttp/params/placement_outcomes/withdrawn_spec.rb
+++ b/spec/lib/dttp/params/placement_outcomes/withdrawn_spec.rb
@@ -17,27 +17,11 @@ module Dttp
             end
           end
 
-          describe "dfe_datestandardsassessmentpassed" do
-            before do
-              trainee.outcome_date = "1/1/2021"
-            end
-
-            it "is set to the trainee outcome_date if it exists" do
-              expect(subject["dfe_datestandardsassessmentpassed"]).to eq(trainee.outcome_date.in_time_zone.iso8601)
-            end
-          end
-
           describe "dfe_ReasonforLeavingId" do
             let(:dttp_reason_for_leaving_id) { Dttp::CodeSets::ReasonsForLeavingCourse::MAPPING[trainee.withdraw_reason][:entity_id] }
 
             it "is set as the trainee's withdrawl reason" do
               expect(subject["dfe_ReasonforLeavingId@odata.bind"]).to eq("/dfe_reasonforleavings(#{dttp_reason_for_leaving_id})")
-            end
-          end
-
-          describe "dfe_ITTQualificationAimId" do
-            it "is set as NO_QUALIFICATION_OBTAINED_ON_EXIT" do
-              expect(subject["dfe_ITTQualificationAimId@odata.bind"]).to eq("/dfe_ittqualificationaims(#{described_class::NO_QUALIFICATION_OBTAINED_ON_EXIT})")
             end
           end
         end


### PR DESCRIPTION
### Context

When a trainee is withdrawn in register they are not appearing correctly in DTTP. 

### Changes proposed in this pull request

Withdrawing a trainee shouldn't:

* set datestandardsassessmentpassed
* change the ITT Qualifaction aim

So... don't do that.

### Guidance to review

