### PR TITLE
[2956] Bug - course duration incorrect in csv export

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -306,6 +306,12 @@ class Trainee < ApplicationRecord
     @hpitt_provider ||= provider&.hpitt_postgrad?
   end
 
+  def course_duration_in_years
+    return unless course_start_date && course_end_date
+
+    ((course_end_date - course_start_date) / 365).ceil
+  end
+
 private
 
   def value_digest

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -88,7 +88,7 @@ module Exports
           "course_study_mode" => course_study_mode(trainee),
           "course_start_date" => trainee.course_start_date&.iso8601,
           "course_end_date" => trainee.course_end_date&.iso8601,
-          "course_duration_in_years" => course&.duration_in_years,
+          "course_duration_in_years" => trainee.course_duration_in_years,
           "course_summary" => course&.summary,
           "commencement_date" => trainee.commencement_date&.iso8601,
           "lead_school_name" => trainee.lead_school&.name,

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -544,4 +544,23 @@ describe Trainee do
       expect(trainee.last_name).to eq("Bloggs")
     end
   end
+
+  describe "#course_duration_in_years" do
+    it "returns nil if no course start/end dates set" do
+      trainee = Trainee.new(course_start_date: Time.zone.today, course_end_date: nil)
+      expect(trainee.course_duration_in_years).to be_nil
+      trainee = Trainee.new(course_start_date: nil, course_end_date: Time.zone.today)
+      expect(trainee.course_duration_in_years).to be_nil
+    end
+
+    it "returns 1 year" do
+      trainee = Trainee.new(course_start_date: "2021-09-10".to_date, course_end_date: "2022-07-01".to_date)
+      expect(trainee.course_duration_in_years).to eq(1)
+    end
+
+    it "returns 2 years" do
+      trainee = Trainee.new(course_start_date: "2021-09-10".to_date, course_end_date: "2023-07-01".to_date)
+      expect(trainee.course_duration_in_years).to eq(2)
+    end
+  end
 end

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -94,7 +94,7 @@ module Exports
           "course_study_mode" => trainee.study_mode.humanize,
           "course_start_date" => trainee.course_start_date&.iso8601,
           "course_end_date" => trainee.course_end_date&.iso8601,
-          "course_duration_in_years" => course&.duration_in_years,
+          "course_duration_in_years" => trainee.course_duration_in_years,
           "course_summary" => course&.summary,
           "commencement_date" => trainee.commencement_date&.iso8601,
           "lead_school_name" => trainee.lead_school&.name,


### PR DESCRIPTION
### Context

https://trello.com/c/EcW149wQ/2956-bug-course-duration-incorrect-in-csv-export

### Changes proposed in this pull request

* Course `duration_in_years` is calculated using the `course_start_date` and `course_end_date`.

### Guidance to review

* Add trainee, set course start/end date
* Export CSV and see if the duration is dynamically set.

