### PR TITLE
[3147] Course starts in the past, no trainee start date — delete

### DIFF
--- a/app/components/dynamic_back_link/view.rb
+++ b/app/components/dynamic_back_link/view.rb
@@ -2,12 +2,13 @@
 
 module DynamicBackLink
   class View < GovukComponent::Base
-    attr_reader :trainee, :text, :last_origin_page
+    attr_reader :trainee, :text, :last_origin_page, :consider_confirm_page
 
-    def initialize(trainee, text: nil, last_origin_page: false)
+    def initialize(trainee, text: nil, last_origin_page: false, consider_confirm_page: true)
       @trainee = trainee
       @text = text
       @last_origin_page = last_origin_page
+      @consider_confirm_page = consider_confirm_page
     end
 
     def link_text
@@ -16,7 +17,11 @@ module DynamicBackLink
 
     def path
       page_tracker = PageTracker.new(trainee_slug: trainee.slug, session: session, request: request)
-      page_tracker.public_send(last_origin_page ? :last_origin_page_path : :previous_page_path)
+      if last_origin_page
+        page_tracker.last_origin_page_path
+      else
+        page_tracker.previous_page_path(consider_confirm_page: consider_confirm_page)
+      end
     end
   end
 end

--- a/app/components/record_actions/view.rb
+++ b/app/components/record_actions/view.rb
@@ -45,7 +45,7 @@ module RecordActions
     end
 
     def delete_link
-      govuk_link_to(t("views.trainees.edit.delete"), trainee_confirm_delete_path(trainee), class: "delete")
+      govuk_link_to(t("views.trainees.edit.delete"), trainee_start_date_verification_path(trainee), class: "delete")
     end
 
     def defer_link

--- a/app/controllers/trainees/forbidden_deletes_controller.rb
+++ b/app/controllers/trainees/forbidden_deletes_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Trainees
+  class ForbiddenDeletesController < BaseController
+    def show
+      page_tracker.save!
+      @trainee_forbidden_deletes_form = TraineeForbiddenDeleteForm.new
+    end
+
+    def create
+      @trainee_forbidden_deletes_form = TraineeForbiddenDeleteForm.new(forbidden_deletes_params)
+
+      if @trainee_forbidden_deletes_form.valid?
+        if @trainee_forbidden_deletes_form.defer?
+          redirect_to(trainee_deferral_path(trainee))
+        elsif @trainee_forbidden_deletes_form.withdraw?
+          redirect_to(trainee_withdrawal_path(trainee))
+        else
+          redirect_to(trainee_path(trainee))
+        end
+      else
+        render(:show)
+      end
+    end
+
+  private
+
+    def forbidden_deletes_params
+      params.require(:trainee_forbidden_delete_form).permit(:alternative_option)
+    end
+  end
+end

--- a/app/controllers/trainees/start_date_verifications_controller.rb
+++ b/app/controllers/trainees/start_date_verifications_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Trainees
+  class StartDateVerificationsController < BaseController
+    def show
+      @start_date_verification_form = StartDateVerificationForm.new
+    end
+
+    def create
+      @start_date_verification_form = StartDateVerificationForm.new(verification_params)
+
+      if @start_date_verification_form.valid?
+        if @start_date_verification_form.already_started?
+          redirect_to(edit_trainee_start_status_path(trainee, context: :delete))
+        else
+          redirect_to(trainee_confirm_delete_path(trainee))
+        end
+      else
+        render(:show)
+      end
+    end
+
+  private
+
+    def verification_params
+      params.require(:start_date_verification_form).permit(:trainee_has_started_course)
+    end
+  end
+end

--- a/app/controllers/trainees/start_statuses_controller.rb
+++ b/app/controllers/trainees/start_statuses_controller.rb
@@ -15,6 +15,11 @@ module Trainees
     def update
       @trainee_start_status_form = TraineeStartStatusForm.new(trainee, params: trainee_params, user: current_user)
 
+      if delete_context?
+        @trainee_start_status_form.save!
+        return redirect_to(trainee_forbidden_deletes_path(trainee))
+      end
+
       if @trainee_start_status_form.stash_or_save!
         if trainee.draft? && trainee.submission_ready?
           Trainees::SubmitForTrn.call(trainee: trainee, dttp_id: current_user.dttp_id)
@@ -36,6 +41,10 @@ module Trainees
       ).transform_keys do |key|
         PARAM_CONVERSION.keys.include?(key) ? PARAM_CONVERSION[key] : key
       end
+    end
+
+    def delete_context?
+      params[:context] == "delete"
     end
   end
 end

--- a/app/forms/start_date_verification_form.rb
+++ b/app/forms/start_date_verification_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class StartDateVerificationForm
+  include ActiveModel::Model
+
+  attr_accessor :trainee_has_started_course
+
+  validates :trainee_has_started_course, presence: true, inclusion: { in: %w[yes no] }
+
+  def initialize(params = {})
+    @trainee_has_started_course = params[:trainee_has_started_course]
+  end
+
+  def already_started?
+    trainee_has_started_course == "yes"
+  end
+end

--- a/app/forms/trainee_forbidden_delete_form.rb
+++ b/app/forms/trainee_forbidden_delete_form.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class TraineeForbiddenDeleteForm
+  include ActiveModel::Model
+
+  attr_accessor :alternative_option
+
+  validates :alternative_option, presence: true, inclusion: { in: %w[defer withdraw exit] }
+
+  def initialize(params = {})
+    @alternative_option = params[:alternative_option]
+  end
+
+  def defer?
+    alternative_option == "defer"
+  end
+
+  def withdraw?
+    alternative_option == "withdraw"
+  end
+end

--- a/app/lib/page_tracker.rb
+++ b/app/lib/page_tracker.rb
@@ -27,8 +27,8 @@ class PageTracker
     origin_pages << request.fullpath unless origin_pages.include?(request.fullpath)
   end
 
-  def previous_page_path
-    return last_origin_page_path if entered_an_edit_page_directly?
+  def previous_page_path(consider_confirm_page: true)
+    return last_origin_page_path if consider_confirm_page && entered_an_edit_page_directly?
 
     on_confirm_page? ? origin_pages[-2] : history[-2]
   end

--- a/app/views/trainees/deferrals/show.html.erb
+++ b/app/views/trainees/deferrals/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(i18n_key: "trainees.deferral.show", has_errors: @deferral_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back), consider_confirm_page: false) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/forbidden_deletes/show.html.erb
+++ b/app/views/trainees/forbidden_deletes/show.html.erb
@@ -1,0 +1,44 @@
+<%= render PageTitle::View.new(i18n_key: "trainees.forbidden_deletes.show",
+                               has_errors: @trainee_forbidden_deletes_form.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back),
+                                                   href: edit_trainee_start_status_path(@trainee, context: :delete)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: @trainee_forbidden_deletes_form,
+                           url: trainee_forbidden_deletes_path(@trainee),
+                           local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.hidden_field :alternative_option %>
+
+      <%= render TraineeName::View.new(@trainee) %>
+
+      <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+      <p class="govuk-body"><%= t(".reason") %></p>
+
+      <%= f.govuk_radio_buttons_fieldset(:alternative_option, legend: { text: t(".legend"), size: "m" }) do %>
+        <%= f.govuk_radio_button(:alternative_option,
+                                 :defer,
+                                 label: { text: t(".defer") },
+                                 link_errors: true) %>
+
+        <%= f.govuk_radio_button(:alternative_option,
+                                 :withdraw,
+                                 label: { text: t(".withdraw") }) %>
+
+        <div class="govuk-radios__divider">or</div>
+
+        <%= f.govuk_radio_button(:alternative_option,
+                                 :exit,
+                                 checked: false,
+                                 label: { text: t(".return_to_record") }) %>
+      <% end %>
+      <%= f.govuk_submit t(:continue) %>
+    <% end %>
+
+    <p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee)) %></p>
+  </div>
+</div>

--- a/app/views/trainees/start_date_verifications/show.html.erb
+++ b/app/views/trainees/start_date_verifications/show.html.erb
@@ -1,0 +1,34 @@
+<%= render PageTitle::View.new(i18n_key: "trainees.start_date_verification.show",
+                               has_errors: @start_date_verification_form.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: @start_date_verification_form,
+                           url: trainee_start_date_verification_path(@trainee),
+                           local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.hidden_field :trainee_has_started_course %>
+
+      <%= render TraineeName::View.new(@trainee) %>
+
+      <%= f.govuk_radio_buttons_fieldset(:trainee_has_started_course,
+                                         legend: { text: t(".legend"), size: "m" }) do %>
+        <%= f.govuk_radio_button(:trainee_has_started_course,
+                                 :yes,
+                                 label: { text: t(".yes_they_started") },
+                                 link_errors: true) %>
+
+        <%= f.govuk_radio_button(:trainee_has_started_course,
+                                 :no,
+                                 label: { text: t(".no_they_did_not_start") }) %>
+      <% end %>
+      <%= f.govuk_submit t(:continue) %>
+    <% end %>
+
+    <p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee)) %></p>
+  </div>
+</div>

--- a/app/views/trainees/start_statuses/edit.html.erb
+++ b/app/views/trainees/start_statuses/edit.html.erb
@@ -1,13 +1,19 @@
 <%= render PageTitle::View.new(i18n_key: "trainees.trainee_start_date.edit", has_errors: @trainee_start_status_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+  <% if params[:context] == "delete" %>
+    <%= render GovukComponent::BackLinkComponent.new(text: t(:back),
+                                                     href: trainee_start_date_verification_path(@trainee)) %>
+  <% else  %>
+    <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+  <% end  %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(model: @trainee_start_status_form, url: trainee_start_status_path, local: true) do |f| %>
       <%= f.govuk_error_summary %>
+      <%= hidden_field_tag :context, params[:context] %>
 
       <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_radio_buttons_fieldset(:commencement_status,
@@ -20,17 +26,20 @@
           <%= f.govuk_radio_button(:commencement_status, :itt_started_later,
                                    label: { text: t('.started_later') }) do %>
             <%= f.govuk_date_field :commencement_date, legend: {
-              text: t(".trainee_start_date"), size: "s", class: "govuk-fieldset__legend govuk-fieldset__legend--s govuk-!-font-weight-regular"
+              text: t(".trainee_start_date"),
+              size: "s",
+              class: "govuk-fieldset__legend govuk-fieldset__legend--s govuk-!-font-weight-regular"
             }, hint: { text: t(".trainee_start_date_hint") } %>
           <% end %>
 
+          <% unless params[:context] == "delete" %>
+            <%= f.govuk_radio_divider %>
 
-          <%= f.govuk_radio_divider %>
-
-          <%= f.govuk_radio_button(:commencement_status,
-                                   :itt_not_yet_started,
-                                   label: { text: t(".itt_not_yet_started") }) do %>
+            <%= f.govuk_radio_button(:commencement_status,
+                                     :itt_not_yet_started,
+                                     label: { text: t(".itt_not_yet_started") }) do %>
           <% end %>
+        <% end %>
       <% end %>
       <%= f.govuk_submit t(:continue) %>
     <% end %>

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -1,7 +1,7 @@
 <%= render PageTitle::View.new(i18n_key: "trainees.withdrawal.show", has_errors: @withdrawal_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back), consider_confirm_page: false) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -315,6 +315,10 @@ en:
             show: Confirm trainee’s course details
           course_details:
             edit: Review course
+        forbidden_deletes:
+          show: Delete forbidden
+        start_date_verification:
+          show: Did the trainee start their course?
       providers:
         index: Providers
         new: Add a provider
@@ -882,6 +886,20 @@ en:
         started_later: No, they started later
         trainee_start_date: *trainee_start_date
         trainee_start_date_hint: For example, 8 11 2021
+    start_date_verifications:
+      show:
+        legend: Did the trainee start their course?
+        yes_they_started: Yes, they started
+        no_they_did_not_start: No, they did not start
+    forbidden_deletes:
+      show:
+        title: Delete forbidden
+        heading: You cannot delete this record
+        reason: You can only delete a trainee record before the trainee starts their course, but you can defer or withdraw the trainee.
+        defer: Defer
+        withdraw: Withdraw
+        return_to_record: Return to trainee record
+        legend: Do you want to defer or withdraw this trainee?
   activerecord:
     attributes:
       trainee:
@@ -1227,8 +1245,8 @@ en:
           attributes:
             query:
               length:
-                one: "Enter at least one character"
-                other: "Enter at least %{count} characters"
+                one: Enter at least one character
+                other: Enter at least %{count} characters
         subject_specialism_form:
           attributes:
             specialism:
@@ -1279,6 +1297,14 @@ en:
           attributes:
             course_education_phase:
               blank: Select primary or secondary
+        start_date_verification_form:
+          attributes:
+            trainee_has_started_course:
+              blank: Choose yes or no
+        trainee_forbidden_delete_form:
+          attributes:
+            alternative_option:
+              blank: Choose defer, withdraw or return to trainee record
   page_headings:
     start_page: Register trainee teachers
   service_updates:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,8 @@ Rails.application.routes.draw do
       resource :timeline, only: :show
 
       resource :subject_specialism, only: %i[edit update], path: "/subject-specialism/:position"
+      resource :start_date_verification, only: %i[show create], path: "/start-date-verification"
+      resource :forbidden_deletes, only: %i[show create], path: "/delete-forbidden"
     end
   end
 

--- a/spec/features/trainee_actions/delete_trainee_spec.rb
+++ b/spec/features/trainee_actions/delete_trainee_spec.rb
@@ -23,18 +23,19 @@ feature "Deleting a trainee" do
       given_a_trainee_starting_a_course_in_the_future
       and_i_am_on_the_trainee_record_page
       and_i_click_the_delete_link
+      and_i_choose_they_have_not_started
       and_i_confirm_delete
       and_i_see_a_success_flash_message
       and_the_trainee_is_soft_deleted
     end
 
-    scenario "course started but trainee hasn't specified a start date" do
+    scenario "trainee started course but hasn't specified a start date" do
       given_a_trainee_with_no_start_date_for_a_course_already_started
       and_i_am_on_the_trainee_record_page
       and_i_click_the_delete_link
-      and_i_confirm_delete
-      and_i_see_a_success_flash_message
-      and_the_trainee_is_soft_deleted
+      and_i_choose_they_have_started
+      when_i_choose_they_started_on_time
+      then_i_should_be_on_the_forbidden_delete_page
     end
   end
 
@@ -69,12 +70,31 @@ private
     confirm_trainee_delete_page.delete_button.click
   end
 
-  def then_i_see_the_confirm_page
-    expect(page).to have_current_path("/trainees/#{trainee.slug}/confirm-delete", ignore_query: true)
+  def and_i_choose_they_have_not_started
+    start_date_verification_page.not_started_option.choose
+    start_date_verification_page.continue.click
+  end
+
+  def and_i_choose_they_have_started
+    start_date_verification_page.started_option.choose
+    start_date_verification_page.continue.click
   end
 
   def then_i_click_the_delete_button
     confirm_draft_deletions_page.delete_this_draft.click
+  end
+
+  def when_i_choose_they_started_on_time
+    trainee_start_status_edit_page.commencement_status_started_on_time.choose
+    trainee_start_status_edit_page.continue.click
+  end
+
+  def then_i_should_be_on_the_forbidden_delete_page
+    expect(delete_forbidden_page).to be_displayed
+  end
+
+  def then_i_see_the_confirm_page
+    expect(page).to have_current_path("/trainees/#{trainee.slug}/confirm-delete", ignore_query: true)
   end
 
   def i_am_redirected_to_the_trainee_records_list

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -286,6 +286,14 @@ module Features
       @privacy_policy_page ||= PageObjects::PrivacyPolicy.new
     end
 
+    def start_date_verification_page
+      @start_date_verification_page ||= PageObjects::Trainees::StartDateVerification.new
+    end
+
+    def delete_forbidden_page
+      @delete_forbidden_page ||= PageObjects::Trainees::DeleteForbidden.new
+    end
+
     def incomplete
       progress_with_prefix(I18n.t("incomplete"))
     end

--- a/spec/support/page_objects/trainees/delete_forbidden.rb
+++ b/spec/support/page_objects/trainees/delete_forbidden.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class DeleteForbidden < PageObjects::Base
+      include PageObjects::Helpers
+      set_url "/trainees/{id}/delete-forbidden"
+
+      element :defer_option, "#trainee-forbidden-delete-form-alternative-option-defer-field"
+      element :withdraw_option, "#trainee-forbidden-delete-form-alternative-option-withdraw-field"
+      element :exit_option, "#trainee-forbidden-delete-form-alternative-option-exit-field"
+
+      element :submit_button, "button[type='submit']"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/start_date_verification.rb
+++ b/spec/support/page_objects/trainees/start_date_verification.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class StartDateVerification < PageObjects::Base
+      include PageObjects::Helpers
+      set_url "/trainees/{id}/start-date-verification"
+
+      element :started_option, "#start-date-verification-form-trainee-has-started-course-yes-field"
+      element :not_started_option, "#start-date-verification-form-trainee-has-started-course-no-field"
+
+      element :continue, "button[type='submit']"
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/NEhZ0PLw/3147-m-course-starts-in-the-past-no-trainee-start-date-delete

### Changes proposed in this pull request
- New controller `Trainees::StartDateVerificationsController` with form object and views for the start date verification page
- New controller `Trainees::ForbiddenDeletesController` with form object and views for the delete forbidden page
- Modified `Trainees::StartStatusesController` so it can be used in the context of deleting a trainee

### Guidance to review
- Click on "Pending TRN" trainees
- Filter by "School direct"
- Click on a trainee and check if it has a "Delete" action. The seed data creates some trainees that can be deleted, but it's done on every other trainee, so you might have to click into the other trainees in the list to find a deletable record.
- Once you find a trainee that can be deleted, click "Delete" which should bring you to a confirm page

#### Scenario 1 - choose "Yes, they started"
- You should now be redirected to the trainee start status page
- Choose any option and continue
- You now see the delete forbidden page which gives you 3 options.
- Choose defer first then withdraw - you should be redirect to the appropriate page

#### Scenario 2 - choose "No, they did not started"
- You should be directed to the confirm delete page
- Click "Delete this record"
- Then you should be redirected back to the trainees index page

#### Start date verification page
<img width="996" alt="Screenshot 2021-11-11 at 15 51 15" src="https://user-images.githubusercontent.com/28728/141327823-1adfdbdc-cb7e-4e48-aceb-7e83f619a138.png">

#### Forbidden delete page
<img width="962" alt="Screenshot 2021-11-11 at 15 52 12" src="https://user-images.githubusercontent.com/28728/141327990-a332e24d-8731-4b14-9e04-972253c0dd75.png">