### PR TITLE
Remove draft from invalid states as they do not exist in DTTP.

### DIFF
--- a/app/jobs/dttp/queue_trainee_updates_job.rb
+++ b/app/jobs/dttp/queue_trainee_updates_job.rb
@@ -4,12 +4,9 @@ module Dttp
   class QueueTraineeUpdatesJob < ApplicationJob
     queue_as :dttp
 
-    INVALID_STATES = %w[
-      draft
-      recommended_for_award
-      withdrawn
-      deferred
-      awarded
+    VALID_STATES = %w[
+      submitted_for_trn
+      trn_received
     ].freeze
 
     def perform
@@ -27,7 +24,7 @@ module Dttp
   private
 
     def fetch_trainees
-      Trainee.where.not(state: INVALID_STATES, submission_ready: false)
+      Trainee.where(state: VALID_STATES, submission_ready: true)
     end
 
     def trainee_already_synced?(trainee)

--- a/spec/jobs/dttp/queue_trainee_updates_job_spec.rb
+++ b/spec/jobs/dttp/queue_trainee_updates_job_spec.rb
@@ -26,14 +26,15 @@ module Dttp
     end
 
     context "with invalid trainees" do
-      let(:trainees) do
-        QueueTraineeUpdatesJob::INVALID_STATES.each do |state|
+      before do
+        create(:trainee, :draft)
+        create(:trainee, :recommended_for_award)
+        create(:trainee, :withdrawn)
+        create(:trainee, :deferred)
+        create(:trainee, :awarded)
+        described_class::VALID_STATES.each do |state|
           create(:trainee, state.to_sym).update_columns(submission_ready: false)
         end
-      end
-
-      before do
-        trainees
       end
 
       it "does not enqueue the UpdateTraineeJob" do


### PR DESCRIPTION
### Context

Changed `queue_trainee_updates_job.rb` query to only fetch valid states. This is causing unnecessary errors in sidekiq as the original query is fetching drafts: The requested resource does not support http method 'PATCH'

https://www.register-trainee-teachers.education.gov.uk/system-admin/sidekiq/morgue/1635897736.6011858-d033ebe78bf0680bfdd12804