### PR TITLE
[3235] Associate trainees with academic cycles

### DIFF
--- a/app/models/academic_cycle.rb
+++ b/app/models/academic_cycle.rb
@@ -2,8 +2,15 @@
 
 class AcademicCycle < ApplicationRecord
   validates :start_date, :end_date, presence: true
-
   validate :start_date_before_end_date
+
+  def trainees_starting
+    query = <<~SQL
+      COALESCE(commencement_date, course_start_date) BETWEEN :start_date AND :end_date
+    SQL
+
+    Trainee.where(query, start_date: start_date, end_date: end_date)
+  end
 
 private
 

--- a/docs/adr/0006-academic-cycles.md
+++ b/docs/adr/0006-academic-cycles.md
@@ -1,0 +1,25 @@
+# 5. Academic Cycles
+
+Date: 2021-11-23
+
+## Status
+
+Accepted
+
+## Context
+
+We have introduced the concept of academic cycles. All trainees, courses and funding rules will need to be linked to an academic cycle.
+
+## Decision
+
+We need a way to "associate" all of the given entities above to reliably know a trainee's academic cycle and the associated funding rules applied for that cycle. 
+
+Our `funding_methods` table will have a foreign key linking to the `academic cyles` table. Since funding rules are cycle specific, it made sense to have a hard association between these two tables as their start and end dates correlate.
+
+## Consequences
+
+In doing the above, we'll be able to query trainees via the `AcademicCycle` model. We can effectively ask the `AcademicCycle` for its trainees and courses using the start dates on the latter two models. 
+
+The `AcademicCycle` model will return all the trainees and courses with start dates falling within its period. 
+
+We'll also be able to check the funding rules since we'll have a hard association between the cycle and the funding rules.

--- a/spec/factories/academic_cycles.rb
+++ b/spec/factories/academic_cycles.rb
@@ -2,7 +2,26 @@
 
 FactoryBot.define do
   factory :academic_cycle do
-    start_date { Faker::Date.in_date_period(month: 9) }
-    end_date { Faker::Date.in_date_period(month: 8, year: Faker::Date.in_date_period.year + 1) }
+    transient do
+      next_cycle { false }
+      previous_cycle { false }
+
+      cycle_year do
+        cycles = [
+          -> { Settings.current_recruitment_cycle_year.to_i + 1 if next_cycle },
+          -> { Settings.current_recruitment_cycle_year.to_i - 1 if previous_cycle },
+        ].map(&:call).compact
+
+        cycles.any? ? cycles.first : Settings.current_recruitment_cycle_year.to_i
+      end
+    end
+
+    start_date do
+      Date.new(cycle_year - 1, 9, 1)
+    end
+
+    end_date do
+      Date.new(cycle_year, 8, 31)
+    end
   end
 end

--- a/spec/models/academic_cycle_spec.rb
+++ b/spec/models/academic_cycle_spec.rb
@@ -25,4 +25,20 @@ describe AcademicCycle, type: :model do
       end
     end
   end
+
+  describe "#trainees" do
+    context "when there are trainees across different year periods" do
+      let(:trainee) { create(:trainee, commencement_date: subject.start_date) }
+      let(:trainee2) { create(:trainee, course_start_date: subject.start_date + 1.day) }
+
+      before do
+        incorrect_day = subject.start_date - 1.day
+        create(:trainee, commencement_date: incorrect_day, course_start_date: incorrect_day)
+      end
+
+      it "returns the trainees based on the start and end date of the cycle" do
+        expect(subject.trainees_starting).to eq([trainee, trainee2])
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/b/BBEuhbHM/register-sprint-board

### Changes proposed in this pull request

We decided to keep this as a soft association with no foreign_key since the trainee's start date can change or end up in another cycle different to the original course details. We'll be able to query the cycle by just passing in dates.

- "associate" trainees to academic cycles based on whether the `commencement_date` or `course_start_date` is available
- add ADR 