### PR TITLE
Fix flake when selecting main/radio age range

### DIFF
--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -150,7 +150,9 @@ FactoryBot.define do
       course_subject_two { nil }
       course_subject_three { nil }
       course_age_range do
-        [11, 18]
+        Dttp::CodeSets::AgeRanges::MAPPING.select do |_, v|
+          v[:levels]&.include?(course_education_phase.to_sym)
+        end.keys.sample
       end
       with_study_mode_and_course_dates
     end

--- a/spec/support/page_objects/trainees/course_details.rb
+++ b/spec/support/page_objects/trainees/course_details.rb
@@ -29,9 +29,10 @@ module PageObjects
       element :itt_end_date_year, "#course_details_form_itt_end_date_1i"
 
       element :main_age_range_3_to_11, "#course-details-form-main-age-range-3-to-11-field"
+      element :main_age_range_3_to_7, "#course-details-form-main-age-range-3-to-7-field"
       element :main_age_range_5_to_11, "#course-details-form-main-age-range-5-to-11-field"
       element :main_age_range_11_to_16, "#course-details-form-main-age-range-11-to-16-field"
-      element :main_age_range_11_to_19, "#course-details-form-main-age-range-11-to-19-field"
+      element :main_age_range_11_to_18, "#course-details-form-main-age-range-11-to-18-field"
       element :main_age_range_other, "#course-details-form-main-age-range-other-field"
 
       element :additional_age_range, "#course-details-form-additional-age-range-field"


### PR DESCRIPTION
### Context
Can be replicated by running `bundle exec rspec spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb` against the first commit.

### Changes proposed in this pull request
Add a missing age range to the course details page object.

### Guidance to review
:shipit: 