### PR TITLE
[3118] Add provider filter for admins

### DIFF
--- a/app/components/admin_feature/script.js
+++ b/app/components/admin_feature/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/admin_feature/style.scss
+++ b/app/components/admin_feature/style.scss
@@ -1,0 +1,47 @@
+@import "../base.scss";
+
+// Mostly copied from https://github.com/DFE-Digital/publish-teacher-training/blob/master/app/webpacker/stylesheets/_status-box.scss
+.app-status-box {
+  @include govuk-responsive-margin(6, "bottom");
+  background-color: govuk-colour("light-grey");
+  padding: govuk-spacing(4);
+
+  > *:last-child {
+    margin-bottom: 0;
+  }
+
+  .autocomplete__input,
+  .govuk-input,
+  .govuk-select {
+    background: govuk-colour("white");
+    width: 100%;
+  }
+
+  // Add a 2px solid border around tags which match colour of the text
+  .govuk-tag--grey {
+    border: 2px solid govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
+  }
+
+  .govuk-tag--yellow {
+    border: 2px solid govuk-shade(govuk-colour("yellow"), 65);
+  }
+
+  .govuk-tag--red {
+    border: 2px solid govuk-shade(govuk-colour("red"), 30);
+  }
+
+  .govuk-tag--green {
+    border: 2px solid govuk-shade(govuk-colour("green"), 20);
+  }
+}
+
+.app-status-box--admin {
+  border-left: $govuk-border-width solid govuk-colour("purple");
+}
+
+// For use in filter box to outdent to the side margins
+// .moj-filter__options has 20px padding - so this expands to that minus the 1px border
+.app-status-box--filter-outdent {
+  margin-left: -19px;
+  margin-right: -19px;
+}

--- a/app/components/admin_feature/view.html.erb
+++ b/app/components/admin_feature/view.html.erb
@@ -1,0 +1,8 @@
+<%= tag.div(class: classes, **html_attributes) do %>
+  <p class="govuk-body">
+    <strong class="govuk-tag govuk-tag--purple">
+      <%= title %>
+    </strong>
+  </p>
+  <%= content %>
+<% end %>

--- a/app/components/admin_feature/view.rb
+++ b/app/components/admin_feature/view.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module AdminFeature
+  class View < GovukComponent::Base
+    attr_reader :title
+
+    def initialize(title: nil, classes: [], html_attributes: {})
+      @title = title || t("components.admin_feature.title")
+      super(classes: classes, html_attributes: default_html_attributes.merge(html_attributes))
+    end
+
+  private
+
+    def default_classes
+      %w[app-status-box app-status-box--admin]
+    end
+
+    def default_html_attributes
+      {}
+    end
+  end
+end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -23,6 +23,7 @@ class TraineesController < ApplicationController
     @training_routes = policy_scope(Trainee)
                          .group(:training_route)
                          .count.keys.sort_by(&TRAINING_ROUTE_ENUMS.values.method(:index))
+    @providers = Provider.all.order(:name)
 
     respond_to do |format|
       format.html
@@ -105,7 +106,17 @@ private
   end
 
   def filter_params
-    params.permit(:subject, :text_search, :sort_by, level: [], training_route: [], state: [], record_source: [])
+    params.permit(permitted_params + permitted_admin_params)
+  end
+
+  def permitted_admin_params
+    return [] unless current_user.system_admin?
+
+    [:provider]
+  end
+
+  def permitted_params
+    [:subject, :text_search, :sort_by, { level: [], training_route: [], state: [], record_source: [] }]
   end
 
   def multiple_record_sources?

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -6,7 +6,8 @@ module FilterHelper
   end
 
   def title_html(filter, value)
-    tag.span("Remove ", class: "govuk-visually-hidden") + value + tag.span(" #{filter.humanize.downcase} filter", class: "govuk-visually-hidden")
+    text = filter == "provider" ? Provider.find(value).name : value
+    tag.span("Remove ", class: "govuk-visually-hidden") + text + tag.span(" #{filter.humanize.downcase} filter", class: "govuk-visually-hidden")
   end
 
   def tags_for_filter(filters, filter, value)

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -24,7 +24,13 @@ private
 
   def merged_filters
     @merged_filters ||= text_search.merge(
-      **level, **training_route, **state, **subject, **text_search, **record_source,
+      **level,
+      **training_route,
+      **state,
+      **subject,
+      **text_search,
+      **record_source,
+      **provider,
     ).with_indifferent_access
   end
 
@@ -84,5 +90,11 @@ private
     return {} if params[:text_search].blank?
 
     { "text_search" => params[:text_search] }
+  end
+
+  def provider
+    return {} if params[:provider].blank?
+
+    { "provider" => params[:provider] }
   end
 end

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -68,6 +68,12 @@ module Trainees
       trainees.with_name_trainee_id_or_trn_like(text_search)
     end
 
+    def provider(trainees, provider)
+      return trainees if provider.blank?
+
+      trainees.where(provider: Provider.find(provider))
+    end
+
     def filter_trainees
       filtered_trainees = trainees
 
@@ -76,6 +82,7 @@ module Trainees
       filtered_trainees = subject(filtered_trainees, filters[:subject])
       filtered_trainees = text_search(filtered_trainees, filters[:text_search])
       filtered_trainees = level(filtered_trainees, filters[:level])
+      filtered_trainees = provider(filtered_trainees, filters[:provider])
 
       record_source(filtered_trainees, filters[:record_source])
     end

--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -7,6 +7,20 @@
     <%= text_field_tag "text_search", (filters[:text_search] if filters), spellcheck: false, class: "govuk-input" %>
   </div>
 
+  <% if current_user.system_admin? %>
+    <%= render AdminFeature::View.new(classes: "app-status-box--filter-outdent") do %>
+      <div class="govuk-form-group">
+        <%= label_tag "provider", t("views.trainees.index.filters.provider"), class: "govuk-label govuk-label--s" %>
+        <%= select_tag(
+          :provider,
+          options_from_collection_for_select(@providers, :id, :name),
+          include_blank: "All providers",
+          class: "govuk-select"
+        ) %>
+      </div>
+    <% end %>
+  <% end %>
+
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,8 @@ en:
       start_date: &commencement_date Trainee’s start date
       region: *region
   components:
+    admin_feature:
+      title: Admin feature
     heading:
       apply_draft:
         registration_data_from_apply: Registration data from Apply
@@ -328,14 +330,15 @@ en:
         search_hint: Search for a school by it’s unique reference number (URN), name or postcode
         search_button: Search again
     filter:
-      title: Filters
-      selected_title: Selected filters
       level: Education phase
-      training_route: Training route
+      provider: Provider
       record_source: Record source
+      selected_title: Selected filters
       state: Status
       subject: Subject
       text_search: Text search
+      title: Filters
+      training_route: Training route
     timeline:
       withdrawal_date: Date of withdrawal
       withdrawal_reason: Reason for withdrawal
@@ -501,6 +504,7 @@ en:
         export: Export these records
         filters:
           level: Education phase
+          provider: Provider
           search: Search for a trainee
           status: Status
           subject: Subject

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -61,6 +61,21 @@ RSpec.feature "Filtering trainees" do
     then_i_should_not_see_sort_links
   end
 
+  scenario "cannot filter by provider" do
+    then_i_should_not_see_the_provider_filter
+  end
+
+  context "as a system-admin" do
+    before do
+      given_i_am_authenticated_as_system_admin
+      when_i_visit_the_trainee_index_page
+    end
+
+    scenario "cannot filter by provider" do
+      then_i_should_see_the_provider_filter
+    end
+  end
+
   context "searching" do
     before { when_i_search_for(search_term) }
 
@@ -243,6 +258,14 @@ private
     values.each do |value|
       expect(trainee_index_page.filter_tags).to have_text(value)
     end
+  end
+
+  def then_i_should_not_see_the_provider_filter
+    expect(trainee_index_page).not_to have_provider_filter
+  end
+
+  def then_i_should_see_the_provider_filter
+    expect(trainee_index_page).to have_provider_filter
   end
 
   def full_name(trainee)

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -26,6 +26,7 @@ module PageObjects
       element :imported_from_apply_checkbox, "#record_source-apply"
       element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"
       element :subject, "#subject"
+      element :provider_filter, "#provider"
 
       element :export_link, ".app-trainee-export"
 


### PR DESCRIPTION
### Context

Adds a provider filter to the trainee index page for system admins only.

### Changes proposed in this pull request

- New provider filter populated with all providers ordered by name.
- Rendered only for system admins.
- New `AdminFeature` component which wraps the provided content in admin feature styles. Can be optionally passed extra classes/html attributes to apply to outermost div. We'll be adding more admin features soon.

<img width="571" alt="Screenshot 2021-11-04 at 16 04 40" src="https://user-images.githubusercontent.com/18436946/140375517-37dcc679-424b-42c7-a6fd-3d091b0e1b49.png">

### Guidance to review
- Sign in as a system admin, check that you can filter by provider.
- Sign in as a normal user, check that the filter is not visible/you cannot filter by provider.
