### PR TITLE
Increase workflow timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ jobs:
   prepare-matrix:
     name: Prepare Environment Matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     outputs:
       environments: ${{ steps.select-environments.outputs.environments || steps.set-pr-environment.outputs.environments }}
     steps:


### PR DESCRIPTION
### Context
Failed deployment: https://github.com/DFE-Digital/register-trainee-teachers/runs/3871503245?check_suite_focus=true

### Changes proposed in this pull request
The timeout on the job is not long enough. It is a left over and is not necessary as we have abort-after-seconds: 1800 on the turnstyle step.

