### PR TITLE
[2787] clear out params for post requests in logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i[email password]

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -7,6 +7,7 @@ class CustomLogFormatter < SemanticLogger::Formatters::Raw
     format_exception
     format_json_message_context
     format_backtrace
+    remove_post_params
     hash.to_json
   end
 
@@ -42,6 +43,16 @@ private
         hash[:message] = "Exception occured: #{message_lines.first}"
       end
     end
+  end
+
+  def remove_post_params
+    if method_is_post_or_put? && hash.dig(:payload, :params).present?
+      hash[:payload][:params].clear
+    end
+  end
+
+  def method_is_post_or_put?
+    hash.dig(:payload, :method).in? %w[PUT POST]
   end
 end
 


### PR DESCRIPTION
We need to ensure we aren't logging personal or sensitive data when we
send logs to any external services. This change adds to the custom log
formatter we use with Semantic logger to remove these params in
non-dev and non-test environments. We could in theory have achieved the
same using Rails' filter_params config, but this approach is more
fullproof and we've established that we don't need this data in the
system logs.

