### PR TITLE
hide withdraw link if trainee is deffered without starting

### DIFF
--- a/app/components/record_actions/view.rb
+++ b/app/components/record_actions/view.rb
@@ -83,7 +83,7 @@ module RecordActions
     end
 
     def withdraw_allowed?
-      !course_starting_in_the_future?
+      !course_starting_in_the_future? && !trainee.itt_not_yet_started?
     end
 
     def course_starting_in_the_future?

--- a/spec/components/record_actions/view_spec.rb
+++ b/spec/components/record_actions/view_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe RecordActions::View do
     end
   end
 
+  context "when a deffered trainee has not started their ITT" do
+    let(:trainee) { build(:trainee, :deferred, commencement_status: :itt_not_yet_started) }
+
+    it "hides the withdraw link" do
+      expect(subject).not_to include("Withdraw")
+    end
+  end
+
   context "when course date is in the past" do
     let(:trainee) { build(:trainee, :submitted_for_trn, course_start_date: 1.day.ago) }
 


### PR DESCRIPTION
### Context

If a deferred trainee did not start their ITT, they cannot be withdrawn.

### Changes proposed in this pull request

Add a condition to withdraw_allowed? to guard against trainee not having started the course.

### Guidance to review

Test out in review app
