### PR TITLE
[2613] & [2615] Surface region information to UI and handle DTTP

### DIFF
--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -15,6 +15,7 @@ module RecordDetails
     def record_detail_rows
       [
         trainee_id_row,
+        region,
         trn_row,
         trainee_progress_row,
         trainee_status_row,
@@ -28,6 +29,12 @@ module RecordDetails
 
     def trainee_id_row
       mappable_field(trainee.trainee_id.presence, t(".trainee_id"), edit_trainee_trainee_id_path(trainee))
+    end
+
+    def region
+      return unless trainee&.provider&.hpitt_postgrad?
+
+      { key: t(".region"), value: trainee.region.presence }
     end
 
     def trn_row

--- a/app/components/training_details/view.html.erb
+++ b/app/components/training_details/view.html.erb
@@ -1,3 +1,5 @@
-<%= render SummaryCard::View.new(trainee: trainee, title: t("components.confirmation.training_details.title"),
-                                 heading_level: 2,
-                                 rows: training_details_rows) %>
+<%= render SummaryCard::View.new(
+  trainee: trainee, title: t(".title"),
+  heading_level: 2,
+  rows: training_details_rows
+) %>

--- a/app/components/training_details/view.rb
+++ b/app/components/training_details/view.rb
@@ -15,14 +15,21 @@ module TrainingDetails
 
     def training_details_rows
       [
-        mappable_field_row(trainee_start_date, t("components.confirmation.training_details.start_date.title")),
+        region,
+        mappable_field_row(trainee_start_date, t(".start_date")),
         mappable_field_row(trainee.trainee_id, t("components.confirmation.trainee_id.title")),
-      ]
+      ].compact
     end
 
   private
 
-    attr_accessor :data_model, :not_provided_copy, :has_errors
+    attr_accessor :data_model, :not_provided_copy, :has_errors, :show_region
+
+    def region
+      return unless trainee&.provider&.hpitt_postgrad?
+
+      { key: t(".region"), value: trainee.region.presence }
+    end
 
     def trainee_start_date
       date_for_summary_view(trainee.commencement_date) if trainee.commencement_date.present?

--- a/app/lib/dttp/code_sets/regions.rb
+++ b/app/lib/dttp/code_sets/regions.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Dttp
+  module CodeSets
+    module Regions
+      MAPPING = {
+        "North East" => { entity_id: "664b1c3c-f272-e711-80d3-005056ac45bb" },
+        "North West" => { entity_id: "684b1c3c-f272-e711-80d3-005056ac45bb" },
+        "Yorkshire and the Humber" => { entity_id: "6a4b1c3c-f272-e711-80d3-005056ac45bb" },
+        "East Midlands" => { entity_id: "6c4b1c3c-f272-e711-80d3-005056ac45bb" },
+        "West Midlands" => { entity_id: "6e4b1c3c-f272-e711-80d3-005056ac45bb" },
+        "East of England" => { entity_id: "704b1c3c-f272-e711-80d3-005056ac45bb" },
+        "London" => { entity_id: "724b1c3c-f272-e711-80d3-005056ac45bb" },
+        "South East" => { entity_id: "744b1c3c-f272-e711-80d3-005056ac45bb" },
+        "South West" => { entity_id: "764b1c3c-f272-e711-80d3-005056ac45bb" },
+        "Wales (pseudo)" => { entity_id: "784b1c3c-f272-e711-80d3-005056ac45bb" },
+        "Not Applicable" => { entity_id: "7a4b1c3c-f272-e711-80d3-005056ac45bb" },
+        "South East and South Coast" => { entity_id: "66e38dc4-404a-e811-80f2-005056ac45bb" },
+        "Non-regional providers" => { entity_id: "b2d8c5bb-424e-e811-80f3-005056ac45bb" },
+        "South Coast" => { entity_id: "1ff128c9-424e-e811-80f3-005056ac45bb" },
+      }.freeze
+    end
+  end
+end

--- a/app/lib/dttp/code_sets/regions.rb
+++ b/app/lib/dttp/code_sets/regions.rb
@@ -2,11 +2,14 @@
 
 module Dttp
   module CodeSets
+    YORKSHIRE_AND_HUMBER_DTTP_ID = "6a4b1c3c-f272-e711-80d3-005056ac45bb"
+
     module Regions
       MAPPING = {
         "North East" => { entity_id: "664b1c3c-f272-e711-80d3-005056ac45bb" },
         "North West" => { entity_id: "684b1c3c-f272-e711-80d3-005056ac45bb" },
-        "Yorkshire and the Humber" => { entity_id: "6a4b1c3c-f272-e711-80d3-005056ac45bb" },
+        "Yorkshire and the Humber" => { entity_id: YORKSHIRE_AND_HUMBER_DTTP_ID },
+        "Yorkshire and Humber" => { entity_id: YORKSHIRE_AND_HUMBER_DTTP_ID },
         "East Midlands" => { entity_id: "6c4b1c3c-f272-e711-80d3-005056ac45bb" },
         "West Midlands" => { entity_id: "6e4b1c3c-f272-e711-80d3-005056ac45bb" },
         "East of England" => { entity_id: "704b1c3c-f272-e711-80d3-005056ac45bb" },

--- a/app/lib/dttp/mappable.rb
+++ b/app/lib/dttp/mappable.rb
@@ -70,6 +70,10 @@ module Dttp
       Dttp::School.active.find_by!(urn: urn)&.dttp_id
     end
 
+    def region_id(region)
+      CodeSets::Regions::MAPPING.dig(region, :entity_id)
+    end
+
     def training_initiative_id(training_initiative)
       CodeSets::TrainingInitiatives::MAPPING.dig(training_initiative, :entity_id)
     end

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -59,6 +59,7 @@ module Dttp
         .merge(study_mode_params)
         .merge(training_initiative_params)
         .merge(bursary_params)
+        .merge(region_params)
       end
 
       def course_level
@@ -138,6 +139,14 @@ module Dttp
         {
           "dfe_allocatedplace" => ALLOCATED_PLACE,
           "dfe_BursaryDetailsId@odata.bind" => "/dfe_bursarydetails(#{bursary_details_id(bursary_type)})",
+        }
+      end
+
+      def region_params
+        return {} unless trainee.hpitt_provider?
+
+        {
+          "dfe_GovernmentOfficeRegionId@odata.bind" => "/dfe_regions(#{region_id(trainee.region)})",
         }
       end
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -280,6 +280,10 @@ class Trainee < ApplicationRecord
     apply_application&.invalid_data.present?
   end
 
+  def hpitt_provider?
+    @hpitt_provider ||= provider&.hpitt_postgrad?
+  end
+
 private
 
   def value_digest
@@ -296,9 +300,5 @@ private
         assoc.map(&:serializable_hash).flat_map(&:values).compact
       end
     ).join(",")
-  end
-
-  def hpitt_provider?
-    @hpitt_provider ||= provider&.hpitt_postgrad?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
   record_details:
     view:
       trainee_id: Trainee ID
+      region: &region Region
       submitted_for_trn: Submitted for TRN
       trainee_status: Trainee status
       last_updated: Last updated
@@ -60,6 +61,11 @@ en:
       status_date_prefix:
         deferred: "Deferral date: "
         withdrawn: "Withdrawal date: "
+  training_details:
+    view: 
+      title: Trainee start date and ID
+      start_date: &commencement_date Trainee’s start date
+      region: *region
   components:
     heading:
       apply_draft:
@@ -85,10 +91,6 @@ en:
         title: &trainee_id Trainee ID
       start_date:
         title: Start date
-      training_details:
-        title: Trainee start date and ID
-        start_date:
-          title: &commencement_date Trainee’s start date
       funding:
         title: Funding
         training_initiative:

--- a/spec/components/record_details/view_preview.rb
+++ b/spec/components/record_details/view_preview.rb
@@ -8,6 +8,15 @@ module RecordDetails
       render(View.new(trainee: mock_trainee("default"), last_updated_event: last_updated_event))
     end
 
+    def with_region
+      trainee = mock_trainee("default").tap do |t|
+        t.region = Dttp::CodeSets::Regions::MAPPING.keys.sample
+        t.provider = Provider.new(code: TEACH_FIRST_PROVIDER_CODE)
+      end
+
+      render(View.new(trainee: trainee, last_updated_event: last_updated_event))
+    end
+
     def with_no_trainee_id
       render(View.new(trainee: mock_trainee(nil), last_updated_event: last_updated_event))
     end
@@ -48,6 +57,7 @@ module RecordDetails
         created_at: Time.zone.today,
         state: state,
         submitted_for_trn_at: Time.zone.today,
+        trn: "1234567",
         defer_date: state == :deferred ? Time.zone.today : nil,
         withdraw_date: state == :withdrawn ? Time.zone.today : nil,
         recommended_for_award_at: state == :recommended_for_award ? Time.zone.now : nil,

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -13,7 +13,7 @@ module RecordDetails
     let(:trainee_progress) { "trainee-progress" }
     let(:timeline_event) { double(date: Time.zone.today) }
 
-    context "when trainee_id data has not been provided" do
+    context "when any data has not been provided" do
       before do
         trainee.trainee_id = nil
         render_inline(View.new(trainee: trainee, last_updated_event: timeline_event))
@@ -24,7 +24,7 @@ module RecordDetails
       end
     end
 
-    context "when trainee_id data has been provided" do
+    context "when data has been provided" do
       before do
         render_inline(View.new(trainee: trainee, last_updated_event: timeline_event))
       end
@@ -46,6 +46,14 @@ module RecordDetails
 
         it "renders the trn submission date" do
           expect(rendered_component).to have_text(date_for_summary_view(trainee.submitted_for_trn_at))
+        end
+      end
+
+      context "when trainee has a hpitt_provider" do
+        let(:trainee) { build(:trainee, :with_hpitt_provider, :trn_received) }
+
+        it "renders the trainee's region" do
+          expect(rendered_component).to have_text(trainee.region)
         end
       end
 

--- a/spec/components/training_details/view_preview.rb
+++ b/spec/components/training_details/view_preview.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module TrainingDetails
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render(View.new(data_model: Trainee.new(shared_attributes)))
+    end
+
+    def with_region
+      render(View.new(data_model: hpitt_trainee))
+    end
+
+  private
+
+    def hpitt_trainee
+      Trainee.new(
+        shared_attributes.merge(
+          region: Dttp::CodeSets::Regions::MAPPING.keys.sample,
+          provider: Provider.new(code: TEACH_FIRST_PROVIDER_CODE),
+        ),
+      )
+    end
+
+    def shared_attributes
+      date = Date.new(2020, 0o1, 28)
+
+      {
+        id: 1,
+        commencement_date: date,
+        trainee_id: "#{date.year}/#{date.year + 1}-1",
+      }
+    end
+  end
+end

--- a/spec/components/training_details/view_spec.rb
+++ b/spec/components/training_details/view_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module TrainingDetails
+  describe View do
+    include SummaryHelper
+
+    describe "when the data isn't provided" do
+      let(:trainee) { build(:trainee) }
+
+      before do
+        trainee.trainee_id = nil
+        render_inline(View.new(data_model: trainee))
+      end
+
+      it "tells the user that the data is missing" do
+        expect(rendered_component).to have_text(t("components.confirmation.missing"), count: 2)
+      end
+    end
+
+    describe "when the data is provided" do
+      let(:trainee) { build(:trainee, :with_start_date) }
+
+      before do
+        trainee.trainee_id = "some id"
+        render_inline(View.new(data_model: trainee))
+      end
+
+      it "renders the trainee start date" do
+        expect(rendered_component).to have_text(date_for_summary_view(trainee.commencement_date))
+      end
+
+      it "renders the trainee_id" do
+        expect(rendered_component).to have_text(trainee.trainee_id)
+      end
+
+      context "when trainee has a hpitt_provider" do
+        let(:trainee) { build(:trainee, :with_hpitt_provider) }
+
+        it "renders the trainee's region" do
+          expect(rendered_component).to have_text(trainee.region)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     dttp_id { SecureRandom.uuid }
     code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     ukprn { Faker::Number.number(digits: 8) }
+
+    trait :teach_first do
+      code { TEACH_FIRST_PROVIDER_CODE }
+    end
   end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -365,5 +365,11 @@ FactoryBot.define do
       applying_for_bursary { true }
       bursary_tier { BURSARY_TIER_ENUMS[:tier_one] }
     end
+
+    trait :with_hpitt_provider do
+      training_route { TRAINING_ROUTE_ENUMS[:hpitt_postgrad] }
+      region { Dttp::CodeSets::Regions::MAPPING.keys.sample }
+      association :provider, factory: %i[provider teach_first]
+    end
   end
 end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -421,6 +421,24 @@ module Dttp
           end
         end
 
+        context "with region information" do
+          let(:provider) { create(:provider, :teach_first) }
+
+          let(:trainee) do
+            create(:trainee, :with_course_details, :with_start_date, :with_hpitt_provider, dttp_id: dttp_contact_id, provider: provider)
+          end
+
+          let(:expected_region_id) { CodeSets::Regions::MAPPING.dig(trainee.region, :entity_id) }
+
+          subject { described_class.new(trainee).params }
+
+          it "returns a hash including the region" do
+            expect(subject).to include({
+              "dfe_GovernmentOfficeRegionId@odata.bind" => "/dfe_regions(#{expected_region_id})",
+            })
+          end
+        end
+
         context "training initiative", feature_show_funding: true do
           before do
             stub_const(


### PR DESCRIPTION
### Context

- https://trello.com/c/YZ5CUl5r/2613-s-surface-region-information-to-ui-for-teach-first-providers
- https://trello.com/c/rBf9Om36/2615-s-handle-sending-region-information-to-dttp-for-teach-first-trainees

### Changes proposed in this pull request

- Surfaces the region information for trainees belonging to a teach first provider (see components in the review app for preview as we don't have any in the system at the moment)
- Handle sending region information to DTTP

### Guidance to review

