### PR TITLE
[xxx] Extend parsing of dttp_placement_assignments during sync

### DIFF
--- a/app/lib/dttp/parsers/placement_assignment.rb
+++ b/app/lib/dttp/parsers/placement_assignment.rb
@@ -9,6 +9,11 @@ module Dttp
             {
               dttp_id: placement_assignment["dfe_placementassignmentid"],
               contact_dttp_id: placement_assignment["_dfe_contactid_value"],
+              provider_dttp_id: placement_assignment["_dfe_providerid_value"],
+              academic_year: placement_assignment["_dfe_academicyearid_value"],
+              programme_start_date: placement_assignment["dfe_programmestartdate"],
+              programme_end_date: placement_assignment["dfe_programmeenddate"],
+              trainee_status: placement_assignment["_dfe_traineestatusid_value"],
               response: placement_assignment,
             }
           end

--- a/db/migrate/20211209144401_add_extra_columns_to_dttp_placement_assignment.rb
+++ b/db/migrate/20211209144401_add_extra_columns_to_dttp_placement_assignment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddExtraColumnsToDttpPlacementAssignment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :dttp_placement_assignments, :provider_dttp_id, :uuid
+    add_column :dttp_placement_assignments, :academic_year, :uuid
+    add_column :dttp_placement_assignments, :programme_start_date, :date
+    add_column :dttp_placement_assignments, :programme_end_date, :date
+    add_column :dttp_placement_assignments, :trainee_status, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_08_144036) do
+ActiveRecord::Schema.define(version: 2021_12_09_144401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -220,6 +220,11 @@ ActiveRecord::Schema.define(version: 2021_12_08_144036) do
     t.uuid "contact_dttp_id"
     t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.uuid "provider_dttp_id"
+    t.uuid "academic_year"
+    t.date "programme_start_date"
+    t.date "programme_end_date"
+    t.uuid "trainee_status"
     t.index ["dttp_id"], name: "index_dttp_placement_assignments_on_dttp_id", unique: true
   end
 

--- a/spec/factories/dttp/api_placement_assignment.rb
+++ b/spec/factories/dttp/api_placement_assignment.rb
@@ -2,8 +2,27 @@
 
 FactoryBot.define do
   factory :api_placement_assignment, class: Hash do
-    dfe_placementassignmentid { SecureRandom.uuid }
-    _dfe_contactid_value { SecureRandom.uuid }
+    transient do
+      dttp_id { SecureRandom.uuid }
+      contact_dttp_id { SecureRandom.uuid }
+      provider_dttp_id { SecureRandom.uuid }
+      enabled_training_routes { TRAINING_ROUTE_ENUMS.values - ["hpitt_postgrad"] }
+    end
+    dfe_placementassignmentid { dttp_id }
+    _dfe_contactid_value { contact_dttp_id }
+    _dfe_providerid_value { provider_dttp_id }
+    _dfe_routeid_value { Dttp::CodeSets::Routes::MAPPING.select { |key, _values| enabled_training_routes.include?(key) }.values.sample[:entity_id] }
+    _dfe_ittsubject1id_value { Dttp::CodeSets::CourseSubjects::MAPPING.to_a.sample[1][:entity_id] }
+    _dfe_ittsubject2id_value { Dttp::CodeSets::CourseSubjects::MAPPING.to_a.sample[1][:entity_id] }
+    _dfe_ittsubject3id_value { Dttp::CodeSets::CourseSubjects::MAPPING.to_a.sample[1][:entity_id] }
+    dfe_programmestartdate { Faker::Date.in_date_period(month: 9).strftime("%Y-%m-%d") }
+    dfe_programmeeenddate { Faker::Date.in_date_period(month: 8, year: Faker::Date.in_date_period.year + 1).strftime("%Y-%m-%d") }
+    dfe_commencementdate { Faker::Date.between(from: dfe_programmestartdate, to: dfe_programmeeenddate).strftime("%Y-%m-%d") }
+    _dfe_coursephaseid_value { Dttp::CodeSets::AgeRanges::MAPPING.to_a.sample[1][:entity_id] }
+    _dfe_studymodeid_value { Dttp::CodeSets::CourseStudyModes::MAPPING.to_a.sample[1][:entity_id] }
+    dfe_trnassessmentdate { dfe_programmestartdate }
+    _dfe_traineestatusid_value { "295af972-9e1b-e711-80c7-0050568902d3" }
+    _dfe_academicyearid_value { SecureRandom.uuid }
 
     initialize_with { attributes.stringify_keys }
     to_create { |instance| instance }

--- a/spec/factories/dttp/placement_assignments.rb
+++ b/spec/factories/dttp/placement_assignments.rb
@@ -4,11 +4,21 @@ FactoryBot.define do
   factory :dttp_placement_assignment, class: "Dttp::PlacementAssignment" do
     dttp_id { SecureRandom.uuid }
     contact_dttp_id { SecureRandom.uuid }
+    provider_dttp_id { SecureRandom.uuid }
+    academic_year { SecureRandom.uuid }
+    programme_start_date { Faker::Date.in_date_period(month: 9) }
+    programme_end_date { Faker::Date.in_date_period(month: 8, year: Faker::Date.in_date_period.year + 1) }
+    trainee_status { SecureRandom.uuid }
     response {
-      {
-        dfe_placementassignmentid: dttp_id,
-        _dfe_contactid_value: contact_dttp_id,
-      }
+      create(
+        :api_placement_assignment,
+        dttp_id: dttp_id,
+        contact_dttp_id: contact_dttp_id,
+        provider_dttp_id: provider_dttp_id,
+        _dfe_academicyearid_value: academic_year,
+        dfe_programmestartdate: programme_start_date.strftime("%Y-%m-%d"),
+        dfe_programmeenddate: programme_end_date.strftime("%Y-%m-%d"),
+      )
     }
     state { "unprocessed" }
   end

--- a/spec/lib/dttp/parsers/placement_assignment_spec.rb
+++ b/spec/lib/dttp/parsers/placement_assignment_spec.rb
@@ -12,6 +12,11 @@ module Dttp
           {
             dttp_id: placement_assignment["dfe_placementassignmentid"],
             contact_dttp_id: placement_assignment["_dfe_contactid_value"],
+            provider_dttp_id: placement_assignment["_dfe_providerid_value"],
+            academic_year: placement_assignment["_dfe_academicyearid_value"],
+            programme_start_date: placement_assignment["dfe_programmestartdate"],
+            programme_end_date: placement_assignment["dfe_programmeenddate"],
+            trainee_status: placement_assignment["_dfe_traineestatusid_value"],
             response: placement_assignment,
           }
         end


### PR DESCRIPTION
### Context

https://trello.com/c/opWyzYH6/3350-pull-more-data-out-of-dttp-sync-into-db-columns-for-analysis

### Changes proposed in this pull request

Pull out provider_dttp_id, academic_year, trainee_status, programme_start_date
and programme_end_date from the dttp_placement_assignment response.

This is to aid analysis of the raw data e.g. "how many active trainees are there in each year?"

We will need to re-run `Dttp::SyncPlacementAssignmentsJob` after this is added.

### Guidance to review

