### PR TITLE
Update non-publish message to be clearer

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,7 +163,7 @@ en:
       course_end_date: Course end date
       itt_end_date: ITT end date
       course_details: Course details
-      details_not_on_publish: Details not on Publish
+      details_not_on_publish: Course details added manually
       study_mode: Full time or part time
       study_mode_values:
         full_time: Full time


### PR DESCRIPTION
We have had several users write in to support thinking this existing message meant that data had been lost / deleted. It's a bug that they saw the message, but clearly the message is miss-communicating.

Hoping this reduces the queries in the short term.