### PR TITLE
[3270] [3265] [3260] General content tweaks

### DIFF
--- a/app/views/trainees/forbidden_withdrawals/show.html.erb
+++ b/app/views/trainees/forbidden_withdrawals/show.html.erb
@@ -21,7 +21,7 @@
   </p>
 
   <p class="govuk-body">
-     <%= t(".support") %> <%= govuk_mail_to(Settings.data_email, Settings.data_email)%>.
+     <%= t(".support") %> <%= govuk_mail_to(Settings.support_email, Settings.support_email)%>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/trainees/start_date_verifications/show.html.erb
+++ b/app/views/trainees/start_date_verifications/show.html.erb
@@ -17,7 +17,7 @@
       <%= render TraineeName::View.new(@trainee) %>
 
       <%= f.govuk_radio_buttons_fieldset(:trainee_has_started_course,
-                                         legend: { text: t(".legend"), size: "m" }) do %>
+                                         legend: { text: t(".legend"), size: "l" }) do %>
         <%= f.govuk_radio_button(:trainee_has_started_course,
                                  :yes,
                                  label: { text: t(".yes_they_started") },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -951,9 +951,9 @@ en:
     forbidden_withdrawals:
       show:
         heading: You cannot withdraw this trainee
-        reason: Trainees can only be withdrawn after they have started their course.
+        reason: You can only withdraw a trainee after they have started their ITT.
         delete: delete this trainee record
-        support: If you need more help, email the Register trainee teachers team at
+        support: If you need more help, email us at
   activerecord:
     attributes:
       trainee:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -943,7 +943,7 @@ en:
       show:
         title: Delete forbidden
         heading: You cannot delete this record
-        reason: You can only delete a trainee record before the trainee starts their ITT, but you can defer or withdraw the trainee.
+        reason: You can only delete a trainee record before the trainee starts their ITT. You can defer or withdraw the trainee.
         defer: Defer
         withdraw: Withdraw
         return_to_record: Return to trainee record

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,16 +93,16 @@ en:
         about_their_teaching_training: About their teacher training
     application_record_card:
       subject:
-        early_years: "Early years teaching"
-        blank: "No subject provided"
+        early_years: Early years teaching
+        blank: No subject provided
       route:
-        blank: "No route provided"
+        blank: No route provided
       trainee_name:
-        blank: "Draft record"
+        blank: Draft record
     confirmation:
       missing: missing
       not_provided: Not provided
-      heading: "Confirm %{section_title}"
+      heading: Confirm %{section_title}
       cancel_and_return: Cancel and return to record
       start_date:
         title: Trainee start date
@@ -439,9 +439,9 @@ en:
   apply_applications:
     trainee_data:
       view:
-        heading_1_name: "Draft record for %{name}"
-        heading_1_no_name: "Draft record"
-        heading_2: "Trainee Data"
+        heading_1_name: Draft record for %{name}
+        heading_1_no_name: Draft record
+        heading_2: Trainee Data
     confirm_course:
       view:
         change: Change
@@ -462,8 +462,8 @@ en:
     all_records: All records
     apply_invalid_data_view:
       invalid_answers_summary:
-        one: "This application contains 1 answer that you need to amend. This is because it was entered in a free text format."
-        other: "This application contains %{count} answers that you need to amend. This is because they were entered in a free text format."
+        one: This application contains 1 answer that you need to amend. This is because it was entered in a free text format.
+        other: This application contains %{count} answers that you need to amend. This is because they were entered in a free text format.
       unrecognised_field_text: "%{invalid_field} is not recognised"
     mappable_field_row:
       default_hint_text_html: 'Enter an answer <span class="govuk-visually-hidden"> for %{field_label}</span>'
@@ -514,8 +514,8 @@ en:
     missing_data_view:
       degrees_form: degree
       missing_fields_summary:
-        one: "This section contains 1 question that you need to complete."
-        other: "This section contains questions which you need to complete."
+        one: This section contains 1 question that you need to complete.
+        other: This section contains questions which you need to complete.
       single_missing_field_text_html: "%{missing_field} is missing"
       multiple_missing_field_text_html: '%{missing_field} is missing<span class="govuk-visually-hidden"> for %{section_label}</span>'
       missing_fields_mapping:
@@ -579,10 +579,10 @@ en:
         recommend_for_award: Recommend trainee for QTS
         recommend_for_eyts: Recommend trainee for EYTS
         status_summary:
-          submitted_for_trn: This record is pending a TRN
-          deferred: This record is deferred
+          submitted_for_trn: This trainee is pending a TRN
+          deferred: This trainee is deferred
       show:
-        draft: "Draft"
+        draft: Draft
       delete:
         draft: Draft deleted
         record: Record deleted
@@ -611,7 +611,7 @@ en:
       apply_applications:
         review_course_form:
           label_names:
-            register: "Yes, register on %{course}"
+            register: Yes, register on %{course}
             change: No, change the course
             change_hint: For trainees, who have changed courses since applying
       common:
@@ -677,7 +677,7 @@ en:
           label: When did the trainee start their ITT?
           hint: Their ITT started on %{course_start_date}
       publish_course_details:
-        route_message: "Your %{route} courses in the Publish service"
+        route_message: Your %{route} courses in the Publish service
         all_courses_message: Your courses in the Publish service
         route_titles:
           provider_led_postgrad: provider-led postgrad
@@ -795,18 +795,18 @@ en:
       support_message_html: If you continue to get this message, email the Register trainee teachers team at %{link}.
   apply_trainee_data:
     view:
-      heading_1_name: "Draft record for %{name}"
-      heading_1_no_name: "Draft record"
-      heading_2: "Trainee Data"
+      heading_1_name: Draft record for %{name}
+      heading_1_no_name: Draft record
+      heading_2: Trainee Data
   invalid_data_summary:
     view:
-      invalid_answers_summary: "This application contains %{total_invalid_fields} answer that you need to amend. This is because they were entered in a free text format."
+      invalid_answers_summary: This application contains %{total_invalid_fields} answer that you need to amend. This is because they were entered in a free text format.
       invalid_answer_text: "%{invalid_field} is not recognised"
   route_indicator:
     view:
-      display_text: "Trainee on the %{training_route_link} route."
-      apply_display_text_with_course: "All conditions met and trainee recruited to %{course_with_code}, on the %{training_route} route."
-      apply_display_text_without_course: "All conditions met and trainee on the %{training_route} route."
+      display_text: Trainee on the %{training_route_link} route.
+      apply_display_text_with_course: All conditions met and trainee recruited to %{course_with_code}, on the %{training_route} route.
+      apply_display_text_without_course: All conditions met and trainee on the %{training_route} route.
   error_summary:
     view:
       heading: There is a problem
@@ -1252,7 +1252,7 @@ en:
         submissions/missing_data_validator:
           attributes:
             trainee:
-              incomplete: "This trainee record has missing fields. Check Submissions::MissingDataValidator#missing_fields"
+              incomplete: This trainee record has missing fields. Check Submissions::MissingDataValidator#missing_fields
         withdrawal_form:
           attributes:
             date_string:

--- a/spec/components/record_actions/view_spec.rb
+++ b/spec/components/record_actions/view_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RecordActions::View do
     context "submitted for TRN" do
       let(:trait) { :submitted_for_trn }
 
-      it { is_expected.to include("This record is pending a TRN", "Defer", "Withdraw") }
+      it { is_expected.to include("This trainee is pending a TRN", "Defer", "Withdraw") }
 
       include_examples "no button"
     end
@@ -53,7 +53,7 @@ RSpec.describe RecordActions::View do
     context "deferred" do
       let(:trait) { :deferred }
 
-      it { is_expected.to include("This record is deferred", "Reinstate", "Withdraw") }
+      it { is_expected.to include("This trainee is deferred", "Reinstate", "Withdraw") }
 
       include_examples "no button"
     end


### PR DESCRIPTION
### Context

https://trello.com/c/HPMGB4uA/3270-snag-you-cannot-withdraw-this-trainee-page-content-update
https://trello.com/c/QvDbu51Q/3265-snag-deleting-a-trainee-you-cannot-delete-this-record-content-update
https://trello.com/c/NN1wWZs1/3260-snag-record-action-bar-trainee-status-content-update

### Changes proposed in this pull request

Updates content to match prototype on following pages:
- `trainees/{slug}/withdrawal-forbidden`
- `trainees/{slug}/delete-forbidden`
- On `trainees/{slug}` record status bar for trainees who are pending TRN and deferred (record -> trainee)

### Guidance to review

<img width="996" alt="Screenshot 2021-11-24 at 13 24 46" src="https://user-images.githubusercontent.com/18436946/143248817-459f6f4e-359f-4052-aed3-1910450737cc.png">
<img width="1015" alt="Screenshot 2021-11-24 at 13 27 16" src="https://user-images.githubusercontent.com/18436946/143248833-610916a8-3a64-4a3f-8d96-ed465e4d8fb0.png">
<img width="983" alt="Screenshot 2021-11-24 at 13 35 42" src="https://user-images.githubusercontent.com/18436946/143248851-258267f4-1487-4151-919a-bc8a245d7a5f.png">
<img width="896" alt="Screenshot 2021-11-24 at 13 36 09" src="https://user-images.githubusercontent.com/18436946/143248869-14bee410-6215-4b44-ad43-bd965c6b0f48.png">

Check the content against the prototype.