### PR TITLE
Use load_from_hash! to ensure stale cron jobs are deleted

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -10,10 +10,6 @@ if ENV.key?("VCAP_SERVICES")
     config.redis = {
       url: redis_credentials["uri"],
     }
-
-    if Settings.bg_jobs
-      Sidekiq::Cron::Job.load_from_hash(Settings.bg_jobs)
-    end
   end
 
   Sidekiq.configure_client do |config|
@@ -25,5 +21,5 @@ end
 
 # Sidekiq Cron
 if Settings.sidekiq.schedule_file && Sidekiq.server?
-  Sidekiq::Cron::Job.load_from_hash(YAML.load_file(Settings.sidekiq.schedule_file))
+  Sidekiq::Cron::Job.load_from_hash!(YAML.load_file(Settings.sidekiq.schedule_file))
 end


### PR DESCRIPTION
### Context
We removed the consistency checks in https://github.com/DFE-Digital/register-trainee-teachers/pull/1656, but the jobs seem to continue to be queued daily. At 2AM.
To get rid of the :ghost: of `Dttp::RunConsistencyChecksJob`, when loading the sidekiq cron config, we need to use the bang version of `load_from_hash!`.

### Changes proposed in this pull request

Use `load_from_hash!` as described in https://github.com/ondrejbartas/sidekiq-cron/issues/267

Also remove a bit of unused code.