### PR TITLE
[xxx] Data migration to backfill trainee UUID

### DIFF
--- a/db/data/20211014133338_add_course_uuids_to_trainees.rb
+++ b/db/data/20211014133338_add_course_uuids_to_trainees.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddCourseUuidsToTrainees < ActiveRecord::Migration[6.1]
+  def up
+    trainees_with_missing_uuid = Trainee.where.not(course_code: nil).where(course_uuid: nil)
+    course_code_to_uuid = Course.all.pluck(:code, :uuid).to_h
+
+    trainees_with_missing_uuid.find_each(batch_size: 500) do |trainee|
+      trainee.update(course_uuid: course_code_to_uuid[trainee.course_code])
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

We now store the UUID when we sync courses with publish. Trainees were associated using the course code but now have `course_uuid` field. 

### Changes proposed in this pull request

* Add the corresponding UUID to the trainee record where the trainee has a course code.

### Guidance to review

* Restore the DB locally
* Run the data migration
* There should be no trainees with a course_code but no course_uuid.
* The course_code and course_uuid should both refer to the same course

