### PR TITLE
[2840] Add Transition to teach initiative for School direct (salaried) trainees

### DIFF
--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -202,6 +202,7 @@ TRAINING_ROUTE_INITIATIVES = {
                                                                                         :now_teach,
                                                                                         :maths_physics_chairs_programme_researchers_in_schools),
   TRAINING_ROUTE_ENUMS[:school_direct_salaried] => ROUTE_INITIATIVES_ENUMS.values_at(:future_teaching_scholars,
+                                                                                     :transition_to_teach,
                                                                                      :maths_physics_chairs_programme_researchers_in_schools,
                                                                                      :now_teach),
   TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => ROUTE_INITIATIVES_ENUMS.values_at(:transition_to_teach,


### PR DESCRIPTION
### Context

https://trello.com/c/mbuYHvRR/2840-add-transition-to-teach-initiative-for-school-direct-salaried-trainees

### Changes proposed in this pull request

We know that this training initiative is definitely available for School direct (salaried) trainees, so this PR includes it as an option.

### Guidance to review
- Select a School direct (salaried) trainee and click into funding
- Ensure that 'Transition to teach' now appears as an option alongside the original three:

<img width="832" alt="Screenshot 2021-09-29 at 11 30 35" src="https://user-images.githubusercontent.com/18436946/135252469-f9640a25-9ad0-41dc-9be1-171e4e12e04d.png">

