### PR TITLE
[3160] Modifying which start date forms are rendered

### DIFF
--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -93,7 +93,13 @@ module RecordDetails
     end
 
     def trainee_start_date_row
-      mappable_field(trainee_start_date, t(".trainee_start_date"), edit_trainee_start_date_path(trainee))
+      return if @trainee.course_start_date.nil?
+
+      if @trainee.course_start_date <= Time.zone.now
+        mappable_field(trainee_start_date, t(".trainee_start_date"), edit_trainee_start_date_path(trainee))
+      else
+        mappable_field(trainee_start_date, t(".trainee_start_date"), nil)
+      end
     end
 
     def render_text_with_hint(date)

--- a/app/controllers/trainees/start_dates_controller.rb
+++ b/app/controllers/trainees/start_dates_controller.rb
@@ -9,6 +9,7 @@ module Trainees
     }.freeze
 
     def edit
+      redirect_to(edit_trainee_start_status_path(trainee)) if @trainee.commencement_date.blank?
       @trainee_start_date_form = TraineeStartDateForm.new(trainee)
     end
 

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -144,6 +144,17 @@ module RecordDetails
           end
         end
       end
+
+      context "when trainee start date is in the future" do
+        let(:trainee) {
+          create(:trainee, state, training_route, trn: Faker::Number.number(digits: 10), provider: provider,
+                                                  course_start_date: Time.zone.tomorrow)
+        }
+
+        it "does not render the change link" do
+          expect(rendered_component).not_to have_link(t("change"), href: "/trainees/#{trainee.slug}/trainee-start-date/edit")
+        end
+      end
     end
   end
 end

--- a/spec/features/form_sections/teacher_training_data/edit_trainee_start_date_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_trainee_start_date_spec.rb
@@ -9,17 +9,23 @@ feature "edit Trainee start date" do
 
   background do
     given_i_am_authenticated
+  end
+
+  scenario "updates the start date" do
     given_a_trainee_exists(:submitted_for_trn)
     when_i_visit_the_edit_trainee_start_date_page
     when_i_change_the_start_date
     when_i_click_continue
-  end
-
-  scenario "updates the start date" do
     then_i_am_taken_to_the_confirmation_page
     when_i_confirm
     then_i_am_redirected_to_the_record_page
     then_the_trainee_start_date_is_updated
+  end
+
+  scenario "start date is not set" do
+    given_a_trainee_exists(:submitted_for_trn, commencement_date: nil)
+    when_i_visit_the_edit_trainee_start_date_page
+    then_i_am_redirected_to_the_edit_trainee_start_status_page
   end
 
   def when_i_visit_the_edit_trainee_start_date_page
@@ -36,6 +42,10 @@ feature "edit Trainee start date" do
 
   def then_i_am_taken_to_the_confirmation_page
     expect(page).to have_current_path("/trainees/#{trainee.slug}/trainee-start-date/confirm", ignore_query: true)
+  end
+
+  def then_i_am_redirected_to_the_edit_trainee_start_status_page
+    expect(page).to have_current_path("/trainees/#{trainee.slug}/trainee-start-status/edit")
   end
 
   def when_i_confirm


### PR DESCRIPTION
### Context

Modifying which start date forms are rendered

### Changes proposed in this pull request

- Redirect to `edit_trainee_start_status_path` if commencement date is blank

-  If commencement date is in the future don't render the change links for trainee start date on summary page

### Guidance to review

- Check that the change link is hidden from the summary page if the ITT date is in the future
- Check that the new form is rendered if the commencement date is blank. You can manually set this to blank on a registered trainee by navigating to a trainee and changing the URL to `trainees/{{slug}}/trainee-start-status/edit`