### PR TITLE
[2963] Add funding step wizard and fix validation bug

### DIFF
--- a/app/controllers/trainees/funding/training_initiatives_controller.rb
+++ b/app/controllers/trainees/funding/training_initiatives_controller.rb
@@ -11,12 +11,7 @@ module Trainees
         @training_initiatives_form = ::Funding::TrainingInitiativesForm.new(trainee, params: trainee_params, user: current_user)
 
         if @training_initiatives_form.stash_or_save!
-          if funding_manager.can_apply_for_funding_type?
-            redirect_to(edit_trainee_funding_bursary_path(trainee))
-          else
-            trainee.update!(applying_for_bursary: false)
-            redirect_to(trainee_funding_confirm_path(trainee))
-          end
+          redirect_to(step_wizard.next_step)
         else
           render(:edit)
         end
@@ -32,6 +27,10 @@ module Trainees
 
       def funding_manager
         @funding_manager ||= FundingManager.new(trainee)
+      end
+
+      def step_wizard
+        @step_wizard ||= Wizards::FundingStepWizard.new(trainee: trainee, page_tracker: page_tracker)
       end
     end
   end

--- a/app/lib/wizards/funding_step_wizard.rb
+++ b/app/lib/wizards/funding_step_wizard.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Wizards
+  class FundingStepWizard
+    include Rails.application.routes.url_helpers
+
+    def initialize(trainee:, page_tracker: nil)
+      @trainee = trainee
+      @page_tracker = page_tracker
+      @funding_manager ||= FundingManager.new(trainee)
+    end
+
+    def next_step
+      origin_page_or_next_step
+    end
+
+  private
+
+    attr_reader :trainee, :page_tracker, :funding_manager
+
+    def origin_page_or_next_step
+      return trainee_funding_confirm_path(trainee) if user_came_from_confirm_or_trainee_page?
+
+      redirect_url
+    end
+
+    def user_came_from_confirm_or_trainee_page?
+      page_tracker.last_origin_page_path&.include?("funding/confirm") || page_tracker.last_origin_page_path == "/trainees/#{trainee.slug}"
+    end
+
+    def redirect_url
+      funding_manager.can_apply_for_funding_type? ? edit_trainee_funding_bursary_path(trainee) : trainee_funding_confirm_path(trainee)
+    end
+  end
+end

--- a/app/lib/wizards/schools_step_wizard.rb
+++ b/app/lib/wizards/schools_step_wizard.rb
@@ -33,21 +33,17 @@ module Wizards
     end
 
     def origin_page_or_next_step
-      return trainee_schools_confirm_path(trainee) if user_come_from_confirm_or_trainee_page?
+      return trainee_schools_confirm_path(trainee) if user_came_from_confirm_or_trainee_page?
 
       redirect_url
     end
 
-    def user_come_from_confirm_or_trainee_page?
+    def user_came_from_confirm_or_trainee_page?
       page_tracker.last_origin_page_path&.include?("schools/confirm") || page_tracker.last_origin_page_path == "/trainees/#{trainee.slug}"
     end
 
     def lead_school_selected?
       ::Schools::LeadSchoolForm.new(trainee, params: { non_search_validation: true }).valid?
-    end
-
-    def employing_school_selected?
-      ::Schools::EmployingSchoolForm.new(trainee, params: { non_search_validation: true }).valid?
     end
 
     def progress_service

--- a/spec/forms/funding/form_validator_spec.rb
+++ b/spec/forms/funding/form_validator_spec.rb
@@ -83,7 +83,7 @@ module Funding
         end
 
         %i[bursary grant].each do |funding_type|
-          context "when funding type #{funding_type} is available" do
+          context "when funding type #{funding_type} is available", feature_grant: true do
             let(:funding_method) { create(:funding_method, funding_type, training_route: :provider_led_postgrad) }
 
             context "when TrainingInitiativesForm is valid" do


### PR DESCRIPTION
### Context

https://trello.com/c/8nPSgaeb/2963-grant-snag-change-link-flow

### Changes proposed in this pull request

- Add a step wizard similar to the schools one to decide which page to progress to (bursary/grants or confirm).
- Fix bug whereby we were validating the bursary form for all trainees, regardless of whether bursaries were applicable.

### Guidance to review

- Find a trainee with a completed funding section for which bursaries are applicable
- Click change on the training initiative row
- Click continue
- Check that you're on the funding confirm page, not the bursary form