### PR TITLE
[3119] Add filter for complete/incomplete records

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -20,9 +20,11 @@ class TraineesController < ApplicationController
     @completed_trainees = paginated_trainees.reject(&:draft?)
 
     # sort_by is to enable alphabetization in line with translations, which is named different to the hash.
-    @training_routes = policy_scope(Trainee)
-                         .group(:training_route)
-                         .count.keys.sort_by(&TRAINING_ROUTE_ENUMS.values.method(:index))
+    @training_routes = policy_scope(Trainee).group(:training_route)
+                                            .count
+                                            .keys
+                                            .sort_by(&TRAINING_ROUTE_ENUMS.values.method(:index))
+
     @providers = Provider.all.order(:name)
 
     respond_to do |format|
@@ -116,7 +118,17 @@ private
   end
 
   def permitted_params
-    [:subject, :text_search, :sort_by, { level: [], training_route: [], state: [], record_source: [] }]
+    [
+      :subject,
+      :text_search,
+      :sort_by, {
+        level: [],
+        training_route: [],
+        state: [],
+        record_source: [],
+        record_completion: [],
+      }
+    ]
   end
 
   def multiple_record_sources?

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -31,6 +31,7 @@ private
       **text_search,
       **record_source,
       **provider,
+      **record_completions,
     ).with_indifferent_access
   end
 
@@ -100,5 +101,17 @@ private
 
   def provider_option
     @provider_option ||= Provider.find_by(id: params[:provider])
+  end
+
+  def record_completions
+    return {} unless record_completion_options.any?
+
+    { "record_completion" => record_completion_options }
+  end
+
+  def record_completion_options
+    %w[complete incomplete].each_with_object([]) do |option, arr|
+      arr << option if params[:record_completion]&.include?(option)
+    end
   end
 end

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -74,6 +74,12 @@ module Trainees
       trainees.where(provider: provider)
     end
 
+    def submission_ready(trainees, record_completion)
+      return trainees if record_completion.blank? || record_completion.size > 1
+
+      trainees.where(submission_ready: record_completion.include?("complete"))
+    end
+
     def filter_trainees
       filtered_trainees = trainees
 
@@ -83,6 +89,7 @@ module Trainees
       filtered_trainees = text_search(filtered_trainees, filters[:text_search])
       filtered_trainees = level(filtered_trainees, filters[:level])
       filtered_trainees = provider(filtered_trainees, filters[:provider])
+      filtered_trainees = submission_ready(filtered_trainees, filters[:record_completion])
 
       record_source(filtered_trainees, filters[:record_source])
     end

--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -24,6 +24,28 @@
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+        <%= t("views.trainees.index.filters.record_completion") %>
+      </legend>
+      <div class="govuk-checkboxes govuk-checkboxes--small">
+        <% [:complete, :incomplete].map do |completion_status| %>
+          <div class="govuk-checkboxes__item">
+            <%= check_box_tag "record_completion[]",
+                              completion_status,
+                              checked?(filters, :record_completion, completion_status.to_s),
+                              id: "record_completion-#{completion_status}",
+                              class: "govuk-checkboxes__input" %>
+            <%= label_tag "record_completion-#{completion_status}",
+                          label_for("record_completion", completion_status),
+                          class: "govuk-label govuk-checkboxes__label" %>
+          </div>
+        <% end %>
+      </div>
+    </fieldset>
+  </div>
+
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
         <%= t("views.trainees.index.filters.level") %>
       </legend>
       <div class="govuk-checkboxes govuk-checkboxes--small">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,6 +341,7 @@ en:
       text_search: Text search
       title: Filters
       training_route: Training route
+      record_completion: Record completion
     timeline:
       withdrawal_date: Date of withdrawal
       withdrawal_reason: Reason for withdrawal
@@ -505,6 +506,9 @@ en:
         no_records: Your trainee records will appear here. You do not have any records yet.
         export: Export these records
         filters:
+          record_completion: Record completion
+          incomplete: Incomplete
+          complete: Complete
           level: Education phase
           provider: Provider
           search: Search for a trainee
@@ -918,6 +922,9 @@ en:
           early_years: Early years
           primary: Primary
           secondary: Secondary
+        record_completions:
+          complete: Complete
+          incomplete: Incomplete
     errors:
       models:
         trainee:

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -11,6 +11,16 @@ RSpec.feature "Filtering trainees" do
     then_all_trainees_are_visible
   end
 
+  scenario "can filter by complete records" do
+    when_i_filter_by_complete
+    then_only_complete_records_are_visible
+  end
+
+  scenario "can filter by incomplete records" do
+    when_i_filter_by_incomplete
+    then_only_incomplete_records_are_visible
+  end
+
   scenario "can filter by subject" do
     when_i_filter_by_subject("Biology")
     then_only_biology_trainees_are_visible
@@ -127,6 +137,7 @@ private
     @history_trainee ||= create(:trainee, :with_subject_specialism, subject_name: CourseSubjects::HISTORY)
     @searchable_trainee ||= create(:trainee, trn: "123")
     @draft_trainee ||= create(:trainee, :draft)
+    @non_draft_trainee ||= create(:trainee, :submitted_for_trn)
     @withdrawn_trainee ||= create(:trainee, :withdrawn)
     @early_years_trainee ||= create(:trainee, :early_years_undergrad)
     @primary_trainee ||= create(:trainee, course_age_range: AgeRange::THREE_TO_EIGHT)
@@ -176,6 +187,16 @@ private
     trainee_index_page.apply_filters.click
   end
 
+  def when_i_filter_by_complete
+    trainee_index_page.complete_checkbox.check
+    trainee_index_page.apply_filters.click
+  end
+
+  def when_i_filter_by_incomplete
+    trainee_index_page.incomplete_checkbox.check
+    trainee_index_page.apply_filters.click
+  end
+
   def when_i_filter_by_early_years_level
     trainee_index_page.early_years_checkbox.click
     trainee_index_page.apply_filters.click
@@ -219,6 +240,14 @@ private
   def then_only_biology_trainees_are_visible
     expect(trainee_index_page).to have_text(full_name(@biology_trainee))
     expect(trainee_index_page).not_to have_text(full_name(@history_trainee))
+  end
+
+  def then_only_complete_records_are_visible
+    expect(trainee_index_page).to have_text(full_name(@non_draft_trainee))
+  end
+
+  def then_only_incomplete_records_are_visible
+    expect(trainee_index_page).to have_text(full_name(@draft_trainee))
   end
 
   def then_only_the_searchable_trainee_is_visible

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -92,6 +92,22 @@ module Trainees
       it { is_expected.to eq([named_trainee]) }
     end
 
+    context "with record_completion filter" do
+      let!(:non_draft_trainee) { create(:trainee, :submitted_for_trn) }
+
+      context "complete" do
+        let(:filters) { { record_completion: ["complete"] } }
+
+        it { is_expected.to match_array([non_draft_trainee]) }
+      end
+
+      context "incomplete" do
+        let(:filters) { { record_completion: ["incomplete"] } }
+
+        it { is_expected.to match_array([draft_trainee, apply_draft_trainee]) }
+      end
+    end
+
     context "with record_source filter set to apply" do
       let(:filters) { { record_source: %w[apply] } }
 

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -21,6 +21,8 @@ module PageObjects
 
       element :text_search, "#text_search"
       element :early_years_checkbox, "#level-early_years"
+      element :complete_checkbox, "#record_completion-complete"
+      element :incomplete_checkbox, "#record_completion-incomplete"
       element :assessment_only_checkbox, "#training_route-assessment_only"
       element :draft_checkbox, "#state-draft"
       element :imported_from_apply_checkbox, "#record_source-apply"


### PR DESCRIPTION
### Context
https://trello.com/c/VxEtBB7h/3119-m-add-filter-for-incomplete-records

### Changes proposed in this pull request
- Add new filter section "Record completion" with checkboxes to filter "complete" or "incomplete" records

### Guidance to review
- Visit trainees index page
- Try the "complete" and "incomplete" options
- If you check both, then it returns all records

<img width="986" alt="Screenshot 2021-11-05 at 10 05 33" src="https://user-images.githubusercontent.com/28728/140493820-36ea2197-1212-4add-be07-6985dd773c93.png">

