### PR TITLE
[2770] Fixed Trainee ID redirect to confirm page issue

### DIFF
--- a/app/controllers/trainees/training_details_controller.rb
+++ b/app/controllers/trainees/training_details_controller.rb
@@ -18,7 +18,7 @@ module Trainees
       @training_details_form = TrainingDetailsForm.new(trainee, params: trainee_params, user: current_user)
 
       if @training_details_form.save
-        redirect_to relevant_redirect_path
+        redirect_to trainee_training_details_confirm_path(trainee)
       else
         render :edit
       end
@@ -39,10 +39,6 @@ module Trainees
 
     def authorize_trainee
       authorize(trainee)
-    end
-
-    def relevant_redirect_path
-      trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_training_details_confirm_path(trainee)
     end
   end
 end

--- a/spec/controllers/trainees/training_details_controller_spec.rb
+++ b/spec/controllers/trainees/training_details_controller_spec.rb
@@ -15,12 +15,11 @@ describe Trainees::TrainingDetailsController do
 
       before do
         allow(TrainingDetailsForm).to receive(:new).and_return(double(save: true))
-        allow(controller).to receive(:page_tracker).and_return(double(last_origin_page_path: "/trainees/#{trainee.slug}/relevant-redirect", save!: nil))
         allow(controller).to receive(:trainee_params).and_return(nil)
       end
 
-      it "redirects to /relevant-redirect after update" do
-        expect(put(:update, params: { trainee_id: trainee.slug })).to redirect_to("/trainees/#{trainee.slug}/relevant-redirect")
+      it "redirects to /training-details/confirm after update" do
+        expect(put(:update, params: { trainee_id: trainee.slug })).to redirect_to("/trainees/#{trainee.slug}/training-details/confirm")
       end
     end
   end


### PR DESCRIPTION
### Context
Trainee ID not showing confirm page

### Changes proposed in this pull request
Fixed redirect to confirm page issue
### Guidance to review
Find a `apply` trainee and go and click `Check trainee record` then edit from there.

#### Before

![2770-before](https://user-images.githubusercontent.com/470137/134313877-814a1b88-76dd-47bb-bbfc-71233c864f53.gif)
#### After
![2770-after](https://user-images.githubusercontent.com/470137/134313864-21485c3a-3493-4292-941d-7df3c3ff7d1a.gif)
