### PR TITLE
[3258] Fix date wrapping

### DIFF
--- a/app/forms/concerns/commencement_date_helpers.rb
+++ b/app/forms/concerns/commencement_date_helpers.rb
@@ -9,7 +9,13 @@ module CommencementDateHelpers
     elsif commencement_date < 10.years.ago
       errors.add(:commencement_date, :too_old)
     elsif trainee.course_end_date.present? && commencement_date > trainee.course_end_date
-      errors.add(:commencement_date, I18n.t("activemodel.errors.models.trainee_start_status_form.attributes.commencement_date.not_after_course_end_date", course_end_date: trainee.course_end_date.strftime("%-d %B %Y")))
+      errors.add(
+        :commencement_date,
+        I18n.t(
+          "activemodel.errors.models.trainee_start_status_form.attributes.commencement_date.not_after_course_end_date_html",
+          course_end_date: trainee.course_end_date.strftime("%-d %B %Y"),
+        ).html_safe,
+      )
     end
   end
 end

--- a/app/views/trainees/start_statuses/edit.html.erb
+++ b/app/views/trainees/start_statuses/edit.html.erb
@@ -23,7 +23,7 @@
                                            classes: "age_range") do %>
 
           <%= f.govuk_radio_button(:commencement_status, :itt_started_on_time,
-                                   label: { text: t('.on_time', course_start_date: @trainee.course_start_date.strftime("%-d %B %Y")) }) %>
+                                   label: { text: t('.on_time_html', course_start_date: @trainee.course_start_date.strftime("%-d %B %Y")) }) %>
 
           <%= f.govuk_radio_button(:commencement_status, :itt_started_later,
                                    label: { text: t('.started_later') }) do %>

--- a/app/webpacker/styles/_govuk_overrides.scss
+++ b/app/webpacker/styles/_govuk_overrides.scss
@@ -1,3 +1,7 @@
 .govuk-notification-banner__content .app-invalid-answer__list a:link {
   font-weight: bold;
 }
+
+.no-wrap {
+  white-space: nowrap;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -932,7 +932,7 @@ en:
       edit:
         itt_not_yet_started: They have not started yet
         label: Did the trainee start their <abbr title="initial teacher training">ITT</abbr> on time?
-        on_time: Yes, they started on time — %{course_start_date}
+        on_time_html: Yes, they started on time — <span class="no-wrap">%{course_start_date}</span>
         started_later: No, they started later
         trainee_start_date: *trainee_start_date
         trainee_start_date_hint: For example, 8 11 2021
@@ -1272,14 +1272,14 @@ en:
             commencement_date:
               blank: Enter a start date
               invalid: Enter a valid start date
-              not_after_course_end_date: Trainee start date must not be after the ITT has finished (%{course_end_date})
+              not_after_course_end_date_html: Trainee start date must not be after the ITT has finished <span class="no-wrap">(%{course_end_date})</span>
               too_old: Trainee start date cannot be more than 10 years in the past
         trainee_start_status_form:
           attributes:
             commencement_date:
               blank: Enter a start date
               invalid: Enter a valid start date
-              not_after_course_end_date: Trainee start date must not be after the ITT has finished (%{course_end_date})
+              not_after_course_end_date_html: Trainee start date must not be after the ITT has finished <span class="no-wrap">(%{course_end_date})</span>
               too_old: Trainee start date cannot be more than 10 years in the past
             commencement_status:
               blank: Select if the trainee started on time

--- a/spec/forms/trainee_start_date_form_spec.rb
+++ b/spec/forms/trainee_start_date_form_spec.rb
@@ -39,7 +39,12 @@ describe TraineeStartDateForm, type: :model do
       end
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include("Trainee start date must not be after the ITT has finished (19 December 2020)")
+        expect(subject.errors[:commencement_date]).to include(
+          I18n.t(
+            "#{error_attr}.not_after_course_end_date_html",
+            course_end_date: trainee.course_end_date.strftime("%-d %B %Y"),
+          ),
+        )
       end
     end
 

--- a/spec/forms/trainee_start_status_form_spec.rb
+++ b/spec/forms/trainee_start_status_form_spec.rb
@@ -74,7 +74,12 @@ describe TraineeStartStatusForm, type: :model do
       end
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include("Trainee start date must not be after the ITT has finished (19 December 2020)")
+        expect(subject.errors[:commencement_date]).to include(
+          I18n.t(
+            "#{error_attr}.not_after_course_end_date_html",
+            course_end_date: trainee.course_end_date.strftime("%-d %B %Y"),
+          ),
+        )
       end
     end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/Yo6JA4jK/3258-snag-error-summaries-date-wrapping

### Changes proposed in this pull request

- Use a custom presenter given to the GOVUK form builder to customise format of error messages as suggested by @peteryates.

Note - This is only half fixed. There is currently an issue with the formbuilder not rendering safe html markup from translation files for individual fields (see image) Have raised the issue https://github.com/DFE-Digital/govuk-formbuilder/issues/328. If that issue can get resolved then we can merge this in after bumping the formbuilder otherwise we may have to consider alternative copy where the text does not wrap in the interim. 

<img width="781" alt="Screenshot 2021-11-26 at 10 56 39" src="https://user-images.githubusercontent.com/616080/143570279-9758f714-fe64-4ff9-af5a-03d1ae6e2b57.png">


