### PR TITLE
[3024]  Strip trailing spaces on Trainee frields first_names and last_name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,8 @@ gem "govuk_notify_rails"
 
 gem "blazer"
 
+gem "auto_strip_attributes"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
     attr_required (1.0.1)
     audited (5.0.2)
       activerecord (>= 5.0, < 7.1)
+    auto_strip_attributes (2.6.0)
+      activerecord (>= 4.0)
     better_html (1.0.16)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -545,6 +547,7 @@ DEPENDENCIES
   activerecord-session_store
   amazing_print (~> 1.4)
   audited (~> 5.0)
+  auto_strip_attributes
   blazer
   bootsnap (>= 1.1.0)
   byebug

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -194,6 +194,8 @@ class Trainee < ApplicationRecord
   audited associated_with: :provider
   has_associated_audits
 
+  auto_strip_attributes :first_names, :last_name, squish: true
+
   def trn_requested!(dttp_id, placement_assignment_dttp_id)
     update!(dttp_id: dttp_id, placement_assignment_dttp_id: placement_assignment_dttp_id)
   end

--- a/db/data/20211021161249_remove_trailing_spaces_from_trainee_first_names_and_last_name.rb
+++ b/db/data/20211021161249_remove_trailing_spaces_from_trainee_first_names_and_last_name.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveTrailingSpacesFromTraineeFirstNamesAndLastName < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.without_auditing do # we don't want this save operation to be in audit trail
+      Trainee.all.find_each(&:save) # auto_strip_attributes will remove all extra whitespace
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -535,4 +535,13 @@ describe Trainee do
       expect(trainee.course_age_range).to eq(AgeRange::ZERO_TO_FIVE)
     end
   end
+
+  context "first name and last name have inside and trailing spaces" do
+    let(:trainee) { create(:trainee, first_names: " Joe   Black ", last_name: " Bloggs   ") }
+
+    it "all inside and outside spaces are removed" do
+      expect(trainee.first_names).to eq("Joe Black")
+      expect(trainee.last_name).to eq("Bloggs")
+    end
+  end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/JmrsDzGg/3024-m-strip-trailing-spaces-on-string-fields

### Changes proposed in this pull request
- Add `auto_strip_attributes` gem to ensure all extra whitespaces are removed for `first_names` and `last_name`
- Data migration to go over the existing trainees and remove all extra whitespaces

