### PR TITLE
A few fixes related to the Apply Integration

### DIFF
--- a/app/components/degrees/view.rb
+++ b/app/components/degrees/view.rb
@@ -18,7 +18,9 @@ module Degrees
 
     def degree_title(degree)
       if degree.uk?
-        degree.subject ? "#{degree.uk_degree}: #{degree.subject&.downcase}" : degree.uk_degree
+        return "#{degree.uk_degree}: #{degree.subject&.downcase}" if degree.uk_degree && degree.subject
+
+        degree.uk_degree.presence || degree.subject.presence
       elsif degree.subject
         "Non-UK #{degree.non_uk_degree_non_enic? ? 'degree' : degree.non_uk_degree}: #{degree.subject&.downcase}"
       else

--- a/app/controllers/concerns/appliable.rb
+++ b/app/controllers/concerns/appliable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Appliable
+  def draft_apply_application?
+    trainee.apply_application? && trainee.draft?
+  end
+end

--- a/app/controllers/trainees/contact_details_controller.rb
+++ b/app/controllers/trainees/contact_details_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class ContactDetailsController < ApplicationController
+    include Appliable
+
     before_action :authorize_trainee
 
     def edit
@@ -35,7 +37,7 @@ module Trainees
     end
 
     def relevant_redirect_path
-      trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_contact_details_confirm_path(trainee)
+      draft_apply_application? ? page_tracker.last_origin_page_path : trainee_contact_details_confirm_path(trainee)
     end
   end
 end

--- a/app/controllers/trainees/course_details_controller.rb
+++ b/app/controllers/trainees/course_details_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class CourseDetailsController < ApplicationController
+    include Appliable
+
     before_action :authorize_trainee
 
     DATE_CONVERSION = {
@@ -72,7 +74,7 @@ module Trainees
       # If there is an application and they are confirming their course for the first time
       # the page_tracker.last_origin_page_path will be the review draft page so we don't want to redirect
       # there in this instance, they need to go to the course details confirm page
-      trainee.apply_application? && trainee.draft? && !page_tracker.last_origin_page_path.include?("/review-draft")
+      draft_apply_application? && !page_tracker.last_origin_page_path.include?("/review-draft")
     end
   end
 end

--- a/app/controllers/trainees/degrees_controller.rb
+++ b/app/controllers/trainees/degrees_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class DegreesController < ApplicationController
+    include Appliable
+
     before_action :authorize_trainee
     before_action :set_degrees_form
     before_action :set_degree_form, only: %i[edit update destroy]
@@ -45,7 +47,7 @@ module Trainees
   private
 
     def redirect_path
-      if trainee.apply_application?
+      if draft_apply_application?
         edit_trainee_apply_applications_trainee_data_path(trainee)
       else
         trainee_degrees_confirm_path(trainee)
@@ -77,7 +79,7 @@ module Trainees
     end
 
     def relevant_redirect_path
-      trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_degrees_confirm_path(trainee)
+      draft_apply_application? ? page_tracker.last_origin_page_path : trainee_degrees_confirm_path(trainee)
     end
   end
 end

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class PersonalDetailsController < ApplicationController
+    include Appliable
+
     before_action :authorize_trainee
     before_action :load_all_nationalities
     before_action :ensure_trainee_is_not_draft!, only: :show
@@ -72,7 +74,7 @@ module Trainees
     end
 
     def relevant_redirect_path
-      trainee.apply_application? ? page_tracker.last_origin_page_path : trainee_personal_details_confirm_path(trainee)
+      draft_apply_application? ? page_tracker.last_origin_page_path : trainee_personal_details_confirm_path(trainee)
     end
   end
 end


### PR DESCRIPTION
### Context

This PR fixes this ticket: https://trello.com/c/adCWoSsb/2813-broken-card-title-when-theres-missing-data and some snags around not being able to update changes for personal/contact details.

Some of the controllers dealt with logic around returning the draft to the correct last page but this is only relevant for apply drafts. Once they're non drafts the controller's default redirect behaviour should be used