### PR TITLE
[3146] Handle course starting in the future for deferring

### DIFF
--- a/app/components/deferral_details/view.html.erb
+++ b/app/components/deferral_details/view.html.erb
@@ -4,7 +4,7 @@
     {
       key: t("components.confirmation.deferral_details.defer_date_label"),
       value: defer_date,
-      action_href: trainee_deferral_path(data_model.trainee),
+      action_href: deferred_before_starting? ? nil: trainee_deferral_path(data_model.trainee),
       action_text: t(:change),
       action_visually_hidden_text: 'date of deferral',
     },

--- a/app/components/deferral_details/view.rb
+++ b/app/components/deferral_details/view.rb
@@ -11,7 +11,11 @@ module DeferralDetails
     end
 
     def defer_date
-      date_for_summary_view(data_model.date)
+      deferred_before_starting? ? t(".deferred_before_starting") : date_for_summary_view(data_model.date)
+    end
+
+    def deferred_before_starting?
+      data_model.date.nil?
     end
   end
 end

--- a/app/components/record_details/trainee_start_date.rb
+++ b/app/components/record_details/trainee_start_date.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RecordDetails
+  class TraineeStartDate
+    include SummaryHelper
+    include Rails.application.routes.url_helpers
+
+    def initialize(trainee)
+      @trainee = trainee
+    end
+
+    def text
+      return I18n.t("record_details.view.itt_has_not_started") if trainee.starts_course_in_the_future?
+      return I18n.t("record_details.view.deferred_before_itt_started") if deferred_with_no_start_date?
+      return date_for_summary_view(trainee.commencement_date) if commencement_date_present?
+
+      I18n.t("record_details.view.not_provided")
+    end
+
+    def link
+      return if trainee.starts_course_in_the_future?
+      return edit_trainee_start_date_path(trainee) if deferred_with_no_start_date? || commencement_date_present?
+
+      edit_trainee_start_status_path(trainee)
+    end
+
+    def course_empty?
+      trainee.course_start_date.nil?
+    end
+
+  private
+
+    attr_reader :trainee
+
+    def commencement_date_present?
+      trainee.commencement_date.present?
+    end
+
+    def deferred_with_no_start_date?
+      trainee.deferred? && trainee.commencement_date.blank?
+    end
+  end
+end

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -93,23 +93,11 @@ module RecordDetails
     end
 
     def trainee_start_date_row
-      return if trainee.course_start_date.nil?
+      start_date = RecordDetails::TraineeStartDate.new(trainee)
 
-      if trainee.starts_course_in_the_future?
-        text = t(".itt_has_not_started")
-        link = nil
-      elsif deferred_with_no_start_date?
-        text = t(".deferred_before_itt_started")
-        link = edit_trainee_start_date_path(trainee)
-      elsif trainee.commencement_date.present?
-        text = date_for_summary_view(trainee.commencement_date)
-        link = edit_trainee_start_date_path(trainee)
-      else
-        text = t(".not_provided")
-        link = edit_trainee_start_status_path(trainee)
-      end
+      return if start_date.course_empty?
 
-      mappable_field(text, t(".trainee_start_date"), link)
+      mappable_field(start_date.text, t(".trainee_start_date"), start_date.link)
     end
 
     def render_text_with_hint(date)
@@ -154,10 +142,6 @@ module RecordDetails
 
     def mappable_field(field_value, field_label, action_url)
       { field_value: field_value, field_label: field_label, action_url: action_url }
-    end
-
-    def deferred_with_no_start_date?
-      trainee.deferred? && trainee.commencement_date.blank?
     end
   end
 end

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -95,9 +95,12 @@ module RecordDetails
     def trainee_start_date_row
       return if trainee.course_start_date.nil?
 
-      if trainee.course_start_date.future?
+      if trainee.starts_course_in_the_future?
         text = t(".itt_has_not_started")
         link = nil
+      elsif deferred_with_no_start_date?
+        text = t(".deferred_before_itt_started")
+        link = edit_trainee_start_date_path(trainee)
       elsif trainee.commencement_date.present?
         text = date_for_summary_view(trainee.commencement_date)
         link = edit_trainee_start_date_path(trainee)
@@ -151,6 +154,10 @@ module RecordDetails
 
     def mappable_field(field_value, field_label, action_url)
       { field_value: field_value, field_label: field_label, action_url: action_url }
+    end
+
+    def deferred_with_no_start_date?
+      trainee.deferred? && trainee.commencement_date.blank?
     end
   end
 end

--- a/app/components/reinstatement_details/view.html.erb
+++ b/app/components/reinstatement_details/view.html.erb
@@ -4,7 +4,7 @@
     {
       key: t("components.confirmation.reinstatement_details.reinstate_date_label"),
       value: reinstate_date,
-      action_href: trainee_reinstatement_path(data_model.trainee),
+      action_href: deferred_before_starting? ? nil: trainee_reinstatement_path(data_model.trainee),
       action_text: t(:change),
     },
   ],

--- a/app/components/reinstatement_details/view.rb
+++ b/app/components/reinstatement_details/view.rb
@@ -11,7 +11,11 @@ module ReinstatementDetails
     end
 
     def reinstate_date
-      date_for_summary_view(data_model.date)
+      deferred_before_starting? ? t(".reinstated_before_starting") : date_for_summary_view(data_model.date)
+    end
+
+    def deferred_before_starting?
+      data_model.date.nil?
     end
   end
 end

--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -8,7 +8,7 @@ module Trainees
     end
 
     def update
-      if deferral_form.save!
+      if deferral_form.save! || trainee.starts_course_in_the_future?
         trainee.defer!
 
         Dttp::DeferJob.perform_later(trainee)

--- a/app/controllers/trainees/confirm_reinstatements_controller.rb
+++ b/app/controllers/trainees/confirm_reinstatements_controller.rb
@@ -8,7 +8,7 @@ module Trainees
     end
 
     def update
-      if reinstatement.save!
+      if reinstatement.save! || trainee.starts_course_in_the_future?
         trainee.trn.present? ? trainee.receive_trn! : trainee.submit_for_trn!
 
         Dttp::ReinstateJob.perform_later(trainee)

--- a/app/controllers/trainees/deferrals_controller.rb
+++ b/app/controllers/trainees/deferrals_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class DeferralsController < BaseController
+    before_action :redirect_to_confirm_deferral, if: -> { trainee.starts_course_in_the_future? }
+
     def show
       @deferral_form = DeferralForm.new(trainee)
     end
@@ -12,7 +14,7 @@ module Trainees
       @deferral_form = DeferralForm.new(trainee, params: trainee_params, user: current_user)
 
       if @deferral_form.stash
-        redirect_to(trainee_confirm_deferral_path(trainee))
+        redirect_to_confirm_deferral
       else
         render(:show)
       end
@@ -26,6 +28,10 @@ module Trainees
         .transform_keys do |key|
           MultiDateForm::PARAM_CONVERSION.fetch(key, key)
         end
+    end
+
+    def redirect_to_confirm_deferral
+      redirect_to(trainee_confirm_deferral_path(trainee))
     end
   end
 end

--- a/app/controllers/trainees/reinstatements_controller.rb
+++ b/app/controllers/trainees/reinstatements_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class ReinstatementsController < BaseController
+    before_action :redirect_to_confirm_reinstatement, if: -> { trainee.starts_course_in_the_future? }
+
     def show
       @reinstatement_form = ReinstatementForm.new(trainee)
     end
@@ -12,7 +14,7 @@ module Trainees
       @reinstatement_form = ReinstatementForm.new(trainee, params: trainee_params, user: current_user)
 
       if @reinstatement_form.stash
-        redirect_to(trainee_confirm_reinstatement_path(@trainee))
+        redirect_to_confirm_reinstatement
       else
         render(:show)
       end
@@ -26,6 +28,10 @@ module Trainees
         .transform_keys do |key|
           MultiDateForm::PARAM_CONVERSION.fetch(key, key)
         end
+    end
+
+    def redirect_to_confirm_reinstatement
+      redirect_to(trainee_confirm_reinstatement_path(trainee))
     end
   end
 end

--- a/app/forms/reinstatement_form.rb
+++ b/app/forms/reinstatement_form.rb
@@ -1,7 +1,22 @@
 # frozen_string_literal: true
 
 class ReinstatementForm < MultiDateForm
+  def save!
+    if valid?
+      update_trainee
+      trainee.save!
+      clear_stash
+    else
+      false
+    end
+  end
+
 private
+
+  def update_trainee
+    trainee[date_field] = date
+    trainee.commencement_date = date if trainee.deferred? && trainee.commencement_date.nil?
+  end
 
   def date_field
     @date_field ||= :reinstate_date

--- a/app/lib/dttp/params/dormancy.rb
+++ b/app/lib/dttp/params/dormancy.rb
@@ -22,7 +22,7 @@ module Dttp
       attr_reader :trainee
 
       def date_left
-        trainee.defer_date.in_time_zone.iso8601
+        trainee.defer_date&.in_time_zone&.iso8601
       end
 
       def date_returned

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -319,7 +319,7 @@ class Trainee < ApplicationRecord
   end
 
   def starts_course_in_the_future?
-    course_start_date && course_start_date > Time.zone.today
+    course_start_date&.future?
   end
 
   def awaiting_action?

--- a/app/views/trainees/start_statuses/edit.html.erb
+++ b/app/views/trainees/start_statuses/edit.html.erb
@@ -5,7 +5,7 @@
     <%= render GovukComponent::BackLinkComponent.new(text: t(:back),
                                                      href: trainee_start_date_verification_path(@trainee)) %>
   <% else  %>
-    <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+    <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>
   <% end  %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,10 +70,17 @@ en:
         withdrawn: "Withdrawal date: "
       itt_has_not_started: ITT has not started
       not_provided: Not provided
+      deferred_before_itt_started: Trainee deferred before starting their ITT
   training_details:
     view:
       title: *trainee_id
       region: *region
+  deferral_details:
+    view:
+      deferred_before_starting: Trainee deferred before their ITT started
+  reinstatement_details:
+    view:
+      reinstated_before_starting: Trainee returned before their ITT started
   components:
     admin_feature:
       title: Admin feature

--- a/spec/components/deferral_details/view_preview.rb
+++ b/spec/components/deferral_details/view_preview.rb
@@ -6,10 +6,17 @@ module DeferralDetails
       render(View.new(data_model))
     end
 
+    def deferred_before_starting
+      render(View.new(OpenStruct.new(trainee: trainee, date: nil)))
+    end
+
   private
 
+    def trainee
+      @trainee ||= Trainee.new(id: 1, defer_date: Time.zone.yesterday)
+    end
+
     def data_model
-      trainee = Trainee.new(id: 1, defer_date: Time.zone.yesterday)
       OpenStruct.new(trainee: trainee, date: trainee.defer_date)
     end
   end

--- a/spec/components/deferral_details/view_spec.rb
+++ b/spec/components/deferral_details/view_spec.rb
@@ -8,15 +8,28 @@ module DeferralDetails
 
     alias_method :component, :page
 
-    let(:trainee_stub) { Trainee.new(defer_date: Time.zone.yesterday) }
     let(:data_model) { OpenStruct.new(trainee: trainee_stub, date: trainee_stub.defer_date) }
 
     before do
       render_inline(View.new(data_model))
     end
 
-    it "renders the deferral end date" do
-      expect(component).to have_text(date_for_summary_view(data_model.date))
+    context "course start date is in the past" do
+      let(:trainee_stub) { Trainee.new(defer_date: Time.zone.yesterday) }
+
+      it "renders the deferral date" do
+        expect(component).to have_text(date_for_summary_view(data_model.date))
+      end
+    end
+
+    context "course start date is in the future" do
+      let(:trainee_stub) { Trainee.new }
+
+      it "renders the deferred before course start date message" do
+        expect(component).to have_text(
+          t("deferral_details.view.deferred_before_starting"),
+        )
+      end
     end
   end
 end

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -133,17 +133,6 @@ module RecordDetails
           end
         end
       end
-
-      context "when trainee start date is in the future" do
-        let(:trainee) {
-          create(:trainee, state, training_route, trn: Faker::Number.number(digits: 10), provider: provider,
-                                                  course_start_date: Time.zone.tomorrow)
-        }
-
-        it "does not render the change link" do
-          expect(rendered_component).not_to have_link(t("change"), href: "/trainees/#{trainee.slug}/trainee-start-date/edit")
-        end
-      end
     end
 
     context "Trainee start date row" do
@@ -200,6 +189,16 @@ module RecordDetails
           it "renders link to trainee start status form" do
             expect(rendered_component).to have_selector(".govuk-summary-list__row.trainee-start-date .govuk-summary-list__actions a", count: 1)
             expect(rendered_component).to have_link(href: "/trainees/#{trainee.to_param}/trainee-start-status/edit")
+          end
+
+          context "when deferred" do
+            let(:trainee) do
+              create(:trainee, :deferred, course_start_date: Time.zone.today)
+            end
+
+            it "renders the trainee deferred before course started message" do
+              expect(rendered_component).to have_text(t("record_details.view.deferred_before_itt_started"))
+            end
           end
         end
       end


### PR DESCRIPTION
### Context

- https://trello.com/c/WjPPrUDt/3146-m-course-starts-in-the-future-defer
- https://trello.com/c/qxWQ8yi5/3164-s-reinstating-a-deferred-trainee

### Changes proposed in this pull request

- Introduce a new defer flow if the course starts in the future
- Trainee can be deferred in the scenario above but date options aren't shown to provider
- If reinstated, the trainee's `commencement_date` is marked the same as the `reinstate_date`

### Guidance to review

This flow hinges on the trainee's commencement date not being set as the course start date is in the future. There are tickets removing capturing this from the draft sections and after the trn has been requested. In that scenario, the commencement date is only requested if the course start date is on the current day or in the past. Therefore this field will show as missing data (spoken with Ed) when the course start date is due.

Test with any of these trainees:

- Change the course start date to be in the future
- The record details component should show a `Course has not started` message
- Defer the trainee, the trainee should be deferred with no date set
- Reinstate the trainee, (you'll have to set the reinstated date on or after the course start date due to validations), the trainee's commencement date should match the reinstated date


