### PR TITLE
Improve logic to find empty drafts

### DIFF
--- a/app/services/find_empty_trainees.rb
+++ b/app/services/find_empty_trainees.rb
@@ -5,58 +5,58 @@ class FindEmptyTrainees
   include ServicePattern
 
   TRAINEE_FIELDS = %w[
-    first_names
-    last_name
-    date_of_birth
-    address_line_one
-    address_line_two
-    town_city
-    postcode
-    email
-    middle_names
-    international_address
+    trainees.first_names
+    trainees.last_name
+    trainees.date_of_birth
+    trainees.address_line_one
+    trainees.address_line_two
+    trainees.town_city
+    trainees.postcode
+    trainees.email
+    trainees.middle_names
+    trainees.international_address
     trainees.locale_code
-    gender
-    diversity_disclosure
-    ethnic_group
-    ethnic_background
-    additional_ethnic_background
-    disability_disclosure
-    course_subject_one
-    course_start_date
-    outcome_date
-    course_end_date
-    trn
-    submitted_for_trn_at
-    withdraw_reason
-    withdraw_date
-    additional_withdraw_reason
-    defer_date
-    recommended_for_award_at
-    commencement_date
-    reinstate_date
-    lead_school_id
-    employing_school_id
-    apply_application_id
-    course_min_age
-    course_max_age
-    course_code
-    course_subject_two
-    course_subject_three
-    awarded_at
-    applying_for_bursary
-    training_initiative
-    bursary_tier
+    trainees.gender
+    trainees.diversity_disclosure
+    trainees.ethnic_group
+    trainees.ethnic_background
+    trainees.additional_ethnic_background
+    trainees.disability_disclosure
+    trainees.course_subject_one
+    trainees.course_start_date
+    trainees.outcome_date
+    trainees.course_end_date
+    trainees.trn
+    trainees.submitted_for_trn_at
+    trainees.withdraw_reason
+    trainees.withdraw_date
+    trainees.additional_withdraw_reason
+    trainees.defer_date
+    trainees.recommended_for_award_at
+    trainees.commencement_date
+    trainees.reinstate_date
+    trainees.lead_school_id
+    trainees.employing_school_id
+    trainees.apply_application_id
+    trainees.course_min_age
+    trainees.course_max_age
+    trainees.course_code
+    trainees.course_subject_two
+    trainees.course_subject_three
+    trainees.awarded_at
+    trainees.applying_for_bursary
+    trainees.training_initiative
+    trainees.bursary_tier
     trainees.study_mode
-    region
-    course_education_phase
-    applying_for_scholarship
+    trainees.region
+    trainees.course_education_phase
+    trainees.applying_for_scholarship
   ].freeze
 
   EARLY_YEARS_FIELDS_TO_EXCLUDE = %w[
-    course_subject_one
-    course_min_age
-    course_max_age
+    trainees.course_subject_one
+    trainees.course_min_age
+    trainees.course_max_age
   ].freeze
 
   class FieldsDoNotExistError < StandardError; end

--- a/spec/services/find_empty_trainees_spec.rb
+++ b/spec/services/find_empty_trainees_spec.rb
@@ -25,16 +25,6 @@ describe FindEmptyTrainees do
     it { is_expected.to match_array([draft_trainee_with_no_data.id]) }
   end
 
-  context "if excluded fields have changed" do
-    before do
-      stub_const("FindEmptyTrainees::EXCLUDED_FIELDS", ["random_field"])
-    end
-
-    it "raises an error" do
-      expect { described_class.call }.to raise_error(FindEmptyTrainees::FieldsDoNotExistError)
-    end
-  end
-
   context "for early year routes" do
     let!(:draft_trainee_with_no_data) do
       create(:trainee, :incomplete, :early_years_salaried)

--- a/spec/services/find_empty_trainees_spec.rb
+++ b/spec/services/find_empty_trainees_spec.rb
@@ -25,6 +25,16 @@ describe FindEmptyTrainees do
     it { is_expected.to match_array([draft_trainee_with_no_data.id]) }
   end
 
+  context "if trainee fields have changed" do
+    before do
+      allow(Trainee).to receive(:column_names).and_return(["random_field"])
+    end
+
+    it "raises an error" do
+      expect { described_class.call }.to raise_error(FindEmptyTrainees::FieldsDoNotExistError)
+    end
+  end
+
   context "for early year routes" do
     let!(:draft_trainee_with_no_data) do
       create(:trainee, :incomplete, :early_years_salaried)


### PR DESCRIPTION
### Changes proposed in this pull request

`FindEmptyTrainees#call` sort of caves when dealing with 30K+ trainees largely due to the transformations we make in Ruby with `#filter_map` to load the records into memory and serialize so we can build a digest of values to check against.

This PR delegates the logic to the database so performance is improved and the trainee index page still loads quickly. Tested with a sample size of 30k trainees locally (since that was the point where things caved) and still worked fine after.


### Guidance to review

- Go to index page
- Check empty trainees are still being filtered out correctly
