### PR TITLE
[2834] Enable Apply filter in production

### DIFF
--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -41,7 +41,7 @@
     </div>
   <% end %>
 
-  <% if FeatureService.enabled?(:imported_from_apply_filter) && multiple_record_sources? %>
+  <% if multiple_record_sources? %>
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,7 +41,6 @@ features:
   persist_to_dttp: false
   show_funding: true
   send_funding_to_dttp: false
-  imported_from_apply_filter: false
   placements: false
   course_study_mode: false
   enable_teach_first_provider: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,7 +6,6 @@ features:
   basic_auth: false
   import_courses_from_ttapi: true
   publish_course_details: true
-  imported_from_apply_filter: true
   enable_teach_first_provider: true
   course_study_mode: true
   scholarship: true

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -11,7 +11,6 @@ features:
   use_dfe_sign_in: false
   import_courses_from_ttapi: true
   publish_course_details: true
-  imported_from_apply_filter: true
   course_study_mode: true
   scholarship: true
   routes:

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -4,7 +4,6 @@ features:
   enable_feedback_link: true
   publish_course_details: true
   persist_to_dttp: false
-  imported_from_apply_filter: true
   course_study_mode: true
   enable_teach_first_provider: true
   scholarship: true

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -17,7 +17,6 @@ features:
   sync_from_dttp: true
   import_courses_from_ttapi: true
   import_applications_from_apply: true
-  imported_from_apply_filter: true
   publish_course_details: true
   persist_to_dttp: true
   show_funding: true

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -22,12 +22,12 @@ RSpec.feature "Filtering trainees" do
     then_all_trainees_are_visible
   end
 
-  scenario "can filter by apply_drafts", feature_imported_from_apply_filter: true do
+  scenario "can filter by apply_drafts" do
     when_i_filter_by_apply_draft_status
     then_only_the_apply_draft_trainee_is_visible
   end
 
-  scenario "when all trainees are from a single source", feature_imported_from_apply_filter: true do
+  scenario "when all trainees are from a single source" do
     given_all_trainees_are_from_a_single_source
     when_i_visit_the_trainee_index_page
     then_the_record_source_filter_is_not_visible


### PR DESCRIPTION
### Context

https://trello.com/c/8NpXzaOP/2834-imported-from-apply-filter-being-removed

### Changes proposed in this pull request

The bug reported was that:
- if you click on 'View draft trainees imported from Apply (xx)' on the homepage
- then the view is correctly filtered by Apply trainees
- but if you add another filter
- the Apply filter disappears

**This was happening only in production, no other environments**

This was actually due to the fact that the feature flag for the filter itself had been left 'off' in prod.

Since we've now have Apply trainees in the system, I've chosen to remove the feature flag completely.

### Guidance to review

- Check for any regressions with filtering by Apply trainees, the bug itself is only on production.