### PR TITLE
[2876] Fix mismatched trainee training routes

### DIFF
--- a/db/data/20211012133011_fix_apply_trainee_training_routes.rb
+++ b/db/data/20211012133011_fix_apply_trainee_training_routes.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FixApplyTraineeTrainingRoutes < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.with_apply_application.where.not(course_code: nil).each do |trainee|
+      if trainee.training_route != trainee.published_course.route
+        trainee.update(training_route: trainee.published_course.route)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/3BPbpbud/2876-bug-changing-course-on-apply-drafts-does-not-update-the-trainee-route

A small number of trainees with apply applications have a training route that is not the same as the route on the published course.

### Changes proposed in this pull request
- Data migration to fix a number of trainee training routes so they match the course route
