### PR TITLE
[xxx] Wire up unless option for TrnSubmissionForm

### DIFF
--- a/app/forms/trn_submission_form.rb
+++ b/app/forms/trn_submission_form.rb
@@ -74,6 +74,7 @@ private
     keys = []
     form_validators.each do |validator, options|
       next if (condition = options[:if]) && !public_send(condition)
+      next if (condition = options[:unless]) && public_send(condition)
 
       keys << validator
     end

--- a/spec/forms/trn_submission_form_spec.rb
+++ b/spec/forms/trn_submission_form_spec.rb
@@ -56,6 +56,22 @@ describe TrnSubmissionForm, type: :model do
           expect(subject.errors).to be_empty
         end
       end
+
+      context "apply application" do
+        let(:trainee) do
+          create(
+            :trainee,
+            :completed,
+            :with_apply_application,
+            progress: progress.merge(trainee_data: true),
+          )
+        end
+
+        it "is valid" do
+          expect(subject.valid?).to be true
+          expect(subject.errors).to be_empty
+        end
+      end
     end
 
     context "when any section is invalid or incomplete" do


### PR DESCRIPTION

The `TrnSubmissionForm` is used to check whether a trainee is valid for TRN submission. It dynamically validates a trainee's state based on their route. There's a private method `progress_keys` which returns the correct keys for the forms to use to validate against. 

This PR wires up an `unless` option so that the keys for the correct forms are returned when using it (looks like this wasn't quite hooked up yet)

These keys: 

<img width="619" alt="Screenshot 2021-10-26 at 16 36 24" src="https://user-images.githubusercontent.com/616080/138914429-b5ea8048-a4a8-4ae2-9b26-d7593a5314f7.png">

Reflect the correct section forms for an apply trainee for eg:

<img width="724" alt="Screenshot 2021-10-26 at 16 36 18" src="https://user-images.githubusercontent.com/616080/138914526-9b806784-0475-4358-a3d7-4ad3264121a8.png">


