### PR TITLE
[2794] Granularize which fields to stash or save

### DIFF
--- a/app/forms/funding/bursary_form.rb
+++ b/app/forms/funding/bursary_form.rb
@@ -81,7 +81,7 @@ module Funding
       :bursary
     end
 
-    def fields_to_ignore_before_stash_or_save
+    def fields_to_ignore_before_save
       NON_TRAINEE_FIELDS
     end
   end

--- a/app/forms/language_specialisms_form.rb
+++ b/app/forms/language_specialisms_form.rb
@@ -58,10 +58,12 @@ private
     end
   end
 
-  def fields_to_ignore_before_stash_or_save
-    %i[
-      language_specialisms
-    ]
+  def fields_to_ignore_before_save
+    %i[language_specialisms]
+  end
+
+  def fields_to_ignore_before_stash
+    %i[language_specialisms]
   end
 
   def languages_specialisms_from_trainee_record

--- a/app/forms/schools/form.rb
+++ b/app/forms/schools/form.rb
@@ -62,7 +62,11 @@ module Schools
       raise NotImplementedError
     end
 
-    def fields_to_ignore_before_stash_or_save
+    def fields_to_ignore_before_save
+      NON_TRAINEE_FIELDS
+    end
+
+    def fields_to_ignore_before_stash
       NON_TRAINEE_FIELDS
     end
 

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -27,7 +27,7 @@ class TraineeForm
 
   def save!
     if valid?
-      trainee.assign_attributes(fields.except(*fields_to_ignore_before_stash_or_save))
+      trainee.assign_attributes(fields.except(*fields_to_ignore_before_save))
       trainee.save!
       clear_stash
     else
@@ -36,7 +36,7 @@ class TraineeForm
   end
 
   def stash
-    valid? && store.set(id, form_store_key, fields.except(*fields_to_ignore_before_stash_or_save))
+    valid? && store.set(id, form_store_key, fields.except(*fields_to_ignore_before_stash))
   end
 
   def course_start_date_attribute_name
@@ -67,7 +67,11 @@ private
     raise NotImplementedError
   end
 
-  def fields_to_ignore_before_stash_or_save
+  def fields_to_ignore_before_stash
+    []
+  end
+
+  def fields_to_ignore_before_save
     []
   end
 

--- a/spec/forms/funding/bursary_form_spec.rb
+++ b/spec/forms/funding/bursary_form_spec.rb
@@ -24,7 +24,7 @@ module Funding
 
     describe "#stash" do
       it "uses FormStore to temporarily save the fields under a key combination of trainee ID and bursary" do
-        expect(form_store).to receive(:set).with(trainee.id, :bursary, subject.fields.except(:funding_type))
+        expect(form_store).to receive(:set).with(trainee.id, :bursary, subject.fields)
 
         subject.stash
       end


### PR DESCRIPTION
### Context

- https://trello.com/c/QCUY3C5L/2794-bug-prod-error-with-funding

### Changes proposed in this pull request

Some form objects will need to stash non model related fields so those fields are properly hydrated when the user is confirming changes (and to also prevent missing data information incorrectly showing). This PR splits out the the method `fields_to_ignore_before_stash_or_save` on the `TraineeForm` into two. So fields can be ignored based on the context (being saved/being stashed)

