### PR TITLE
[2754] max length validation for names

### DIFF
--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -25,8 +25,9 @@ class PersonalDetailsForm < TraineeForm
 
   before_validation :set_nationalities_from_raw_values
 
-  validates :first_names, presence: true
-  validates :last_name, presence: true
+  validates :first_names, presence: true, length: { maximum: 50 }
+  validates :last_name, presence: true, length: { maximum: 50 }
+  validates :middle_names, length: { maximum: 50 }, allow_nil: true
   validates :date_of_birth, presence: true
   validate :date_of_birth_valid
   validate :date_of_birth_not_in_future

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1003,8 +1003,12 @@ en:
           attributes:
             first_names:
               blank: Enter a first name
+              too_long: First name must be 50 characters or fewer
             last_name:
               blank: Enter a last name
+              too_long: Last name must be 50 characters or fewer
+            middle_names:
+              too_long: Middle name must be 50 characters or fewer
             date_of_birth:
               blank: Enter a date of birth
               invalid: Enter a valid date

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -44,6 +44,9 @@ describe PersonalDetailsForm, type: :model do
     it { is_expected.to validate_presence_of(:last_name) }
     it { is_expected.to validate_presence_of(:gender) }
     it { is_expected.to validate_inclusion_of(:gender).in_array(Trainee.genders.keys) }
+    it { is_expected.to validate_length_of(:first_names).is_at_most(50).with_message("First name must be 50 characters or fewer") }
+    it { is_expected.to validate_length_of(:last_name).is_at_most(50).with_message("Last name must be 50 characters or fewer") }
+    it { is_expected.to validate_length_of(:middle_names).is_at_most(50).with_message("Middle name must be 50 characters or fewer") }
 
     context "nationalities" do
       let(:params) { {} }


### PR DESCRIPTION
### Context

https://trello.com/c/HGzkiWRF/2754-first-name-exceeds-50-chars

### Changes proposed in this pull request

* Added validation for `first_names`, `middle_names` and `last_name` for max length 50

### Guidance to review

* Personal details section