### PR TITLE
[xxx] Only sync 2021 courses

### DIFF
--- a/app/services/teacher_training_api/retrieve_courses.rb
+++ b/app/services/teacher_training_api/retrieve_courses.rb
@@ -4,7 +4,7 @@ module TeacherTrainingApi
   class RetrieveCourses
     include ServicePattern
 
-    DEFAULT_PATH = "/courses?include=accredited_body,provider&sort=name,provider.provider_name"
+    DEFAULT_PATH = "/recruitment_cycles/2021/courses?include=accredited_body,provider&sort=name,provider.provider_name"
 
     def initialize(request_uri: nil)
       @request_uri = request_uri.presence || DEFAULT_PATH

--- a/spec/services/teacher_training_api/retrieve_courses_spec.rb
+++ b/spec/services/teacher_training_api/retrieve_courses_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module TeacherTrainingApi
   describe RetrieveCourses do
     describe "#call" do
-      let(:path) { "/courses?include=accredited_body,provider&sort=name,provider.provider_name" }
+      let(:path) { "/recruitment_cycles/2021/courses?include=accredited_body,provider&sort=name,provider.provider_name" }
       let(:request_url) { "#{Settings.teacher_training_api.base_url}#{path}" }
 
       before do


### PR DESCRIPTION
### Context

We only want 2021 courses at the moment. 

### Changes proposed in this pull request

Scope the courses query to 2021 recruitment cycle. Hard coding for now to fix a production issue.

Further work will be done to handle years in preparation for registering next cycle's users.

### Guidance to review

