### PR TITLE
[2774] Fixed sections confirmation view

### DIFF
--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -23,12 +23,16 @@ module Sections
     delegate :funding_options, to: :helpers
 
     def confirmation_view_args
-      confirmation_view_args = { data_model: form_klass.new(trainee), has_errors: form_has_errors? }
+      if section == :trainee_data
+        { trainee_data_form: form_klass.new(trainee) }
+      else
+        confirmation_view_args = { data_model: form_klass.new(trainee), has_errors: form_has_errors? }
 
-      if section == :degrees
-        confirmation_view_args.merge!(show_add_another_degree_button: true, show_delete_button: true)
+        if section == :degrees
+          confirmation_view_args.merge!(show_add_another_degree_button: true, show_delete_button: true)
+        end
+        confirmation_view_args
       end
-      confirmation_view_args
     end
 
     def collapsed_funding_inactive_section_args

--- a/spec/components/sections/view_preview.rb
+++ b/spec/components/sections/view_preview.rb
@@ -11,7 +11,8 @@ module Sections
        course_details
        training_details
        schools
-       funding].each do |section|
+       funding
+       trainee_data].each do |section|
       define_method "continue_sections_#{section}" do
         trainee = continue_sections_trainee(section)
         form = TrnSubmissionForm.new(trainee: trainee)

--- a/spec/components/sections/view_spec.rb
+++ b/spec/components/sections/view_spec.rb
@@ -53,6 +53,7 @@ module Sections
       include_examples renders_incomplete_section, :degrees, :incomplete
       include_examples renders_incomplete_section, :course_details, :incomplete
       include_examples renders_incomplete_section, :training_details, :incomplete
+      include_examples renders_incomplete_section, :trainee_data, :incomplete
 
       context "requires school" do
         include_examples renders_incomplete_section, :schools, :incomplete
@@ -73,6 +74,7 @@ module Sections
       include_examples renders_incomplete_section, :degrees, :in_progress_valid
       include_examples renders_incomplete_section, :course_details, :in_progress_valid
       include_examples renders_incomplete_section, :training_details, :in_progress_valid
+      include_examples renders_incomplete_section, :trainee_data, :in_progress_valid
 
       context "requires school" do
         let(:trainee) { create(:trainee, :with_lead_school, :in_progress) }
@@ -98,6 +100,7 @@ module Sections
       include_examples renders_confirmation, :degrees
       include_examples renders_confirmation, :course_details
       include_examples renders_confirmation, :training_details
+      include_examples renders_confirmation, :trainee_data
 
       context "requires school" do
         let(:trainee) { create(:trainee, :with_lead_school, :completed) }
@@ -159,6 +162,10 @@ module Sections
           incomplete: "edit_trainee_funding_training_initiative_path",
           in_progress_valid: "trainee_funding_confirm_path",
         },
+        trainee_data: {
+          incomplete: "edit_trainee_apply_applications_trainee_data_path",
+          in_progress_valid: "edit_trainee_apply_applications_trainee_data_path",
+        },
       }[section][status]
     end
 
@@ -172,6 +179,7 @@ module Sections
         training_details: TrainingDetails::View,
         schools: Schools::View,
         funding: Funding::View,
+        trainee_data: ApplyApplications::TraineeData::View,
       }[section]
     end
   end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -99,6 +99,7 @@ FactoryBot.define do
           placement_details: true,
           schools: true,
           funding: true,
+          trainee_data: true,
         )
       end
     end


### PR DESCRIPTION
### Context
sections confirmation view for `trainee_data`

### Changes proposed in this pull request
Fixed sections confirmation view
Increase test coverage

### Guidance to review

Previously a keyword argument parameter was added ([see](https://github.com/DFE-Digital/register-trainee-teachers/pull/1494)) , not enough test broke.

Complete data entry for an `Apply application` go thru the flow etc, when you complete it and get to `/check-details` (example http://127.0.0.1:5000/trainees/r1qUB31EeE6F3YPLdisaFzww/check-details)
 it goes :boom: 
#### Before
On master ![image](https://user-images.githubusercontent.com/470137/134647038-031640b7-ef30-4afd-af8e-4f6c8f6302f7.png)


#### After 
![image](https://user-images.githubusercontent.com/470137/134647420-5076a9dc-fc1f-4b0f-9dbe-de1035177eb8.png)


