### PR TITLE
[3233] Start syncing 2022 courses and applications from publish

### DIFF
--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -6,6 +6,7 @@ module Trainees
 
     def edit
       @courses = trainee.available_courses
+      @courses = @courses.where(recruitment_cycle_year: 2021) # TODO: remove when start year filter is implemented
       @publish_course_details_form = PublishCourseDetailsForm.new(trainee)
     end
 

--- a/app/jobs/apply_api/import_applications_job.rb
+++ b/app/jobs/apply_api/import_applications_job.rb
@@ -4,22 +4,25 @@ module ApplyApi
   class ImportApplicationsJob < ApplicationJob
     queue_as :default
 
-    def perform(from_date: nil)
+    def perform(from_date: nil, recruitment_cycle_years: Settings.apply_applications.import.recruitment_cycle_years)
       @from_date = from_date
 
       return unless FeatureService.enabled?("import_applications_from_apply")
 
-      new_applications.each do |application_data|
-        ImportApplication.call(application_data: application_data)
-      rescue ApplyApi::ImportApplication::ApplyApiMissingDataError => e
-        Sentry.capture_exception(e)
+      recruitment_cycle_years.each do |recruitment_cycle_year|
+        new_applications(recruitment_cycle_year).each do |application_data|
+          ImportApplication.call(application_data: application_data)
+        rescue ApplyApi::ImportApplication::ApplyApiMissingDataError => e
+          Sentry.capture_exception(e)
+        end
       end
     end
 
   private
 
-    def new_applications
-      RetrieveApplications.call(changed_since: @from_date || last_successful_sync)
+    def new_applications(recruitment_cycle_year)
+      RetrieveApplications.call(changed_since: @from_date || last_successful_sync,
+                                recruitment_cycle_year: recruitment_cycle_year)
     end
 
     def last_successful_sync

--- a/app/jobs/trainees/create_from_apply_job.rb
+++ b/app/jobs/trainees/create_from_apply_job.rb
@@ -9,7 +9,7 @@ module Trainees
 
       ApplyApplication.joins(:provider).where(
         providers: { apply_sync_enabled: true },
-        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        recruitment_cycle_year: Settings.apply_applications.create.recruitment_cycle_year,
       ).importable.each do |application|
         CreateFromApply.call(application: application)
       rescue Trainees::CreateFromApply::MissingCourseError => e

--- a/app/services/apply_api/retrieve_applications.rb
+++ b/app/services/apply_api/retrieve_applications.rb
@@ -4,8 +4,9 @@ module ApplyApi
   class RetrieveApplications
     include ServicePattern
 
-    def initialize(changed_since:)
+    def initialize(changed_since:, recruitment_cycle_year:)
       @changed_since = changed_since
+      @recruitment_cycle_year = recruitment_cycle_year
     end
 
     def call
@@ -14,7 +15,7 @@ module ApplyApi
 
   private
 
-    attr_reader :changed_since
+    attr_reader :changed_since, :recruitment_cycle_year
 
     def applications
       JSON(response.body)["data"]
@@ -26,7 +27,7 @@ module ApplyApi
 
     def query
       {
-        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        recruitment_cycle_year: recruitment_cycle_year,
         changed_since: changed_since&.utc&.iso8601,
       }.compact.to_query
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,6 +70,14 @@ apply_api:
 
 current_recruitment_cycle_year: 2022
 
+apply_applications:
+  import:
+    recruitment_cycle_years:
+      - 2021
+      - 2022
+  create:
+    recruitment_cycle_year: 2021
+
 jobs:
   poll_delay_hours: 1
   max_poll_duration_days: 4

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -68,7 +68,7 @@ apply_api:
   base_url: "https://www.apply-for-teacher-training.service.gov.uk/register-api"
   auth_token: "auth-token-from-env"
 
-current_recruitment_cycle_year: 2021
+current_recruitment_cycle_year: 2022
 
 jobs:
   poll_delay_hours: 1

--- a/db/data/20211123145536_create_job_to_import_2022_apply_applications.rb
+++ b/db/data/20211123145536_create_job_to_import_2022_apply_applications.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateJobToImport2022ApplyApplications < ActiveRecord::Migration[6.1]
+  def up
+    ApplyApi::ImportApplicationsJob.perform_later(from_date: Date.parse("01/09/2021"), recruitment_cycle_years: [2022])
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/factories/apply_applications.rb
+++ b/spec/factories/apply_applications.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     application { JSON.parse(ApiStubs::ApplyApi.application) }
     invalid_data { {} }
     accredited_body_code { create(:provider).code }
-    recruitment_cycle_year { Settings.current_recruitment_cycle_year }
+    recruitment_cycle_year { Settings.apply_applications.create.recruitment_cycle_year }
 
     trait :importable do
       state { "importable" }

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -23,6 +23,7 @@ FactoryBot.define do
     route { TRAINING_ROUTES_FOR_COURSE.keys.sample }
     study_mode { TRAINEE_STUDY_MODE_ENUMS.keys.sample }
     uuid { SecureRandom.uuid }
+    recruitment_cycle_year { Time.zone.today.year }
 
     summary do |builder|
       qualifications = builder.qualification.to_s.gsub("_", " ").upcase.gsub("WITH", "with")

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -283,8 +283,13 @@ feature "publish course details", type: :feature, feature_publish_course_details
     end
   end
 
-  def given_a_trainee_exists_with_some_courses(with_subjects: [], with_training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
-    given_a_trainee_exists(:with_related_courses, :with_secondary_education, subject_names: with_subjects, training_route: with_training_route, study_mode: study_mode)
+  def given_a_trainee_exists_with_some_courses(with_subjects: [],
+                                               with_training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
+    given_a_trainee_exists(:with_related_courses,
+                           :with_secondary_education,
+                           subject_names: with_subjects,
+                           training_route: with_training_route,
+                           study_mode: study_mode)
     @matching_courses = trainee.provider.courses.where(route: trainee.training_route)
   end
 

--- a/spec/jobs/trainees/create_trainees_from_apply_job_spec.rb
+++ b/spec/jobs/trainees/create_trainees_from_apply_job_spec.rb
@@ -21,7 +21,10 @@ module Trainees
 
         context "application is not for current cycle" do
           let(:apply_application) do
-            create(:apply_application, accredited_body_code: provider_code.code, state: state, recruitment_cycle_year: Settings.current_recruitment_cycle_year + 1)
+            create(:apply_application,
+                   accredited_body_code: provider_code.code,
+                   state: state,
+                   recruitment_cycle_year: Settings.apply_applications.create.recruitment_cycle_year + 1)
           end
 
           it "does not create a trainee" do

--- a/spec/services/apply_api/retrieve_applications_spec.rb
+++ b/spec/services/apply_api/retrieve_applications_spec.rb
@@ -5,11 +5,12 @@ require "rails_helper"
 module ApplyApi
   describe RetrieveApplications do
     let(:changed_since) { nil }
-    let(:expected_path) { "/applications?recruitment_cycle_year=2021" }
+    let(:recruitment_cycle_year) { Settings.current_recruitment_cycle_year }
+    let(:expected_path) { "/applications?recruitment_cycle_year=#{recruitment_cycle_year}" }
     let(:http_response) { { status: status, body: ApiStubs::ApplyApi.applications } }
     let(:request_url) { "#{Settings.apply_api.base_url}#{expected_path}" }
 
-    subject { described_class.call(changed_since: changed_since) }
+    subject { described_class.call(changed_since: changed_since, recruitment_cycle_year: recruitment_cycle_year) }
 
     before do
       stub_request(:get, request_url).to_return(http_response)
@@ -42,7 +43,7 @@ module ApplyApi
 
         context "when a 'changed_at' is provided" do
           let(:changed_since) { Time.zone.now }
-          let(:expected_query) { { recruitment_cycle_year: 2021, changed_since: changed_since.utc.iso8601 }.to_query }
+          let(:expected_query) { { recruitment_cycle_year: recruitment_cycle_year, changed_since: changed_since.utc.iso8601 }.to_query }
           let(:expected_path) { "/applications?#{expected_query}" }
 
           it "includes the changed_at param in the request" do

--- a/spec/services/teacher_training_api/retrieve_courses_spec.rb
+++ b/spec/services/teacher_training_api/retrieve_courses_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 module TeacherTrainingApi
   describe RetrieveCourses do
     describe "#call" do
-      let(:path) { "/recruitment_cycles/2021/courses?include=accredited_body,provider&sort=name,provider.provider_name" }
+      let(:query_params) { "include=accredited_body,provider&sort=name,provider.provider_name" }
+      let(:path) { "/recruitment_cycles/#{Settings.current_recruitment_cycle_year}/courses?#{query_params}" }
       let(:request_url) { "#{Settings.teacher_training_api.base_url}#{path}" }
 
       before do


### PR DESCRIPTION
### Context
https://trello.com/c/u7A7YdxV/3233-m-start-syncing-2022-courses-and-applications-from-publish

### Changes proposed in this pull request
- Add filter to published courses so that it ignores 2022 courses
- Add new config to allow the Apply import job to fetch 2021 and 2022 applications but only create trainees for 2021 for the moment
- Data migration to kick off the 2022 Apply application import

### Guidance to review
- This is low-level backend preparation.
