### PR TITLE
[2999] snag map not provided non uk degree type

### DIFF
--- a/app/lib/bulk_import.rb
+++ b/app/lib/bulk_import.rb
@@ -84,7 +84,7 @@ module BulkImport
     def build_non_uk_degree(trainee, country:, non_uk_degree:, subject:, graduation_year:)
       trainee.degrees.build do |degree|
         degree.locale_code = :non_uk
-        degree.country = country
+        degree.country = validate_country(country)
         degree.non_uk_degree = validate_enic_non_uk_degree(non_uk_degree)
         degree.subject = validate_degree_subject(subject)
         degree.graduation_year = Date.new(graduation_year.to_i).year if graduation_year.present?
@@ -271,8 +271,16 @@ module BulkImport
       end
     end
 
+    def validate_country(raw_string)
+      Dttp::CodeSets::Countries::MAPPING.keys.select do |country|
+        normalise_string(country) == normalise_string(raw_string)
+      end&.first
+    end
+
     def validate_enic_non_uk_degree(raw_string)
       return NON_ENIC if raw_string.blank?
+
+      return NON_ENIC if normalise_string(raw_string).include?("notprovided")
 
       ENIC_NON_UK.include?(raw_string) ? raw_string : nil
     end

--- a/spec/lib/bulk_import_spec.rb
+++ b/spec/lib/bulk_import_spec.rb
@@ -142,10 +142,13 @@ describe BulkImport do
   end
 
   describe ".build_non_uk_degree" do
+    let(:country_name) { "France" }
+    let(:non_uk_degree) { "Bachelor degree" }
+
     subject do
       described_class.build_non_uk_degree(trainee,
-                                          country: "France",
-                                          non_uk_degree: "Bachelor degree",
+                                          country: country_name,
+                                          non_uk_degree: non_uk_degree,
                                           subject: "Combined Studies",
                                           graduation_year: "2021")
     end
@@ -157,6 +160,22 @@ describe BulkImport do
       expect(subject.graduation_year).to eq 2021
       expect(subject.subject).to eq "Combined Studies"
       expect(subject.country).to eq "France"
+    end
+
+    context "with invalid country name" do
+      let(:country_name) { "american" }
+
+      it "does not set country name" do
+        expect(subject.country).to be_nil
+      end
+    end
+
+    context "with ENIC not provided" do
+      let(:non_uk_degree) { "ENIC not provided" }
+
+      it "does not set country name" do
+        expect(subject.non_uk_degree).to eq(NON_ENIC)
+      end
     end
   end
 


### PR DESCRIPTION
### Context
Fix a snag to unset country when a valid value is not provided, and where ENIC if not provided.

### Guidance to review
:shipit: 
