### PR TITLE
[2722] Add 11-18 age range

### DIFF
--- a/app/lib/dttp/code_sets/age_ranges.rb
+++ b/app/lib/dttp/code_sets/age_ranges.rb
@@ -7,7 +7,7 @@ module Dttp
         AgeRange::THREE_TO_ELEVEN => { option: :main, entity_id: "efa15e61-8ec0-e611-80be-00155d010316" },
         AgeRange::FIVE_TO_ELEVEN => { option: :main, entity_id: "22215c74-8ec0-e611-80be-00155d010316" },
         AgeRange::ELEVEN_TO_SIXTEEN => { option: :main, entity_id: "feed86a2-8ec0-e611-80be-00155d010316" },
-        AgeRange::ELEVEN_TO_NINETEEN => { option: :main, entity_id: "69e663ac-8ec0-e611-80be-00155d010316" },
+        AgeRange::ELEVEN_TO_EIGHTEEN => { option: :main, entity_id: "69e663ac-8ec0-e611-80be-00155d010316" }, # this is currently mapped to 11-19 in DTTP as there isn't an option for 11-18 yet.
         AgeRange::ZERO_TO_FIVE => { option: :additional, entity_id: "4660ff36-3c6d-e711-80d2-005056ac45bb" },
         AgeRange::THREE_TO_SEVEN => { option: :additional, entity_id: "b86eee51-8ec0-e611-80be-00155d010316" },
         AgeRange::THREE_TO_EIGHT => { option: :additional, entity_id: "49a9eb3f-5a9c-e711-80d9-005056ac45bb" },
@@ -19,6 +19,7 @@ module Dttp
         AgeRange::SEVEN_TO_SIXTEEN => { option: :additional, entity_id: "1a7ee9f5-569c-e711-80d9-005056ac45bb" },
         AgeRange::NINE_TO_FOURTEEN => { option: :additional, entity_id: "7064d397-8ec0-e611-80be-00155d010316" },
         AgeRange::NINE_TO_SIXTEEN => { option: :additional, entity_id: "1c7ee9f5-569c-e711-80d9-005056ac45bb" },
+        AgeRange::ELEVEN_TO_NINETEEN => { option: :additional, entity_id: "69e663ac-8ec0-e611-80be-00155d010316" },
         AgeRange::FOURTEEN_TO_NINETEEN => { option: :additional, entity_id: "73a86fb7-8ec0-e611-80be-00155d010316" },
       }.freeze
     end

--- a/config/initializers/age_ranges.rb
+++ b/config/initializers/age_ranges.rb
@@ -4,7 +4,7 @@ module AgeRange
   THREE_TO_ELEVEN = [3, 11].freeze
   FIVE_TO_ELEVEN = [5, 11].freeze
   ELEVEN_TO_SIXTEEN = [11, 16].freeze
-  ELEVEN_TO_NINETEEN = [11, 18].freeze # there isn't currently an 11-18 in DTTP. Update when there is
+  ELEVEN_TO_EIGHTEEN = [11, 18].freeze
   ELEVEN_TO_NINETEEN = [11, 19].freeze
   ZERO_TO_FIVE = [0, 5].freeze
   THREE_TO_SEVEN = [3, 7].freeze

--- a/config/initializers/course_levels.rb
+++ b/config/initializers/course_levels.rb
@@ -24,6 +24,7 @@ COURSE_LEVELS = {
     AgeRange::SEVEN_TO_SIXTEEN,
     AgeRange::NINE_TO_FOURTEEN,
     AgeRange::NINE_TO_SIXTEEN,
+    AgeRange::ELEVEN_TO_EIGHTEEN,
     AgeRange::FOURTEEN_TO_NINETEEN,
   ],
 }.freeze


### PR DESCRIPTION
### Context

We have a lot of publish courses with 11-18 age ranges but not many with
11-19. DTTP doesn't currently have 11-18 so we'll map it to 11-19 for
now.

### Changes proposed in this pull request

* Add 11-18
* Move 11-19 into the other age range drop down
* Map 11-18 to the 11-19 age range in DTTP

### Guidance to review

* Check the course details form. 11-18 should now be a radio option. 11-19 will be in the dropdown
* Select an 11-18 course from publish and make sure it is properly rendered in the 'change' form

I’ve made Mathematics (DPN6) an 11-18 course on the review app. 
* Login as Provider A 
* Open Evon Raynor's course details and that course should be available there.

