### PR TITLE
[3311] Enable draft records page

### DIFF
--- a/app/components/status_tag/view.rb
+++ b/app/components/status_tag/view.rb
@@ -42,7 +42,7 @@ private
   end
 
   def record_progress_tag
-    return if @trainee.submission_ready? || !@trainee.awaiting_action?
+    return if @trainee.draft? || @trainee.submission_ready? || !@trainee.awaiting_action?
 
     { status: "incomplete", status_colour: "grey", classes: classes.concat(%w[govuk-tag--white]) }
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,7 +8,6 @@ class PagesController < ApplicationController
     if authenticated?
       @trainees = policy_scope(Trainee.all)
       @home_view = HomeView.new(@trainees)
-      @registered_states_for_filter = HomeView::REGISTERED_STATES_FOR_FILTER
       render(:home)
     else
       render(:start)

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -51,9 +51,7 @@ private
   end
 
   def search_primary_result_set
-    # We can't use `#draft` to find @draft_trainees since that applies a `WHERE`
-    # clause, removing Kaminari's pagination. Hence the use of `#select`.
-    paginated_trainees.select(&:draft?)
+    []
   end
 
   def search_secondary_result_title
@@ -65,7 +63,7 @@ private
   end
 
   def trainee_search_scope
-    Trainee.includes(provider: [:courses])
+    Trainee.includes(provider: [:courses]).where.not(state: "draft")
   end
 
   def export_results_path

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 module NavigationHelper
-  def active_link_for(segment)
+  def active_link_for(segment, trainee = nil)
     url = request.path_info
-    url.include?("/#{segment}")
+
+    {
+      drafts: -> { trainee&.draft? && segment == "drafts" },
+      trainees: -> { url.include?("/#{segment}") && !trainee&.draft? },
+    }[segment.to_sym].call
   end
 end

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -16,19 +16,21 @@ module TraineeHelper
     end
   end
 
-  def trainees_page_title(trainees, total_trainees_count)
+  def trainees_page_title(trainees, total_trainees_count, draft: false)
     total_pages = trainees.total_pages
     total_trainees_count_text = "#{total_trainees_count} #{'record'.pluralize(total_trainees_count)}"
 
+    i18n_prefix = draft ? "components.page_titles.draft_trainees" : "components.page_titles.trainees"
+
     if total_pages <= 1
       return I18n.t(
-        "components.page_titles.trainees.index",
+        "#{i18n_prefix}.index",
         total_trainees_count_text: total_trainees_count_text,
       )
     end
 
     I18n.t(
-      "components.page_titles.trainees.paginated_index",
+      "#{i18n_prefix}.paginated_index",
       current_page: trainees.current_page,
       total_pages: total_pages,
       total_trainees_count_text: total_trainees_count_text,

--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class HomeView
-  REGISTERED_STATES_FOR_FILTER = %w[submitted_for_trn trn_received qts_recommended
-                                    eyts_recommended withdrawn deferred qts_awarded
-                                    eyts_awarded].freeze
-
   def initialize(trainees)
     @trainees = Trainees::Filter.call(trainees: trainees, filters: {})
     populate_state_counts!

--- a/app/views/drafts/index.html.erb
+++ b/app/views/drafts/index.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <h1 class="govuk-heading-xl" aria-live="polite">
-  Draft trainees (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
+  Draft records (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
 </h1>
 
 <% unless current_user.system_admin? %>

--- a/app/views/drafts/index.html.erb
+++ b/app/views/drafts/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: trainees_page_title(paginated_trainees, total_trainees_count)) %>
+<%= render PageTitle::View.new(text: trainees_page_title(paginated_trainees, total_trainees_count, draft: true)) %>
 
 <% if paginated_trainees.current_page > 1 %>
   <span class="govuk-caption-xl">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,8 @@
     <%= render NavigationBar::View.new(
       items: [
         { name: "Home", url: root_path },
-        { name: "Trainee records", url: trainees_path, current: active_link_for("trainees") },
+        { name: "Draft records", url: drafts_path, current: active_link_for("drafts", @trainee) },
+        { name: "Trainee records", url: trainees_path, current: active_link_for("trainees", @trainee) },
       ],
       current_path: request.path,
       current_user: @current_user,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
       items: [
         { name: "Home", url: root_path },
         { name: "Draft records", url: drafts_path, current: active_link_for("drafts", @trainee) },
-        { name: "Trainee records", url: trainees_path, current: active_link_for("trainees", @trainee) },
+        { name: "Registered trainees", url: trainees_path, current: active_link_for("trainees", @trainee) },
       ],
       current_path: request.path,
       current_user: @current_user,

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -12,7 +12,7 @@
         <li>
           <%= govuk_link_to(
             t(".draft_trainees_link", count: @home_view.draft_trainees_count),
-            trainees_path("state[]": :draft),
+            drafts_path,
             { class: "govuk-link--no-visited-state" }
           )%>
         </li>
@@ -21,7 +21,7 @@
         <li>
           <%= govuk_link_to(
             t(".draft_apply_trainees_link", count: @home_view.draft_apply_trainees_count),
-            trainees_path("state[]": :draft, "record_source[]": :apply),
+            drafts_path("record_source[]": :apply),
             { class: "govuk-link--no-visited-state" }
           )%>
         </li>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -49,7 +49,7 @@
         <li>
           <%= govuk_link_to(
             t(".registered_trainees_link", count: @home_view.registered_trainees_count),
-            trainees_path({ "state": @registered_states_for_filter }),
+            trainees_path,
             { class: "govuk-link--no-visited-state" }
           )%>
         </li>

--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -163,6 +163,7 @@
         </legend>
         <div class="govuk-checkboxes govuk-checkboxes--small">
           <% TraineeFilter::STATES.each do |state, _| %>
+            <% next if state == "draft" %>
             <div class="govuk-checkboxes__item">
               <%= check_box_tag "state[]", state, checked?(filters, :state, state), id: "state-#{state}", class: "govuk-checkboxes__input" %>
               <%= label_tag "state-#{state}", label_for("state", state), class: "govuk-label govuk-checkboxes__label" %>

--- a/app/views/trainees/_results.html.erb
+++ b/app/views/trainees/_results.html.erb
@@ -1,6 +1,6 @@
 <% if paginated_trainees.any? %>
   <% if search_primary_result_set.any? %>
-    <div class="govuk-!-margin-bottom-8 app-draft-records">
+    <div class="govuk-!-margin-bottom-8">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <h2 class="govuk-heading-m"><%= search_primary_result_title %></h2>
@@ -11,7 +11,7 @@
   <% end %>
 
   <% if search_secondary_result_set.any? %>
-    <div class="govuk-!-margin-bottom-8 app-non-draft-records">
+    <div class="govuk-!-margin-bottom-8">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <h2 class="govuk-heading-m"><%= search_secondary_result_title %></h2>

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -54,4 +54,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Return to this draft later", trainees_path, { id: "return-to-draft-later" }) %></p>
+<p class="govuk-body"><%= govuk_link_to("Return to this draft later", drafts_path, { id: "return-to-draft-later" }) %></p>

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <h1 class="govuk-heading-xl" aria-live="polite">
-  Trainee records (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
+  Registered trainees (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
 </h1>
 
 <% unless current_user.system_admin? %>

--- a/app/views/trainees/new.html.erb
+++ b/app/views/trainees/new.html.erb
@@ -11,6 +11,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with model: @trainee, local: true do |f| %>
       <%= f.govuk_error_summary %>
+      <%= render TraineeName::View.new(@trainee) %>
       <%= render "trainees/training_routes/form_fields", f: f %>
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/trainees/review_drafts/show.html.erb
+++ b/app/views/trainees/review_drafts/show.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render FilteredBackLink::View.new(
     href: trainees_path,
-    text: t("views.all_records"),
+    text: t("views.draft_records"),
   ) %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,9 @@ en:
         show: Successfully submitted
       check_details:
         show: Check trainee record
+      draft_trainees:
+        index: Draft records (%{total_trainees_count_text})
+        paginated_index: Draft records (%{total_trainees_count_text}) - page %{current_page} of %{total_pages}
       trainees:
         delete: Delete this draft record
         index: Trainee records (%{total_trainees_count_text})

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -239,8 +239,8 @@ en:
         paginated_index: Draft records (%{total_trainees_count_text}) - page %{current_page} of %{total_pages}
       trainees:
         delete: Delete this draft record
-        index: Trainee records (%{total_trainees_count_text})
-        paginated_index: Trainee records (%{total_trainees_count_text}) - page %{current_page} of %{total_pages}
+        index: Registered trainees (%{total_trainees_count_text})
+        paginated_index: Registered trainees (%{total_trainees_count_text}) - page %{current_page} of %{total_pages}
         not_supported_route: Other routes not supported
         show:
           overview: Trainee record overview

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -478,6 +478,7 @@ en:
         study_mode: Full time or part time
   views:
     all_records: All records
+    draft_records: All drafts
     apply_invalid_data_view:
       invalid_answers_summary:
         one: This application contains 1 answer that you need to amend. This is because it was entered in a free text format.

--- a/db/service_updates.yml
+++ b/db/service_updates.yml
@@ -1,16 +1,21 @@
+- date: '2022-01-04'
+  title: Draft records are now separate from the list of registered records
+  content: >-
+    Instead of having a single list with all of your records, there are now separate lists for draft and registered records.
+
 - date: '2021-12-21'
   title: Support during the Christmas period
   content: >-
     The support desk will close at 2pm on Friday 24 December 2021. It will open again on Tuesday 4 January 2022.
-    
-    
+
+
     If you have an urgent problem during this time, you can still contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
-    
+
 - date: '2021-12-03'
   title: The Department for Education (DfE) has published the provisional data for the 2021 initial teacher training (ITT) census
   content: >-
     DfE has published the provisional data for the ITT census for September and October 2021. The publication provides national and provider-level information about the numbers and characteristics of new entrants to <span class="no-wrap">initial teacher training</span> in England in the academic year <span class="no-wrap">2021 to 2022</span>.
-    
+
 
     [Read the provisional 2021 census data publication](https://www.gov.uk/government/statistics/initial-teacher-training-trainee-number-census-2021-to-2022)
 

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Filtering trainees" do
 
   scenario "can filter by apply_drafts" do
     when_i_filter_by_apply_draft_status
-    then_only_the_apply_draft_trainee_is_visible
+    then_only_the_apply_non_draft_trainee_is_visible
   end
 
   scenario "when all trainees are from a single source" do
@@ -44,8 +44,8 @@ RSpec.feature "Filtering trainees" do
   end
 
   scenario "can filter by status" do
-    when_i_filter_by_draft_status
-    then_only_the_draft_trainee_is_visible
+    when_i_filter_by_trn_received_status
+    then_only_the_trn_received_trainee_is_visible
   end
 
   scenario "can filter by level" do
@@ -131,17 +131,18 @@ RSpec.feature "Filtering trainees" do
 private
 
   def given_trainees_exist_in_the_system
-    @assessment_only_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
-    @provider_led_postgrad_trainee ||= create(:trainee, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
-    @biology_trainee ||= create(:trainee, :with_subject_specialism, subject_name: CourseSubjects::BIOLOGY)
-    @history_trainee ||= create(:trainee, :with_subject_specialism, subject_name: CourseSubjects::HISTORY)
-    @searchable_trainee ||= create(:trainee, trn: "123")
-    @draft_trainee ||= create(:trainee, :draft)
-    @non_draft_trainee ||= create(:trainee, :submitted_for_trn)
+    @assessment_only_trainee ||= create(:trainee, :submitted_for_trn, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
+    @provider_led_postgrad_trainee ||= create(:trainee, :submitted_for_trn, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
+    @biology_trainee ||= create(:trainee, :submitted_for_trn, :with_subject_specialism, subject_name: CourseSubjects::BIOLOGY)
+    @history_trainee ||= create(:trainee, :submitted_for_trn, :with_subject_specialism, subject_name: CourseSubjects::HISTORY)
+    @searchable_trainee ||= create(:trainee, :submitted_for_trn, trn: "123")
+    @complete_trainee ||= create(:trainee, :completed, :submitted_with_start_date)
+    @incomplete_trainee ||= create(:trainee, :submitted_for_trn)
+    @trn_received_trainee ||= create(:trainee, :submitted_for_trn, :trn_received)
     @withdrawn_trainee ||= create(:trainee, :withdrawn)
-    @early_years_trainee ||= create(:trainee, :early_years_undergrad)
-    @primary_trainee ||= create(:trainee, course_age_range: AgeRange::THREE_TO_EIGHT)
-    @apply_draft_trainee ||= create(:trainee, :with_apply_application)
+    @early_years_trainee ||= create(:trainee, :submitted_for_trn, :early_years_undergrad)
+    @primary_trainee ||= create(:trainee, :submitted_for_trn, course_age_range: AgeRange::THREE_TO_EIGHT)
+    @apply_non_draft_trainee ||= create(:trainee, :submitted_for_trn, :with_apply_application)
     Trainee.update_all(provider_id: @current_user.provider.id)
   end
 
@@ -167,8 +168,8 @@ private
     trainee_index_page.apply_filters.click
   end
 
-  def when_i_filter_by_draft_status
-    trainee_index_page.draft_checkbox.click
+  def when_i_filter_by_trn_received_status
+    trainee_index_page.trn_received_checkbox.click
     trainee_index_page.apply_filters.click
   end
 
@@ -193,6 +194,7 @@ private
   end
 
   def when_i_filter_by_incomplete
+    @incomplete_trainee.update(commencement_date: nil)
     trainee_index_page.incomplete_checkbox.check
     trainee_index_page.apply_filters.click
   end
@@ -234,7 +236,7 @@ private
   end
 
   def then_all_trainees_are_visible
-    Trainee.all.each { |trainee| expect(trainee_index_page).to have_text(full_name(trainee)) }
+    Trainee.where.not(state: "draft").each { |trainee| expect(trainee_index_page).to have_text(full_name(trainee)) }
   end
 
   def then_only_biology_trainees_are_visible
@@ -243,11 +245,11 @@ private
   end
 
   def then_only_complete_records_are_visible
-    expect(trainee_index_page).to have_text(full_name(@non_draft_trainee))
+    expect(trainee_index_page).to have_text(full_name(@complete_trainee))
   end
 
   def then_only_incomplete_records_are_visible
-    expect(trainee_index_page).to have_text(full_name(@draft_trainee))
+    expect(trainee_index_page).to have_text(full_name(@incomplete_trainee))
   end
 
   def then_only_the_searchable_trainee_is_visible
@@ -257,19 +259,17 @@ private
       @provider_led_postgrad_trainee,
       @history_trainee,
       @biology_trainee,
-      @draft_trainee,
     ].each do |trainee|
       expect(trainee_index_page).not_to have_text(full_name(trainee))
     end
   end
 
-  def then_only_the_apply_draft_trainee_is_visible
-    expect(trainee_index_page).to have_text(full_name(@apply_draft_trainee))
-    expect(trainee_index_page).not_to have_text(full_name(@draft_trainee))
+  def then_only_the_apply_non_draft_trainee_is_visible
+    expect(trainee_index_page).to have_text(full_name(@apply_non_draft_trainee))
   end
 
-  def then_only_the_draft_trainee_is_visible
-    expect(trainee_index_page).to have_text(full_name(@draft_trainee))
+  def then_only_the_trn_received_trainee_is_visible
+    expect(trainee_index_page).to have_text(full_name(@trn_received_trainee))
     expect(trainee_index_page).not_to have_text(full_name(@withdrawn_trainee))
   end
 

--- a/spec/features/trainee_actions/submit_for_trn_spec.rb
+++ b/spec/features/trainee_actions/submit_for_trn_spec.rb
@@ -98,11 +98,11 @@ feature "submit for TRN" do
     end
 
     context "clicking return to draft record later" do
-      scenario "returns the user to the trainee records page" do
+      scenario "returns the user to the draft records page" do
         given_a_trainee_exists
         and_i_am_on_the_check_details_page
         when_i_click_return_to_draft_later
-        then_i_am_redirected_to_the_trainee_records_page
+        then_i_am_redirected_to_the_draft_records_page
       end
     end
   end
@@ -162,8 +162,8 @@ feature "submit for TRN" do
     check_details_page.return_to_draft_later.click
   end
 
-  def then_i_am_redirected_to_the_trainee_records_page
-    expect(trainee_index_page).to be_displayed
+  def then_i_am_redirected_to_the_draft_records_page
+    expect(trainee_drafts_page).to be_displayed
   end
 
   def then_i_am_redirected_to_the_trainee_start_status_page

--- a/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
+++ b/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
@@ -6,12 +6,20 @@ feature "View trainees" do
   background { given_i_am_authenticated }
 
   context "when trainee belongs to me" do
-    scenario "viewing the personal details of trainee" do
+    scenario "viewing the personal details of a draft trainee" do
       given_a_trainee_exists
+      when_i_view_the_trainee_drafts_page
+      then_i_see_the_trainee_data_on_the(trainee_drafts_page)
+      and_i_click_the_trainee_name_on_the(trainee_drafts_page)
+      then_i_should_see_the_trainee_details_on_the(review_draft_page)
+    end
+
+    scenario "viewing the personal details of a registered trainee" do
+      given_a_trainee_exists(:submitted_with_start_date)
       when_i_view_the_trainee_index_page
-      then_i_see_the_draft_trainee_data
-      and_i_click_on_trainee_name
-      then_i_should_see_the_trainee_details
+      then_i_see_the_trainee_data_on_the(trainee_index_page)
+      and_i_click_the_trainee_name_on_the(trainee_index_page)
+      then_i_should_see_the_trainee_details_on_the(record_page)
     end
   end
 
@@ -30,20 +38,24 @@ private
     trainee_index_page.load
   end
 
-  def then_i_see_the_draft_trainee_data
-    expect(trainee_index_page).to have_draft_trainee_data
+  def when_i_view_the_trainee_drafts_page
+    trainee_drafts_page.load
   end
 
-  def and_i_click_on_trainee_name
-    trainee_index_page.trainee_name.first.click
+  def then_i_see_the_trainee_data_on_the(expected_page)
+    expect(expected_page).to have_trainee_data
   end
 
-  def then_i_should_see_the_trainee_details
-    expect(review_draft_page).to be_displayed(id: trainee.slug)
+  def and_i_click_the_trainee_name_on_the(expected_page)
+    expected_page.trainee_name.first.click
+  end
+
+  def then_i_should_see_the_trainee_details_on_the(expected_page)
+    expect(expected_page).to be_displayed(id: trainee.slug)
   end
 
   def then_i_should_see_no_access_text
-    expect(review_draft_page).to have_text(t("components.page_titles.pages.forbidden"))
+    expect(record_page).to have_text(t("components.page_titles.pages.forbidden"))
   end
 
   def and_i_visit_the_trainee

--- a/spec/helpers/trainee_helper_spec.rb
+++ b/spec/helpers/trainee_helper_spec.rb
@@ -87,7 +87,7 @@ describe TraineeHelper do
       let(:total_count) { page_size }
 
       it "returns the title containing the total count" do
-        expect(subject).to eq "Trainee records (25 records)"
+        expect(subject).to eq "Registered trainees (25 records)"
       end
     end
 
@@ -95,7 +95,7 @@ describe TraineeHelper do
       let(:total_count) { page_size + 1 }
 
       it "returns the title containing the total count and which page you're on" do
-        expect(subject).to eq "Trainee records (26 records) - page 1 of 2"
+        expect(subject).to eq "Registered trainees (26 records) - page 1 of 2"
       end
     end
 
@@ -103,7 +103,7 @@ describe TraineeHelper do
       let(:total_count) { 0 }
 
       it "returns the title containing the 0 count" do
-        expect(subject).to eq "Trainee records (0 records)"
+        expect(subject).to eq "Registered trainees (0 records)"
       end
     end
   end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -6,6 +6,10 @@ module Features
       @trainee_index_page ||= PageObjects::Trainees::Index.new
     end
 
+    def trainee_drafts_page
+      @trainee_drafts_page ||= PageObjects::Trainees::Drafts.new
+    end
+
     def request_an_account_page
       @request_an_account_page ||= PageObjects::RequestAnAccount.new
     end

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -2,14 +2,10 @@
 
 module PageObjects
   module Trainees
-    class Index < PageObjects::Base
-      set_url "/trainees"
-
+    class Base < PageObjects::Base
       element :page_heading, ".govuk-heading-xl"
 
       element :add_trainee_link, "a", text: "Create a trainee record"
-
-      element :draft_trainee_data, ".app-draft-records"
 
       elements :trainee_data, ".application-record-card"
 
@@ -24,7 +20,6 @@ module PageObjects
       element :complete_checkbox, "#record_completion-complete"
       element :incomplete_checkbox, "#record_completion-incomplete"
       element :assessment_only_checkbox, "#training_route-assessment_only"
-      element :draft_checkbox, "#state-draft"
       element :imported_from_apply_checkbox, "#record_source-apply"
       element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"
       element :subject, "#subject"
@@ -33,6 +28,16 @@ module PageObjects
       element :export_link, ".app-trainee-export"
 
       element :no_records_found, "h2", text: "No records found"
+    end
+
+    class Index < Base
+      set_url "/trainees"
+
+      element :trn_received_checkbox, "#state-trn_received"
+    end
+
+    class Drafts < Base
+      set_url "/drafts"
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/wcIowvJW/3311-s-enable-draft-record-page

### Changes proposed in this pull request

- Render the drafts page in the main nav bar
- Update links on the homepage 
- Remove draft sets from registered trainees results
- Fix tests

### Guidance to review

Have a play with the review app

