### PR TITLE
[2777] Improve grade mapping based on hesa_degclss or grade name

### DIFF
--- a/app/lib/dttp/code_sets/grades.rb
+++ b/app/lib/dttp/code_sets/grades.rb
@@ -8,11 +8,26 @@ module Dttp
       OTHER = "Other"
 
       MAPPING = {
-        FIRST_CLASS_HONOURS => { entity_id: "fe2fca5f-766d-e711-80d2-005056ac45bb" },
-        "Upper second-class honours (2:1)" => { entity_id: "0030ca5f-766d-e711-80d2-005056ac45bb" },
-        "Lower second-class honours (2:2)" => { entity_id: "0230ca5f-766d-e711-80d2-005056ac45bb" },
-        "Third-class honours" => { entity_id: "0630ca5f-766d-e711-80d2-005056ac45bb" },
-        "Pass" => { entity_id: "0e30ca5f-766d-e711-80d2-005056ac45bb" },
+        FIRST_CLASS_HONOURS => {
+          entity_id: "fe2fca5f-766d-e711-80d2-005056ac45bb",
+          hesa_code: "01",
+        },
+        "Upper second-class honours (2:1)" => {
+          entity_id: "0030ca5f-766d-e711-80d2-005056ac45bb",
+          hesa_code: "02",
+        },
+        "Lower second-class honours (2:2)" => {
+          entity_id: "0230ca5f-766d-e711-80d2-005056ac45bb",
+          hesa_code: "03",
+        },
+        "Third-class honours" => {
+          entity_id: "0630ca5f-766d-e711-80d2-005056ac45bb",
+          hesa_code: "05",
+        },
+        "Pass" => {
+          entity_id: "0e30ca5f-766d-e711-80d2-005056ac45bb",
+          hesa_code: "14",
+        },
         OTHER => { entity_id: "1c30ca5f-766d-e711-80d2-005056ac45bb" },
       }.freeze
     end

--- a/app/services/degrees/map_from_apply.rb
+++ b/app/services/degrees/map_from_apply.rb
@@ -81,9 +81,13 @@ module Degrees
     end
 
     def grade
-      @grade ||= Dttp::CodeSets::Grades::MAPPING.keys.find do |grade|
-        same_string?(grade, attributes["grade"])
-      end
+      @grade ||= Dttp::CodeSets::Grades::MAPPING.find do |key, value|
+        same_hesa_code?(value[:hesa_code], attributes["hesa_degclss"]) || same_string?(key, normalised_grade)
+      end&.first
+    end
+
+    def normalised_grade
+      attributes["grade"]&.gsub(/predicted/i, "")
     end
 
     def country

--- a/spec/services/degrees/map_from_apply_spec.rb
+++ b/spec/services/degrees/map_from_apply_spec.rb
@@ -100,11 +100,37 @@ module Degrees
       end
 
       context "grade" do
+        let(:expected_grade) { Dttp::CodeSets::Grades::FIRST_CLASS_HONOURS }
+
+        context "with hesa code" do
+          let(:application_data) do
+            ApiStubs::ApplyApi.application(degree_attributes: { hesa_degclss: "01", grade: "First class honours" })
+          end
+
+          it "sets the value to the actual grade" do
+            expect(subject).to include(
+              expected_uk_degree_attributes.merge(other_grade: nil),
+            )
+          end
+        end
+
+        context "when the grade is predicted" do
+          let(:application_data) do
+            ApiStubs::ApplyApi.application(degree_attributes: { hesa_degclss: nil, grade: "First class honours (Predicted)" })
+          end
+
+          it "sets the value to the actual grade" do
+            expect(subject).to include(
+              expected_uk_degree_attributes.merge(other_grade: nil),
+            )
+          end
+        end
+
         context "when the grade can't be found" do
           let(:expected_grade) { Dttp::CodeSets::Grades::OTHER }
 
           let(:application_data) do
-            ApiStubs::ApplyApi.application(degree_attributes: { grade: "merit" })
+            ApiStubs::ApplyApi.application(degree_attributes: { hesa_degclss: nil, grade: "merit" })
           end
 
           it "sets the value to other" do


### PR DESCRIPTION
### Context
We sometimes receive predicted grades from apply, eg: "First class honours (predicted)"
This PR aims to handle them and map them based on HESA codes or the actual predicted grade.

### Changes proposed in this pull request
1. Add hesa codes to grades based on https://www.hesa.ac.uk/collection/c20051/a/class
2. When hesa codes are not available, strip the word "predicted" from the grade text, and let the Mapping service work its magic as it does with institution et al.

### Guidance to review
Try importing and asserting against staging data dump. (of these, some would previously have been marked with a degree grade of "other" and free text.
The expectation here is that they would be mapped correctly to the specified hesa grade code or the predicted degree where possible.


