### PR TITLE
[3182] Add course start date validations to both start date forms

### DIFF
--- a/app/components/confirm_publish_course/view.rb
+++ b/app/components/confirm_publish_course/view.rb
@@ -37,7 +37,7 @@ module ConfirmPublishCourse
         { key: subject_key, value: subject_names },
         { key: t(".level"), value: level },
         { key: t(".age_range"), value: age_range },
-        { key: t(".#{itt_route? ? 'itt' : 'course'}_start_date"), value: start_date },
+        { key: t(".itt_start_date"), value: start_date },
         { key: t(".duration"), value: duration },
         ({ key: t(".study_mode"), value: study_mode } if requires_study_mode?),
       ].compact
@@ -77,10 +77,6 @@ module ConfirmPublishCourse
     end
 
   private
-
-    def itt_route?
-      trainee.itt_route?
-    end
 
     def subject_key
       course.subjects.count > 1 ? t(".multiple_subjects") : t(".subject")

--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -76,11 +76,7 @@ module CourseDetails
     end
 
     def course_date_row(value, context)
-      default_mappable_field(value, t("components.course_detail.#{itt_route? ? 'itt' : 'course'}_#{context}_date"))
-    end
-
-    def itt_route?
-      trainee.itt_route?
+      default_mappable_field(value, t("components.course_detail.itt_#{context}_date"))
     end
 
     def non_early_year_route?

--- a/app/controllers/trainees/course_details_controller.rb
+++ b/app/controllers/trainees/course_details_controller.rb
@@ -40,7 +40,7 @@ module Trainees
 
     def date_conversion
       @date_conversion ||= DATE_CONVERSION.transform_keys do |key|
-        "#{trainee.itt_route? ? 'itt' : 'course'}#{key}"
+        "itt#{key}"
       end
     end
 

--- a/app/forms/concerns/commencement_date_helpers.rb
+++ b/app/forms/concerns/commencement_date_helpers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module CommencementDateHelpers
+  def commencement_date_valid
+    if [day, month, year].all?(&:blank?)
+      errors.add(:commencement_date, :blank)
+    elsif !commencement_date.is_a?(Date)
+      errors.add(:commencement_date, :invalid)
+    elsif commencement_date < 10.years.ago
+      errors.add(:commencement_date, :too_old)
+    elsif trainee.course_end_date.present? && commencement_date > trainee.course_end_date
+      errors.add(:commencement_date, I18n.t("activemodel.errors.models.trainee_start_status_form.attributes.commencement_date.not_after_course_end_date", course_end_date: trainee.course_end_date.strftime("%-d %B %Y")))
+    end
+  end
+end

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -69,11 +69,7 @@ class TraineeForm
 private
 
   def course_date_attribute_name_prefix
-    itt_route? ? :itt : :course
-  end
-
-  def itt_route?
-    trainee.itt_route?
+    :itt
   end
 
   def compute_fields

--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -2,6 +2,7 @@
 
 class TraineeStartDateForm < TraineeForm
   include DatesHelper
+  include CommencementDateHelpers
 
   attr_accessor :day, :month, :year
 
@@ -36,16 +37,6 @@ private
 
   def update_trainee_commencement_date
     trainee.assign_attributes(commencement_date: commencement_date) if errors.empty?
-  end
-
-  def commencement_date_valid
-    if [day, month, year].all?(&:blank?)
-      errors.add(:commencement_date, :blank)
-    elsif !commencement_date.is_a?(Date)
-      errors.add(:commencement_date, :invalid)
-    elsif date_before_course_start_date?(commencement_date, trainee.course_start_date)
-      errors.add(:commencement_date, :not_before_course_start_date)
-    end
   end
 
   def fields_from_store

--- a/app/forms/trainee_start_status_form.rb
+++ b/app/forms/trainee_start_status_form.rb
@@ -2,6 +2,7 @@
 
 class TraineeStartStatusForm < TraineeForm
   include DatesHelper
+  include CommencementDateHelpers
 
   FIELDS = %i[
     commencement_status
@@ -77,16 +78,6 @@ private
     return unless errors.empty?
 
     trainee.assign_attributes(commencement_date: formatted_commencement_date, commencement_status: commencement_status)
-  end
-
-  def commencement_date_valid
-    if [day, month, year].all?(&:blank?)
-      errors.add(:commencement_date, :blank)
-    elsif !commencement_date.is_a?(Date)
-      errors.add(:commencement_date, :invalid)
-    elsif date_before_course_start_date?(commencement_date, trainee.course_start_date)
-      errors.add(:commencement_date, :not_before_course_start_date)
-    end
   end
 
   def fields_from_store

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -33,10 +33,6 @@ class TrainingRouteManager
     EARLY_YEARS_TRAINING_ROUTES.keys.include?(training_route.to_s)
   end
 
-  def itt_route?
-    ITT_TRAINING_ROUTES.keys.include?(training_route)
-  end
-
   def requires_study_mode?
     [
       TRAINING_ROUTE_ENUMS[:assessment_only],

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -31,7 +31,6 @@ class Trainee < ApplicationRecord
            :early_years_route?,
            :undergrad_route?,
            :requires_itt_start_date?,
-           :itt_route?,
            :requires_study_mode?,
            :requires_degree?,
            to: :training_route_manager

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -12,7 +12,7 @@
       <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_date_field :commencement_date, legend: {
         text: t("views.forms.start_dates.commencement_date.label"), size: "l", tag: "h1"
-      }, hint: { text: t("views.forms.start_dates.commencement_date.hint") } %>
+      }, hint: { text: t("views.forms.start_dates.commencement_date.hint", course_start_date: @trainee.course_start_date.strftime("%d %m %Y")) } %>
       <%= f.govuk_submit "Continue" %>
     <% end %>
 

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -55,13 +55,6 @@ TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|
                                  :pg_teaching_apprenticeship).include?(training_route)
 }.freeze
 
-ITT_TRAINING_ROUTES = TRAINING_ROUTES.select { |training_route|
-  TRAINING_ROUTE_ENUMS.values_at(:early_years_undergrad,
-                                 :pg_teaching_apprenticeship,
-                                 :provider_led_undergrad,
-                                 :opt_in_undergrad).include?(training_route)
-}.freeze
-
 UNDERGRAD_ROUTES = TRAINING_ROUTES.select { |training_route|
   TRAINING_ROUTE_ENUMS.values_at(:early_years_undergrad, :provider_led_undergrad, :opt_in_undergrad).include?(training_route)
 }.freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,9 +166,7 @@ en:
       education_phase: Education phase
       subject: Subject
       age_range: Age range
-      course_start_date: Course start date
       itt_start_date: ITT start date
-      course_end_date: Course end date
       itt_end_date: ITT end date
       route: Training route
       course_details: Course details
@@ -319,7 +317,7 @@ en:
         forbidden_deletes:
           show: Delete forbidden
         start_date_verification:
-          show: Did the trainee start their course?
+          show: Did the trainee start their ITT?
       providers:
         index: Providers
         new: Add a provider
@@ -448,8 +446,6 @@ en:
         age_range: &course_age_range Age range
         itt_start_date: &itt_start_date ITT start date
         itt_end_date: &itt_end_date ITT end date
-        course_start_date: &course_start_date Course start date
-        course_end_date: &course_end_date Course end date
         duration: Duration
         course_details: Course details
         study_mode: Full time or part time
@@ -486,8 +482,6 @@ en:
         course_subject_one: *course_subject
         course_subject_two: *course_subject
         course_subject_three: *course_subject
-        course_start_date: *course_start_date
-        course_end_date: *course_end_date
         main_age_range: *course_age_range
         itt_start_date: *itt_start_date
         itt_end_date: *itt_end_date
@@ -625,8 +619,8 @@ en:
             We may also use it if we need to get in touch with you about this trainee.
       start_dates:
         commencement_date:
-          label: What is the trainee’s start date?
-          hint: This is the date the trainee starts on the course. This can be different from the course start date.
+          label: When did the trainee start their ITT?
+          hint: Their ITT started on %{course_start_date}
       publish_course_details:
         route_message: "Your %{route} courses in the Publish service"
         all_courses_message: Your courses in the Publish service
@@ -775,8 +769,6 @@ en:
       age_range: Age range
       itt_start_date: ITT start date
       itt_end_date: ITT end date
-      course_start_date: Course start date
-      course_end_date: Course end date
       duration: Duration
       study_mode: Full time or part time
       course_details: Course details
@@ -889,14 +881,14 @@ en:
         trainee_start_date_hint: For example, 8 11 2021
     start_date_verifications:
       show:
-        legend: Did the trainee start their course?
+        legend: Did the trainee start their ITT?
         yes_they_started: Yes, they started
         no_they_did_not_start: No, they did not start
     forbidden_deletes:
       show:
         title: Delete forbidden
         heading: You cannot delete this record
-        reason: You can only delete a trainee record before the trainee starts their course, but you can defer or withdraw the trainee.
+        reason: You can only delete a trainee record before the trainee starts their ITT, but you can defer or withdraw the trainee.
         defer: Defer
         withdraw: Withdraw
         return_to_record: Return to trainee record
@@ -996,9 +988,7 @@ en:
   activemodel:
     attributes:
       course_details_form:
-        course_start_date: Course start date
         itt_start_date: ITT start date
-        course_end_date: Course end date
         itt_end_date: ITT end date
     errors:
       validators:
@@ -1052,7 +1042,7 @@ en:
             date:
               blank: Enter a deferral date
               invalid: Enter a valid deferral date
-              not_before_course_start_date: &not_before_course_start_date The date must not be before the course start date
+              not_before_course_start_date: &not_before_course_start_date The date must not be before the ITT start date
         degrees_form:
           attributes:
             degree_ids:
@@ -1164,19 +1154,6 @@ en:
               blank: Select an age range
             study_mode:
               inclusion: Select full time or part time
-            course_start_date:
-              blank: Enter a course start date
-              future: Enter a course start date closer to today
-              invalid: Enter a valid course start date
-              too_old: The course start date must be after 31 July 2020
-              hint_html: For example, 11 3 %{year}
-            course_end_date:
-              blank: Enter a course end date
-              future: Enter a course end date closer to today
-              invalid: Enter a valid course end date
-              too_old: Enter a valid course end date
-              before_or_same_as_start_date: The course end date must be after the start date
-              hint_html: For example, 11 3 %{year}
             itt_start_date:
               blank: Enter an ITT start date
               future: Enter an ITT start date closer to today
@@ -1232,13 +1209,15 @@ en:
             commencement_date:
               blank: Enter a start date
               invalid: Enter a valid start date
-              not_before_course_start_date: *not_before_course_start_date
+              not_after_course_end_date: Trainee start date must not be after the ITT has finished (%{course_end_date})
+              too_old: Trainee start date cannot be more than 10 years in the past
         trainee_start_status_form:
           attributes:
             commencement_date:
               blank: Enter a start date
               invalid: Enter a valid start date
-              not_before_course_start_date: *not_before_course_start_date
+              not_after_course_end_date: Trainee start date must not be after the ITT has finished (%{course_end_date})
+              too_old: Trainee start date cannot be more than 10 years in the past
             commencement_status:
               blank: Select if the trainee started on time
         training_details_form:

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -42,11 +42,11 @@ module CourseDetails
       end
 
       it "renders missing hint for course start date" do
-        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: "Course start date is missing")
+        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: "ITT start date is missing")
       end
 
       it "renders missing hint for course end date" do
-        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: "Course end date is missing")
+        expect(rendered_component).to have_selector(".govuk-summary-list__value", text: "ITT end date is missing")
       end
     end
 

--- a/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
@@ -82,8 +82,8 @@ private
   end
 
   def and_i_enter_valid_parameters
-    course_details_page.set_date_fields("course_start_date", trainee.course_start_date.strftime("%d/%m/%Y"))
-    course_details_page.set_date_fields("course_end_date", trainee.course_end_date.strftime("%d/%m/%Y"))
+    course_details_page.set_date_fields("itt_start_date", trainee.course_start_date.strftime("%d/%m/%Y"))
+    course_details_page.set_date_fields("itt_end_date", trainee.course_end_date.strftime("%d/%m/%Y"))
 
     age_range = Dttp::CodeSets::AgeRanges::MAPPING[trainee.course_age_range]
 
@@ -101,14 +101,15 @@ private
 
   def then_the_course_details_are_updated
     when_i_visit_the_course_details_page
+    # save_and_open_page
 
     expect(course_details_page.subject.value).to eq(trainee.reload.course_subject_one)
-    expect(course_details_page.course_start_date_day.value).to eq(trainee.course_start_date.day.to_s)
-    expect(course_details_page.course_start_date_month.value).to eq(trainee.course_start_date.month.to_s)
-    expect(course_details_page.course_start_date_year.value).to eq(trainee.course_start_date.year.to_s)
-    expect(course_details_page.course_end_date_day.value).to eq(trainee.course_end_date.day.to_s)
-    expect(course_details_page.course_end_date_month.value).to eq(trainee.course_end_date.month.to_s)
-    expect(course_details_page.course_end_date_year.value).to eq(trainee.course_end_date.year.to_s)
+    expect(course_details_page.itt_start_date_day.value).to eq(trainee.course_start_date.day.to_s)
+    expect(course_details_page.itt_start_date_month.value).to eq(trainee.course_start_date.month.to_s)
+    expect(course_details_page.itt_start_date_year.value).to eq(trainee.course_start_date.year.to_s)
+    expect(course_details_page.itt_end_date_day.value).to eq(trainee.course_end_date.day.to_s)
+    expect(course_details_page.itt_end_date_month.value).to eq(trainee.course_end_date.month.to_s)
+    expect(course_details_page.itt_end_date_year.value).to eq(trainee.course_end_date.year.to_s)
 
     age_range = Dttp::CodeSets::AgeRanges::MAPPING[trainee.course_age_range]
 
@@ -151,7 +152,7 @@ private
       I18n.t("#{translation_key_prefix}.main_age_range.blank"),
     )
     expect(course_details_page).to have_content(
-      I18n.t("#{translation_key_prefix}.course_start_date.blank"),
+      I18n.t("#{translation_key_prefix}.itt_start_date.blank"),
     )
   end
 

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -8,7 +8,7 @@ feature "publish course details", type: :feature, feature_publish_course_details
   let(:subjects) { [] }
   let(:training_route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
   let(:study_mode) { "full_time" }
-  let(:course_end_date) { 1.year.from_now.to_date }
+  let(:itt_end_date) { 1.year.from_now.to_date }
 
   background do
     given_i_am_authenticated
@@ -39,9 +39,9 @@ feature "publish course details", type: :feature, feature_publish_course_details
         and_i_select_a_course
         and_i_submit_the_form
         then_i_should_see_the_subject_described_as("History")
-        and_i_see_course_end_date_missing_error
-        and_i_click_enter_answer_for_course_end_date
-        and_i_enter_course_end_date(course_end_date)
+        and_i_see_itt_end_date_missing_error
+        and_i_click_enter_answer_for_itt_end_date
+        and_i_enter_itt_end_date(itt_end_date)
         and_i_submit_the_course_details_form
         and_i_confirm_the_course
         and_i_visit_the_review_draft_page
@@ -57,9 +57,9 @@ feature "publish course details", type: :feature, feature_publish_course_details
         and_i_select_a_course
         and_i_submit_the_form
         then_i_should_see_the_subject_described_as("French")
-        and_i_see_course_end_date_missing_error
-        and_i_click_enter_answer_for_course_end_date
-        and_i_enter_course_end_date(course_end_date)
+        and_i_see_itt_end_date_missing_error
+        and_i_click_enter_answer_for_itt_end_date
+        and_i_enter_itt_end_date(itt_end_date)
         and_i_submit_the_course_details_form
         and_i_confirm_the_course
         and_i_visit_the_review_draft_page
@@ -78,9 +78,9 @@ feature "publish course details", type: :feature, feature_publish_course_details
         and_i_select_a_specialism("Computer science")
         and_i_submit_the_specialism_form
         then_i_should_see_the_subject_described_as("Computer science")
-        and_i_see_course_end_date_missing_error
-        and_i_click_enter_answer_for_course_end_date
-        and_i_enter_course_end_date(course_end_date)
+        and_i_see_itt_end_date_missing_error
+        and_i_click_enter_answer_for_itt_end_date
+        and_i_enter_itt_end_date(itt_end_date)
         and_i_submit_the_course_details_form
         and_i_confirm_the_course
         and_i_visit_the_review_draft_page
@@ -101,9 +101,9 @@ feature "publish course details", type: :feature, feature_publish_course_details
         and_i_select_a_specialism("Mathematics")
         and_i_submit_the_specialism_form
         then_i_should_see_the_subject_described_as("Applied computing with mathematics")
-        and_i_see_course_end_date_missing_error
-        and_i_click_enter_answer_for_course_end_date
-        and_i_enter_course_end_date(course_end_date)
+        and_i_see_itt_end_date_missing_error
+        and_i_click_enter_answer_for_itt_end_date
+        and_i_enter_itt_end_date(itt_end_date)
         and_i_submit_the_course_details_form
         and_i_confirm_the_course
         and_i_visit_the_review_draft_page
@@ -124,9 +124,9 @@ feature "publish course details", type: :feature, feature_publish_course_details
         and_i_select_languages("Arabic languages", "Welsh", "Portuguese")
         and_i_submit_the_language_specialism_form
         then_i_should_see_the_subject_described_as("Arabic languages with Portuguese and Welsh")
-        and_i_see_course_end_date_missing_error
-        and_i_click_enter_answer_for_course_end_date
-        and_i_enter_course_end_date(course_end_date)
+        and_i_see_itt_end_date_missing_error
+        and_i_click_enter_answer_for_itt_end_date
+        and_i_enter_itt_end_date(itt_end_date)
         and_i_submit_the_course_details_form
         and_i_confirm_the_course
         and_i_visit_the_review_draft_page
@@ -153,9 +153,9 @@ feature "publish course details", type: :feature, feature_publish_course_details
         and_i_select_a_specialism("Applied computing")
         and_i_submit_the_specialism_form
         then_i_should_see_the_subject_described_as("Music education and teaching with applied computing and history")
-        and_i_see_course_end_date_missing_error
-        and_i_click_enter_answer_for_course_end_date
-        and_i_enter_course_end_date(course_end_date)
+        and_i_see_itt_end_date_missing_error
+        and_i_click_enter_answer_for_itt_end_date
+        and_i_enter_itt_end_date(itt_end_date)
         and_i_submit_the_course_details_form
         and_i_confirm_the_course
         and_i_visit_the_review_draft_page
@@ -438,17 +438,17 @@ feature "publish course details", type: :feature, feature_publish_course_details
     expect(confirm_publish_course_details_page.subject_description).to eq(description)
   end
 
-  def and_i_see_course_end_date_missing_error
-    expect(confirm_publish_course_details_page).to have_content("Course end date is missing")
+  def and_i_see_itt_end_date_missing_error
+    expect(confirm_publish_course_details_page).to have_content("ITT end date is missing")
   end
 
-  def and_i_click_enter_answer_for_course_end_date
+  def and_i_click_enter_answer_for_itt_end_date
     confirm_publish_course_details_page.enter_an_answer_for_course_end_date_link.click
   end
 
-  def and_i_enter_course_end_date(date)
+  def and_i_enter_itt_end_date(date)
     course_details_page.subject_primary.click
-    course_details_page.set_date_fields("course_end_date", date.strftime("%d/%m/%Y"))
+    course_details_page.set_date_fields("itt_end_date", date.strftime("%d/%m/%Y"))
   end
 
   def and_i_submit_the_course_details_form

--- a/spec/features/form_sections/teacher_training_data/edit_trainee_start_date_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_trainee_start_date_spec.rb
@@ -5,14 +5,14 @@ require "rails_helper"
 feature "edit Trainee start date" do
   include SummaryHelper
 
-  let(:new_start_date) { Date.tomorrow }
+  let(:new_start_date) { Date.parse("14/09/2021") }
 
   background do
     given_i_am_authenticated
   end
 
   scenario "updates the start date" do
-    given_a_trainee_exists(:submitted_for_trn)
+    given_a_trainee_exists(:submitted_for_trn, course_start_date: Date.parse("14/09/2021"))
     when_i_visit_the_edit_trainee_start_date_page
     when_i_change_the_start_date
     when_i_click_continue

--- a/spec/features/form_sections/teacher_training_data/edit_trainee_start_status_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_trainee_start_status_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "edit Trainee start status" do
   include SummaryHelper
 
-  let(:new_start_date) { Date.tomorrow }
+  let(:new_start_date) { Date.parse("1/1/2021") }
 
   context "for a non-draft trainee" do
     background do
@@ -25,7 +25,7 @@ feature "edit Trainee start status" do
     end
 
     scenario "when the trainee has started later" do
-      given_a_trainee_exists(:submitted_for_trn, :course_start_date_in_the_past)
+      given_a_trainee_exists(:submitted_for_trn, :course_start_date_in_the_past, course_start_date: Date.parse("30/12/2020"))
       when_i_visit_the_edit_trainee_start_status_page
       when_i_choose_the_trainee_has_started_later
       when_i_change_the_start_date

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -50,8 +50,8 @@ describe CourseDetailsForm, type: :model do
       before { subject.valid? }
 
       it "does not return course date errors" do
-        expect(subject.errors[:course_start_date]).to be_empty
-        expect(subject.errors[:course_end_date]).to be_empty
+        expect(subject.errors[:itt_start_date]).to be_empty
+        expect(subject.errors[:itt_end_date]).to be_empty
       end
     end
   end
@@ -209,7 +209,7 @@ describe CourseDetailsForm, type: :model do
         date_error_message = "date error message"
 
         shared_examples date_error_message do |attribute_name, translation_key_suffix, day, month, year|
-          if attribute_name == :course_start_date
+          if attribute_name == :itt_start_date
             let(:start_date_attributes) do
               { start_day: day, start_month: month, start_year: year }
             end
@@ -239,17 +239,17 @@ describe CourseDetailsForm, type: :model do
             end
 
             it "does not return an error message for course start date" do
-              expect(subject.errors[:course_start_date]).to be_empty
+              expect(subject.errors[:itt_start_date]).to be_empty
             end
           end
 
-          include_examples date_error_message, :course_start_date, :blank,
+          include_examples date_error_message, :itt_start_date, :blank,
                            "", "", ""
-          include_examples date_error_message, :course_start_date, :invalid,
+          include_examples date_error_message, :itt_start_date, :invalid,
                            "foo", "foo", "foo"
 
           start_date = 10.years.ago
-          include_examples date_error_message, :course_start_date, :too_old,
+          include_examples date_error_message, :itt_start_date, :too_old,
                            start_date.day, start_date.month, start_date.year
 
           context "the start date fields are too far in future" do
@@ -258,7 +258,7 @@ describe CourseDetailsForm, type: :model do
             end
 
             it "returns an error message for course start date" do
-              expect(subject.errors.messages[:course_start_date]).to include I18n.t("activemodel.errors.models.course_details_form.attributes.course_start_date.future")
+              expect(subject.errors.messages[:itt_start_date]).to include I18n.t("activemodel.errors.models.course_details_form.attributes.itt_start_date.future")
             end
           end
 
@@ -268,7 +268,7 @@ describe CourseDetailsForm, type: :model do
             end
 
             it "returns an error message for course start date" do
-              expect(subject.errors.messages[:course_start_date]).to include I18n.t("activemodel.errors.models.course_details_form.attributes.course_start_date.too_old")
+              expect(subject.errors.messages[:itt_start_date]).to include I18n.t("activemodel.errors.models.course_details_form.attributes.itt_start_date.too_old")
             end
           end
         end
@@ -294,17 +294,17 @@ describe CourseDetailsForm, type: :model do
             end
 
             it "does not return an error message for end date" do
-              expect(subject.errors[:course_end_date]).to be_empty
+              expect(subject.errors[:itt_end_date]).to be_empty
             end
           end
 
-          include_examples date_error_message, :course_end_date, :blank,
+          include_examples date_error_message, :itt_end_date, :blank,
                            "", "", ""
-          include_examples date_error_message, :course_end_date, :invalid,
+          include_examples date_error_message, :itt_end_date, :invalid,
                            "foo", "foo", "foo"
-          include_examples date_error_message, :course_end_date, :before_or_same_as_start_date,
+          include_examples date_error_message, :itt_end_date, :before_or_same_as_start_date,
                            start_date.day, start_date.month, start_date.year
-          include_examples date_error_message, :course_end_date, :before_or_same_as_start_date,
+          include_examples date_error_message, :itt_end_date, :before_or_same_as_start_date,
                            start_date.day, start_date.month, start_date.year - 1
 
           context "the end date fields are too far in future" do
@@ -313,7 +313,7 @@ describe CourseDetailsForm, type: :model do
             end
 
             it "returns an error message for course end date" do
-              expect(subject.errors.messages[:course_end_date]).to include I18n.t("activemodel.errors.models.course_details_form.attributes.course_end_date.future")
+              expect(subject.errors.messages[:itt_end_date]).to include I18n.t("activemodel.errors.models.course_details_form.attributes.itt_end_date.future")
             end
           end
 
@@ -323,7 +323,7 @@ describe CourseDetailsForm, type: :model do
             end
 
             it "returns an error message for course end date" do
-              expect(subject.errors.messages[:course_end_date]).to include I18n.t("activemodel.errors.models.course_details_form.attributes.course_end_date.too_old")
+              expect(subject.errors.messages[:itt_end_date]).to include I18n.t("activemodel.errors.models.course_details_form.attributes.itt_end_date.too_old")
             end
           end
         end

--- a/spec/forms/trainee_start_date_form_spec.rb
+++ b/spec/forms/trainee_start_date_form_spec.rb
@@ -33,13 +33,21 @@ describe TraineeStartDateForm, type: :model do
       end
     end
 
-    context "date is before the course start date" do
+    context "date is after the course end date" do
       let(:trainee) do
-        build(:trainee, course_start_date: Time.zone.today, commencement_date: 1.day.ago)
+        build(:trainee, course_end_date: Date.parse("19/12/2020"))
       end
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.not_before_course_start_date"))
+        expect(subject.errors[:commencement_date]).to include("Trainee start date must not be after the ITT has finished (19 December 2020)")
+      end
+    end
+
+    context "date is more than 10 years in the past" do
+      let(:params) { { year: "2009", month: "12", day: "20" } }
+
+      it "is invalid" do
+        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.too_old"))
       end
     end
   end

--- a/spec/forms/trainee_start_status_form_spec.rb
+++ b/spec/forms/trainee_start_status_form_spec.rb
@@ -68,13 +68,21 @@ describe TraineeStartStatusForm, type: :model do
       end
     end
 
-    context "date is before the course start date" do
+    context "date is after the course end date" do
       let(:trainee) do
-        build(:trainee, course_start_date: Time.zone.today, commencement_date: 1.day.ago)
+        build(:trainee, course_end_date: Date.parse("19/12/2020"))
       end
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.not_before_course_start_date"))
+        expect(subject.errors[:commencement_date]).to include("Trainee start date must not be after the ITT has finished (19 December 2020)")
+      end
+    end
+
+    context "date is more than 10 years in the past" do
+      let(:params) { { year: "2009", month: "12", day: "20", commencement_status: "itt_started_later" } }
+
+      it "is invalid" do
+        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.too_old"))
       end
     end
   end

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -163,28 +163,6 @@ describe TrainingRouteManager do
     end
   end
 
-  describe "#itt_route?" do
-    %i[early_years_undergrad pg_teaching_apprenticeship].each do |route|
-      context "with an itt trainee" do
-        let(:trainee) { build(:trainee, route) }
-
-        it "returns true" do
-          expect(subject.itt_route?).to be true
-        end
-      end
-
-      context "with the :routes_#{route} feature flag disabled", "feature_routes.#{route}": false do
-        context "with a non itt trainee" do
-          let(:trainee) { build(:trainee) }
-
-          it "returns false" do
-            expect(subject.itt_route?).to be false
-          end
-        end
-      end
-    end
-  end
-
   describe "#requires_study_mode?" do
     (TRAINING_ROUTES.keys - %w[early_years_assessment_only assessment_only]).each do |route|
       context "for route #{route}" do

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -83,7 +83,7 @@ module Features
     end
 
     def and_i_see_course_end_date_missing_error
-      expect(confirm_publish_course_details_page).to have_content("Course end date is missing")
+      expect(confirm_publish_course_details_page).to have_content("ITT end date is missing")
     end
 
     def and_i_click_enter_answer_for_course_end_date
@@ -94,7 +94,7 @@ module Features
     end
 
     def and_i_enter_course_end_date
-      course_details_page.set_date_fields("course_end_date", 1.year.from_now.strftime("%d/%m/%Y"))
+      course_details_page.set_date_fields("itt_end_date", 1.year.from_now.strftime("%d/%m/%Y"))
     end
 
     def and_i_submit_the_course_details_form
@@ -108,13 +108,11 @@ module Features
   private
 
     def start_date
-      trainee = trainee_from_url
-      trainee.itt_route? ? "itt_start_date" : "course_start_date"
+      "itt_start_date"
     end
 
     def end_date
-      trainee = trainee_from_url
-      trainee.itt_route? ? "itt_end_date" : "course_end_date"
+      "itt_end_date"
     end
   end
 end

--- a/spec/support/page_objects/trainees/course_details.rb
+++ b/spec/support/page_objects/trainees/course_details.rb
@@ -12,14 +12,6 @@ module PageObjects
       element :study_mode_full_time, "input[name='course_details_form[study_mode]'][value='full_time']"
       element :study_mode_part_time, "input[name='course_details_form[study_mode]'][value='part_time']"
 
-      element :course_start_date_day, "#course_details_form_course_start_date_3i"
-      element :course_start_date_month, "#course_details_form_course_start_date_2i"
-      element :course_start_date_year, "#course_details_form_course_start_date_1i"
-
-      element :course_end_date_day, "#course_details_form_course_end_date_3i"
-      element :course_end_date_month, "#course_details_form_course_end_date_2i"
-      element :course_end_date_year, "#course_details_form_course_end_date_1i"
-
       element :itt_start_date_day, "#course_details_form_itt_start_date_3i"
       element :itt_start_date_month, "#course_details_form_itt_start_date_2i"
       element :itt_start_date_year, "#course_details_form_itt_start_date_1i"


### PR DESCRIPTION
### Context
Adding validation to the start date forms and change course to ITT 

### Changes proposed in this pull request

- commencement date cannot be more then 10 years ago

- ~commencement date cannot be before course start date~ **This PR has been amended to remove this validation, based on an ongoing discussion with @ralph-hawkins**

- commencement date cannot be after the course end date
- Remove the constant ITT_TRAINING_ROUTES as this is now redundant
- Change course to ITT 

### Guidance to review

- Navigate to both start date forms and enter a range of valid and invalid dates as per the changes detailed above and check that we get the expected behaviour. 

- Check that `trainee-start-date/edit` now matches the prototype (screenshot in the Trello ticket).