### PR TITLE
[3326] Fix course list label linking

### DIFF
--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -25,11 +25,12 @@
           legend: { text: t(".course_code_label"), tag: "h1", size: "m" },
           hint: { text: courses_fieldset_text_for(@trainee) },
           classes: "published-courses" do %>
-          <% @courses.each do |course| %>
+          <% @courses.each_with_index do |course, i| %>
             <%= f.govuk_radio_button :course_uuid, course.uuid,
               label: { text: "#{course.name} (#{course.code})" },
-              hint: { text: course_summary_text_for(@trainee, course) },
-              link_errors: true %>
+              hint: { text: course_summary_text_for(@trainee, course) }, 
+              link_errors: i == 0
+            %>
           <% end %>
 
           <div class="govuk-radios__divider">or</div>


### PR DESCRIPTION
### Context

We use the form builder to render a list of courses. When that form goes into an error state the link between the label and the radio is broken.

This is happening when all radio buttons are set to `link_errors: true` the form builder names them all identically so every label in the list is effectively linked to the first radio button.

![image](https://user-images.githubusercontent.com/5216/144872174-72d362f1-f446-4254-8e22-6dab80e1ad99.gif)

Removing `link_errors: true` on all radios breaks the link from the error summary.

We want both the error summary link and the label behaviour 🤔

We do have this working on the training route page but on that page the `Assessment only` radio is rendered individually with `link_errors: true` and the rest are then rendered in a loop without that attribute.

### Changes proposed in this pull request

So... 🥁 Make only the first radio button `link_errors: true` on the course list page and the rest false.

![2021-12-06 15 49 22](https://user-images.githubusercontent.com/5216/144877754-7bb11cc5-4bab-4d2b-8a2b-82aaf14717fe.gif)


@peteryates is there a 'proper' way to do this that I'm missing? 

### Guidance to review

