### PR TITLE
[2738] Snag fix: use course name if specialism is not set yet

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -23,7 +23,7 @@ module ApplicationRecordCard
 
     def subject
       return I18n.t("components.application_record_card.subject.early_years") if record.early_years_route?
-      return I18n.t("components.application_record_card.subject.blank") if record.course_subject_one.blank?
+      return course_name if record.course_subject_one.blank?
 
       subjects_for_summary_view(record.course_subject_one, record.course_subject_two, record.course_subject_three)
     end
@@ -66,6 +66,10 @@ module ApplicationRecordCard
 
     def last_name_first
       [record.last_name, record.first_names].join(", ")
+    end
+
+    def course_name
+      record.published_course&.name
     end
   end
 end

--- a/app/components/route_indicator/view.rb
+++ b/app/components/route_indicator/view.rb
@@ -23,7 +23,7 @@ module RouteIndicator
     end
 
     def course_with_code
-      "#{trainee.course_subject_one} #{course_code}".strip
+      "#{trainee.course_subject_one || course_name} #{course_code}".strip
     end
 
     def course_code
@@ -38,6 +38,10 @@ module RouteIndicator
 
     def training_route_link
       govuk_link_to training_route.downcase, edit_trainee_training_route_path(trainee)
+    end
+
+    def course_name
+      trainee.published_course&.name
     end
   end
 end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -85,7 +85,7 @@ private
 
   def ordered_trainees
     sort_scope = filter_params[:sort_by] == "last_name" ? :ordered_by_last_name : :ordered_by_date
-    policy_scope(Trainee.ordered_by_drafts.public_send(sort_scope))
+    policy_scope(Trainee.includes(:published_course).ordered_by_drafts.public_send(sort_scope))
   end
 
   def filters

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 module ApplicationRecordCard
   describe View do
-    let(:trainee) { Trainee.new(created_at: Time.zone.now) }
+    let(:course) { create(:course) }
+    let(:trainee) { Trainee.new(created_at: Time.zone.now, course_code: course.code) }
 
     before do
       allow(trainee).to receive(:timeline).and_return([double(date: Time.zone.now)])
@@ -18,14 +19,14 @@ module ApplicationRecordCard
     end
 
     context "when the Trainee has no subject" do
-      it "renders 'No subject provided'" do
-        expect(rendered_component).to have_text("No subject provided")
+      it "renders the course name" do
+        expect(rendered_component).to have_text(course.name)
       end
 
       context "and is an Early Years trainee" do
         let(:trainee) { Trainee.new(created_at: Time.zone.now, training_route: TRAINING_ROUTE_ENUMS[:early_years_undergrad]) }
 
-        it "renders 'Early uears teaching'" do
+        it "renders 'Early years teaching'" do
           expect(rendered_component).to have_text("Early years teaching")
         end
       end


### PR DESCRIPTION
### Context
https://trello.com/c/srD42qU5/2738-snag-use-course-name-if-specialism-is-not-set-yet

### Changes proposed in this pull request
- Update the `ApplicationRecordCard` and `RouteIndicator::View` to use course name for subject if subject specialism is not set

### Guidance to review
- Visit the trainee index page filter by "Imported from Apply"
- The course names should be displayed in each item in the list
- Click on a record
- The course name should be displayed in the inset text area just before the course code

### Trainee's index page
<img width="657" alt="Screenshot 2021-09-15 at 12 34 25" src="https://user-images.githubusercontent.com/28728/133426065-b78ef35e-0394-4fca-96ee-07fe12b21660.png">

### Apply draft review page
<img width="670" alt="Screenshot 2021-09-15 at 12 33 31" src="https://user-images.githubusercontent.com/28728/133425935-cd2bff80-9b9a-4094-8bfc-04982fe570a8.png">