### PR TITLE
[2957] Fix error unknown attribute 'code' for ApplyApplications::ConfirmCourseForm

### DIFF
--- a/app/controllers/trainees/apply_applications/course_details_controller.rb
+++ b/app/controllers/trainees/apply_applications/course_details_controller.rb
@@ -75,7 +75,7 @@ module Trainees
           trainee,
           course_has_one_specialism? ? specialisms : [],
           IttStartDateForm.new(@trainee).date,
-          { code: review_course_params[:code] },
+          { uuid: review_course_params[:uuid] },
         ).save
       end
 

--- a/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
@@ -62,7 +62,9 @@ private
 
   def and_a_trainee_exists_created_from_apply
     given_a_trainee_exists(:with_apply_application, :with_related_courses, courses_count: 1, subject_names: subjects)
-    trainee.update(course_uuid: Course.first.uuid)
+    Course.first.tap do |course|
+      trainee.update(course_code: course.code, course_uuid: course.uuid)
+    end
   end
 
   def given_the_trainee_does_not_have_a_course_code


### PR DESCRIPTION
### Context
https://trello.com/c/IjyTRlKG/2957-unknown-attribute-code-for-applyapplicationsconfirmcourseform

### Changes proposed in this pull request
- Update `Trainees::ApplyApplications::CourseDetailsController#save_course` to `uuid` instead of `code`.

