### PR TITLE
[3150] Re-structure providers sub tab navigation

### DIFF
--- a/app/controllers/system_admin/dttp_users_controller.rb
+++ b/app/controllers/system_admin/dttp_users_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class DttpUsersController < ApplicationController
+    def index
+      @users_view = UsersView.new(provider)
+    end
+
+  private
+
+    def provider
+      @provider ||= Provider.find(params[:provider_id])
+    end
+  end
+end

--- a/app/views/system_admin/_provider_tab_nav.html.erb
+++ b/app/views/system_admin/_provider_tab_nav.html.erb
@@ -1,0 +1,4 @@
+<%= render TabNavigation::View.new(items: [
+  { name: "Users", url: provider_path(@provider) },
+  { name: "Dttp users", url: provider_dttp_users_path(@provider) },
+]) %>

--- a/app/views/system_admin/_tab_nav.html.erb
+++ b/app/views/system_admin/_tab_nav.html.erb
@@ -1,5 +1,5 @@
 <%= render TabNavigation::View.new(items: [
-  { name: "Providers", url: providers_path, current: request.path.starts_with?(providers_path) },
+  { name: "Providers", url: providers_path },
   { name: "Dttp providers", url: dttp_providers_path },
   { name: "Validation errors", url: validation_errors_path },
 ]) %>

--- a/app/views/system_admin/dttp_providers/index.html.erb
+++ b/app/views/system_admin/dttp_providers/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-l">Dttp Providers</h1>
 
-<%= render "system_admin/menu" %>
+<%= render "system_admin/tab_nav" %>
 
 <%= render Dttp::Providers::Collection::View.new(filters: @filter_params, collection: @providers) do %>
   <table class="govuk-table" summary="DTTP Providers list">

--- a/app/views/system_admin/dttp_users/index.html.erb
+++ b/app/views/system_admin/dttp_users/index.html.erb
@@ -1,0 +1,30 @@
+<%= render PageTitle::View.new(text: @provider.name, has_errors: @provider.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: t("back"),
+    href: providers_path,
+    ) %>
+<% end %>
+
+<h1 class="govuk-heading-l"><%= @provider.name %></h1>
+
+<p> <%= govuk_link_to "Edit this provider", edit_provider_path(@provider), { class: "govuk-link govuk-link--no-visited-state" } %> </p>
+
+<%= render "system_admin/provider_tab_nav" %>
+
+<% if @users_view.not_registered.any? %>
+  <div class="govuk-!-margin-bottom-8 unregistered-users">
+    <div class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-3">
+      These users are not registered with the provider on this service.
+    </div>
+
+    <%= render UserCard::View.with_collection(
+      @users_view.not_registered,
+      show_register_button: true,
+      registration_form_path: provider_import_user_path(@provider.id),
+      ) %>
+  </div>
+<% else %>
+  <p class="govuk-body">All users with this provider are registered.</p>
+<% end %>

--- a/app/views/system_admin/providers/index.html.erb
+++ b/app/views/system_admin/providers/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-l">Providers</h1>
 
-<%= render "system_admin/menu" %>
+<%= render "system_admin/tab_nav" %>
 
 <p class="govuk-body">
   <%= render GovukComponent::StartButtonComponent.new(

--- a/app/views/system_admin/providers/show.html.erb
+++ b/app/views/system_admin/providers/show.html.erb
@@ -9,9 +9,9 @@
 
 <h1 class="govuk-heading-l"><%= @provider.name %></h1>
 
-<p> <%= govuk_link_to "Edit this provider", edit_provider_path, { class: "govuk-link govuk-link--no-visited-state" } %> </p>
+<p> <%= govuk_link_to "Edit this provider", edit_provider_path(@provider), { class: "govuk-link govuk-link--no-visited-state" } %> </p>
 
-<%= render "system_admin/menu" %>
+<%= render "system_admin/provider_tab_nav" %>
 
 <p class="govuk-body">
   <%= render GovukComponent::StartButtonComponent.new(
@@ -20,30 +20,10 @@
 ) %>
 </p>
 
-<h1 class="govuk-heading-m">Registered users</h1>
-
 <% if @users_view.registered.any? %>
   <div class="govuk-!-margin-bottom-8 registered-users">
     <%= render UserCard::View.with_collection(@users_view.registered, show_register_button: false) %>
   </div>
 <% else %>
   <p class="govuk-body">There are no users yet.</p>
-<% end %>
-
-<h1 class="govuk-heading-m">DTTP users</h1>
-
-<% if @users_view.not_registered.any? %>
-  <div class="govuk-!-margin-bottom-8 unregistered-users">
-    <div class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-bottom-3">
-      These users are not registered with the provider on this service.
-    </div>
-
-    <%= render UserCard::View.with_collection(
-      @users_view.not_registered,
-      show_register_button: true,
-      registration_form_path: provider_import_user_path(@provider.id),
-    ) %>
-  </div>
-<% else %>
-  <p class="govuk-body">All users with this provider are registered.</p>
 <% end %>

--- a/app/views/system_admin/validation_errors/index.html.erb
+++ b/app/views/system_admin/validation_errors/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-<%= render "system_admin/menu" %>
+<%= render "system_admin/tab_nav" %>
 
 <table class="govuk-table" summary="<%= t(".attribute_error") %>">
   <thead class="govuk-table__head">

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -13,8 +13,9 @@ module SystemAdminRoutes
         mount Sidekiq::Web, at: "/sidekiq", constraints: SystemAdminConstraint.new
         get "/sidekiq", to: redirect("/sign-in"), status: 302
 
-        resources :providers, only: %i[index new create show edit update], shallow: true do
-          resources :users, only: %i[new create edit update]
+        resources :providers, except: %i[destroy], shallow: true do
+          resources :users, except: %i[destroy]
+          resources :dttp_users, only: %i[index], path: "/dttp-users"
 
           scope module: :imports do
             post "/users/import", to: "users#create", as: :import_user

--- a/spec/features/system_admin/dttp_providers/list_providers_spec.rb
+++ b/spec/features/system_admin/dttp_providers/list_providers_spec.rb
@@ -31,11 +31,11 @@ feature "List providers" do
   end
 
   def when_i_visit_the_dttp_provider_index_page
-    dttp_provider_index_page.load
+    dttp_providers_index_page.load
   end
 
   def then_i_see_the_dttp_provider
-    expect(dttp_provider_index_page).to have_text("Test 1")
+    expect(dttp_providers_index_page).to have_text("Test 1")
   end
 
   def and_i_click_on_create_provider_button

--- a/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
+++ b/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
@@ -28,11 +28,11 @@ feature "Creating a new provider" do
 private
 
   def when_i_visit_the_provider_index_page
-    provider_index_page.load
+    providers_index_page.load
   end
 
   def and_i_click_on_add_provider_button
-    provider_index_page.add_provider_link.click
+    providers_index_page.add_provider_link.click
   end
 
   def and_i_fill_in_name
@@ -52,7 +52,7 @@ private
   end
 
   def then_i_should_see_the_provider_index_page
-    expect(provider_index_page).to be_displayed
+    expect(providers_index_page).to be_displayed
   end
 
   def then_i_see_error_messages

--- a/spec/features/system_admin/providers/editing_a_provider_spec.rb
+++ b/spec/features/system_admin/providers/editing_a_provider_spec.rb
@@ -21,11 +21,11 @@ feature "Edit providers" do
   end
 
   def when_i_visit_the_provider_index_page
-    provider_index_page.load
+    providers_index_page.load
   end
 
   def when_i_click_on_provider_name
-    provider_index_page.provider_card.name.click
+    providers_index_page.provider_card.name.click
   end
 
   def and_i_click_edit_this_provider

--- a/spec/features/system_admin/providers/viewing_providers_spec.rb
+++ b/spec/features/system_admin/providers/viewing_providers_spec.rb
@@ -18,14 +18,14 @@ feature "View providers" do
   end
 
   def when_i_visit_the_provider_index_page
-    provider_index_page.load
+    providers_index_page.load
   end
 
   def then_i_see_the_provider
-    expect(provider_index_page).to have_provider_card
+    expect(providers_index_page).to have_provider_card
   end
 
   def when_i_click_on_provider_name
-    provider_index_page.provider_card.name.click
+    providers_index_page.provider_card.name.click
   end
 end

--- a/spec/features/system_admin/users/creating_a_new_user_spec.rb
+++ b/spec/features/system_admin/users/creating_a_new_user_spec.rb
@@ -37,11 +37,11 @@ feature "Creating a new user" do
 private
 
   def when_i_visit_the_provider_index_page
-    provider_index_page.load
+    providers_index_page.load
   end
 
   def and_i_click_on_a_provider
-    provider_index_page.provider_card.name.click
+    providers_index_page.provider_card.name.click
   end
 
   def then_i_am_taken_to_the_provider_show_page
@@ -50,10 +50,6 @@ private
 
   def and_i_click_on_add_a_user
     provider_show_page.add_a_user.click
-  end
-
-  def provider_show_page
-    @provider_show_page ||= PageObjects::Providers::Show.new
   end
 
   def and_i_fill_in_first_name
@@ -78,13 +74,5 @@ private
 
   def then_i_should_see_the_error_summary
     expect(new_user_page.error_summary).to be_visible
-  end
-
-  def provider_index_page
-    @provider_index_page ||= PageObjects::Providers::Index.new
-  end
-
-  def new_user_page
-    @new_user_page ||= PageObjects::Users::New.new
   end
 end

--- a/spec/features/system_admin/users/viewing_users_spec.rb
+++ b/spec/features/system_admin/users/viewing_users_spec.rb
@@ -16,17 +16,22 @@ feature "View users" do
 
     scenario "I can view the users" do
       then_i_see_the_registered_users
-      and_i_see_the_unregistered_users
+    end
+
+    scenario "I can view the DTTP users" do
+      and_i_click_on_dttp_users_tab
+      then_i_see_the_unregistered_users
     end
 
     scenario "I can register a dttp user to the provider" do
+      and_i_click_on_dttp_users_tab
       when_i_register_the_dttp_user
       then_the_dttp_user_is_registered
     end
   end
 
   def when_i_visit_the_provider_index_page
-    provider_index_page.load
+    providers_index_page.load
   end
 
   def and_there_is_a_dttp_user
@@ -34,7 +39,7 @@ feature "View users" do
   end
 
   def and_i_click_on_a_provider
-    provider_index_page.provider_card.name.click
+    providers_index_page.provider_card.name.click
   end
 
   def then_i_am_taken_to_the_provider_show_page
@@ -45,24 +50,19 @@ feature "View users" do
     expect(provider_show_page.registered_users.size).to eq(1)
   end
 
-  def and_i_see_the_unregistered_users
-    expect(provider_show_page.unregistered_users.size).to eq(1)
+  def then_i_see_the_unregistered_users
+    expect(provider_dttp_users_index_page.unregistered_users.size).to eq(1)
   end
 
   def when_i_register_the_dttp_user
     provider_show_page.register_user.click
   end
 
+  def and_i_click_on_dttp_users_tab
+    provider_dttp_users_index_page.dttp_users_tab.click
+  end
+
   def then_the_dttp_user_is_registered
-    expect(provider_show_page.registered_users.size).to eq(2)
-    expect(provider_show_page).not_to have_unregistered_user_data
-  end
-
-  def provider_show_page
-    @provider_show_page ||= PageObjects::Providers::Show.new
-  end
-
-  def provider_index_page
-    @provider_index_page ||= PageObjects::Providers::Index.new
+    expect(provider_dttp_users_index_page).not_to have_unregistered_user_data
   end
 end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -70,16 +70,24 @@ module Features
       @new_provider_page ||= PageObjects::Providers::New.new
     end
 
-    def provider_index_page
+    def providers_index_page
       @provider_index_page ||= PageObjects::Providers::Index.new
+    end
+
+    def dttp_providers_index_page
+      @provider_index_page ||= PageObjects::DttpProviders::Index.new
+    end
+
+    def new_user_page
+      @new_user_page ||= PageObjects::Users::New.new
     end
 
     def provider_show_page
       @provider_show_page ||= PageObjects::Providers::Show.new
     end
 
-    def dttp_provider_index_page
-      @provider_index_page ||= PageObjects::DttpProviders::Index.new
+    def provider_dttp_users_index_page
+      @provider_dttp_users_index_page ||= PageObjects::Provider::DttpUsers::Index.new
     end
 
     def validation_errors_index_page

--- a/spec/support/page_objects/dttp_users/index.rb
+++ b/spec/support/page_objects/dttp_users/index.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Provider
+    module DttpUsers
+      class Index < PageObjects::Base
+        set_url "system-admin/providers/{id}/dttp_users"
+
+        element :add_a_user, "a", text: "Add a user"
+        element :dttp_users_tab, "a", text: "Dttp users"
+        element :edit_this_provider, "a", text: "Edit this provider"
+        element :register_user, "#register-dttp-user"
+        element :unregistered_user_data, ".unregistered-users"
+
+        def unregistered_users
+          user_cards(unregistered_user_data)
+        end
+
+      private
+
+        def user_cards(element_node)
+          within(element_node) do
+            find_all(".user-card")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/providers/show.rb
+++ b/spec/support/page_objects/providers/show.rb
@@ -18,10 +18,6 @@ module PageObjects
         user_cards(registered_user_data)
       end
 
-      def unregistered_users
-        user_cards(unregistered_user_data)
-      end
-
     private
 
       def user_cards(element_node)


### PR DESCRIPTION
### Context
https://trello.com/c/vBfdbZOT/3150-s-re-structure-providers-sub-tab-navigation

### Changes proposed in this pull request
- Replace providers sub tab with a new version that lists "Registered users" and "DTTP users"

### Guidance to review
- Make sure your user record has the field `system_admin` set to `true`
- Visit the the `/system-admin/providers`
- Click on a provider
- You should see the follow screen:

<img width="971" alt="Screenshot 2021-11-03 at 16 24 03" src="https://user-images.githubusercontent.com/28728/140101092-9bfd36a8-360e-4ffd-869e-ed210b043529.png">
