### PR TITLE
[2814] Make sure published course is scope to trainee's provider

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -23,7 +23,7 @@ module ApplicationRecordCard
 
     def subject
       return I18n.t("components.application_record_card.subject.early_years") if record.early_years_route?
-      return course_name if record.course_subject_one.blank?
+      return course_name_for(record) if record.course_subject_one.blank?
 
       subjects_for_summary_view(record.course_subject_one, record.course_subject_two, record.course_subject_three)
     end
@@ -66,10 +66,6 @@ module ApplicationRecordCard
 
     def last_name_first
       [record.last_name, record.first_names].join(", ")
-    end
-
-    def course_name
-      record.published_course&.name
     end
   end
 end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -85,7 +85,7 @@ private
 
   def ordered_trainees
     sort_scope = filter_params[:sort_by] == "last_name" ? :ordered_by_last_name : :ordered_by_date
-    policy_scope(Trainee.includes(:published_course).ordered_by_drafts.public_send(sort_scope))
+    policy_scope(Trainee.includes(provider: [:courses]).ordered_by_drafts.public_send(sort_scope))
   end
 
   def filters

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -74,4 +74,9 @@ module TraineeHelper
   def form_error_class(form, field)
     form.errors.messages.keys.include?(field.to_sym) ? "govuk-form-group govuk-form-group--error" : "govuk-form-group"
   end
+
+  # Use this method if you're preloading courses in bulk as it won't make further database calls
+  def course_name_for(trainee)
+    trainee.provider&.courses&.find { |course| course.code == trainee.course_code }&.name
+  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -8,7 +8,7 @@ class Provider < ApplicationRecord
   validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
   validates :code, format: { with: /\A[A-Z0-9]+\z/i }, allow_blank: true
 
-  has_many :courses, ->(provider) { unscope(:where).where(accredited_body_code: provider.code) }
+  has_many :courses, class_name: "Course", foreign_key: :accredited_body_code, primary_key: :code, inverse_of: :provider
   has_many :apply_applications, ->(provider) { unscope(:where).where(accredited_body_code: provider.code) }
 
   audited

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -14,6 +14,7 @@ class Trainee < ApplicationRecord
   belongs_to :lead_school, optional: true, class_name: "School"
   belongs_to :employing_school, optional: true, class_name: "School"
   belongs_to :published_course,
+             ->(trainee) { where(accredited_body_code: trainee.provider.code) },
              class_name: "Course",
              foreign_key: :course_code,
              primary_key: :code,

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 module ApplicationRecordCard
   describe View do
-    let(:course) { create(:course) }
+    let(:provider) { create(:provider, :with_courses) }
+    let(:course) { provider.courses.first }
     let(:trainee) { Trainee.new(created_at: Time.zone.now, course_code: course.code) }
 
     before do
@@ -19,6 +20,14 @@ module ApplicationRecordCard
     end
 
     context "when the Trainee has no subject" do
+      let(:trainee) do
+        create(:trainee, provider: provider, course_code: course.code)
+      end
+
+      before do
+        trainee
+      end
+
       it "renders the course name" do
         expect(rendered_component).to have_text(course.name)
       end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -12,5 +12,16 @@ FactoryBot.define do
     trait :teach_first do
       code { TEACH_FIRST_PROVIDER_CODE }
     end
+
+    trait :with_courses do
+      transient do
+        courses_count { 1 }
+        course_code { Faker::Alphanumeric.unique.alphanumeric(number: 4, min_alpha: 1).upcase }
+      end
+
+      after(:create) do |provider, evaluator|
+        create_list(:course, evaluator.courses_count, code: evaluator.course_code, accredited_body_code: provider.code)
+      end
+    end
   end
 end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -131,6 +131,16 @@ describe Trainee do
     it { is_expected.to have_many(:disabilities).through(:trainee_disabilities) }
     it { is_expected.to belong_to(:lead_school).class_name("School").optional }
     it { is_expected.to belong_to(:employing_school).class_name("School").optional }
+
+    describe "#published_course" do
+      let(:same_code) { "1TX" }
+      let(:provider_a) { create(:provider, :with_courses, course_code: same_code) }
+      let!(:provider_b) { create(:provider, :with_courses, course_code: same_code) }
+
+      subject { create(:trainee, provider: provider_a, course_code: same_code).published_course.provider }
+
+      it { is_expected.to eq(provider_a) }
+    end
   end
 
   context "validations" do


### PR DESCRIPTION
### Context

Reference issue https://sentry.io/organizations/dfe-bat/issues/2482629234/?environment=production&project=5552118&query=is%3Aunresolved

### Changes proposed in this pull request

Some providers will list courses with the same code. Make sure `#published_course` on the `Trainee` is scope to their own provider

### Guidance to review

