### PR TITLE
[3099] Map qualification aim for HPITT

### DIFF
--- a/app/lib/dttp/code_sets/qualification_aims.rb
+++ b/app/lib/dttp/code_sets/qualification_aims.rb
@@ -20,6 +20,7 @@ module Dttp
         TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => { entity_id: "d4113eff-141e-e711-80c8-0050568902d3" },
         TRAINING_ROUTE_ENUMS[:early_years_salaried] => { entity_id: EYTS },
         TRAINING_ROUTE_ENUMS[:opt_in_undergrad] => { entity_id: QTS },
+        TRAINING_ROUTE_ENUMS[:hpitt_postgrad] => { entity_id: QTS },
       }.freeze
     end
   end


### PR DESCRIPTION
### Context

We map routes to qualification aims in DTTP. The HPITT route is missing a mapping.

### Changes proposed in this pull request

Map the HPITT route to the QTS qualification aim.

### Guidance to review

