### PR TITLE
[2985] Don't track / load GA if user rejects cookies

### DIFF
--- a/app/components/form_components/tracker.js
+++ b/app/components/form_components/tracker.js
@@ -10,26 +10,28 @@ function Tracker () {
   // Push an 'autocomplete-search' event to the dataLayer with the searches and
   // the final choice (if present).
   this.sendTrackingEvent = (match, fieldName) => {
-    let successfulSearch
-    const filteredSearches = this.searches.filter(s => !this._containsStringStartingWith(s))
+    if (window.dataLayer) {
+      let successfulSearch
+      const filteredSearches = this.searches.filter(s => !this._containsStringStartingWith(s))
 
-    // If the user selected something i.e. match !== nil, then the last tracked
-    // search counts as successful. Remove this.
-    if (match) { successfulSearch = filteredSearches.pop() }
+      // If the user selected something i.e. match !== nil, then the last tracked
+      // search counts as successful. Remove this.
+      if (match) { successfulSearch = filteredSearches.pop() }
 
-    if (filteredSearches.length > 0) {
-      window.dataLayer.push({
-        event: 'autocomplete-search',
-        fieldName: fieldName,
-        failedSearches: filteredSearches,
-        successfulSearch: successfulSearch,
-        match: this._match(fieldName, match),
-        timeTaken: this._timeTaken()
-      })
+      if (filteredSearches.length > 0) {
+        window.dataLayer.push({
+          event: 'autocomplete-search',
+          fieldName: fieldName,
+          failedSearches: filteredSearches,
+          successfulSearch: successfulSearch,
+          match: this._match(fieldName, match),
+          timeTaken: this._timeTaken()
+        })
+      }
+      // Empty out the searches array.
+      this.searches.splice(0, this.searches.length)
+      this.startTime = false
     }
-    // Empty out the searches array.
-    this.searches.splice(0, this.searches.length)
-    this.startTime = false
   }
 
   // Returns true/false if any string in the array starts with the item (excluding)

--- a/app/helpers/cookies_helper.rb
+++ b/app/helpers/cookies_helper.rb
@@ -4,4 +4,8 @@ module CookiesHelper
   def hide_cookie_banner?
     cookies[Settings.cookies.consent.name] =~ /yes|no/ || controller_name == "cookie_preferences"
   end
+
+  def google_analytics_allowed?
+    cookies[Settings.cookies.consent.name] == "yes"
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,17 +17,22 @@
     <%= favicon_link_tag asset_pack_path("media/images/govuk-apple-touch-icon-180x180.png"), rel: "apple-touch-icon", type: "image/png", size: "180x180" %>
     <%= stylesheet_pack_tag "application", media: "all" %>
     <%= javascript_pack_tag "application", defer: true %>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=<%= Settings.google_tag_manager.auth_id %>&gtm_preview=env-<%= Settings.google_tag_manager.env_id %>&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','<%= Settings.google_tag_manager.tracking_id %>');</script>
+    <% if google_analytics_allowed? %>
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=<%= Settings.google_tag_manager.auth_id %>&gtm_preview=env-<%= Settings.google_tag_manager.env_id %>&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','<%= Settings.google_tag_manager.tracking_id %>');</script>
+    <% end %>
   </head>
 
   <body class="govuk-template__body <%= yield :body_class %>">
-    <noscript>
-      <iframe title="Google Tag Manager" src="https://www.googletagmanager.com/ns.html?id=<%= Settings.google_tag_manager.tracking_id %>&<%= Settings.google_tag_manager.auth_id %>&gtm_preview=env-<%= Settings.google_tag_manager.env_id %>&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
+    <% if google_analytics_allowed? %>
+      <noscript>
+        <iframe title="Google Tag Manager" src="https://www.googletagmanager.com/ns.html?id=<%= Settings.google_tag_manager.tracking_id %>&<%= Settings.google_tag_manager.auth_id %>&gtm_preview=env-<%= Settings.google_tag_manager.env_id %>&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      </noscript>
+    <% end %>
+
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>


### PR DESCRIPTION
### Context
https://trello.com/c/v0FVxKqj/2985-m-dont-track-load-ga-if-user-rejects-cookies

### Changes proposed in this pull request
- Wrapped GA code in guard clause based on the answer given by the user via cookie banner

### Guidance to review
- Visit start page and make sure to clear all cookies
- Reject cookies
- Inspect source and check no GA code is rendered

