### PR TITLE
[3099] Map HPITT route to DTTP

### DIFF
--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -17,6 +17,7 @@ module Dttp
         ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars] => { entity_id: "e7b6efbc-8d96-ea11-a811-000d3ab55801" },
         TRAINING_ROUTE_ENUMS[:early_years_salaried] => { entity_id: "6989922e-acc2-e611-80be-00155d010316" },
         TRAINING_ROUTE_ENUMS[:opt_in_undergrad] => { entity_id: "51a5f96f-e122-e811-80ec-005056ac45bb" },
+        TRAINING_ROUTE_ENUMS[:hpitt_postgrad] => { entity_id: "7b89922e-acc2-e611-80be-00155d010316" },
       }.freeze
     end
   end


### PR DESCRIPTION
### Context

We map our routes in register to their equivalent in DTTP.

### Changes proposed in this pull request

Add DTTP route id for `:hpitt_postgrad`

### Guidance to review

The route in DTTP:

<img width="628" alt="Screenshot 2021-10-29 at 15 08 13" src="https://user-images.githubusercontent.com/5216/139451608-76529709-5cd0-4d30-ae47-9eaffa0f9461.png">

