### PR TITLE
[xxx] Remove null constraint from `dttp_placement_assignments`

### DIFF
--- a/db/migrate/20211208144036_remove_null_constraint_from_dttp_placement_assignments.rb
+++ b/db/migrate/20211208144036_remove_null_constraint_from_dttp_placement_assignments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNullConstraintFromDttpPlacementAssignments < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :dttp_placement_assignments, :contact_dttp_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_02_142506) do
+ActiveRecord::Schema.define(version: 2021_12_08_144036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -217,7 +217,7 @@ ActiveRecord::Schema.define(version: 2021_12_02_142506) do
     t.jsonb "response"
     t.integer "state", default: 0
     t.uuid "dttp_id", null: false
-    t.uuid "contact_dttp_id", null: false
+    t.uuid "contact_dttp_id"
     t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["dttp_id"], name: "index_dttp_placement_assignments_on_dttp_id", unique: true


### PR DESCRIPTION
### Context

Remove null constraint from contact_dttp_id column on dttp_placement_assignments table
When testing the sync, there were dttp_placement_assignment records with no contact_dttp_id.

### Changes proposed in this pull request

- Migration to remove null constraint.

### Guidance to review

🚢 