### PR TITLE
[2725] Fix: changing course on a non-draft trainee record fails to save the subject specialisms

### DIFF
--- a/app/controllers/trainees/apply_applications/course_details_controller.rb
+++ b/app/controllers/trainees/apply_applications/course_details_controller.rb
@@ -14,7 +14,7 @@ module Trainees
     private
 
       def set_course
-        @course = trainee.available_courses.find_by(code: trainee.course_code)
+        @course = trainee.published_course
       end
 
       def trainee

--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -19,8 +19,6 @@ module Trainees
           @publish_course_details_form.process_manual_entry!
         end
 
-        clear_form_stash(trainee)
-
         redirect_to next_step_path
       else
         @courses = trainee.available_courses
@@ -46,6 +44,10 @@ module Trainees
 
     def course_params
       params.fetch(:publish_course_details_form, {}).permit(:course_code)
+    end
+
+    def trainee
+      @trainee ||= Trainee.from_param(params[:trainee_id])
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -13,10 +13,13 @@ module Trainees
 
     def update
       @publish_course_details_form = PublishCourseDetailsForm.new(trainee, params: course_params, user: current_user)
+
       if @publish_course_details_form.stash_or_save!
         if @publish_course_details_form.manual_entry_chosen?
           @publish_course_details_form.process_manual_entry!
         end
+
+        clear_form_stash(trainee)
 
         redirect_to next_step_path
       else
@@ -34,8 +37,6 @@ module Trainees
     def next_step_path
       if @publish_course_details_form.manual_entry_chosen?
         edit_trainee_course_details_path(trainee)
-      elsif @publish_course_details_form.course_has_one_specialism?
-        publish_course_next_path
       elsif @publish_course_details_form.language_specialism?
         edit_trainee_language_specialisms_path(trainee)
       else

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -40,6 +40,7 @@ class PublishCourseDetailsForm < TraineeForm
     update_trainee_attributes
     clear_bursary_information if course_subjects_changed?
     trainee.save!
+    clear_stash
   end
 
   def stash

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -29,6 +29,8 @@ class Course < ApplicationRecord
 
   belongs_to :provider, foreign_key: :accredited_body_code, primary_key: :code, inverse_of: :courses, optional: true
 
+  has_many :trainees, ->(course) { unscope(:where).where(course_code: course.code) }, inverse_of: :trainee
+
   has_many :course_subjects
 
   # Order scope is critical - do not remove (see TeacherTrainingApi::ImportCourse#subjects)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -27,6 +27,8 @@ class Course < ApplicationRecord
   enum route: TRAINING_ROUTES_FOR_COURSE
   enum study_mode: COURSE_STUDY_MODE_ENUMS
 
+  belongs_to :provider, foreign_key: :accredited_body_code, primary_key: :code, inverse_of: :courses, optional: true
+
   has_many :course_subjects
 
   # Order scope is critical - do not remove (see TeacherTrainingApi::ImportCourse#subjects)

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -13,6 +13,12 @@ class Trainee < ApplicationRecord
   has_many :disabilities, through: :trainee_disabilities
   belongs_to :lead_school, optional: true, class_name: "School"
   belongs_to :employing_school, optional: true, class_name: "School"
+  belongs_to :published_course,
+             class_name: "Course",
+             foreign_key: :course_code,
+             primary_key: :code,
+             inverse_of: :trainees,
+             optional: true
 
   attribute :progress, Progress.to_type
 

--- a/app/views/trainees/subject_specialisms/edit.html.erb
+++ b/app/views/trainees/subject_specialisms/edit.html.erb
@@ -1,4 +1,5 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.subject_specialisms.edit", has_errors: @subject_specialism_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.subject_specialisms.edit",
+                               has_errors: @subject_specialism_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -13,21 +14,19 @@
       <%= f.govuk_error_summary %>
 
     <div class="govuk-form-group">
-      <%= f.govuk_radio_buttons_fieldset :"course_subject_#{position_in_words}",
-                                        legend: { text: t(".heading", subject: @subject.downcase), tag: "h1", size: "l" } do %>
+      <%= f.govuk_radio_buttons_fieldset course_subject_attribute_name,
+                                        legend: { text: t(".heading", subject: @subject.downcase),
+                                                  tag: "h1", size: "l" } do %>
 
           <div class="govuk-hint">
             <p class="govuk-body govuk-hint"><%= t(".hint") %></p>
           </div>
 
         <% sort_specialisms(@subject, @specialisms).each_with_index do |specialism, index| %>
-          <%= f.govuk_radio_button(
-              :"course_subject_#{position_in_words}",
-              specialism,
-              multiple: true,
-              link_errors: index.zero?,
-              label: { text: specialism.upcase_first },
-            ) %>
+          <%= f.govuk_radio_button(course_subject_attribute_name,
+                                   specialism, multiple: true,
+                                   link_errors: index.zero?,
+                                   label: { text: specialism.upcase_first },) %>
         <% end %>
       <% end %>
     </div>

--- a/config/initializers/mappings/publish_to_allocation_subject_mapping.rb
+++ b/config/initializers/mappings/publish_to_allocation_subject_mapping.rb
@@ -41,6 +41,7 @@ PUBLISH_SUBJECT_SPECIALISM_MAPPING = {
   "Physics" => [CourseSubjects::PHYSICS],
   "Psychology" => [CourseSubjects::PSYCHOLOGY],
   "Religious education" => [CourseSubjects::RELIGIOUS_STUDIES],
+  "Science" => [CourseSubjects::GENERAL_SCIENCES],
   "Social sciences" => [CourseSubjects::SOCIAL_SCIENCES],
 
   PublishSubjects::ENGLISH => [CourseSubjects::ENGLISH_STUDIES],

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -50,7 +50,7 @@ module CourseDetails
       let(:trainee) do
         create(:trainee,
                :provider_led_postgrad,
-               :with_course_details,
+               :with_publish_course_details,
                :with_apply_application,
                course_subject_one: nil,
                course_min_age: nil,
@@ -63,7 +63,7 @@ module CourseDetails
 
       let(:data_model) { ::ApplyApplications::ConfirmCourseForm.new(trainee, specialisms, itt_start_date, { code: course.code }) }
 
-      let!(:course) { create(:course_with_subjects, code: trainee.course_code, accredited_body_code: trainee.provider.code, route: trainee.training_route) }
+      let(:course) { trainee.published_course }
 
       before do
         render_inline(View.new(data_model: data_model))
@@ -100,27 +100,15 @@ module CourseDetails
 
     context "when data has been provided" do
       context "with a publish course", feature_publish_course_details: true do
-        let(:trainee) { create(:trainee, :with_course_details, training_route: training_route) }
-        let(:training_route) { TRAINING_ROUTES_FOR_COURSE.keys.sample }
-
-        let(:course) { create(:course_with_subjects, code: trainee.course_code, accredited_body_code: trainee.provider.code, route: training_route) }
-
-        let(:unrelated_course) { create(:course_with_subjects, code: trainee.course_code) }
+        let(:trainee) { create(:trainee, :with_publish_course_details) }
 
         before do
-          unrelated_course
-          course
           render_inline(View.new(data_model: trainee))
-        end
-
-        it "doesn't render the incorrect course details" do
-          expect(rendered_component)
-          .not_to have_text("#{unrelated_course.name} (#{unrelated_course.code})")
         end
 
         it "renders the correct course details" do
           expect(rendered_component)
-            .to have_text("#{course.name} (#{course.code})")
+            .to have_text("#{trainee.published_course.name} (#{trainee.published_course.code})")
         end
 
         it "renders the course type" do

--- a/spec/components/publish_course_details/view_spec.rb
+++ b/spec/components/publish_course_details/view_spec.rb
@@ -7,19 +7,11 @@ module PublishCourseDetails
     include SummaryHelper
 
     context "with a publish course", feature_publish_course_details: true do
-      let(:course) { create(:course_with_subjects, code: trainee.course_code, accredited_body_code: trainee.provider.code, route: training_route) }
-      let(:unrelated_course) { create(:course_with_subjects, code: trainee.course_code) }
-      let(:training_route) { TRAINING_ROUTES_FOR_COURSE.keys.sample }
-      let(:trainee) { create(:trainee, :with_course_details, training_route: training_route) }
+      let(:course) { trainee.published_course }
+      let(:trainee) { create(:trainee, :with_publish_course_details) }
 
       before do
-        course
-        unrelated_course
         render_inline(View.new(data_model: trainee))
-      end
-
-      it "doesnt render the incorrect course details" do
-        expect(rendered_component).not_to have_text("#{unrelated_course.name} (#{unrelated_course.code})")
       end
 
       it "render the correct course details" do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     qualification { %i[qts pgce_with_qts pgde_with_qts pgce pgde].sample }
     course_length { %w[OneYear TwoYears].sample }
     route { TRAINING_ROUTES_FOR_COURSE.keys.sample }
-    study_mode { COURSE_STUDY_MODES.keys.sample }
+    study_mode { TRAINEE_STUDY_MODE_ENUMS.keys.sample }
 
     summary do |builder|
       qualifications = builder.qualification.to_s.gsub("_", " ").upcase.gsub("WITH", "with")

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -113,10 +113,15 @@ FactoryBot.define do
 
     trait :with_course_details do
       course_subject_one { ::CourseSubjects::MATHEMATICS }
-      course_code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
       course_age_range { Dttp::CodeSets::AgeRanges::MAPPING.reject { |_k, v| v[:option] == :main }.keys.sample }
       course_start_date { Faker::Date.between(from: 1.year.ago, to: 2.days.ago) }
       course_end_date { Faker::Date.between(from: course_start_date + 1.day, to: Time.zone.today) }
+    end
+
+    trait :with_publish_course_details do
+      training_route { TRAINING_ROUTES_FOR_COURSE.keys.sample }
+      with_course_details
+      course_code { create(:course_with_subjects, route: training_route, accredited_body_code: provider.code).code }
     end
 
     trait :with_course_details_and_study_mode do

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Change course", type: :feature, feature_publish_course_details: true do
+  scenario "TRN received" do
+    given_i_am_authenticated
+    and_a_trainee_exists_with_trn_received
+    and_trainee_related_courses_exist
+    and_i_am_on_the_trainee_record_page
+    when_i_click_to_change_course_details
+    and_i_choose_a_different_course
+    and_i_click_continue
+    and_select_a_specialism_if_necessary
+    and_i_click_update_record
+    then_the_trainee_course_has_changed
+  end
+
+private
+
+  def and_trainee_related_courses_exist
+    @different_course = create(:course_with_subjects,
+                               accredited_body_code: trainee.provider.code,
+                               route: trainee.training_route)
+  end
+
+  def and_a_trainee_exists_with_trn_received
+    given_a_trainee_exists(:trn_received, :with_publish_course_details)
+  end
+
+  def when_i_click_to_change_course_details
+    record_page.change_course_details.click
+  end
+
+  def and_i_choose_a_different_course
+    publish_course_details_page.course_options.find { |o| o.label.text.include?(@different_course.name) }.choose
+  end
+
+  def and_i_click_continue
+    publish_course_details_page.submit_button.click
+  end
+
+  def and_i_click_update_record
+    confirm_publish_course_details_page.continue_button.click
+  end
+
+  def and_select_a_specialism_if_necessary
+    if page.current_path.include?("subject-specialism")
+      subject_specialism_page.specialism_options.sample.choose
+      subject_specialism_page.submit_button.click
+    end
+
+    if page.current_path.include?("language-specialism")
+      language_specialism_page.language_specialism_options.sample.check
+      language_specialism_page.submit_button.click
+    end
+  end
+
+  def then_the_trainee_course_has_changed
+    expect(trainee.reload.course_code).to eq(@different_course.code)
+  end
+end

--- a/spec/lib/route_data_manager_spec.rb
+++ b/spec/lib/route_data_manager_spec.rb
@@ -24,9 +24,7 @@ describe RouteDataManager do
 
         it "wipes the course details" do
           expect { subject }
-            .to change { trainee.course_code }
-            .from(trainee.course_code).to(nil)
-            .and change { trainee.course_subject_one }
+            .to change { trainee.course_subject_one }
             .from(trainee.course_subject_one).to(nil)
             .and change { trainee.course_age_range }
             .from(trainee.course_age_range).to([])
@@ -100,8 +98,8 @@ describe RouteDataManager do
         trainee.reload
       end
 
-      context "when a trainee has course details" do
-        let(:trainee) { create(:trainee, :provider_led_postgrad, :with_course_details) }
+      context "when a trainee has publish course details" do
+        let(:trainee) { create(:trainee, :with_publish_course_details, :provider_led_postgrad) }
 
         it "does not clear the course details section of the trainee" do
           expect(trainee.course_code).to be_present

--- a/spec/support/page_objects/trainees/confirm_publish_course_details.rb
+++ b/spec/support/page_objects/trainees/confirm_publish_course_details.rb
@@ -11,7 +11,7 @@ module PageObjects
       set_url "/trainees/{trainee_id}/publish-course-details/confirm"
 
       element :confirm, "input[name='confirm_detail_form[mark_as_completed]']"
-      element :continue_button, "button[type='submit']", text: "Continue"
+      element :continue_button, "button[type='submit']"
 
       sections :summary_list_rows, SummaryListRows, ".govuk-summary-list__row"
 

--- a/spec/support/page_objects/trainees/record.rb
+++ b/spec/support/page_objects/trainees/record.rb
@@ -26,6 +26,7 @@ module PageObjects
 
       element :change_lead_school, "a", text: "Change lead school", visible: false
       element :change_employing_school, "a", text: "Change employing school", visible: false
+      element :change_course_details, "a", text: "Change course details", visible: false
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/Iie17NYp/2725-bug-changing-course-on-a-non-draft-trainee-record-fails-to-save-the-subject-specialisms

### Changes proposed in this pull request
- Remove all the form stash clearing in `PublishCourseDetailsForm` and leave that responsibility to `Trainees::PublishCourseDetailsController` so that it's done towards the end of the request. The was the main source of the bug.
- Remove `PublishCourseDetailsForm#reset_course_subject_fields` as it also interfered with data currently stored in `SubjectSpecialismForm`. It was created to handle the case where a publish subject only has one specialism. We can handle that scenario by updating `Trainees::PublishCourseDetailsController#next_step_path` so that it always directs the user to the specialisms controller which already has the logic to handle single specialisms.

### Guidance to review

From the master branch

- On home page, choose the square "TRN received"
- Filter by "School direct (tuition fee)" 
- Click a trainee
- Click "Change" under course and choose an option
- Select specialisms (if necessary)
- Update record
- The course should display a missing notification for subject

Now checkout branch and go through the same steps. The missing notification no longer appears and the subject specialisms are persisted to the DB
