### PR TITLE
[xxx] Update funding guidance link to be generic

### DIFF
--- a/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
@@ -13,8 +13,8 @@
 
   <p class="govuk-body">
     <%= govuk_link_to(
-      t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_link_text' : 'guidance_link_text'}"),
-      t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_url' : 'guidance_url'}"),
+      t("views.forms.funding.bursaries.guidance_link_text"),
+      t("views.forms.funding.bursaries.guidance_url"),
       { target: "_blank", rel: "noreferrer noopener" }
     ) %>
   </p>

--- a/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
@@ -6,8 +6,8 @@
 
   <p class="govuk-body">
     <%= govuk_link_to(
-      t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_link_text' : 'guidance_link_text'}"),
-      t("views.forms.funding.bursaries.#{@trainee.early_years_route? ? 'early_years_guidance_url' : 'guidance_url'}"),
+      t("views.forms.funding.bursaries.guidance_link_text"),
+      t("views.forms.funding.bursaries.guidance_url"),
       { target: "_blank", rel: "noreferrer noopener" }
     ) %>
   </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,10 +615,8 @@ en:
             tier_three:
               label: Yes - Tier 3 (£2,000)
               hint: 2:2 honours degree
-          guidance_link_text: DfE bursary guidance for the academic year 2021 to 2022 (opens in new tab)
-          guidance_url: https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-funding-manual/initial-teacher-training-bursaries-funding-manual-2021-to-2022-academic-year#training-bursary-award-and-eligibility
-          early_years_guidance_link_text: "Early years initial teacher training: 2021 to 2022 funding guidance (opens in new tab)"
-          early_years_guidance_url: https://www.gov.uk/guidance/early-years-initial-teacher-training-2021-to-2022-funding-guidance
+          guidance_link_text: "Funding: initial teacher training (ITT), academic year 2021 to 2022 (opens in new tab)"
+          guidance_url: https://www.gov.uk/government/publications/funding-initial-teacher-training-itt/funding-initial-teacher-training-itt-academic-year-2021-to-2022
           title: Are you applying for a bursary for this trainee?
           true: Yes, apply for a bursary
           false: No, do not apply for a bursary


### PR DESCRIPTION
### Context

The funding guidance links should be the same for all trainees regardless of whether they're Early years or not.

https://www.gov.uk/government/publications/funding-initial-teacher-training-itt/funding-initial-teacher-training-itt-academic-year-2021-to-2022

### Changes proposed in this pull request

Updates url and link text.

### Guidance to review
