### PR TITLE
[3148] course starts in the past no trainee start date defer

### DIFF
--- a/app/components/deferral_details/view.html.erb
+++ b/app/components/deferral_details/view.html.erb
@@ -1,12 +1,4 @@
 <%= render SummaryCard::View.new(
-  title: t("components.confirmation.deferral_details.summary_title"),
-  rows: [
-    {
-      key: t("components.confirmation.deferral_details.defer_date_label"),
-      value: defer_date,
-      action_href: deferred_before_starting? ? nil: trainee_deferral_path(data_model.trainee),
-      action_text: t(:change),
-      action_visually_hidden_text: 'date of deferral',
-    },
-  ],
+  title: t(".summary_title"),
+  rows: rows,
 ) %>

--- a/app/components/deferral_details/view.rb
+++ b/app/components/deferral_details/view.rb
@@ -23,7 +23,7 @@ module DeferralDetails
       {
         key: t(".start_date_label"),
         value: trainee_start_date,
-        action_href: edit_trainee_start_date_path(data_model.trainee, context: :defer),
+        action_href: trainee_start_date_verification_path(data_model.trainee, context: :defer),
         action_text: t(:change),
         action_visually_hidden_text: "itt start date",
       }
@@ -46,7 +46,7 @@ module DeferralDetails
     end
 
     def deferred_before_starting?
-      data_model.date.nil?
+      data_model.itt_not_yet_started? || data_model.date.nil?
     end
 
     def trainee_start_date

--- a/app/components/deferral_details/view.rb
+++ b/app/components/deferral_details/view.rb
@@ -33,7 +33,7 @@ module DeferralDetails
       {
         key: t(".defer_date_label"),
         value: defer_date,
-        action_href: deferred_before_starting? ? nil : trainee_deferral_path(data_model.trainee),
+        action_href: deferred_before_itt_started? ? nil : trainee_deferral_path(data_model.trainee),
         action_text: t(:change),
         action_visually_hidden_text: "date of deferral",
       }
@@ -42,11 +42,23 @@ module DeferralDetails
   private
 
     def defer_date
-      deferred_before_starting? ? t(".deferred_before_starting").html_safe : date_for_summary_view(data_model.date)
+      return t(".deferred_before_itt_started").html_safe if deferred_before_itt_started?
+
+      return t(".itt_started_but_trainee_did_not_start").html_safe if itt_not_yet_started?
+
+      date_for_summary_view(data_model.date)
     end
 
-    def deferred_before_starting?
+    def deferred_before_itt_started?
+      starts_course_in_the_future? && itt_not_yet_started?
+    end
+
+    def itt_not_yet_started?
       data_model.itt_not_yet_started? || data_model.date.nil?
+    end
+
+    def starts_course_in_the_future?
+      data_model.trainee.starts_course_in_the_future?
     end
 
     def trainee_start_date

--- a/app/components/deferral_details/view.rb
+++ b/app/components/deferral_details/view.rb
@@ -54,7 +54,7 @@ module DeferralDetails
     end
 
     def trainee_started_itt?
-      data_model.itt_start_date.present?
+      data_model.itt_start_date.is_a?(Date)
     end
   end
 end

--- a/app/components/deferral_details/view.rb
+++ b/app/components/deferral_details/view.rb
@@ -10,12 +10,51 @@ module DeferralDetails
       @data_model = data_model
     end
 
+    def rows
+      [
+        trainee_start_date_row,
+        deferral_date_row,
+      ].compact
+    end
+
+    def trainee_start_date_row
+      return unless trainee_started_itt?
+
+      {
+        key: t(".start_date_label"),
+        value: trainee_start_date,
+        action_href: edit_trainee_start_date_path(data_model.trainee, context: :defer),
+        action_text: t(:change),
+        action_visually_hidden_text: "itt start date",
+      }
+    end
+
+    def deferral_date_row
+      {
+        key: t(".defer_date_label"),
+        value: defer_date,
+        action_href: deferred_before_starting? ? nil : trainee_deferral_path(data_model.trainee),
+        action_text: t(:change),
+        action_visually_hidden_text: "date of deferral",
+      }
+    end
+
+  private
+
     def defer_date
       deferred_before_starting? ? t(".deferred_before_starting").html_safe : date_for_summary_view(data_model.date)
     end
 
     def deferred_before_starting?
       data_model.date.nil?
+    end
+
+    def trainee_start_date
+      date_for_summary_view(data_model.itt_start_date)
+    end
+
+    def trainee_started_itt?
+      data_model.itt_start_date.present?
     end
   end
 end

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -121,7 +121,11 @@ module RecordDetails
     end
 
     def status_date
-      return I18n.t("deferral_details.view.deferred_before_starting").html_safe if trainee.itt_not_yet_started?
+      if trainee.itt_not_yet_started?
+        return I18n.t("deferral_details.view.deferred_before_itt_started").html_safe if trainee.starts_course_in_the_future?
+
+        return I18n.t("deferral_details.view.itt_started_but_trainee_did_not_start").html_safe
+      end
 
       return unless trainee_status_date
 

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -121,7 +121,7 @@ module RecordDetails
     end
 
     def status_date
-      return I18n.t("deferral_details.view.deferred_before_starting") if trainee.itt_not_yet_started?
+      return I18n.t("deferral_details.view.deferred_before_starting").html_safe if trainee.itt_not_yet_started?
 
       return unless trainee_status_date
 

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -121,6 +121,8 @@ module RecordDetails
     end
 
     def status_date
+      return I18n.t("deferral_details.view.deferred_before_starting") if trainee.itt_not_yet_started?
+
       return unless trainee_status_date
 
       I18n.t("record_details.view.status_date_prefix.#{trainee.state}") + date_for_summary_view(trainee_status_date)

--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -8,7 +8,7 @@ module Trainees
     end
 
     def update
-      if deferral_form.save! || trainee.starts_course_in_the_future?
+      if deferral_form.save!
         trainee.defer!
 
         Dttp::DeferJob.perform_later(trainee)

--- a/app/controllers/trainees/deferrals_controller.rb
+++ b/app/controllers/trainees/deferrals_controller.rb
@@ -6,6 +6,7 @@ module Trainees
 
     def show
       @deferral_form = DeferralForm.new(trainee)
+      redirect_to_start_date_selection unless @deferral_form.itt_start_date.is_a?(Date)
     end
 
     def update
@@ -32,6 +33,10 @@ module Trainees
 
     def redirect_to_confirm_deferral
       redirect_to(trainee_confirm_deferral_path(trainee))
+    end
+
+    def redirect_to_start_date_selection
+      redirect_to(trainee_start_date_verification_path(trainee, context: :defer))
     end
   end
 end

--- a/app/controllers/trainees/start_dates_controller.rb
+++ b/app/controllers/trainees/start_dates_controller.rb
@@ -17,11 +17,7 @@ module Trainees
       @trainee_start_date_form = TraineeStartDateForm.new(trainee, params: trainee_params, user: current_user)
 
       if @trainee_start_date_form.stash_or_save!
-        if defer_context?
-          redirect_to(trainee_deferral_path(trainee))
-        else
-          redirect_to(trainee_start_date_confirm_path(trainee))
-        end
+        redirect_to(relevant_redirect_path)
       else
         render(:edit)
       end
@@ -30,14 +26,20 @@ module Trainees
   private
 
     def trainee_params
-      params.require(:trainee_start_date_form).permit(:commencement_date, *PARAM_CONVERSION.keys)
+      params.require(:trainee_start_date_form).permit(:commencement_date, :context, *PARAM_CONVERSION.keys)
             .transform_keys do |key|
         PARAM_CONVERSION.keys.include?(key) ? PARAM_CONVERSION[key] : key
       end
     end
 
-    def defer_context?
-      params[:context] == "defer"
+    def relevant_redirect_path
+      if @trainee_start_date_form.deferring?
+        return trainee_deferral_path(trainee) if @trainee_start_date_form.itt_start_date_is_after_deferral_date?
+
+        return trainee_confirm_deferral_path(trainee)
+      end
+
+      trainee_start_date_confirm_path(trainee)
     end
   end
 end

--- a/app/controllers/trainees/start_dates_controller.rb
+++ b/app/controllers/trainees/start_dates_controller.rb
@@ -10,14 +10,18 @@ module Trainees
 
     def edit
       redirect_to(edit_trainee_start_status_path(trainee)) if @trainee.commencement_date.blank?
-      @trainee_start_date_form = TraineeStartDateForm.new(trainee)
+      @trainee_start_date_form = TraineeStartDateForm.new(trainee, params: params.slice(:context).permit!)
     end
 
     def update
       @trainee_start_date_form = TraineeStartDateForm.new(trainee, params: trainee_params, user: current_user)
 
       if @trainee_start_date_form.stash_or_save!
-        redirect_to(trainee_start_date_confirm_path(trainee))
+        if defer_context?
+          redirect_to(trainee_deferral_path(trainee))
+        else
+          redirect_to(trainee_start_date_confirm_path(trainee))
+        end
       else
         render(:edit)
       end
@@ -30,6 +34,10 @@ module Trainees
             .transform_keys do |key|
         PARAM_CONVERSION.keys.include?(key) ? PARAM_CONVERSION[key] : key
       end
+    end
+
+    def defer_context?
+      params[:context] == "defer"
     end
   end
 end

--- a/app/controllers/trainees/start_statuses_controller.rb
+++ b/app/controllers/trainees/start_statuses_controller.rb
@@ -43,7 +43,11 @@ module Trainees
 
       return trainee_withdrawal_path(trainee) if @trainee_start_status_form.withdrawing?
 
-      return trainee_deferral_path(trainee) if @trainee_start_status_form.deferring?
+      if @trainee_start_status_form.deferring?
+        return trainee_deferral_path(trainee) if @trainee_start_status_form.needs_deferral_date?
+
+        return trainee_confirm_deferral_path(trainee)
+      end
 
       trainee_start_status_confirm_path(trainee)
     end

--- a/app/controllers/trainees/start_statuses_controller.rb
+++ b/app/controllers/trainees/start_statuses_controller.rb
@@ -9,22 +9,19 @@ module Trainees
     }.freeze
 
     def edit
-      @trainee_start_status_form = TraineeStartStatusForm.new(trainee)
+      @trainee_start_status_form = TraineeStartStatusForm.new(trainee, params: params.slice(:context).permit!)
     end
 
     def update
       @trainee_start_status_form = TraineeStartStatusForm.new(trainee, params: trainee_params, user: current_user)
 
-      if @trainee_start_status_form.public_send(context_present? ? :save! : :stash_or_save!)
-        return redirect_to(trainee_forbidden_deletes_path(trainee)) if delete_context?
-        return redirect_to(trainee_withdrawal_path(trainee)) if withdraw_context?
-
+      if @trainee_start_status_form.stash_or_save!
         if trainee.draft? && trainee.submission_ready?
           Trainees::SubmitForTrn.call(trainee: trainee, dttp_id: current_user.dttp_id)
           return redirect_to(trn_submission_path(trainee))
         end
 
-        redirect_to(trainee_start_status_confirm_path(trainee))
+        redirect_to(relevant_redirect_path)
       else
         render(:edit)
       end
@@ -41,16 +38,14 @@ module Trainees
       end
     end
 
-    def delete_context?
-      params[:context] == StartDateVerificationForm::DELETE
-    end
+    def relevant_redirect_path
+      return trainee_forbidden_deletes_path(trainee) if @trainee_start_status_form.deleting?
 
-    def withdraw_context?
-      params[:context] == StartDateVerificationForm::WITHDRAW
-    end
+      return trainee_withdrawal_path(trainee) if @trainee_start_status_form.withdrawing?
 
-    def context_present?
-      params[:context].present?
+      return trainee_deferral_path(trainee) if @trainee_start_status_form.deferring?
+
+      trainee_start_status_confirm_path(trainee)
     end
   end
 end

--- a/app/forms/concerns/commencement_date_helpers.rb
+++ b/app/forms/concerns/commencement_date_helpers.rb
@@ -8,6 +8,8 @@ module CommencementDateHelpers
       errors.add(:commencement_date, :invalid)
     elsif commencement_date < 10.years.ago
       errors.add(:commencement_date, :too_old)
+    elsif commencement_date.future?
+      errors.add(:commencement_date, :future)
     elsif trainee.course_end_date.present? && commencement_date > trainee.course_end_date
       errors.add(
         :commencement_date,

--- a/app/forms/deferral_form.rb
+++ b/app/forms/deferral_form.rb
@@ -4,12 +4,12 @@ class DeferralForm < MultiDateForm
   validate :date_valid, if: :requires_start_date?
 
   def itt_start_date
-    @itt_start_date ||= if trainee.commencement_date.blank?
-                          ::TraineeStartStatusForm.new(trainee).commencement_date
-                        else
-                          ::TraineeStartDateForm.new(trainee).commencement_date
-                        end
+    return if itt_not_yet_started?
+
+    @itt_start_date ||= ::TraineeStartStatusForm.new(trainee).commencement_date
   end
+
+  delegate :itt_not_yet_started?, to: :trainee
 
 private
 
@@ -34,8 +34,8 @@ private
 
   def clear_stash
     [
-      TraineeStartDateForm,
       TraineeStartStatusForm,
+      StartDateVerificationForm,
     ].each do |klass|
       klass.new(trainee).clear_stash
     end

--- a/app/forms/deferral_form.rb
+++ b/app/forms/deferral_form.rb
@@ -1,7 +1,28 @@
 # frozen_string_literal: true
 
 class DeferralForm < MultiDateForm
+  validate :date_valid, if: :requires_start_date?
+
+  def itt_start_date
+    @itt_start_date ||= if trainee.commencement_date.blank?
+                          ::TraineeStartStatusForm.new(trainee).commencement_date
+                        else
+                          ::TraineeStartDateForm.new(trainee).commencement_date
+                        end
+  end
+
 private
+
+  def assign_attributes_to_trainee
+    trainee.commencement_date = itt_start_date if itt_start_date.is_a?(Date)
+    trainee[date_field] = date
+  end
+
+  def requires_start_date?
+    return false if trainee.starts_course_in_the_future?
+
+    !trainee.itt_not_yet_started?
+  end
 
   def date_field
     @date_field ||= :defer_date
@@ -9,5 +30,16 @@ private
 
   def form_store_key
     :deferral
+  end
+
+  def clear_stash
+    [
+      TraineeStartDateForm,
+      TraineeStartStatusForm,
+    ].each do |klass|
+      klass.new(trainee).clear_stash
+    end
+
+    super
   end
 end

--- a/app/forms/itt_start_date_form.rb
+++ b/app/forms/itt_start_date_form.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class IttStartDateForm < MultiDateForm
+  validate :date_valid
+
   def stash
     form = CourseDetailsForm.new(trainee)
     form.assign_attributes_and_stash({

--- a/app/forms/multi_date_form.rb
+++ b/app/forms/multi_date_form.rb
@@ -5,8 +5,6 @@ class MultiDateForm < TraineeForm
 
   attr_accessor :day, :month, :year, :date_string
 
-  validate :date_valid
-
   PARAM_CONVERSION = {
     "date(3i)" => "day",
     "date(2i)" => "month",
@@ -21,16 +19,6 @@ class MultiDateForm < TraineeForm
       yesterday: Time.zone.yesterday,
       other: other_date,
     }[date_string.to_sym]
-  end
-
-  def save!
-    if valid?
-      update_trainee
-      trainee.save!
-      clear_stash
-    else
-      false
-    end
   end
 
   def add_date_fields(new_d)
@@ -78,7 +66,7 @@ private
     end
   end
 
-  def update_trainee
+  def assign_attributes_to_trainee
     trainee[date_field] = date
   end
 

--- a/app/forms/multi_date_form.rb
+++ b/app/forms/multi_date_form.rb
@@ -85,7 +85,7 @@ private
     elsif !date.is_a?(Date)
       errors.add(:date, :invalid)
     elsif date_before_course_start_date?(date, trainee.course_start_date)
-      errors.add(:date, :not_before_course_start_date)
+      errors.add(:date, I18n.t("activemodel.errors.models.deferral_form.attributes.date.not_before_course_start_date").html_safe)
     end
   end
 end

--- a/app/forms/outcome_date_form.rb
+++ b/app/forms/outcome_date_form.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class OutcomeDateForm < MultiDateForm
+  validate :date_valid
   validate :date_is_not_in_future
 
 private

--- a/app/forms/reinstatement_form.rb
+++ b/app/forms/reinstatement_form.rb
@@ -1,19 +1,11 @@
 # frozen_string_literal: true
 
 class ReinstatementForm < MultiDateForm
-  def save!
-    if valid?
-      update_trainee
-      trainee.save!
-      clear_stash
-    else
-      false
-    end
-  end
+  validate :date_valid
 
 private
 
-  def update_trainee
+  def assign_attributes_to_trainee
     trainee[date_field] = date
     trainee.commencement_date = date if trainee.deferred? && trainee.commencement_date.nil?
   end

--- a/app/forms/start_date_verification_form.rb
+++ b/app/forms/start_date_verification_form.rb
@@ -1,14 +1,28 @@
 # frozen_string_literal: true
 
-class StartDateVerificationForm
-  include ActiveModel::Model
+class StartDateVerificationForm < TraineeForm
+  FIELDS = %i[
+    context
+    trainee_has_started_course
+  ].freeze
 
   WITHDRAW = "withdraw"
+  DEFER = "defer"
   DELETE = "delete"
 
-  attr_accessor :trainee_has_started_course, :context
+  attr_accessor(*FIELDS)
 
   validates :trainee_has_started_course, presence: true, inclusion: { in: %w[yes no] }
+
+  def save!
+    if valid?
+      update_trainee_commencement_status
+      trainee.save!
+      clear_stash
+    else
+      false
+    end
+  end
 
   def already_started?
     trainee_has_started_course == "yes"
@@ -16,5 +30,23 @@ class StartDateVerificationForm
 
   def withdrawing?
     context == WITHDRAW
+  end
+
+  def deferring?
+    context == DEFER
+  end
+
+private
+
+  def update_trainee_commencement_status
+    trainee.assign_attributes(commencement_status: commencement_status)
+  end
+
+  def commencement_status
+    trainee_has_started_course == "no" ? :itt_not_yet_started : nil
+  end
+
+  def compute_fields
+    new_attributes.slice(*FIELDS)
   end
 end

--- a/app/forms/start_date_verification_form.rb
+++ b/app/forms/start_date_verification_form.rb
@@ -39,11 +39,19 @@ class StartDateVerificationForm < TraineeForm
 private
 
   def update_trainee_commencement_status
-    trainee.assign_attributes(commencement_status: commencement_status)
+    attributes = { commencement_status: commencement_status }
+
+    attributes.merge!(commencement_date: nil) if not_yet_started?
+
+    trainee.assign_attributes(attributes)
   end
 
   def commencement_status
-    trainee_has_started_course == "no" ? :itt_not_yet_started : nil
+    not_yet_started? ? :itt_not_yet_started : nil
+  end
+
+  def not_yet_started?
+    trainee_has_started_course == "no"
   end
 
   def compute_fields

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -30,7 +30,7 @@ class TraineeForm
 
   def save!
     if valid?
-      trainee.assign_attributes(fields.except(*fields_to_ignore_before_save))
+      assign_attributes_to_trainee
       trainee.save!
       clear_stash
     else
@@ -67,6 +67,10 @@ class TraineeForm
   end
 
 private
+
+  def assign_attributes_to_trainee
+    trainee.assign_attributes(fields.except(*fields_to_ignore_before_save))
+  end
 
   def course_date_attribute_name_prefix
     :itt

--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -36,7 +36,7 @@ private
   end
 
   def update_trainee_commencement_date
-    trainee.assign_attributes(commencement_date: commencement_date) if errors.empty?
+    trainee.assign_attributes(commencement_date: commencement_date)
   end
 
   def fields_from_store

--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -52,7 +52,15 @@ private
   end
 
   def update_trainee_commencement_date
-    trainee.assign_attributes(commencement_date: commencement_date)
+    trainee.assign_attributes(commencement_date: commencement_date, commencement_status: commencement_status)
+  end
+
+  def commencement_status
+    if commencement_date.after?(trainee.course_start_date)
+      COMMENCEMENT_STATUS_ENUMS[:itt_started_later]
+    else
+      COMMENCEMENT_STATUS_ENUMS[:itt_started_on_time]
+    end
   end
 
   def fields_from_store

--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -4,7 +4,11 @@ class TraineeStartDateForm < TraineeForm
   include DatesHelper
   include CommencementDateHelpers
 
-  attr_accessor :day, :month, :year
+  attr_accessor :day, :month, :year, :context
+
+  WITHDRAW = "withdraw"
+  DEFER = "defer"
+  DELETE = "delete"
 
   validate :commencement_date_valid
 
@@ -25,14 +29,26 @@ class TraineeStartDateForm < TraineeForm
     valid_date?(date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
   end
 
+  def deferring?
+    context == DEFER
+  end
+
+  def itt_start_date_is_after_deferral_date?
+    deferral_date.is_a?(Date) && commencement_date.after?(deferral_date)
+  end
+
 private
+
+  def deferral_date
+    @deferral_date ||= ::DeferralForm.new(trainee).date
+  end
 
   def compute_fields
     {
       day: trainee.commencement_date&.day,
       month: trainee.commencement_date&.month,
       year: trainee.commencement_date&.year,
-    }.merge(new_attributes.slice(:day, :month, :year))
+    }.merge(new_attributes.slice(:day, :month, :year, :context))
   end
 
   def update_trainee_commencement_date

--- a/app/forms/trainee_start_status_form.rb
+++ b/app/forms/trainee_start_status_form.rb
@@ -72,7 +72,19 @@ class TraineeStartStatusForm < TraineeForm
     context == DEFER
   end
 
+  def needs_deferral_date?
+    itt_start_date_is_after_deferral_date? || deferral_date.blank?
+  end
+
 private
+
+  def itt_start_date_is_after_deferral_date?
+    deferral_date.is_a?(Date) && commencement_date.after?(deferral_date)
+  end
+
+  def deferral_date
+    @deferral_date ||= ::DeferralForm.new(trainee).date
+  end
 
   def set_on_time_itt_start_date
     self.day = trainee.course_start_date.day

--- a/app/forms/trainee_start_status_form.rb
+++ b/app/forms/trainee_start_status_form.rb
@@ -4,9 +4,14 @@ class TraineeStartStatusForm < TraineeForm
   include DatesHelper
   include CommencementDateHelpers
 
+  WITHDRAW = "withdraw"
+  DEFER = "defer"
+  DELETE = "delete"
+
   FIELDS = %i[
     commencement_status
     commencement_date
+    context
     day
     month
     year
@@ -51,6 +56,22 @@ class TraineeStartStatusForm < TraineeForm
     commencement_status&.to_sym == :itt_started_later
   end
 
+  def next_step_context?
+    [WITHDRAW, DEFER, DELETE].include?(context)
+  end
+
+  def deleting?
+    context == DELETE
+  end
+
+  def withdrawing?
+    context == WITHDRAW
+  end
+
+  def deferring?
+    context == DEFER
+  end
+
 private
 
   def set_on_time_itt_start_date
@@ -71,7 +92,7 @@ private
       day: trainee.commencement_date&.day,
       month: trainee.commencement_date&.month,
       year: trainee.commencement_date&.year,
-    }.merge(new_attributes.slice(:day, :month, :year, :commencement_status))
+    }.merge(new_attributes.slice(:day, :month, :year, :commencement_status, :context))
   end
 
   def update_trainee_commencement_date

--- a/app/forms/withdrawal_form.rb
+++ b/app/forms/withdrawal_form.rb
@@ -3,6 +3,7 @@
 class WithdrawalForm < MultiDateForm
   attr_accessor :withdraw_reason, :additional_withdraw_reason
 
+  validate :date_valid
   validate :withdraw_reason_valid
   validate :additional_withdraw_reason_valid
 
@@ -27,7 +28,7 @@ private
     withdraw_reason == WithdrawalReasons::FOR_ANOTHER_REASON
   end
 
-  def update_trainee
+  def assign_attributes_to_trainee
     trainee.assign_attributes({
       withdraw_date: date,
       withdraw_reason: withdraw_reason,

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -30,6 +30,7 @@ class FormStore
     language_specialisms
     subject_specialism
     itt_start_date
+    start_date_verification
     study_modes
     course_education_phase
     training_details

--- a/app/views/trainees/start_date_verifications/show.html.erb
+++ b/app/views/trainees/start_date_verifications/show.html.erb
@@ -12,12 +12,13 @@
                            local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.hidden_field :context, value: params[:context] %>
+      <%= f.hidden_field :context %>
+      <%= f.hidden_field :trainee_has_started_course %>
 
       <%= render TraineeName::View.new(@trainee) %>
 
       <%= f.govuk_radio_buttons_fieldset(:trainee_has_started_course,
-                                         legend: { text: t(".legend").html_safe, size: "l" }) do %>
+                                         legend: { text: t(".legend").html_safe, size: "l", tag: "h1" }) do %>
         <%= f.govuk_radio_button(:trainee_has_started_course,
                                  :yes,
                                  label: { text: t(".yes_they_started") },

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -8,6 +8,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(model: @trainee_start_date_form, url: trainee_start_date_path, local: true) do |f| %>
       <%= f.govuk_error_summary %>
+      <%= hidden_field_tag :context, params[:context] %>
 
       <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_date_field :commencement_date, legend: {

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(model: @trainee_start_date_form, url: trainee_start_date_path, local: true) do |f| %>
       <%= f.govuk_error_summary %>
-      <%= hidden_field_tag :context, params[:context] %>
+      <%= f.hidden_field :context, value: params[:context] %>
 
       <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_date_field :commencement_date, legend: {

--- a/app/views/trainees/start_statuses/edit.html.erb
+++ b/app/views/trainees/start_statuses/edit.html.erb
@@ -1,9 +1,9 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.trainee_start_date.edit", has_errors: @trainee_start_status_form.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.trainee_start_status.edit", has_errors: @trainee_start_status_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <% if params[:context] == "delete" %>
+  <% if @trainee_start_status_form.next_step_context? %>
     <%= render GovukComponent::BackLinkComponent.new(text: t(:back),
-                                                     href: trainee_start_date_verification_path(@trainee)) %>
+                                                     href: trainee_start_date_verification_path(@trainee, context: @trainee_start_status_form.context)) %>
   <% else  %>
     <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>
   <% end  %>
@@ -12,9 +12,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(model: @trainee_start_status_form,
-                           url: trainee_start_status_path(context: params[:context]),
+                           url: trainee_start_status_path,
                            local: true) do |f| %>
       <%= f.govuk_error_summary %>
+
+      <%= f.hidden_field :context %>
 
       <%= render TraineeName::View.new(@trainee) %>
 
@@ -34,7 +36,7 @@
             }, hint: { text: t(".trainee_start_date_hint") } %>
           <% end %>
 
-          <% unless %w[delete withdraw].include?(params[:context]) %>
+          <% unless @trainee_start_status_form.next_step_context? %>
             <%= f.govuk_radio_divider %>
 
             <%= f.govuk_radio_button(:commencement_status,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,7 +78,8 @@ en:
   deferral_details:
     view:
       defer_date_label: Date of deferral
-      deferred_before_starting: Trainee deferred before their <abbr title="initial teacher training">ITT</abbr> started
+      deferred_before_itt_started: Trainee deferred before their <abbr title="initial teacher training">ITT</abbr> started
+      itt_started_but_trainee_did_not_start: The trainee deferred before starting their <abbr title="initial teacher training">ITT</abbr>
       summary_title: Deferral details
       start_date_label: *trainee_start_date
   reinstatement_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,10 @@ en:
       region: *region
   deferral_details:
     view:
+      defer_date_label: Date of deferral
       deferred_before_starting: Trainee deferred before their <abbr title="initial teacher training">ITT</abbr> started
+      summary_title: Deferral details
+      start_date_label: *trainee_start_date
   reinstatement_details:
     view:
       reinstated_before_starting: Trainee returned before their <abbr title="initial teacher training">ITT</abbr> started
@@ -160,9 +163,6 @@ en:
           transferred_to_another_provider: Transferred to another provider
           unknown: Unknown
           written_off_after_lapse_of_time: Written off after lapse of time
-      deferral_details:
-        summary_title: Deferral details
-        defer_date_label: Date of deferral
       flash:
         diversity: disclosure
         disclosure: diversity information
@@ -268,6 +268,8 @@ en:
           edit: Trainee personal details
         trainee_start_date:
           edit: &commencement_date Trainee’s start date
+        trainee_start_status:
+          edit: Did the trainee start their ITT on time?
         training_details:
           edit: Edit training details
         training_routes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1275,6 +1275,7 @@ en:
               blank: Enter a start date
               invalid: Enter a valid start date
               not_after_course_end_date_html: Trainee start date must not be after the ITT has finished <span class="no-wrap">(%{course_end_date})</span>
+              future: Trainee start date must be in the past
               too_old: Trainee start date cannot be more than 10 years in the past
         trainee_start_status_form:
           attributes:
@@ -1282,6 +1283,7 @@ en:
               blank: Enter a start date
               invalid: Enter a valid start date
               not_after_course_end_date_html: Trainee start date must not be after the ITT has finished <span class="no-wrap">(%{course_end_date})</span>
+              future: Trainee start date must be in the past
               too_old: Trainee start date cannot be more than 10 years in the past
             commencement_status:
               blank: Select if the trainee started on time

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1351,7 +1351,7 @@ en:
         start_date_verification_form:
           attributes:
             trainee_has_started_course:
-              blank: Select yes or no
+              blank: Select if the trainee started their ITT
         trainee_forbidden_delete_form:
           attributes:
             alternative_option:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1351,7 +1351,7 @@ en:
         start_date_verification_form:
           attributes:
             trainee_has_started_course:
-              blank: Select if the trainee started their ITT
+              blank: Select yes if the trainee started their ITT
         trainee_forbidden_delete_form:
           attributes:
             alternative_option:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,7 @@ Rails.application.routes.draw do
       resource :timeline, only: :show
 
       resource :subject_specialism, only: %i[edit update], path: "/subject-specialism/:position"
-      resource :start_date_verification, only: %i[show create], path: "/start-date-verification"
+      resource :start_date_verification, only: %i[show update], path: "/start-date-verification"
       resource :forbidden_deletes, only: %i[show create], path: "/delete-forbidden"
       resource :forbidden_withdrawal, only: %i[show], path: "/withdrawal-forbidden"
     end

--- a/spec/components/deferral_details/view_preview.rb
+++ b/spec/components/deferral_details/view_preview.rb
@@ -13,11 +13,11 @@ module DeferralDetails
   private
 
     def trainee
-      @trainee ||= Trainee.new(id: 1, defer_date: Time.zone.yesterday)
+      @trainee ||= Trainee.new(id: 1, defer_date: Time.zone.today)
     end
 
     def data_model
-      OpenStruct.new(trainee: trainee, date: trainee.defer_date)
+      OpenStruct.new(trainee: trainee, date: trainee.defer_date, itt_start_date: Time.zone.yesterday)
     end
   end
 end

--- a/spec/components/deferral_details/view_spec.rb
+++ b/spec/components/deferral_details/view_spec.rb
@@ -30,9 +30,7 @@ module DeferralDetails
         let(:trainee_stub) { Trainee.new }
 
         it "renders the deferred before starting" do
-          expect(component).to have_text(
-            t("deferral_details.view.deferred_before_starting"),
-          )
+          expect(component).to have_text(strip_tags(t("deferral_details.view.deferred_before_starting")))
         end
       end
     end

--- a/spec/components/deferral_details/view_spec.rb
+++ b/spec/components/deferral_details/view_spec.rb
@@ -9,7 +9,7 @@ module DeferralDetails
 
     alias_method :component, :page
 
-    let(:data_model) { OpenStruct.new(trainee: trainee_stub, date: trainee_stub.defer_date) }
+    let(:data_model) { OpenStruct.new(trainee: trainee_stub, date: trainee_stub.defer_date, itt_start_date: Time.zone.today) }
 
     before do
       render_inline(View.new(data_model))
@@ -20,6 +20,20 @@ module DeferralDetails
 
       it "renders the deferral date" do
         expect(component).to have_text(date_for_summary_view(data_model.date))
+      end
+
+      it "renders the itt start date" do
+        expect(component).to have_text(date_for_summary_view(data_model.itt_start_date))
+      end
+
+      context "when trainee did not start" do
+        let(:trainee_stub) { Trainee.new }
+
+        it "renders the deferred before starting" do
+          expect(component).to have_text(
+            t("deferral_details.view.deferred_before_starting"),
+          )
+        end
       end
     end
 

--- a/spec/components/deferral_details/view_spec.rb
+++ b/spec/components/deferral_details/view_spec.rb
@@ -30,16 +30,16 @@ module DeferralDetails
         let(:trainee_stub) { Trainee.new }
 
         it "renders the deferred before starting" do
-          expect(component).to have_text(strip_tags(t("deferral_details.view.deferred_before_starting")))
+          expect(component).to have_text(strip_tags(t("deferral_details.view.itt_started_but_trainee_did_not_start")))
         end
       end
     end
 
     context "course start date is in the future" do
-      let(:trainee_stub) { Trainee.new }
+      let(:trainee_stub) { Trainee.new(course_start_date: 1.year.from_now) }
 
       it "renders the deferred before course start date message" do
-        expect(component).to have_text(strip_tags(t("deferral_details.view.deferred_before_starting")))
+        expect(component).to have_text(strip_tags(t("deferral_details.view.deferred_before_itt_started")))
       end
     end
   end

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -89,6 +89,14 @@ module RecordDetails
         it "renders the trainee status tag" do
           expect(rendered_component).to have_text("deferred")
         end
+
+        context "when trainee did not start ITT" do
+          let(:trainee) { create(:trainee, state, commencement_status: :itt_not_yet_started) }
+
+          it "renders text stating that the trainee deferred before starting" do
+            expect(rendered_component).to have_text("Trainee deferred before their ITT started")
+          end
+        end
       end
 
       context "when trainee state is withdrawn" do

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -94,7 +94,7 @@ module RecordDetails
           let(:trainee) { create(:trainee, state, commencement_status: :itt_not_yet_started) }
 
           it "renders text stating that the trainee deferred before starting" do
-            expect(rendered_component).to have_text("Trainee deferred before their ITT started")
+            expect(rendered_component).to have_text(strip_tags(t("deferral_details.view.itt_started_but_trainee_did_not_start")))
           end
         end
       end

--- a/spec/controllers/trainees/start_statuses_controller_spec.rb
+++ b/spec/controllers/trainees/start_statuses_controller_spec.rb
@@ -13,12 +13,12 @@ describe Trainees::StartStatusesController, type: :controller do
       post(:update,
            params: {
              trainee_id: trainee,
-             context: page_context,
              trainee_start_status_form: {
                "commencement_status" => "itt_started_on_time",
                "commencement_date(3i)" => "",
                "commencement_date(2i)" => "",
                "commencement_date(1i)" => "",
+               context: page_context,
              },
            })
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -192,7 +192,7 @@ FactoryBot.define do
     end
 
     trait :with_start_date do
-      commencement_date { Faker::Date.between(from: course_start_date, to: course_end_date) }
+      commencement_date { Faker::Date.between(from: course_start_date, to: Time.zone.today) }
     end
 
     trait :course_start_date_in_the_past do

--- a/spec/features/trainee_actions/defer_trainee_spec.rb
+++ b/spec/features/trainee_actions/defer_trainee_spec.rb
@@ -106,9 +106,20 @@ feature "Deferring a trainee", type: :feature do
   end
 
   scenario "changing start date from deferral confirmation page" do
+    given_a_trainee_exists_to_be_deferred
     given_i_am_on_the_deferral_confirmation_page
     and_i_click_on_the_change_link_for_start_date
     then_i_am_redirected_to_trainee_start_date_page
+    and_i_continue
+    then_i_am_redirected_to_deferral_confirmation_page
+  end
+
+  scenario "changing start date to be after the deferral date" do
+    given_a_trainee_exists_with_a_deferral_date
+    given_i_am_on_the_deferral_confirmation_page
+    and_i_click_on_the_change_link_for_start_date
+    then_i_am_redirected_to_trainee_start_date_page
+    and_i_enter_a_start_date_after_the_deferral_date
     and_i_continue
     then_i_am_redirected_to_the_deferral_page
     when_i_choose_today
@@ -134,7 +145,6 @@ feature "Deferring a trainee", type: :feature do
   end
 
   def given_i_am_on_the_deferral_confirmation_page
-    given_a_trainee_exists_to_be_deferred
     deferral_confirmation_page.load(id: trainee.slug)
   end
 
@@ -221,8 +231,21 @@ feature "Deferring a trainee", type: :feature do
     expect(trainee_start_date_edit_page).to be_displayed(trainee_id: trainee.slug)
   end
 
+  def and_i_enter_a_start_date_after_the_deferral_date
+    new_start_date = trainee.defer_date + 1.day
+    trainee_start_date_edit_page.set_date_fields(:commencement_date, new_start_date.strftime("%d/%m/%Y"))
+  end
+
   def given_a_trainee_exists_to_be_deferred
     given_a_trainee_exists(%i[submitted_for_trn trn_received].sample, :with_start_date)
+  end
+
+  def given_a_trainee_exists_with_a_deferral_date
+    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample,
+                           commencement_date: 1.month.ago,
+                           course_start_date: 1.year.ago,
+                           course_end_date: 1.year.from_now,
+                           defer_date: 1.week.ago)
   end
 
   def given_a_trainee_with_course_starting_in_the_future_exists

--- a/spec/features/trainee_actions/defer_trainee_spec.rb
+++ b/spec/features/trainee_actions/defer_trainee_spec.rb
@@ -6,8 +6,13 @@ feature "Deferring a trainee", type: :feature do
   include SummaryHelper
   include ActionView::Helpers::SanitizeHelper
 
+  background do
+    given_i_am_authenticated
+  end
+
   context "trainee deferral date" do
     before do
+      given_a_trainee_exists_to_be_deferred
       given_i_initiate_a_deferral
     end
 
@@ -62,14 +67,57 @@ feature "Deferring a trainee", type: :feature do
   end
 
   scenario "course start date is in the future" do
-    given_i_initiate_a_deferral(commencement_date: nil, course_start_date: Time.zone.tomorrow)
+    given_a_trainee_with_course_starting_in_the_future_exists
+    given_i_initiate_a_deferral
     then_i_am_redirected_to_deferral_confirmation_page
-    and_i_see_a_message_for_course_start_date_in_the_future
+    and_i_see_a_message_for_trainee_deferred_before_starting
     when_i_defer
     then_the_trainee_is_deferred
   end
 
+  describe "course start date is in the past" do
+    background do
+      given_a_trainee_with_course_started_in_the_past_exists
+      given_i_initiate_a_deferral
+    end
+
+    scenario "and the trainee did not start" do
+      then_i_am_redirected_to_start_date_verification_page
+      and_i_choose_they_have_not_started
+      and_i_see_a_message_for_trainee_deferred_before_starting
+      when_i_defer
+      then_the_trainee_is_deferred
+    end
+
+    scenario "and the trainee started" do
+      then_i_am_redirected_to_start_date_verification_page
+      and_i_choose_they_have_started
+      then_i_am_redirected_to_trainee_start_status_page
+      when_i_choose_they_started_on_time
+      then_i_am_redirected_to_the_deferral_page
+      when_i_choose_today
+      and_i_continue
+      then_i_am_redirected_to_deferral_confirmation_page
+      and_i_see_my_date(Time.zone.today)
+      and_i_see_my_itt_start_date
+      when_i_defer
+      then_the_trainee_is_deferred
+    end
+  end
+
+  scenario "changing start date from deferral confirmation page" do
+    given_i_am_on_the_deferral_confirmation_page
+    and_i_click_on_the_change_link_for_start_date
+    then_i_am_redirected_to_trainee_start_date_page
+    and_i_continue
+    then_i_am_redirected_to_the_deferral_page
+    when_i_choose_today
+    and_i_continue
+    then_i_am_redirected_to_deferral_confirmation_page
+  end
+
   scenario "cancelling changes" do
+    given_a_trainee_exists_to_be_deferred
     given_i_initiate_a_deferral
     when_i_choose_today
     and_i_continue
@@ -80,11 +128,18 @@ feature "Deferring a trainee", type: :feature do
     and_the_defer_date_i_chose_is_cleared
   end
 
-  def given_i_initiate_a_deferral(trainee_attributes = {})
-    given_i_am_authenticated
-    given_a_trainee_exists_to_be_deferred(trainee_attributes)
+  def given_i_initiate_a_deferral
     and_i_am_on_the_trainee_record_page
     and_i_click_on_defer
+  end
+
+  def given_i_am_on_the_deferral_confirmation_page
+    given_a_trainee_exists_to_be_deferred
+    deferral_confirmation_page.load(id: trainee.slug)
+  end
+
+  def and_i_click_on_the_change_link_for_start_date
+    deferral_confirmation_page.start_date_change_link.click
   end
 
   def when_i_choose_today
@@ -122,10 +177,14 @@ feature "Deferring a trainee", type: :feature do
     deferral_page.continue.click
   end
 
-  def and_i_see_a_message_for_course_start_date_in_the_future
+  def and_i_see_a_message_for_trainee_deferred_before_starting
     expect(deferral_confirmation_page).to have_content(
       strip_tags(I18n.t("deferral_details.view.deferred_before_starting")),
     )
+  end
+
+  def and_i_see_my_itt_start_date
+    and_i_see_my_date(trainee.course_start_date)
   end
 
   def then_i_see_the_error_message_for_invalid_date
@@ -150,8 +209,47 @@ feature "Deferring a trainee", type: :feature do
     expect(deferral_confirmation_page).to be_displayed(id: trainee.slug)
   end
 
-  def given_a_trainee_exists_to_be_deferred(attributes = { commencement_date: 10.days.ago })
-    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample, attributes)
+  def then_i_am_redirected_to_start_date_verification_page
+    expect(start_date_verification_page).to be_displayed(id: trainee.slug)
+  end
+
+  def then_i_am_redirected_to_trainee_start_status_page
+    expect(trainee_start_status_edit_page).to be_displayed(trainee_id: trainee.slug)
+  end
+
+  def then_i_am_redirected_to_trainee_start_date_page
+    expect(trainee_start_date_edit_page).to be_displayed(trainee_id: trainee.slug)
+  end
+
+  def given_a_trainee_exists_to_be_deferred
+    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample, :with_start_date)
+  end
+
+  def given_a_trainee_with_course_starting_in_the_future_exists
+    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample,
+                           commencement_date: nil,
+                           course_start_date: Time.zone.today + 1.day)
+  end
+
+  def given_a_trainee_with_course_started_in_the_past_exists
+    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample,
+                           commencement_date: nil,
+                           course_start_date: Time.zone.today - 1.day)
+  end
+
+  def and_i_choose_they_have_not_started
+    start_date_verification_page.not_started_option.choose
+    start_date_verification_page.continue.click
+  end
+
+  def and_i_choose_they_have_started
+    start_date_verification_page.started_option.choose
+    start_date_verification_page.continue.click
+  end
+
+  def when_i_choose_they_started_on_time
+    trainee_start_status_edit_page.commencement_status_started_on_time.choose
+    trainee_start_status_edit_page.continue.click
   end
 
   def then_the_defer_date_is_updated
@@ -168,6 +266,10 @@ feature "Deferring a trainee", type: :feature do
 
   def then_i_am_redirected_to_the_record_page
     expect(record_page).to be_displayed(id: trainee.slug)
+  end
+
+  def then_i_am_redirected_to_the_deferral_page
+    expect(deferral_page).to be_displayed(trainee_id: trainee.slug)
   end
 
   def and_the_defer_date_i_chose_is_cleared

--- a/spec/features/trainee_actions/defer_trainee_spec.rb
+++ b/spec/features/trainee_actions/defer_trainee_spec.rb
@@ -70,7 +70,7 @@ feature "Deferring a trainee", type: :feature do
     given_a_trainee_with_course_starting_in_the_future_exists
     given_i_initiate_a_deferral
     then_i_am_redirected_to_deferral_confirmation_page
-    and_i_see_a_message_for_trainee_deferred_before_starting
+    and_i_see_a_message_for_trainee_deferred_before_itt_started
     when_i_defer
     then_the_trainee_is_deferred
   end
@@ -84,7 +84,7 @@ feature "Deferring a trainee", type: :feature do
     scenario "and the trainee did not start" do
       then_i_am_redirected_to_start_date_verification_page
       and_i_choose_they_have_not_started
-      and_i_see_a_message_for_trainee_deferred_before_starting
+      and_i_see_a_message_for_itt_started_but_trainee_deferred_before_starting
       when_i_defer
       then_the_trainee_is_deferred
     end
@@ -113,7 +113,6 @@ feature "Deferring a trainee", type: :feature do
     and_i_choose_they_have_started
     then_i_am_redirected_to_trainee_start_status_page
     when_i_choose_they_started_on_time
-    and_i_continue
     then_i_am_redirected_to_deferral_confirmation_page
   end
 
@@ -121,7 +120,6 @@ feature "Deferring a trainee", type: :feature do
     given_a_trainee_exists_with_a_deferral_date
     given_i_am_on_the_deferral_confirmation_page
     and_i_click_on_the_change_link_for_start_date
-
     then_i_am_redirected_to_start_date_verification_page
     and_i_choose_they_have_started
     then_i_am_redirected_to_trainee_start_status_page
@@ -194,9 +192,15 @@ feature "Deferring a trainee", type: :feature do
     deferral_page.continue.click
   end
 
-  def and_i_see_a_message_for_trainee_deferred_before_starting
+  def and_i_see_a_message_for_trainee_deferred_before_itt_started
     expect(deferral_confirmation_page).to have_content(
-      strip_tags(I18n.t("deferral_details.view.deferred_before_starting")),
+      strip_tags(I18n.t("deferral_details.view.deferred_before_itt_started")),
+    )
+  end
+
+  def and_i_see_a_message_for_itt_started_but_trainee_deferred_before_starting
+    expect(deferral_confirmation_page).to have_content(
+      strip_tags(I18n.t("deferral_details.view.itt_started_but_trainee_did_not_start")),
     )
   end
 

--- a/spec/features/trainee_actions/defer_trainee_spec.rb
+++ b/spec/features/trainee_actions/defer_trainee_spec.rb
@@ -106,10 +106,13 @@ feature "Deferring a trainee", type: :feature do
   end
 
   scenario "changing start date from deferral confirmation page" do
-    given_a_trainee_exists_to_be_deferred
+    given_a_trainee_exists_with_a_deferral_date
     given_i_am_on_the_deferral_confirmation_page
     and_i_click_on_the_change_link_for_start_date
-    then_i_am_redirected_to_trainee_start_date_page
+    then_i_am_redirected_to_start_date_verification_page
+    and_i_choose_they_have_started
+    then_i_am_redirected_to_trainee_start_status_page
+    when_i_choose_they_started_on_time
     and_i_continue
     then_i_am_redirected_to_deferral_confirmation_page
   end
@@ -118,7 +121,11 @@ feature "Deferring a trainee", type: :feature do
     given_a_trainee_exists_with_a_deferral_date
     given_i_am_on_the_deferral_confirmation_page
     and_i_click_on_the_change_link_for_start_date
-    then_i_am_redirected_to_trainee_start_date_page
+
+    then_i_am_redirected_to_start_date_verification_page
+    and_i_choose_they_have_started
+    then_i_am_redirected_to_trainee_start_status_page
+    when_i_choose_the_trainee_has_started_later
     and_i_enter_a_start_date_after_the_deferral_date
     and_i_continue
     then_i_am_redirected_to_the_deferral_page
@@ -231,9 +238,13 @@ feature "Deferring a trainee", type: :feature do
     expect(trainee_start_date_edit_page).to be_displayed(trainee_id: trainee.slug)
   end
 
+  def when_i_choose_the_trainee_has_started_later
+    trainee_start_status_edit_page.commencement_status_started_later.choose
+  end
+
   def and_i_enter_a_start_date_after_the_deferral_date
     new_start_date = trainee.defer_date + 1.day
-    trainee_start_date_edit_page.set_date_fields(:commencement_date, new_start_date.strftime("%d/%m/%Y"))
+    trainee_start_status_edit_page.set_date_fields(:commencement_date, new_start_date.strftime("%d/%m/%Y"))
   end
 
   def given_a_trainee_exists_to_be_deferred

--- a/spec/forms/deferral_form_spec.rb
+++ b/spec/forms/deferral_form_spec.rb
@@ -117,6 +117,16 @@ describe DeferralForm, type: :model do
       allow(FormStore).to receive(:get)
     end
 
+    shared_examples "deferral form to database save" do
+      it "takes any data from the form store and saves it to the database and clears the store data" do
+        expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
+        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_date, nil)
+        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_status, nil)
+
+        expect { subject.save! }.to change(trainee, :commencement_date).to(Date.parse("21-9-2021"))
+      end
+    end
+
     it "takes any data from the form store and saves it to the database and clears the store data" do
       expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
 
@@ -153,13 +163,7 @@ describe DeferralForm, type: :model do
         })
       end
 
-      it "takes any data from the form store and saves it to the database and clears the store data" do
-        expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
-        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_date, nil)
-        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_status, nil)
-
-        expect { subject.save! }.to change(trainee, :commencement_date).to(Date.parse("21-9-2021"))
-      end
+      it_behaves_like "deferral form to database save"
     end
   end
 end

--- a/spec/forms/deferral_form_spec.rb
+++ b/spec/forms/deferral_form_spec.rb
@@ -117,16 +117,6 @@ describe DeferralForm, type: :model do
       allow(FormStore).to receive(:get)
     end
 
-    shared_examples "deferral form to database save" do
-      it "takes any data from the form store and saves it to the database and clears the store data" do
-        expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
-        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_date, nil)
-        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_status, nil)
-
-        expect { subject.save! }.to change(trainee, :commencement_date).to(Date.parse("21-9-2021"))
-      end
-    end
-
     it "takes any data from the form store and saves it to the database and clears the store data" do
       expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
 
@@ -135,24 +125,6 @@ describe DeferralForm, type: :model do
     end
 
     context "when start date is changed" do
-      before do
-        allow(FormStore).to receive(:get).with(trainee.id, :trainee_start_date).and_return({
-          "day" => "21",
-          "month" => "9",
-          "year" => "2021",
-        })
-      end
-
-      it "takes any data from the form store and saves it to the database and clears the store data" do
-        expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
-        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_date, nil)
-        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_status, nil)
-
-        expect { subject.save! }.to change(trainee, :commencement_date).to(Date.parse("21-9-2021"))
-      end
-    end
-
-    context "when start date is added for the first time" do
       let(:trainee) { create(:trainee, :deferred, commencement_date: nil) }
 
       before do
@@ -163,7 +135,13 @@ describe DeferralForm, type: :model do
         })
       end
 
-      it_behaves_like "deferral form to database save"
+      it "takes any data from the form store and saves it to the database and clears the store data" do
+        expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
+        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_status, nil)
+        expect(FormStore).to receive(:set).with(trainee.id, :start_date_verification, nil)
+
+        expect { subject.save! }.to change(trainee, :commencement_date).to(Date.parse("21-9-2021"))
+      end
     end
   end
 end

--- a/spec/forms/deferral_form_spec.rb
+++ b/spec/forms/deferral_form_spec.rb
@@ -53,6 +53,38 @@ describe DeferralForm, type: :model do
         end
       end
 
+      context "when course start date is in the future" do
+        let(:trainee) { create(:trainee, course_start_date: 10.days.from_now) }
+
+        let(:params) do
+          {}
+        end
+
+        before do
+          subject.validate
+        end
+
+        it "is valid" do
+          expect(subject.errors).to be_empty
+        end
+      end
+
+      context "when course start date is in the past, but the trainee has not started" do
+        let(:trainee) { create(:trainee, course_start_date: 1.day.ago, commencement_status: :itt_not_yet_started) }
+
+        let(:params) do
+          {}
+        end
+
+        before do
+          subject.validate
+        end
+
+        it "is valid" do
+          expect(subject.errors).to be_empty
+        end
+      end
+
       include_examples "date is not before course start date", :deferral_form
     end
   end
@@ -81,11 +113,53 @@ describe DeferralForm, type: :model do
       }
     end
 
+    before do
+      allow(FormStore).to receive(:get)
+    end
+
     it "takes any data from the form store and saves it to the database and clears the store data" do
       expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
 
       date_params = params.except("date_string").values.map(&:to_i)
       expect { subject.save! }.to change(trainee, :defer_date).to(Date.new(*date_params))
+    end
+
+    context "when start date is changed" do
+      before do
+        allow(FormStore).to receive(:get).with(trainee.id, :trainee_start_date).and_return({
+          "day" => "21",
+          "month" => "9",
+          "year" => "2021",
+        })
+      end
+
+      it "takes any data from the form store and saves it to the database and clears the store data" do
+        expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
+        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_date, nil)
+        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_status, nil)
+
+        expect { subject.save! }.to change(trainee, :commencement_date).to(Date.parse("21-9-2021"))
+      end
+    end
+
+    context "when start date is added for the first time" do
+      let(:trainee) { create(:trainee, :deferred, commencement_date: nil) }
+
+      before do
+        allow(FormStore).to receive(:get).with(trainee.id, :trainee_start_status).and_return({
+          "day" => "21",
+          "month" => "9",
+          "year" => "2021",
+        })
+      end
+
+      it "takes any data from the form store and saves it to the database and clears the store data" do
+        expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
+        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_date, nil)
+        expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_status, nil)
+
+        expect { subject.save! }.to change(trainee, :commencement_date).to(Date.parse("21-9-2021"))
+      end
     end
   end
 end

--- a/spec/forms/start_date_verification_form_spec.rb
+++ b/spec/forms/start_date_verification_form_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe StartDateVerificationForm, type: :model do
+  let(:trainee) { create(:trainee, :deferred) }
+  let(:form_store) { class_double(FormStore) }
+  let(:trainee_has_started_course) { "yes" }
+
+  let(:params) do
+    {
+      trainee_has_started_course: trainee_has_started_course,
+    }
+  end
+
+  subject { described_class.new(trainee, params: params.stringify_keys, store: form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    context "trainee_has_started_course" do
+      let(:trainee_has_started_course) { nil }
+
+      context "when not provided" do
+        it { is_expected.to validate_presence_of(:trainee_has_started_course) }
+        it { is_expected.to validate_inclusion_of(:trainee_has_started_course).in_array(%w[yes no]) }
+      end
+    end
+  end
+
+  describe "#save!" do
+    let(:trainee_has_started_course) { "no" }
+
+    it "takes any data from the form store and saves it to the database and clears the store data" do
+      expect(form_store).to receive(:set).with(trainee.id, :start_date_verification, nil)
+
+      expect { subject.save! }.to change(trainee, :commencement_status).to("itt_not_yet_started")
+    end
+  end
+end

--- a/spec/forms/start_date_verification_form_spec.rb
+++ b/spec/forms/start_date_verification_form_spec.rb
@@ -36,7 +36,10 @@ describe StartDateVerificationForm, type: :model do
     it "takes any data from the form store and saves it to the database and clears the store data" do
       expect(form_store).to receive(:set).with(trainee.id, :start_date_verification, nil)
 
-      expect { subject.save! }.to change(trainee, :commencement_status).to("itt_not_yet_started")
+      expect {
+        subject.save!
+      }.to change(trainee, :commencement_status).to("itt_not_yet_started")
+      .and change(trainee, :commencement_date).to(nil)
     end
   end
 end

--- a/spec/forms/trainee_start_date_form_spec.rb
+++ b/spec/forms/trainee_start_date_form_spec.rb
@@ -48,6 +48,19 @@ describe TraineeStartDateForm, type: :model do
       end
     end
 
+    context "date is in the future" do
+      let(:trainee) do
+        build(:trainee, course_start_date: Time.zone.today, course_end_date: 1.year.from_now)
+      end
+      let(:future_date) { 1.month.from_now }
+
+      let(:params) { { day: future_date.day, month: future_date.month, year: future_date.year, commencement_status: "itt_started_later" } }
+
+      it "is invalid" do
+        expect(subject.errors[:commencement_date]).to include("Trainee start date must be in the past")
+      end
+    end
+
     context "date is more than 10 years in the past" do
       let(:params) { { year: "2009", month: "12", day: "20" } }
 

--- a/spec/forms/trainee_start_date_form_spec.rb
+++ b/spec/forms/trainee_start_date_form_spec.rb
@@ -48,18 +48,7 @@ describe TraineeStartDateForm, type: :model do
       end
     end
 
-    context "date is in the future" do
-      let(:trainee) do
-        build(:trainee, course_start_date: Time.zone.today, course_end_date: 1.year.from_now)
-      end
-      let(:future_date) { 1.month.from_now }
-
-      let(:params) { { day: future_date.day, month: future_date.month, year: future_date.year, commencement_status: "itt_started_later" } }
-
-      it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include("Trainee start date must be in the past")
-      end
-    end
+    include_examples "start date validations"
 
     context "date is more than 10 years in the past" do
       let(:params) { { year: "2009", month: "12", day: "20" } }

--- a/spec/forms/trainee_start_date_form_spec.rb
+++ b/spec/forms/trainee_start_date_form_spec.rb
@@ -70,7 +70,7 @@ describe TraineeStartDateForm, type: :model do
   end
 
   describe "#save!" do
-    let(:trainee) { create(:trainee) }
+    let(:trainee) { create(:trainee, course_start_date: Time.zone.today) }
 
     before do
       allow(form_store).to receive(:set).with(trainee.id, :trainee_start_date, nil)

--- a/spec/forms/trainee_start_status_form_spec.rb
+++ b/spec/forms/trainee_start_status_form_spec.rb
@@ -83,6 +83,19 @@ describe TraineeStartStatusForm, type: :model do
       end
     end
 
+    context "date is in the future" do
+      let(:trainee) do
+        build(:trainee, course_start_date: Time.zone.today, course_end_date: 1.year.from_now)
+      end
+      let(:future_date) { 1.month.from_now }
+
+      let(:params) { { day: future_date.day, month: future_date.month, year: future_date.year, commencement_status: "itt_started_later" } }
+
+      it "is invalid" do
+        expect(subject.errors[:commencement_date]).to include("Trainee start date must be in the past")
+      end
+    end
+
     context "date is more than 10 years in the past" do
       let(:params) { { year: "2009", month: "12", day: "20", commencement_status: "itt_started_later" } }
 

--- a/spec/forms/trainee_start_status_form_spec.rb
+++ b/spec/forms/trainee_start_status_form_spec.rb
@@ -83,18 +83,7 @@ describe TraineeStartStatusForm, type: :model do
       end
     end
 
-    context "date is in the future" do
-      let(:trainee) do
-        build(:trainee, course_start_date: Time.zone.today, course_end_date: 1.year.from_now)
-      end
-      let(:future_date) { 1.month.from_now }
-
-      let(:params) { { day: future_date.day, month: future_date.month, year: future_date.year, commencement_status: "itt_started_later" } }
-
-      it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include("Trainee start date must be in the past")
-      end
-    end
+    include_examples "start date validations"
 
     context "date is more than 10 years in the past" do
       let(:params) { { year: "2009", month: "12", day: "20", commencement_status: "itt_started_later" } }

--- a/spec/support/page_objects/trainees/confirm_deferral_details.rb
+++ b/spec/support/page_objects/trainees/confirm_deferral_details.rb
@@ -5,6 +5,7 @@ module PageObjects
     class ConfirmDeferral < PageObjects::Base
       set_url "/trainees/{id}/defer/confirm"
 
+      element :start_date_change_link, "#trainee-start-date .govuk-link"
       element :defer, "button[type='submit']"
       element :cancel, ".govuk-link.qa-cancel-link"
     end

--- a/spec/support/page_objects/trainees/edit_deferral_date.rb
+++ b/spec/support/page_objects/trainees/edit_deferral_date.rb
@@ -4,7 +4,7 @@ module PageObjects
   module Trainees
     class Deferral < PageObjects::Base
       include PageObjects::Helpers
-      set_url "/trainees/{trainee_id}/deferral-details/deferral-date/edit"
+      set_url "/trainees/{trainee_id}/defer"
 
       element :defer_date_radios, ".govuk-radios.deferral-date"
 

--- a/spec/support/shared_examples/start_date_validations.rb
+++ b/spec/support/shared_examples/start_date_validations.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "start date validations" do
+  context "when date is in the future" do
+    let(:trainee) do
+      build(:trainee, course_start_date: Time.zone.today, course_end_date: 1.year.from_now)
+    end
+    let(:future_date) { 1.month.from_now }
+
+    let(:params) { { day: future_date.day, month: future_date.month, year: future_date.year, commencement_status: "itt_started_later" } }
+
+    it "is invalid" do
+      expect(subject.errors[:commencement_date]).to include("Trainee start date must be in the past")
+    end
+  end
+end


### PR DESCRIPTION
### Context
Adds deferral flow for when course start date is in the past for the following two scenarios:
1. If the course start date is in the past and the trainee did not start
2. If the trainee already started the course

### Changes proposed in this pull request
1. Builds off https://github.com/DFE-Digital/register-trainee-teachers/pull/1726
2. Move the `date_valid` validation out of `MultiDateForm` and into subclasses, so that it can be conditionally turned off.
3. Tweak the `StartDateVerificationForm` to set `commencement_status` against a trainee if the user selects "no"
4. Ensure that the user is redirected to the new start date capture flow.

### Guidance to review
Against a non-draft trainee, try out various deferral scenarios listed in https://trello.com/c/vIuO1GFo/3148-l-course-starts-in-the-past-no-trainee-start-date-defer. (All the flows should work, since this PR is built on top of the future course start date PR)
