### PR TITLE
Reduce timeline heading levels

### DIFF
--- a/app/components/timeline/view.html.erb
+++ b/app/components/timeline/view.html.erb
@@ -3,7 +3,7 @@
   <% events.map do |event| %>
     <div class="app-timeline__item">
       <div class="app-timeline__header">
-        <h2 class="app-timeline__title"><%= event.title %></h2>
+        <h3 class="app-timeline__title"><%= event.title %></h3>
       </div>
       <p class="app-timeline__actor_and_date">
         <%= actor_for(event) %>


### PR DESCRIPTION
These appear to be at the wrong level - there's already an h2 `Timeline` so these should be one level lower.