### PR TITLE
[2590] Surface withdrawal date and reason on timeline

### DIFF
--- a/app/components/timeline/style.scss
+++ b/app/components/timeline/style.scss
@@ -67,3 +67,24 @@
   color: $govuk-secondary-text-colour;
   margin: 0;
 }
+
+.app-timeline__description {
+  margin-top: govuk-spacing(3);
+}
+
+.app-timeline__description :last-child {
+  margin-bottom: govuk-spacing(0);
+}
+
+.app-timeline__metadata-term {
+  box-sizing: border-box;
+  float: left;
+  clear: left;
+  padding-right: 5px;
+  margin-top: 0;
+}
+
+.app-timeline__metadata-container {
+  @include govuk-font($size: 19);
+  color: $govuk-text-colour;
+}

--- a/app/components/timeline/view.html.erb
+++ b/app/components/timeline/view.html.erb
@@ -11,6 +11,16 @@
           <%= event.date.to_s(:govuk_date_and_time) %>
         </time>
       </p>
-    </div>
-  <% end %>
+        <% if event.items.present? %>
+        <div class="app-timeline__description">
+          <dl class="app-timeline__metadata-container">
+            <% event.items.each do |key, value| %>
+              <dt class="app-timeline__metadata-term"><%= key %></dt>
+              <dd class="app-timeline__metadata-definition"><%= value %></dd>
+            <% end %>
+          </dl>
+        </div>
+        <% end %>
+      </div>
+    <% end %>
 </div>

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class TimelineEvent
-  attr_reader :title, :date, :username
+  attr_reader :title, :date, :username, :items
 
-  def initialize(title:, date:, username:)
+  def initialize(title:, date:, username:, items:)
     @title = title
     @date = date
     @username = username
+    @items = items
   end
 end

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -63,6 +63,7 @@ module Trainees
           title: single_event_title,
           date: created_at,
           username: username,
+          items: items,
         )
       else
         audited_changes.map do |field, change|
@@ -75,6 +76,7 @@ module Trainees
             title: I18n.t("components.timeline.titles.#{model}.#{field}", default: "#{field.humanize} updated"),
             date: created_at,
             username: username,
+            items: nil,
           )
         end
       end
@@ -102,6 +104,15 @@ module Trainees
       return state_change_title if action == STATE_CHANGE
 
       I18n.t("components.timeline.titles.#{model}.#{action}")
+    end
+
+    def items
+      if action == STATE_CHANGE && state_change_action == "withdrawn"
+        [
+          ["#{I18n.t('components.timeline.withdrawal_date')}:", auditable.withdraw_date.strftime("%e %B %Y").to_s],
+          ["#{I18n.t('components.timeline.withdrawal_reason')}:", (auditable.additional_withdraw_reason&.upcase_first || auditable.withdraw_reason&.humanize).to_s],
+        ]
+      end
     end
 
     def state_change_title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -336,6 +336,8 @@ en:
       subject: Subject
       text_search: Text search
     timeline:
+      withdrawal_date: Date of withdrawal
+      withdrawal_reason: Reason for withdrawal
       titles:
         trainee:
           create: Record created

--- a/spec/components/timeline/view_spec.rb
+++ b/spec/components/timeline/view_spec.rb
@@ -6,11 +6,21 @@ module Timeline
   describe View do
     alias_method :component, :page
 
-    let(:title) { "Title" }
+    let(:title) { "Trainee withdrawn" }
     let(:username) { "User" }
     let(:date) { Time.zone.now }
+    let(:items) {
+      [
+        "#{I18n.t('components.timeline.withdrawal_date')}: #{withdrawal_date.strftime('%e %B %Y')}",
+        "#{I18n.t('components.timeline.withdrawal_reason')}: #{additional_withdraw_reason}",
+      ]
+    }
 
-    let(:event) { double(title: title, username: username, date: date) }
+    let(:event) { double(title: title, username: username, date: date, items: items) }
+    let(:trainee) { build(:trainee, withdraw_date: withdrawal_date, withdraw_reason: withdraw_reason, additional_withdraw_reason: additional_withdraw_reason) }
+    let(:withdrawal_date) { Time.zone.now + 1 }
+    let(:withdraw_reason) { "for_another_reason" }
+    let(:additional_withdraw_reason) { "became lazy" }
 
     before do
       render_inline(described_class.new(events: [event]))
@@ -20,6 +30,14 @@ module Timeline
       expect(component).to have_text(title)
       expect(component).to have_text(username)
       expect(component).to have_text(date.to_s(:govuk_date_and_time))
+    end
+
+    it "displays the reason for withdrawal" do
+      expect(component).to have_text("#{I18n.t('components.timeline.withdrawal_reason')}: became lazy")
+    end
+
+    it "displays the date of withdrawal" do
+      expect(component).to have_text("#{I18n.t('components.timeline.withdrawal_date')}: #{withdrawal_date.strftime('%e %B %Y')}")
     end
   end
 end

--- a/spec/services/trainees/create_timeline_spec.rb
+++ b/spec/services/trainees/create_timeline_spec.rb
@@ -47,6 +47,21 @@ module Trainees
           expect(subject.map(&:date)).to eq(expected_order)
         end
       end
+
+      context "when a trainee has been withdrawn" do
+        let(:trainee) { create(:trainee, :trn_received) }
+
+        before do
+          trainee.withdraw_date = "2021-09-21"
+          trainee.withdraw_reason = WithdrawalReasons::FOR_ANOTHER_REASON
+          trainee.additional_withdraw_reason = "lost interest"
+          trainee.withdraw!
+        end
+
+        it "returns the date of withdrawal in the correct format and reason" do
+          expect(subject.first.items).to eq([["Date of withdrawal:", "21 September 2021"], ["Reason for withdrawal:", "Lost interest"]])
+        end
+      end
     end
 
     def update_name


### PR DESCRIPTION
### Context

Surfacing the withdrawal date and reason on the timeline.

### Changes proposed in this pull request

- Pass items method containing the withdraw date and reason to the TimelineEvent
- Add withdrawal date and reason if trainee state is 'withdrawn'
- If the `withdraw_reason` is `for_another_reason` surface the `additional_withdraw_reason`

### Guidance to review

- Navigate to a 'withdrawable' trainee
- Check the timeline is as it should be
- Withdraw the trainee
- Check that the correct reason and date is displayed on the timeline
- Repeat for the different `Reasons for leaving` and try entering free text too using the `For another reason` radio button
- Repeat for a couple of different trainees

### Screenshot

![image](https://user-images.githubusercontent.com/50492247/138527194-0cf4a186-cdf3-4915-b6ef-f57efe9373fd.png)
