### PR TITLE
[3168] Incomplete records

### DIFF
--- a/app/controllers/trainees/check_details_controller.rb
+++ b/app/controllers/trainees/check_details_controller.rb
@@ -6,7 +6,7 @@ module Trainees
 
     def show
       page_tracker.save_as_origin!
-      @form = TrnSubmissionForm.new(trainee: trainee)
+      @form = SubmissionReadyForm.new(trainee: trainee)
     end
   end
 end

--- a/app/controllers/trn_submissions_controller.rb
+++ b/app/controllers/trn_submissions_controller.rb
@@ -5,7 +5,7 @@ class TrnSubmissionsController < ApplicationController
 
   def create
     unless trainee.submission_ready?
-      @form = TrnSubmissionForm.new(trainee: trainee)
+      @form = SubmissionReadyForm.new(trainee: trainee)
       @form.validate
       return render("trainees/check_details/show")
     end

--- a/app/forms/submission_ready_form.rb
+++ b/app/forms/submission_ready_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TrnSubmissionForm
+class SubmissionReadyForm
   include ActiveModel::Model
 
   class_attribute :form_validators, instance_writer: false, default: {}
@@ -29,6 +29,7 @@ class TrnSubmissionForm
     @trainee = trainee
   end
 
+  # Only used for draft workflows to track progress of record completion
   def progress_status(progress_key)
     progress_service(progress_key).status.parameterize(separator: "_").to_sym
   end
@@ -39,6 +40,8 @@ class TrnSubmissionForm
   end
 
   def all_sections_complete?
+    return true unless trainee.draft?
+
     progress_keys.all? do |progress_key|
       progress_is_completed?(progress_key)
     end

--- a/app/jobs/trainees/update_submission_readiness_job.rb
+++ b/app/jobs/trainees/update_submission_readiness_job.rb
@@ -6,7 +6,7 @@ module Trainees
     queue_as :default
 
     def perform(trainee)
-      trainee.update(submission_ready: TrnSubmissionForm.new(trainee: trainee).valid?)
+      trainee.update(submission_ready: SubmissionReadyForm.new(trainee: trainee).valid?)
     end
   end
 end

--- a/app/lib/bulk_import.rb
+++ b/app/lib/bulk_import.rb
@@ -384,7 +384,7 @@ module BulkImport
     end
 
     def validate_and_set_progress(trainee)
-      TrnSubmissionForm.new(trainee: trainee).form_validators.each do |section, validator|
+      SubmissionReadyForm.new(trainee: trainee).form_validators.each do |section, validator|
         section_valid = validator[:form].constantize.new(trainee).valid?
         trainee.progress.public_send("#{section}=", section_valid)
       end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -351,6 +351,6 @@ private
   end
 
   def set_submission_ready
-    self.submission_ready = TrnSubmissionForm.new(trainee: self).valid?
+    self.submission_ready = SubmissionReadyForm.new(trainee: self).valid?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1172,7 +1172,7 @@ en:
               invalid: Enter a valid date of return
               hint_html: For example, 15 6 %{year}
               not_before_course_start_date: *not_before_course_start_date
-        trn_submission_form:
+        submission_ready_form:
           attributes:
             trainee:
               incomplete: Complete all sections before submitting for TRN

--- a/db/data/20211105134900_fix_up_submission_ready.rb
+++ b/db/data/20211105134900_fix_up_submission_ready.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FixUpSubmissionReady < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.where.not(state: :draft).find_each do |trainee|
+      Trainees::UpdateSubmissionReadinessJob.perform_later(trainee)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/tasks/hpitt_bulk_submit.rake
+++ b/lib/tasks/hpitt_bulk_submit.rake
@@ -16,7 +16,7 @@ namespace :hpitt do
       trainee_group.each do |trainee|
         next if trainees_to_exclude.include?(trainee.trainee_id)
 
-        next unless TrnSubmissionForm.new(trainee: trainee).valid?
+        next unless SubmissionReadyForm.new(trainee: trainee).valid?
 
         trainee.submit_for_trn!
 

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -14,14 +14,14 @@ module Pages
           define_method sections do
             @trainee = trainee(sections)
 
-            @form = TrnSubmissionForm.new(trainee: @trainee)
+            @form = SubmissionReadyForm.new(trainee: @trainee)
             render template: template, locals: { "@trainee": @trainee, "@form": @form }
           end
 
           define_method "#{sections}_validated" do
             @trainee = trainee(sections)
 
-            @form = TrnSubmissionForm.new(trainee: @trainee)
+            @form = SubmissionReadyForm.new(trainee: @trainee)
             @form.validate
             render template: template, locals: { "@trainee": @trainee, "@form": @form }
           end
@@ -29,14 +29,14 @@ module Pages
           define_method "#{sections}_itt" do
             @trainee = itt_trainee(sections)
 
-            @form = TrnSubmissionForm.new(trainee: @trainee)
+            @form = SubmissionReadyForm.new(trainee: @trainee)
             render template: template, locals: { "@trainee": @trainee, "@form": @form }
           end
 
           define_method "#{sections}_itt_validated" do
             @trainee = itt_trainee(sections)
 
-            @form = TrnSubmissionForm.new(trainee: @trainee)
+            @form = SubmissionReadyForm.new(trainee: @trainee)
             @form.validate
             render template: template, locals: { "@trainee": @trainee, "@form": @form }
           end

--- a/spec/components/sections/view_preview.rb
+++ b/spec/components/sections/view_preview.rb
@@ -15,26 +15,26 @@ module Sections
        trainee_data].each do |section|
       define_method "continue_sections_#{section}" do
         trainee = continue_sections_trainee(section)
-        form = TrnSubmissionForm.new(trainee: trainee)
+        form = SubmissionReadyForm.new(trainee: trainee)
         render(View.new(trainee: trainee, section: section, form: form))
       end
 
       define_method "continue_sections_#{section}_validated" do
         trainee = continue_sections_trainee(section)
-        form = TrnSubmissionForm.new(trainee: trainee)
+        form = SubmissionReadyForm.new(trainee: trainee)
         form.validate
         render(View.new(trainee: trainee, section: section, form: form))
       end
 
       define_method "start_sections_#{section}" do
         trainee = start_sections_trainee(section)
-        form = TrnSubmissionForm.new(trainee: trainee)
+        form = SubmissionReadyForm.new(trainee: trainee)
         render(View.new(trainee: trainee, section: section, form: form))
       end
 
       define_method "start_sections_#{section}_validated" do
         trainee = start_sections_trainee(section)
-        form = TrnSubmissionForm.new(trainee: trainee)
+        form = SubmissionReadyForm.new(trainee: trainee)
         form.validate
         render(View.new(trainee: trainee, section: section, form: form))
       end

--- a/spec/components/sections/view_spec.rb
+++ b/spec/components/sections/view_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Sections
   describe View do
     let(:trainees_sections_component) do
-      form = TrnSubmissionForm.new(trainee: trainee)
+      form = SubmissionReadyForm.new(trainee: trainee)
       described_class.new(trainee: trainee, section: section, form: form)
     end
 

--- a/spec/features/trainee_actions/submit_for_trn_spec.rb
+++ b/spec/features/trainee_actions/submit_for_trn_spec.rb
@@ -108,7 +108,7 @@ feature "submit for TRN" do
 
   def then_i_see_an_error_message
     expect(page).to have_content(
-      I18n.t("activemodel.errors.models.trn_submission_form.attributes.trainee.incomplete"),
+      I18n.t("activemodel.errors.models.submission_ready_form.attributes.trainee.incomplete"),
     )
   end
 

--- a/spec/forms/submission_ready_form_spec.rb
+++ b/spec/forms/submission_ready_form_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe TrnSubmissionForm, type: :model do
+describe SubmissionReadyForm, type: :model do
   let(:trainee) do
     create(
       :trainee,
@@ -14,7 +14,7 @@ describe TrnSubmissionForm, type: :model do
   shared_examples "error" do
     it "is invalid and returns an error message" do
       expect(subject.valid?).to be false
-      expect(subject.errors.messages[:trainee]).to include(I18n.t("activemodel.errors.models.trn_submission_form.attributes.trainee.incomplete"))
+      expect(subject.errors.messages[:trainee]).to include(I18n.t("activemodel.errors.models.submission_ready_form.attributes.trainee.incomplete"))
     end
   end
 
@@ -226,6 +226,26 @@ describe TrnSubmissionForm, type: :model do
       let(:progress) { {} }
 
       include_examples "error"
+    end
+  end
+
+  describe "#all_sections_complete?" do
+    subject { described_class.new(trainee: trainee) }
+
+    context "when trainee is non draft" do
+      let(:trainee) { build(:trainee, :completed, :trn_received) }
+
+      it "returns true" do
+        expect(subject.all_sections_complete?).to be(true)
+      end
+    end
+
+    context "when trainee is draft" do
+      let(:trainee) { build(:trainee, :draft) }
+
+      it "returns false" do
+        expect(subject.all_sections_complete?).to be(false)
+      end
     end
   end
 end

--- a/spec/jobs/dttp/recommend_for_award_job_spec.rb
+++ b/spec/jobs/dttp/recommend_for_award_job_spec.rb
@@ -26,7 +26,7 @@ module Dttp
 
     before do
       enable_features(:persist_to_dttp)
-      allow(TrnSubmissionForm).to receive(:new).and_return(double(valid?: true))
+      allow(SubmissionReadyForm).to receive(:new).and_return(double(valid?: true))
       allow(RecommendForAward).to receive(:call).with(trainee: trainee)
       allow(UpdateTraineeStatus).to receive(:call).with(expected_contact_params)
       allow(UpdateTraineeStatus).to receive(:call).with(expected_placement_assignment_params)

--- a/spec/jobs/dttp/register_for_trn_job_spec.rb
+++ b/spec/jobs/dttp/register_for_trn_job_spec.rb
@@ -11,7 +11,7 @@ module Dttp
 
     before do
       enable_features(:persist_to_dttp)
-      allow(TrnSubmissionForm).to receive(:new).and_return(double(valid?: true))
+      allow(SubmissionReadyForm).to receive(:new).and_return(double(valid?: true))
       allow(RegisterForTrn).to receive(:call)
     end
 

--- a/spec/jobs/dttp/retrieve_award_job_spec.rb
+++ b/spec/jobs/dttp/retrieve_award_job_spec.rb
@@ -14,7 +14,7 @@ module Dttp
 
     before do
       enable_features(:persist_to_dttp)
-      allow(TrnSubmissionForm).to receive(:new).and_return(double(valid?: true))
+      allow(SubmissionReadyForm).to receive(:new).and_return(double(valid?: true))
       allow(RetrieveAward).to receive(:call).with(trainee: trainee).and_return(award_status)
       allow(Settings.jobs).to receive(:poll_delay_hours).and_return(configured_delay)
       allow(Settings.jobs).to receive(:max_poll_duration_days).and_return(configured_poll_timeout_days)

--- a/spec/jobs/dttp/retrieve_trn_job_spec.rb
+++ b/spec/jobs/dttp/retrieve_trn_job_spec.rb
@@ -14,7 +14,7 @@ module Dttp
 
     before do
       enable_features(:sync_from_dttp)
-      allow(TrnSubmissionForm).to receive(:new).and_return(double(valid?: true))
+      allow(SubmissionReadyForm).to receive(:new).and_return(double(valid?: true))
       allow(RetrieveTrn).to receive(:call).with(trainee: trainee).and_return(trn)
       allow(Settings.jobs).to receive(:poll_delay_hours).and_return(configured_delay)
       allow(Settings.jobs).to receive(:max_poll_duration_days).and_return(configured_poll_timeout_days)

--- a/spec/services/dttp/create_dormancy_spec.rb
+++ b/spec/services/dttp/create_dormancy_spec.rb
@@ -16,7 +16,7 @@ module Dttp
 
       before do
         enable_features(:persist_to_dttp)
-        allow(TrnSubmissionForm).to receive(:new).and_return(double(valid?: true))
+        allow(SubmissionReadyForm).to receive(:new).and_return(double(valid?: true))
         allow(AccessToken).to receive(:fetch).and_return("token")
         stub_request(:post, request_url).to_return(http_response)
         allow(Dttp::OdataParser).to receive(:entity_id).with(trainee.id, HTTParty::Response).and_return(expected_dormant_id)

--- a/spec/services/dttp/update_dormancy_spec.rb
+++ b/spec/services/dttp/update_dormancy_spec.rb
@@ -15,7 +15,7 @@ module Dttp
 
       before do
         enable_features(:persist_to_dttp)
-        allow(TrnSubmissionForm).to receive(:new).and_return(double(valid?: true))
+        allow(SubmissionReadyForm).to receive(:new).and_return(double(valid?: true))
         allow(AccessToken).to receive(:fetch).and_return("token")
         stub_request(:patch, request_url).to_return(http_response)
         allow(Params::Dormancy).to receive(:new).with(trainee: trainee)

--- a/spec/services/dttp/update_trainee_status_spec.rb
+++ b/spec/services/dttp/update_trainee_status_spec.rb
@@ -16,7 +16,7 @@ module Dttp
 
       before do
         enable_features(:persist_to_dttp)
-        allow(TrnSubmissionForm).to receive(:new).and_return(double(valid?: true))
+        allow(SubmissionReadyForm).to receive(:new).and_return(double(valid?: true))
         allow(AccessToken).to receive(:fetch).and_return("token")
         stub_request(:patch, request_url).to_return(http_response)
       end


### PR DESCRIPTION
### Context

- https://trello.com/c/jbLUTBHD/3168-incomplete-records-that-are-submitted-cant-be-fixed-if-the-complete-checkbox-is-unchecked

### Changes proposed in this pull request

This PR fixes a bug whereby non draft trainees would be marked as incomplete due to the `SubmissionReadyForm` returning `valid? => false` for these records. The change is to consider the progress of these records "completed" (business decision) so it returns true for the validity.

The `progress` jsonb field is only relevant to track the record progress for draft trainees so it DOES need to be considered for that state during draft workflows.

There's also a data migration to fix up non draft trainees in prod and I've renamed the form from `TrnSubmissionForm` to `SubmissionReadyForm` to better reflect the puropose

### Guidance to review

