### PR TITLE
[2885] Uncomplicate course details summary card and refactor

### DIFF
--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -18,6 +18,7 @@ module CourseDetails
 
     def rows
       [
+        training_route_row,
         education_phase,
         subject_row,
         age_range_row,
@@ -42,7 +43,7 @@ module CourseDetails
     attr_accessor :data_model, :trainee, :has_errors
 
     def education_phase
-      if require_education_phase?
+      if non_early_year_route?
         mappable_field(trainee.course_education_phase&.upcase_first,
                        t("components.course_detail.education_phase"),
                        action_url: edit_trainee_course_education_phase_path(trainee))
@@ -50,13 +51,20 @@ module CourseDetails
     end
 
     def subject_row
-      if require_subject?
+      if non_early_year_route?
         mappable_field(subject_names, t("components.course_detail.subject"))
       end
     end
 
+    def training_route_row
+      unless trainee.draft?
+        mappable_field(t("activerecord.attributes.trainee.training_routes.#{trainee.training_route}"), t("components.course_detail.route"),
+                       action_url: nil)
+      end
+    end
+
     def age_range_row
-      if require_age_range?
+      if non_early_year_route?
         mappable_field(course_age_range, t("components.course_detail.age_range"))
       end
     end
@@ -75,18 +83,8 @@ module CourseDetails
       trainee.itt_route?
     end
 
-    def require_subject?
+    def non_early_year_route?
       !trainee.early_years_route?
-    end
-
-    def require_age_range?
-      !trainee.early_years_route?
-    end
-
-    def require_education_phase?
-      return true unless trainee.early_years_route?
-
-      !trainee.draft?
     end
 
     def course_details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,7 @@ en:
       itt_start_date: ITT start date
       course_end_date: Course end date
       itt_end_date: ITT end date
+      route: Training route
       course_details: Course details
       details_not_on_publish: Course details added manually
       study_mode: Full time or part time

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -6,6 +6,10 @@ module CourseDetails
   describe View do
     include SummaryHelper
 
+    let(:training_route) { "Training route" }
+    let(:education_phase) { "Education phase" }
+    let(:age_range) { "Age range" }
+
     context "when data has not been provided" do
       let(:trainee) do
         build(:trainee, id: 1,
@@ -158,19 +162,28 @@ module CourseDetails
       context "non draft" do
         let(:trainee) { create(:trainee, :early_years_undergrad, :with_early_years_course_details, :submitted_for_trn) }
 
-        it "renders education phase" do
-          expect(rendered_component).to have_text("Education phase")
-          expect(rendered_component)
-            .to have_text("Secondary")
+        it "renders the training route" do
+          expect(rendered_component).to have_text(training_route)
+        end
+
+        it "does not render education phase" do
+          expect(rendered_component).not_to have_text(education_phase)
+        end
+
+        it "does not render course age range" do
+          expect(rendered_component).not_to have_text(age_range)
         end
       end
 
       context "draft" do
         let(:trainee) { create(:trainee, :early_years_undergrad, :with_early_years_course_details, :draft) }
 
+        it "does not render the training route" do
+          expect(rendered_component).not_to have_text(training_route)
+        end
+
         it "does not render education phase" do
-          expect(rendered_component).not_to have_text("Education phase")
-          expect(rendered_component).not_to have_text("Secondary")
+          expect(rendered_component).not_to have_text(education_phase)
         end
       end
     end
@@ -183,20 +196,36 @@ module CourseDetails
       context "draft" do
         let(:trainee) { create(:trainee, :with_secondary_course_details, :draft) }
 
+        it "does not render the training route" do
+          expect(rendered_component).not_to have_text(training_route)
+        end
+
         it "renders route" do
-          expect(rendered_component).to have_text("Education phase")
+          expect(rendered_component).to have_text(education_phase)
           expect(rendered_component)
             .to have_text("Secondary")
+        end
+
+        it "renders course age range" do
+          expect(rendered_component).to have_text(age_range)
         end
       end
 
       context "non draft" do
         let(:trainee) { create(:trainee, :with_secondary_course_details, :submitted_for_trn) }
 
+        it "renders the training route" do
+          expect(rendered_component).to have_text(training_route)
+        end
+
         it "renders route" do
-          expect(rendered_component).to have_text("Education phase")
+          expect(rendered_component).to have_text(education_phase)
           expect(rendered_component)
             .to have_text("Secondary")
+        end
+
+        it "renders course age range" do
+          expect(rendered_component).to have_text(age_range)
         end
       end
     end


### PR DESCRIPTION
### Context

There are currently too many variations of the course details summary card. This PR aims to reduce the complexity in line with [the prototype](https://github.com/DFE-Digital/register-trainee-teachers-prototype/pull/341). 

### Changes proposed in this pull request

The following rows should show on the course details summary card, given that they satisfy the conditionals. If they do not they are omitted. 

- Route (if non draft, non editable)
- Study mode (if study mode on route)
- Course start date
- Course end date
- Course (if route has published courses)
- Education phase (if non early years route)
- Age range (if non early years route)


### Guidance to review

Visit the course details summary card for a range of different scenarios, i.e. draft, non draft, different routes and check that the criteria outlined above is consistent. 