### PR TITLE
[3021] Data migration to backfill existing apply applications

### DIFF
--- a/db/data/20211022101431_add_recruitment_cycle_year_to_applications.rb
+++ b/db/data/20211022101431_add_recruitment_cycle_year_to_applications.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddRecruitmentCycleYearToApplications < ActiveRecord::Migration[6.1]
+  def up
+    ApplyApplication.where(recruitment_cycle_year: nil).update_all(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/b/BBEuhbHM/register-sprint-board

### Changes proposed in this pull request

Building up from this PR https://github.com/DFE-Digital/register-trainee-teachers/pull/1653, backfills the recruitment cycle year for existing apply applications in prod

The 3 in prod for the next cycle have already been updated manually to `2022`

### Guidance to review

