### PR TITLE
[2773] Stop pre-populating the ITT start date with the course start date

### DIFF
--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -96,17 +96,24 @@ private
   end
 
   def update_trainee_attributes
-    trainee.assign_attributes({
+    attributes = {
       course_code: course_code,
       course_subject_one: course_subject_one,
       course_subject_two: course_subject_two,
       course_subject_three: course_subject_three,
 
       course_age_range: course_age_range,
-      course_start_date: course_start_date,
       course_end_date: course_end_date,
       study_mode: study_mode,
-    })
+    }
+
+    unless trainee.pg_teaching_apprenticeship?
+      attributes.merge!({
+        course_start_date: course_start_date,
+      })
+    end
+
+    trainee.assign_attributes(attributes)
   end
 
   def course_study_mode_if_valid

--- a/spec/forms/publish_course_details_form_spec.rb
+++ b/spec/forms/publish_course_details_form_spec.rb
@@ -21,7 +21,7 @@ describe PublishCourseDetailsForm, type: :model do
   context "valid course_code" do
     let(:route) { TRAINING_ROUTES_FOR_COURSE.keys.sample }
     let(:params) { { course_code: "c0de" } }
-    let(:trainee) { create(:trainee, :submitted_for_trn, training_route: route, course_subject_one: nil) }
+    let(:trainee) { create(:trainee, :submitted_for_trn, route, course_subject_one: nil) }
 
     describe "#stash" do
       it "uses FormStore to temporarily save the fields under a key combination of trainee ID and course_details" do
@@ -52,6 +52,15 @@ describe PublishCourseDetailsForm, type: :model do
 
         it "updates the trainee with the publish course details" do
           expect { subject.save! }.to change { trainee.course_subject_one }.to(subject_name)
+        end
+
+        context "with a pg_teaching_apprenticeship trainee" do
+          let(:route) { :pg_teaching_apprenticeship }
+          let(:trainee) { build(:trainee, route) }
+
+          it "does not change the trainee's course start date" do
+            expect { subject.save! }.not_to(change { trainee.course_start_date })
+          end
         end
       end
     end


### PR DESCRIPTION
### Context

https://trello.com/c/0OT3KsCK/2733-bug-itt-start-date-pre-population

### Changes proposed in this pull request

- Stop saving the publish course start date as the trainee's start date for `pg_teaching_apprenticeship` trainees before asking them the ITT start date question

### Guidance to review
- Create a pgta trainee
- Select a publish course
- Click continue until you get to the ITT start date form
- Check that it's not pre-populated with the publish course start date