### PR TITLE
[2810] Blue info deep link does not work on trainee data page

### DIFF
--- a/app/components/apply_applications/trainee_data/view.rb
+++ b/app/components/apply_applications/trainee_data/view.rb
@@ -10,7 +10,7 @@ module ApplyApplications
 
       def initialize(trainee_data_form:)
         @form = trainee_data_form
-        @invalid_data_view = ApplyInvalidDataView.new(trainee.apply_application)
+        @invalid_data_view = ApplyInvalidDataView.new(trainee.apply_application, degrees_sort_order: trainee.degrees.pluck(:slug))
       end
 
       delegate :trainee, to: :form

--- a/app/controllers/trainees/apply_applications/trainee_data_controller.rb
+++ b/app/controllers/trainees/apply_applications/trainee_data_controller.rb
@@ -36,7 +36,7 @@ module Trainees
       end
 
       def invalid_data_view
-        @invalid_data_view ||= ApplyInvalidDataView.new(trainee.apply_application)
+        @invalid_data_view ||= ApplyInvalidDataView.new(trainee.apply_application, degrees_sort_order: trainee.degrees.pluck(:slug))
       end
 
       def authorize_trainee

--- a/app/view_objects/apply_invalid_data_view.rb
+++ b/app/view_objects/apply_invalid_data_view.rb
@@ -14,10 +14,11 @@ class ApplyInvalidDataView
     graduation_year
   ].freeze
 
-  def initialize(apply_application, degree: nil, on_form_page: false)
+  def initialize(apply_application, degree: nil, on_form_page: false, degrees_sort_order: [])
     @apply_application = apply_application
     @degree = degree
     @on_form_page = on_form_page
+    @degrees_sort_order = degrees_sort_order
     @invalid_fields = populate_invalid_fields
   end
 
@@ -47,7 +48,7 @@ class ApplyInvalidDataView
 
 private
 
-  attr_reader :apply_application, :invalid_fields, :degree, :on_form_page
+  attr_reader :apply_application, :invalid_fields, :degree, :on_form_page, :degrees_sort_order
 
   def get_link_anchor(field, index)
     return get_form_page_link_anchor(field) if on_form_page
@@ -75,9 +76,10 @@ private
 
   def populate_degree_fields(degree_fields)
     return [degree_fields[degree.to_param]&.keys].compact if degree.present?
+    return degree_fields.map { |_slug, field| field.keys } if degrees_sort_order.size <= 1
 
-    degree_fields.map do |_k, field_and_values|
-      field_and_values.keys
+    degrees_sort_order.map do |slug|
+      degree_fields[slug].keys
     end
   end
 

--- a/app/view_objects/apply_invalid_data_view.rb
+++ b/app/view_objects/apply_invalid_data_view.rb
@@ -57,7 +57,7 @@ private
   end
 
   def get_form_page_link_anchor(field)
-    "#degree-#{field.parameterize}-field"
+    field == "Degree type" ? "##{field.parameterize}" : "#degree-#{field.parameterize}-field"
   end
 
   def populate_invalid_fields

--- a/app/views/trainees/degrees/_non_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_non_uk_degree_form.html.erb
@@ -12,7 +12,7 @@
   <%= render FormComponents::CountryAutocomplete::View.new(
     f,
     attribute_name: :country,
-    form_field: f.govuk_collection_select(:country, 
+    form_field: f.govuk_collection_select(:country,
                                           countries_options,
                                           :value,
                                           :text,
@@ -26,18 +26,18 @@
     f,
     attribute_name: :subject,
     form_field: f.govuk_select(
-      :subject, 
+      :subject,
       options_for_select(subjects_options, @degree_form.degree.subject),
-      form_group: { 
+      form_group: {
         class: invalid_data_class(form: @degree_form, field: "subject")
       },
       label: { text: "Degree subject", size: "s" },
       hint: -> { render InvalidDataText::View.new(form_section: :subject, hint: 'Search for the closest matching subject', degree_form: @degree_form) }),
   ) %>
 
-  <div class="govuk-form-group" id="non_uk_degree">
+  <div class="govuk-form-group" id="degree-type">
     <%= f.govuk_radio_buttons_fieldset(:non_uk_degree, legend: { text: "Select the UK ENIC comparable degree", size: "s" },
-        form_group: { class: invalid_data_class(form: @degree_form, field: "non_uk_degree") },
+        form_group: { class: invalid_data_class(form: @degree_form, field: "non_uk_degree"), id: "degree-non-uk-degree-field" },
         hint: -> {  render InvalidDataText::View.new(form_section: :non_uk_degree, degree_form: @degree_form) },
         ) do %>
       <% ENIC_NON_UK.each do |name| %>
@@ -51,7 +51,7 @@
   <%= f.govuk_text_field :graduation_year,
                          form_group: { class: invalid_data_class(form: @degree_form, field: "graduation_year"), id: :graduation_year },
                          width: "one-quarter",
-                         autocomplete: :disabled, 
+                         autocomplete: :disabled,
                          label: { text: "Graduation year", size: "s" } do
                             render InvalidDataText::View.new(form_section: :graduation_year, degree_form: @degree_form)
                           end %>

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -34,16 +34,18 @@
       hint: -> { render InvalidDataText::View.new(form_section: :subject, degree_form: @degree_form, hint: 'Search for the closest matching subject') }),
   ) %>
 
-  <%= render FormComponents::Autocomplete::View.new(
-    f,
-    attribute_name: :uk_degree,
-    form_field: f.govuk_select(
-      :uk_degree,
-      options_for_select(degree_type_options, @degree_form.degree.uk_degree),
-      form_group: { class: invalid_data_class(form: @degree_form, field: "uk_degree") },
-      label: { text: "Type of degree", size: "s" },
-      hint: -> { render InvalidDataText::View.new(form_section: :uk_degree, degree_form: @degree_form, hint: 'For example, BA, BSc or other (please specify)') }),
-    ) %>
+  <div class="govuk-form-group" id="degree-type">
+    <%= render FormComponents::Autocomplete::View.new(
+      f,
+      attribute_name: :uk_degree,
+      form_field: f.govuk_select(
+        :uk_degree,
+        options_for_select(degree_type_options, @degree_form.degree.uk_degree),
+        form_group: { class: invalid_data_class(form: @degree_form, field: "uk_degree") },
+        label: { text: "Type of degree", size: "s" },
+        hint: -> { render InvalidDataText::View.new(form_section: :uk_degree, degree_form: @degree_form, hint: 'For example, BA, BSc or other (please specify)') }),
+      ) %>
+  </div>
 
   <%= f.govuk_radio_buttons_fieldset(:grade,
         legend: { text: "Degree grade", size: "s" },

--- a/spec/view_objects/apply_invalid_data_view_spec.rb
+++ b/spec/view_objects/apply_invalid_data_view_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe ApplyInvalidDataView do
   let(:application) { create(:apply_application, :with_invalid_data) }
 
-  subject { described_class.new(application) }
+  subject { described_class.new(application, degrees_sort_order: application.invalid_data["degrees"].keys) }
 
   describe "#summary_content" do
     context "when there is only one invalid data" do
@@ -28,7 +28,7 @@ describe ApplyInvalidDataView do
   end
 
   describe "#invalid_data?" do
-    subject { described_class.new(application, degree: degree).invalid_data? }
+    subject { described_class.new(application, degree: degree, degrees_sort_order: application.invalid_data["degrees"].keys).invalid_data? }
 
     let(:degree) { nil }
 


### PR DESCRIPTION
### Context
https://trello.com/c/3Ll89Y51/2810-blue-info-deep-link-does-not-work-on-trainee-data-page
The issue was that the degree slug order in the invalid data field was not the same as the order of the degree slugs when they're saved. This means the invalid data fields have the wrong index for the anchor tag. 
### Changes proposed in this pull request
*The invalid degree fields are mapped to the degree order. However, if there is only one degree the re-ordering is unnecessary. 
### Guidance to review
Create an Apply draft trainee with both 1 and multiple invalid degrees
