### PR TITLE
[2812] Upcase first letter of course

### DIFF
--- a/app/components/route_indicator/view.rb
+++ b/app/components/route_indicator/view.rb
@@ -16,7 +16,7 @@ module RouteIndicator
 
     def display_text
       if trainee.apply_application?
-        t(".apply_display_text", course_with_code: course_with_code, training_route: training_route.downcase)
+        t(".apply_display_text", course_with_code: course_with_code.upcase_first, training_route: training_route.downcase)
       else
         t(".display_text", training_route_link: training_route_link).html_safe
       end

--- a/spec/components/route_indicator/view_spec.rb
+++ b/spec/components/route_indicator/view_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RouteIndicator::View do
     let(:trainee) { create(:trainee, :with_apply_application, :with_course_details) }
 
     it "renders" do
-      expect(component).to have_content(trainee.course_subject_one)
+      expect(component).to have_content(trainee.course_subject_one.upcase_first)
       expect(component).to have_content(trainee.course_code)
     end
 


### PR DESCRIPTION
### Context
https://trello.com/c/X724UQ5Y/2812-capitalising-for-course-title
### Changes proposed in this pull request
Upcases only first letter of course in route indicator component

### Guidance to review
Check apply draft trainee and make sure their course name is upcased in on the review draft page
