### PR TITLE
[3123] Add ability to update a user's email address

### DIFF
--- a/app/components/user_card/view.html.erb
+++ b/app/components/user_card/view.html.erb
@@ -16,6 +16,10 @@
     <%= email_address %>
   </div>
 
+  <div class="govuk-caption-m govuk-!-font-size-16">
+    <%= govuk_link_to('Edit', edit_user_path(user)) %>
+  </div>
+
   <% if show_register_button %>
     <%= govuk_button_to(
       "Register user to provider",

--- a/app/controllers/system_admin/users_controller.rb
+++ b/app/controllers/system_admin/users_controller.rb
@@ -7,11 +7,26 @@ module SystemAdmin
     end
 
     def create
-      @user = authorize(provider.users.build(user_params))
+      @user = authorize(provider.users.build(permitted_attributes(User)))
       if @user.save
-        redirect_to(provider_path(provider))
+        redirect_to(provider_path(provider), flash: { success: t(".success") })
       else
         render(:new)
+      end
+    end
+
+    def edit
+      @user = authorize(User.find(params[:id]))
+      @provider = @user.provider
+    end
+
+    def update
+      @user = authorize(User.find(params[:id]))
+      @provider = @user.provider
+      if @user.update(permitted_attributes(@user))
+        redirect_to(provider_path(provider), flash: { success: t(".success") })
+      else
+        render(:edit)
       end
     end
 
@@ -19,10 +34,6 @@ module SystemAdmin
 
     def provider
       @provider ||= Provider.find(params[:provider_id])
-    end
-
-    def user_params
-      params.require(:user).permit(:first_name, :last_name, :email, :dttp_id)
     end
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class UserPolicy < ProviderPolicy
+  def permitted_attributes_for_create
+    %i[first_name last_name email dttp_id]
+  end
+
+  def permitted_attributes_for_update
+    [:email]
+  end
 end

--- a/app/views/system_admin/users/edit.html.erb
+++ b/app/views/system_admin/users/edit.html.erb
@@ -1,0 +1,23 @@
+<%= render PageTitle::View.new(i18n_key: "users.edit", has_errors: @user.errors.present?) %>
+
+<%= render GovukComponent::BackLinkComponent.new(
+      text: "Back",
+      href: provider_path(@provider),
+    ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with model: @user, local: true do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        Edit user <%= @user.name %>
+      </h1>
+
+      <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: 20, autocomplete: :disabled %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,6 +320,7 @@ en:
         index: Dttp Providers
       users:
         new: Add a user
+        edit: Edit user
       validation_errors:
         page_title: Validation errors
       search_schools:
@@ -1271,6 +1272,11 @@ en:
   page_headings:
     start_page: Register trainee teachers
   system_admin:
+    users:
+      create:
+        success: User has been successfully added.
+      update:
+        success: User details have been successfully updated.
     validation_errors:
       index:
         heading: Validation errors

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -13,8 +13,8 @@ module SystemAdminRoutes
         mount Sidekiq::Web, at: "/sidekiq", constraints: SystemAdminConstraint.new
         get "/sidekiq", to: redirect("/sign-in"), status: 302
 
-        resources :providers, only: %i[index new create show edit update] do
-          resources :users, only: %i[new create]
+        resources :providers, only: %i[index new create show edit update], shallow: true do
+          resources :users, only: %i[new create edit update]
 
           scope module: :imports do
             post "/users/import", to: "users#create", as: :import_user

--- a/spec/components/user_card/view_preview.rb
+++ b/spec/components/user_card/view_preview.rb
@@ -15,6 +15,7 @@ module UserCard
 
     def mock_user
       User.new(
+        id: 123,
         first_name: "Luke",
         last_name: "Skywalker",
         email: "luke@email.com",

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     provider
 
     trait :system_admin do
+      provider { nil }
       system_admin { true }
     end
   end

--- a/spec/features/system_admin/users/creating_a_new_user_spec.rb
+++ b/spec/features/system_admin/users/creating_a_new_user_spec.rb
@@ -45,7 +45,7 @@ private
   end
 
   def then_i_am_taken_to_the_provider_show_page
-    provider_show_page.load(id: user.provider.id)
+    expect(provider_show_page).to be_displayed(id: user.provider.id)
   end
 
   def and_i_click_on_add_a_user

--- a/spec/features/system_admin/users/updating_a_user_spec.rb
+++ b/spec/features/system_admin/users/updating_a_user_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Creating a new user" do
+  let(:system_admin) { create(:user, system_admin: true) }
+  let(:user) { create(:user) }
+  let(:dttp_id) { SecureRandom.uuid }
+
+  before do
+    given_i_am_authenticated(user: system_admin)
+    when_i_visit_the_provider_show_page
+    and_i_click_on_edit_user_link
+    then_i_am_taken_to_the_edit_user_page
+  end
+
+  describe "Editing user details" do
+    context "Valid details" do
+      scenario "Editing a user record associated with a provider" do
+        and_i_fill_in_email(email: "darthvader@email.com")
+        when_i_save_the_form
+        then_i_am_taken_to_the_provider_show_page
+      end
+    end
+
+    context "Invalid details" do
+      scenario "Failing to add a user trigging the validations" do
+        and_i_fill_in_email(email: "darthvader email com")
+        when_i_save_the_form
+        then_i_should_see_the_error_summary
+      end
+    end
+  end
+
+private
+
+  def when_i_visit_the_provider_show_page
+    provider_show_page.load(id: user.provider.id)
+  end
+
+  def and_i_click_on_edit_user_link
+    provider_show_page.edit_user_data.click
+  end
+
+  def then_i_am_taken_to_the_edit_user_page
+    edit_user_page.load(id: user.id)
+  end
+
+  def and_i_click_on_add_a_user
+    provider_show_page.add_a_user.click
+  end
+
+  def provider_show_page
+    @provider_show_page ||= PageObjects::Providers::Show.new
+  end
+
+  def and_i_fill_in_email(email:)
+    edit_user_page.email.set(email)
+  end
+
+  def when_i_save_the_form
+    edit_user_page.submit.click
+  end
+
+  def then_i_should_see_the_error_summary
+    expect(edit_user_page.error_summary).to be_visible
+  end
+
+  def then_i_am_taken_to_the_provider_show_page
+    expect(provider_show_page).to be_displayed(id: user.provider.id)
+  end
+
+  def edit_user_page
+    @edit_user_page ||= PageObjects::Users::Edit.new
+  end
+end

--- a/spec/features/system_admin/users/viewing_users_spec.rb
+++ b/spec/features/system_admin/users/viewing_users_spec.rb
@@ -38,7 +38,7 @@ feature "View users" do
   end
 
   def then_i_am_taken_to_the_provider_show_page
-    provider_show_page.load(id: user.provider.id)
+    expect(provider_show_page).to be_displayed(id: user.provider.id)
   end
 
   def then_i_see_the_registered_users

--- a/spec/support/page_objects/providers/show.rb
+++ b/spec/support/page_objects/providers/show.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Providers
     class Show < PageObjects::Base
-      set_url "system-admin/providers/{id}"
+      set_url "/system-admin/providers/{id}"
 
       element :add_a_user, "a", text: "Add a user"
       element :edit_this_provider, "a", text: "Edit this provider"
@@ -12,6 +12,7 @@ module PageObjects
 
       element :registered_user_data, ".registered-users"
       element :unregistered_user_data, ".unregistered-users"
+      element :edit_user_data, ".registered-users .user-card a"
 
       def registered_users
         user_cards(registered_user_data)

--- a/spec/support/page_objects/users/edit.rb
+++ b/spec/support/page_objects/users/edit.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Users
+    class Edit < PageObjects::Base
+      set_url "system-admin/users/{id}/edit"
+
+      element :email, "#user-email-field"
+
+      element :error_summary, ".govuk-error-summary"
+
+      element :submit, 'button.govuk-button[type="submit"]'
+    end
+  end
+end


### PR DESCRIPTION
### Context
Add ability to update a user's email from system-admin.

### Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/910019/140286992-c2093cf5-550a-4036-9d75-9dad4fec3d8c.png)

![image](https://user-images.githubusercontent.com/910019/140287020-98c5c485-da47-4727-a421-c378676e933d.png)

![image](https://user-images.githubusercontent.com/910019/140287053-8537b2f2-0985-4a7c-ba28-61035e5fa827.png)


### Guidance to review
1. Login as Administrator
2. Find an edit link against any registered user and click on it.
3. Expect to be presented with a form to edit the email address. Make a change, and click "continue"
4. Assert that a success message is shown.

