### PR TITLE
[3262] & [3264] Fix snags in delete flows

### DIFF
--- a/app/controllers/trainees/start_date_verifications_controller.rb
+++ b/app/controllers/trainees/start_date_verifications_controller.rb
@@ -2,6 +2,8 @@
 
 module Trainees
   class StartDateVerificationsController < BaseController
+    before_action :redirect_to_confirm_delete, if: :deleting_course_and_not_started?
+
     def show
       @start_date_verification_form = StartDateVerificationForm.new
     end
@@ -30,7 +32,7 @@ module Trainees
       elsif trainee_started_course?
         edit_trainee_start_status_path(trainee, context: :delete)
       else
-        trainee_confirm_delete_path(trainee)
+        confirm_delete_path
       end
     end
 
@@ -40,6 +42,18 @@ module Trainees
 
     def withdrawing?
       @start_date_verification_form.withdrawing?
+    end
+
+    def redirect_to_confirm_delete
+      redirect_to(confirm_delete_path)
+    end
+
+    def confirm_delete_path
+      trainee_confirm_delete_path(trainee)
+    end
+
+    def deleting_course_and_not_started?
+      trainee.starts_course_in_the_future? && params[:context] == StartDateVerificationForm::DELETE
     end
   end
 end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -4,6 +4,7 @@ class TraineesController < ApplicationController
   include TraineeHelper
   include ActivityTracker
 
+  before_action :redirect_to_not_found, if: -> { trainee.discarded? }, only: :show
   before_action :ensure_trainee_is_not_draft!, :load_missing_data_view, only: :show
   before_action :save_filter, only: :index
   helper_method :filter_params, :multiple_record_sources?
@@ -70,6 +71,10 @@ class TraineesController < ApplicationController
   end
 
 private
+
+  def redirect_to_not_found
+    redirect_to(not_found_path)
+  end
 
   def load_missing_data_view
     @missing_data_view = MissingDataBannerView.new(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get "/guidance", to: "pages#guidance"
   get "/check-data", to: "pages#check_data"
 
-  get "/404", to: "errors#not_found", via: :all
+  get "/404", to: "errors#not_found", via: :all, as: :not_found
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all
 

--- a/spec/features/trainee_actions/delete_trainee_spec.rb
+++ b/spec/features/trainee_actions/delete_trainee_spec.rb
@@ -23,7 +23,6 @@ feature "Deleting a trainee" do
       given_a_trainee_starting_a_course_in_the_future
       and_i_am_on_the_trainee_record_page
       and_i_click_the_delete_link
-      and_i_choose_they_have_not_started
       and_i_confirm_delete
       and_i_see_a_success_flash_message
       and_the_trainee_is_soft_deleted
@@ -39,6 +38,12 @@ feature "Deleting a trainee" do
     end
   end
 
+  scenario "viewing a trainee that's deleted" do
+    given_a_trainee_thats_deleted
+    when_i_attempt_to_view_the_deleted_trainee
+    then_i_should_see_the_not_found_page
+  end
+
 private
 
   def given_a_trainee_starting_a_course_in_the_future
@@ -52,6 +57,14 @@ private
                            :with_publish_course_details,
                            course_start_date: 10.days.ago,
                            commencement_date: nil)
+  end
+
+  def given_a_trainee_thats_deleted
+    given_a_trainee_starting_a_course_in_the_future
+    and_i_am_on_the_trainee_record_page
+    and_i_click_the_delete_link
+    and_i_confirm_delete
+    and_i_see_a_success_flash_message
   end
 
   def and_i_save_the_form
@@ -115,5 +128,13 @@ private
 
   def and_the_trainee_is_soft_deleted
     expect(trainee.reload.discarded_at).to be_present
+  end
+
+  def when_i_attempt_to_view_the_deleted_trainee
+    record_page.load(id: trainee.slug)
+  end
+
+  def then_i_should_see_the_not_found_page
+    expect(not_found_page).to be_displayed
   end
 end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -102,6 +102,10 @@ module Features
       @sign_in_page ||= PageObjects::SignIn.new
     end
 
+    def not_found_page
+      @not_found_page ||= PageObjects::NotFound.new
+    end
+
     def degree_type_page
       @degree_type_page ||= PageObjects::Trainees::DegreeType.new
     end

--- a/spec/support/page_objects/not_found.rb
+++ b/spec/support/page_objects/not_found.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PageObjects
+  class NotFound < PageObjects::Base
+    set_url "/404"
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/BtsPLd5D/3262-snag-deleting-a-trainee-itt-start-date-is-in-the-future
- https://trello.com/c/i2eL7YPt/3264-snag-deleting-a-trainee-redirecting-away-from-trainee-show-page

### Changes proposed in this pull request

- If a course starts in the future, redirect straight to the confirm delete path when deleting a trainee
- Redirect to 404 page if you attempt to view a deleted trainee

### Guidance to review

- Create a trainee with a course starting in the future
- Delete the trainee (confirm you're taken straight to the confirm delete page)
- Attempt to return to the trainee slug with `trainees/{slug}` and assert you're redirected to the 404 page

