### PR TITLE
[3241] Add outstanding actions content to trainee status inset text

### DIFF
--- a/app/components/record_actions/view.html.erb
+++ b/app/components/record_actions/view.html.erb
@@ -5,7 +5,7 @@
       <%= render GovukButtonLinkTo::View.new(body: button_text, url: edit_trainee_outcome_details_outcome_date_path(trainee), class_option: "govuk-!-margin-bottom-0") %>
     <% else %>
       <div class="govuk-inset-text govuk-!-margin-0">
-        <%= t("views.trainees.edit.status_summary.#{trainee.state}") %>
+        <%= inset_text %>
       </div>
     <% end %>
 

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -77,9 +77,11 @@ private
   end
 
   def load_missing_data_view
-    @missing_data_view = MissingDataBannerView.new(
-      Submissions::MissingDataValidator.new(trainee: trainee).missing_fields, trainee
-    )
+    @missing_data_view = MissingDataBannerView.new(missing_fields, trainee)
+  end
+
+  def missing_fields
+    @missing_fields ||= Submissions::MissingDataValidator.new(trainee: trainee).missing_fields
   end
 
   def trainee

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -1,5 +1,5 @@
 <div class="record-outcome-action-bar">
-  <%= render RecordActions::View.new(@trainee) %>
+  <%= render RecordActions::View.new(@trainee, has_missing_fields: @missing_fields.present?) %>
 </div>
 
 <div class="record-details">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -579,6 +579,8 @@ en:
         recommend_for_award: Recommend trainee for QTS
         recommend_for_eyts: Recommend trainee for EYTS
         status_summary:
+          missing_fields: This trainee record requires additional details
+          itt_not_started: The trainee’s ITT starts on %{itt_start_date}
           submitted_for_trn: This trainee is pending a TRN
           deferred: This trainee is deferred
       show:

--- a/spec/components/record_actions/view_preview.rb
+++ b/spec/components/record_actions/view_preview.rb
@@ -14,6 +14,17 @@ module RecordActions
       render View.new(trainee)
     end
 
+    def missing_fields
+      trainee.state = :submitted_for_trn
+      render View.new(trainee, has_missing_fields: true)
+    end
+
+    def itt_starts_in_future
+      trainee.state = :submitted_for_trn
+      trainee.course_start_date = Time.zone.tomorrow
+      render View.new(trainee)
+    end
+
   private
 
     def trainee

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -96,7 +96,9 @@ FactoryBot.define do
     trait :completed do
       in_progress
       training_initiative { ROUTE_INITIATIVES_ENUMS.keys.sample }
-      applying_for_bursary { Faker::Boolean.boolean }
+      applying_for_bursary { false }
+      applying_for_scholarship { false }
+      applying_for_grant { false }
       nationalities { [build(:nationality)] }
       progress do
         Progress.new(


### PR DESCRIPTION
### Context

https://trello.com/c/10ILGPQN/3241-m-add-outstanding-actions-to-trainees-trainee-status-inset-text

### Changes proposed in this pull request

1. If a trainee is missing data, reflect that in the record actions inset text "This trainee requires additional details":

<img width="974" alt="Screenshot 2021-11-22 at 14 00 09" src="https://user-images.githubusercontent.com/18436946/142874616-b5cc3128-017d-4f0d-81d1-f664d9181978.png">

2. If their course has not started yet, reflect that instead "The trainee's ITT starts on...":

<img width="977" alt="Screenshot 2021-11-22 at 14 00 20" src="https://user-images.githubusercontent.com/18436946/142874630-b6f6cc73-042b-4721-87ab-c3f77b826066.png">

### Guidance to review

For a trainee missing their start date, and their ITT has started:
https://register-pr-1755.london.cloudapps.digital/trainees/icuJGW9pdMB5DdsJiaGWUXCu

For a trainee missing their start date, and their ITT starts in the future:
https://register-pr-1755.london.cloudapps.digital/trainees/FPReEdyCLXPqt3vP64CpvEYc