### PR TITLE
[2982] [2983] Add not applicable school checkbox to Lead/Employing school UI

### DIFF
--- a/app/components/school_details/view.rb
+++ b/app/components/school_details/view.rb
@@ -12,6 +12,13 @@ module SchoolDetails
       @employing_school = trainee.employing_school
     end
 
+    def school_rows
+      [
+        lead_school_row(not_applicable: trainee.lead_school_not_applicable?),
+        employing_school_row(not_applicable: trainee.employing_school_not_applicable?),
+      ].compact
+    end
+
   private
 
     def change_paths(school_type)

--- a/app/components/schools/view.rb
+++ b/app/components/schools/view.rb
@@ -16,9 +16,32 @@ module Schools
       data_model.is_a?(Trainee) ? data_model : data_model.trainee
     end
 
+    def school_rows
+      [
+        lead_school_row(not_applicable: lead_school_not_applicable?),
+        employing_school_row(not_applicable: employing_school_not_applicable?),
+      ].compact
+    end
+
   private
 
     attr_accessor :data_model, :lead_school, :employing_school, :has_errors
+
+    def lead_school_not_applicable?
+      if data_model.is_a?(Schools::FormValidator)
+        data_model.lead_school_form.school_not_applicable?
+      else
+        data_model.lead_school_not_applicable?
+      end
+    end
+
+    def employing_school_not_applicable?
+      if data_model.is_a?(Schools::FormValidator)
+        data_model.employing_school_form.school_not_applicable?
+      else
+        data_model.employing_school_not_applicable?
+      end
+    end
 
     def change_paths(school_type)
       {

--- a/app/controllers/trainees/employing_schools_controller.rb
+++ b/app/controllers/trainees/employing_schools_controller.rb
@@ -36,7 +36,8 @@ module Trainees
 
     def trainee_params
       params.fetch(:schools_employing_school_form, {})
-            .permit(:employing_school_id, *Schools::EmployingSchoolForm::NON_TRAINEE_FIELDS)
+            .permit(*Schools::EmployingSchoolForm::FIELDS,
+                    *Schools::EmployingSchoolForm::NON_TRAINEE_FIELDS)
     end
 
     def query

--- a/app/controllers/trainees/lead_schools_controller.rb
+++ b/app/controllers/trainees/lead_schools_controller.rb
@@ -33,7 +33,9 @@ module Trainees
   private
 
     def trainee_params
-      params.fetch(:schools_lead_school_form, {}).permit(:lead_school_id, *Schools::LeadSchoolForm::NON_TRAINEE_FIELDS)
+      params.fetch(:schools_lead_school_form, {})
+            .permit(*Schools::LeadSchoolForm::FIELDS,
+                    *Schools::LeadSchoolForm::NON_TRAINEE_FIELDS)
     end
 
     def query

--- a/app/forms/schools/employing_school_form.rb
+++ b/app/forms/schools/employing_school_form.rb
@@ -4,20 +4,18 @@ module Schools
   class EmployingSchoolForm < Form
     FIELDS = %i[
       employing_school_id
+      employing_school_not_applicable
     ].freeze
 
     attr_accessor(*FIELDS)
 
-    validates :employing_school_id,
-              presence: true,
-              if: -> { non_search_validation? || (search_results_found? && results_search_again_query.blank?) }
-
     alias_method :school_id, :employing_school_id
+    alias_method :school_not_applicable, :employing_school_not_applicable
 
   private
 
     def compute_fields
-      trainee.attributes.symbolize_keys.slice(:employing_school_id).merge(new_attributes)
+      trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
     end
   end
 end

--- a/app/forms/schools/lead_school_form.rb
+++ b/app/forms/schools/lead_school_form.rb
@@ -4,20 +4,18 @@ module Schools
   class LeadSchoolForm < Form
     FIELDS = %i[
       lead_school_id
+      lead_school_not_applicable
     ].freeze
 
     attr_accessor(*FIELDS)
 
-    validates :lead_school_id,
-              presence: true,
-              if: -> { non_search_validation? || (search_results_found? && results_search_again_query.blank?) }
-
     alias_method :school_id, :lead_school_id
+    alias_method :school_not_applicable, :lead_school_not_applicable
 
   private
 
     def compute_fields
-      trainee.attributes.symbolize_keys.slice(:lead_school_id).merge(new_attributes)
+      trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
     end
   end
 end

--- a/app/helpers/school_helper.rb
+++ b/app/helpers/school_helper.rb
@@ -11,23 +11,19 @@ module SchoolHelper
     tag.p(school.name, class: "govuk-body") + tag.span(school_urn_and_location(school), class: "govuk-hint")
   end
 
-  def school_rows
-    [lead_school_row, employing_school_row].compact
-  end
-
-  def lead_school_row
+  def lead_school_row(not_applicable: false)
     mappable_field(
-      school_detail(lead_school),
+      not_applicable ? t(:not_applicable) : school_detail(lead_school),
       t("components.school_details.lead_school_key"),
       change_paths(:lead),
     )
   end
 
-  def employing_school_row
+  def employing_school_row(not_applicable: false)
     return unless trainee.requires_employing_school?
 
     mappable_field(
-      school_detail(employing_school),
+      not_applicable ? t(:not_applicable) : school_detail(employing_school),
       t("components.school_details.employing_school_key"),
       change_paths(:employing),
     )

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -196,6 +196,9 @@ class Trainee < ApplicationRecord
 
   auto_strip_attributes :first_names, :last_name, squish: true
 
+  before_save :clear_employing_school_id, if: :employing_school_not_applicable?
+  before_save :clear_lead_school_id, if: :lead_school_not_applicable?
+
   def trn_requested!(dttp_id, placement_assignment_dttp_id)
     update!(dttp_id: dttp_id, placement_assignment_dttp_id: placement_assignment_dttp_id)
   end
@@ -322,5 +325,13 @@ private
         assoc.map(&:serializable_hash).flat_map(&:values).compact
       end
     ).join(",")
+  end
+
+  def clear_employing_school_id
+    self.employing_school_id = nil
+  end
+
+  def clear_lead_school_id
+    self.lead_school_id = nil
   end
 end

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -91,9 +91,9 @@ module Exports
           "course_duration_in_years" => course&.duration_in_years,
           "course_summary" => course&.summary,
           "commencement_date" => trainee.commencement_date&.iso8601,
-          "lead_school_name" => trainee.lead_school&.name,
+          "lead_school_name" => lead_school_name(trainee),
           "lead_school_urn" => trainee.lead_school&.urn,
-          "employing_school_name" => trainee.employing_school&.name,
+          "employing_school_name" => employing_school_name(trainee),
           "employing_school_urn" => trainee.employing_school&.urn,
           "training_initiative" => training_initiative(trainee),
           "funding_method" => funding_method(trainee),
@@ -257,6 +257,14 @@ module Exports
       return value unless value.is_a?(String)
 
       value.start_with?(*VULNERABLE_CHARACTERS) ? value.prepend("'") : value
+    end
+
+    def lead_school_name(trainee)
+      trainee.lead_school_not_applicable? ? I18n.t(:not_applicable) : trainee.lead_school&.name
+    end
+
+    def employing_school_name(trainee)
+      trainee.employing_school_not_applicable? ? I18n.t(:not_applicable) : trainee.employing_school&.name
     end
   end
 end

--- a/app/views/trainees/employing_schools/edit.html.erb
+++ b/app/views/trainees/employing_schools/edit.html.erb
@@ -19,6 +19,13 @@
       ) %>
       <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-default-value="<%= query %>" data-field-name="schools_employing_school_form[query]"></div>
 
+      <%= render GovukComponent::DetailsComponent.new(summary_text: t(".not_applicable_details.summary_text"),
+                                                      open: f.object.school_not_applicable? ) do %>
+        <%= t(".not_applicable_details.body", contact_link: govuk_mail_to(Settings.support_email)).html_safe %>
+        <%= f.govuk_check_box(:employing_school_not_applicable, "1", "0", multiple: false,
+                              label: { text: t(".not_applicable_details.label_text") }) %>
+      <% end  %>
+
       <%= f.hidden_field :employing_school_id, id: "school-id", value: nil %>
       <%= f.govuk_submit t("continue") %>
     <% end %>

--- a/app/views/trainees/lead_schools/edit.html.erb
+++ b/app/views/trainees/lead_schools/edit.html.erb
@@ -21,6 +21,13 @@
       <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-only-lead-schools=true
            data-default-value="<%= query %>" data-field-name="schools_lead_school_form[query]"></div>
 
+      <%= render GovukComponent::DetailsComponent.new(summary_text: t(".not_applicable_details.summary_text"),
+                                                      open: f.object.school_not_applicable? ) do %>
+        <%= t(".not_applicable_details.body", contact_link: govuk_mail_to(Settings.support_email)).html_safe %>
+        <%= f.govuk_check_box(:lead_school_not_applicable, "1", "0", multiple: false,
+                              label: { text: t(".not_applicable_details.label_text") }) %>
+      <% end  %>
+
       <%= f.hidden_field :lead_school_id, id: "school-id", value: nil %>
       <%= f.govuk_submit t("continue") %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
   in_progress_invalid: in progress
   review: review
   completed: completed
+  not_applicable: Not applicable
   header:
     items:
       sign_out: Sign out
@@ -831,10 +832,22 @@ en:
         heading: Lead school
         hint: Search for a school by its unique reference number (URN), name or postcode
         description: The lead school is the main organisation and point of contact for training providers, placements and partner schools in the school direct partnership.
+        not_applicable_details:
+          summary_text: Trainee is not at a state school or lead school is not listed
+          label_text: Lead school is not applicable
+          body:
+            <p> If the lead school is missing from the list, contact %{contact_link}</p>
+            <p>You only need to provide a lead school if the trainee is employed or funded by a state school</p>
     employing_schools:
       edit:
         heading: Employing school
         hint: Search for a school by its unique reference number (URN), name or postcode
+        not_applicable_details:
+          summary_text: Trainee is not at a state school or employing school is not listed
+          label_text: Employing school is not applicable
+          body:
+            <p> If the employing school is missing from the list, contact %{contact_link}</p>
+            <p>You only need to provide an employing school if the trainee is employed or funded by a state school</p>
     subject_specialisms:
       edit:
         heading: Which %{subject} specialism has the trainee chosen to study?
@@ -1208,8 +1221,9 @@ en:
           attributes:
             query:
               blank: Enter a school unique reference number (URN), name or postcode
-            lead_school_id:
+            school_id:
               blank: Select a lead school or search again
+              both_fields_are_present: Select a lead school or select lead school not applicable
             results_search_again_query:
               blank: Enter a school unique reference number (URN), name or postcode
             no_results_search_again_query:
@@ -1218,8 +1232,9 @@ en:
           attributes:
             query:
               blank: Enter a school unique reference number (URN), name or postcode
-            employing_school_id:
+            school_id:
               blank: Select an employing school or search again
+              both_fields_are_present: Select an employing school or select employing school not applicable
             results_search_again_query:
               blank: Enter a school unique reference number (URN), name or postcode
             no_results_search_again_query:

--- a/spec/features/form_sections/teacher_training_data/edit_schools_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_schools_spec.rb
@@ -21,6 +21,15 @@ RSpec.feature "edit schools spec", type: :feature do
       then_i_am_redirected_to_the_confirm_schools_page
     end
 
+    scenario "choosing not applicable for lead school" do
+      i_click_on_change_school(:lead_school)
+      and_i_am_on_the_edit_lead_school_page
+      and_i_check_lead_school_is_not_applicable
+      and_i_continue
+      then_i_am_redirected_to_the_confirm_schools_page
+      and_the_lead_school_displays_not_applicable
+    end
+
     scenario "changing the employing school", js: true do
       i_click_on_change_school(:employing_school)
       and_i_am_on_the_edit_employing_school_page
@@ -28,6 +37,15 @@ RSpec.feature "edit schools spec", type: :feature do
       and_i_click_the_first_item_in_the_list_employing_school
       and_i_continue
       then_i_am_redirected_to_the_confirm_schools_page
+    end
+
+    scenario "choosing not applicable for employing school" do
+      i_click_on_change_school(:employing_school)
+      and_i_am_on_the_edit_employing_school_page
+      and_i_check_employing_school_is_not_applicable
+      and_i_continue
+      then_i_am_redirected_to_the_confirm_schools_page
+      and_the_employing_school_displays_not_applicable
     end
   end
 
@@ -130,5 +148,21 @@ private
 
   def then_i_am_redirected_to_the_confirm_schools_page
     expect(confirm_schools_page).to be_displayed(id: trainee.slug)
+  end
+
+  def and_i_check_employing_school_is_not_applicable
+    edit_employing_school_page.not_applicable_checkbox.check
+  end
+
+  def and_i_check_lead_school_is_not_applicable
+    edit_lead_school_page.not_applicable_checkbox.check
+  end
+
+  def and_the_employing_school_displays_not_applicable
+    expect(confirm_schools_page.employing_school_row).to have_text(I18n.t(:not_applicable))
+  end
+
+  def and_the_lead_school_displays_not_applicable
+    expect(confirm_schools_page.lead_school_row).to have_text(I18n.t(:not_applicable))
   end
 end

--- a/spec/support/page_objects/trainees/confirm_school_details.rb
+++ b/spec/support/page_objects/trainees/confirm_school_details.rb
@@ -6,6 +6,8 @@ module PageObjects
       set_url "/trainees/{id}/schools/confirm"
 
       element :continue, "button[type='submit']"
+      element :employing_school_row, ".employing-school"
+      element :lead_school_row, ".lead-school"
     end
   end
 end

--- a/spec/support/page_objects/trainees/edit_employing_school.rb
+++ b/spec/support/page_objects/trainees/edit_employing_school.rb
@@ -8,6 +8,7 @@ module PageObjects
       element :employing_school, "#schools-employing-school-form-query-field"
       element :no_js_employing_school, "#schools-employing-school-form-query-field"
       element :autocomplete_list_item, "#schools-employing-school-form-query-field__listbox li:first-child"
+      element :not_applicable_checkbox, "#schools-employing-school-form-employing-school-not-applicable-1-field", visible: false
       element :submit, 'button.govuk-button[type="submit"]'
     end
   end

--- a/spec/support/page_objects/trainees/edit_lead_school.rb
+++ b/spec/support/page_objects/trainees/edit_lead_school.rb
@@ -8,6 +8,7 @@ module PageObjects
       element :lead_school, "#schools-lead-school-form-query-field"
       element :no_js_lead_school, "#schools-lead-school-form-query-field"
       element :autocomplete_list_item, "#schools-lead-school-form-query-field__listbox li:first-child"
+      element :not_applicable_checkbox, "#schools-lead-school-form-lead-school-not-applicable-1-field", visible: false
       element :submit, 'button.govuk-button[type="submit"]'
     end
   end

--- a/spec/support/shared_examples/school_form_validations.rb
+++ b/spec/support/shared_examples/school_form_validations.rb
@@ -24,8 +24,19 @@ RSpec.shared_examples "school form validations" do |school_id_key|
     let(:params) { { "results_search_again_query" => "", school_id_key => "", "search_results_found" => "true" } }
 
     it "returns an error" do
-      expect(subject.errors[school_id_key]).to include(
-        I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.#{school_id_key}.blank"),
+      expect(subject.errors[:school_id]).to include(
+        I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.school_id.blank"),
+      )
+    end
+  end
+
+  context "school chosen but also marked as not applicable" do
+    let(:form_name) { school_id_key.sub("id", "form") }
+    let(:params) { { school_id_key => "1", school_id_key.sub("id", "not_applicable") => "1", query: "school" } }
+
+    it "returns an error" do
+      expect(subject.errors[:school_id]).to include(
+        I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.school_id.both_fields_are_present"),
       )
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/7SB3gYhc/2982-not-applicable-school-employing-school-ui
https://trello.com/c/1Ku7oNpv/2983-not-applicable-school-lead-school-ui

### Changes proposed in this pull request
 - Added checkbox for not applicable lead/employing schools
 - Refactored the lead and employing schools forms; pushed more logic into the base class
 - Updated the school view components to handle not applicable schools
 
### Guidance to review
- Find school direct (salaried) draft trainee
- Click on "Lead and employing schools"
- Click change under "Lead school"
- Click "Continue" (leave the search field blank)
- The error message should be the same as before
- Search for a school
- Click on the expandable link "Trainee is not at a state school or lead school is not listed"
- Check the box and click continue
- The error mesage should now be different indicating only one option can be chosen
- Clear the search field and click continue
- The confirmation page should now display "Not applicable" for lead school

Repeat above steps for employing school and do the same for non-draft trainees.


