### PR TITLE
[2943][3261][3261] Snag fixes

### DIFF
--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -76,7 +76,7 @@ module CourseDetails
     end
 
     def course_date_row(value, context)
-      default_mappable_field(value, t("components.course_detail.itt_#{context}_date"))
+      default_mappable_field(value, t("components.course_detail.itt_#{context}_date").html_safe)
     end
 
     def non_early_year_route?

--- a/app/components/deferral_details/view.rb
+++ b/app/components/deferral_details/view.rb
@@ -11,7 +11,7 @@ module DeferralDetails
     end
 
     def defer_date
-      deferred_before_starting? ? t(".deferred_before_starting") : date_for_summary_view(data_model.date)
+      deferred_before_starting? ? t(".deferred_before_starting").html_safe : date_for_summary_view(data_model.date)
     end
 
     def deferred_before_starting?

--- a/app/components/record_details/trainee_start_date.rb
+++ b/app/components/record_details/trainee_start_date.rb
@@ -10,8 +10,8 @@ module RecordDetails
     end
 
     def text
-      return I18n.t("record_details.view.itt_has_not_started") if trainee.starts_course_in_the_future?
-      return I18n.t("record_details.view.deferred_before_itt_started") if deferred_with_no_start_date?
+      return I18n.t("record_details.view.itt_has_not_started").html_safe if trainee.starts_course_in_the_future?
+      return I18n.t("record_details.view.deferred_before_itt_started").html_safe if deferred_with_no_start_date?
       return date_for_summary_view(trainee.commencement_date) if commencement_date_present?
 
       I18n.t("record_details.view.not_provided")

--- a/app/components/reinstatement_details/view.rb
+++ b/app/components/reinstatement_details/view.rb
@@ -11,7 +11,7 @@ module ReinstatementDetails
     end
 
     def reinstate_date
-      deferred_before_starting? ? t(".reinstated_before_starting") : date_for_summary_view(data_model.date)
+      deferred_before_starting? ? t(".reinstated_before_starting").html_safe : date_for_summary_view(data_model.date)
     end
 
     def deferred_before_starting?

--- a/app/controllers/trainees/start_statuses_controller.rb
+++ b/app/controllers/trainees/start_statuses_controller.rb
@@ -15,17 +15,10 @@ module Trainees
     def update
       @trainee_start_status_form = TraineeStartStatusForm.new(trainee, params: trainee_params, user: current_user)
 
-      if delete_context?
-        @trainee_start_status_form.save!
-        return redirect_to(trainee_forbidden_deletes_path(trainee))
-      end
+      if @trainee_start_status_form.public_send(context_present? ? :save! : :stash_or_save!)
+        return redirect_to(trainee_forbidden_deletes_path(trainee)) if delete_context?
+        return redirect_to(trainee_withdrawal_path(trainee)) if withdraw_context?
 
-      if withdraw_context?
-        @trainee_start_status_form.save!
-        return redirect_to(trainee_withdrawal_path(trainee))
-      end
-
-      if @trainee_start_status_form.stash_or_save!
         if trainee.draft? && trainee.submission_ready?
           Trainees::SubmitForTrn.call(trainee: trainee, dttp_id: current_user.dttp_id)
           return redirect_to(trn_submission_path(trainee))
@@ -54,6 +47,10 @@ module Trainees
 
     def withdraw_context?
       params[:context] == StartDateVerificationForm::WITHDRAW
+    end
+
+    def context_present?
+      params[:context].present?
     end
   end
 end

--- a/app/view_objects/missing_data_banner_view.rb
+++ b/app/view_objects/missing_data_banner_view.rb
@@ -34,7 +34,7 @@ private
       missing_fields.map do |field|
         tag.li(
           link_to(
-            link_text(field),
+            link_text(field).html_safe,
             link_path(field),
             class: "govuk-notification-banner__link",
           ),

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -56,12 +56,12 @@
 
       <%= f.govuk_date_field(f.object.course_start_date_attribute_name,
                              date_of_birth: false,
-                             legend: { text: CourseDetailsForm.human_attribute_name(f.object.course_start_date_attribute_name), size: "s" },
+                             legend: { text: t("publish_course_details.view.itt_start_date").html_safe, size: "s" },
                              hint: { text: t("activemodel.errors.models.course_details_form.attributes.#{f.object.course_start_date_attribute_name}.hint_html", year: Time.zone.now.year) }) %>
 
        <%= f.govuk_date_field(f.object.course_end_date_attribute_name,
                               date_of_birth: false,
-                              legend: { text: CourseDetailsForm.human_attribute_name(f.object.course_end_date_attribute_name), size: "s" },
+                              legend: { text: t("publish_course_details.view.itt_end_date").html_safe, size: "s" },
                               hint: { text: t("activemodel.errors.models.course_details_form.attributes.#{f.object.course_end_date_attribute_name}.hint_html", year: Time.zone.now.next_year.year) }) %>
 
       <%= f.govuk_submit %>

--- a/app/views/trainees/forbidden_deletes/show.html.erb
+++ b/app/views/trainees/forbidden_deletes/show.html.erb
@@ -17,7 +17,7 @@
       <%= render TraineeName::View.new(@trainee) %>
 
       <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
-      <p class="govuk-body"><%= t(".reason") %></p>
+      <p class="govuk-body"><%= t(".reason").html_safe %></p>
 
       <%= f.govuk_radio_buttons_fieldset(:alternative_option, legend: { text: t(".legend"), size: "m" }) do %>
         <%= f.govuk_radio_button(:alternative_option,

--- a/app/views/trainees/itt_start_dates/edit.html.erb
+++ b/app/views/trainees/itt_start_dates/edit.html.erb
@@ -16,7 +16,7 @@
                            local: true) do |f| %>
       <%= f.govuk_error_summary %>
       <%= render TraineeName::View.new(@trainee) %>
-      <%= f.govuk_date_field :date, legend: { text: text, tag: "h1", size: "l" }, hint: -> do %>
+      <%= f.govuk_date_field :date, legend: { text: text.html_safe, tag: "h1", size: "l" }, hint: -> do %>
         <p class="govuk-body govuk-hint"><%= t("components.itt_start_date.hint") %></p>
         <p class="govuk-body govuk-hint"><%= "#{t('views.forms.common.for_example')}, 26 7 2021" %></p>
       <% end %>

--- a/app/views/trainees/start_date_verifications/show.html.erb
+++ b/app/views/trainees/start_date_verifications/show.html.erb
@@ -17,7 +17,7 @@
       <%= render TraineeName::View.new(@trainee) %>
 
       <%= f.govuk_radio_buttons_fieldset(:trainee_has_started_course,
-                                         legend: { text: t(".legend"), size: "l" }) do %>
+                                         legend: { text: t(".legend").html_safe, size: "l" }) do %>
         <%= f.govuk_radio_button(:trainee_has_started_course,
                                  :yes,
                                  label: { text: t(".yes_they_started") },

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -11,8 +11,10 @@
 
       <%= render TraineeName::View.new(@trainee) %>
       <%= f.govuk_date_field :commencement_date, legend: {
-        text: t("views.forms.start_dates.commencement_date.label"), size: "l", tag: "h1"
-      }, hint: { text: t("views.forms.start_dates.commencement_date.hint", course_start_date: @trainee.course_start_date.strftime("%d %m %Y")) } %>
+        text: t("views.forms.start_dates.commencement_date.label").html_safe, size: "l", tag: "h1"
+      }, hint: {
+        text: t("views.forms.start_dates.commencement_date.hint",
+                course_start_date: @trainee.course_start_date.strftime("%d %m %Y")).html_safe } %>
       <%= f.govuk_submit "Continue" %>
     <% end %>
 

--- a/app/views/trainees/start_statuses/edit.html.erb
+++ b/app/views/trainees/start_statuses/edit.html.erb
@@ -19,7 +19,7 @@
       <%= render TraineeName::View.new(@trainee) %>
 
       <%= f.govuk_radio_buttons_fieldset(:commencement_status,
-                                           legend: { text: t(".label"), size: "l", tag: "h1" },
+                                           legend: { text: t(".label").html_safe, size: "l", tag: "h1" },
                                            classes: "age_range") do %>
 
           <%= f.govuk_radio_button(:commencement_status, :itt_started_on_time,

--- a/app/views/trainees/start_statuses/edit.html.erb
+++ b/app/views/trainees/start_statuses/edit.html.erb
@@ -11,11 +11,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with(model: @trainee_start_status_form, url: trainee_start_status_path, local: true) do |f| %>
+    <%= register_form_with(model: @trainee_start_status_form,
+                           url: trainee_start_status_path(context: params[:context]),
+                           local: true) do |f| %>
       <%= f.govuk_error_summary %>
-      <%= hidden_field_tag :context, params[:context] %>
 
       <%= render TraineeName::View.new(@trainee) %>
+
       <%= f.govuk_radio_buttons_fieldset(:commencement_status,
                                            legend: { text: t(".label"), size: "l", tag: "h1" },
                                            classes: "age_range") do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1101,7 +1101,7 @@ en:
         deferral_form:
           attributes:
             date_string:
-              blank: Choose a deferral date
+              blank: Select a deferral date
             date:
               blank: Enter a deferral date
               invalid: Enter a valid deferral date
@@ -1241,7 +1241,7 @@ en:
         reinstatement_form:
           attributes:
             date_string:
-              blank: Choose a date of return
+              blank: Select a date of return
             date:
               blank: Enter a date of return
               invalid: Enter a valid date of return
@@ -1258,7 +1258,7 @@ en:
         withdrawal_form:
           attributes:
             date_string:
-              blank: Choose a withdrawal date
+              blank: Select a withdrawal date
             date:
               blank: Enter a withdrawal date
               invalid: Enter a valid withdrawal date
@@ -1266,7 +1266,7 @@ en:
             additional_withdraw_reason:
               blank: Enter a reason
             withdraw_reason:
-              invalid: Choose a reason
+              invalid: Select a withdrawal reason
         trainee_start_date_form:
           attributes:
             commencement_date:
@@ -1347,11 +1347,11 @@ en:
         start_date_verification_form:
           attributes:
             trainee_has_started_course:
-              blank: Choose yes or no
+              blank: Select yes or no
         trainee_forbidden_delete_form:
           attributes:
             alternative_option:
-              blank: Choose defer, withdraw or return to trainee record
+              blank: Select defer, withdraw or return to trainee record
   page_headings:
     start_page: Register trainee teachers
   service_updates:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,19 +68,19 @@ en:
       status_date_prefix:
         deferred: "Deferral date: "
         withdrawn: "Withdrawal date: "
-      itt_has_not_started: ITT has not started
+      itt_has_not_started: <abbr title="Initial teacher training">ITT</abbr> has not started
       not_provided: Not provided
-      deferred_before_itt_started: Trainee deferred before starting their ITT
+      deferred_before_itt_started: Trainee deferred before starting their <abbr title="initial teacher training">ITT</abbr>
   training_details:
     view:
       title: *trainee_id
       region: *region
   deferral_details:
     view:
-      deferred_before_starting: Trainee deferred before their ITT started
+      deferred_before_starting: Trainee deferred before their <abbr title="initial teacher training">ITT</abbr> started
   reinstatement_details:
     view:
-      reinstated_before_starting: Trainee returned before their ITT started
+      reinstated_before_starting: Trainee returned before their <abbr title="initial teacher training">ITT</abbr> started
   components:
     admin_feature:
       title: Admin feature
@@ -173,8 +173,8 @@ en:
       education_phase: Education phase
       subject: Subject
       age_range: Age range
-      itt_start_date: ITT start date
-      itt_end_date: ITT end date
+      itt_start_date: <abbr title='Initial teacher training'>ITT</abbr> start date
+      itt_end_date: <abbr title='Initial teacher training'>ITT</abbr> end date
       route: Training route
       course_details: Course details
       details_not_on_publish: Course details added manually
@@ -453,8 +453,8 @@ en:
         multiple_subjects: Subjects
         level: Level
         age_range: &course_age_range Age range
-        itt_start_date: &itt_start_date ITT start date
-        itt_end_date: &itt_end_date ITT end date
+        itt_start_date: &itt_start_date <abbr title="Initial teacher training">ITT</abbr> start date
+        itt_end_date: &itt_end_date <abbr title="Initial teacher training">ITT</abbr> end date
         duration: Duration
         course_details: Course details
         study_mode: Full time or part time
@@ -676,8 +676,8 @@ en:
             We may also use it if we need to get in touch with you about this trainee.
       start_dates:
         commencement_date:
-          label: When did the trainee start their ITT?
-          hint: Their ITT started on %{course_start_date}
+          label: When did the trainee start their <abbr title="initial teacher training">ITT</abbr>?
+          hint: Their <abbr title="initial teacher training">ITT</abbr> started on %{course_start_date}
       publish_course_details:
         route_message: Your %{route} courses in the Publish service
         all_courses_message: Your courses in the Publish service
@@ -824,8 +824,8 @@ en:
       multiple_subjects: Subjects
       level: Level
       age_range: Age range
-      itt_start_date: ITT start date
-      itt_end_date: ITT end date
+      itt_start_date: <abbr title="Initial teacher training">ITT</abbr> start date
+      itt_end_date: <abbr title="Initial teacher training">ITT</abbr> end date
       duration: Duration
       study_mode: Full time or part time
       course_details: Course details
@@ -931,21 +931,21 @@ en:
     start_statuses:
       edit:
         itt_not_yet_started: They have not started yet
-        label: Did the trainee start their ITT on time?
+        label: Did the trainee start their <abbr title="initial teacher training">ITT</abbr> on time?
         on_time: Yes, they started on time — %{course_start_date}
         started_later: No, they started later
         trainee_start_date: *trainee_start_date
         trainee_start_date_hint: For example, 8 11 2021
     start_date_verifications:
       show:
-        legend: Did the trainee start their ITT?
+        legend: Did the trainee start their <abbr title="initial teacher training">ITT</abbr>?
         yes_they_started: Yes, they started
         no_they_did_not_start: No, they did not start
     forbidden_deletes:
       show:
         title: Delete forbidden
         heading: You cannot delete this record
-        reason: You can only delete a trainee record before the trainee starts their ITT. You can defer or withdraw the trainee.
+        reason: You can only delete a trainee record before the trainee starts their <abbr title="initial teacher training">ITT</abbr>. You can defer or withdraw the trainee.
         defer: Defer
         withdraw: Withdraw
         return_to_record: Return to trainee record
@@ -1105,7 +1105,7 @@ en:
             date:
               blank: Enter a deferral date
               invalid: Enter a valid deferral date
-              not_before_course_start_date: &not_before_course_start_date The date must not be before the ITT start date
+              not_before_course_start_date: &not_before_course_start_date The date must not be before the <abbr title="initial teacher training">ITT</abbr> start date
         degrees_form:
           attributes:
             degree_ids:

--- a/spec/components/deferral_details/view_spec.rb
+++ b/spec/components/deferral_details/view_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 module DeferralDetails
   describe View do
     include SummaryHelper
+    include ActionView::Helpers::SanitizeHelper
 
     alias_method :component, :page
 
@@ -26,9 +27,7 @@ module DeferralDetails
       let(:trainee_stub) { Trainee.new }
 
       it "renders the deferred before course start date message" do
-        expect(component).to have_text(
-          t("deferral_details.view.deferred_before_starting"),
-        )
+        expect(component).to have_text(strip_tags(t("deferral_details.view.deferred_before_starting")))
       end
     end
   end

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 module RecordDetails
   describe View do
     include SummaryHelper
+    include ActionView::Helpers::SanitizeHelper
 
     let(:state) { :trn_received }
     let(:training_route) { TRAINING_ROUTE_ENUMS[:assessment_only] }
@@ -144,7 +145,7 @@ module RecordDetails
         end
 
         it "renders itt has not started text" do
-          expect(rendered_component).to have_text(t("record_details.view.itt_has_not_started"))
+          expect(rendered_component).to have_text(strip_tags(t("record_details.view.itt_has_not_started")))
         end
 
         it "does not render link" do
@@ -197,7 +198,7 @@ module RecordDetails
             end
 
             it "renders the trainee deferred before course started message" do
-              expect(rendered_component).to have_text(t("record_details.view.deferred_before_itt_started"))
+              expect(rendered_component).to have_text(strip_tags(t("record_details.view.deferred_before_itt_started")))
             end
           end
         end

--- a/spec/controllers/trainees/start_statuses_controller_spec.rb
+++ b/spec/controllers/trainees/start_statuses_controller_spec.rb
@@ -7,18 +7,34 @@ describe Trainees::StartStatusesController, type: :controller do
 
   describe "#update" do
     let(:current_user) { create(:user) }
+    let(:page_context) { nil }
+
+    let(:send_request) do
+      post(:update,
+           params: {
+             trainee_id: trainee,
+             context: page_context,
+             trainee_start_status_form: {
+               "commencement_status" => "itt_started_on_time",
+               "commencement_date(3i)" => "",
+               "commencement_date(2i)" => "",
+               "commencement_date(1i)" => "",
+             },
+           })
+    end
 
     before do
       allow(controller).to receive(:current_user).and_return(current_user)
+      allow(controller).to receive(:authorize_trainee).and_return(true)
     end
 
     context "when the trainee is draft" do
       context "but not submission ready" do
-        let(:trainee) { create(:trainee) }
+        let(:trainee) { create(:trainee, :with_study_mode_and_course_dates) }
 
         it "does not submit for TRN" do
           expect(Trainees::SubmitForTrn).not_to receive(:call)
-          post(:update, params: { trainee_id: trainee })
+          send_request
         end
       end
 
@@ -26,8 +42,8 @@ describe Trainees::StartStatusesController, type: :controller do
         let(:trainee) { create(:trainee, :completed) }
 
         it "submits for TRN" do
-          expect(Trainees::SubmitForTrn).not_to receive(:call).with({ trainee: trainee, dttp_id: current_user.dttp_id })
-          post(:update, params: { trainee_id: trainee })
+          expect(Trainees::SubmitForTrn).to receive(:call).with({ trainee: trainee, dttp_id: current_user.dttp_id })
+          send_request
         end
       end
     end
@@ -37,7 +53,29 @@ describe Trainees::StartStatusesController, type: :controller do
 
       it "does not submit them for TRN" do
         expect(Trainees::SubmitForTrn).not_to receive(:call)
-        post(:update, params: { trainee_id: trainee })
+        send_request
+      end
+    end
+
+    context "updating trainee start status in a different context" do
+      let(:trainee) { create(:trainee, :submitted_for_trn) }
+
+      before { send_request }
+
+      context "delete" do
+        let(:page_context) { :delete }
+
+        it "redirects to the delete forbidden page" do
+          expect(response).to redirect_to(trainee_forbidden_deletes_path(trainee))
+        end
+      end
+
+      context "withdraw" do
+        let(:page_context) { :withdraw }
+
+        it "redirects to the withdrawal page" do
+          expect(response).to redirect_to(trainee_withdrawal_path(trainee))
+        end
       end
     end
   end

--- a/spec/features/form_sections/teacher_training_data/edit_trainee_start_status_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_trainee_start_status_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "edit Trainee start status" do
   include SummaryHelper
+  include ActionView::Helpers::SanitizeHelper
 
   let(:new_start_date) { Date.parse("1/1/2021") }
 
@@ -103,7 +104,7 @@ feature "edit Trainee start status" do
   end
 
   def then_the_trainee_commencement_status_is_updated_to_not_yet_started
-    expect(record_page.record_detail.start_date_row).to have_text(I18n.t("record_details.view.itt_has_not_started"))
+    expect(record_page.record_detail.start_date_row).to have_text(strip_tags(I18n.t("record_details.view.itt_has_not_started")))
   end
 
   def then_i_am_redirected_to_the_trn_success_page

--- a/spec/features/trainee_actions/defer_trainee_spec.rb
+++ b/spec/features/trainee_actions/defer_trainee_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Deferring a trainee", type: :feature do
   include SummaryHelper
+  include ActionView::Helpers::SanitizeHelper
 
   context "trainee deferral date" do
     before do
@@ -123,7 +124,7 @@ feature "Deferring a trainee", type: :feature do
 
   def and_i_see_a_message_for_course_start_date_in_the_future
     expect(deferral_confirmation_page).to have_content(
-      I18n.t("deferral_details.view.deferred_before_starting"),
+      strip_tags(I18n.t("deferral_details.view.deferred_before_starting")),
     )
   end
 


### PR DESCRIPTION
### Context
https://trello.com/c/hX8pkaM4/3266-snag-deleting-withdrawing-deferring-a-trainee-start-date-validations

### Changes proposed in this pull request
- Fix `Trainees::StartStatusesController#update` so that it saves the form which will trigger the validations. [2943]
- Fixed the the other specs because they passed previously only because the requests were not authorised. [2943]
- Deferring a trainee - error message content change [3268]
- HTML abbreviation tag for 'ITT' [3261]

### Guidance to review [2943]
- Visit a non-draft trainee
- Use the console to nullify `commencement_date`
- Click on the "Delete" or "Withdraw" link
- Choose "Yes, they started"
- Play around with the start status form - all the expected behaviour should be there since it was already working in a non-draft context.

### Guidance to review [3268]
- Visit a non-draft trainee
- Click defer
- Submit form without choosing an option
- It should show the correct error message

### Guidance to review [3261]
- Visit a draft or non-draft trainee (provider-led postgrad)
- Enter the course details section or change existing course
- The ITT text should be be wrapped in a `<abbr>` tag

