### PR TITLE
[2811] Trainee start date validation

### DIFF
--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -62,6 +62,8 @@ private
 
     if [day, month, year].all?(&:blank?)
       errors.add(:commencement_date, :blank)
+    elsif commencement_date.year.to_i > next_year
+      errors.add(:commencement_date, :future)
     elsif !commencement_date.is_a?(Date)
       errors.add(:commencement_date, :invalid)
     elsif date_before_course_start_date?(commencement_date, trainee.course_start_date)
@@ -71,5 +73,9 @@ private
 
   def commencement_date_year_is_four_digits
     errors.add(:commencement_date, :invalid_year) if commencement_date.is_a?(Date) && commencement_date.year.digits.length != 4
+  end
+
+  def next_year
+    Time.zone.now.year.next
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1152,6 +1152,7 @@ en:
             commencement_date:
               blank: Enter a start date
               invalid: Enter a valid start date
+              future: Enter a start date closer to today
               invalid_year: The year must include 4 numbers
               not_before_course_start_date: *not_before_course_start_date
             trainee_id:

--- a/spec/forms/training_details_form_spec.rb
+++ b/spec/forms/training_details_form_spec.rb
@@ -80,6 +80,14 @@ describe TrainingDetailsForm, type: :model do
         end
       end
 
+      context "commencement date too far in the future" do
+        let(:trainee) { build(:trainee, commencement_date: Date.parse("1/1/2099")) }
+
+        it "returns an invalid year error message" do
+          expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.commencement_date.future"))
+        end
+      end
+
       context "date is before the course start date" do
         let(:trainee) do
           build(:trainee, course_start_date: Time.zone.today, commencement_date: 1.day.ago)


### PR DESCRIPTION
### Context
https://trello.com/c/1UQBl0LA/2811-trainee-start-date-can-be-2099

### Changes proposed in this pull request
Add validation so that trainee start date cannot be more than 1 year in future (same as course start date validation)

### Guidance to review
Test validation on `/training-details` page

