### PR TITLE
[3149] Course starts in the past, no trainee start date - withdraw

### DIFF
--- a/app/components/record_actions/view.rb
+++ b/app/components/record_actions/view.rb
@@ -19,7 +19,11 @@ module RecordActions
     end
 
     def action_links
-      links = [withdraw_link]
+      links = []
+
+      if withdraw_allowed?
+        links.prepend(withdraw_link)
+      end
 
       if trainee.deferred?
         links.prepend(reinstate_link)
@@ -53,7 +57,7 @@ module RecordActions
     end
 
     def withdraw_link
-      govuk_link_to(t("views.trainees.edit.withdraw"), trainee_start_date_verification_path(trainee, context: :withdraw), class: "withdraw")
+      govuk_link_to(t("views.trainees.edit.withdraw"), relevant_redirect_path, class: "withdraw")
     end
 
     def reinstate_link
@@ -64,12 +68,24 @@ module RecordActions
       course_starting_in_the_future? || course_started_but_trainee_has_not_specified_start_date?
     end
 
+    def withdraw_allowed?
+      !course_starting_in_the_future?
+    end
+
     def course_starting_in_the_future?
       trainee.course_start_date && trainee.course_start_date > Time.zone.now
     end
 
     def course_started_but_trainee_has_not_specified_start_date?
       !course_starting_in_the_future? && trainee.commencement_date.blank?
+    end
+
+    def relevant_redirect_path
+      if trainee.commencement_date.present?
+        trainee_withdrawal_path(trainee)
+      else
+        trainee_start_date_verification_path(trainee, context: :withdraw)
+      end
     end
   end
 end

--- a/app/components/record_actions/view.rb
+++ b/app/components/record_actions/view.rb
@@ -45,7 +45,7 @@ module RecordActions
     end
 
     def delete_link
-      govuk_link_to(t("views.trainees.edit.delete"), trainee_start_date_verification_path(trainee), class: "delete")
+      govuk_link_to(t("views.trainees.edit.delete"), trainee_start_date_verification_path(trainee, context: :delete), class: "delete")
     end
 
     def defer_link
@@ -53,7 +53,7 @@ module RecordActions
     end
 
     def withdraw_link
-      govuk_link_to(t("views.trainees.edit.withdraw"), trainee_withdrawal_path(trainee), class: "withdraw")
+      govuk_link_to(t("views.trainees.edit.withdraw"), trainee_start_date_verification_path(trainee, context: :withdraw), class: "withdraw")
     end
 
     def reinstate_link

--- a/app/controllers/trainees/forbidden_withdrawals_controller.rb
+++ b/app/controllers/trainees/forbidden_withdrawals_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Trainees
+  class ForbiddenWithdrawalsController < BaseController
+    def show; end
+  end
+end

--- a/app/controllers/trainees/start_date_verifications_controller.rb
+++ b/app/controllers/trainees/start_date_verifications_controller.rb
@@ -10,11 +10,7 @@ module Trainees
       @start_date_verification_form = StartDateVerificationForm.new(verification_params)
 
       if @start_date_verification_form.valid?
-        if @start_date_verification_form.already_started?
-          redirect_to(edit_trainee_start_status_path(trainee, context: :delete))
-        else
-          redirect_to(trainee_confirm_delete_path(trainee))
-        end
+        redirect_to(relevant_redirect_path)
       else
         render(:show)
       end
@@ -23,7 +19,27 @@ module Trainees
   private
 
     def verification_params
-      params.require(:start_date_verification_form).permit(:trainee_has_started_course)
+      params.require(:start_date_verification_form).permit(:trainee_has_started_course, :context)
+    end
+
+    def relevant_redirect_path
+      if trainee_started_course? && withdrawing?
+        edit_trainee_start_status_path(trainee, context: :withdraw)
+      elsif !trainee_started_course? && withdrawing?
+        trainee_forbidden_withdrawal_path(trainee)
+      elsif trainee_started_course?
+        edit_trainee_start_status_path(trainee, context: :delete)
+      else
+        trainee_confirm_delete_path(trainee)
+      end
+    end
+
+    def trainee_started_course?
+      @start_date_verification_form.already_started?
+    end
+
+    def withdrawing?
+      @start_date_verification_form.withdrawing?
     end
   end
 end

--- a/app/controllers/trainees/start_statuses_controller.rb
+++ b/app/controllers/trainees/start_statuses_controller.rb
@@ -20,6 +20,11 @@ module Trainees
         return redirect_to(trainee_forbidden_deletes_path(trainee))
       end
 
+      if withdraw_context?
+        @trainee_start_status_form.save!
+        return redirect_to(trainee_withdrawal_path(trainee))
+      end
+
       if @trainee_start_status_form.stash_or_save!
         if trainee.draft? && trainee.submission_ready?
           Trainees::SubmitForTrn.call(trainee: trainee, dttp_id: current_user.dttp_id)
@@ -44,7 +49,11 @@ module Trainees
     end
 
     def delete_context?
-      params[:context] == "delete"
+      params[:context] == StartDateVerificationForm::DELETE
+    end
+
+    def withdraw_context?
+      params[:context] == StartDateVerificationForm::WITHDRAW
     end
   end
 end

--- a/app/forms/start_date_verification_form.rb
+++ b/app/forms/start_date_verification_form.rb
@@ -3,15 +3,18 @@
 class StartDateVerificationForm
   include ActiveModel::Model
 
-  attr_accessor :trainee_has_started_course
+  WITHDRAW = "withdraw"
+  DELETE = "delete"
+
+  attr_accessor :trainee_has_started_course, :context
 
   validates :trainee_has_started_course, presence: true, inclusion: { in: %w[yes no] }
 
-  def initialize(params = {})
-    @trainee_has_started_course = params[:trainee_has_started_course]
-  end
-
   def already_started?
     trainee_has_started_course == "yes"
+  end
+
+  def withdrawing?
+    context == WITHDRAW
   end
 end

--- a/app/views/trainees/forbidden_withdrawals/show.html.erb
+++ b/app/views/trainees/forbidden_withdrawals/show.html.erb
@@ -1,0 +1,32 @@
+<%= render PageTitle::View.new(i18n_key: "trainees.forbidden_withdrawals.show") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+  <%= render TraineeName::View.new(@trainee) %>
+
+  <h1 class="govuk-heading-l">
+    <%= t(".heading") %> 
+  </h1>
+
+  <p class="govuk-body">
+     <%= t(".reason") %> 
+  </p>
+
+  <p class="govuk-body">
+    You can <%= govuk_link_to(t(".delete"), trainee_confirm_delete_path(@trainee), class: "govuk-link--no-visited-state") %>.
+  </p>
+
+  <p class="govuk-body">
+     <%= t(".support") %> <%= govuk_mail_to(Settings.data_email, Settings.data_email)%>.
+  </p>
+
+  <p class="govuk-body">
+    <%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee)) %>
+  </p>
+
+  </div>
+</div>

--- a/app/views/trainees/start_date_verifications/show.html.erb
+++ b/app/views/trainees/start_date_verifications/show.html.erb
@@ -11,7 +11,8 @@
                            url: trainee_start_date_verification_path(@trainee),
                            local: true) do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.hidden_field :trainee_has_started_course %>
+
+      <%= f.hidden_field :context, value: params[:context] %>
 
       <%= render TraineeName::View.new(@trainee) %>
 

--- a/app/views/trainees/start_statuses/edit.html.erb
+++ b/app/views/trainees/start_statuses/edit.html.erb
@@ -32,7 +32,7 @@
             }, hint: { text: t(".trainee_start_date_hint") } %>
           <% end %>
 
-          <% unless params[:context] == "delete" %>
+          <% unless %w[delete withdraw].include?(params[:context]) %>
             <%= f.govuk_radio_divider %>
 
             <%= f.govuk_radio_button(:commencement_status,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,6 +317,8 @@ en:
             edit: Review course
         forbidden_deletes:
           show: Delete forbidden
+        forbidden_withdrawals:
+          show: Withdrawal forbidden
         start_date_verification:
           show: Did the trainee start their course?
       providers:
@@ -900,6 +902,12 @@ en:
         withdraw: Withdraw
         return_to_record: Return to trainee record
         legend: Do you want to defer or withdraw this trainee?
+    forbidden_withdrawals:
+      show:
+        heading: You cannot withdraw this trainee
+        reason: Trainees can only be withdrawn after they have started their course.
+        delete: delete this trainee record
+        support: If you need more help, email the Register trainee teachers team at
   activerecord:
     attributes:
       trainee:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,7 @@ Rails.application.routes.draw do
       resource :subject_specialism, only: %i[edit update], path: "/subject-specialism/:position"
       resource :start_date_verification, only: %i[show create], path: "/start-date-verification"
       resource :forbidden_deletes, only: %i[show create], path: "/delete-forbidden"
+      resource :forbidden_withdrawal, only: %i[show], path: "/withdrawal-forbidden"
     end
   end
 

--- a/spec/components/record_actions/view_spec.rb
+++ b/spec/components/record_actions/view_spec.rb
@@ -64,4 +64,20 @@ RSpec.describe RecordActions::View do
       include_examples "no actions"
     end
   end
+
+  context "when course date is in the future" do
+    let(:trainee) { build(:trainee, :submitted_for_trn, course_start_date: 1.day.from_now) }
+
+    it "withdraw link is hidden" do
+      expect(subject).not_to include("Withdraw")
+    end
+  end
+
+  context "when course date is in the past" do
+    let(:trainee) { build(:trainee, :submitted_for_trn, course_start_date: 1.day.ago) }
+
+    it "withdraw link is shown" do
+      expect(subject).to include("Withdraw")
+    end
+  end
 end

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -87,11 +87,21 @@ feature "Withdrawing a trainee", type: :feature do
 
   scenario "trainee has not started course" do
     given_i_am_authenticated
-    given_a_trainee_exists_to_be_withdrawn
+    given_a_trainee_exists_to_be_withdrawn_with_no_start_date
     and_i_am_on_the_trainee_record_page
     and_i_click_on_withdraw
     and_i_choose_they_have_not_started
     then_i_am_taken_to_the_forbidden_withdrawal_page
+  end
+
+  scenario "trainee is withdrawn but there is no existing start date" do
+    given_i_am_authenticated
+    given_a_trainee_exists_to_be_withdrawn_with_no_start_date
+    and_i_am_on_the_trainee_record_page
+    and_i_click_on_withdraw
+    and_i_choose_they_have_started
+    when_i_choose_they_started_on_time
+    then_i_should_be_on_the_withdrawal_page
   end
 
   scenario "cancelling changes" do
@@ -111,8 +121,6 @@ feature "Withdrawing a trainee", type: :feature do
     given_a_deferred_trainee_exists
     and_i_am_on_the_trainee_record_page
     and_i_click_on_withdraw
-    and_i_choose_they_have_started
-    when_i_choose_they_started_on_time
     then_the_deferral_text_should_be_shown
     when_i_choose_a_specific_reason
     and_i_continue
@@ -125,9 +133,6 @@ feature "Withdrawing a trainee", type: :feature do
     given_a_trainee_exists_to_be_withdrawn
     and_i_am_on_the_trainee_record_page
     and_i_click_on_withdraw
-    and_i_choose_they_have_started
-    when_i_choose_they_started_on_time
-    then_i_should_be_on_the_withdrawal_page
   end
 
   def when_i_choose_today
@@ -238,6 +243,10 @@ feature "Withdrawing a trainee", type: :feature do
 
   def given_a_trainee_exists_to_be_withdrawn
     given_a_trainee_exists(%i[submitted_for_trn trn_received].sample, commencement_date: 10.days.ago)
+  end
+
+  def given_a_trainee_exists_to_be_withdrawn_with_no_start_date
+    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample, commencement_date: nil)
   end
 
   def given_a_deferred_trainee_exists

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -85,6 +85,15 @@ feature "Withdrawing a trainee", type: :feature do
     end
   end
 
+  scenario "trainee has not started course" do
+    given_i_am_authenticated
+    given_a_trainee_exists_to_be_withdrawn
+    and_i_am_on_the_trainee_record_page
+    and_i_click_on_withdraw
+    and_i_choose_they_have_not_started
+    then_i_am_taken_to_the_forbidden_withdrawal_page
+  end
+
   scenario "cancelling changes" do
     when_i_am_on_the_withdrawal_page
     and_i_choose_today
@@ -102,6 +111,8 @@ feature "Withdrawing a trainee", type: :feature do
     given_a_deferred_trainee_exists
     and_i_am_on_the_trainee_record_page
     and_i_click_on_withdraw
+    and_i_choose_they_have_started
+    when_i_choose_they_started_on_time
     then_the_deferral_text_should_be_shown
     when_i_choose_a_specific_reason
     and_i_continue
@@ -114,6 +125,9 @@ feature "Withdrawing a trainee", type: :feature do
     given_a_trainee_exists_to_be_withdrawn
     and_i_am_on_the_trainee_record_page
     and_i_click_on_withdraw
+    and_i_choose_they_have_started
+    when_i_choose_they_started_on_time
+    then_i_should_be_on_the_withdrawal_page
   end
 
   def when_i_choose_today
@@ -257,5 +271,28 @@ feature "Withdrawing a trainee", type: :feature do
     expect(withdrawal_confirmation_page).to have_text(
       t("components.confirmation.withdrawal_details.withdrawal_date", date: date_for_summary_view(trainee.defer_date)),
     )
+  end
+
+  def and_i_choose_they_have_started
+    start_date_verification_page.started_option.choose
+    start_date_verification_page.continue.click
+  end
+
+  def when_i_choose_they_started_on_time
+    trainee_start_status_edit_page.commencement_status_started_on_time.choose
+    trainee_start_status_edit_page.continue.click
+  end
+
+  def then_i_should_be_on_the_withdrawal_page
+    expect(withdrawal_page).to be_displayed
+  end
+
+  def and_i_choose_they_have_not_started
+    start_date_verification_page.not_started_option.choose
+    start_date_verification_page.continue.click
+  end
+
+  def then_i_am_taken_to_the_forbidden_withdrawal_page
+    expect(withdrawal_forbidden_page).to be_displayed
   end
 end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -222,6 +222,10 @@ module Features
       @withdrawal_confirmation_page ||= PageObjects::Trainees::ConfirmWithdrawal.new
     end
 
+    def withdrawal_forbidden_page
+      @withdrawal_forbidden_page ||= PageObjects::Trainees::WithdrawalForbidden.new
+    end
+
     def reinstatement_page
       @reinstatement_page ||= PageObjects::Trainees::Reinstatement.new
     end

--- a/spec/support/page_objects/trainees/withdrawal_forbidden.rb
+++ b/spec/support/page_objects/trainees/withdrawal_forbidden.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Trainees
+    class WithdrawalForbidden < PageObjects::Base
+      set_url "/trainees/{id}/withdrawal-forbidden"
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/Neir6RLo/3149-m-course-starts-in-the-past-no-trainee-start-date-withdraw

### Changes proposed in this pull request
* New withdraw flow for if trainee has started course but trainee start date is not present. If course start date is in future, withdraw link is hidden. If trainee start date is present, trainee is taken straight to withdrawal page. 
* Modified the StartDateVerificationsController to decide whether withdrawal or deletion
* If user says that they haven't started course and the course starts date is in past they are taken to withdrawal forbidden page

### Guidance to review
Select a non-draft trainee e.g pending trn and make sure it has a 'withdraw' link and go through the withdrawal flow. You should be able to do the routes highlighted in the attachment on the ticket above.
