### PR TITLE
[3093] Rake task to bulk submit HPITT trainees

### DIFF
--- a/lib/tasks/hpitt_bulk_submit.rake
+++ b/lib/tasks/hpitt_bulk_submit.rake
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+namespace :hpitt do
+  desc "Task to submit all of the HPITT records for TRN"
+  task bulk_submit: :environment do
+    trainees_to_exclude = %w[0034G00002fqS22QAE]
+    teach_first_provider_id = 209
+    teach_first = Provider.find(teach_first_provider_id)
+    teach_first_user_dttp_id = "7004f0e7-2506-ea11-a811-000d3ab4df6c"
+
+    current_interval = 0
+    interval_increment = 15
+    batch_size = 10
+
+    teach_first.trainees.draft.find_in_batches(batch_size: batch_size) do |trainee_group|
+      trainee_group.each do |trainee|
+        next if trainees_to_exclude.include?(trainee.trainee_id)
+
+        next unless TrnSubmissionForm.new(trainee: trainee).valid?
+
+        trainee.submit_for_trn!
+
+        Dttp::RegisterForTrnJob.set(wait: current_interval.seconds).perform_later(trainee, teach_first_user_dttp_id)
+        Dttp::RetrieveTrnJob.perform_with_default_delay(trainee)
+      end
+      current_interval += interval_increment
+    end
+  end
+end


### PR DESCRIPTION


One trainee isn't ready to be submitted so they are excluded.

### Context

We need to bulk submit ~1500 trainees on the HPITT program that are now ready to be submitted for TRN.

### Changes proposed in this pull request

Add a rake task to do this.

The task:

* loops through the HPITT trainees in batches of 10
* if they are valid and draft sets them to submitted
* queues up a job to register them
* queues up a job to poll for the TRN
* increments the delay by 15 seconds after each batch to limit the load
  on DTTP

It doesn't log any that aren't valid as these will just remain draft so we'll be able to track that in the app.

### Guidance to review

This can be run locally on the sanitised prod dump without sidekiq running.

3040 jobs will be put into the ScheduledSet - 2 jobs per trainee.

All of the HPITT trainees will be set to `submitted_for_trn` and the `submitted_at` date will be now(ish)

