### PR TITLE
[2905] Sentry bug: undefined method `keys' for nil:NilClass - Apply Application

### DIFF
--- a/app/view_objects/apply_invalid_data_view.rb
+++ b/app/view_objects/apply_invalid_data_view.rb
@@ -76,6 +76,8 @@ private
   end
 
   def populate_degree_fields(degree_fields)
+    return [] unless degree_sort_order_in(degree_fields)
+
     return [degree_fields[degree.to_param]&.keys].compact if degree.present?
     return degree_fields.map { |_slug, field| field.keys } if degrees_sort_order.size <= 1
 
@@ -86,5 +88,9 @@ private
 
   def get_field_name(field)
     I18n.t("views.missing_data_view.missing_fields_mapping.#{field}")
+  end
+
+  def degree_sort_order_in(degree_fields)
+    degrees_sort_order.all? { |slug| degree_fields.key?(slug) }
   end
 end


### PR DESCRIPTION
### Context

- https://sentry.io/organizations/dfe-bat/issues/2700253332/?project=5552118&referrer=slack

### Changes proposed in this pull request

This PR returns from a method early (one that deals with displaying invalid data for an apply draft) if the trainee has had their degrees completely replaced from what's on their apply application.

Currently, it attempts to interogate degree slugs from the application using the current degrees on the trainee which causes an error if they're different

### Guidance to review

