### PR TITLE
[3054] Bug - course_summary is not updating to 'QTS part-time'

### DIFF
--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -89,7 +89,7 @@ module Exports
           "course_start_date" => trainee.course_start_date&.iso8601,
           "course_end_date" => trainee.course_end_date&.iso8601,
           "course_duration_in_years" => trainee.course_duration_in_years,
-          "course_summary" => course&.summary,
+          "course_summary" => course_summary(trainee, course),
           "commencement_date" => trainee.commencement_date&.iso8601,
           "lead_school_name" => trainee.lead_school&.name,
           "lead_school_urn" => trainee.lead_school&.urn,
@@ -107,6 +107,17 @@ module Exports
           "withdraw_reason" => trainee.withdraw_reason,
           "additional_withdraw_reason" => trainee.additional_withdraw_reason,
         }
+      end
+    end
+
+    def course_summary(trainee, course)
+      return if course&.summary.blank?
+
+      case trainee.study_mode
+      when "part_time"
+        course.summary.gsub(/(full time)/i, "part time")
+      when "full_time"
+        course.summary.gsub(/(part time)/i, "full time")
       end
     end
 

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -177,5 +177,37 @@ module Exports
         expect(subject.send(:funding_method, trainee)).to eq("not funded")
       end
     end
+
+    describe "#course_summary" do
+      it "returns blank" do
+        trainee = Trainee.new(study_mode: "full_time")
+        course = Course.new(summary: nil)
+        expect(subject.send(:course_summary, trainee, course)).to be_nil
+
+        trainee = Trainee.new(study_mode: nil)
+        course = Course.new(summary: "PGCE full time")
+        expect(subject.send(:course_summary, trainee, course)).to be_nil
+      end
+
+      it "returns full time" do
+        trainee = Trainee.new(study_mode: "full_time")
+        course = Course.new(summary: "PGCE full time")
+        expect(subject.send(:course_summary, trainee, course)).to eq("PGCE full time")
+
+        trainee = Trainee.new(study_mode: "full_time")
+        course = Course.new(summary: "PGCE part time")
+        expect(subject.send(:course_summary, trainee, course)).to eq("PGCE full time")
+      end
+
+      it "returns part time" do
+        trainee = Trainee.new(study_mode: "part_time")
+        course = Course.new(summary: "PGCE with QTS part time")
+        expect(subject.send(:course_summary, trainee, course)).to eq("PGCE with QTS part time")
+
+        trainee = Trainee.new(study_mode: "part_time")
+        course = Course.new(summary: "PGCE with QTS full time")
+        expect(subject.send(:course_summary, trainee, course)).to eq("PGCE with QTS part time")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/ZQFStVkA/3054-bug-coursesummary-is-not-updating-to-qts-part-time

### Changes proposed in this pull request

* `Course.course_summary` is dynamically updated with `trainee.study_mode`

### Guidance to review

