### PR TITLE
[3240] Add 2022 funding rules

### DIFF
--- a/config/initializers/academic_cycles.rb
+++ b/config/initializers/academic_cycles.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+CURRENT_ACADEMIC_CYCLE_ID = 7 # { start_date: "01/9/2021", end_date: "31/8/2022" },
+
 ACADEMIC_CYCLES = [
   { start_date: "01/9/2015", end_date: "31/8/2016" },
   { start_date: "01/9/2016", end_date: "31/8/2017" },

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -93,6 +93,7 @@ EARLY_YEARS_TRAINING_ROUTES = TRAINING_ROUTES.select { |t| t.starts_with?(EARLY_
 EARLY_YEARS_GRANT = OpenStruct.new(
   training_route: TRAINING_ROUTE_ENUMS[:early_years_salaried],
   amount: 14_000,
+  academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
   allocation_subjects: [AllocationSubjects::EARLY_YEARS_ITT],
 ).freeze
 
@@ -100,6 +101,7 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_undergrad],
     amount: 9_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MATHEMATICS,
       AllocationSubjects::PHYSICS,
@@ -108,6 +110,7 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 24_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -118,6 +121,7 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 10_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MODERN_LANGUAGES,
       AllocationSubjects::CLASSICS,
@@ -126,6 +130,7 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 7_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::BIOLOGY,
     ],
@@ -133,6 +138,7 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 24_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -143,6 +149,7 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 10_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MODERN_LANGUAGES,
       AllocationSubjects::CLASSICS,
@@ -151,6 +158,7 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 7_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::BIOLOGY,
     ],
@@ -158,6 +166,7 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:opt_in_undergrad],
     amount: 9_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MATHEMATICS,
       AllocationSubjects::PHYSICS,
@@ -171,6 +180,7 @@ SEED_SCHOLARSHIPS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 26_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -181,6 +191,7 @@ SEED_SCHOLARSHIPS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 26_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -195,6 +206,7 @@ SEED_GRANTS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
     amount: 24_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -205,6 +217,7 @@ SEED_GRANTS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
     amount: 10_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MODERN_LANGUAGES,
       AllocationSubjects::CLASSICS,
@@ -213,6 +226,7 @@ SEED_GRANTS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
     amount: 7_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::BIOLOGY,
     ],
@@ -220,6 +234,7 @@ SEED_GRANTS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
     amount: 15_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -230,6 +245,7 @@ SEED_GRANTS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
     amount: 1_000,
+    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MODERN_LANGUAGES,
       AllocationSubjects::CLASSICS,

--- a/db/data/20211207165346_seed_academic_cycles_for_2021_2022.rb
+++ b/db/data/20211207165346_seed_academic_cycles_for_2021_2022.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class SeedAcademicCyclesFor20212022 < ActiveRecord::Migration[6.1]
+  def up
+    SEED_BURSARIES.each do |b|
+      bursary = FundingMethod.find_or_create_by!(training_route: b.training_route, amount: b.amount, academic_cycle_id: b.academic_cycle_id)
+      bursary.funding_type = :bursary
+      bursary.save!
+      b.allocation_subjects.map do |subject|
+        allocation_subject = AllocationSubject.find_by!(name: subject)
+        bursary.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
+      end
+    end
+
+    SEED_SCHOLARSHIPS.each do |s|
+      funding_method = FundingMethod.find_or_create_by!(
+        training_route: s.training_route,
+        amount: s.amount,
+        funding_type: FUNDING_TYPE_ENUMS[:scholarship],
+        academic_cycle_id: s.academic_cycle_id,
+      )
+      s.allocation_subjects.map do |subject|
+        allocation_subject = AllocationSubject.find_by!(name: subject)
+        funding_method.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
+      end
+    end
+
+    SEED_GRANTS.each do |s|
+      funding_method = FundingMethod.find_or_create_by!(
+        training_route: s.training_route,
+        amount: s.amount,
+        funding_type: FUNDING_TYPE_ENUMS[:grant],
+        academic_cycle_id: s.academic_cycle_id,
+      )
+      s.allocation_subjects.map do |subject|
+        allocation_subject = AllocationSubject.find_by!(name: subject)
+        funding_method.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

Add the 2022 funding rules with a migration to implement them.
https://trello.com/c/livHHuKM/3240-m-add-2022-funding-rules

### Changes proposed in this pull request

Update the new funding rules. Note: there is no such subject grouping currently as 'Ancient languages' and so funding rules couldnt be added.

### Guidance to review

Check the rules are correct against: https://www.gov.uk/government/publications/funding-initial-teacher-training-itt/funding-initial-teacher-training-itt-academic-year-2022-to-2023