### PR TITLE
[3297] Add stop words support to autocomplete

### DIFF
--- a/app/components/form_components/autocomplete/sort/calculateWeight.js
+++ b/app/components/form_components/autocomplete/sort/calculateWeight.js
@@ -1,33 +1,40 @@
+import removeStopWords from './stop_words'
+
 const exactMatch = (word, query) => (word === query)
 
 const startsWithRegExp = (query) => new RegExp('\\b' + query, 'i')
 const startsWith = (word, query) => (word.search(startsWithRegExp(query)) === 0)
 
-const wordsStartsWithQuery = (word, regExps) => regExps.every(
-  (regExp) => (word.search(regExp) >= 0)
-)
+const wordsStartsWithQuery = (word, regExps) => regExps.every((regExp) => (word.search(regExp) >= 0))
 
-const anyMatch = (words, query, evaluatorFunc) =>
-  words.some((word) => evaluatorFunc(word, query))
-const synonymsExactMatch = (synonyms, query) =>
-  anyMatch(synonyms, query, exactMatch)
-const synonymsStartsWith = (synonyms, query) =>
-  anyMatch(synonyms, query, startsWith)
+const anyMatch = (words, query, evaluatorFunc) => words.some((word) => evaluatorFunc(word, query))
+const synonymsExactMatch = (synonyms, query) => anyMatch(synonyms, query, exactMatch)
+const synonymsStartsWith = (synonyms, query) => anyMatch(synonyms, query, startsWith)
+
 const wordInSynonymStartsWithQuery = (synonyms, startsWithQueryWordsRegexes) =>
   anyMatch(synonyms, startsWithQueryWordsRegexes, wordsStartsWithQuery)
 
 // NOTE: Determines how the query matches either an option's name/synonyms.
 // Returns an integer ranging from 0 (no match) to 100 (exact match).
-const calculateWeight = ({ name, synonyms }, query) => {
+const calculateWeight = ({ name, synonyms, nameWithoutStopWords, synonymsWithoutStopWords }, query) => {
+  const queryWithoutStopWords = removeStopWords(query)
+
   if (exactMatch(name, query)) return 100
+  if (exactMatch(nameWithoutStopWords, queryWithoutStopWords)) return 95
+
   if (synonymsExactMatch(synonyms, query)) return 75
+  if (synonymsExactMatch(synonymsWithoutStopWords, queryWithoutStopWords)) return 70
+
   if (startsWith(name, query)) return 60
+  if (startsWith(nameWithoutStopWords, queryWithoutStopWords)) return 55
+
   if (synonymsStartsWith(synonyms, query)) return 50
+  if (synonymsStartsWith(synonyms, queryWithoutStopWords)) return 40
 
-  const startsWithRegExps = query.split(/\s+/).map(startsWithRegExp)
+  const startsWithRegExps = queryWithoutStopWords.split(/\s+/).map(startsWithRegExp)
 
-  if (wordsStartsWithQuery(name, startsWithRegExps)) return 25
-  if (wordInSynonymStartsWithQuery(synonyms, startsWithRegExps)) return 10
+  if (wordsStartsWithQuery(nameWithoutStopWords, startsWithRegExps)) return 25
+  if (wordInSynonymStartsWithQuery(synonymsWithoutStopWords, startsWithRegExps)) return 10
 
   return 0
 }

--- a/app/components/form_components/autocomplete/sort/clean.js
+++ b/app/components/form_components/autocomplete/sort/clean.js
@@ -1,4 +1,4 @@
-const clean = (word) => word.trim()
+const clean = (text) => text.trim()
   .replace(/['’]/g, '')
   .replace(/[.,"/#!$%^&*;:{}=\-_`~()]/g, ' ')
   .toLowerCase()

--- a/app/components/form_components/autocomplete/sort/index.js
+++ b/app/components/form_components/autocomplete/sort/index.js
@@ -1,4 +1,5 @@
 import clean from './clean'
+import removeStopWords from './stop_words'
 import calculateWeight from './calculateWeight'
 
 const addWeightWithBoost = (option, query) => {
@@ -8,9 +9,13 @@ const addWeightWithBoost = (option, query) => {
 }
 
 const cleanseOption = (option) => {
+  const synonyms = (option.synonyms || []).map(clean)
+
   option.clean = {
     name: clean(option.name),
-    synonyms: (option.synonyms || []).map(clean),
+    nameWithoutStopWords: removeStopWords(option.name),
+    synonyms: synonyms,
+    synonymsWithoutStopWords: synonyms.map(removeStopWords),
     boost: (option.boost || 1)
   }
 

--- a/app/components/form_components/autocomplete/sort/stop_words.js
+++ b/app/components/form_components/autocomplete/sort/stop_words.js
@@ -1,0 +1,17 @@
+const stopWords = ['the', 'of', 'in', 'and', 'at', '&']
+
+const removeStopWords = (text) => {
+  const isAllStopWords = text.trim().split(' ').every((word) => stopWords.includes(word))
+
+  // We don't want to filter out stops words too early.
+  // For example, the user could start off typing "the the"
+  // with the intention of entering "the theatre".
+  if (isAllStopWords) {
+    return text
+  }
+
+  const regex = new RegExp(stopWords.map(word => `(\\s+)?${word}(\\s+)?`).join('|'), 'gi')
+  return text.replace(regex, ' ').trim()
+}
+
+export default removeStopWords

--- a/app/webpacker/scripts/autocomplete/calculateWeight.spec.js
+++ b/app/webpacker/scripts/autocomplete/calculateWeight.spec.js
@@ -9,13 +9,27 @@ import calculateWeight, {
 } from '../../../components/form_components/autocomplete/sort/calculateWeight'
 
 describe('calculateWeight', () => {
-  const option = { name: 'ab cd', synonyms: ['abc ghi'] }
+  const option = {
+    name: 'ab cd',
+    synonyms: ['abc ghi'],
+    nameWithoutStopWords: 'ab cd',
+    synonymsWithoutStopWords: ['abc ghi']
+  }
+
   it('returns 100', () => {
     expect(calculateWeight(option, 'ab cd')).toEqual(100)
   })
 
+  it('returns 95', () => {
+    expect(calculateWeight(option, 'ab cd in')).toEqual(95)
+  })
+
   it('returns 75', () => {
     expect(calculateWeight(option, 'abc ghi')).toEqual(75)
+  })
+
+  it('returns 70', () => {
+    expect(calculateWeight(option, 'abc ghi and')).toEqual(70)
   })
 
   it('returns 60', () => {

--- a/app/webpacker/scripts/autocomplete/sort.spec.js
+++ b/app/webpacker/scripts/autocomplete/sort.spec.js
@@ -60,8 +60,8 @@ describe('sort', () => {
       { name: 'rose', synonyms: ['pretty the flower'] },
       { name: 'lily', synonyms: ['the flower pretty'] }
     ]
-    expect(sort('the pre', options)).toEqual(['the pretty flower', 'pretty the flower', 'lily', 'rose'])
-    expect(sort('the pretty', options)).toEqual(['the pretty flower', 'pretty the flower', 'lily', 'rose'])
+    expect(sort('the pre', options)).toEqual(['the pretty flower', 'pretty the flower', 'rose', 'lily'])
+    expect(sort('the pretty', options)).toEqual(['the pretty flower', 'pretty the flower', 'rose', 'lily'])
     expect(sort('the pretty flo', options)).toEqual(['the pretty flower', 'pretty the flower', 'lily', 'rose'])
   })
 
@@ -164,7 +164,9 @@ describe('cleanseOption', () => {
       name: 'abc',
       clean: {
         name: 'abc',
+        nameWithoutStopWords: 'abc',
         synonyms: [],
+        synonymsWithoutStopWords: [],
         boost: 1
       }
     })
@@ -181,6 +183,8 @@ describe('cleanseOption', () => {
       boost: 2,
       clean: {
         name: 'abc',
+        nameWithoutStopWords: 'aBc',
+        synonymsWithoutStopWords: ['xyz'],
         synonyms: ['xyz'],
         boost: 2
       }

--- a/app/webpacker/scripts/autocomplete/stop_words.spec.js
+++ b/app/webpacker/scripts/autocomplete/stop_words.spec.js
@@ -1,0 +1,27 @@
+import removeStopWords from '../../../components/form_components/autocomplete/sort/stop_words'
+
+describe('removeStopWords', () => {
+  describe('text with multiple stop words', () => {
+    it('removes all stop words', () => {
+      expect(removeStopWords('the university of southampton')).toEqual('university southampton')
+    })
+  })
+
+  describe('text has only one stop word', () => {
+    it("doesn't remove it", () => {
+      expect(removeStopWords('the')).toEqual('the')
+    })
+  })
+
+  describe('all words are stop words', () => {
+    it("doesn't remove any", () => {
+      expect(removeStopWords('the and')).toEqual('the and')
+    })
+  })
+
+  describe('last character has the potential to be a stop word', () => {
+    it("is kept in the text", () => {
+      expect(removeStopWords('bachelor o')).toEqual('bachelor o')
+    })
+  })
+})


### PR DESCRIPTION
### Context
https://trello.com/c/clMYnXgB/3297-m-autocomplete-add-stop-words-normalisation-support-to-autocomplete

### Changes proposed in this pull request
- Extended the autocomplete `clean` function to remove stop words

### Guide to review
- Pick an autocomplete field (e.g. degree institutions)
- Try entering a search term with a stop word
- The search results will ignore the stop word
