### PR TITLE
[xxx] Wipe scholarship details on route/course change

### DIFF
--- a/app/forms/concerns/course_form_helpers.rb
+++ b/app/forms/concerns/course_form_helpers.rb
@@ -6,6 +6,7 @@ module CourseFormHelpers
 
     trainee.assign_attributes({
       applying_for_bursary: nil,
+      applying_for_scholarship: nil,
     })
   end
 

--- a/app/lib/route_data_manager.rb
+++ b/app/lib/route_data_manager.rb
@@ -38,6 +38,7 @@ private
     {
       training_initiative: nil,
       applying_for_bursary: nil,
+      applying_for_scholarship: nil,
       bursary_tier: nil,
     }
   end

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -380,7 +380,7 @@ describe CourseDetailsForm, type: :model do
 
       context "when the course_subject has changed" do
         let(:progress) { Progress.new(course_details: true, funding: true, personal_details: true) }
-        let(:trainee) { create(:trainee, :with_funding, :with_course_details, course_subject_one: CourseSubjects::BIOLOGY, progress: progress) }
+        let(:trainee) { create(:trainee, :with_funding, :with_course_details, applying_for_scholarship: true, course_subject_one: CourseSubjects::BIOLOGY, progress: progress) }
         let(:params) do
           {
             course_subject_one: CourseSubjects::HISTORICAL_LINGUISTICS,
@@ -391,8 +391,8 @@ describe CourseDetailsForm, type: :model do
           expect { subject.save! }
           .to change { trainee.applying_for_bursary }
           .from(trainee.applying_for_bursary).to(nil)
-          .and change { trainee.progress.funding }
-          .from(true).to(false)
+          .and change { trainee.applying_for_scholarship }.to(nil)
+          .and change { trainee.progress.funding }.from(true).to(false)
         end
       end
     end

--- a/spec/lib/route_data_manager_spec.rb
+++ b/spec/lib/route_data_manager_spec.rb
@@ -50,7 +50,7 @@ describe RouteDataManager do
       end
 
       context "when the trainee has funding" do
-        let(:trainee) { create(:trainee, :assessment_only, :with_funding, :with_tiered_bursary, progress: progress) }
+        let(:trainee) { create(:trainee, :assessment_only, :with_funding, :with_tiered_bursary, applying_for_scholarship: true, progress: progress) }
 
         it "wipes initiative details" do
           expect { subject }
@@ -64,6 +64,7 @@ describe RouteDataManager do
           expect { subject }
             .to change { trainee.applying_for_bursary }
             .from(trainee.applying_for_bursary).to(nil)
+            .and change { trainee.applying_for_scholarship }.to(nil)
             .and change { trainee.bursary_tier }
             .from(trainee.bursary_tier).to(nil)
         end


### PR DESCRIPTION
### Context

If a trainee changes route or course, any previously entered scholarship details may be wrong.

### Changes proposed in this pull request

Wipe the scholarship details on route and course change, just like we do for `applying_for_bursary`.

### Guidance to review