### PR TITLE
Create dttpimport test environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       with:
         workflow: 'Deploy to PaaS'
         token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}
-        inputs: '{"qa": "true", "staging": "true", "production": "true", "sandbox": "true", "sha": "${{ env.IMAGE_TAG }}"}'
+        inputs: '{"qa": "true", "staging": "true", "production": "true", "sandbox": "true", "dttpimport": "true", "sha": "${{ env.IMAGE_TAG }}"}'
 
     - name: Check for Failure
       if: ${{ failure() && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,10 @@ on:
         description: Deploy to sandbox?
         default: 'false'
         required: true
+      dttpimport:
+        description: Deploy to dttpimport?
+        default: 'false'
+        required: true
       pr:
         description: PR number for the review app
         required: false
@@ -36,6 +40,8 @@ jobs:
       - id:   select-environments
         if:  github.event.inputs.pr == ''
         uses: DFE-Digital/bat-infrastructure/actions/prepare-environment-matrix@main
+        with:
+          available-environments: qa,staging,production,sandbox,research,dttpimport
 
       - id:  set-pr-environment
         if:  github.event.inputs.pr != ''

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,12 @@ production:
 	$(eval SPACE=bat-prod)
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-production)
 
+dttpimport:
+	$(if $(CONFIRM_PRODUCTION), , $(error Can only run with CONFIRM_PRODUCTION))
+	$(eval DEPLOY_ENV=dttpimport)
+	$(eval SPACE=bat-prod)
+	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-production)
+
 sandbox:
 	$(eval DEPLOY_ENV=sandbox)
 	$(eval SPACE=bat-prod)

--- a/config/environments/dttpimport.rb
+++ b/config/environments/dttpimport.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require Rails.root.join("config/environments/production")

--- a/config/settings/dttpimport.yml
+++ b/config/settings/dttpimport.yml
@@ -1,0 +1,39 @@
+# The url for this app, also used by `dfe_sign_in`
+base_url: https://register-dttpimport.london.cloudapps.digital
+
+dttp:
+  back_office_url: https://dttp.crm4.dynamics.com/
+  scope: https://dttp.crm4.dynamics.com/.default
+  api_base_url: https://dttp.crm4.dynamics.com/api/data/v9.1
+
+dfe_sign_in:
+  # URL that the users are redirected to for signing in
+  issuer: https://oidc.signin.education.gov.uk
+  # URL of the users profile
+  profile: https://profile.signin.education.gov.uk
+
+features:
+  basic_auth: true
+  enable_feedback_link: false
+  sync_from_dttp: true
+  send_emails: false
+  persist_to_dttp: false
+  import_courses_from_ttapi: true
+  import_applications_from_apply: false
+  publish_course_details: true
+  routes:
+    early_years_assessment_only: true
+    early_years_postgrad: true
+    early_years_salaried: true
+    early_years_undergrad: true
+    opt_in_undergrad: true
+    pg_teaching_apprenticeship: true
+    provider_led_postgrad: true
+    provider_led_undergrad: true
+    school_direct_salaried: true
+    school_direct_tuition_fee: true
+  google:
+    send_data_to_big_query: false
+
+environment:
+  name: dttpimport

--- a/terraform/workspace-variables/app_config.yml
+++ b/terraform/workspace-variables/app_config.yml
@@ -25,3 +25,8 @@ review:
   <<: *default
   RAILS_ENV: review
   RACK_ENV: review
+
+dttpimport:
+  <<: *default
+  RAILS_ENV: dttpimport
+  RACK_ENV: dttpimport

--- a/terraform/workspace-variables/dttpimport.tfvars.json
+++ b/terraform/workspace-variables/dttpimport.tfvars.json
@@ -1,0 +1,17 @@
+{
+  "env_config": "dttpimport",
+  "key_vault_app_secret_name": "REGISTER-APP-SECRETS-DTTPIMPORT",
+  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-PRODUCTION",
+  "key_vault_name": "s121p01-shared-kv-01",
+  "key_vault_resource_group": "s121p01-shared-rg",
+  "paas_app_environment": "dttpimport",
+  "paas_app_start_timeout": 180,
+  "paas_postgres_service_plan": "small-11",
+  "paas_redis_service_plan": "tiny-5_x",
+  "paas_space_name": "bat-prod",
+  "paas_web_app_hostname": "dttpimport",
+  "paas_web_app_instances": 2,
+  "paas_web_app_memory": 1536,
+  "paas_worker_app_instances": 2,
+  "paas_worker_app_memory": 512
+}

--- a/terraform/workspace-variables/dttpimport_backend.tfvars
+++ b/terraform/workspace-variables/dttpimport_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s121p01-register"
+storage_account_name = "s121p01registerterraform"
+container_name       = "tfstate"
+key                  = "dttpimport-bat.tfstate"


### PR DESCRIPTION
### Context
We need a new production like environment to test import from DTTP

### Changes proposed in this pull request
Add DTTPIMPORT configuration in app, terraform, makefile, pipeline

### Guidance to review
Deployed app: https://register-dttpimport.london.cloudapps.digital/
Pipeline run: https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/1535998439
