### PR TITLE
[2917] Remove/card up old TODO comments

### DIFF
--- a/app/components/placement_details/view.rb
+++ b/app/components/placement_details/view.rb
@@ -15,7 +15,6 @@ module PlacementDetails
       I18n.t("components.placement_detail.title")
     end
 
-    # TODO: Render the names of the trainee's placements, if any.
     def placements
       @not_provided_copy
     end

--- a/app/forms/placement_detail_form.rb
+++ b/app/forms/placement_detail_form.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# TODO: Flesh out - this is just a placeholder
 class PlacementDetailForm
   include ActiveModel::Model
 

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -52,8 +52,8 @@ module Dttp
           "dfe_sendforregistration" => true,
           "dfe_ProviderId@odata.bind" => "/accounts(#{trainee.provider.dttp_id})",
           "dfe_ITTQualificationAimId@odata.bind" => "/dfe_ittqualificationaims(#{dttp_qualification_aim_id(trainee.training_route)})",
-          "dfe_programmeyear" => 1, # TODO: this will need to be derived for other routes. It's n of x year course e.g. 1 of 2
-          "dfe_programmelength" => 1, # TODO: this will change for other routes as above. So these two are course_year of course_length
+          "dfe_programmeyear" => 1,
+          "dfe_programmelength" => 1,
         }
         .merge(degree_params)
         .merge(school_params)

--- a/app/lib/dttp/params/placement_outcomes/qts.rb
+++ b/app/lib/dttp/params/placement_outcomes/qts.rb
@@ -28,8 +28,6 @@ module Dttp
         attr_reader :trainee
 
         def date_left
-          # TODO: this will be different for non-assessment only routes
-          # we don't currently collect a leaving date for assessment only
           date_standards_assessed
         end
 

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -213,8 +213,6 @@ module Exports
     end
 
     def course_study_mode(trainee)
-      return unless trainee.respond_to?(:study_mode) #  TODO remove after trello card 2326 is merged
-
       {
         "full_time" => "Full time",
         "part_time" => "Part time",

--- a/db/migrate/20200914163852_add_dttp_id_to_trainees.rb
+++ b/db/migrate/20200914163852_add_dttp_id_to_trainees.rb
@@ -2,7 +2,6 @@
 
 class AddDttpIdToTrainees < ActiveRecord::Migration[6.0]
   def change
-    # TODO: make this null: false
     add_column :trainees, :dttp_id, :uuid
     add_index :trainees, :dttp_id
   end

--- a/spec/lib/dttp/params/placement_outcomes/qts_spec.rb
+++ b/spec/lib/dttp/params/placement_outcomes/qts_spec.rb
@@ -13,7 +13,6 @@ module Dttp
         describe "params" do
           describe "date left" do
             it "is set to outcome_date" do
-              # TODO: this will be different for non-assessment only routes
               expect(subject["dfe_dateleft"]).to eq(trainee.outcome_date.in_time_zone.iso8601)
             end
           end


### PR DESCRIPTION
### Context

https://trello.com/c/dxcd2lns/2917-todo-comment-review

### Changes proposed in this pull request

Removed old TODOs and carded up here:

https://trello.com/c/vuFIqbZk/2319-send-correct-programmeyear-and-programmelength-to-dttp
https://trello.com/c/yNV5kCFi/2320-send-correct-dateleft-to-dttp

Left in three very recent TODOs regarding HPITT integration (cc. @archferns), since they may be address soon and didn't want to stand on anyone's toes.

### Guidance to review
