### PR TITLE
[2878] Fixed casing of training initiatives names

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -860,10 +860,10 @@ en:
           eyts_recommended: EYTS recommended
           eyts_awarded: EYTS awarded
         training_initiatives:
-          transition_to_teach: Transition to teach
-          now_teach: Now teach
-          maths_physics_chairs_programme_researchers_in_schools: Maths and physics chairs programme / Researchers in schools
-          future_teaching_scholars: Future teaching scholars
+          transition_to_teach: Transition to Teach
+          now_teach: Now Teach
+          maths_physics_chairs_programme_researchers_in_schools: Maths and Physics Chairs programme / Researchers in Schools
+          future_teaching_scholars: Future Teaching Scholars
           no_initiative: Not on a training initiative
         levels:
           early_years: Early years

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -104,7 +104,7 @@ module Exports
           "lead_school_urn" => trainee.lead_school&.urn,
           "employing_school_name" => trainee.employing_school&.name,
           "employing_school_urn" => trainee.employing_school&.urn,
-          "training_initiative" => "Transition to teach",
+          "training_initiative" => "Transition to Teach",
           "applying_for_bursary" => trainee.applying_for_bursary.to_s.upcase,
           "bursary_value" => (funding_manager.bursary_amount if trainee.applying_for_bursary),
           "bursary_tier" => ("Tier #{BURSARY_TIERS[trainee.bursary_tier] + 1}" if trainee.bursary_tier),


### PR DESCRIPTION
### Context
Casing of training initiatives names
### Changes proposed in this pull request
Fixed casing of training initiatives names
### Guidance to review
:shipit: 

#### Before
![image](https://user-images.githubusercontent.com/470137/136010639-8607fdf1-c471-41c4-87f1-dbcdadd15ab0.png)


#### After
![image](https://user-images.githubusercontent.com/470137/136010422-7bd32131-11f5-4a27-85b1-647afb5fd69b.png)

