### PR TITLE
[3277] Improve example data generation

### DIFF
--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -14,11 +14,11 @@ class TrainingRouteManager
   end
 
   def requires_schools?
-    %i[school_direct_salaried school_direct_tuition_fee pg_teaching_apprenticeship].any? { |training_route_enums_key| enabled?(training_route_enums_key) }
+    LEAD_SCHOOL_ROUTES.any? { |training_route_enums_key| enabled?(training_route_enums_key) }
   end
 
   def requires_employing_school?
-    %i[school_direct_salaried pg_teaching_apprenticeship].any? { |training_route_enums_key| enabled?(training_route_enums_key) }
+    EMPLOYING_SCHOOL_ROUTES.any? { |training_route_enums_key| enabled?(training_route_enums_key) }
   end
 
   def requires_itt_start_date?

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -59,6 +59,9 @@ UNDERGRAD_ROUTES = TRAINING_ROUTES.select { |training_route|
   TRAINING_ROUTE_ENUMS.values_at(:early_years_undergrad, :provider_led_undergrad, :opt_in_undergrad).include?(training_route)
 }.freeze
 
+LEAD_SCHOOL_ROUTES = %i[school_direct_salaried school_direct_tuition_fee pg_teaching_apprenticeship].freeze
+EMPLOYING_SCHOOL_ROUTES = %i[school_direct_salaried pg_teaching_apprenticeship].freeze
+
 TRAINING_ROUTE_FEATURE_FLAGS = TRAINING_ROUTE_ENUMS.keys.reject { |training_route|
   %i[assessment_only].include?(training_route)
 }.freeze

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -123,8 +123,8 @@ namespace :example_data do
             attrs.merge!(provider: provider) if provider
 
             # Some route-specific logic, but could move into factories too
-            attrs.merge!(lead_school: lead_schools.sample) if %i[school_direct_salaried school_direct_tuition_fee].include?(route)
-            attrs.merge!(employing_school: employing_schools.sample) if route == :school_direct_salaried
+            attrs.merge!(lead_school: lead_schools.sample) if LEAD_SCHOOL_ROUTES.include?(route)
+            attrs.merge!(employing_school: employing_schools.sample) if EMPLOYING_SCHOOL_ROUTES.include?(route)
 
             if state != :draft
               course = provider.courses.where(route: TRAINING_ROUTES_FOR_COURSE[route.to_s]).sample

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -192,7 +192,7 @@ FactoryBot.define do
     end
 
     trait :with_start_date do
-      commencement_date { Faker::Date.in_date_period(month: 10) }
+      commencement_date { Faker::Date.between(from: course_start_date, to: course_end_date) }
     end
 
     trait :course_start_date_in_the_past do


### PR DESCRIPTION
### Context
Define two new constants LEAD_SCHOOL_ROUTES and EMPLOYING_SCHOOL_ROUTES
and use them in the example_data.rake task, to ensure consistent lead
and employing school assignment.

Also, ensure that the commencement_date (trainee start date) is
generated between the itt/course start and course end dates.

### Guidance to review
:shipit: 
