### PR TITLE
[3186] Set disability disclosure for trainees who have not provided diversity info

### DIFF
--- a/app/forms/diversities/disclosure_form.rb
+++ b/app/forms/diversities/disclosure_form.rb
@@ -18,7 +18,22 @@ module Diversities
       diversity_disclosure == Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed]
     end
 
+    def save!
+      if valid?
+        save_trainee!
+        clear_stash
+      else
+        false
+      end
+    end
+
   private
+
+    def save_trainee!
+      trainee.assign_attributes(fields.except(*fields_to_ignore_before_save))
+      trainee.disability_disclosure = diversity_not_disclosed? ? Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] : nil
+      trainee.save!
+    end
 
     def compute_fields
       trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)

--- a/db/data/20211111161328_fix_up_disability_disclosures.rb
+++ b/db/data/20211111161328_fix_up_disability_disclosures.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FixUpDisabilityDisclosures < ActiveRecord::Migration[6.1]
+  def up
+    Trainee
+      .where(diversity_disclosure: Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed])
+      .update_all(disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided])
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/forms/diversities/disclosure_form_spec.rb
+++ b/spec/forms/diversities/disclosure_form_spec.rb
@@ -28,15 +28,39 @@ module Diversities
     end
 
     describe "#save!" do
-      let(:diversity_not_disclosed) { Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed] }
-
       before do
-        allow(form_store).to receive(:get).and_return({ "diversity_disclosure" => diversity_not_disclosed })
+        allow(form_store).to receive(:get).and_return({ "diversity_disclosure" => diversity_disclosure_value })
         allow(form_store).to receive(:set).with(trainee.id, :diversity_disclosure, nil)
       end
 
-      it "takes any data from the form store and saves it to the database" do
-        expect { subject.save! }.to change(trainee, :diversity_disclosure).to(diversity_not_disclosed)
+      context "diversity not disclosed" do
+        let(:diversity_disclosure_value) { Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed] }
+
+        it "saves the diversity disclosure value" do
+          expect { subject.save! }.to change(trainee, :diversity_disclosure).to(diversity_disclosure_value)
+        end
+
+        it "saves the disability disclosure as not provided" do
+          expect { subject.save! }.to change(trainee, :disability_disclosure).to(
+            Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided],
+          )
+        end
+      end
+
+      context "diversity changed to disclosed" do
+        let(:trainee) do
+          create(
+            :trainee,
+            :diversity_not_disclosed,
+            disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided],
+          )
+        end
+
+        let(:diversity_disclosure_value) { Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed] }
+
+        it "resets the disability disclosure" do
+          expect { subject.save! }.to change(trainee, :disability_disclosure).to(nil)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/M4R3fohK/3186-confirm-reason-for-disability-disclosure-null-entries

### Changes proposed in this pull request

- We need to set the `disability_disclosure` field to `disability_not_provided` if a trainee does not disclose diversity information
- Update the `DisclosuresForm` object to toggle this field based on the diversity disclosure value
- Add a data migration to backfill existing trainees in prod

### Guidance to review

