### PR TITLE
Do not raise an Invalid Transition when attempting to receive_trn on an already trn_received trainee

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -209,7 +209,7 @@ class Trainee < ApplicationRecord
 
     # Skip deferred and withdrawn to avoid state change
     # but to still register trn
-    receive_trn! unless deferred? || withdrawn?
+    receive_trn! unless deferred? || withdrawn? || trn_received?
     # A deferred trainee will probably already have a trn - don't overwrite that!
     update!(trn: new_trn) unless trn
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -118,7 +118,7 @@ class Trainee < ApplicationRecord
     end
 
     event :receive_trn do
-      transition %i[submitted_for_trn deferred] => :trn_received
+      transition %i[submitted_for_trn deferred trn_received] => :trn_received
     end
 
     event :recommend_for_award do
@@ -209,7 +209,7 @@ class Trainee < ApplicationRecord
 
     # Skip deferred and withdrawn to avoid state change
     # but to still register trn
-    receive_trn! unless deferred? || withdrawn? || trn_received?
+    receive_trn! unless deferred? || withdrawn?
     # A deferred trainee will probably already have a trn - don't overwrite that!
     update!(trn: new_trn) unless trn
   end

--- a/spec/models/trainee/state_transitions_spec.rb
+++ b/spec/models/trainee/state_transitions_spec.rb
@@ -83,6 +83,33 @@ describe "Trainee state transitions" do
       end
     end
 
+    context "with a :trn_received trainee" do
+      context "with an existing trn" do
+        let(:trainee) { create(:trainee, :trn_received, trn: old_trn) }
+
+        it "updates the trn" do
+          trainee.trn_received!
+          expect(trainee.trn).to eq(old_trn)
+        end
+      end
+
+      context "without an existing trn" do
+        let(:trainee) { create(:trainee, :trn_received, trn: nil) }
+
+        it "raises an error if no trn is provided" do
+          expect {
+            trainee.trn_received!
+          }.to raise_error(StateTransitionError)
+        end
+
+        it "updates the trn but not the trainee state" do
+          trainee.trn_received!(new_trn)
+          expect(trainee.state).to eq("trn_received")
+          expect(trainee.trn).to eq(new_trn)
+        end
+      end
+    end
+
     context "with a :deferred trainee with an existing trn" do
       let(:trainee) { create(:trainee, :deferred, trn: old_trn) }
 

--- a/spec/models/trainee/state_transitions_spec.rb
+++ b/spec/models/trainee/state_transitions_spec.rb
@@ -142,7 +142,7 @@ describe "Trainee state transitions" do
       end
     end
 
-    (Trainee.states.keys - %w[submitted_for_trn deferred]).each do |state|
+    (Trainee.states.keys - %w[submitted_for_trn deferred trn_received]).each do |state|
       context "with a :#{state} trainee" do
         let(:trainee) { create(:trainee, state) }
 


### PR DESCRIPTION
### Context
Potential fix fox https://sentry.io/organizations/dfe-bat/issues/2635933991
Often, if a `Dttp::RetreiveTrnJob` has been requeued, it will fail as the trainee has already transitioned to a `trn_received` state. This PR aims to make that job idempotent.

### Changes proposed in this pull request
Do not raise an `Invalid Transition` exception when retrying `Dttp::RetreiveTrnJob`

### Guidance to review

