### PR TITLE
[3100] Incomplete badge snags

### DIFF
--- a/app/components/status_tag/view.rb
+++ b/app/components/status_tag/view.rb
@@ -42,7 +42,7 @@ private
   end
 
   def record_progress_tag
-    return if @trainee.submission_ready?
+    return if @trainee.submission_ready? || !@trainee.awaiting_action?
 
     { status: "incomplete", status_colour: "grey", classes: classes.concat(%w[govuk-tag--white]) }
   end

--- a/app/controllers/trainees/award_recommendations_controller.rb
+++ b/app/controllers/trainees/award_recommendations_controller.rb
@@ -3,7 +3,7 @@
 module Trainees
   class AwardRecommendationsController < BaseController
     def create
-      if OutcomeDateForm.new(trainee).save!
+      if OutcomeDateForm.new(trainee).save! && trainee.submission_ready?
         trainee.recommend_for_award!
 
         Dttp::RecommendForAwardJob.perform_later(trainee)

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -198,7 +198,7 @@ class Trainee < ApplicationRecord
 
   before_save :clear_employing_school_id, if: :employing_school_not_applicable?
   before_save :clear_lead_school_id, if: :lead_school_not_applicable?
-  before_save :set_submission_ready, if: :changed?
+  before_save :set_submission_ready, if: :completion_trackable?
 
   def trn_requested!(dttp_id, placement_assignment_dttp_id)
     update!(dttp_id: dttp_id, placement_assignment_dttp_id: placement_assignment_dttp_id)
@@ -316,6 +316,10 @@ class Trainee < ApplicationRecord
     ((course_end_date - course_start_date) / 365).ceil
   end
 
+  def awaiting_action?
+    !%w[recommended_for_award withdrawn awarded].include?(state)
+  end
+
 private
 
   def value_digest
@@ -340,6 +344,10 @@ private
 
   def clear_lead_school_id
     self.lead_school_id = nil
+  end
+
+  def completion_trackable?
+    changed? && awaiting_action?
   end
 
   def set_submission_ready

--- a/db/data/20211102131145_fix_submission_ready_field.rb
+++ b/db/data/20211102131145_fix_submission_ready_field.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FixSubmissionReadyField < ActiveRecord::Migration[6.1]
+  # Mark this cycle's submissions as ready for the states below as we consider them complete
+  def up
+    states = %w[recommended_for_award withdrawn awarded]
+    Trainee.where(state: states, submission_ready: false).update_all(submission_ready: true)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/components/status_tag/view_spec.rb
+++ b/spec/components/status_tag/view_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe StatusTag::View do
   end
 
   context "with a trainee recommended for EYTS" do
-    let(:trainee) { create(:trainee, :early_years_undergrad, :recommended_for_award) }
+    let(:trainee) { build(:trainee, :early_years_undergrad, :recommended_for_award) }
 
     it "renders the correct status" do
       expect(rendered_component).to have_text("EYTS recommended")
@@ -16,7 +16,7 @@ RSpec.describe StatusTag::View do
   end
 
   context "with a trainee awarded EYTS" do
-    let(:trainee) { create(:trainee, :early_years_undergrad, :awarded) }
+    let(:trainee) { build(:trainee, :early_years_undergrad, :awarded) }
 
     it "renders the correct status" do
       expect(rendered_component).to have_text("EYTS awarded")
@@ -24,7 +24,7 @@ RSpec.describe StatusTag::View do
   end
 
   context "with a trainee recommended for QTS" do
-    let(:trainee) { create(:trainee, :recommended_for_award) }
+    let(:trainee) { build(:trainee, :recommended_for_award) }
 
     it "renders the correct status" do
       expect(rendered_component).to have_text("QTS recommended")
@@ -32,7 +32,7 @@ RSpec.describe StatusTag::View do
   end
 
   context "with a trainee awarded QTS" do
-    let(:trainee) { create(:trainee, :awarded) }
+    let(:trainee) { build(:trainee, :awarded) }
 
     it "renders the correct status" do
       expect(rendered_component).to have_text("QTS awarded")
@@ -40,7 +40,7 @@ RSpec.describe StatusTag::View do
   end
 
   context "with a trainee that's not submission ready" do
-    let(:trainee) { create(:trainee, :not_submission_ready) }
+    let(:trainee) { build(:trainee, :trn_received, :not_submission_ready) }
 
     it "renders the correct status" do
       expect(rendered_component).to have_text("incomplete")

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -193,22 +193,36 @@ describe Trainee do
 
   context "callbacks" do
     describe "submission_ready" do
-      subject { create(:trainee, :completed) }
+      context "when complection is trackable" do
+        subject { create(:trainee, :completed, :draft) }
 
-      context "when trainee has not changed" do
-        it "does not toggle the submission_ready field" do
-          expect { subject.save }.not_to change { subject.submission_ready }
+        context "when trainee has not changed" do
+          it "does not toggle the submission_ready field" do
+            expect { subject.save }.not_to change { subject.submission_ready }
+          end
+        end
+
+        context "when trainee has changed with invalid information" do
+          before do
+            subject.first_names = nil
+          end
+
+          it "toggles the submission_ready field" do
+            expect { subject.save }.to change { subject.submission_ready }
+            expect(subject).not_to(be_submission_ready)
+          end
         end
       end
 
-      context "when trainee has changed with invalid information" do
+      context "when completion is not trackable" do
+        subject { create(:trainee, :completed, :recommended_for_award) }
+
         before do
           subject.first_names = nil
         end
 
-        it "toggles the submission_ready field" do
-          expect { subject.save }.to change { subject.submission_ready }
-          expect(subject).not_to(be_submission_ready)
+        it "does not toggle the submission_ready field" do
+          expect { subject.save }.not_to change { subject.submission_ready }
         end
       end
     end


### PR DESCRIPTION
### Context

- https://trello.com/c/PHOyn4ok/3100-incomplete-badge-snags

### Changes proposed in this pull request

A few snags around the incomplete badge work:

- Conditionally handle tracking completeness only for states waiting on provider action
- Don't show the badge for records considered final
- Fix up 225 records in prod and mark them as complete as per this cycle's requirements

### Guidance to review

