### PR TITLE
[2772] Fix: single language subject not mapping correctly on apply confirm course page

### DIFF
--- a/app/controllers/trainees/apply_applications/confirm_courses_controller.rb
+++ b/app/controllers/trainees/apply_applications/confirm_courses_controller.rb
@@ -72,18 +72,11 @@ module Trainees
       end
 
       def selected_or_calculated_specialisms
-        return selected_specialisms if publish_course_details_form.general_specialism? || selected_specialisms&.any?
-        return selected_language_specialisms if publish_course_details_form.language_specialism? || selected_language_specialisms&.any?
-
-        CalculateSubjectSpecialisms.call(subjects: @course.subjects.pluck(:name)).values.map(&:first).compact
-      end
-
-      def selected_specialisms
-        @selected_specialisms ||= SubjectSpecialismForm.new(trainee).specialisms
-      end
-
-      def selected_language_specialisms
-        @selected_language_specialisms ||= LanguageSpecialismsForm.new(trainee).languages
+        if publish_course_details_form.selected_specialisms.any?
+          publish_course_details_form.selected_specialisms
+        else
+          CalculateSubjectSpecialisms.call(subjects: @course.subjects.pluck(:name)).values.map(&:first).compact
+        end
       end
 
       def manual_entry_chosen?

--- a/app/controllers/trainees/language_specialisms_controller.rb
+++ b/app/controllers/trainees/language_specialisms_controller.rb
@@ -5,6 +5,7 @@ module Trainees
     include PublishCourseNextPath
 
     before_action :authorize_trainee
+    before_action :skip_manual_selection, if: :course_has_one_language_specialism?
     before_action :load_language_specialisms
 
     def edit
@@ -12,9 +13,12 @@ module Trainees
     end
 
     def update
-      @language_specialisms_form = LanguageSpecialismsForm.new(trainee, params: language_specialism_params, user: current_user)
+      @language_specialisms_form = LanguageSpecialismsForm.new(trainee,
+                                                               params: language_specialism_params,
+                                                               user: current_user)
+
       if @language_specialisms_form.stash_or_save!
-        redirect_to next_step_path
+        redirect_to publish_course_next_path
       else
         render :edit
       end
@@ -22,8 +26,16 @@ module Trainees
 
   private
 
-    def next_step_path
-      publish_course_next_path
+    def skip_manual_selection
+      LanguageSpecialismsForm.new(trainee, params: {
+        course_subject_one: subject_specialisms.first,
+      }).stash_or_save!
+
+      redirect_to publish_course_next_path
+    end
+
+    def course_has_one_language_specialism?
+      subject_specialisms.all? { |_, v| v.count < 2 }
     end
 
     def load_language_specialisms
@@ -40,6 +52,18 @@ module Trainees
 
     def course_code
       publish_course_details_form.course_code || trainee.course_code
+    end
+
+    def subject_specialisms
+      @subject_specialisms ||= CalculateSubjectSpecialisms.call(subjects: course_subjects)
+    end
+
+    def course_subjects
+      @course_subjects ||= course.subjects.pluck(:name)
+    end
+
+    def course
+      @course ||= trainee.available_courses.find_by_code!(course_code)
     end
   end
 end

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -72,8 +72,8 @@ class PublishCourseDetailsForm < TraineeForm
     specialism_type == :language
   end
 
-  def general_specialism?
-    specialism_type == :general
+  def selected_specialisms
+    language_specialism? ? specialism_form.languages : specialism_form.specialisms
   end
 
 private


### PR DESCRIPTION
### Context
https://trello.com/c/FL1O6Slw/2772-1-2-day-spanish-specialism-subject-didnt-map-correctly

### Changes proposed in this pull request
- Fix `Trainees::ApplyApplications::ConfirmCoursesController` so it can map language courses with a single language
- Updated `Trainees::LanguageSpecialismsController` to check if the course has one language specialism and if so just skip the manual selection page and go straight on to the next page (ITT date page or confirmation page)

### Guidance to review
- Running the following code in the console to find a language course that has one subject mapping to one specialism:
```ruby
Course.all.find { |c| c.subjects.count == 1 && PUBLISH_MODERN_LANGUAGES.include?(c.subjects.pluck(:name).first) }
```
- Visit a trainee with an application
- Enter the course details page
- Change course and select the one matching the course code found earlier in the console
- You should be be directed to the confirmation and subject information should be present