### PR TITLE
[2856] Backfill courses' uuid field first

### DIFF
--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -23,19 +23,22 @@ module TeacherTrainingApi
       return unless IMPORTABLE_STATES.include?(course_attributes[:state])
       return if further_education_level_course? || invalid_age_range?
 
-      course.update!(name: course_attributes[:name],
-                     start_date: start_date,
-                     level: course_attributes[:level],
-                     qualification: qualification,
-                     min_age: course_attributes[:age_minimum],
-                     max_age: course_attributes[:age_maximum],
-                     duration_in_years: duration_in_years,
-                     course_length: course_attributes[:course_length],
-                     subjects: subjects,
-                     route: route,
-                     summary: course_attributes[:summary],
-                     study_mode: course_attributes[:study_mode],
-                     accredited_body_code: accredited_body_code)
+      course.update!(
+        name: course_attributes[:name],
+        start_date: start_date,
+        level: course_attributes[:level],
+        qualification: qualification,
+        min_age: course_attributes[:age_minimum],
+        max_age: course_attributes[:age_maximum],
+        duration_in_years: duration_in_years,
+        course_length: course_attributes[:course_length],
+        subjects: subjects,
+        route: route,
+        summary: course_attributes[:summary],
+        study_mode: course_attributes[:study_mode],
+        uuid: course_attributes[:uuid],
+        accredited_body_code: accredited_body_code,
+      )
     end
 
   private
@@ -95,8 +98,10 @@ module TeacherTrainingApi
     end
 
     def course
-      @course ||= Course.find_or_initialize_by(code: course_attributes[:code],
-                                               accredited_body_code: accredited_body_code)
+      @course ||= Course.find_or_initialize_by(
+        code: course_attributes[:code],
+        accredited_body_code: accredited_body_code,
+      )
     end
   end
 end

--- a/spec/services/teacher_training_api/import_course_spec.rb
+++ b/spec/services/teacher_training_api/import_course_spec.rb
@@ -54,6 +54,10 @@ module TeacherTrainingApi
           it "parses qualification" do
             expect(course.qualification).to eq("pgce_with_qts")
           end
+
+          it "stores the uuid" do
+            expect(course.uuid).to eq(course_data[:attributes][:uuid])
+          end
         end
 
         context "course has a further_education level" do


### PR DESCRIPTION
### Context

Part 1 of this to backfill the `uuid` for courses in prod https://trello.com/c/PCLpq8Zf/2856-m-use-uuid-for-courses
Part 2 will switch to lookup by the uuid so we don't create duplicate courses by using it exclusively first