### PR TITLE
[2798] Turn apply flag on for prod

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -28,6 +28,7 @@ features:
   send_emails: true
   persist_to_dttp: true
   import_courses_from_ttapi: true
+  import_applications_from_apply: true
   publish_course_details: true
   send_funding_to_dttp: true
   scholarship: true


### PR DESCRIPTION
### Context

This will import all the applications but not create any trainees as all providers in prod do not have `apply_sync_enabled` set to true. There will be a sep. PR for that which will "turn things on".
