### PR TITLE
[2849] Don't save empty strings as course subjects

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -161,8 +161,8 @@ private
     unless trainee.early_years_route?
       attributes.merge!({
         course_subject_one: course_subject_one,
-        course_subject_two: course_subject_two,
-        course_subject_three: course_subject_three,
+        course_subject_two: course_subject_two.presence,
+        course_subject_three: course_subject_three.presence,
         course_age_range: course_age_range,
       })
     end


### PR DESCRIPTION
### Context

https://trello.com/c/oFFhj2gs/2849-funding-is-cleared-when-only-course-dates-are-changed

### Changes proposed in this pull request

This fixes a bug whereby if you re-entered a complete course section and changed the course_start_date, it would clear the funding section because the form changed `course_subject_two` from `nil` to empty string.

### Guidance to review
- Complete a trainee with a scholarship
- Go back into course details and change the start/end date
- Save
- See that the scholarship information is still present and the funding section is still complete
