### PR TITLE
[3283] Build draft records page

### DIFF
--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+class BaseTraineeController < ApplicationController
+  HELPER_METHODS = %i[
+    export_results_path
+    filter_params
+    filters
+    multiple_record_sources?
+    paginated_trainees
+    providers
+    search_primary_result_set
+    search_primary_result_title
+    search_secondary_result_set
+    search_secondary_result_title
+    total_trainees_count
+    training_routes
+  ].freeze
+
+  before_action :save_filter, only: :index
+
+  helper_method(*HELPER_METHODS)
+
+  def index
+    return redirect_to(search_path(filter_params)) if current_page_exceeds_total_pages?
+
+    respond_to do |format|
+      format.html
+      format.js { render(json: json_response) }
+      format.csv do
+        track_activity
+        send_data(data_export.data, filename: data_export.filename, disposition: :attachment)
+      end
+    end
+  end
+
+private
+
+  def search_path
+    raise(NotImplementedError)
+  end
+
+  def search_primary_result_title
+    raise(NotImplementedError)
+  end
+
+  def search_primary_result_set
+    raise(NotImplementedError)
+  end
+
+  def search_secondary_result_title
+    raise(NotImplementedError)
+  end
+
+  def search_secondary_result_set
+    raise(NotImplementedError)
+  end
+
+  def trainee_search_scope
+    raise(NotImplementedError)
+  end
+
+  def export_results_path
+    raise(NotImplementedError)
+  end
+
+  def total_trainees_count
+    filtered_trainees.count(:id)
+  end
+
+  def providers
+    @providers ||= Provider.all.order(:name)
+  end
+
+  def training_routes
+    policy_scope(Trainee)
+      .group(:training_route)
+      .count
+      .keys
+      .sort_by(&TRAINING_ROUTE_ENUMS.values.method(:index))
+  end
+
+  def current_page_exceeds_total_pages?
+    paginated_trainees.total_pages.nonzero? && paginated_trainees.current_page > paginated_trainees.total_pages
+  end
+
+  def filtered_trainees
+    @filtered_trainees ||= Trainees::Filter.call(
+      trainees: policy_scope(trainee_search_scope),
+      filters: filters,
+    )
+  end
+
+  def field
+    @field ||= filter_params[:sort_by] == "last_name" ? :last_name : :updated_at
+  end
+
+  def paginated_trainees
+    @paginated_trainees ||= filtered_trainees.ordered_by_drafts_then_by(field).page(params[:page] || 1)
+  end
+
+  def filters
+    @filters ||= TraineeFilter.new(params: filter_params).filters
+  end
+
+  def filter_params
+    params.permit(permitted_params + permitted_admin_params)
+  end
+
+  def permitted_admin_params
+    return [] unless current_user.system_admin?
+
+    [:provider]
+  end
+
+  def permitted_params
+    [
+      :subject,
+      :text_search,
+      :sort_by,
+      {
+        level: [],
+        training_route: [],
+        state: [],
+        record_source: [],
+        record_completion: [],
+        trainee_start_year: [],
+      },
+    ]
+  end
+
+  def multiple_record_sources?
+    @multiple_record_sources ||= begin
+      apply_count = policy_scope(Trainee).with_apply_application.count
+      manual_count = policy_scope(Trainee).with_manual_application.count
+      apply_count.positive? && manual_count.positive?
+    end
+  end
+
+  def save_filter
+    return if request.format.csv?
+
+    FilteredBackLink::Tracker.new(session: session, href: trainees_path).save_path(request.fullpath)
+  end
+
+  def data_export
+    @data_export ||= Exports::TraineeSearchData.new(filtered_trainees)
+  end
+
+  def json_response
+    {
+      results: render_partial("trainees/results", {
+        paginated_trainees: paginated_trainees,
+        search_primary_result_title: search_primary_result_title,
+        search_primary_result_set: search_primary_result_set,
+        search_secondary_result_title: search_secondary_result_title,
+        search_secondary_result_set: search_secondary_result_set,
+        search_path: search_path,
+        filters: filters,
+      }),
+      selected_filters: render_partial("trainees/selected_filters", {
+        filters: filters,
+        search_path: search_path,
+      }),
+      action_bar: render_partial("trainees/action_bar", {
+        paginated_trainees: paginated_trainees,
+        export_results_path: export_results_path,
+      }),
+      trainee_count: total_trainees_count,
+      page_title: trainees_page_title(paginated_trainees, total_trainees_count),
+    }
+  end
+
+  def render_partial(partial, locals)
+    (render_to_string(formats: %w[html], partial: partial, locals: locals) || "").squish
+  end
+end

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class DraftsController < BaseTraineeController
+  include TraineeHelper
+  include ActivityTracker
+
+private
+
+  def search_path(filter_params = nil)
+    drafts_path(filter_params)
+  end
+
+  def search_primary_result_title
+    @search_primary_result_title ||= t("views.drafts.index.results.above_the_fold_title")
+  end
+
+  def search_primary_result_set
+    paginated_trainees.select(&:submission_ready?)
+  end
+
+  def search_secondary_result_title
+    @search_secondary_result_title ||= t("views.drafts.index.results.below_the_fold_title")
+  end
+
+  def search_secondary_result_set
+    paginated_trainees.reject(&:submission_ready?)
+  end
+
+  def trainee_search_scope
+    Trainee.draft.includes(provider: [:courses])
+  end
+
+  def export_results_path
+    drafts_path(filter_params.merge(format: "csv"))
+  end
+end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module NavigationHelper
-  def trainee_link_is_current?
+  def active_link_for(segment)
     url = request.path_info
-    url.include?("/trainees")
+    url.include?("/#{segment}")
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SearchHelper
+  def trainee_search_path?(search_path)
+    search_path == "/trainees"
+  end
+end

--- a/app/views/drafts/index.html.erb
+++ b/app/views/drafts/index.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <h1 class="govuk-heading-xl" aria-live="polite">
-  Trainee records (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
+  Draft trainees (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
 </h1>
 
 <% unless current_user.system_admin? %>
@@ -25,7 +25,7 @@
   search_primary_result_set: search_primary_result_set,
   search_secondary_result_title: search_secondary_result_title,
   search_secondary_result_set: search_secondary_result_set,
-  search_path: trainees_path,
+  search_path: drafts_path,
   filters: filters,
   training_routes: training_routes,
   export_results_path: export_results_path

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
     <%= render NavigationBar::View.new(
       items: [
         { name: "Home", url: root_path },
-        { name: "Trainee records", url: trainees_path, current: trainee_link_is_current? },
+        { name: "Trainee records", url: trainees_path, current: active_link_for("trainees") },
       ],
       current_path: request.path,
       current_user: @current_user,

--- a/app/views/trainees/_action_bar.html.erb
+++ b/app/views/trainees/_action_bar.html.erb
@@ -3,7 +3,7 @@
     <div class="app-export--link">
       <%= govuk_link_to(
         I18n.t("views.trainees.index.export"),
-        trainees_path(filter_params.merge(format: "csv")),
+        export_results_path,
         class: "app-trainee-export",
       ) %>
     </div>

--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -1,4 +1,4 @@
-<form method="get" id="js-live-filter">
+<form method="get" id="js-live-filter" data-search-endpoint="<%= search_path %>">
   <%= submit_tag "Apply filters", class: "govuk-button", id: "js-submit" %>
   <%= hidden_field_tag :sort_by, params[:sort_by] %>
 
@@ -13,7 +13,7 @@
         <%= label_tag "provider", t("views.trainees.index.filters.provider"), class: "govuk-label govuk-label--s" %>
         <%= select_tag(
           :provider,
-          options_from_collection_for_select(@providers, :id, :name),
+          options_from_collection_for_select(providers, :id, :name),
           include_blank: "All providers",
           class: "govuk-select"
         ) %>
@@ -24,7 +24,11 @@
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-        <%= t("views.trainees.index.filters.record_completion") %>
+        <% if trainee_search_path?(search_path) %>
+          <%= t("views.trainees.index.filters.record_completion") %>
+        <% else %>
+          <%= t("views.drafts.index.filters.record_completion") %>
+        <% end %>
       </legend>
       <div class="govuk-checkboxes govuk-checkboxes--small">
         <% [:complete, :incomplete].map do |completion_status| %>
@@ -65,40 +69,6 @@
     </fieldset>
   </div>
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-        <%= t("views.trainees.index.filters.level") %>
-      </legend>
-      <div class="govuk-checkboxes govuk-checkboxes--small">
-        <% COURSE_LEVELS.keys.map do |level| %>
-          <div class="govuk-checkboxes__item">
-            <%= check_box_tag "level[]", level, checked?(filters, :level, level.to_s), id: "level-#{level}", class: "govuk-checkboxes__input" %>
-            <%= label_tag "level-#{level}", label_for("level", level), class: "govuk-label govuk-checkboxes__label" %>
-          </div>
-        <% end %>
-      </div>
-    </fieldset>
-  </div>
-
-  <% unless training_routes.count < 2 %>
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-          <%= t("views.trainees.index.filters.type_of_training") %>
-        </legend>
-        <div class="govuk-checkboxes govuk-checkboxes--small">
-          <% training_routes.map do |training_route, _| %>
-            <div class="govuk-checkboxes__item">
-              <%= check_box_tag "training_route[]", training_route, checked?(filters, :training_route, training_route), id: "training_route-#{training_route}", class: "govuk-checkboxes__input" %>
-              <%= label_tag "training_route-#{training_route}", label_for("training_route", training_route), class: "govuk-label govuk-checkboxes__label" %>
-            </div>
-          <% end %>
-        </div>
-      </fieldset>
-    </div>
-  <% end %>
-
   <% if multiple_record_sources? %>
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">
@@ -122,13 +92,13 @@
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-        <%= t("views.trainees.index.filters.status") %>
+        <%= t("views.trainees.index.filters.level") %>
       </legend>
       <div class="govuk-checkboxes govuk-checkboxes--small">
-        <% TraineeFilter::STATES.each do |state, _| %>
+        <% COURSE_LEVELS.keys.map do |level| %>
           <div class="govuk-checkboxes__item">
-            <%= check_box_tag "state[]", state, checked?(filters, :state, state), id: "state-#{state}", class: "govuk-checkboxes__input" %>
-            <%= label_tag "state-#{state}", label_for("state", state), class: "govuk-label govuk-checkboxes__label" %>
+            <%= check_box_tag "level[]", level, checked?(filters, :level, level.to_s), id: "level-#{level}", class: "govuk-checkboxes__input" %>
+            <%= label_tag "level-#{level}", label_for("level", level), class: "govuk-label govuk-checkboxes__label" %>
           </div>
         <% end %>
       </div>
@@ -144,4 +114,40 @@
       ->(object) { object.text == filters[:subject] if filters },
     ), class: "govuk-select" %>
   </div>
+
+  <% unless training_routes.count < 2 %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          <%= t("views.trainees.index.filters.type_of_training") %>
+        </legend>
+        <div class="govuk-checkboxes govuk-checkboxes--small">
+          <% training_routes.map do |training_route, _| %>
+            <div class="govuk-checkboxes__item">
+              <%= check_box_tag "training_route[]", training_route, checked?(filters, :training_route, training_route), id: "training_route-#{training_route}", class: "govuk-checkboxes__input" %>
+              <%= label_tag "training_route-#{training_route}", label_for("training_route", training_route), class: "govuk-label govuk-checkboxes__label" %>
+            </div>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+  <% end %>
+
+  <% if trainee_search_path?(search_path) %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          <%= t("views.trainees.index.filters.status") %>
+        </legend>
+        <div class="govuk-checkboxes govuk-checkboxes--small">
+          <% TraineeFilter::STATES.each do |state, _| %>
+            <div class="govuk-checkboxes__item">
+              <%= check_box_tag "state[]", state, checked?(filters, :state, state), id: "state-#{state}", class: "govuk-checkboxes__input" %>
+              <%= label_tag "state-#{state}", label_for("state", state), class: "govuk-label govuk-checkboxes__label" %>
+            </div>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+  <% end %>
 </form>

--- a/app/views/trainees/_results.html.erb
+++ b/app/views/trainees/_results.html.erb
@@ -1,23 +1,23 @@
 <% if paginated_trainees.any? %>
-  <% if draft_trainees.any? %>
+  <% if search_primary_result_set.any? %>
     <div class="govuk-!-margin-bottom-8 app-draft-records">
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half">
-          <h2 class="govuk-heading-m">Draft trainees</h2>
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m"><%= search_primary_result_title %></h2>
         </div>
       </div>
-      <%= render ApplicationRecordCard::View.with_collection(draft_trainees, system_admin: @current_user.system_admin?) %>
+      <%= render ApplicationRecordCard::View.with_collection(search_primary_result_set, system_admin: @current_user.system_admin?) %>
     </div>
   <% end %>
 
-  <% if completed_trainees.any? %>
+  <% if search_secondary_result_set.any? %>
     <div class="govuk-!-margin-bottom-8 app-non-draft-records">
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half">
-          <h2 class="govuk-heading-m">Registered trainees</h2>
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m"><%= search_secondary_result_title %></h2>
         </div>
       </div>
-      <%= render ApplicationRecordCard::View.with_collection(completed_trainees, system_admin: @current_user.system_admin?) %>
+      <%= render ApplicationRecordCard::View.with_collection(search_secondary_result_set, system_admin: @current_user.system_admin?) %>
     </div>
   <% end %>
 
@@ -25,7 +25,7 @@
   <h2 class="govuk-heading-m">No records found</h2>
   <p class="govuk-body">
     Try
-    <%= govuk_link_to "clearing your search and filters", trainees_path %>.
+    <%= govuk_link_to "clearing your search and filters", search_path %>.
   </p>
 
 <% else %>

--- a/app/views/trainees/_search_results.html.erb
+++ b/app/views/trainees/_search_results.html.erb
@@ -1,0 +1,52 @@
+<div class='moj-filter-layout'>
+  <div class="moj-filter-layout__filter-wrapper app-filter">
+    <div class="moj-filter-layout__filter">
+      <div class="moj-filter">
+        <div class="moj-filter__header">
+          <div class="moj-filter__header-title">
+            <h2 class="govuk-heading-m"><%= t("components.filter.title")%></h2>
+          </div>
+          <div class="moj-filter__header-action">
+          </div>
+        </div>
+
+        <!-- Div made focusable to 'catch' focus from filters. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640 -->
+        <div class="moj-filter__content" tabindex="-1">
+          <div id='js-selected-filters'>
+            <%= render "trainees/selected_filters", filters: filters, search_path: search_path %>
+          </div>
+          <div class="moj-filter__options">
+            <%= render "trainees/filters",
+              filters: filters,
+              training_routes: training_routes,
+              search_path: search_path
+            %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class='moj-filter-layout__content'>
+    <div class="app-records-actions">
+      <div class="app-records-actions-text-links" id="js-action-bar">
+        <%= render "trainees/action_bar", paginated_trainees: paginated_trainees, export_results_path: export_results_path %>
+      </div>
+      <div class="moj-action-bar">
+        <div class="moj-action-bar__filter"></div>
+      </div>
+    </div>
+
+    <div id='js-results'>
+      <%= render "trainees/results",
+        paginated_trainees: paginated_trainees,
+        search_primary_result_title: search_primary_result_title,
+        search_primary_result_set: search_primary_result_set,
+        search_secondary_result_title: search_secondary_result_title,
+        search_secondary_result_set: search_secondary_result_set,
+        search_path: search_path,
+        filters: filters
+      %>
+    </div>
+  </div>
+</div>

--- a/app/views/trainees/_selected_filters.html.erb
+++ b/app/views/trainees/_selected_filters.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="moj-filter__heading-action">
         <p class="govuk-body">
-        <%= govuk_link_to 'Clear<span class="govuk-visually-hidden"> all filters</span>'.html_safe, trainees_path, class: "govuk-link--no-visited-state" %>
+        <%= govuk_link_to 'Clear<span class="govuk-visually-hidden"> all filters</span>'.html_safe, search_path, class: "govuk-link--no-visited-state" %>
         </p>
       </div>
     </div>

--- a/app/webpacker/scripts/live_filter.js
+++ b/app/webpacker/scripts/live_filter.js
@@ -8,6 +8,7 @@ export default class LiveFilter {
   constructor () {
     this.form = document.querySelector('#js-live-filter')
     this.resultsDiv = document.querySelector('#js-results')
+    this.endpoint = this.form.attributes['data-search-endpoint'].value
     this.selectedFiltersDiv = document.querySelector('#js-selected-filters')
     this.traineeCount = document.querySelector('#js-trainee-count')
     this.actionBar = document.querySelector('#js-action-bar')
@@ -37,7 +38,7 @@ export default class LiveFilter {
 
   fetchResults (shouldUpdateUrl = true) {
     return $.ajax({
-      url: '/trainees',
+      url: this.endpoint,
       dataType: 'json',
       data: this.state
     }).done((response) => {

--- a/app/webpacker/scripts/live_filter.js
+++ b/app/webpacker/scripts/live_filter.js
@@ -8,7 +8,6 @@ export default class LiveFilter {
   constructor () {
     this.form = document.querySelector('#js-live-filter')
     this.resultsDiv = document.querySelector('#js-results')
-    this.endpoint = this.form.attributes['data-search-endpoint'].value
     this.selectedFiltersDiv = document.querySelector('#js-selected-filters')
     this.traineeCount = document.querySelector('#js-trainee-count')
     this.actionBar = document.querySelector('#js-action-bar')
@@ -16,6 +15,8 @@ export default class LiveFilter {
     this.state = null
 
     if (!(this.form && this.resultsDiv && this.selectedFiltersDiv)) return
+
+    this.endpoint = this.form.attributes["data-search-endpoint"].value
 
     this.saveState()
     this.setInitialStateToHistory()

--- a/app/webpacker/scripts/live_filter.spec.js
+++ b/app/webpacker/scripts/live_filter.spec.js
@@ -3,7 +3,8 @@ import LiveFilter from './live_filter'
 
 describe('LiveFilter', () => {
   beforeEach(() => {
-    const $form = $(`<form method="get" id="js-live-filter">
+    const $form =
+      $(`<form method="get" id="js-live-filter" data-search-endpoint="/endpoint">
     <input type="submit" name="commit" value="Apply filters" id="js-submit">
     <input type="checkbox" name="level[]" id="level-early_years" value="early_years">
     <input type="checkbox" name="level[]" id="level-primary" value="primary">
@@ -12,7 +13,7 @@ describe('LiveFilter', () => {
       <option value="applied biology">Applied biology</option>
       <option value="applied chemistry">Applied chemistry</option>
     </select>
-    </form>`)
+    </form>`);
 
     const $results = $('<div id="js-results"></div>')
     const $selectedFilters = $('<div id="js-selected-filters"></div>')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -562,10 +562,20 @@ en:
         commencement_date_radio_option: *commencement_date
         trainee_id: *trainee_id
         study_mode: Select if the trainee is full time or part time
+    drafts:
+      index:
+        results:
+          above_the_fold_title: Complete drafts - ready to register
+          below_the_fold_title: Incomplete drafts
+        filters:
+          record_completion: Draft completion
     trainees:
       index:
         no_records: Your trainee records will appear here. You do not have any records yet.
         export: Export these records
+        results:
+          above_the_fold_title: Draft trainees
+          below_the_fold_title: Registered trainees
         filters:
           record_completion: Record completion
           trainee_start_year: *trainee_start_year

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Rails.application.routes.draw do
     resource :confirm_details, as: :confirm, only: %i[show update], path: "/confirm", controller: "/trainees/confirm_details"
   end
 
+  resources :drafts, only: :index
+
   resources :trainees, except: :edit do
     scope module: :trainees do
       resource :training_details, concerns: :confirmable, only: %i[edit update], path: "/training-details"


### PR DESCRIPTION
### Context

- https://trello.com/c/xmrQ8Nzt/3310-l-draft-records-filters
- https://trello.com/c/xmrQ8Nzt/3310-l-draft-records-filters

### Changes proposed in this pull request

- Create a sep. page to split draft trainees into their own view
- Create a base trainee controller to be shared between the registered and draft ones
- Clean up mix of instance_vars and helper methods to all just be helper methods lazily invoked from the view, organised into a const so we know which is used where
- Wire up filters for drafts searching

### Guidance to review

https://register-pr-1792.london.cloudapps.digital/drafts

Test searching and filtering works correctly for the drafts page (and also the trainees page for regressions?)

Notes:

- This page is not linked to at the moment
- The final page may live within `trainees/drafts` and will be a part of a bigger refactor of the routes when its time to turn this on so the tab navigation remains active under drafts when performing sub actions (eg editing/adding drafts)