### PR TITLE
Fix unwithdrawn trainees

### DIFF
--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -107,7 +107,7 @@ module Trainees
     end
 
     def items
-      if action == STATE_CHANGE && state_change_action == "withdrawn"
+      if action == STATE_CHANGE && state_change_action == "withdrawn" && auditable.withdraw_date
         [
           ["#{I18n.t('components.timeline.withdrawal_date')}:", auditable.withdraw_date.strftime("%e %B %Y").to_s],
           ["#{I18n.t('components.timeline.withdrawal_reason')}:", (auditable.additional_withdraw_reason&.upcase_first || auditable.withdraw_reason&.humanize).to_s],


### PR DESCRIPTION
### Context

There's a trainee in the system which has a withdrawal audit with no withdrawal date, so its preventing the trainee from being rendered and causing Sentry errors. 

https://sentry.io/organizations/dfe-bat/issues/2763510133/?project=5552118&referrer=slack

### Changes proposed in this pull request

Check that there's a date before trying to render the date.

