### PR TITLE
[3121] Add trainee name as a caption

### DIFF
--- a/app/components/trainee_name/view.html.erb
+++ b/app/components/trainee_name/view.html.erb
@@ -1,0 +1,1 @@
+<span class="govuk-caption-l"><%= display_text %></span>

--- a/app/components/trainee_name/view.rb
+++ b/app/components/trainee_name/view.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module TraineeName
+  class View < GovukComponent::Base
+    attr_reader :trainee
+
+    def initialize(trainee)
+      @trainee = trainee
+    end
+
+    def render?
+      display_text.present?
+    end
+
+    def display_text
+      trainee.short_name || draft_text
+    end
+
+    def draft_text
+      t("views.trainees.show.draft") if trainee.draft?
+    end
+  end
+end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -320,6 +320,21 @@ class Trainee < ApplicationRecord
     !%w[recommended_for_award withdrawn awarded].include?(state)
   end
 
+  def short_name
+    [
+      first_names,
+      last_name,
+    ].select(&:present?).join(" ").presence
+  end
+
+  def full_name
+    [
+      first_names,
+      middle_names,
+      last_name,
+    ].select(&:present?).join(" ").presence
+  end
+
 private
 
   def value_digest

--- a/app/views/trainees/apply_applications/confirm_courses/show.html.erb
+++ b/app/views/trainees/apply_applications/confirm_courses/show.html.erb
@@ -6,6 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render TraineeName::View.new(@trainee) %>
     <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
     <%= render CourseDetails::View.new(data_model: @confirm_course_form) %>
 

--- a/app/views/trainees/apply_applications/course_details/edit.html.erb
+++ b/app/views/trainees/apply_applications/course_details/edit.html.erb
@@ -11,6 +11,7 @@
 
       <%= f.hidden_field :uuid, value: @course.uuid %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <h1 class="govuk-heading-l"><%= t(".summary_title") %></h1>
 
       <p class="govuk-body">The trainee is being registered on <%= apply_course_and_route_summary(@course) %></p>

--- a/app/views/trainees/confirm_details/_form.html.erb
+++ b/app/views/trainees/confirm_details/_form.html.erb
@@ -1,11 +1,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render TraineeName::View.new(trainee) %>
     <h1 class="govuk-heading-l"><%= heading %></h1>
 
     <%= render(component) %>
 
     <%= register_form_with(model: confirm_detail_form, url: resource_confirm_update_path, method: :put, local: true) do |f| %>
-      <% if @trainee.draft? %>
+      <% if trainee.draft? %>
         <%= f.govuk_check_boxes_fieldset :mark_as_completed, multiple: false, legend: nil do %>
           <%= f.govuk_check_box :mark_as_completed, 1, 0, multiple: false, link_errors: true, label: { text: checkbox_text(trainee_section_key, trainee) } %>
         <% end %>

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -4,6 +4,7 @@
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
+<%= render TraineeName::View.new(@trainee) %>
 <h1 class="govuk-heading-l">Contact details</h1>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -11,6 +11,7 @@
 
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
       <% if f.object.is_primary_phase? %>

--- a/app/views/trainees/course_education_phases/edit.html.erb
+++ b/app/views/trainees/course_education_phases/edit.html.erb
@@ -11,6 +11,7 @@
                            method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_collection_radio_buttons(:course_education_phase, COURSE_EDUCATION_PHASE_ENUMS.values,
         ->(value) { value },
         ->(label) { I18n.t("views.forms.course_education_phase.label_names.#{label}") },

--- a/app/views/trainees/degrees/_non_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_non_uk_degree_form.html.erb
@@ -7,6 +7,7 @@
     <%= render ReviewSummary::View.new(form: @degree_form, invalid_data_view: ApplyInvalidDataView.new(@trainee.apply_application, degree: @degree_form.degree, on_form_page: true)) %>
   <% end %>
 
+  <%= render TraineeName::View.new(@trainee) %>
   <h1 class="govuk-heading-l">Non-UK degree details</h1>
 
   <%= render FormComponents::CountryAutocomplete::View.new(

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -7,6 +7,7 @@
     <%= render ReviewSummary::View.new(form: @degree_form, invalid_data_view: ApplyInvalidDataView.new(@trainee.apply_application, degree: @degree_form.degree, on_form_page: true)) %>
   <% end %>
 
+  <%= render TraineeName::View.new(@trainee) %>
   <h1 class="govuk-heading-l">UK degree details</h1>
 
   <%= render FormComponents::Autocomplete::View.new(

--- a/app/views/trainees/degrees/type/new.html.erb
+++ b/app/views/trainees/degrees/type/new.html.erb
@@ -9,6 +9,7 @@
     <%= register_form_with(model: @degree, url: trainee_degrees_new_type_path, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <% if @trainee.degrees.size > 1 %>
         <h1 class="govuk-heading-l">Add another degree</h1>
       <% else %>

--- a/app/views/trainees/diversity/disability_details/edit.html.erb
+++ b/app/views/trainees/diversity/disability_details/edit.html.erb
@@ -14,6 +14,7 @@
                            method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_check_boxes_fieldset :disability_ids,
           legend: { text: t("components.page_titles.trainees.diversity.disabilities.edit"), tag: "h1", size: "l" },
           hint: { text: "Select all that apply" },

--- a/app/views/trainees/diversity/disability_disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disability_disclosures/edit.html.erb
@@ -12,6 +12,7 @@
                            method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+        <%= render TraineeName::View.new(@trainee) %>
         <%= f.govuk_radio_buttons_fieldset(:disability_disclosure,
                                            legend: { text: t("components.page_titles.trainees.diversity.disability_disclosure.edit"),
                                                      tag: "h1",

--- a/app/views/trainees/diversity/disclosures/edit.html.erb
+++ b/app/views/trainees/diversity/disclosures/edit.html.erb
@@ -11,6 +11,7 @@
                            method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+        <%= render TraineeName::View.new(@trainee) %>
         <%= f.govuk_collection_radio_buttons(
           :diversity_disclosure,
           Diversities::DIVERSITY_DISCLOSURE_ENUMS.values,

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -17,6 +17,7 @@
                            url: trainee_diversity_ethnic_background_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+        <%= render TraineeName::View.new(@trainee) %>
         <%= f.govuk_radio_buttons_fieldset(
           :ethnic_background,
           legend: {

--- a/app/views/trainees/diversity/ethnic_groups/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_groups/edit.html.erb
@@ -9,6 +9,7 @@
     <%= register_form_with(model: @ethnic_group_form, url: trainee_diversity_ethnic_group_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+        <%= render TraineeName::View.new(@trainee) %>
         <%= f.govuk_radio_buttons_fieldset(:ethnic_group, legend: { text: t("components.page_titles.trainees.diversity.ethnic_group.edit"), tag: "h1", size: "l" }) do %>
           <% format_ethnic_group_options(Diversities::ETHNIC_GROUP_ENUMS.values).each_with_index do |ethnic_option, index| %>
             <%= f.govuk_radio_button(

--- a/app/views/trainees/employing_schools/_no_results.html.erb
+++ b/app/views/trainees/employing_schools/_no_results.html.erb
@@ -12,6 +12,7 @@
 
 <%= f.hidden_field :employing_school_id, value: :no_results_search_again %>
 
+<%= render TraineeName::View.new(@trainee) %>
 <%= f.govuk_text_field :no_results_search_again_query,
                        label: { text: t("components.page_titles.search_schools.search_hint") },
                        width: "three-quarters" %>

--- a/app/views/trainees/employing_schools/_results.html.erb
+++ b/app/views/trainees/employing_schools/_results.html.erb
@@ -3,6 +3,7 @@
 <%= f.hidden_field :employing_school_id, value: nil %>
 <%= f.hidden_field :search_results_found, value: "true" %>
 
+<%= render TraineeName::View.new(@trainee) %>
 <%= f.govuk_radio_buttons_fieldset :employing_school_id,
   legend: { text: t("components.page_titles.trainees.employing_schools.index"), tag: "h1", size: "l" },
   hint: { text: "#{t('components.page_titles.search_schools.sub_text_results')} ‘#{query}’" } do %>

--- a/app/views/trainees/employing_schools/edit.html.erb
+++ b/app/views/trainees/employing_schools/edit.html.erb
@@ -9,6 +9,7 @@
     <%= register_form_with model: @employing_school_form, url: trainee_employing_schools_path(@trainee), local: true, html: { data: { module: "app-schools-autocomplete" } } do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_text_field(
         :query,
         label: { text: t(".heading"), size: "l", tag: "h1" },

--- a/app/views/trainees/funding/bursaries/_grant_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_grant_form.html.erb
@@ -1,6 +1,7 @@
 <%= register_form_with(model: @bursary_form, url: trainee_funding_bursary_path(@trainee), method: :put, local: true) do |f| %>
   <%= f.govuk_error_summary %>
 
+  <%= render TraineeName::View.new(@trainee) %>
   <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.grants.edit") %></h1>
   <p class="govuk-body">
     <%= t(

--- a/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
@@ -1,6 +1,7 @@
 <%= register_form_with(model: @bursary_form, url: trainee_funding_bursary_path(@trainee), method: :put, local: true) do |f| %>
   <%= f.govuk_error_summary %>
 
+  <%= render TraineeName::View.new(@trainee) %>
   <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %></h1>
   <p class="govuk-body">
     <%= t(

--- a/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
@@ -1,6 +1,7 @@
 <%= register_form_with(model: @bursary_form, url: trainee_funding_bursary_path(@trainee), method: :put, local: true) do |f| %>
   <%= f.govuk_error_summary %>
 
+  <%= render TraineeName::View.new(@trainee) %>
   <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %></h1>
   <p class="govuk-body"><%= t("views.forms.funding.bursaries.tiered.description") %></p>
 

--- a/app/views/trainees/funding/training_initiatives/edit.html.erb
+++ b/app/views/trainees/funding/training_initiatives/edit.html.erb
@@ -10,6 +10,7 @@
     <%= register_form_with(model: @training_initiatives_form, url: trainee_funding_training_initiative_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.training_initiatives.edit") %><h1>
       <p class="govuk-body"><%= t("views.forms.funding.training_initiatives.description_html") %></p>
 

--- a/app/views/trainees/itt_start_dates/edit.html.erb
+++ b/app/views/trainees/itt_start_dates/edit.html.erb
@@ -11,10 +11,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @itt_start_date_form, 
-                           url: trainee_course_details_itt_start_date_path(@trainee), 
+    <%= register_form_with(model: @itt_start_date_form,
+                           url: trainee_course_details_itt_start_date_path(@trainee),
                            local: true) do |f| %>
       <%= f.govuk_error_summary %>
+      <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_date_field :date, legend: { text: text, tag: "h1", size: "l" }, hint: -> do %>
         <p class="govuk-body govuk-hint"><%= t("components.itt_start_date.hint") %></p>
         <p class="govuk-body govuk-hint"><%= "#{t('views.forms.common.for_example')}, 26 7 2021" %></p>

--- a/app/views/trainees/language_specialisms/edit.html.erb
+++ b/app/views/trainees/language_specialisms/edit.html.erb
@@ -11,6 +11,7 @@
 
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <div class="govuk-form-group">
         <%= f.govuk_check_boxes_fieldset :language_specialisms,
                                           legend: { text: t(".heading"), tag: "h1", size: "l" },

--- a/app/views/trainees/lead_schools/edit.html.erb
+++ b/app/views/trainees/lead_schools/edit.html.erb
@@ -10,6 +10,7 @@
                            html: { data: { module: "app-schools-autocomplete" } } do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_text_field(
         :query,
         label: { text: t(".heading"), size: "l", tag: "h1" },

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -9,6 +9,7 @@
     <%= register_form_with(model: @personal_detail_form, url: trainee_personal_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <h1 class="govuk-heading-l">Trainee personal details</h1>
 
       <%= f.govuk_text_field :first_names,

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -13,6 +13,7 @@
                           local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset :course_uuid,
           legend: { text: t(".heading"), tag: "h1", size: "l" },

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -9,6 +9,7 @@
     <%= register_form_with(model: @trainee_start_date_form, url: trainee_start_date_path, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_date_field :commencement_date, legend: {
         text: t("views.forms.start_dates.commencement_date.label"), size: "l", tag: "h1"
       }, hint: { text: t("views.forms.start_dates.commencement_date.hint") } %>

--- a/app/views/trainees/study_modes/edit.html.erb
+++ b/app/views/trainees/study_modes/edit.html.erb
@@ -8,10 +8,12 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(model: @study_mode_form, url: trainee_course_details_study_mode_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
-        <%= f.govuk_radio_buttons_fieldset(:study_mode, legend: { text: t("components.page_titles.trainees.study_mode.edit"), size: "l", tag: "h1" }) do %>
+      <%= render TraineeName::View.new(@trainee) %>
+
+      <%= f.govuk_radio_buttons_fieldset(:study_mode, legend: { text: t("components.page_titles.trainees.study_mode.edit"), size: "l", tag: "h1" }) do %>
         <%= f.govuk_radio_button :study_mode, COURSE_STUDY_MODES[:full_time], checked: (f.object.study_mode == COURSE_STUDY_MODES[:full_time]), label: { text: t("components.course_detail.study_mode_values.full_time") }, link_errors: true %>
         <%= f.govuk_radio_button :study_mode, COURSE_STUDY_MODES[:part_time], checked: (f.object.study_mode == COURSE_STUDY_MODES[:part_time]), label: { text: t("components.course_detail.study_mode_values.part_time") } %>
-    <% end %>
+      <% end %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/trainees/subject_specialisms/edit.html.erb
+++ b/app/views/trainees/subject_specialisms/edit.html.erb
@@ -13,6 +13,7 @@
                            local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
     <div class="govuk-form-group">
       <%= f.govuk_radio_buttons_fieldset course_subject_attribute_name,
                                         legend: { text: t(".heading", subject: @subject.downcase),

--- a/app/views/trainees/trainee_ids/edit.html.erb
+++ b/app/views/trainees/trainee_ids/edit.html.erb
@@ -9,6 +9,7 @@
     <%= register_form_with(model: @trainee_id_form, url: trainee_trainee_id_path, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_text_field :trainee_id,
                              label: { text: "Trainee ID", tag: "h1", size: "l" },
                              width: 20,

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -9,6 +9,7 @@
     <%= register_form_with(model: @training_details_form, url: trainee_training_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <h1 class="govuk-heading-l"><%= t("views.forms.training_details.title") %></h1>
 
       <% if @training_details_form.course_start_date %>

--- a/app/views/trainees/training_routes/edit.html.erb
+++ b/app/views/trainees/training_routes/edit.html.erb
@@ -8,6 +8,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with model: @trainee, url: trainee_training_route_path(@trainee), local: true do |f| %>
       <%= f.govuk_error_summary %>
+      <%= render TraineeName::View.new(@trainee) %>
       <%= render "form_fields", f: f %>
       <%= f.govuk_submit %>
     <% end %>

--- a/spec/components/trainee_name/view_preview.rb
+++ b/spec/components/trainee_name/view_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module TraineeName
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render(View.new(
+               Trainee.new(first_names: "Joe", middle_names: "Smith", last_name: "Blogs"),
+             ))
+    end
+
+    def draft_with_no_name
+      render(View.new(
+               Trainee.new(state: "draft", first_names: nil, middle_names: nil, last_name: nil),
+             ))
+    end
+
+    def non_draft_with_no_name
+      render(View.new(
+               Trainee.new(state: "submitted_for_trn", first_names: nil, middle_names: nil, last_name: nil),
+             ))
+    end
+  end
+end

--- a/spec/components/trainee_name/view_spec.rb
+++ b/spec/components/trainee_name/view_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module TraineeName
+  describe View do
+    alias_method :component, :page
+
+    before do
+      render_inline(described_class.new(trainee))
+    end
+
+    context "name not set" do
+      context "draft trainee" do
+        let(:trainee) { build(:trainee, first_names: nil, middle_names: nil, last_name: nil) }
+
+        it "displays draft" do
+          expect(component).to have_text("Draft")
+        end
+      end
+
+      context "non draft trainee" do
+        let(:trainee) { build(:trainee, :submitted_for_trn, first_names: nil, middle_names: nil, last_name: nil) }
+
+        it "does not display draft" do
+          expect(component).not_to have_text("Draft")
+        end
+      end
+    end
+
+    context "name is set" do
+      let(:trainee) { build(:trainee, first_names: "Joe", middle_names: "Smith", last_name: "Blogs") }
+
+      it "displays short name" do
+        expect(component).to have_text("Joe Blogs")
+      end
+    end
+  end
+end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -601,4 +601,26 @@ describe Trainee do
       expect(trainee.course_duration_in_years).to eq(2)
     end
   end
+
+  describe "#short_name" do
+    it "returns short name" do
+      trainee = Trainee.new(first_names: "Joe", middle_names: nil, last_name: "Blogs")
+      expect(trainee.short_name).to eql("Joe Blogs")
+    end
+
+    it "returns name without middle names" do
+      trainee = Trainee.new(first_names: "Joe", middle_names: "Smith", last_name: "Blogs")
+      expect(trainee.short_name).to eql("Joe Blogs")
+    end
+  end
+
+  describe "#full_name" do
+    it "returns full name" do
+      trainee = Trainee.new(first_names: "Joe", middle_names: nil, last_name: "Blogs")
+      expect(trainee.full_name).to eql("Joe Blogs")
+
+      trainee = Trainee.new(first_names: "Joe", middle_names: "Smith", last_name: "Blogs")
+      expect(trainee.full_name).to eql("Joe Smith Blogs")
+    end
+  end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/umv4i8vg/3121-add-trainee-name-as-a-caption-to-all-record-forms-and-record-confirmation-pages

### Changes proposed in this pull request

* New component `TraineeName`
* Add render for all pages under trainee

### Guidance to review

