### PR TITLE
[3029] Allow route change on apply drafts

### DIFF
--- a/app/components/route_indicator/view.rb
+++ b/app/components/route_indicator/view.rb
@@ -16,9 +16,17 @@ module RouteIndicator
 
     def display_text
       if trainee.apply_application?
-        t(".apply_display_text", course_with_code: course_with_code.upcase_first, training_route: training_route.downcase)
+        apply_text
       else
         t(".display_text", training_route_link: training_route_link).html_safe
+      end
+    end
+
+    def apply_text
+      if course_with_code.present?
+        t(".apply_display_text_with_course", course_with_code: course_with_code.upcase_first, training_route: training_route_link).html_safe
+      else
+        t(".apply_display_text_without_course", training_route: training_route_link).html_safe
       end
     end
 
@@ -41,9 +49,8 @@ module RouteIndicator
     end
 
     def apply_course_code
-      return if trainee.apply_application.course.blank?
-
-      "(#{trainee.published_course&.code || trainee.apply_application.course.code})"
+      code = (trainee.published_course || trainee.apply_application.course)&.code
+      "(#{code})" if code.present?
     end
 
     def training_route

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(i18n_key: "trainees.course_details.edit", has_errors: @publish_course_details_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -745,7 +745,8 @@ en:
   route_indicator:
     view:
       display_text: "Trainee on the %{training_route_link} route."
-      apply_display_text: "All conditions met and trainee recruited to %{course_with_code}, %{training_route}."
+      apply_display_text_with_course: "All conditions met and trainee recruited to %{course_with_code}, on the %{training_route} route."
+      apply_display_text_without_course: "All conditions met and trainee on the %{training_route} route."
   error_summary:
     view:
       heading: There is a problem
@@ -794,7 +795,7 @@ en:
       edit:
         heading: What course are they doing?
         course_not_listed: Another course not listed
-        enter_course_details: Enter course details
+        enter_course_details: Enter course details manually
         summary_with_route: &summary_with_route "%{summary}, %{route}"
     language_specialisms:
       edit:

--- a/spec/components/route_indicator/view_preview.rb
+++ b/spec/components/route_indicator/view_preview.rb
@@ -13,6 +13,7 @@ module RouteIndicator
           apply_application: ApplyApplication.new(application: { attributes: {} }),
           course_subject_one: "Ancient Hebrew",
           course_uuid: SecureRandom.uuid,
+          provider: Provider.new(name: "Provider A"),
         )))
       end
     end

--- a/spec/components/route_indicator/view_spec.rb
+++ b/spec/components/route_indicator/view_spec.rb
@@ -32,7 +32,11 @@ RSpec.describe RouteIndicator::View do
       expect(component).to have_content(trainee.course_subject_one.upcase_first)
     end
 
-    context "with course details not set" do
+    it "renders the correct training route link" do
+      expect(component).to have_link(href: "/trainees/#{trainee.slug}/training-routes/edit")
+    end
+
+    context "with course details set" do
       let(:trainee) do
         create(:trainee, :with_apply_application, course_uuid: nil) do |trainee|
           create(:course, name: "Citizenship", uuid: ApiStubs::ApplyApi.course[:course_uuid], code: ApiStubs::ApplyApi.course[:course_code], provider: trainee.apply_application.provider)
@@ -41,7 +45,17 @@ RSpec.describe RouteIndicator::View do
 
       it "renders the apply application's course code" do
         expect(component).to have_content("Citizenship (V6X1)")
-        expect(component).to have_content("assessment only.")
+        expect(component).to have_content("assessment only route.")
+        expect(component).to have_content("recruited to")
+      end
+    end
+
+    context "with course details not set" do
+      let(:trainee) { create(:trainee, :with_apply_application) }
+
+      it "does not render course details" do
+        expect(component).not_to have_content("recruited to")
+        expect(component).not_to have_content("Citizenship (V6X1)")
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/nYZYSq7v/3029-m-allow-route-change-on-apply-drafts
Clears courses and funding when route is changed, same as manual drafts

### Changes proposed in this pull request
Alter route indicator component as per https://github.com/DFE-Digital/register-trainee-teachers-prototype/pull/381
Change manual option text for publish course flow but this isn't being used in the service currently? (bug?)

### Guidance to review
Create or view apply draft trainee. 
See that text changes on the route indicator inset text:
1)  When course picked
2) After course is cleared when the route is changed

