### PR TITLE
[3104] Multi-synonym bug in autocomplete

### DIFF
--- a/app/components/form_components/autocomplete/sort.js
+++ b/app/components/form_components/autocomplete/sort.js
@@ -13,14 +13,11 @@ const calculateWeight = (rawName, query, rawSynonyms = []) => {
   const synonyms = rawSynonyms.map(s => clean(s))
 
   const nameMatchPositions = matchPositions(name, regexes)
-  const synonymMatchPositions = synonyms
-    .map(synonym => matchPositions(synonym, regexes))
-    // Flatten the array, but don't use flat() - breaks on Edge.
-    .reduce((acc, val) => acc.concat(val), [])
+  const synonymMatchPositions = synonyms.map(synonym => matchPositions(synonym, regexes))
 
   // Require either all parts of a name to be matched, or all parts of a synonym
   const allNameMatches = nameMatchPositions.length === regexes.length
-  const allSynonymMatches = synonymMatchPositions.length >= regexes.length
+  const allSynonymMatches = synonymMatchPositions.some(x => x.length === regexes.length)
   if (!allNameMatches && !allSynonymMatches) return 0
 
   // Case insensitive exact matches:
@@ -29,9 +26,9 @@ const calculateWeight = (rawName, query, rawSynonyms = []) => {
 
   // Case insensitive 'starts with':
   const nameStartsWithQuery = nameMatchPositions.includes(0)
-  const synonymStartsWithQuery = synonymMatchPositions.includes(0)
+  const synonymStartsWithQuery = synonymMatchPositions.some(x => x.includes(0))
   const wordInNameStartsWithQuery = nameMatchPositions.length > 0
-  const wordInSynonymStartsWithQuery = synonymMatchPositions.length > 0
+  const wordInSynonymStartsWithQuery = synonymMatchPositions.some(x => x.length > 0)
 
   if (nameIsExactMatch) return 100
   if (synonymIsExactMatch) return 75

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -5,8 +5,9 @@ module DegreesHelper
 
   def degree_type_options
     to_enhanced_options(degree_type_data) do |name, attributes|
+      synonyms = (attributes[:synonyms] || []) << attributes[:abbreviation]
       data = {
-        "data-synonyms" => (attributes[:synonyms] || []) << attributes[:abbreviation],
+        "data-synonyms" => synonyms.join("|"),
         "data-append" => attributes[:abbreviation] && tag.strong("(#{attributes[:abbreviation]})"),
         "data-boost" => (Dttp::CodeSets::DegreeTypes::COMMON.include?(name) ? 1.5 : 1),
       }
@@ -16,13 +17,13 @@ module DegreesHelper
 
   def institutions_options
     to_enhanced_options(institution_data) do |name, attributes|
-      [name, name, { "data-synonyms" => attributes[:synonyms] }]
+      [name, name, { "data-synonyms" => (attributes[:synonyms] || []).join("|") }]
     end
   end
 
   def subjects_options
     to_enhanced_options(subject_data) do |name, attributes|
-      [name, name, { "data-synonyms" => attributes[:synonyms] }]
+      [name, name, { "data-synonyms" => (attributes[:synonyms] || []).join("|") }]
     end
   end
 

--- a/app/webpacker/scripts/autocomplete_sort.spec.js
+++ b/app/webpacker/scripts/autocomplete_sort.spec.js
@@ -74,11 +74,17 @@ describe('sort', () => {
     expect(sort('plant', options)).toEqual(['plant b', 'plant a'])
   })
 
-  it('can handle multiple synonyms', () => {
+  it('can handle multiple synonyms - must match all parts', () => {
     const options = [
-      { name: 'plant', synonyms: ['flower', 'leaf'] }
+      { name: 'plant a', synonyms: ['flower thing', 'leaf'] },
+      { name: 'plant b', synonyms: ['nice bear', 'rose plant'] }
     ]
-    expect(sort('leaf flower', options)).toEqual(['plant'])
+    // Doesn't search across synonyms
+    expect(sort('leaf flower', options)).toEqual([])
+    // Doesn't count partial matches in separate synonyms
+    expect(sort('rose bear', options)).toEqual([])
+    // Returns correct match
+    expect(sort('flower thi', options)).toEqual(['plant a'])
   })
 
   it('can handle query with extra punctuation', () => {

--- a/spec/helpers/degree_helper_spec.rb
+++ b/spec/helpers/degree_helper_spec.rb
@@ -26,7 +26,7 @@ describe DegreesHelper do
           {
             "data-append" => "<strong>(#{degree_abbreviation})</strong>",
             "data-boost" => 1.5,
-            "data-synonyms" => [degree_synonym, degree_abbreviation],
+            "data-synonyms" => "#{degree_synonym}|#{degree_abbreviation}",
           },
         ],
       ])
@@ -46,7 +46,7 @@ describe DegreesHelper do
     it "iterates over array and prints out correct institutions options" do
       expect(institutions_options).to match([
         [nil, nil, nil],
-        [institution, institution, { "data-synonyms" => [synonym] }],
+        [institution, institution, { "data-synonyms" => synonym }],
       ])
     end
   end
@@ -64,7 +64,7 @@ describe DegreesHelper do
     it "iterates over array and prints out correct subjects values" do
       expect(subjects_options).to match([
         [nil, nil, nil],
-        [degree_subject, degree_subject, { "data-synonyms" => [synonym] }],
+        [degree_subject, degree_subject, { "data-synonyms" => synonym }],
       ])
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/ugUIdcik/3104-multi-synonym-bug-in-autocomplete

### Changes proposed in this pull request

- Pipe-separate synonyms so that they can be correctly pulled from the data-attribute in JS
- Require **all parts of _at least one_ synonym** to match before progressing onto calculating weights (previously it was reducing the array of synonym matches which didn't make sense)

### Guidance to review