### PR TITLE
[2650] Fix JS on Edge by replacing flat function

### DIFF
--- a/app/components/form_components/autocomplete/sort.js
+++ b/app/components/form_components/autocomplete/sort.js
@@ -13,7 +13,10 @@ const calculateWeight = (rawName, query, rawSynonyms = []) => {
   const synonyms = rawSynonyms.map(s => clean(s))
 
   const nameMatchPositions = matchPositions(name, regexes)
-  const synonymMatchPositions = synonyms.map(synonym => matchPositions(synonym, regexes)).flat()
+  const synonymMatchPositions = synonyms
+    .map(synonym => matchPositions(synonym, regexes))
+    // Flatten the array, but don't use flat() - breaks on Edge.
+    .reduce((acc, val) => acc.concat(val), [])
 
   // Require either all parts of a name to be matched, or all parts of a synonym
   const allNameMatches = nameMatchPositions.length === regexes.length


### PR DESCRIPTION
### Context

https://trello.com/c/Pey3mefl/2650-zendesk-user-cannot-find-degree-organisation

### Changes proposed in this pull request

We're using @babel/polyfill (core-js@2) to provide ES6 functionality to older browsers.

However, the function `fill()` only works from core-js@3.

[@babel/polyfil is now deprecated](https://babeljs.io/docs/en/babel-polyfill) and instead of migrating from core-js@2 to core-js@3 I've fixed the immediate issue be replacing `flat()`.

### Guidance to review

- Ensure the autocompletes work as before
- Test that the autocompletes work on Edge (old versions 12 - 18)