### PR TITLE
[3282] Prevent duplicate trainee IDs

### DIFF
--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -3,11 +3,13 @@
 class TrainingDetailsForm < TraineeForm
   attr_accessor :trainee_id
 
+  validate :strip_trainee_id
   validates :trainee_id, presence: true,
                          length: {
                            maximum: 100,
                            message: I18n.t("activemodel.errors.models.training_details_form.attributes.trainee_id.max_char_exceeded"),
                          }
+  validate :trainee_id_uniqueness
 
   after_validation :update_trainee_attributes, if: -> { errors.empty? }
 
@@ -15,7 +17,49 @@ class TrainingDetailsForm < TraineeForm
     valid? && trainee.save
   end
 
+  def existing_short_name
+    existing_trainee_with_id.short_name || "another trainee"
+  end
+
+  def existing_created
+    date = existing_trainee_with_id.created_at
+    if date.today?
+      "today"
+    elsif date.yesterday?
+      "yesterday"
+    else
+      date.strftime("%-d %B %Y")
+    end
+  end
+
+  def duplicate_error?
+    errors[:trainee_id].include?(duplicate_error_message)
+  end
+
 private
+
+  delegate :provider_id, to: :trainee
+
+  def trainee_id_uniqueness
+    return if trainee_id.blank?
+    return unless existing_trainee_with_id
+
+    errors.add(:trainee_id, duplicate_error_message)
+  end
+
+  def existing_trainee_with_id
+    @existing_trainee_with_id ||= Trainee.where.not(id: trainee.id)
+      .where(provider_id: provider_id)
+      .where("UPPER(trainee_id) = ?", trainee_id.upcase).first
+  end
+
+  def duplicate_error_message
+    I18n.t("activemodel.errors.models.training_details_form.attributes.trainee_id.uniqueness")
+  end
+
+  def strip_trainee_id
+    self.trainee_id = trainee_id.to_s.strip
+  end
 
   def compute_fields
     trainee.attributes.symbolize_keys.slice(:trainee_id).merge(new_attributes)

--- a/app/views/trainees/training_details/_duplicate_error.html.erb
+++ b/app/views/trainees/training_details/_duplicate_error.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
+  <h2 id="error-summary-title" class="govuk-error-summary__title">
+    <%= GOVUKDesignSystemFormBuilder.default_error_summary_title %>
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <a data-turbolinks="false" href="#training-details-form-trainee-id-field-error">
+          <%= I18n.t("activemodel.errors.models.training_details_form.attributes.trainee_id.uniqueness") %>
+        </a>
+        <div class="govuk-error-summary__item-description">
+          <%= I18n.t(
+            "activemodel.errors.models.training_details_form.attributes.trainee_id.uniqueness_explanation",
+            trainee_id: form.object.trainee_id.strip,
+            short_name: form.object.existing_short_name,
+            created: form.object.existing_created,
+          ).html_safe %>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -7,7 +7,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(model: @training_details_form, url: trainee_training_details_path(@trainee), method: :put, local: true) do |f| %>
-      <%= f.govuk_error_summary %>
+      <% if f.object.duplicate_error? %>
+        <%= render "duplicate_error", form: f %>
+      <% else %>
+        <%= f.govuk_error_summary %>
+      <% end %>
 
       <%= render TraineeName::View.new(@trainee) %>
 

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -78,6 +78,12 @@
 .govuk-error-summary__list {
   color: $govuk-error-colour;
   font-weight: 700;
+
+  .govuk-error-summary__item-description {
+    font-weight: 400;
+    color: $govuk-error-colour;
+    margin-top: govuk-spacing(1);
+  }
 }
 
 .app-link--warning {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1307,6 +1307,8 @@ en:
             trainee_id:
               blank: Enter a trainee ID
               max_char_exceeded: Your entry must not exceed 100 characters
+              uniqueness: The trainee ID has already been used for another trainee
+              uniqueness_explanation: The ID ‘<span class="no-wrap">%{trainee_id}</span>’ has already been used for <span class="no-wrap">%{short_name}</span> (created <span class="no-wrap">%{created}</span>). Choose a new one or check if this is a duplicate trainee record.
         schools_form:
           attributes:
             query:

--- a/spec/forms/training_details_form_spec.rb
+++ b/spec/forms/training_details_form_spec.rb
@@ -47,6 +47,97 @@ describe TrainingDetailsForm, type: :model do
           expect(subject).to be_valid
         end
       end
+
+      context "duplicate" do
+        let!(:existing_trainee) { create(:trainee, trainee_id: "Test123") }
+        let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: "TEST123") }
+
+        it "returns a duplicate error message" do
+          expect(subject.errors[:trainee_id]).to include(
+            I18n.t("#{error_attr}.trainee_id.uniqueness"),
+          )
+          expect(subject.duplicate_error?).to be_truthy
+        end
+      end
+
+      context "same id but different provider" do
+        let!(:existing_trainee) { create(:trainee, trainee_id: "Test123") }
+        let(:trainee) { build(:trainee, trainee_id: "TEST123") }
+
+        it "returns a duplicate error message" do
+          expect(subject.errors[:trainee_id]).not_to include(
+            I18n.t("#{error_attr}.trainee_id.uniqueness"),
+          )
+          expect(subject.duplicate_error?).to be_falsey
+        end
+      end
+    end
+  end
+
+  describe "#existing_trainee_with_id" do
+    context "same provider and id" do
+      let!(:existing_trainee) { create(:trainee, trainee_id: "Test123") }
+      let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: "TEST123") }
+
+      it "returns existing_trainee" do
+        expect(subject.send(:existing_trainee_with_id)).to eql(existing_trainee)
+      end
+    end
+
+    context "different provider and same id" do
+      let!(:existing_trainee) { create(:trainee, trainee_id: "Test123") }
+      let(:trainee) { build(:trainee, trainee_id: "TEST123") }
+
+      it "returns existing_trainee" do
+        expect(subject.send(:existing_trainee_with_id)).not_to eql(existing_trainee)
+      end
+    end
+  end
+
+  describe "#existing_short_name" do
+    let!(:existing_trainee) { create(:trainee, trainee_id: "Test123") }
+    let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: "TEST123") }
+
+    it "returns short_name" do
+      expect(subject.existing_short_name).to eql(existing_trainee.short_name)
+    end
+  end
+
+  describe "#existing_created" do
+    context "today" do
+      let!(:existing_trainee) { create(:trainee, trainee_id: "Test123", created_at: Time.zone.now) }
+      let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: "TEST123") }
+
+      it "returns today" do
+        expect(subject.existing_created).to eql("today")
+      end
+    end
+
+    context "yesterday" do
+      let!(:existing_trainee) { create(:trainee, trainee_id: "Test123", created_at: 1.day.ago) }
+      let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: "TEST123") }
+
+      it "returns yesterday" do
+        expect(subject.existing_created).to eql("yesterday")
+      end
+    end
+
+    context "other dates" do
+      let!(:existing_trainee) { create(:trainee, trainee_id: "Test123", created_at: 10.days.ago) }
+      let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: "TEST123") }
+
+      it "returns date formatted" do
+        expect(subject.existing_created).to eql(existing_trainee.created_at.strftime("%-d %B %Y"))
+      end
+    end
+  end
+
+  describe "remove white space" do
+    let(:trainee) { build(:trainee, trainee_id: "  TEST123  ") }
+
+    it "returns short_name" do
+      subject.valid?
+      expect(subject.trainee_id).to eql("TEST123")
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/JhlzfNTy/3282-m-prevent-duplicate-trainee-ids

### Changes proposed in this pull request

* Added uniqueness validation to `trainee_id` scoped to `provider_id`
* Add partial for the custom error message for duplicate trainee_id

### Guidance to review

* Copy trainee_id from an existing record
* Add new trainee, set trainee_id and try to submit Trainee ID form
