### PR TITLE
[3259] Record action bar - 'sentencify' the delete/defer/withdraw links

### DIFF
--- a/app/components/record_actions/view.html.erb
+++ b/app/components/record_actions/view.html.erb
@@ -11,8 +11,7 @@
 
     <div class="record-actions__links">
       <p class="govuk-body govuk-!-margin-bottom-0">
-        <%= action_links %>
-        <%= t("views.trainees.edit.this_trainee") %>
+        <%= action_links_sentence %>
       </p>
     </div>
   </div>

--- a/app/components/record_actions/view.rb
+++ b/app/components/record_actions/view.rb
@@ -24,20 +24,22 @@ module RecordActions
       links = []
 
       if withdraw_allowed?
-        links.prepend(withdraw_link)
+        links.prepend(:withdraw_link)
       end
 
       if trainee.deferred?
-        links.prepend(reinstate_link)
+        links.prepend(:reinstate_link)
       else
-        links.prepend(defer_link)
+        links.prepend(:defer_link)
       end
 
       if delete_allowed?
-        links.prepend(delete_link)
+        links.prepend(:delete_link)
       end
 
-      links.join(" or ").html_safe
+      links.map.with_index { |method, i| send(method, i.zero?) }
+        .join(" or ")
+        .html_safe
     end
 
     def inset_text
@@ -62,20 +64,24 @@ module RecordActions
 
     attr_reader :has_missing_fields
 
-    def delete_link
-      govuk_link_to(t("views.trainees.edit.delete"), trainee_start_date_verification_path(trainee, context: :delete), class: "delete")
+    def delete_link(capitalise)
+      text = maybe_capitalise(t("views.trainees.edit.delete"), capitalise)
+      govuk_link_to(text, trainee_start_date_verification_path(trainee, context: :delete), class: "delete")
     end
 
-    def defer_link
-      govuk_link_to(t("views.trainees.edit.defer"), trainee_deferral_path(trainee), class: "defer")
+    def defer_link(capitalise)
+      text = maybe_capitalise(t("views.trainees.edit.defer"), capitalise)
+      govuk_link_to(text, trainee_deferral_path(trainee), class: "defer")
     end
 
-    def withdraw_link
-      govuk_link_to(t("views.trainees.edit.withdraw"), relevant_redirect_path, class: "withdraw")
+    def withdraw_link(capitalise)
+      text = maybe_capitalise(t("views.trainees.edit.withdraw"), capitalise)
+      govuk_link_to(text, relevant_redirect_path, class: "withdraw")
     end
 
-    def reinstate_link
-      govuk_link_to(t("views.trainees.edit.reinstate"), trainee_reinstatement_path(trainee), class: "reinstate")
+    def reinstate_link(capitalise)
+      text = maybe_capitalise(t("views.trainees.edit.reinstate"), capitalise)
+      govuk_link_to(text, trainee_reinstatement_path(trainee), class: "reinstate")
     end
 
     def delete_allowed?
@@ -92,6 +98,11 @@ module RecordActions
 
     def course_started_but_no_specified_start_date?
       !course_starting_in_the_future? && trainee.commencement_date.blank?
+    end
+
+    def maybe_capitalise(text, condition)
+      text.capitalize! if condition
+      text
     end
 
     def relevant_redirect_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -571,10 +571,10 @@ en:
           subject: Subject
           type_of_training: Type of training
       edit:
-        delete: Delete
-        defer: Defer
-        withdraw: Withdraw
-        reinstate: Reinstate
+        delete: delete
+        defer: defer
+        withdraw: withdraw
+        reinstate: reinstate
         this_trainee: this trainee
         recommend_for_award: Recommend trainee for QTS
         recommend_for_eyts: Recommend trainee for EYTS

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -571,7 +571,7 @@ en:
           subject: Subject
           type_of_training: Type of training
       edit:
-        delete: delete
+        delete: delete this record,
         defer: defer
         withdraw: withdraw
         reinstate: reinstate

--- a/spec/components/record_actions/view_spec.rb
+++ b/spec/components/record_actions/view_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RecordActions::View do
     context "submitted for TRN" do
       let(:trait) { :submitted_for_trn }
 
-      it { is_expected.to include("This trainee is pending a TRN", "Defer", "Withdraw") }
+      it { is_expected.to include("This trainee is pending a TRN", "Defer", "withdraw") }
 
       include_examples "no button"
     end
@@ -37,7 +37,7 @@ RSpec.describe RecordActions::View do
     context "TRN received" do
       let(:trait) { :trn_received }
 
-      it { is_expected.to include(button_text, "Defer", "Withdraw") }
+      it { is_expected.to include(button_text, "Defer", "withdraw") }
     end
 
     context "recommended for QTS" do
@@ -55,7 +55,7 @@ RSpec.describe RecordActions::View do
     context "deferred" do
       let(:trait) { :deferred }
 
-      it { is_expected.to include("This trainee is deferred", "Reinstate", "Withdraw") }
+      it { is_expected.to include("This trainee is deferred", "Reinstate", "withdraw") }
 
       include_examples "no button"
     end
@@ -77,7 +77,7 @@ RSpec.describe RecordActions::View do
     end
 
     it "withdraw link is hidden" do
-      expect(subject).not_to include("Withdraw")
+      expect(subject).not_to include("withdraw")
     end
   end
 
@@ -85,7 +85,7 @@ RSpec.describe RecordActions::View do
     let(:trainee) { build(:trainee, :submitted_for_trn, course_start_date: 1.day.ago) }
 
     it "withdraw link is shown" do
-      expect(subject).to include("Withdraw")
+      expect(subject).to include("withdraw")
     end
   end
 


### PR DESCRIPTION
### Context

https://trello.com/c/5pfKZUJX/3259-snag-record-action-bar-sentencify-the-delete-defer-withdraw-links

### Changes proposed in this pull request

Updates the logic in `RecordAction::View` for rendering the link sentence to account for different combinations of actions:

(parts in bold represent what should be part of the link tag)

#### When delete is not an option:

* "**Defer** or **withdraw** this trainee" (lowercase withdraw, 'this trainee' not part of the link)
* "**Reinstate** or **withdraw** this trainee" (lowercase withdraw, 'this trainee' not part of the link)

#### When delete is an option:

* "**Delete this record**, or **defer this trainee**" (record/trainee difference, 'this trainee' part of the link)
* "**Delete this record**, or **reinstate this trainee**" (record/trainee difference, 'this trainee' part of the link)
* "**Delete this record**, or **defer** or **withdraw** this trainee" (record/trainee difference, 'this trainee' not part of the link)

### Guidance to review

Go to a registered trainee and check that the links are formatted correctly. Manipulating them as follows:
- You'll need to move the course start date into the past to be able to withdraw a trainee.
- You'll need to defer a trainee to be able to reinstate them.

I've manually removed a start dates from the following trainees so you can test the rendering of the delete link: