### PR TITLE
[3152] Add missing fields banner to registered trainees

### DIFF
--- a/app/components/notice_banner/script.js
+++ b/app/components/notice_banner/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/notice_banner/style.scss
+++ b/app/components/notice_banner/style.scss
@@ -1,0 +1,41 @@
+@import "../base.scss";
+
+.app-notice-banner {
+  @include govuk-text-colour;
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(8, "bottom");
+
+  border: $govuk-border-width solid $govuk-brand-colour;
+
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
+}
+
+.app-notice-banner__title {
+  @include govuk-font($size: 24, $weight: bold);
+
+  margin-top: 0;
+  @include govuk-responsive-margin(4, "bottom");
+}
+
+.app-notice-banner__body {
+  @include govuk-font($size: 19);
+
+  p {
+    margin-top: 0;
+    @include govuk-responsive-margin(4, "bottom");
+  }
+}
+
+// Cross-component class - adjusts styling of list component
+.app-notice-banner__list {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.app-notice-banner__list a {
+  @include govuk-typography-weight-bold;
+  @include govuk-link-common;
+  @include govuk-link-style-no-visited-state;
+}

--- a/app/components/notice_banner/view.html.erb
+++ b/app/components/notice_banner/view.html.erb
@@ -1,0 +1,14 @@
+<div class="app-notice-banner" aria-labelledby="app-notice-banner-title">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h2 class="app-notice-banner__title" id="app-notice-banner-title">
+        <%= header %>
+      </h2>
+      <div class="app-notice-banner__body">
+        <ul class="govuk-list app-notice-banner__list">
+          <%= content %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/notice_banner/view.rb
+++ b/app/components/notice_banner/view.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module NoticeBanner
+  class View < GovukComponent::Base
+    renders_one :header
+
+    def initialize; end
+
+    def render?
+      content.present?
+    end
+  end
+end

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -5,7 +5,7 @@ module Trainees
     include Appliable
 
     before_action :load_all_nationalities
-    before_action :ensure_trainee_is_not_draft!, only: :show
+    before_action :ensure_trainee_is_not_draft!, :load_missing_data_view, only: :show
 
     DOB_CONVERSION = {
       "date_of_birth(3i)" => "day",
@@ -39,6 +39,12 @@ module Trainees
     end
 
   private
+
+    def load_missing_data_view
+      @missing_data_view = MissingDataBannerView.new(
+        Submissions::MissingDataValidator.new(trainee: trainee).missing_fields, trainee
+      )
+    end
 
     def load_all_nationalities
       @nationalities = Nationality.where(name: NATIONALITIES)

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -4,7 +4,7 @@ class TraineesController < ApplicationController
   include TraineeHelper
   include ActivityTracker
 
-  before_action :ensure_trainee_is_not_draft!, only: :show
+  before_action :ensure_trainee_is_not_draft!, :load_missing_data_view, only: :show
   before_action :save_filter, only: :index
   helper_method :filter_params, :multiple_record_sources?
 
@@ -70,6 +70,12 @@ class TraineesController < ApplicationController
   end
 
 private
+
+  def load_missing_data_view
+    @missing_data_view = MissingDataBannerView.new(
+      Submissions::MissingDataValidator.new(trainee: trainee).missing_fields, trainee
+    )
+  end
 
   def trainee
     @trainee ||= Trainee.from_param(params[:id])

--- a/app/forms/submissions/base_validator.rb
+++ b/app/forms/submissions/base_validator.rb
@@ -4,23 +4,23 @@ module Submissions
   class BaseValidator
     include ActiveModel::Model
 
-    class_attribute :form_validators, instance_writer: false, default: {}
+    class_attribute :validators, instance_writer: false, default: {}
 
     class << self
-      def trn_validator(name, options)
-        form_validators[name] = options
+      def validator(name, options)
+        validators[name] = options
       end
     end
 
-    trn_validator :personal_details, form: "PersonalDetailsForm", unless: :apply_application_and_draft?
-    trn_validator :contact_details, form: "ContactDetailsForm", unless: :apply_application_and_draft?
-    trn_validator :diversity, form: "Diversities::FormValidator", unless: :apply_application_and_draft?
-    trn_validator :degrees, form: "DegreesForm", if: :validate_degree?
-    trn_validator :course_details, form: "CourseDetailsForm"
-    trn_validator :training_details, form: "TrainingDetailsForm"
-    trn_validator :trainee_data, form: "ApplyApplications::TraineeDataForm", if: :apply_application_and_draft?
-    trn_validator :schools, form: "Schools::FormValidator", if: :requires_schools?
-    trn_validator :funding, form: "Funding::FormValidator"
+    validator :personal_details, form: "PersonalDetailsForm", unless: :apply_application_and_draft?
+    validator :contact_details, form: "ContactDetailsForm", unless: :apply_application_and_draft?
+    validator :diversity, form: "Diversities::FormValidator", unless: :apply_application_and_draft?
+    validator :degrees, form: "DegreesForm", if: :validate_degree?
+    validator :course_details, form: "CourseDetailsForm"
+    validator :training_details, form: "TrainingDetailsForm"
+    validator :trainee_data, form: "ApplyApplications::TraineeDataForm", if: :apply_application_and_draft?
+    validator :schools, form: "Schools::FormValidator", if: :requires_schools?
+    validator :funding, form: "Funding::FormValidator"
 
     delegate :requires_schools?, :requires_degree?, :apply_application?, to: :trainee
 
@@ -44,7 +44,7 @@ module Submissions
 
     def validator_keys
       keys = []
-      form_validators.each do |validator, options|
+      all_validators.each do |validator, options|
         next if (condition = options[:if]) && !public_send(condition)
         next if (condition = options[:unless]) && public_send(condition)
 
@@ -55,7 +55,7 @@ module Submissions
     end
 
     def validator(progress_key)
-      validator = form_validators[progress_key][:form].constantize
+      validator = all_validators[progress_key][:form].constantize
       if progress_key == :schools
         validator.new(trainee, non_search_validation: true)
       else
@@ -65,6 +65,10 @@ module Submissions
 
     def submission_ready
       raise(NotImplementedError)
+    end
+
+    def all_validators
+      defined?(extra_validators) ? validators.merge(extra_validators) : validators
     end
   end
 end

--- a/app/forms/submissions/missing_data_validator.rb
+++ b/app/forms/submissions/missing_data_validator.rb
@@ -2,15 +2,29 @@
 
 module Submissions
   class MissingDataValidator < BaseValidator
+    class_attribute :extra_validators, instance_writer: false, default: {}
+
+    class << self
+      def missing_data_validator(name, options)
+        extra_validators[name] = options
+      end
+    end
+
+    missing_data_validator :trainee_start_date, form: "TraineeStartDateForm", if: :course_already_started?
+
     def missing_fields
       forms.map(&:missing_fields).flatten.uniq
     end
 
-    def forms
-      validator_keys.map { |key| validator(key) }
+    def course_already_started?
+      !trainee.starts_course_in_the_future?
     end
 
   private
+
+    def forms
+      validator_keys.map { |key| validator(key) }
+    end
 
     def submission_ready
       errors.add(:trainee, :incomplete) unless missing_fields.empty?

--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -47,6 +47,14 @@ module CourseDetailsHelper
     languages.sort { |a, b| a.include?(AllocationSubjects::MODERN_LANGUAGES.downcase) ? -1 : a <=> b }
   end
 
+  def path_for_course_details(trainee)
+    return edit_trainee_apply_applications_course_details_path(trainee) if trainee.apply_application?
+
+    return edit_trainee_course_details_path(trainee) if trainee.early_years_route?
+
+    edit_trainee_course_education_phase_path(trainee)
+  end
+
 private
 
   def age_ranges(option:, level:)

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -35,6 +35,12 @@ module DegreesHelper
     Dttp::CodeSets::Grades::MAPPING.keys
   end
 
+  def path_for_degrees(trainee)
+    return trainee_degrees_new_type_path(trainee) if trainee.degrees.empty?
+
+    trainee_degrees_confirm_path(trainee)
+  end
+
 private
 
   def institution_data

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module TaskListHelper
+  include CourseDetailsHelper
+  include DegreesHelper
+
   def row_helper(trainee, task)
     case task
 
@@ -163,19 +166,5 @@ private
       school_direct_salaried: salaried_title,
       pg_teaching_apprenticeship: pg_teaching_apprenticeship_title,
     }[route.to_sym]
-  end
-
-  def path_for_course_details(trainee)
-    return edit_trainee_apply_applications_course_details_path(trainee) if trainee.apply_application?
-
-    return edit_trainee_course_details_path(trainee) if trainee.early_years_route?
-
-    edit_trainee_course_education_phase_path(trainee)
-  end
-
-  def path_for_degrees(trainee)
-    return trainee_degrees_new_type_path(trainee) if trainee.degrees.empty?
-
-    trainee_degrees_confirm_path(trainee)
   end
 end

--- a/app/lib/bulk_import.rb
+++ b/app/lib/bulk_import.rb
@@ -384,7 +384,7 @@ module BulkImport
     end
 
     def validate_and_set_progress(trainee)
-      Submissions::TrnValidator.new(trainee: trainee).form_validators.each do |section, validator|
+      Submissions::TrnValidator.new(trainee: trainee).validators.each do |section, validator|
         section_valid = validator[:form].constantize.new(trainee).valid?
         trainee.progress.public_send("#{section}=", section_valid)
       end

--- a/app/view_objects/missing_data_banner_view.rb
+++ b/app/view_objects/missing_data_banner_view.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class MissingDataBannerView
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::UrlHelper
+  include ActionView::Context
+
+  include CourseDetailsHelper
+  include DegreesHelper
+
+  def initialize(missing_fields, trainee)
+    @missing_fields = missing_fields
+    @trainee = trainee
+  end
+
+  def header
+    I18n.t("views.missing_data_banner_view.header")
+  end
+
+  def content
+    return unless missing_fields.any?
+
+    tag.ul(class: "govuk-list app-notice-banner__list") do
+      render_links
+    end
+  end
+
+private
+
+  attr_reader :trainee, :missing_fields
+
+  def render_links
+    safe_join(
+      missing_fields.map do |field|
+        tag.li(
+          link_to(
+            link_text(field),
+            link_path(field),
+            class: "govuk-notification-banner__link",
+          ),
+        )
+      end,
+    )
+  end
+
+  def link_path(field)
+    path_helper = I18n.t("views.missing_data_banner_view.missing_field_link.#{field}")
+
+    case path_helper
+    when "course_path"
+      path_for_course_details(trainee)
+    when "degree_path"
+      path_for_degrees(trainee)
+    else
+      public_send(path_helper, trainee)
+    end
+  end
+
+  def link_text(field)
+    I18n.t("views.missing_data_banner_view.missing_field_text", missing_field: display_name(field))
+  end
+
+  def display_name(field)
+    I18n.t("views.missing_data_view.missing_fields_mapping.#{field}").downcase
+  end
+end

--- a/app/view_objects/missing_data_banner_view.rb
+++ b/app/view_objects/missing_data_banner_view.rb
@@ -61,6 +61,6 @@ private
   end
 
   def display_name(field)
-    I18n.t("views.missing_data_view.missing_fields_mapping.#{field}").downcase
+    I18n.t("views.missing_data_view.missing_fields_mapping.#{field}")
   end
 end

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -10,6 +10,13 @@
 
   <%= render RecordHeader::View.new(trainee: @trainee) %>
 
+  <% if @missing_data_view %>
+    <%= render NoticeBanner::View.new do |component| %>
+      <% component.header { @missing_data_view.header } %>
+      <%= @missing_data_view.content %>
+    <% end %>
+  <% end %>
+
   <%= render TabNavigation::View.new(items: [
     { name: "About their teacher training", url: trainee_path(@trainee) },
     { name: @trainee.requires_degree? ? "Personal details and education" : "Personal details", url: trainee_personal_details_path(@trainee) },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -468,6 +468,49 @@ en:
     mappable_field_row:
       default_hint_text_html: 'Enter an answer <span class="govuk-visually-hidden"> for %{field_label}</span>'
       apply_field_hint_text_html: 'Review the trainee’s answer<span class="govuk-visually-hidden"> for %{field_label}</span>'
+    missing_data_banner_view:
+      header: You need to provide additional details before recording an outcome
+      missing_field_text: Please provide a %{missing_field}
+      missing_field_link:
+        first_names: &personal_details_path edit_trainee_personal_details_path
+        last_name: *personal_details_path
+        date_of_birth: *personal_details_path
+        gender: *personal_details_path
+        nationality_names: *personal_details_path
+        locale_code: &contact_details_path edit_trainee_contact_details_path
+        email: *contact_details_path
+        ethnic_background: edit_trainee_diversity_ethnic_background_path
+        ethnic_group: edit_trainee_diversity_ethnic_group_path
+        diversity_disclosure: edit_trainee_diversity_disclosure_path
+        disability_disclosure: edit_trainee_diversity_disability_disclosure_path
+        disability_ids: edit_trainee_diversity_disability_detail_path
+        course_subject_one: &course_path course_path
+        course_subject_two: *course_path
+        course_subject_three: *course_path
+        course_start_date: *course_path
+        course_end_date: *course_path
+        main_age_range: *course_path
+        itt_start_date: *course_path
+        itt_end_date: *course_path
+        training_initiative: edit_trainee_funding_training_initiative_path
+        applying_for_bursary: &funding_method_path edit_trainee_funding_bursary_path
+        applying_for_grant: *funding_method_path
+        applying_for_scholarship: *funding_method_path
+        funding_type: *funding_method_path
+        institution: &degree_path degree_path
+        subject: *degree_path
+        uk_degree: *degree_path
+        non_uk_degree: *degree_path
+        grade: *degree_path
+        graduation_year: *degree_path
+        country: *degree_path
+        lead_school_id: &lead_school_path edit_trainee_lead_schools_path
+        employing_school_id: edit_trainee_employing_schools_path
+        school_id: *lead_school_path
+        commencement_date: &commencement_date_path edit_trainee_start_date_path
+        commencement_date_radio_option: *commencement_date_path
+        trainee_id: edit_trainee_training_details_path
+        study_mode: *course_path
     missing_data_view:
       degrees_form: degree
       missing_fields_summary:
@@ -508,7 +551,8 @@ en:
         country: *country
         lead_school_id: *lead_school
         employing_school_id: *employing_school
-        commencement_date: *commencement_date
+        school_id: school
+        commencement_date: *trainee_start_date
         commencement_date_radio_option: *commencement_date
         trainee_id: *trainee_id
         study_mode: Select if the trainee is full time or part time

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -470,7 +470,7 @@ en:
       apply_field_hint_text_html: 'Review the trainee’s answer<span class="govuk-visually-hidden"> for %{field_label}</span>'
     missing_data_banner_view:
       header: You need to provide additional details before recording an outcome
-      missing_field_text: Please provide a %{missing_field}
+      missing_field_text: "%{missing_field} is missing"
       missing_field_link:
         first_names: &personal_details_path edit_trainee_personal_details_path
         last_name: *personal_details_path
@@ -551,7 +551,7 @@ en:
         country: *country
         lead_school_id: *lead_school
         employing_school_id: *employing_school
-        school_id: school
+        school_id: *lead_school
         commencement_date: *trainee_start_date
         commencement_date_radio_option: *commencement_date
         trainee_id: *trainee_id

--- a/spec/components/notice_banner/view_preview.rb
+++ b/spec/components/notice_banner/view_preview.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module NoticeBanner
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render NoticeBanner::View.new do |component|
+        component.header { "Header" }
+        "Content"
+      end
+    end
+  end
+end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :abstract_trainee, class: "Trainee" do
     transient do
       randomise_subjects { false }
-      potential_course_start_date { course_start_date || Faker::Date.between(from: 1.year.ago, to: Time.zone.today) }
+      potential_course_start_date { course_start_date || Faker::Date.in_date_period(month: 9) }
     end
 
     sequence :trainee_id do |n|
@@ -115,6 +115,11 @@ FactoryBot.define do
       submission_ready
     end
 
+    trait :submitted_with_start_date do
+      submitted_for_trn
+      with_start_date
+    end
+
     trait :with_subject_specialism do
       transient do
         subject_name { nil }
@@ -168,14 +173,14 @@ FactoryBot.define do
 
     trait :with_study_mode_and_course_dates do
       study_mode { TRAINEE_STUDY_MODE_ENUMS.keys.sample }
-      course_start_date { Faker::Date.between(from: 1.year.ago, to: 2.days.ago) }
-      course_end_date { Faker::Date.between(from: course_start_date + 1.day, to: Time.zone.today) }
+      course_start_date { Faker::Date.in_date_period(month: 9) }
+      course_end_date { Faker::Date.in_date_period(month: 8, year: Faker::Date.in_date_period.year + 1) }
     end
 
     trait :with_study_mode_and_future_course_dates do
       study_mode { TRAINEE_STUDY_MODE_ENUMS.keys.sample }
-      course_start_date { Faker::Date.between(from: Time.zone.tomorrow, to: 1.year.from_now) }
-      course_end_date { Faker::Date.between(from: course_start_date + 1.day, to: 2.years.from_now + 1.day) }
+      course_start_date { Faker::Date.in_date_period(month: 9, year: Faker::Date.in_date_period.year + 1) }
+      course_end_date { Faker::Date.in_date_period(month: 8, year: course_start_date.year + 1) }
     end
 
     trait :with_publish_course_details do
@@ -185,7 +190,7 @@ FactoryBot.define do
     end
 
     trait :with_start_date do
-      commencement_date { Faker::Date.between(from: 6.months.from_now, to: Time.zone.today) }
+      commencement_date { Faker::Date.in_date_period(month: 10) }
     end
 
     trait :course_start_date_in_the_past do
@@ -288,10 +293,6 @@ FactoryBot.define do
 
     trait :opt_in_undergrad do
       training_route { TRAINING_ROUTE_ENUMS[:opt_in_undergrad] }
-    end
-
-    trait :draft do
-      state { "draft" }
     end
 
     trait :submitted_for_trn do

--- a/spec/forms/submissions/missing_data_validator_spec.rb
+++ b/spec/forms/submissions/missing_data_validator_spec.rb
@@ -8,7 +8,7 @@ module Submissions
       subject { described_class.new(trainee: trainee) }
 
       context "when all sections are valid" do
-        let(:trainee) { build(:trainee, :completed) }
+        let(:trainee) { build(:trainee, :submitted_with_start_date) }
 
         it "is valid" do
           expect(subject.valid?).to be true
@@ -17,7 +17,7 @@ module Submissions
       end
 
       context "when a section is invalid" do
-        let(:trainee) { build(:trainee, :completed, first_names: nil) }
+        let(:trainee) { build(:trainee, :submitted_with_start_date, first_names: nil) }
 
         it "is invalid and returns an error message" do
           expect(subject.valid?).to be false
@@ -31,7 +31,7 @@ module Submissions
       subject { described_class.new(trainee: trainee) }
 
       context "when trainee has no missing data" do
-        let(:trainee) { build(:trainee, :completed) }
+        let(:trainee) { build(:trainee, :submitted_with_start_date) }
 
         it "returns an empty array" do
           expect(subject.missing_fields).to be_empty
@@ -39,10 +39,28 @@ module Submissions
       end
 
       context "when trainee has missing data" do
-        let(:trainee) { build(:trainee, :completed, first_names: nil) }
+        let(:trainee) { build(:trainee, :submitted_with_start_date, first_names: nil) }
 
         it "returns the correct attributes from the invalid form" do
           expect(subject.missing_fields).to contain_exactly(:first_names)
+        end
+      end
+
+      context "when trainee start date is missing" do
+        context "and the course has not started" do
+          let(:trainee) { build(:trainee, :submitted_for_trn, :course_start_date_in_the_future, commencement_date: nil) }
+
+          it "returns an empty array" do
+            expect(subject.missing_fields).to be_empty
+          end
+        end
+
+        context "and the course has already started" do
+          let(:trainee) { build(:trainee, :submitted_for_trn, :course_start_date_in_the_past, commencement_date: nil) }
+
+          it "returns the correct attributes from the invalid form" do
+            expect(subject.missing_fields).to contain_exactly(:commencement_date)
+          end
         end
       end
     end

--- a/spec/view_objects/missing_data_banner_view_spec.rb
+++ b/spec/view_objects/missing_data_banner_view_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe MissingDataBannerView do
+  include Rails.application.routes.url_helpers
+
+  let(:missing_fields) { Submissions::MissingDataValidator.new(trainee: trainee).missing_fields }
+
+  subject { described_class.new(missing_fields, trainee).content }
+
+  describe "#content" do
+    context "when there is no missing data" do
+      let(:trainee) { create(:trainee, :completed) }
+
+      it "returns nothing" do
+        expect(subject).to be_falsey
+      end
+    end
+
+    context "when the trainee is missing data" do
+      let(:trainee) { create(:trainee, :completed, :course_start_date_in_the_past, field => nil) }
+
+      let(:expected_display_name) { I18n.t("views.missing_data_view.missing_fields_mapping.#{field}").downcase }
+      let(:expected_html) do
+        "<ul class=\"govuk-list app-notice-banner__list\"><li><a class=\"govuk-notification-banner__link\" href=\"#{expected_path}\">Please provide a #{expected_display_name}</a></li></ul>"
+      end
+
+      context "first_names" do
+        let(:field) { :first_names }
+        let(:expected_path) { edit_trainee_personal_details_path(trainee) }
+
+        it "returns the link to the form containing the missing data" do
+          expect(subject).to eq(expected_html)
+        end
+      end
+
+      context "commencement_date" do
+        let(:field) { :commencement_date }
+        let(:expected_path) { edit_trainee_start_date_path(trainee) }
+
+        it "returns the link to the form containing the missing data" do
+          expect(subject).to eq(expected_html)
+        end
+      end
+    end
+  end
+end

--- a/spec/view_objects/missing_data_banner_view_spec.rb
+++ b/spec/view_objects/missing_data_banner_view_spec.rb
@@ -21,9 +21,9 @@ describe MissingDataBannerView do
     context "when the trainee is missing data" do
       let(:trainee) { create(:trainee, :completed, :course_start_date_in_the_past, field => nil) }
 
-      let(:expected_display_name) { I18n.t("views.missing_data_view.missing_fields_mapping.#{field}").downcase }
+      let(:expected_display_name) { I18n.t("views.missing_data_view.missing_fields_mapping.#{field}") }
       let(:expected_html) do
-        "<ul class=\"govuk-list app-notice-banner__list\"><li><a class=\"govuk-notification-banner__link\" href=\"#{expected_path}\">Please provide a #{expected_display_name}</a></li></ul>"
+        "<ul class=\"govuk-list app-notice-banner__list\"><li><a class=\"govuk-notification-banner__link\" href=\"#{expected_path}\">#{expected_display_name} is missing</a></li></ul>"
       end
 
       context "first_names" do


### PR DESCRIPTION
### Context

https://trello.com/c/905rEvfQ/3152-l-add-outstanding-actions-to-trainees-missing-fields-banner

### Changes proposed in this pull request

- Adds a generic 'dumb' `NoticeBanner` component which renders and heading and some content with the correct stying, if content is present.
- Adds a mechanism to `Submissions::BaseValidator` by which extra validators can be added to its subclasses. This is needed because we now have a form `TraineeStartDateForm` which needs to be validated for determining whether a trainee has missing fields (and eventually for QTS recommendation) BUT does not need to be validated for TRN in the `TrnValidator`.
- Adds the extra validator to `MissingDataValidator`.
- Adds a new `MissingDataBannerView` which transforms the missing fields for a trainee into a bulleted list of links, linking to the page containing the form that needs to be completed.

**For free!**
- The addition of the extra validator to `MissingDataValidator` should mean that the 'INCOMPLETE' tag now correctly renders for registered trainees who's **course has already started** but **missing a trainee start date**. Up until now they would have looked complete.

<img width="1016" alt="Screenshot 2021-11-18 at 14 23 22" src="https://user-images.githubusercontent.com/18436946/142612395-d9024bb3-1792-49be-81e1-c3494ba146d4.png">


### Out of scope
- The grouping of missing field links into one link if a whole form is incomplete. I will card this up separately.
- The trainee status inset text - this is already carded up separately https://trello.com/c/10ILGPQN/3241-m-add-outstanding-actions-to-trainees-trainee-status-inset-text

### Guidance to review

**These trainees should have the correct banner content, plus an incomplete label:**

For a trainee with no start date, ITT in the past:
https://register-pr-1745.london.cloudapps.digital/trainees/regs7T1w7o7Eh9C3vyVcayPV

For a trainee missing a training initiative:
https://register-pr-1745.london.cloudapps.digital/trainees/pLMycBxBZ3tGuwK7oJTFSf6W

For a trainee missing an initiative and funding:
https://register-pr-1745.london.cloudapps.digital/trainees/hSQ1Qa4cXNehKcrXGXTyfC5n

**This trainee should have no banner and no incomplete tag (ITT in the future)**
https://register-pr-1745.london.cloudapps.digital/trainees/y1fbzXYmEAMJS1gNfk9L6ymF