### PR TITLE
[2779] Import non-findable courses from TTAPI

### DIFF
--- a/app/jobs/trainees/create_from_apply_job.rb
+++ b/app/jobs/trainees/create_from_apply_job.rb
@@ -9,6 +9,8 @@ module Trainees
 
       ApplyApplication.joins(:provider).where(providers: { apply_sync_enabled: true }).importable.each do |application|
         CreateFromApply.call(application: application)
+      rescue Trainees::CreateFromApply::MissingCourseError => e
+        Sentry.capture_exception(e)
       end
     end
   end

--- a/app/services/teacher_training_api/retrieve_courses.rb
+++ b/app/services/teacher_training_api/retrieve_courses.rb
@@ -4,7 +4,7 @@ module TeacherTrainingApi
   class RetrieveCourses
     include ServicePattern
 
-    DEFAULT_PATH = "/courses?filter[findable]=true&include=accredited_body,provider&sort=name,provider.provider_name"
+    DEFAULT_PATH = "/courses?include=accredited_body,provider&sort=name,provider.provider_name"
 
     def initialize(request_uri: nil)
       @request_uri = request_uri.presence || DEFAULT_PATH

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -4,6 +4,8 @@ module Trainees
   class CreateFromApply
     include ServicePattern
 
+    class MissingCourseError < StandardError; end
+
     def initialize(application:)
       @application = application
       @raw_course = application.application_attributes["course"]
@@ -22,7 +24,7 @@ module Trainees
         return
       end
 
-      return if course.nil? # Courses can be missing in non-prod environments
+      raise MissingCourseError, "Cannot find course with code: #{@raw_course['course_code']}" if course.nil? # Courses can be missing in non-prod environments
 
       trainee.save!
       save_personal_details!

--- a/spec/jobs/trainees/create_trainees_from_apply_job_spec.rb
+++ b/spec/jobs/trainees/create_trainees_from_apply_job_spec.rb
@@ -28,6 +28,17 @@ module Trainees
             described_class.perform_now
           end
         end
+
+        context "when CreateFromApply returns MissingCourseError" do
+          before do
+            allow(CreateFromApply).to receive(:call).with(application: apply_application).and_raise Trainees::CreateFromApply::MissingCourseError
+          end
+
+          it "is rescued and captured by Sentry" do
+            expect(Sentry).to receive(:capture_exception).with(Trainees::CreateFromApply::MissingCourseError)
+            described_class.perform_now
+          end
+        end
       end
 
       context "provider has opted out to import applications from Apply" do

--- a/spec/services/teacher_training_api/retrieve_courses_spec.rb
+++ b/spec/services/teacher_training_api/retrieve_courses_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module TeacherTrainingApi
   describe RetrieveCourses do
     describe "#call" do
-      let(:path) { "/courses?filter[findable]=true&include=accredited_body,provider&sort=name,provider.provider_name" }
+      let(:path) { "/courses?include=accredited_body,provider&sort=name,provider.provider_name" }
       let(:request_url) { "#{Settings.teacher_training_api.base_url}#{path}" }
 
       before do

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -86,10 +86,10 @@ module Trainees
     context "course doesn't exist" do
       let(:course_code) { "ABC" }
 
-      it "doesn't change the state" do
+      it "raises a MissingCourseError" do
         expect {
           create_trainee_from_apply
-        }.not_to change(apply_application, :state)
+        }.to raise_error described_class::MissingCourseError
       end
     end
 


### PR DESCRIPTION
### Context
Some courses get withdrawn over the course of time, and these non-findable courses sometimes have apply applications associated with them.
This change is to ensure that we fetch all courses non-findable courses, to enable us to map them to trainees correctly.

### Changes proposed in this pull request
1. Ensure we import all courses (including non-findable)
2. in case of a course still not found, raise and capture an exception to sentry

