### PR TITLE
[3105] Sort degrees chronologically using graduation year

### DIFF
--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -6,6 +6,7 @@ class Degree < ApplicationRecord
   INSTITUTIONS = Dttp::CodeSets::Institutions::MAPPING.keys
   SUBJECTS = Dttp::CodeSets::DegreeSubjects::MAPPING.keys
   DEGREE_TYPES = Dttp::CodeSets::DegreeTypes::MAPPING.keys
+  MAX_GRAD_YEARS = 60
 
   attr_writer :is_apply_import
 
@@ -28,7 +29,7 @@ class Degree < ApplicationRecord
 
   audited associated_with: :trainee
 
-  MAX_GRAD_YEARS = 60
+  default_scope { order(graduation_year: :asc) }
 
   def graduation_year_valid
     errors.add(:graduation_year, :future) if graduation_year > next_year

--- a/spec/forms/degrees_form_spec.rb
+++ b/spec/forms/degrees_form_spec.rb
@@ -106,8 +106,8 @@ describe DegreesForm, type: :model do
   end
 
   describe "#degrees" do
-    let(:degree1) { build(:degree, :uk_degree_with_details, trainee: trainee) }
-    let(:degree2) { build(:degree, :non_uk_degree_with_details, trainee: trainee) }
+    let(:degree1) { build(:degree, :uk_degree_with_details, trainee: trainee, graduation_year: 2020) }
+    let(:degree2) { build(:degree, :non_uk_degree_with_details, trainee: trainee, graduation_year: 2021) }
 
     before do
       allow(form_store).to receive(:get).and_return({

--- a/spec/models/degree_spec.rb
+++ b/spec/models/degree_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Degree, type: :model do
     it { is_expected.to belong_to(:trainee) }
   end
 
+  describe "default scope" do
+    it { expect(Degree.all.to_sql).to eq(Degree.all.order(graduation_year: :asc).to_sql) }
+  end
+
   describe "validation" do
     context "when locale code is present" do
       it "expect it to be valid" do


### PR DESCRIPTION
### Context
https://trello.com/c/X7QI3sDi/3105-sort-degrees-chronologically-when-importing-from-apply

### Changes proposed in this pull request
- Add `default_scope` to `Degree` so that the UI renders degrees chronologically (oldest to newest)