### PR TITLE
[xxx] Fix bug when downloading drafts with no subjects set

### DIFF
--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -230,10 +230,10 @@ module Exports
     def course_allocation_subject(course)
       return unless course
 
-      subject_specialism = CalculateSubjectSpecialisms.call(subjects: course.subjects.pluck(:name))
+      subject = CalculateSubjectSpecialisms.call(subjects: course.subjects.pluck(:name))
         .values.map(&:first).first
 
-      subject_specialism.allocation_subject
+      trainee_allocation_subject(subject)
     end
 
     def trainee_education_phase(trainee)


### PR DESCRIPTION
### Context

The CSV export is currently erroring if a user downloads a trainee with no course_subject_one set.

### Changes proposed in this pull request

Correctly calculates the allocation subject from a course.

### Guidance to review

🚢 