### PR TITLE
[2763] Town is not required

### DIFF
--- a/app/forms/contact_details_form.rb
+++ b/app/forms/contact_details_form.rb
@@ -3,13 +3,13 @@
 class ContactDetailsForm < TraineeForm
   MANDATORY_UK_ADDRESS_FIELDS = %i[
     address_line_one
-    town_city
     postcode
   ].freeze
 
   FIELDS = %i[
     locale_code
     address_line_two
+    town_city
     international_address
     email
   ].concat(MANDATORY_UK_ADDRESS_FIELDS).freeze


### PR DESCRIPTION
### Context

We get a lot of validation errors from users trying to submit the form without a value in 'town'.

### Changes proposed in this pull request

* Remove the presence validation from 'town'

### Guidance to review

Add personal details to a trainee but omit town. Should be valid.
