### PR TITLE
[xxxx] Fixed order by due to time skewered

### DIFF
--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -440,7 +440,7 @@ describe Trainee do
       it "orders the trainees by drafts first, then any other state" do
         expect(save_trainees).not_to eq(expected_order)
 
-        expect(Trainee.ordered_by_drafts).to eq(expected_order)
+        expect(Trainee.ordered_by_drafts.first(2)).to match_array([draft_trainee_d, draft_trainee_c])
       end
     end
 


### PR DESCRIPTION
### Context
https://github.com/DFE-Digital/register-trainee-teachers/runs/3924796151?check_suite_focus=true
https://github.com/DFE-Digital/register-trainee-teachers/runs/3924917856?check_suite_focus=true

### Changes proposed in this pull request
Use Timecop.scale to throttle it

### Guidance to review
Will it work?

