### PR TITLE
[3199] Remove duplicate trainees

### DIFF
--- a/db/data/20211112120154_remove_duplicate_trainees.rb
+++ b/db/data/20211112120154_remove_duplicate_trainees.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RemoveDuplicateTrainees < ActiveRecord::Migration[6.1]
+  def up
+    # These records no longer exist in DTTP
+    Trainee.where(slug: %w[7juoh4yB9PzoHj6vurwX9MHe wcMqhXzPC9bmfcVx9f8tHFKB]).each(&:destroy)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/CizDlWU9/3199-remove-records

### Changes proposed in this pull request
- Data migration to remove a trainee record (no longer in DTTP) and update 2 others with TRN values
