### PR TITLE
[2838] Add hint to provider led radio buttons

### DIFF
--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -7,7 +7,12 @@
 
     <% TRAINING_ROUTE_FEATURE_FLAGS.each do |training_route| %>
       <% if FeatureService.enabled?("routes.#{training_route}") %>
-        <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[training_route], label: { text: t("activerecord.attributes.trainee.training_routes.#{training_route}") } %>
+        <%= f.govuk_radio_button(
+          :training_route,
+          TRAINING_ROUTE_ENUMS[training_route],
+          hint: { text: (TRAINING_ROUTE_ENUMS[training_route].starts_with?("provider_led") && t(".provider_led_hint")) },
+          label: { text: t("activerecord.attributes.trainee.training_routes.#{training_route}") }
+        ) %>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -823,6 +823,9 @@ en:
         edit:
           summary_title: Confirm training course
           summary_with_route: *summary_with_route
+    training_routes:
+      form_fields:
+        provider_led_hint: Training run by higher education institutions (HEIs) or school centred initial teacher training (SCITT) providers
   activerecord:
     attributes:
       trainee:


### PR DESCRIPTION
### Context

https://trello.com/c/zy9zN1ou/2838-add-hint-text-to-provider-led-radios-on-the-route-selection-page

### Changes proposed in this pull request

What it says on the tin.

### Guidance to review

- Add a new trainee and check that the correct hint text appears only below the provider led radio buttons

<img width="832" alt="Screenshot 2021-09-29 at 12 32 59" src="https://user-images.githubusercontent.com/18436946/135261263-cb7d2306-873c-4b17-8c3d-127e71abed85.png">


