### PR TITLE
[3296] Improve degree type option for `Higher Degree`

### DIFF
--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -10,7 +10,8 @@ const defaultValueOption = component => component.getAttribute('data-default-val
 const suggestion = (value, options) => {
   const option = options.find(o => o.name === value)
   if (option) {
-    return option.append ? `<span>${value}</span> ${option.append}` : `<span>${value}</span>`
+    const html = option.append ? `<span>${value}</span> ${option.append}` : `<span>${value}</span>`
+    return option.hint ? `${html}<br>${option.hint}` : html
   }
 }
 
@@ -19,6 +20,7 @@ const enhanceOption = (option) => {
     name: option.label,
     synonyms: (option.getAttribute('data-synonyms') ? option.getAttribute('data-synonyms').split('|') : []),
     append: option.getAttribute('data-append'),
+    hint: option.getAttribute('data-hint'),
     boost: (parseFloat(option.getAttribute('data-boost')) || 1)
   }
 }

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -10,7 +10,8 @@ module DegreesHelper
         "data-synonyms" => synonyms.join("|"),
         "data-append" => attributes[:abbreviation] && tag.strong("(#{attributes[:abbreviation]})"),
         "data-boost" => (Dttp::CodeSets::DegreeTypes::COMMON.include?(name) ? 1.5 : 1),
-      }
+        "data-hint" => attributes[:hint],
+      }.compact
       [name, name, data]
     end
   end

--- a/app/lib/dttp/code_sets/degree_types.rb
+++ b/app/lib/dttp/code_sets/degree_types.rb
@@ -56,12 +56,12 @@ module Dttp
         "Bachelor of Veterinary Science" => { entity_id: "356a5652-c197-e711-80d8-005056ac45bb", abbreviation: "BVsc", hesa_code: "96" },
         "Bachelor of Education Scotland and Northern Ireland" => { entity_id: "376a5652-c197-e711-80d8-005056ac45bb", abbreviation: "BEd", hesa_code: "97" },
         "Bachelor of Philosophy" => { entity_id: "396a5652-c197-e711-80d8-005056ac45bb", abbreviation: "BPhil", hesa_code: "98" },
-        "BEd" => { entity_id: "c1695652-c197-e711-80d8-005056ac45bb", abbreviation: nil, hesa_code: "1" },
-        "BSc/Education" => { entity_id: "c5695652-c197-e711-80d8-005056ac45bb", abbreviation: nil, hesa_code: "3" },
-        "BTech/Education" => { entity_id: "c9695652-c197-e711-80d8-005056ac45bb", abbreviation: nil, hesa_code: "5" },
-        "BA/Education" => { entity_id: "c9695652-c197-e711-80d8-005056ac45bb", abbreviation: nil, hesa_code: "7" },
-        "BA Combined Studies/Education of the Deaf" => { entity_id: "d1695652-c197-e711-80d8-005056ac45bb", abbreviation: nil, hesa_code: "9" },
-        "BA with intercalated PGCE" => { entity_id: "d5695652-c197-e711-80d8-005056ac45bb", abbreviation: nil, hesa_code: "12" },
+        "BEd" => { entity_id: "c1695652-c197-e711-80d8-005056ac45bb", hesa_code: "1" },
+        "BSc/Education" => { entity_id: "c5695652-c197-e711-80d8-005056ac45bb", hesa_code: "3" },
+        "BTech/Education" => { entity_id: "c9695652-c197-e711-80d8-005056ac45bb", hesa_code: "5" },
+        "BA/Education" => { entity_id: "c9695652-c197-e711-80d8-005056ac45bb", hesa_code: "7" },
+        "BA Combined Studies/Education of the Deaf" => { entity_id: "d1695652-c197-e711-80d8-005056ac45bb", hesa_code: "9" },
+        "BA with intercalated PGCE" => { entity_id: "d5695652-c197-e711-80d8-005056ac45bb", hesa_code: "12" },
         "Master of Arts" => {
           entity_id: "3b6a5652-c197-e711-80d8-005056ac45bb",
           abbreviation: "MA",
@@ -104,7 +104,7 @@ module Dttp
           synonyms: ["masters of theology"],
           hesa_code: "206",
         },
-        "Certificate of Membership of Cranfield Institute of Technology" => { entity_id: "496a5652-c197-e711-80d8-005056ac45bb", abbreviation: nil, hesa_code: "207" },
+        "Certificate of Membership of Cranfield Institute of Technology" => { entity_id: "496a5652-c197-e711-80d8-005056ac45bb", hesa_code: "207" },
         "Master of Education" =>
         {
           entity_id: "4b6a5652-c197-e711-80d8-005056ac45bb",
@@ -160,11 +160,11 @@ module Dttp
         "Doctor of Music" => { entity_id: "616a5652-c197-e711-80d8-005056ac45bb", abbreviation: "DMu", hesa_code: "303" },
         "Doctor of Science" => { entity_id: "636a5652-c197-e711-80d8-005056ac45bb", abbreviation: "DSc", hesa_code: "304" },
         "Doctor of Philosophy" => { entity_id: "656a5652-c197-e711-80d8-005056ac45bb", abbreviation: "DPhil", hesa_code: "305" },
-        "PhD" => { entity_id: "676a5652-c197-e711-80d8-005056ac45bb", abbreviation: nil, hesa_code: "306" },
-        "First Degree" => { entity_id: "696a5652-c197-e711-80d8-005056ac45bb", abbreviation: nil, hesa_code: "400" },
-        "Higher Degree" => {
+        "PhD" => { entity_id: "676a5652-c197-e711-80d8-005056ac45bb", hesa_code: "306" },
+        "First Degree" => { entity_id: "696a5652-c197-e711-80d8-005056ac45bb", hesa_code: "400" },
+        "Higher degree or equivalent" => {
           entity_id: "6b6a5652-c197-e711-80d8-005056ac45bb",
-          abbreviation: nil,
+          hint: "Including level 7, level 8, masters, postgraduate certificates and diplomas",
           synonyms: [
             "Other",
             # Level 7 qualifications
@@ -190,7 +190,6 @@ module Dttp
         },
         "Degree equivalent" => {
           entity_id: "6d6a5652-c197-e711-80d8-005056ac45bb",
-          abbreviation: nil,
           synonyms: [
             "Other",
             # Level 6 qualifications

--- a/db/data/20211210162725_change_higher_degree_to_higher_degree_or_equivalent.rb
+++ b/db/data/20211210162725_change_higher_degree_to_higher_degree_or_equivalent.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeHigherDegreeToHigherDegreeOrEquivalent < ActiveRecord::Migration[6.1]
+  def up
+    Degree.where(uk_degree: "Higher Degree").update_all(uk_degree: "Higher degree or equivalent")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
[3295-substitution-phrases-for-school-search](https://trello.com/c/MBxMhgWo/3296-improve-degree-type-option-for-higher-degree)

### Changes proposed in this pull request
- Changed "Higher Degree" to "Higher degree or equivalent"
- Data migration to change existing degrees with "Higher Degree" to "Higher degree or equivalent"

### Guidance to review
- Visit degree form page
- Type "postgrad" in degree type field
- Hint text should be displayed underneath "Higher Degree"

<img width="441" alt="Screenshot 2021-12-10 at 14 43 39" src="https://user-images.githubusercontent.com/28728/145591992-a98aa963-db4c-49b1-8c57-cfebc4e7b291.png">

