### PR TITLE
[2836] Update trainees with old subject to their new ones

### DIFF
--- a/db/data/20210928103544_update_old_subjects_for_trainees.rb
+++ b/db/data/20210928103544_update_old_subjects_for_trainees.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UpdateOldSubjectsForTrainees < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.where(course_subject_one: "creative arts and design").update_all(course_subject_one: CourseSubjects::ART_AND_DESIGN)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

There are 4 awarded trainees and one draft who have the `course_subject_one` as `creative arts and design`, an old subject which  we changed to `art and design`. 

This PR updates those subjects to the new `Dttp::CodeSets::CourseSubjects::ARTS_AND_DESIGN`
