### PR TITLE
[2579] Remove ReviewSummary banner from confirm details show page.

### DIFF
--- a/app/view_objects/missing_data_view.rb
+++ b/app/view_objects/missing_data_view.rb
@@ -31,7 +31,7 @@ class MissingDataView
   end
 
   def invalid_data?
-    missing_fields.flatten.size.positive?
+    false
   end
 
 private


### PR DESCRIPTION
### Context

Remove the missing data blue notice banners. 

### Changes proposed in this pull request

 - Remove the `ReviewSummary` component from the confirm details show page.

### Guidance to review

- Navigate to an apply trainee which has missing details.
- On the `check-details` page, click the Review data/Continue section links.
- Ensure that the blue banner does not appear on any of these pages.
- Ensure that the inset text highlighting the missing details does.
- Check if there is anywhere else that it needs to be removed. 

### Before screenshot

![image](https://user-images.githubusercontent.com/50492247/134979322-44929be1-d930-43f0-a201-cd31d5fd10d2.png)


### After screenshot

![image](https://user-images.githubusercontent.com/50492247/134979444-85439d9d-028e-4cf5-9a25-4f89e48e5ee6.png)