### PR TITLE
[3117] Show provider name in record card and record when signed in as an admin

### DIFF
--- a/app/components/application_record_card/view.html.erb
+++ b/app/components/application_record_card/view.html.erb
@@ -13,6 +13,7 @@
     <div class="application-record-card__col">
       <div>
         <%= trainee_id %>
+        <%= provider_name %>
         <%= trn %>      
       </div>
 

--- a/app/components/application_record_card/view.html.erb
+++ b/app/components/application_record_card/view.html.erb
@@ -13,8 +13,8 @@
     <div class="application-record-card__col">
       <div>
         <%= trainee_id %>
-        <%= provider_name %>
         <%= trn %>      
+        <%= provider_name %>
       </div>
 
       <div>

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -8,11 +8,12 @@ module ApplicationRecordCard
 
     with_collection_parameter :record
 
-    attr_reader :record, :heading_level
+    attr_reader :record, :heading_level, :system_admin
 
-    def initialize(heading_level = 3, record:)
+    def initialize(heading_level = 3, record:, system_admin:)
       @record = record
       @heading_level = heading_level
+      @system_admin = system_admin
     end
 
     def trainee_name
@@ -46,6 +47,12 @@ module ApplicationRecordCard
       return if record.trainee_id.blank?
 
       tag.p("Trainee ID: #{record.trainee_id}", class: "govuk-caption-m govuk-!-font-size-16 application-record-card__id govuk-!-margin-top-0 govuk-!-margin-bottom-1")
+    end
+
+    def provider_name
+      return unless system_admin
+
+      tag.p("Provider: #{record.provider.name}", class: "govuk-caption-m govuk-!-font-size-16 application-record-card__provider_name govuk-!-margin-top-0 govuk-!-margin-bottom-1")
     end
 
     def trn

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -52,7 +52,7 @@ module ApplicationRecordCard
     def provider_name
       return unless system_admin
 
-      tag.p("Provider: #{record.provider.name}", class: "govuk-caption-m govuk-!-font-size-16 application-record-card__provider_name govuk-!-margin-top-0 govuk-!-margin-bottom-1")
+      tag.p(record.provider.name.to_s, class: "govuk-caption-m govuk-!-font-size-16 application-record-card__provider_name govuk-!-margin-bottom-0 govuk-!-margin-top-2")
     end
 
     def trn

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -15,6 +15,7 @@ module RecordDetails
 
     def record_detail_rows
       [
+        provider_row,
         trainee_id_row,
         region,
         trn_row,
@@ -27,6 +28,13 @@ module RecordDetails
     end
 
   private
+
+    def provider_row
+      return unless system_admin
+
+      { field_label: t(".provider"),
+        field_value: trainee.provider.name_and_code }
+    end
 
     def trainee_id_row
       mappable_field(trainee.trainee_id.presence, t(".trainee_id"), edit_trainee_trainee_id_path(trainee))

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -23,4 +23,8 @@ class Provider < ApplicationRecord
     # TODO: An arbitrary provider set here until we receive a list of teach first providers
     code == TEACH_FIRST_PROVIDER_CODE
   end
+
+  def name_and_code
+    "#{name} (#{code})"
+  end
 end

--- a/app/views/trainees/_results.html.erb
+++ b/app/views/trainees/_results.html.erb
@@ -6,7 +6,7 @@
           <h2 class="govuk-heading-m">Draft trainees</h2>
         </div>
       </div>
-      <%= render ApplicationRecordCard::View.with_collection(draft_trainees) %>
+      <%= render ApplicationRecordCard::View.with_collection(draft_trainees, system_admin: @current_user.system_admin?) %>
     </div>
   <% end %>
 
@@ -17,7 +17,7 @@
           <h2 class="govuk-heading-m">Registered trainees</h2>
         </div>
       </div>
-      <%= render ApplicationRecordCard::View.with_collection(completed_trainees) %>
+      <%= render ApplicationRecordCard::View.with_collection(completed_trainees, system_admin: @current_user.system_admin?) %>
     </div>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
       employing_school: &employing_school Employing school
   record_details:
     view:
+      provider: Provider
       trainee_id: Trainee ID
       region: &region Region
       submitted_for_trn: Submitted for TRN

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,7 @@ en:
       employing_school: &employing_school Employing school
   record_details:
     view:
-      provider: Provider
+      provider: Accrediting provider
       trainee_id: Trainee ID
       region: &region Region
       submitted_for_trn: Submitted for TRN

--- a/spec/components/application_record_card/view_preview.rb
+++ b/spec/components/application_record_card/view_preview.rb
@@ -8,6 +8,10 @@ module ApplicationRecordCard
         render(ApplicationRecordCard::View.new(record: mock_trainee, system_admin: system_admin))
       end
 
+      define_method "single_card_with_trn_and_trainee_id#{suffice}" do
+        render(ApplicationRecordCard::View.new(record: mock_trainee_with_trn_and_trainee_id, system_admin: system_admin))
+      end
+
       define_method "multiple_cards#{suffice}" do
         render(ApplicationRecordCard::View.with_collection(mock_multiple_trainees, system_admin: system_admin))
       end
@@ -36,6 +40,20 @@ module ApplicationRecordCard
         training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
         course_subject_one: "Primary",
         provider: mock_provider,
+      )
+    end
+
+    def mock_trainee_with_trn_and_trainee_id
+      Trainee.new(
+        id: 1,
+        created_at: Time.zone.now,
+        first_names: "Tom",
+        last_name: "Jones",
+        training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+        course_subject_one: "Primary",
+        provider: mock_provider,
+        trn: 1234567,
+        trainee_id: "xxxx - yy/zz",
       )
     end
 

--- a/spec/components/application_record_card/view_preview.rb
+++ b/spec/components/application_record_card/view_preview.rb
@@ -2,24 +2,27 @@
 
 module ApplicationRecordCard
   class ViewPreview < ViewComponent::Preview
-    def single_card
-      render(ApplicationRecordCard::View.new(record: mock_trainee))
-    end
+    [true, false].each do |system_admin|
+      suffice = system_admin ? "_as_system_admin" : ""
+      define_method "single_card#{suffice}" do
+        render(ApplicationRecordCard::View.new(record: mock_trainee, system_admin: system_admin))
+      end
 
-    def multiple_cards
-      render(ApplicationRecordCard::View.with_collection(mock_multiple_trainees))
-    end
+      define_method "multiple_cards#{suffice}" do
+        render(ApplicationRecordCard::View.with_collection(mock_multiple_trainees, system_admin: system_admin))
+      end
 
-    def single_card_with_incomplete_data
-      render(ApplicationRecordCard::View.new(record: Trainee.new(id: 1, created_at: Time.zone.now)))
-    end
+      define_method "single_card_with_incomplete_data#{suffice}" do
+        render(ApplicationRecordCard::View.new(record: Trainee.new(id: 1, created_at: Time.zone.now, provider: mock_provider), system_admin: system_admin))
+      end
 
-    def single_card_with_two_subjects
-      render(ApplicationRecordCard::View.new(record: mock_trainee_with_two_subjects))
-    end
+      define_method "single_card_with_two_subjects#{suffice}" do
+        render(ApplicationRecordCard::View.new(record: mock_trainee_with_two_subjects, system_admin: system_admin))
+      end
 
-    def single_card_with_three_subjects
-      render(ApplicationRecordCard::View.new(record: mock_trainee_with_three_subjects))
+      define_method "single_card_with_three_subjects#{suffice}" do
+        render(ApplicationRecordCard::View.new(record: mock_trainee_with_three_subjects, system_admin: system_admin))
+      end
     end
 
   private
@@ -32,6 +35,7 @@ module ApplicationRecordCard
         last_name: "Jones",
         training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
         course_subject_one: "Primary",
+        provider: mock_provider,
       )
     end
 
@@ -44,6 +48,7 @@ module ApplicationRecordCard
         training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
         course_subject_one: "Primary",
         course_subject_two: "Science",
+        provider: mock_provider,
       )
     end
 
@@ -57,17 +62,22 @@ module ApplicationRecordCard
         course_subject_one: "Primary",
         course_subject_two: "Science",
         course_subject_three: "Mathematics",
+        provider: mock_provider,
       )
     end
 
     def mock_multiple_trainees
       [
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Primary", course_subject_two: "Mathematics", course_subject_three: "Latin"),
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Paddington", last_name: "Bear", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Science", course_subject_two: "Mathematics"),
-        Trainee.new(id: 1, created_at: Time.zone.now),
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tim", last_name: "Knight", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Maths"),
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Toby", last_name: "Rocker"),
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Primary", course_subject_two: "Mathematics", course_subject_three: "Latin", provider: mock_provider),
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Paddington", last_name: "Bear", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Science", course_subject_two: "Mathematics", provider: mock_provider),
+        Trainee.new(id: 1, created_at: Time.zone.now, provider: mock_provider),
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tim", last_name: "Knight", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Maths", provider: mock_provider),
+        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Toby", last_name: "Rocker", provider: mock_provider),
       ]
+    end
+
+    def mock_provider
+      Provider.new(code: "B1T", name: "DfE University")
     end
   end
 end

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -22,7 +22,7 @@ module ApplicationRecordCard
       let(:system_admin) { true }
 
       it "renders provider name" do
-        expect(rendered_component).to have_selector(".application-record-card__provider_name", text: "Provider: #{provider.name}")
+        expect(rendered_component).to have_selector(".application-record-card__provider_name", text: provider.name.to_s)
       end
     end
 
@@ -132,7 +132,7 @@ module ApplicationRecordCard
         let(:system_admin) { true }
 
         it "renders provider name" do
-          expect(rendered_component).to have_selector(".application-record-card__provider_name", text: "Provider: #{provider.name}")
+          expect(rendered_component).to have_selector(".application-record-card__provider_name", text: provider.name.to_s)
         end
       end
 

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -6,11 +6,24 @@ module ApplicationRecordCard
   describe View do
     let(:provider) { create(:provider, :with_courses) }
     let(:course) { provider.courses.first }
-    let(:trainee) { Trainee.new(created_at: Time.zone.now, course_uuid: course.uuid) }
+    let(:trainee) { Trainee.new(created_at: Time.zone.now, course_uuid: course.uuid, provider: provider) }
+    let(:system_admin) { false }
 
     before do
       allow(trainee).to receive(:timeline).and_return([double(date: Time.zone.now)])
-      render_inline(described_class.new(record: trainee))
+      render_inline(described_class.new(record: trainee, system_admin: system_admin))
+    end
+
+    it "does not render provider name" do
+      expect(rendered_component).not_to have_selector(".application-record-card__provider_name")
+    end
+
+    context "when system admin is true" do
+      let(:system_admin) { true }
+
+      it "renders provider name" do
+        expect(rendered_component).to have_selector(".application-record-card__provider_name", text: "Provider: #{provider.name}")
+      end
     end
 
     context "when the Trainee has no names" do
@@ -100,12 +113,27 @@ module ApplicationRecordCard
             trainee_id: "132456",
             created_at: Time.zone.now,
             trn: "789456",
+            provider: provider,
           )
         end
       end
 
+      let(:system_admin) { false }
+
       before do
-        render_inline(described_class.new(record: trainee))
+        render_inline(described_class.new(record: trainee, system_admin: system_admin))
+      end
+
+      it "does not render provider name" do
+        expect(rendered_component).not_to have_selector(".application-record-card__provider_name")
+      end
+
+      context "when system admin is true" do
+        let(:system_admin) { true }
+
+        it "renders provider name" do
+          expect(rendered_component).to have_selector(".application-record-card__provider_name", text: "Provider: #{provider.name}")
+        end
       end
 
       it "renders trainee ID" do

--- a/spec/components/record_details/view_preview.rb
+++ b/spec/components/record_details/view_preview.rb
@@ -17,6 +17,10 @@ module RecordDetails
       render(View.new(trainee: trainee, last_updated_event: last_updated_event))
     end
 
+    def as_system_admin
+      render(View.new(trainee: mock_trainee(nil), last_updated_event: last_updated_event, system_admin: true))
+    end
+
     def with_no_trainee_id
       render(View.new(trainee: mock_trainee(nil), last_updated_event: last_updated_event))
     end
@@ -62,7 +66,12 @@ module RecordDetails
         withdraw_date: state == :withdrawn ? Time.zone.today : nil,
         recommended_for_award_at: state == :recommended_for_award ? Time.zone.now : nil,
         awarded_at: state == :awarded ? Time.zone.now : nil,
+        provider: mock_provider,
       )
+    end
+
+    def mock_provider
+      Provider.new(code: "B1T", name: "DfE University")
     end
 
     def last_updated_event

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -8,10 +8,31 @@ module RecordDetails
 
     let(:state) { :trn_received }
     let(:training_route) { TRAINING_ROUTE_ENUMS[:assessment_only] }
-    let(:trainee) { create(:trainee, state, training_route, trn: Faker::Number.number(digits: 10)) }
+    let(:provider) { create(:provider) }
+    let(:trainee) { create(:trainee, state, training_route, trn: Faker::Number.number(digits: 10), provider: provider) }
     let(:trainee_status) { "trainee-status" }
     let(:trainee_progress) { "trainee-progress" }
     let(:timeline_event) { double(date: Time.zone.today) }
+
+    context "when system admin is true" do
+      before do
+        render_inline(View.new(trainee: trainee, last_updated_event: timeline_event, system_admin: true))
+      end
+
+      it "renders the provider name and code" do
+        expect(rendered_component).to have_text(provider.name_and_code)
+      end
+    end
+
+    context "when system admin is false" do
+      before do
+        render_inline(View.new(trainee: trainee, last_updated_event: timeline_event, system_admin: false))
+      end
+
+      it "renders the provider name and code" do
+        expect(rendered_component).not_to have_text(provider.name_and_code)
+      end
+    end
 
     context "when any data has not been provided" do
       before do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -54,4 +54,12 @@ describe Provider do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe "#name_and_code" do
+    subject { create(:provider, code: "B1T", name: "DfE University").name_and_code }
+
+    it "returns name and code" do
+      expect(subject).to eq("DfE University (B1T)")
+    end
+  end
 end


### PR DESCRIPTION
### Context
Showing provider name / provider name and code

### Changes proposed in this pull request
Showing provider name for application record card
Showing provider name and code for record details

### Guidance to review
Any of the *`_as_system_admin`
https://register-pr-1705.london.cloudapps.digital/view_components/application_record_card/view

https://register-pr-1705.london.cloudapps.digital/view_components/record_details/view

![image](https://user-images.githubusercontent.com/470137/140310487-434bd898-d8c9-4287-aa65-3f817b6cd81c.png)

![image](https://user-images.githubusercontent.com/470137/140306180-cb0ab873-f204-49a6-8e9b-ee2247484077.png)

