### PR TITLE
[2760] Bug - missing publish subject specialism mapping "Dance"

### DIFF
--- a/config/initializers/mappings/publish_to_allocation_subject_mapping.rb
+++ b/config/initializers/mappings/publish_to_allocation_subject_mapping.rb
@@ -32,6 +32,7 @@ PUBLISH_SUBJECT_SPECIALISM_MAPPING = {
   # Subjects with a simple 1-to-1 specialism mapping
   "Citizenship" => [CourseSubjects::CITIZENSHIP],
   "Communication and media studies" => [CourseSubjects::MEDIA_AND_COMMUNICATION_STUDIES],
+  "Dance" => [CourseSubjects::DANCE],
   "Economics" => [CourseSubjects::ECONOMICS],
   "Geography" => [CourseSubjects::GEOGRAPHY],
   "Health and social care" => [CourseSubjects::HEALTH_AND_SOCIAL_CARE],

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -12,6 +12,7 @@ REAL_PUBLISH_COURSES_WITH_SUBJECTS = {
   "Chemistry" => ["Chemistry"],
   "Citizenship with Religious education" => ["Citizenship", "Religious education"],
   "Computer Science" => ["Computing"],
+  "Dance" => ["Dance"],
   "Design and technology" => ["Design and technology"],
   "Drama (with English)" => %w[Drama English],
   "Drama" => ["Drama"],


### PR DESCRIPTION
### Context
https://trello.com/c/K3nX2HLn/2760-bug-missing-subject-specialism-mapping-dance

Customer reported that selecting the dance course caused her to land on the specialisms page but with no specialiams:

![image](https://user-images.githubusercontent.com/28728/134021979-5c935341-dfed-4e2b-804c-b4d77ff3277d.png)

We didn't have it declared in the publish subject specialism mapping.

### Changes proposed in this pull request
- Add "Dance" specialism mapping
- Update rake `example_data` task to include "Dance" course

### Guidance to review
- Visit a trainee with published courses
- Change course and select Dance
- It should go straight to the confirm page
