### PR TITLE
[xxx] Fix region entity name

### DIFF
--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -171,7 +171,7 @@ module Dttp
         return {} unless trainee.hpitt_provider?
 
         {
-          "dfe_GovernmentOfficeRegionId@odata.bind" => "/dfe_regions(#{region_id(trainee.region)})",
+          "dfe_GovernmentOfficeRegionId@odata.bind" => "/dfe_goregions(#{region_id(trainee.region)})",
         }
       end
 

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -558,7 +558,7 @@ module Dttp
 
           it "returns a hash including the region" do
             expect(subject).to include({
-              "dfe_GovernmentOfficeRegionId@odata.bind" => "/dfe_regions(#{expected_region_id})",
+              "dfe_GovernmentOfficeRegionId@odata.bind" => "/dfe_goregions(#{expected_region_id})",
             })
           end
         end


### PR DESCRIPTION
### Context

HPITT trainees have a 'region'. The entity for regions in DTTP is `dfe_goregions` not `dfe_regions`

### Changes proposed in this pull request

Fix it.

### Guidance to review

