### PR TITLE
[xxx] Return all provider courses for a trainee post trn

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -238,7 +238,7 @@ class Trainee < ApplicationRecord
   end
 
   def available_courses
-    return provider.courses.order(:name) if apply_application?
+    return provider.courses.order(:name) if apply_application? || !draft?
 
     provider.courses.where(route: training_route) if TRAINING_ROUTES_FOR_COURSE.keys.include?(training_route)
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/qvDNHT5z/2925-course-amendment

### Changes proposed in this pull request

We tend to get support requests asking for publish course codes to be changed on the trainee (regardless of which route they're for) but unless they're an apply application, we currently only return a slice of the provider's courses based on the route. 

Prior to this change, setting a new course code which has a route that's different to what the trainee is on will prevent the course from being found by other parts of the code using `trainee.available_courses` and this will cause subsequent issues such as the components not displaying the course information properly

This PR returns all courses for trainees post trn submission

### Guidance to review

