### PR TITLE
[2869] Update withdrawn status we send to dttp and back update

### DIFF
--- a/app/jobs/dttp/withdraw_job.rb
+++ b/app/jobs/dttp/withdraw_job.rb
@@ -7,13 +7,13 @@ module Dttp
 
     def perform(trainee)
       UpdateTraineeStatus.call(
-        status: DttpStatuses::REJECTED,
+        status: DttpStatuses::LEFT_COURSE_BEFORE_END,
         trainee: trainee,
         entity_type: UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
       )
 
       UpdateTraineeStatus.call(
-        status: DttpStatuses::REJECTED,
+        status: DttpStatuses::LEFT_COURSE_BEFORE_END,
         trainee: trainee,
         entity_type: UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
       )

--- a/db/data/20211014125920_update_withdrawn_dttp_status.rb
+++ b/db/data/20211014125920_update_withdrawn_dttp_status.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class UpdateWithdrawnDttpStatus < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.withdrawn.each do |trainee|
+      # Withdraw the trainee again to update their status, everything else should remain the same.
+      Dttp::WithdrawJob.perform_later(trainee)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/hlu9LEo1/2869-correct-the-guid-for-withdrawn-trainees

 We need to update the GUID that we're sending for withdrawn. This PR makes the change and introduces a data migration to update existing withdrawn trainees in DTTP

