### PR TITLE
[3239] Choose which funding rules to use based on trainee academic cycle

### DIFF
--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -155,7 +155,7 @@ module Dttp
       end
 
       def funding_params
-        if applying_for_funding?
+        if applying_for_funding? && !course_starting_in_2022? # 2022 rules don't exist yet
           return {
             "dfe_allocatedplace" => ALLOCATED_PLACE,
             "dfe_BursaryDetailsId@odata.bind" => "/dfe_bursarydetails(#{funding_details_id})",
@@ -192,10 +192,10 @@ module Dttp
       end
 
       def academic_year
-        return ACADEMIC_YEAR_2020_2021 if trainee.course_start_date.between?(Date.parse("1/8/2020"), Date.parse("31/7/2021"))
-        return ACADEMIC_YEAR_2021_2022 if trainee.course_start_date.between?(Date.parse("1/8/2021"), Date.parse("31/7/2022"))
+        return ACADEMIC_YEAR_2020_2021 if course_start_date_between?("1/8/2020", "31/7/2021")
+        return ACADEMIC_YEAR_2021_2022 if course_start_date_between?("1/8/2021", "31/7/2022")
 
-        ACADEMIC_YEAR_2022_2023 if trainee.course_start_date.between?(Date.parse("1/8/2022"), Date.parse("31/7/2023"))
+        ACADEMIC_YEAR_2022_2023 if course_starting_in_2022?
       end
 
       def training_route
@@ -211,6 +211,14 @@ module Dttp
           ROUTE_INITIATIVES_ENUMS[:now_teach],
           ROUTE_INITIATIVES_ENUMS[:maths_physics_chairs_programme_researchers_in_schools],
         ].include?(trainee.training_initiative)
+      end
+
+      def course_starting_in_2022?
+        course_start_date_between?("1/8/2022", "31/7/2023")
+      end
+
+      def course_start_date_between?(min, max)
+        trainee.course_start_date.between?(Date.parse(min), Date.parse(max))
       end
     end
   end

--- a/app/models/academic_cycle.rb
+++ b/app/models/academic_cycle.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AcademicCycle < ApplicationRecord
+  has_many :funding_methods
+
   validates :start_date, :end_date, presence: true
   validate :start_date_before_end_date
 
@@ -10,6 +12,10 @@ class AcademicCycle < ApplicationRecord
     from_date = Date.new(year.to_i, 1, 1)
     to_date = from_date.end_of_year
     where(start_date: from_date..to_date).first
+  end
+
+  def self.for_date(date)
+    where("end_date >= :date AND start_date <= :date", date: date).first
   end
 
   def trainees_starting

--- a/app/models/funding_method.rb
+++ b/app/models/funding_method.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FundingMethod < ApplicationRecord
+  belongs_to :academic_cycle
+
   has_many :funding_method_subjects, inverse_of: :funding_method, dependent: :destroy
   has_many :allocation_subjects, through: :funding_method_subjects, inverse_of: :funding_methods
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -7,11 +7,6 @@ class Trainee < ApplicationRecord
 
   belongs_to :provider
   belongs_to :apply_application, optional: true
-  has_many :degrees, dependent: :destroy
-  has_many :nationalisations, dependent: :destroy, inverse_of: :trainee
-  has_many :nationalities, through: :nationalisations
-  has_many :trainee_disabilities, dependent: :destroy, inverse_of: :trainee
-  has_many :disabilities, through: :trainee_disabilities
   belongs_to :lead_school, optional: true, class_name: "School"
   belongs_to :employing_school, optional: true, class_name: "School"
   belongs_to :published_course,
@@ -21,6 +16,12 @@ class Trainee < ApplicationRecord
              primary_key: :uuid,
              inverse_of: :trainees,
              optional: true
+
+  has_many :degrees, dependent: :destroy
+  has_many :nationalisations, dependent: :destroy, inverse_of: :trainee
+  has_many :nationalities, through: :nationalisations
+  has_many :trainee_disabilities, dependent: :destroy, inverse_of: :trainee
+  has_many :disabilities, through: :trainee_disabilities
 
   attribute :progress, Progress.to_type
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,10 +35,19 @@ ALLOCATION_SUBJECT_SPECIALISM_MAPPING.each do |allocation_subject, subject_speci
   end
 end
 
+ACADEMIC_CYCLES.each do |academic_cycle|
+  AcademicCycle.find_or_create_by!(start_date: academic_cycle[:start_date], end_date: academic_cycle[:end_date])
+end
+
+academic_cycle = AcademicCycle.for_date(Time.zone.today)
+
 SEED_BURSARIES.each do |b|
-  bursary = FundingMethod.find_or_create_by!(training_route: b.training_route, amount: b.amount)
+  bursary = FundingMethod.find_or_create_by!(training_route: b.training_route,
+                                             amount: b.amount,
+                                             academic_cycle: academic_cycle)
   bursary.funding_type = :bursary
   bursary.save!
+
   b.allocation_subjects.map do |subject|
     allocation_subject = AllocationSubject.find_by!(name: subject)
     bursary.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
@@ -46,7 +55,10 @@ SEED_BURSARIES.each do |b|
 end
 
 SEED_SCHOLARSHIPS.each do |s|
-  funding_method = FundingMethod.find_or_create_by!(training_route: s.training_route, amount: s.amount, funding_type: FUNDING_TYPE_ENUMS[:scholarship])
+  funding_method = FundingMethod.find_or_create_by!(training_route: s.training_route,
+                                                    amount: s.amount,
+                                                    funding_type: FUNDING_TYPE_ENUMS[:scholarship],
+                                                    academic_cycle: academic_cycle)
   s.allocation_subjects.map do |subject|
     allocation_subject = AllocationSubject.find_by!(name: subject)
     funding_method.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
@@ -54,13 +66,12 @@ SEED_SCHOLARSHIPS.each do |s|
 end
 
 SEED_GRANTS.each do |s|
-  funding_method = FundingMethod.find_or_create_by!(training_route: s.training_route, amount: s.amount, funding_type: FUNDING_TYPE_ENUMS[:grant])
+  funding_method = FundingMethod.find_or_create_by!(training_route: s.training_route,
+                                                    amount: s.amount,
+                                                    funding_type: FUNDING_TYPE_ENUMS[:grant],
+                                                    academic_cycle: academic_cycle)
   s.allocation_subjects.map do |subject|
     allocation_subject = AllocationSubject.find_by!(name: subject)
     funding_method.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
   end
-end
-
-ACADEMIC_CYCLES.each do |academic_cycle|
-  AcademicCycle.find_or_create_by!(start_date: academic_cycle[:start_date], end_date: academic_cycle[:end_date])
 end

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -4,12 +4,15 @@ require "rails_helper"
 
 module Funding
   describe View do
-    before do
-      render_inline(View.new(data_model: trainee))
-    end
+    before { render_inline(View.new(data_model: trainee)) }
 
     context "with tieried bursary" do
-      let(:trainee) { build(:trainee, :early_years_postgrad, applying_for_bursary: true, bursary_tier: BURSARY_TIERS.keys.first) }
+      let(:trainee) do
+        build(:trainee,
+              :early_years_postgrad,
+              applying_for_bursary: true,
+              bursary_tier: BURSARY_TIERS.keys.first)
+      end
 
       it "renders tiered bursary text" do
         expect(rendered_component).to have_text("Applied for Tier 1")
@@ -22,7 +25,14 @@ module Funding
       let(:route) { "opt_in_undergrad" }
       let(:training_initiative) { ROUTE_INITIATIVES_ENUMS.keys.first }
       let(:trainee) do
-        build(:trainee, state, training_initiative: training_initiative, training_route: route, applying_for_bursary: true, course_subject_one: subject_specialism.name)
+        build(:trainee,
+              state,
+              :with_start_date,
+              :with_study_mode_and_course_dates,
+              training_initiative: training_initiative,
+              training_route: route,
+              applying_for_bursary: true,
+              course_subject_one: subject_specialism.name)
       end
 
       let(:subject_specialism) { create(:subject_specialism, name: AllocationSubjects::MATHEMATICS) }
@@ -31,7 +41,9 @@ module Funding
 
       context "when there is a bursary available" do
         before do
-          create(:funding_method_subject, funding_method: funding_method, allocation_subject: subject_specialism.allocation_subject)
+          create(:funding_method_subject,
+                 funding_method: funding_method,
+                 allocation_subject: subject_specialism.allocation_subject)
           render_inline(View.new(data_model: trainee))
         end
 
@@ -57,7 +69,14 @@ module Funding
       let(:training_initiative) { ROUTE_INITIATIVES_ENUMS.keys.first }
 
       let(:trainee) do
-        build(:trainee, state, training_initiative: training_initiative, training_route: route, applying_for_bursary: applying_for_bursary, course_subject_one: course_subject_one)
+        build(:trainee,
+              state,
+              :with_start_date,
+              :with_study_mode_and_course_dates,
+              training_initiative: training_initiative,
+              training_route: route,
+              applying_for_bursary: applying_for_bursary,
+              course_subject_one: course_subject_one)
       end
 
       let(:course_subject_one) { nil }
@@ -100,7 +119,9 @@ module Funding
           let(:course_subject_one) { subject_specialism.name }
 
           before do
-            create(:funding_method_subject, funding_method: funding_method, allocation_subject: subject_specialism.allocation_subject)
+            create(:funding_method_subject,
+                   funding_method: funding_method,
+                   allocation_subject: subject_specialism.allocation_subject)
 
             render_inline(View.new(data_model: trainee))
           end
@@ -148,19 +169,32 @@ module Funding
 
     context "with grant" do
       let!(:allocation_subject) { create(:allocation_subject, name: "Chemistry") }
-      let!(:subject_specialism) { create(:subject_specialism, name: trainee.course_subject_one, allocation_subject: allocation_subject) }
+      let!(:subject_specialism) do
+        create(:subject_specialism, name: trainee.course_subject_one, allocation_subject: allocation_subject)
+      end
 
       let(:amount) { 25_000 }
-      let!(:funding_method) { create(:funding_method, funding_type: "grant", training_route: trainee.training_route, amount: amount) }
+      let!(:funding_method) do
+        create(:funding_method, funding_type: "grant", training_route: trainee.training_route, amount: amount)
+      end
 
-      let!(:funding_method_subject) { create(:funding_method_subject, funding_method: funding_method, allocation_subject: allocation_subject) }
+      let!(:funding_method_subject) do
+        create(:funding_method_subject, funding_method: funding_method, allocation_subject: allocation_subject)
+      end
 
       before do
         render_inline(View.new(data_model: trainee))
       end
 
       context "when trainee applying_for_grant is true" do
-        let!(:trainee) { create(:trainee, :school_direct_salaried, :with_grant, course_subject_one: "chemistry") }
+        let!(:trainee) do
+          create(:trainee,
+                 :with_start_date,
+                 :with_study_mode_and_course_dates,
+                 :school_direct_salaried,
+                 :with_grant,
+                 course_subject_one: "chemistry")
+        end
 
         it "renders grant text" do
           expect(rendered_component).to have_text("Grant applied for")
@@ -169,7 +203,15 @@ module Funding
       end
 
       context "when trainee applying_for_grant is false" do
-        let!(:trainee) { create(:trainee, :school_direct_salaried, :with_grant, course_subject_one: "chemistry", applying_for_grant: false) }
+        let!(:trainee) do
+          create(:trainee,
+                 :with_start_date,
+                 :with_study_mode_and_course_dates,
+                 :school_direct_salaried,
+                 :with_grant,
+                 course_subject_one: "chemistry",
+                 applying_for_grant: false)
+        end
 
         it "renders grant text" do
           expect(rendered_component).to have_text("Not grant funded")
@@ -181,7 +223,15 @@ module Funding
       end
 
       context "when trainee applying_for_grant is nil" do
-        let!(:trainee) { create(:trainee, :school_direct_salaried, :with_grant, course_subject_one: "chemistry", applying_for_grant: nil) }
+        let!(:trainee) do
+          create(:trainee,
+                 :with_start_date,
+                 :with_study_mode_and_course_dates,
+                 :school_direct_salaried,
+                 :with_grant,
+                 course_subject_one: "chemistry",
+                 applying_for_grant: nil)
+        end
 
         it "renders grant text" do
           expect(rendered_component).to have_text("Funding method is missing")

--- a/spec/factories/funding_methods.rb
+++ b/spec/factories/funding_methods.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     training_route { TRAINING_ROUTES.keys.sample }
     amount { Faker::Number.number(digits: 5) }
     funding_type { FUNDING_TYPE_ENUMS[:bursary] }
+    academic_cycle { AcademicCycle.first || create(:academic_cycle) }
 
     trait :with_subjects do
       after(:create) do |funding_method, _|

--- a/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
@@ -8,7 +8,7 @@ feature "edit training initiative", type: :feature do
   let(:course_subject) { CourseSubjects::LAW }
 
   scenario "edit with valid parameters with bursary" do
-    given_a_trainee_exists(:provider_led_postgrad, course_subject_one: course_subject)
+    given_a_provider_led_postgrad_trainee_exists
     and_a_bursary_exists_for_their_subject
     when_i_visit_the_training_initiative_page
     and_i_update_the_training_initiative
@@ -40,6 +40,13 @@ feature "edit training initiative", type: :feature do
   end
 
 private
+
+  def given_a_provider_led_postgrad_trainee_exists
+    given_a_trainee_exists(:provider_led_postgrad,
+                           :with_start_date,
+                           :with_study_mode_and_course_dates,
+                           course_subject_one: course_subject)
+  end
 
   def when_i_visit_the_training_initiative_page
     training_initiative_page.load(id: trainee.slug)

--- a/spec/forms/funding/form_validator_spec.rb
+++ b/spec/forms/funding/form_validator_spec.rb
@@ -69,7 +69,13 @@ module Funding
         let(:allocation_subject) { create(:allocation_subject) }
         let(:subject_specialism) { create(:subject_specialism, allocation_subject: allocation_subject) }
 
-        let(:trainee) { create(:trainee, training_route: funding_method.training_route.to_sym, course_subject_one: subject_specialism.name) }
+        let(:trainee) do
+          create(:trainee,
+                 :with_start_date,
+                 :with_study_mode_and_course_dates,
+                 training_route: funding_method.training_route.to_sym,
+                 course_subject_one: subject_specialism.name)
+        end
 
         let(:training_initiative_form) { instance_double(Funding::TrainingInitiativesForm, fields: nil, training_initiative: nil) }
         let(:bursary_form) do

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -547,6 +547,23 @@ module Dttp
               })
             end
           end
+
+          context "and course starts in 2022" do
+            let(:trainee) do
+              create(
+                :trainee,
+                :with_secondary_course_details,
+                :with_start_date,
+                :with_early_years_grant,
+                dttp_id: dttp_contact_id,
+                course_start_date: Date.parse("1/8/2022"),
+              )
+            end
+
+            it "sends the correct params" do
+              expect(subject).to include({ "dfe_allocatedplace" => 2 })
+            end
+          end
         end
 
         context "with region information" do

--- a/spec/lib/funding_manager_spec.rb
+++ b/spec/lib/funding_manager_spec.rb
@@ -6,7 +6,14 @@ describe FundingManager do
   let(:course_subject_one) { nil }
   let(:bursary_tier) { nil }
   let(:training_route) { :early_years_postgrad }
-  let(:trainee) { build(:trainee, course_subject_one: course_subject_one, training_route: training_route, bursary_tier: bursary_tier) }
+  let(:trainee) do
+    build(:trainee,
+          :with_start_date,
+          :with_study_mode_and_course_dates,
+          course_subject_one: course_subject_one,
+          training_route: training_route,
+          bursary_tier: bursary_tier)
+  end
   let(:funding_manager) { described_class.new(trainee) }
 
   describe "#bursary_amount" do
@@ -121,7 +128,7 @@ describe FundingManager do
         let(:course_subject_one) { subject_specialism.name }
 
         it "returns amount" do
-          expect(subject).to be amount
+          expect(subject).to be(amount)
         end
       end
     end

--- a/spec/models/funding_method_spec.rb
+++ b/spec/models/funding_method_spec.rb
@@ -12,6 +12,7 @@ describe FundingMethod do
   end
 
   describe "associations" do
+    it { is_expected.to belong_to(:academic_cycle) }
     it { is_expected.to have_many(:funding_method_subjects) }
     it { is_expected.to have_many(:allocation_subjects).through(:funding_method_subjects) }
   end

--- a/spec/support/shared_examples/rendering_the_funding_section.rb
+++ b/spec/support/shared_examples/rendering_the_funding_section.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples "rendering the funding section" do
   context "when a trainee on a route with a bursary" do
     let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
-    let(:trainee) { create(:trainee, :draft, route) }
+    let(:trainee) { create(:trainee, :with_start_date, :with_study_mode_and_course_dates, :draft, route) }
 
     before { create(:funding_method, :with_subjects, training_route: route) }
 


### PR DESCRIPTION
### Context
https://trello.com/c/eeflRypa/3239-m-choose-which-funding-rules-to-use-based-on-trainee-academic-cycle

### Changes proposed in this pull request
- Add `Trainee#academic_cycle`
- Update `FundingManager` to scope funding methods to academic cycle
- Update `Dttp::Params::PlacementAssignment` to not send funding information if the course starts in 2022

The card suggested the Early Years can't have funding info added until the course details are completed (this is existing behaviour for other routes but not currently EY). But after looking into this, it appears that for Early Years, the bursary amount does not come from the database, but `FundingManager::BURSARY_TIER_AMOUNTS`.

### Guidance to review
The seeds file now associates the funding methods with the current academic cycle: 2021-2022.

- Create a trainee that requires funding information (try various training routes)
- It should all work as before
