### PR TITLE
Don't log active record queries in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,6 +46,9 @@ Rails.application.configure do
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug
+  config.active_record.logger = nil # Don't log SQL in production
+
+  config.rails_semantic_logger.add_file_appender = false
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -71,19 +74,6 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
### Context
Production logging config is defined in `config/initializers/semantic_logger.rb`

### Changes proposed in this pull request

Don't log active record queries in production
Remove redundant logging config

### Guidance to review

