### PR TITLE
[3274] Remove trainees

### DIFF
--- a/db/data/20211129143641_remove_trainee_records.rb
+++ b/db/data/20211129143641_remove_trainee_records.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RemoveTraineeRecords < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.where(dttp_id: %w[
+      dd9f6f8b-3449-ec11-8c62-000d3ab0691d
+      e61e03af-3449-ec11-8c62-000d3ab8e8ce
+      e96eedfc-3049-ec11-8c62-000d3ab8e8ce
+    ]).each(&:destroy)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/pIPfv1SW/3274-remove-duplicate-trainee-records-on-register

These trainees were duplicated in CRM (subsequently remove). The Register versions should never have been created as they already have an older version on the DTTP CRM.

### Changes proposed in this pull request
- Data migration

