### PR TITLE
Change to service update content

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -860,7 +860,7 @@ en:
           label_text: Employing school is not applicable
           body:
             <p> If the employing school is missing from the list, contact %{contact_link}</p>
-            <p>You do not need to provide an employing school if the trainee is funded and employed privately.</p>
+            <p>You do not need to provide an employing school if the trainee is funded or employed privately.</p>
     subject_specialisms:
       edit:
         heading: Which %{subject} specialism has the trainee chosen to study?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -846,21 +846,21 @@ en:
         hint: Search for a school by its unique reference number (URN), name or postcode
         description: The lead school is the main organisation and point of contact for training providers, placements and partner schools in the school direct partnership.
         not_applicable_details:
-          summary_text: Lead school is not listed, or the trainee is employed or funded privately
+          summary_text: Lead school is not listed, or the trainee is funded or employed privately
           label_text: Lead school is not applicable
           body:
             <p> If the lead school is missing from the list, contact %{contact_link}</p>
-            <p>You do not need to provide a lead school if the trainee is employed or funded privately.</p>
+            <p>You do not need to provide a lead school if the trainee is funded or employed privately.</p>
     employing_schools:
       edit:
         heading: Employing school
         hint: Search for a school by its unique reference number (URN), name or postcode
         not_applicable_details:
-          summary_text: Employing school is not listed, or the trainee is employed or funded privately
+          summary_text: Employing school is not listed, or the trainee is funded or employed privately
           label_text: Employing school is not applicable
           body:
             <p> If the employing school is missing from the list, contact %{contact_link}</p>
-            <p>You do not need to provide an employing school if the trainee is employed or funded privately.</p>
+            <p>You do not need to provide an employing school if the trainee is funded and employed privately.</p>
     subject_specialisms:
       edit:
         heading: Which %{subject} specialism has the trainee chosen to study?

--- a/db/service_updates.yml
+++ b/db/service_updates.yml
@@ -1,4 +1,4 @@
 - date: '2021-11-15'
-  title: You no longer need to provide a lead or employing school for trainees who are employed or funded privately
+  title: You no longer need to provide a lead or employing school for trainees who are funded or employed privately
   content: >-
-    When you’re registering a trainee, we were asking for a lead or employing school in all cases. If a trainee is employed or funded privately, we do not need this information so we’ve added a ‘not applicable’ option to the lead and employing schools sections. You do not need to provide lead or employing schools if the trainee is employed or funded privately.
+    When you’re registering a trainee, we were asking for a lead or employing school in all cases. If a trainee is funded or employed privately, we do not need this information so we’ve added a ‘not applicable’ option to the lead and employing schools sections. You do not need to provide lead or employing schools if the trainee is funded or employed privately.


### PR DESCRIPTION
### Context

The copy '...the trainee is employed or funded privately', which appears in the service updates content and on the lead and employing schools pages is ambiguous and not clear enough.

### Changes proposed in this pull request

Changed the copy to '...the trainee is funded or employed privately'

### Guidance to review

Review copy changes in:
- service updates content
- employing schools content
- lead schools content

