### PR TITLE
[3052] Ensure changes to route are updated in DTTP

### DIFF
--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -31,7 +31,6 @@ module Dttp
         if contact_change_set_id
           @params.merge!({
             "dfe_ContactId@odata.bind" => "$#{contact_change_set_id}",
-            "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id(training_route)})",
           })
         end
       end
@@ -44,6 +43,7 @@ module Dttp
 
       def build_params
         {
+          "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id(training_route)})",
           "dfe_CoursePhaseId@odata.bind" => "/dfe_coursephases(#{course_phase_id(trainee.course_age_range)})",
           "dfe_programmestartdate" => trainee.course_start_date.in_time_zone.iso8601,
           "dfe_programmeenddate" => trainee.course_end_date.in_time_zone.iso8601,

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -188,6 +188,12 @@ module Dttp
               { "dfe_ContactId@odata.bind" => "$#{contact_change_set_id}" },
             )
           end
+
+          it "includes route" do
+            expect(subject).to include(
+              { "dfe_RouteId@odata.bind" => "/dfe_routes(#{dttp_route_id})" },
+            )
+          end
         end
 
         context "Future Teaching Scholars route" do


### PR DESCRIPTION
### Context
Currently, changes to a route are only sent through to DTTP if `contact_change_set_id` is available.
We need the route change to be sent through to DTTP to ensure that when trainee routes are changed in register, regardless of `contact_change_set_id`

### Changes proposed in this pull request
Always send route info to DTTP.

