### PR TITLE
Fix csv spec flake

### DIFF
--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
 
       subject { Dttp::CodeSets::DegreeSubjects::MAPPING.keys.sample }
 
-      institution { "The Surrey Institute of Art and Design, University College" }
+      institution { Dttp::CodeSets::Institutions::MAPPING.keys.sample }
       grade { Dttp::CodeSets::Grades::MAPPING.keys.sample }
       graduation_year { rand(NEXT_YEAR - Degree::MAX_GRAD_YEARS..NEXT_YEAR) }
     end

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -7,7 +7,6 @@ module Exports
     let(:trainee) do
       create(
         :trainee,
-        :with_degree,
         :with_primary_course_details,
         :submitted_for_trn,
         :trn_received,
@@ -26,8 +25,10 @@ module Exports
         training_initiative: "transition_to_teach",
         applying_for_bursary: true,
         international_address: "Test addr",
+        degrees: degrees,
       )
     end
+    let(:degrees) { [build(:degree, :uk_degree_with_details, institution: Dttp::CodeSets::Institutions::MAPPING.keys.first)] }
     let(:funding_manager) do
       FundingManager.new(trainee)
     end


### PR DESCRIPTION
### Context
Having a institution name like "The Surrey Institute of Art and Design, University College"
will cause the generated CSV to add double quotes around it to avoid it from spilling into two columns.

### Changes proposed in this pull request
This change ensures that the degree institution is fixed to the first available value in `Dttp::CodeSets::Institutions::MAPPING` to make the test deterministic.

### Guidance to review
Run `bundle exec rspec ./spec/services/exports/trainee_search_data_spec.rb` against each of the commits to verify the change.
