### PR TITLE
[3234] Course years UI

### DIFF
--- a/app/controllers/trainees/course_years_controller.rb
+++ b/app/controllers/trainees/course_years_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Trainees
+  class CourseYearsController < BaseController
+    def edit
+      @course_years_form = CourseYearsForm.new
+    end
+
+    def update
+      @course_years_form = CourseYearsForm.new(course_years_params)
+      if @course_years_form.valid?
+        trainee.update(course_uuid: nil)
+        redirect_to(edit_trainee_publish_course_details_path(trainee, year: @course_years_form.course_year))
+      else
+        render(:edit)
+      end
+    end
+
+  private
+
+    def course_years_params
+      params.fetch(:course_years_form, {}).permit(:course_year)
+    end
+  end
+end

--- a/app/forms/course_education_phase_form.rb
+++ b/app/forms/course_education_phase_form.rb
@@ -20,6 +20,14 @@ class CourseEducationPhaseForm < TraineeForm
     end
   end
 
+  def nullify_and_stash!
+    opts = FIELDS.inject({}) { |sum, f|
+      sum[f] = nil
+      sum
+    }
+    assign_attributes_and_stash(opts)
+  end
+
 private
 
   def compute_fields

--- a/app/forms/course_years_form.rb
+++ b/app/forms/course_years_form.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CourseYearsForm
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations::Callbacks
+
+  attr_writer :course_year
+
+  validates :course_year, inclusion: { in: ->(rec) { rec.course_years_options.keys } }
+
+  def initialize(params = {})
+    assign_attributes(params)
+  end
+
+  def course_year
+    @course_year.to_i
+  end
+
+  def course_years_options
+    [
+      default_course_year + 1,
+      default_course_year,
+      default_course_year - 1,
+    ].inject({}) do |sum, y|
+      sum[y] = "#{y} to #{y + 1}#{' (current year)' if y == default_course_year}"
+      sum
+    end
+  end
+
+  def default_course_year
+    Settings.current_default_course_year
+  end
+end

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -34,9 +34,11 @@ class PublishCourseDetailsForm < TraineeForm
         course_start_date: nil,
         course_end_date: nil,
         study_mode: nil,
+        course_education_phase: nil,
       )
     else
       CourseDetailsForm.new(trainee).nullify_and_stash!
+      CourseEducationPhaseForm.new(trainee).nullify_and_stash!
     end
   end
 

--- a/app/lib/page_tracker.rb
+++ b/app/lib/page_tracker.rb
@@ -46,6 +46,10 @@ class PageTracker
     origin_pages.reject { |path| path.include?("confirm") }.last
   end
 
+  def remove_last_page
+    history.pop
+  end
+
 private
 
   attr_reader :session, :request, :history_session_key, :origin_pages_session_key

--- a/app/views/trainees/course_years/edit.html.erb
+++ b/app/views/trainees/course_years/edit.html.erb
@@ -1,0 +1,31 @@
+<%= render PageTitle::View.new(i18n_key: "trainees.course_years.edit", has_errors: @course_years_form.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <%= register_form_with(model: @course_years_form,
+                          url: trainee_course_years_path(@trainee),
+                          method: :put,
+                          local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= render TraineeName::View.new(@trainee) %>
+      <div class="govuk-form-group">
+        <%= f.govuk_radio_buttons_fieldset :course_year, legend: { text: t(".heading"), tag: "h1", size: "l" } do %>
+          <% f.object.course_years_options.each do |val, name| %>
+            <%= f.govuk_radio_button :course_year, val,
+              checked: (val == params[:year].to_i),
+              label: { text: name },
+              link_errors: false %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -8,15 +8,21 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
     <%= register_form_with(model: @publish_course_details_form,
-                          url: trainee_publish_course_details_path(@trainee),
+                          url: trainee_publish_course_details_path(@trainee, year: @course_year),
                           method: :put,
                           local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= render TraineeName::View.new(@trainee) %>
+
+      <h1 class="govuk-heading-l"><%= t(".heading", from_year: @course_year, to_year: (@course_year + 1)) %></h1>
+      <div class="govuk-inset-text">
+        <%= link_to t(".change_year_link_text"), edit_trainee_course_years_path(@trainee, year: @course_year), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset :course_uuid,
-          legend: { text: t(".heading"), tag: "h1", size: "l" },
+          legend: { text: t(".course_code_label"), tag: "h1", size: "m" },
           hint: { text: courses_fieldset_text_for(@trainee) },
           classes: "published-courses" do %>
           <% @courses.each do |course| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,6 +277,8 @@ en:
           edit: What type of training are they doing?
         course_details:
           edit: Course details
+        course_years:
+          edit: Course year
         course_education_phases:
           show: Which phase of education will the trainee teach?
         itt_start_date:
@@ -854,9 +856,15 @@ en:
       bullet_desc: "You can:"
       go_back: go back and change your answer
       use_dttp: use DTTP to register a different route
+    course_years:
+      edit:
+        heading: Which year’s course do you want to choose from?
+        summary_with_route: &summary_with_route "%{summary}, %{route}"
     publish_course_details:
       edit:
-        heading: What course are they doing?
+        heading: "Your courses starting in %{from_year} to %{to_year}"
+        change_year_link_text: Choose from courses starting in a different year
+        course_code_label: What course are they doing?
         course_not_listed: Another course not listed
         enter_course_details: Enter course details manually
         summary_with_route: &summary_with_route "%{summary}, %{route}"
@@ -1241,6 +1249,10 @@ en:
           attributes:
             course_uuid:
               blank: Select a course
+        course_years_form:
+          attributes:
+            course_year:
+              inclusion: Select a course year
         reinstatement_form:
           attributes:
             date_string:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
   resources :trainees, except: :edit do
     scope module: :trainees do
       resource :training_details, concerns: :confirmable, only: %i[edit update], path: "/training-details"
+      resource :course_years, only: %i[edit update], path: "/course-years"
       resource :publish_course_details, only: %i[edit update], path: "/publish-course-details" do
         concerns :confirmable
       end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -69,6 +69,7 @@ apply_api:
   auth_token: "auth-token-from-env"
 
 current_recruitment_cycle_year: 2022
+current_default_course_year: 2021
 
 apply_applications:
   import:

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -96,13 +96,48 @@ namespace :example_data do
       # For each of the course routes enabled...
       enabled_course_routes.each do |route|
         REAL_PUBLISH_COURSES_WITH_SUBJECTS.each_with_index do |(course_name, subject_names), index|
-          FactoryBot.build(:course,
-                           accredited_body_code: provider.code,
-                           start_date: index.even? ? Time.zone.now : 1.month.from_now,
-                           route: route,
-                           name: course_name,
-                           level: course_name.include?("Primary") ? :primary : :secondary,
-                           study_mode: TRAINEE_STUDY_MODE_ENUMS.keys.sample) { |course|
+          FactoryBot.build(
+            :course,
+            accredited_body_code: provider.code,
+            start_date: index.even? ? Time.zone.now : 1.month.from_now,
+            route: route,
+            name: course_name,
+            level: course_name.include?("Primary") ? :primary : :secondary,
+            study_mode: TRAINEE_STUDY_MODE_ENUMS.keys.sample,
+            recruitment_cycle_year: Time.zone.today.year,
+          ) { |course|
+            course.subjects = Subject.where(name: subject_names)
+          }.save!
+
+          # Last cycle year
+          if SecureRandom.random_number(100) > 50
+            FactoryBot.build(
+              :course,
+              accredited_body_code: provider.code,
+              start_date: index.even? ? Time.zone.now : 1.month.from_now,
+              route: route,
+              name: course_name,
+              level: course_name.include?("Primary") ? :primary : :secondary,
+              study_mode: TRAINEE_STUDY_MODE_ENUMS.keys.sample,
+              recruitment_cycle_year: 1.year.ago.year,
+            ) { |course|
+              course.subjects = Subject.where(name: subject_names)
+            }.save!
+          end
+
+          # Next cycle year
+          next unless SecureRandom.random_number(100) > 50
+
+          FactoryBot.build(
+            :course,
+            accredited_body_code: provider.code,
+            start_date: index.even? ? Time.zone.now : 1.month.from_now,
+            route: route,
+            name: course_name,
+            level: course_name.include?("Primary") ? :primary : :secondary,
+            study_mode: TRAINEE_STUDY_MODE_ENUMS.keys.sample,
+            recruitment_cycle_year: 1.year.from_now.year,
+          ) { |course|
             course.subjects = Subject.where(name: subject_names)
           }.save!
         end

--- a/spec/forms/course_years_form_spec.rb
+++ b/spec/forms/course_years_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CourseYearsForm, type: :model do
+  let(:params) { {} }
+
+  subject { described_class.new(params) }
+
+  describe "validations" do
+    it { is_expected.to validate_inclusion_of(:course_year).in_array(subject.course_years_options.keys) }
+  end
+
+  describe "#course_years_options" do
+    before do
+      allow(Settings).to receive(:current_default_course_year).and_return(2010)
+    end
+
+    it "returns course years hash" do
+      expect(subject.course_years_options).to eql({
+        2011 => "2011 to 2012",
+        2010 => "2010 to 2011 (current year)",
+        2009 => "2009 to 2010",
+      })
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/6me29388/3234-l-course-years-ui

### Changes proposed in this pull request

* Change course year page added
* Publish course details form courses are filtered based on the `year` query param
* `@course_year` defaults to `@trainee.published_course.recruitment_cycle_year` if available otherwise to `Settings.current_default_course_year`.
* If `year` param is invalid, redirected to change course year page.

### Guidance to review

*  Add provider-led (postgrad) trainee, go to Course details section.

