### PR TITLE
[xxx] Refactor sorted autocomplete code

### DIFF
--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -7,11 +7,14 @@ import tracker from '../tracker.js'
 const $allAutocompleteElements = document.querySelectorAll('[data-module="app-autocomplete"]')
 const defaultValueOption = component => component.getAttribute('data-default-value') || ''
 
-const suggestion = (value, options) => {
-  const option = options.find(o => o.name === value)
-  if (option) {
-    return option.append ? `<span>${value}</span> ${option.append}` : `<span>${value}</span>`
+const suggestionTemplate = (value) => {
+  if (value) {
+    return value.append ? `<span>${value.name}</span> ${value.append}` : `<span>${value.name}</span>`
   }
+}
+
+const inputTemplate = (value) => {
+  return value && value.name
 }
 
 const enhanceOption = (option) => {
@@ -45,7 +48,10 @@ const setupAutoComplete = (component) => {
       populateResults(sort(query, options))
     },
     autoselect: true,
-    templates: { suggestion: (value) => suggestion(value, options) },
+    templates: {
+      inputValue: inputTemplate,
+      suggestion: suggestionTemplate
+    },
     name: rawFieldName,
     onConfirm: (val) => {
       tracker.sendTrackingEvent(val, selectEl.name)

--- a/app/components/form_components/autocomplete/sort.js
+++ b/app/components/form_components/autocomplete/sort.js
@@ -66,5 +66,4 @@ export default (query, options) => {
 
   return options.filter(o => o.weight > 0)
     .sort(byWeightThenAlphabetically)
-    .map(o => o.name)
 }


### PR DESCRIPTION
Just trying something out.

### Context

Ed said "why you do dis?" and he was right.

### Changes proposed in this pull request

Turns out `populateResults` works with an object, not just a string array. So if makes sense to pass around the object with its metadata.

### Guidance to review

The autocompletes (e.g. on degree sections) should work the same.