### PR TITLE
fix link issue

### DIFF
--- a/db/service_updates.yml
+++ b/db/service_updates.yml
@@ -2,6 +2,7 @@
   title: The Department for Education (DfE) has published the provisional data for the 2021 initial teacher training (ITT) census
   content: >-
     DfE has published the provisional data for the ITT census for September and October 2021. The publication provides national and provider-level information about the numbers and characteristics of new entrants to <span class="no-wrap">initial teacher training</span> in England in the academic year <span class="no-wrap">2021 to 2022</span>.
+    
 
     [Read the provisional 2021 census data publication](https://www.gov.uk/government/statistics/initial-teacher-training-trainee-number-census-2021-to-2022)
 


### PR DESCRIPTION
The census link should be on its own and not wrapped on to the end of the para. 

Make the census link stand-alone underneath the copy.


