### PR TITLE
[3074] Fixed dupe browser history

### DIFF
--- a/app/webpacker/scripts/live_filter.js
+++ b/app/webpacker/scripts/live_filter.js
@@ -17,7 +17,7 @@ export default class LiveFilter {
     if (!(this.form && this.resultsDiv && this.selectedFiltersDiv)) return
 
     this.saveState()
-    this.addStateToHistory()
+    this.setInitialStateToHistory()
     this.hideButton()
     this.bindEvents()
   }
@@ -102,8 +102,8 @@ export default class LiveFilter {
     }
   }
 
-  addStateToHistory () {
-    window.history.pushState(this.state, '')
+  setInitialStateToHistory () {
+    window.history.replaceState(this.state, '')
   }
 
   formChange () {


### PR DESCRIPTION
### Context
Duplicated history

### Changes proposed in this pull request
Replace vs push state in the offending code

### Guidance to review
When page first loads it is added in the browser history, when javascript loads it is then added to browser history hence the duplication.

 
![dupe-history](https://user-images.githubusercontent.com/470137/139428077-3c7312d4-c4b6-4e2b-8b6d-80ba710e5b84.gif)


