### PR TITLE
[3107] Reimport apply applications changed since 09 Dec 2020 14:00

### DIFF
--- a/db/data/20211102125813_reimport_apply_applications_with_course_uuid.rb
+++ b/db/data/20211102125813_reimport_apply_applications_with_course_uuid.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ReimportApplyApplicationsWithCourseUuid < ActiveRecord::Migration[6.1]
+  def up
+    ApplyApi::ImportApplicationsJob.perform_later(from_date: Time.zone.parse("09 Dec 2020 14:00"))
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
Some of the apply applications imported into register are missing the
course uuid that we added in recently. To ensure that we re-import these
applications, we want to trigger the import job by passing in the
`changed_since` parameter to the apply request.

The earliest changed_since/updated_at value found in our database is
Wed, 09 Dec 2020 14:23:24.000000000 UTC +00:00.
Hence this data migration will ensure that we fetch all applications
added/changed since.

### Changes proposed in this pull request
Data migration to re-import all apply applications changed since 9th December 2020

