### PR TITLE
[xxx] Set sidekiq log level to WARN

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -10,6 +10,7 @@ if ENV.key?("VCAP_SERVICES")
     config.redis = {
       url: redis_credentials["uri"],
     }
+    config.logger.level = Logger::WARN
   end
 
   Sidekiq.configure_client do |config|


### PR DESCRIPTION
### Context
Logit filling up because of BigQuery

### Changes proposed in this pull request
Set sidekiq log level to WARN
This will avoid basic start/stop log messages. They are already provided by ActiveJobs.

### Guidance to review
Same set up as Find and TT API

