### PR TITLE
[xxx] Add timeline translation for course uuid

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,6 +348,7 @@ en:
           qts_awarded: QTS awarded
           eyts_awarded: EYTS awarded
           reinstated: Trainee reinstated
+          course_uuid: Course updated
           course_max_age: Course age range updated
           course_subject_one: Course subject updated
           commencement_date: Start date updated


### PR DESCRIPTION
### Context

We recently changed the column on the trainee from course_code to course_uuid, so the timeline was reading "Course uuid updated"

### Changes proposed in this pull request

Adds a translation for the new field so that the timeline reads "Course updated".

### Guidance to review
- Change the publish course for a non-draft trainee and check the timeline.