### PR TITLE
[2774] Missing data turns red on UI on submission

### DIFF
--- a/app/components/apply_applications/trainee_data/view.rb
+++ b/app/components/apply_applications/trainee_data/view.rb
@@ -6,17 +6,14 @@ module ApplyApplications
       include ApplicationHelper
       include TraineeHelper
 
-      attr_reader :data_model, :form, :invalid_data_view
+      attr_reader :form, :invalid_data_view
 
-      def initialize(data_model)
-        @data_model = data_model[:data_model] || data_model
-        @form = TraineeDataForm.new(trainee)
+      def initialize(trainee_data_form:)
+        @form = trainee_data_form
         @invalid_data_view = ApplyInvalidDataView.new(trainee.apply_application)
       end
 
-      def trainee
-        data_model.is_a?(Trainee) ? data_model : data_model.trainee
-      end
+      delegate :trainee, to: :form
     end
   end
 end

--- a/app/views/trainees/apply_applications/trainee_data/edit.html.erb
+++ b/app/views/trainees/apply_applications/trainee_data/edit.html.erb
@@ -27,7 +27,7 @@
         </h1>
       </div>
     </div>
-    <%= render ApplyApplications::TraineeData::View.new(@trainee) %>
+    <%= render ApplyApplications::TraineeData::View.new(trainee_data_form: @trainee_data_form) %>
 
     <%= register_form_with(model: @trainee_data_form, builder: GOVUKDesignSystemFormBuilder::FormBuilder,
                            url: trainee_apply_applications_trainee_data_path(@trainee),

--- a/spec/components/apply_applications/trainee_data/view_preview.rb
+++ b/spec/components/apply_applications/trainee_data/view_preview.rb
@@ -6,11 +6,23 @@ module ApplyApplications
   module TraineeData
     class ViewPreview < ViewComponent::Preview
       def default
-        render(View.new(trainee([degree])))
+        render(View.new(trainee_data_form: ::ApplyApplications::TraineeDataForm.new(trainee([degree]))))
       end
 
       def with_no_degrees
-        render(View.new(trainee))
+        render(View.new(trainee_data_form: ::ApplyApplications::TraineeDataForm.new(trainee)))
+      end
+
+      def default_error
+        form = ::ApplyApplications::TraineeDataForm.new(trainee([degree]))
+        form.valid?
+        render(View.new(trainee_data_form: form))
+      end
+
+      def with_no_degrees_error
+        form = ::ApplyApplications::TraineeDataForm.new(trainee)
+        form.valid?
+        render(View.new(trainee_data_form: form))
       end
 
     private

--- a/spec/components/apply_applications/trainee_data/view_spec.rb
+++ b/spec/components/apply_applications/trainee_data/view_spec.rb
@@ -10,7 +10,7 @@ module ApplyApplications
       let(:apply_application) { create(:apply_application) }
 
       before do
-        render_inline(View.new(trainee))
+        render_inline(View.new(trainee_data_form: ::ApplyApplications::TraineeDataForm.new(trainee)))
       end
 
       context "trainee with degrees" do


### PR DESCRIPTION
### Context
https://trello.com/c/GSquLmWl/2774-missing-data-ui-should-turn-red-on-validation

### Changes proposed in this pull request
* One form object instead of two separate ones. Therefore, the errors are carried down from the TraineeDataForm and then into the UI
* Fix tests and view preview

### Guidance to review
Try to submit an Apply draft with missing data at `trainees/{trainee.slug}/apply-application/trainee-data`. The styling should turn from blue to red. There is another bug where invalid non-degree fields always has 'contains 0 answers that you need to amend'. 

