### PR TITLE
[3227] Add duplicate notice to withdrawal page

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -341,6 +341,10 @@ class Trainee < ApplicationRecord
     ].select(&:present?).join(" ").presence
   end
 
+  def duplicate?
+    Trainee.where(first_names: first_names, last_name: last_name, date_of_birth: date_of_birth, email: email).count > 1
+  end
+
 private
 
   def value_digest

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -13,11 +13,20 @@
         <span class="govuk-caption-l">
           <%= trainee_name(@trainee) %>
         </span>
-        Withdraw trainee
+        <%= t("components.page_titles.trainees.withdrawal.show") %>
       </h1>
 
+      <% if @trainee.duplicate? %>
+        <%= render GovukComponent::InsetTextComponent.new(classes: "duplicate-notice") do %>
+          <p class="govuk-body duplicate-notice_text">
+            <%= t("views.forms.withdrawal_date.duplicate_record_notice",
+                  contact_link: govuk_mail_to(Settings.support_email)).html_safe %>
+          </p>
+        <% end %>
+      <% end %>
+
       <% if @trainee.deferred? %>
-        <h3 class="govuk-heading-s">Withdrawal date</h3>
+        <h3 class="govuk-heading-s"><%= t("views.forms.withdrawal_date.deferral_notice_heading") %></h3>
         <%= render GovukComponent::InsetTextComponent.new(classes: "deferral-notice") do %>
           <p class="govuk-body deferral-notice_text">
             <%= t("views.forms.withdrawal_date.deferral_notice_html", date: date_for_summary_view(@trainee.defer_date)) %>
@@ -27,7 +36,6 @@
           </p>
         <% end %>
       <% else %>
-
         <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: t("views.forms.withdrawal_reasons.headings.withdrawal_date"), size: "s" }, classes: "withdraw-date") do %>
           <%= f.govuk_radio_button :date_string, :today, label: { text: t("views.forms.common.today") }, link_errors: true %>
           <%= f.govuk_radio_button :date_string, :yesterday, label: { text: t("views.forms.common.yesterday") } %>
@@ -35,7 +43,6 @@
             <%= f.govuk_date_field :date, legend: { text: t("views.forms.common.on_what_date"), size: "s" }, hint: { text: "#{t('views.forms.common.for_example')}, 3 12 2020" } %>
           <% end %>
         <% end %>
-
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset(:withdraw_reason, legend: { text: t("views.forms.withdrawal_reasons.headings.withdrawal_reason"), size: "s" }) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -610,6 +610,8 @@ en:
       reinstatement:
         heading: When did the trainee return?
       withdrawal_date:
+        duplicate_record_notice: Do not withdraw duplicate records. If you need to remove a duplicate record, contact us at %{contact_link}.
+        deferral_notice_heading: Withdrawal date
         deferral_notice_html: We’ll use the trainee’s deferral date of <span class="govuk-!-font-weight-bold">%{date}</span> as their withdrawal date.
         deferral_notice_link_html: To use a different date, %{reinstatement_link}, then withdraw them.
       withdrawal_reasons:

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -128,6 +128,15 @@ feature "Withdrawing a trainee", type: :feature do
     and_the_deferral_date_is_used
   end
 
+  scenario "when the trainee is a duplicate" do
+    given_i_am_authenticated
+    given_a_trainee_exists_to_be_withdrawn
+    and_the_trainee_has_a_duplicate
+    and_i_am_on_the_trainee_record_page
+    and_i_click_on_withdraw
+    then_the_duplicate_record_text_should_be_shown
+  end
+
   def when_i_am_on_the_withdrawal_page
     given_i_am_authenticated
     given_a_trainee_exists_to_be_withdrawn
@@ -253,6 +262,10 @@ feature "Withdrawing a trainee", type: :feature do
     given_a_trainee_exists(:deferred)
   end
 
+  def and_the_trainee_has_a_duplicate
+    @trainee.dup.tap { |t| t.slug = t.generate_slug }.save
+  end
+
   def additional_withdraw_reason
     @additional_withdraw_reason ||= Faker::Lorem.paragraph
   end
@@ -274,6 +287,10 @@ feature "Withdrawing a trainee", type: :feature do
 
   def then_the_deferral_text_should_be_shown
     expect(withdrawal_page).to have_deferral_notice
+  end
+
+  def then_the_duplicate_record_text_should_be_shown
+    expect(withdrawal_page).to have_duplicate_notice
   end
 
   def and_the_deferral_date_is_used

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -641,4 +641,14 @@ describe Trainee do
       expect(trainee.full_name).to eql("Joe Smith Blogs")
     end
   end
+
+  describe "#duplicate?" do
+    let(:trainee) { create(:trainee) }
+
+    before { trainee.dup.tap { |t| t.slug = t.generate_slug }.save }
+
+    it "returns true if another trainee has the same nam, date of birth and email address" do
+      expect(trainee.duplicate?).to eq(true)
+    end
+  end
 end

--- a/spec/support/page_objects/sections/duplicate_notice.rb
+++ b/spec/support/page_objects/sections/duplicate_notice.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class DuplicateNotice < PageObjects::Sections::Base
+      element :text, ".duplicate-notice_text"
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/withdrawal.rb
+++ b/spec/support/page_objects/trainees/withdrawal.rb
@@ -15,6 +15,7 @@ module PageObjects
 
       element :continue, "button[type='submit']"
 
+      section :duplicate_notice, PageObjects::Sections::DuplicateNotice, ".duplicate-notice"
       section :deferral_notice, PageObjects::Sections::DeferralNotice, ".deferral-notice"
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/L7Ml1NN5/3227-add-content-to-warn-users-not-to-withdraw-duplicate-records

### Changes proposed in this pull request
- Add duplicate notice to withdrawal page

### Guidance to review
- Visit a non-draft trainee
- Contact me so I can create a duplicate
- Refresh page
- Duplicate record notice should appear

<img width="892" alt="Screenshot 2021-11-18 at 12 18 48" src="https://user-images.githubusercontent.com/28728/142414125-af9dba37-4016-489b-9a09-26c720a9de63.png">