### PR TITLE
[2941] Change teach first route to hpitt

### DIFF
--- a/config/initializers/personas.rb
+++ b/config/initializers/personas.rb
@@ -3,7 +3,7 @@
 PROVIDER_A = "Provider A"
 PROVIDER_B = "Provider B"
 PROVIDER_C = "Teach First"
-TEACH_FIRST_PROVIDER_CODE = "HPPIT"
+TEACH_FIRST_PROVIDER_CODE = "HPITT"
 
 PERSONAS = [
   { first_name: "Adam", last_name: "Baker", email: "adam_baker@example.org", system_admin: true },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -863,7 +863,7 @@ en:
           school_direct_salaried: School direct (salaried)
           school_direct_tuition_fee: School direct (tuition fee)
           pg_teaching_apprenticeship: Teaching apprenticeship (postgrad)
-          hpitt_postgrad: Teach First
+          hpitt_postgrad: HPITT
           opt_in_undergrad: Opt-in (undergrad)
         states:
           draft: Draft


### PR DESCRIPTION
### Context
https://trello.com/c/MQ1gryC4/2941-teach-first-route-should-be-called-hpitt
Change Teach first route to HPITT in the UI
### Changes proposed in this pull request
Only changed the route in UI as per ticket. The persona still uses Teach First as that is the name of the provider. 
Shouldn't need to update current trainees as the value for `training_route` attribute on trainees table was `"hpitt_postgrad"` anyway. 
### Guidance to review
Create a new trainee and also view existing HPITT trainees 

