### PR TITLE
[2747] bug changing an existing trainees route to other errors

### DIFF
--- a/app/controllers/trainees/not_supported_routes_controller.rb
+++ b/app/controllers/trainees/not_supported_routes_controller.rb
@@ -3,7 +3,16 @@
 module Trainees
   class NotSupportedRoutesController < ApplicationController
     def index
+      find_trainee
       render "trainees/not_supported_route"
+    end
+
+  private
+
+    def find_trainee
+      return unless params[:trainee_id]
+
+      @trainee = Trainee.from_param(params[:trainee_id])
     end
   end
 end

--- a/app/controllers/trainees/training_routes_controller.rb
+++ b/app/controllers/trainees/training_routes_controller.rb
@@ -8,9 +8,12 @@ module Trainees
     def edit; end
 
     def update
-      trainee.update_training_route!(training_route)
-
-      redirect_url
+      if training_route == "other"
+        redirect_to trainees_not_supported_route_path(trainee_id: trainee)
+      else
+        trainee.update_training_route!(training_route)
+        redirect_url
+      end
     end
 
   private

--- a/app/views/trainees/not_supported_route.html.erb
+++ b/app/views/trainees/not_supported_route.html.erb
@@ -20,7 +20,7 @@
     <p class="govuk-body"><%= t(".bullet_desc") %></p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        <%= govuk_link_to t(".go_back"), new_trainee_path %>
+        <%= govuk_link_to t(".go_back"), @trainee.present? ? edit_trainee_training_route_path(trainee_id: @trainee): new_trainee_path %>
       </li>
       <li>
         <%= govuk_link_to t(".use_dttp"), Settings.dttp.back_office_url %>

--- a/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
+++ b/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
@@ -17,11 +17,19 @@ feature "editing a trainee training route", type: :feature do
       and_current_training_route_should_be_selected
     end
 
-    scenario "editing a draft-trainee's current training route", "feature_routes.provider_led_postgrad": true do
-      then_i_select_provider_led_postgrad
-      and_i_submit_the_new_route
-      and_i_visit_the_edit_training_route_page
-      and_provider_led_postgrad_should_be_selected
+    context "editing a draft trainee's current training route" do
+      scenario "selecting a valid training route", "feature_routes.provider_led_postgrad": true do
+        then_i_select_provider_led_postgrad
+        and_i_submit_the_new_route
+        and_i_visit_the_edit_training_route_page
+        and_provider_led_postgrad_should_be_selected
+      end
+
+      scenario "selecting a not supported route" do
+        then_i_select_other
+        and_i_submit_the_new_route
+        and_i_am_redirected_to_the_not_supported_page
+      end
     end
   end
 
@@ -57,5 +65,13 @@ private
 
   def and_provider_led_postgrad_should_be_selected
     expect(trainee_edit_training_route_page.provider_led_postgrad).to be_checked
+  end
+
+  def then_i_select_other
+    trainee_edit_training_route_page.other.click
+  end
+
+  def and_i_am_redirected_to_the_not_supported_page
+    expect(not_supported_route_page).to be_displayed
   end
 end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -111,7 +111,7 @@ module Features
     end
 
     def not_supported_route_page
-      @not_supported_route_page ||= PageObjects::Trainees::NotSupportedRoute.newx
+      @not_supported_route_page ||= PageObjects::Trainees::NotSupportedRoute.new
     end
 
     def deferral_page


### PR DESCRIPTION
### Context
https://trello.com/c/4meZO55D/2747-bug-changing-an-existing-trainees-route-to-other-errors
Fixes two bugs
1) Error on selecting "other" as a training route on an existing trainee
2) When the user goes to not supported route view after selecting other, the go back link takes the user to the `/trainees/new` page. If the trainee has already been created and the route simply needs to be edited, this is not correct. 

### Changes proposed in this pull request
* The go back link will take user to `trainees/#{trainee_id}/training-routes/edit` if trainee exists. If a new trainee then `/trainees/new` as before
* Update trainee method returned if 'other' selected to avoid error

### Guidance to review
Edit an existing trainees route and select 'other' option. And also create a new trainee and do the same.
