### PR TITLE
[3299] Show not available in the export if funding not available

### DIFF
--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -121,6 +121,10 @@ module Exports
       end
     end
 
+    def funding_manager(trainee)
+      FundingManager.new(trainee)
+    end
+
     def funding_method(trainee)
       if trainee.applying_for_bursary?
         FUNDING_TYPE_ENUMS[:bursary]
@@ -130,11 +134,13 @@ module Exports
         FUNDING_TYPE_ENUMS[:grant]
       elsif [trainee.applying_for_bursary, trainee.applying_for_scholarship, trainee.applying_for_grant].include?(false)
         "not funded"
+      elsif !funding_manager(trainee).funding_available?
+        "not available"
       end
     end
 
     def funding_value(trainee)
-      funding_manager = FundingManager.new(trainee)
+      funding_manager = funding_manager(trainee)
 
       if trainee.applying_for_bursary?
         funding_manager.bursary_amount

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -178,6 +178,11 @@ module Exports
         trainee = Trainee.new(applying_for_grant: false)
         expect(subject.send(:funding_method, trainee)).to eq("not funded")
       end
+
+      it "returns not available" do
+        trainee = Trainee.new(training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
+        expect(subject.send(:funding_method, trainee)).to eq("not available")
+      end
     end
 
     describe "#course_summary" do


### PR DESCRIPTION
### Context

Where funding isn't available for a trainee / their course, we should show `not applicable` in the export.

### Changes proposed in this pull request

Add not available option to conditional in export.

### Guidance to review

