### PR TITLE
[2952] Allow job to retrieve from a specific date

### DIFF
--- a/app/jobs/apply_api/import_applications_job.rb
+++ b/app/jobs/apply_api/import_applications_job.rb
@@ -4,7 +4,9 @@ module ApplyApi
   class ImportApplicationsJob < ApplicationJob
     queue_as :default
 
-    def perform
+    def perform(from_date: nil)
+      @from_date = from_date
+
       return unless FeatureService.enabled?("import_applications_from_apply")
 
       new_applications.each do |application_data|
@@ -17,7 +19,7 @@ module ApplyApi
   private
 
     def new_applications
-      RetrieveApplications.call(changed_since: last_successful_sync)
+      RetrieveApplications.call(changed_since: @from_date || last_successful_sync)
     end
 
     def last_successful_sync

--- a/app/services/apply_api/import_application.rb
+++ b/app/services/apply_api/import_application.rb
@@ -11,6 +11,8 @@ module ApplyApi
     end
 
     def call
+      return unless application.new_record?
+
       ApplyApplication.transaction do
         application.update!(application: application_data.to_json, accredited_body_code: accredited_body_code)
         hei_provider? ? application.non_importable_hei! : application.importable!

--- a/db/data/20211013125651_add_uuids_to_applications.rb
+++ b/db/data/20211013125651_add_uuids_to_applications.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddUuidsToApplications < ActiveRecord::Migration[6.1]
+  def up
+    ApplyApi::ImportApplicationsJob.perform_later(from_date: Time.zone.parse("24 Sep 2021 12:19:59"))
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/factories/apply_applications.rb
+++ b/spec/factories/apply_applications.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
       state { "importable" }
     end
 
+    trait :imported do
+      state { "imported" }
+    end
+
     trait :with_invalid_data do
       invalid_data do
         {

--- a/spec/jobs/apply_api/import_applications_job_spec.rb
+++ b/spec/jobs/apply_api/import_applications_job_spec.rb
@@ -14,6 +14,17 @@ module ApplyApi
     end
 
     context "when the feature flag is turned on", feature_import_applications_from_apply: true do
+      context "when a from_date param is given" do
+        let(:from_date) { "2019-01-01" }
+
+        it "calls the RetrieveApplications service with the from_date param" do
+          expect(RetrieveApplications).to receive(:call).with(changed_since: from_date)
+          expect(ImportApplication).to receive(:call).with(application_data: application_data).and_return(application_record)
+
+          described_class.perform_now(from_date: from_date)
+        end
+      end
+
       context "when there have been no previous syncs" do
         it "imports application data from Apply and creates a trainee record" do
           expect(RetrieveApplications).to receive(:call).with(changed_since: nil)

--- a/spec/services/apply_api/import_application_spec.rb
+++ b/spec/services/apply_api/import_application_spec.rb
@@ -24,11 +24,15 @@ module ApplyApi
 
         context "and the apply application_data also exists in register" do
           before do
-            create(:apply_application, apply_id: application_data["id"])
+            create(:apply_application, :imported, apply_id: application_data["id"])
           end
 
           it "does not create a duplicate" do
             expect { subject }.not_to(change { ApplyApplication.count })
+          end
+
+          it "does not update old values" do
+            expect { subject }.not_to(change { ApplyApplication.last.state })
           end
         end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/6ubEquns/2952-fix-apply-applications-missing-uuids

### Changes proposed in this pull request

We have around 22 `apply_applications` which don't have a course `uuid` as they were imported before the changes. This PR makes a change to the job so it can be used to retrieve applications retrospectively. There's also a data migration to run it.

### Guidance to review

