### PR TITLE
[2809] Redirect to publish course details page when course code is not found

### DIFF
--- a/app/components/route_indicator/view.rb
+++ b/app/components/route_indicator/view.rb
@@ -27,9 +27,23 @@ module RouteIndicator
     end
 
     def course_code
+      if trainee.apply_application?
+        apply_course_code
+      else
+        manual_course_code
+      end
+    end
+
+    def manual_course_code
       return if trainee.course_code.blank?
 
       "(#{trainee.course_code})"
+    end
+
+    def apply_course_code
+      return if trainee.apply_application.course.blank?
+
+      "(#{trainee.course_code || trainee.apply_application.course.code})"
     end
 
     def training_route
@@ -41,7 +55,7 @@ module RouteIndicator
     end
 
     def course_name
-      trainee.published_course&.name
+      trainee.published_course&.name || trainee.apply_application.course&.name
     end
   end
 end

--- a/app/components/route_indicator/view.rb
+++ b/app/components/route_indicator/view.rb
@@ -16,7 +16,7 @@ module RouteIndicator
 
     def display_text
       if trainee.apply_application?
-        t(".apply_display_text", course_with_code: course_with_code, training_route: training_route)
+        t(".apply_display_text", course_with_code: course_with_code, training_route: training_route.downcase)
       else
         t(".display_text", training_route_link: training_route_link).html_safe
       end

--- a/app/controllers/trainees/apply_applications/course_details_controller.rb
+++ b/app/controllers/trainees/apply_applications/course_details_controller.rb
@@ -6,6 +6,7 @@ module Trainees
       before_action :authorize_trainee
       before_action :set_course
       before_action :redirect_to_confirm_page, if: :already_confirmed_course?
+      before_action :redirect_to_publish_course_details_path, if: :course_not_found?
 
       def edit
         @review_course_form = ::ApplyApplications::ReviewCourseForm.new
@@ -69,6 +70,10 @@ module Trainees
         redirect_to(trainee_apply_applications_confirm_courses_path(trainee))
       end
 
+      def redirect_to_publish_course_details_path
+        redirect_to(edit_trainee_publish_course_details_path(trainee))
+      end
+
       def save_course_and_continue
         save_course
         redirect_to_relevant_step
@@ -93,6 +98,10 @@ module Trainees
 
       def already_confirmed_course?
         trainee.course_subjects.any?
+      end
+
+      def course_not_found?
+        @course.blank?
       end
     end
   end

--- a/app/models/apply_application.rb
+++ b/app/models/apply_application.rb
@@ -22,7 +22,15 @@ class ApplyApplication < ApplicationRecord
     @application_attributes ||= parsed_application["attributes"]
   end
 
+  def course
+    provider.courses.find_by(code: course_code) if course_code.present?
+  end
+
 private
+
+  def course_code
+    application_attributes.dig("course", "course_code")
+  end
 
   def parsed_application
     @parsed_application ||= JSON.parse(application)

--- a/spec/components/route_indicator/view_preview.rb
+++ b/spec/components/route_indicator/view_preview.rb
@@ -10,7 +10,7 @@ module RouteIndicator
       define_method "apply_#{training_route}" do
         render(View.new(trainee: Trainee.new(
           training_route: training_route,
-          apply_application: ApplyApplication.new,
+          apply_application: ApplyApplication.new(application: { attributes: {} }.to_json),
           course_subject_one: "Ancient Hebrew",
           course_code: Faker::Alphanumeric.alphanumeric(number: 4).upcase,
         )))

--- a/spec/components/route_indicator/view_spec.rb
+++ b/spec/components/route_indicator/view_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe RouteIndicator::View do
 
       it "renders the apply application's course code" do
         expect(component).to have_content("Citizenship (V6X1)")
+        expect(component).to have_content("assessment only.")
       end
     end
   end

--- a/spec/components/route_indicator/view_spec.rb
+++ b/spec/components/route_indicator/view_spec.rb
@@ -32,5 +32,17 @@ RSpec.describe RouteIndicator::View do
       expect(component).to have_content(trainee.course_subject_one)
       expect(component).to have_content(trainee.course_code)
     end
+
+    context "with course details not set" do
+      let(:trainee) do
+        create(:trainee, :with_apply_application, course_code: nil) do |trainee|
+          create(:course, name: "Citizenship", code: ApiStubs::ApplyApi.course[:course_code], provider: trainee.apply_application.provider)
+        end
+      end
+
+      it "renders the apply application's course code" do
+        expect(component).to have_content("Citizenship (V6X1)")
+      end
+    end
   end
 end

--- a/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
@@ -9,13 +9,23 @@ feature "apply registrations", type: :feature do
     given_i_am_authenticated
     and_a_trainee_exists_created_from_apply
     given_i_am_on_the_review_draft_page
-    when_i_enter_the_course_details_page
+  end
+
+  describe "with a missing course code against the trainee" do
+    let(:subjects) { ["History"] }
+
+    scenario "reviewing course" do
+      given_the_trainee_does_not_have_a_course_code
+      when_i_enter_the_course_details_page
+      then_i_am_on_the_publish_course_details_page
+    end
   end
 
   describe "with a course that doesn't require selecting a specialism" do
     let(:subjects) { ["History"] }
 
     scenario "reviewing course" do
+      when_i_enter_the_course_details_page
       then_i_am_on_the_apply_applications_course_details_page
       when_i_confirm_the_course_details
       then_i_am_redirected_to_the_apply_applications_confirm_course_page
@@ -29,6 +39,7 @@ feature "apply registrations", type: :feature do
     let(:subjects) { ["Art and design"] }
 
     scenario "selecting specialisms" do
+      when_i_enter_the_course_details_page
       then_i_am_on_the_apply_applications_course_details_page
       when_i_confirm_the_course_details
       and_i_select_a_specialism("Graphic design")
@@ -41,6 +52,7 @@ feature "apply registrations", type: :feature do
     let(:subjects) { ["Modern languages (other)"] }
 
     scenario "selecting languages" do
+      when_i_enter_the_course_details_page
       then_i_am_on_the_apply_applications_course_details_page
       when_i_confirm_the_course_details
       and_i_choose_my_languages
@@ -56,12 +68,20 @@ private
     trainee.update(course_code: Course.first.code)
   end
 
+  def given_the_trainee_does_not_have_a_course_code
+    trainee.update(course_code: nil)
+  end
+
   def then_the_section_should_be(status)
     expect(review_draft_page.course_details.status.text).to eq(status)
   end
 
   def then_i_am_on_the_apply_applications_course_details_page
     expect(apply_registrations_course_details_page).to be_displayed(id: trainee.slug)
+  end
+
+  def then_i_am_on_the_publish_course_details_page
+    expect(publish_course_details_page).to be_displayed(id: trainee.slug)
   end
 
   def when_i_visit_the_apply_applications_course_details_page

--- a/spec/models/apply_application_spec.rb
+++ b/spec/models/apply_application_spec.rb
@@ -25,4 +25,18 @@ describe ApplyApplication do
       it { is_expected.to eq({ "subject" => "Math" }) }
     end
   end
+
+  describe "#course" do
+    let(:apply_application) { create(:apply_application) }
+
+    subject { apply_application.course }
+
+    it { is_expected.to be_nil }
+
+    context "when the course exists" do
+      let!(:course) { create(:course, code: "V6X1", provider: apply_application.provider) }
+
+      it { is_expected.to eq(course) }
+    end
+  end
 end


### PR DESCRIPTION
### Context
fixes https://trello.com/c/CREaXO17/2809-changing-course-details-to-another-course-not-listed-crashes-the-course-details-page

### Changes proposed in this pull request

Redirect to the publish course selection in the event a trainee does not have a course code assinged to them.

### Guidance to review
1. Visit course details on an apply draft and optionally, if prompted to "confirm course" choose "No, change the course"
2. On the "What course are they doing" choose "Another course not listed"
3. Continue so that you are taken to the Course details page.
4. From here, skip to the Trainees index page, and visit the same draft trainee. (you are taken to the review draft page)
5. Try to visit the course details section, you are redirected to the publish course selection page.

Compare the same against [main version](https://qa.register-trainee-teachers.education.gov.uk/)

