### PR TITLE
[3059] Bugfix where education phase is not set/available

### DIFF
--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -44,7 +44,7 @@ module CourseDetails
 
     def education_phase
       if non_early_year_route?
-        mappable_field(trainee.course_education_phase&.upcase_first,
+        mappable_field(data_model.course_education_phase&.upcase_first,
                        t("components.course_detail.education_phase"),
                        action_url: edit_trainee_course_education_phase_path(trainee))
       end

--- a/app/controllers/trainees/course_details_controller.rb
+++ b/app/controllers/trainees/course_details_controller.rb
@@ -15,6 +15,7 @@ module Trainees
 
     def edit
       @course_details_form = CourseDetailsForm.new(trainee)
+      redirect_to(edit_trainee_course_education_phase_path(trainee)) if requires_education_phase?
     end
 
     def update
@@ -32,6 +33,10 @@ module Trainees
     end
 
   private
+
+    def requires_education_phase?
+      !@trainee.early_years_route? && @course_details_form.course_education_phase.blank?
+    end
 
     def date_conversion
       @date_conversion ||= DATE_CONVERSION.transform_keys do |key|

--- a/app/forms/apply_applications/confirm_course_form.rb
+++ b/app/forms/apply_applications/confirm_course_form.rb
@@ -64,6 +64,10 @@ module ApplyApplications
       course&.study_mode || trainee.study_mode
     end
 
+    def course_education_phase
+      @course_education_phase ||= ::CourseEducationPhaseForm.new(trainee).course_education_phase
+    end
+
   private
 
     def update_trainee_attributes

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -104,8 +104,12 @@ class CourseDetailsForm < TraineeForm
     !trainee.early_years_route?
   end
 
+  def course_education_phase
+    @course_education_phase ||= ::CourseEducationPhaseForm.new(trainee).course_education_phase
+  end
+
   def is_primary_phase?
-    trainee.course_education_phase == COURSE_EDUCATION_PHASE_ENUMS[:primary]
+    course_education_phase == COURSE_EDUCATION_PHASE_ENUMS[:primary]
   end
 
   def attrs_from_course_age_range(course_age_range)
@@ -169,6 +173,7 @@ private
       course_uuid: course_uuid,
       course_start_date: course_start_date,
       course_end_date: course_end_date,
+      course_education_phase: course_education_phase,
     }
 
     set_course_subject_from_primary_phase if is_primary_phase?

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -104,6 +104,10 @@ class PublishCourseDetailsForm < TraineeForm
     super
   end
 
+  def course_education_phase
+    @course_education_phase ||= ::CourseEducationPhaseForm.new(trainee).course_education_phase
+  end
+
 private
 
   def update_stashed_attrs_to_new_course_attrs

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -24,7 +24,7 @@
                                            legend: { text: t(".age_range_label"), size: "s" },
                                            classes: "age_range") do %>
 
-          <% main_age_ranges_options(level: @trainee.course_education_phase).each_with_index do |age_range, index| %>
+          <% main_age_ranges_options(level: @course_details_form.course_education_phase).each_with_index do |age_range, index| %>
             <%= f.govuk_radio_button(:main_age_range, age_range,
                                      label: { text: age_range },
                                      link_errors: index.zero?) %>
@@ -37,7 +37,7 @@
                                    label: { text: t(".other_age_range_label") }) do %>
 
             <%= f.govuk_collection_select(:additional_age_range,
-                                          additional_age_ranges_options(level: @trainee.course_education_phase),
+                                          additional_age_ranges_options(level: @course_details_form.course_education_phase),
                                           :value,
                                           :text,
                                           label: { text: t(".additional_age_range_label") }) %>

--- a/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
@@ -14,6 +14,12 @@ feature "course details", type: :feature do
       and_i_submit_the_form
       then_i_see_error_messages
     end
+
+    scenario "when the education phase is not selected" do
+      given_a_trainee_exists
+      when_i_visit_the_course_details_page
+      then_i_am_redirected_to_the_edit_course_education_phase_page
+    end
   end
 
   context "trainee has existing course details" do
@@ -174,6 +180,10 @@ private
 
   def then_i_am_redirected_to_the_confirm_page
     expect(confirm_details_page).to be_displayed(id: trainee.slug, section: course_details_section)
+  end
+
+  def then_i_am_redirected_to_the_edit_course_education_phase_page
+    expect(course_education_phase_page).to be_displayed(id: trainee.slug)
   end
 
   def course_details_section

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -478,6 +478,24 @@ describe CourseDetailsForm, type: :model do
           .and change { trainee.progress.funding }.from(true).to(false)
         end
       end
+
+      context "with a non-draft updating the course details" do
+        let(:trainee) { create(:trainee, :with_secondary_course_details, :trn_received) }
+
+        let(:described_instance) { described_class.new(trainee, params: params, store: form_store) }
+
+        subject { described_instance.save! }
+
+        before do
+          allow(described_instance).to receive(:course_education_phase).and_return(COURSE_EDUCATION_PHASE_ENUMS[:primary])
+        end
+
+        it "updates the course education phase" do
+          expect { subject }
+            .to change { trainee.course_education_phase }
+            .from(trainee.course_education_phase).to(COURSE_EDUCATION_PHASE_ENUMS[:primary])
+        end
+      end
     end
 
     describe "#stash" do


### PR DESCRIPTION
### Context
On changing route, since we clear out the course details section, and the user tries to enter course details, the age range is broken. This happens as the age range is dependent on the course education phase (primary/secondary) and the user should be expected to add that in first.

### Changes proposed in this pull request
1. Fix to ensure that the user is redirected to course education step if they attempt to visit the course details page, and the education phase is not yet set.
2. Ensure that stashed course details are shown/updated on non-draft trainees. (including in the confirmation view)

### Guidance to review
On non-draft trainees, try changing the course details. 
1. When the education phase is not present (note that this can only happen when a trainee's route is manually changed by us)
This should redirect you to the course education phase form.

2. When the education phase is present, try changing it, to a different value. The primary/secondary form should be rendered based on your selection.
Complete the form, view the confirmation page, and update the record. The updated details should be persisted against the trainee.
 
