### PR TITLE
Fix flake

### DIFF
--- a/app/components/degrees/view.rb
+++ b/app/components/degrees/view.rb
@@ -62,7 +62,7 @@ module Degrees
     def grade_for(degree)
       return degree.grade += " (#{degree.other_grade})" if degree.other_grade.present?
 
-      degree.grade&.capitalize
+      degree.grade
     end
 
     def mappable_field_row(degree, field_name, field_label, field_value = nil)

--- a/app/lib/dttp/code_sets/grades.rb
+++ b/app/lib/dttp/code_sets/grades.rb
@@ -4,7 +4,7 @@ module Dttp
   module CodeSets
     module Grades
       # Do not make any changes to the keys. If necessary, change Degree#grade to enum type first
-      FIRST_CLASS_HONOURS = "First-class Honours"
+      FIRST_CLASS_HONOURS = "First-class honours"
       OTHER = "Other"
 
       MAPPING = {

--- a/db/data/20210928121312_update_first_class_honours_capitalisation.rb
+++ b/db/data/20210928121312_update_first_class_honours_capitalisation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UpdateFirstClassHonoursCapitalisation < ActiveRecord::Migration[6.1]
+  def up
+    Degree.where(grade: "First-class Honours").update_all(grade: Dttp::CodeSets::Grades::FIRST_CLASS_HONOURS)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
       subject { Dttp::CodeSets::DegreeSubjects::MAPPING.keys.sample }
 
       institution { Dttp::CodeSets::Institutions::MAPPING.keys.sample }
-      grade { Dttp::CodeSets::Grades::MAPPING.keys.first }
+      grade { Dttp::CodeSets::Grades::MAPPING.keys.sample }
       graduation_year { rand(NEXT_YEAR - Degree::MAX_GRAD_YEARS..NEXT_YEAR) }
     end
 

--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
       subject { Dttp::CodeSets::DegreeSubjects::MAPPING.keys.sample }
 
       institution { Dttp::CodeSets::Institutions::MAPPING.keys.sample }
-      grade { Dttp::CodeSets::Grades::MAPPING.keys.sample }
+      grade { Dttp::CodeSets::Grades::MAPPING.keys.first }
       graduation_year { rand(NEXT_YEAR - Degree::MAX_GRAD_YEARS..NEXT_YEAR) }
     end
 

--- a/spec/lib/hpitt_spec.rb
+++ b/spec/lib/hpitt_spec.rb
@@ -229,7 +229,7 @@ describe HPITT do
       let(:degree_grade) { "First-class honours" }
 
       it "returns it" do
-        expect(subject).to eq("First-class Honours")
+        expect(subject).to eq("First-class honours")
       end
     end
 


### PR DESCRIPTION
### Context
Fixes flaky spec caused at `bundle exec rspec './spec/components/degrees/view_spec.rb[1:1:1:6:1]'`

### Changes proposed in this pull request
1. Add a data migration to rename "First-class Honours" to "First-class honours"
2. Get rid of `grade.capitalize` which in conjuntion with [this sample](https://github.com/DFE-Digital/register-trainee-teachers/pull/1510/commits/320fbab529fd9ee68e39122788f430eb1f5dc3bc) causes the failure.

