### PR TITLE
[3085] Fix edit contact details link

### DIFF
--- a/app/components/contact_details/view.rb
+++ b/app/components/contact_details/view.rb
@@ -58,7 +58,7 @@ module ContactDetails
     end
 
     def mappable_field(field_value, field_label)
-      { field_value: field_value, field_label: field_label, action_url: trainee_contact_details_path(trainee) }
+      { field_value: field_value, field_label: field_label, action_url: edit_trainee_contact_details_path(trainee) }
     end
   end
 end

--- a/spec/components/contact_details/view_spec.rb
+++ b/spec/components/contact_details/view_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe ContactDetails::View do
       expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 2)
     end
 
+    it "renders the contact details change link" do
+      expect(rendered_component)
+        .to have_link(t("change"), href: "/trainees/#{mock_trainee.slug}/contact-details/edit")
+    end
+
     it "renders the address" do
       expect(rendered_component)
         .to have_text([


### PR DESCRIPTION
### Context

Fixes https://trello.com/c/LScHLBLA/3085-cannot-edit-contact-details-on-apply-drafts
Contact details edit link was pointing to a non existent route, and triggering a 404.
![image](https://user-images.githubusercontent.com/910019/139220070-52841431-b7b0-496f-befd-c2f69854c950.png)


### Changes proposed in this pull request
Use the correct edit route.

### Guidance to review
:shipit: 
1. Have a draft trainee 
2. Visit "Trainee Data" and attempt to edit the contact details section
3. Contact details form should be rendered
