### PR TITLE
[xxxx] Add safe navigation when changing routes

### DIFF
--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "l", text: t("components.page_titles.trainees.training_routes.edit"), tag: "h1" }) do %>
 
-  <% if current_user.provider.hpitt_postgrad? %>
+  <% if current_user.provider&.hpitt_postgrad? %>
     <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:hpitt_postgrad], label: { text: t("activerecord.attributes.trainee.training_routes.hpitt_postgrad") } %>
   <% else %>
     <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:assessment_only], label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>


### PR DESCRIPTION
### Context
Fixes [this sentry error](https://sentry.io/organizations/dfe-bat/issues/2712440748/?project=5552118)

When visiting the change route step, currently, we check against the logged in users => provider if they are a HPITT provider.
This breaks for system admin users, since they don't belong to a provider.

### Changes proposed in this pull request
This PR adds a safe navigation to not fail when a provider does not exist.

### Guidance to review
Login as various personas, and try changing routes on a trainee.
