### PR TITLE
Turn on undergrad routes in staging

### DIFF
--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -24,10 +24,14 @@ features:
   send_funding_to_dttp: true
   routes:
     early_years_assessment_only: true
+    early_years_salaried: true
     early_years_postgrad: true
+    early_years_undergrad: true
     provider_led_postgrad: true
     school_direct_salaried: true
     school_direct_tuition_fee: true
+    provider_led_undergrad: true
+    opt_in_undergrad: true
     pg_teaching_apprenticeship: true
 
 environment:


### PR DESCRIPTION
### Context

- https://trello.com/c/BjJpySL8/2609-send-test-opt-in-undergrad-route-trainee-to-dttp-staging
- https://trello.com/c/n7TYg06U/2611-send-test-early-years-undergrad-route-trainee-to-dttp-staging
- https://trello.com/c/y08mSLVi/2589-provider-led-ug-send-test-in-staging-and-confirm-trn-and-qts-are-working

### Changes proposed in this pull request

Turn on flags in staging for undergrad routes in current sprint

### Guidance to review

