### PR TITLE
[2748] Ethnicity regression fixes and more

### DIFF
--- a/app/controllers/trainees/diversity/confirm_details_controller.rb
+++ b/app/controllers/trainees/diversity/confirm_details_controller.rb
@@ -4,6 +4,7 @@ module Trainees
   module Diversity
     class ConfirmDetailsController < Trainees::ConfirmDetailsController
       before_action :authorize_trainee
+      before_action :save_data_and_bypass_confirmation_page, if: :draft_apply_application?
       before_action :load_missing_data_view
 
       def show
@@ -59,6 +60,15 @@ module Trainees
 
       def build_form
         DiversityForm.new(trainee)
+      end
+
+      def save_data_and_bypass_confirmation_page
+        form.save!
+        redirect_to edit_trainee_apply_applications_trainee_data_path(trainee)
+      end
+
+      def draft_apply_application?
+        trainee.draft? && trainee.apply_application?
       end
 
       def authorize_trainee

--- a/app/controllers/trainees/diversity/disability_disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disability_disclosures_controller.rb
@@ -16,10 +16,8 @@ module Trainees
           user: current_user,
         )
 
-        save_strategy = trainee.draft? ? :save! : :stash
-
-        if @disability_disclosure_form.public_send(save_strategy)
-          redirect_to_relevant_step
+        if @disability_disclosure_form.stash_or_save!
+          redirect_to relevant_path
         else
           render :edit
         end
@@ -37,11 +35,11 @@ module Trainees
         params.require(:diversities_disability_disclosure_form).permit(*Diversities::DisabilityDisclosureForm::FIELDS)
       end
 
-      def redirect_to_relevant_step
+      def relevant_path
         if @disability_disclosure_form.disability_not_provided? || @disability_disclosure_form.no_disability?
-          redirect_to(trainee_diversity_confirm_path(trainee))
+          trainee_diversity_confirm_path(trainee)
         else
-          redirect_to(edit_trainee_diversity_disability_detail_path(trainee))
+          edit_trainee_diversity_disability_detail_path(trainee)
         end
       end
 

--- a/app/controllers/trainees/diversity/disclosures_controller.rb
+++ b/app/controllers/trainees/diversity/disclosures_controller.rb
@@ -12,9 +12,7 @@ module Trainees
       def update
         @disclosure_form = Diversities::DisclosureForm.new(trainee, params: disclosure_params, user: current_user)
 
-        save_strategy = trainee.draft? ? :save! : :stash
-
-        if @disclosure_form.public_send(save_strategy)
+        if @disclosure_form.stash_or_save!
           redirect_to step_wizard.next_step
         else
           render :edit
@@ -33,10 +31,6 @@ module Trainees
         params.require(:diversities_disclosure_form).permit(*Diversities::DisclosureForm::FIELDS)
       end
 
-      def authorize_trainee
-        authorize(trainee)
-      end
-
       def step_wizard
         @step_wizard ||= Wizards::DiversitiesStepWizard.new(trainee: trainee, page_tracker: page_tracker)
       end
@@ -46,6 +40,10 @@ module Trainees
         return if user_came_from_backlink?
 
         redirect_to step_wizard.start_point if step_wizard.start_point.present?
+      end
+
+      def authorize_trainee
+        authorize(trainee)
       end
     end
   end

--- a/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_backgrounds_controller.rb
@@ -16,10 +16,8 @@ module Trainees
           user: current_user,
         )
 
-        save_strategy = trainee.draft? ? :save! : :stash
-
-        if @ethnic_background_form.public_send(save_strategy)
-          redirect_to(origin_page_or_next_step)
+        if @ethnic_background_form.stash_or_save!
+          redirect_to relevant_path
         else
           render :edit
         end
@@ -46,10 +44,12 @@ module Trainees
         trainee.ethnic_background.present? && trainee.ethnic_background != required_params[:ethnic_background]
       end
 
-      def origin_page_or_next_step
-        return page_tracker.last_origin_page_path if page_tracker.last_origin_page_path&.include?("diversity/confirm")
-
-        edit_trainee_diversity_disability_disclosure_path(trainee)
+      def relevant_path
+        if trainee.disability_disclosure.present?
+          trainee_diversity_confirm_path(trainee)
+        else
+          edit_trainee_diversity_disability_disclosure_path(trainee)
+        end
       end
 
       def authorize_trainee

--- a/app/controllers/trainees/diversity/ethnic_groups_controller.rb
+++ b/app/controllers/trainees/diversity/ethnic_groups_controller.rb
@@ -16,10 +16,8 @@ module Trainees
           user: current_user,
         )
 
-        save_strategy = trainee.draft? ? :save! : :stash
-
-        if @ethnic_group_form.public_send(save_strategy)
-          redirect_to_relevant_step
+        if @ethnic_group_form.stash_or_save!
+          redirect_to relevant_path
         else
           render :edit
         end
@@ -37,16 +35,20 @@ module Trainees
         params.require(:diversities_ethnic_group_form).permit(*Diversities::EthnicGroupForm::FIELDS)
       end
 
-      def redirect_to_relevant_step
+      def relevant_path
         if @ethnic_group_form.not_provided_ethnic_group?
           if trainee.disability_disclosure.present?
-            redirect_to(page_tracker.last_origin_page_path)
+            trainee_diversity_confirm_path(trainee)
           else
-            redirect_to(edit_trainee_diversity_disability_disclosure_path(trainee))
+            edit_trainee_diversity_disability_disclosure_path(trainee)
           end
         else
-          redirect_to(edit_trainee_diversity_ethnic_background_path(trainee))
+          edit_trainee_diversity_ethnic_background_path(trainee)
         end
+      end
+
+      def disclosure_form
+        @disclosure_form ||= Diversities::DisclosureForm.new(trainee)
       end
 
       def authorize_trainee

--- a/app/forms/diversities/ethnic_background_form.rb
+++ b/app/forms/diversities/ethnic_background_form.rb
@@ -19,20 +19,20 @@ module Diversities
       super(trainee, **kwargs)
     end
 
+    def requires_ethnic_background?
+      disclosure_form.diversity_disclosed? && ethnic_group_form.ethnic_group_disclosed?
+    end
+
   private
 
     attr_reader :disclosure_form, :ethnic_group_form
-
-    def requires_ethnic_background?
-      disclosure_form.diversity_disclosed? && !ethnic_group_form.not_provided_ethnic_group?
-    end
 
     def compute_fields
       trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
     end
 
     def new_attributes
-      if disclosure_form.diversity_disclosed?
+      if requires_ethnic_background?
         fields_from_store.merge(params).symbolize_keys
       else
         { ethnic_background: nil, additional_ethnic_background: nil }

--- a/app/forms/diversities/ethnic_group_form.rb
+++ b/app/forms/diversities/ethnic_group_form.rb
@@ -4,8 +4,6 @@ module Diversities
   class EthnicGroupForm < TraineeForm
     FIELDS = %i[
       ethnic_group
-      ethnic_background
-      additional_ethnic_background
     ].freeze
 
     attr_accessor(*FIELDS)
@@ -24,6 +22,10 @@ module Diversities
       fields[:ethnic_group] == Diversities::ETHNIC_GROUP_ENUMS[:not_provided]
     end
 
+    def ethnic_group_disclosed?
+      !not_provided_ethnic_group?
+    end
+
   private
 
     attr_reader :disclosure_form
@@ -33,11 +35,7 @@ module Diversities
     end
 
     def new_attributes
-      (disclosure_form.diversity_disclosed? ? fields_from_store.merge(params).symbolize_keys : { ethnic_group: nil }).tap do |attrs|
-        if attrs[:ethnic_group] == Diversities::ETHNIC_GROUP_ENUMS[:not_provided]
-          attrs.merge!(ethnic_background: nil, additional_ethnic_background: nil)
-        end
-      end
+      disclosure_form.diversity_disclosed? ? fields_from_store.merge(params).symbolize_keys : { ethnic_group: nil }
     end
   end
 end

--- a/app/lib/wizards/diversities_step_wizard.rb
+++ b/app/lib/wizards/diversities_step_wizard.rb
@@ -13,7 +13,7 @@ module Wizards
       if disclosure_form.diversity_disclosed?
         edit_trainee_diversity_ethnic_group_path(trainee)
       else
-        trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_diversity_confirm_path(trainee)
+        trainee_diversity_confirm_path(trainee)
       end
     end
 

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -1,5 +1,6 @@
 <%= render PageTitle::View.new(
-  text: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")),
+  text: t("components.page_titles.trainees.diversity.ethnic_background.edit",
+          background: I18n.t("views.forms.ethnic_groups.labels.#{@ethnic_background_form.ethnic_group}")),
   has_errors: @ethnic_background_form.errors.present?,
 ) %>
 
@@ -12,13 +13,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @ethnic_background_form, url: trainee_diversity_ethnic_background_path(@trainee), method: :put, local: true) do |f| %>
+    <%= register_form_with(model: @ethnic_background_form,
+                           url: trainee_diversity_ethnic_background_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
         <%= f.govuk_radio_buttons_fieldset(
           :ethnic_background,
           legend: {
-            text: t("components.page_titles.trainees.diversity.ethnic_background.edit", background: I18n.t("views.forms.ethnic_groups.labels.#{@trainee.ethnic_group}")),
+            text: t("components.page_titles.trainees.diversity.ethnic_background.edit",
+                    background: I18n.t("views.forms.ethnic_groups.labels.#{@ethnic_background_form.ethnic_group}")),
             tag: "h1",
             size: "l",
 },

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -29,23 +29,25 @@
 
           <% Diversities::BACKGROUNDS[@ethnic_background_form.ethnic_group].each_with_index do |ethnic_background, index| %>
             <% if other_ethnic_background_option?(ethnic_background) %>
-              <%= f.govuk_radio_button(:ethnic_background, ethnic_background, label: { text: ethnic_background }, link_errors: index.zero?) do %>
+              <%= f.govuk_radio_button(:ethnic_background, ethnic_background, label: { text: ethnic_background },
+                                       link_errors: index.zero?) do %>
                 <%= f.govuk_text_field(
                   :additional_ethnic_background,
                   width: "two-thirds",
                   autocomplete: :disabled,
-                  label: { text: I18n.t("views.forms.ethnic_backgrounds.another_ethnic_background_labels.#{@trainee.ethnic_group}") },
+                  label: { text: I18n.t("views.forms.ethnic_backgrounds.another_ethnic_background_labels.#{@ethnic_background_form.ethnic_group}") },
                 ) %>
               <% end %>
             <% else %>
-              <%= f.govuk_radio_button(:ethnic_background, ethnic_background, label: { text: ethnic_background }, link_errors: index.zero?) %>
+              <%= f.govuk_radio_button(:ethnic_background, ethnic_background, label: { text: ethnic_background },
+                                       link_errors: index.zero?) %>
             <% end %>
           <% end %>
 
           <%= f.govuk_radio_divider %>
+
           <%= f.govuk_radio_button :ethnic_background, Diversities::NOT_PROVIDED, label: { text: "Not provided" } %>
         <% end %>
-
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     ethnic_group { nil }
     ethnic_background { nil }
     additional_ethnic_background { nil }
-    disability_disclosure { Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] }
+    disability_disclosure { nil }
 
     address_line_one { Faker::Address.street_address }
     address_line_two { Faker::Address.street_name }
@@ -139,6 +139,10 @@ FactoryBot.define do
 
     trait :diversity_not_disclosed do
       diversity_disclosure { Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed] }
+    end
+
+    trait :disability_not_provided do
+      disability_disclosure { Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] }
     end
 
     trait :with_ethnic_group do

--- a/spec/features/form_sections/personal_and_education_details/diversities/edit_ethnic_group_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/diversities/edit_ethnic_group_spec.rb
@@ -52,7 +52,7 @@ feature "edit ethnic group", type: :feature do
   end
 
   def given_a_trainee_exists
-    @trainee = create(:trainee, :diversity_disclosed, ethnic_group: nil, provider: current_user.provider)
+    @trainee = create(:trainee, :diversity_disclosed, :disability_not_provided, provider: current_user.provider)
   end
 
   def given_a_trainee_with_a_background_exists

--- a/spec/forms/diversities/disability_disclosure_form_spec.rb
+++ b/spec/forms/diversities/disability_disclosure_form_spec.rb
@@ -25,6 +25,8 @@ module Diversities
     end
 
     describe "#stash" do
+      let(:params) { { "disability_disclosure" => Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] } }
+
       it "uses FormStore to temporarily save the fields under a key combination of trainee ID and disability_disclosure" do
         expect(form_store).to receive(:set).with(trainee.id, :disability_disclosure, subject.fields)
 

--- a/spec/forms/diversities/ethnic_group_form_spec.rb
+++ b/spec/forms/diversities/ethnic_group_form_spec.rb
@@ -10,8 +10,6 @@ module Diversities
         :trainee,
         :diversity_disclosed,
         ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:other],
-        ethnic_background: Diversities::ANOTHER_ETHNIC_BACKGROUND,
-        additional_ethnic_background: "Crab people",
       )
     end
     let(:form_store) { class_double(FormStore) }
@@ -45,24 +43,6 @@ module Diversities
 
       it "takes any data from the form store and saves it to the database" do
         expect { subject.save! }.to change(trainee, :ethnic_group).to(ethnic_group)
-      end
-
-      context "ethnic_group is set to not provided" do
-        let(:ethnic_background) { Diversities::ETHNIC_GROUP_ENUMS[:not_provided] }
-
-        before do
-          allow(form_store).to receive(:get).and_return(
-            {
-              "ethnic_group" => ethnic_group,
-              "ethnic_background" => Diversities::ANOTHER_ETHNIC_BACKGROUND,
-            },
-          )
-        end
-
-        it "clears any ethnic background info" do
-          expect { subject.save! }.to change(trainee, :ethnic_background).to(nil)
-            .and change(trainee, :additional_ethnic_background).to(nil)
-        end
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/mP11oLki/2748-ethnicity-regression-follow-the-gif-and-scream-afterwards

### Changes proposed in this pull request
- Fixed translation rendering on ethnic background page
- Fixed some diversity bugs related to persisting the choices made in the context of editing non-draft trainees or draft trainees created from an Apply import
- There was a bug in the example data where trainees by default don't disclose diversity information but still had a value for `Trainee#disability_disclosure` which messes the page flow when choosing to disclose diversity information.
- Fix translation bug for label "Another White background"

### Guidance to review
- Reset local DB: `rake db:reset && rake db:seed && rake example_data:generate`
- Pick a trainee in draft state, imported from Apply and TRN received
- For each trainee, play around with the diversity journey
- For draft Apply imported trainees, there should be no confirmation page after updating diversity information. For everything else, you should get a confirmation page.
