### PR TITLE
[3170] Add award type mapping for HPTT route

### DIFF
--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -85,6 +85,7 @@ TRAINING_ROUTE_AWARD_TYPE = {
   school_direct_salaried: QTS_AWARD_TYPE,
   school_direct_tuition_fee: QTS_AWARD_TYPE,
   opt_in_undergrad: QTS_AWARD_TYPE,
+  hpitt_postgrad: QTS_AWARD_TYPE,
 }.freeze
 
 EARLY_YEARS_ROUTES = TRAINING_ROUTE_AWARD_TYPE.select { |_, v| v == EYTS_AWARD_TYPE }.keys.freeze


### PR DESCRIPTION
### Context

https://trello.com/c/TsR7moUC/3170-system-admin-unable-to-view-awarded-trainees

### Changes proposed in this pull request

We were missing a mapping for HPITT award type, so the view was breaking trying to render the tag 'QTS AWARDED'.

### Guidance to review

Check that you can view an HPITT trainee who has been awarded QTS.
