### PR TITLE
[3080] School not available validation bug

### DIFF
--- a/app/forms/schools/form.rb
+++ b/app/forms/schools/form.rb
@@ -96,7 +96,7 @@ module Schools
 
     def both_fields_are_not_selected
       if school_id.present? && params[:query].present? && school_not_applicable?
-        errors.add(:school_id, :both_fields_are_present)
+        errors.add(:query, :both_fields_are_present)
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1224,9 +1224,9 @@ en:
           attributes:
             query:
               blank: Enter a school unique reference number (URN), name or postcode
+              both_fields_are_present: Select a lead school or select lead school not applicable
             school_id:
               blank: Select a lead school or search again
-              both_fields_are_present: Select a lead school or select lead school not applicable
             results_search_again_query:
               blank: Enter a school unique reference number (URN), name or postcode
             no_results_search_again_query:
@@ -1235,9 +1235,9 @@ en:
           attributes:
             query:
               blank: Enter a school unique reference number (URN), name or postcode
+              both_fields_are_present: Select an employing school or select employing school not applicable
             school_id:
               blank: Select an employing school or search again
-              both_fields_are_present: Select an employing school or select employing school not applicable
             results_search_again_query:
               blank: Enter a school unique reference number (URN), name or postcode
             no_results_search_again_query:

--- a/spec/support/shared_examples/school_form_validations.rb
+++ b/spec/support/shared_examples/school_form_validations.rb
@@ -35,8 +35,8 @@ RSpec.shared_examples "school form validations" do |school_id_key|
     let(:params) { { school_id_key => "1", school_id_key.sub("id", "not_applicable") => "1", query: "school" } }
 
     it "returns an error" do
-      expect(subject.errors[:school_id]).to include(
-        I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.school_id.both_fields_are_present"),
+      expect(subject.errors[:query]).to include(
+        I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.query.both_fields_are_present"),
       )
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/bVoqgmQ4/3080-school-not-available-validation-issue
### Changes proposed in this pull request
When error is thrown for both fields being selected, the query field is now highlighted in error
### Guidance to review


<img width="1085" alt="Screenshot 2021-11-02 at 12 50 06" src="https://user-images.githubusercontent.com/58793682/139849810-106e3895-0002-423e-a1d0-c2f2b7c5edaa.png">

