### PR TITLE
[2661] Add missing values to CSV export

### DIFF
--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -77,6 +77,7 @@ module Exports
           "course_code" => trainee.course_code,
           "course_name" => course&.name,
           "course_route" => course_route(trainee),
+          "course_qualification" => trainee.award_type,
           "course_education_phase" => trainee_education_phase(trainee) || course_education_phase(course),
           "course_allocation_subject" => trainee_allocation_subject(trainee.course_subject_one) || course_allocation_subject(course),
           "course_itt_subject_1" => trainee.course_subject_one,

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -84,6 +84,7 @@ module Exports
           "course_code" => trainee.course_code,
           "course_name" => course&.name,
           "course_route" => "Assessment only",
+          "course_qualification" => trainee.award_type,
           "course_education_phase" => trainee.course_education_phase.upcase_first,
           "course_allocation_subject" => nil,
           "course_itt_subject_1" => trainee.course_subject_one,


### PR DESCRIPTION
### Context

https://trello.com/c/NPrKko2H/2661-bug-missing-data-in-production-csv-export

### Changes proposed in this pull request

- `course_qualification`: removed for now since this is causing confusion with providers
- `course_qualification_type`: removed... this was just being set as nil?
- `course_level`: removed, this is the same as education phase
- `course_education_phase`: updated so that it tries to locate on the trainee first, then falls back to the course
- `course_allocation_subject`: as above, updated so that it tries to locate on the trainee first, then falls back to the course
- `degree_1_institution`: changed to `degree_1_awarding_institution`

### Guidance to review
