### PR TITLE
[2775] Snag remove diversity confirm page for review data page

### DIFF
--- a/app/controllers/trainees/diversity/disability_details_controller.rb
+++ b/app/controllers/trainees/diversity/disability_details_controller.rb
@@ -20,7 +20,7 @@ module Trainees
         save_strategy = trainee.draft? ? :save! : :stash
 
         if @disability_detail_form.public_send(save_strategy)
-          redirect_to trainee_diversity_confirm_path(trainee)
+          redirect_to relevant_path
         else
           render :edit
         end
@@ -44,6 +44,10 @@ module Trainees
 
       def authorize_trainee
         authorize(trainee)
+      end
+
+      def relevant_path
+        trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_diversity_confirm_path(trainee)
       end
     end
   end

--- a/app/controllers/trainees/diversity/disability_disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disability_disclosures_controller.rb
@@ -39,7 +39,7 @@ module Trainees
 
       def redirect_to_relevant_step
         if @disability_disclosure_form.disability_not_provided? || @disability_disclosure_form.no_disability?
-          redirect_to(trainee_diversity_confirm_path(trainee))
+          redirect_to(trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_diversity_confirm_path(trainee))
         else
           redirect_to(edit_trainee_diversity_disability_detail_path(trainee))
         end


### PR DESCRIPTION
### Context
https://trello.com/c/wi5imIjR/2775-changing-diversity-should-not-redirect-to-a-confirm-page
When a user edits disability details or disability disclosure page for Apply draft trainee they would be taken to a confirm page. 
### Changes proposed in this pull request
If Apply draft trainee, the confirm page is ignored if answers on those pages are edited
### Guidance to review
Edit diversity section from review trainee details 

