### PR TITLE
[2870] Use the interstitial confirmation page when invalid degrees exist

### DIFF
--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -115,7 +115,7 @@ module TaskListHelper
       degree:
         {
           task_name: "Degree",
-          path: trainee_degrees_new_type_path(trainee),
+          path: path_for_degrees(trainee),
           confirm_path: trainee_degrees_confirm_path(trainee),
           status: ProgressService.call(
             validator: DegreesForm.new(trainee),
@@ -171,5 +171,11 @@ private
     return edit_trainee_course_details_path(trainee) if trainee.early_years_route?
 
     edit_trainee_course_education_phase_path(trainee)
+  end
+
+  def path_for_degrees(trainee)
+    return trainee_degrees_new_type_path(trainee) if trainee.degrees.empty?
+
+    trainee_degrees_confirm_path(trainee)
   end
 end

--- a/spec/features/form_sections/personal_and_education_details/degrees/adding_degree_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/degrees/adding_degree_spec.rb
@@ -13,6 +13,13 @@ RSpec.feature "Adding a degree" do
       given_i_am_on_the_review_draft_page
       then_the_degree_status_should_be(incomplete)
     end
+
+    scenario "with incomplete or invalid degrees present" do
+      given_an_invalid_degree_exists
+      given_i_am_on_the_review_draft_page
+      and_i_click_the_degree_on_the_review_draft_page
+      then_i_am_redirected_to_the_trainee_degrees_confirmation_page
+    end
   end
 
   describe "Validation before route is picked" do
@@ -119,6 +126,10 @@ RSpec.feature "Adding a degree" do
   end
 
 private
+
+  def given_an_invalid_degree_exists
+    create(:degree, :uk_degree_with_details, trainee: trainee, subject: "gibberish")
+  end
 
   def and_i_click_the_degree_on_the_review_draft_page
     review_draft_page.degree_details.link.click


### PR DESCRIPTION
### Context
Now, since we have data coming in from various sources, for example, via csv import, 
it is possible that a trainee has degree(s) which might be invalid. 
The current flow from the review-draft page is to take the user to a form
 to add a new degree (as opposed to enabling them to edit an existing degree).

This change will ensure that users are redirected to the degrees confirm
page, when some degree data is avaiblable against that trainee, so that
the user can decide to amend the existing degree information, as opposed
to being forced to add a new degree.
![image](https://user-images.githubusercontent.com/910019/136794926-1113dd55-ce83-4737-8a92-6ddc2001226f.png)

![image](https://user-images.githubusercontent.com/910019/136795140-0edce179-e845-46c5-b4ce-f544c0dd3c7e.png)


### Changes proposed in this pull request
Redirect to the degrees confirm page if the trainee has any (invalid) degrees present.

### Guidance to review
1. On a trainee with invalid degree data, navigate to the review-draft page, and from there, try to visit the link to edit the degree information. This should take you to the degrees confirm page. (Current behaviour in production is to take you to the "Add another degree" form)


