### PR TITLE
[3362] Validate that date of birth is not too long ago

### DIFF
--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -30,8 +30,6 @@ class PersonalDetailsForm < TraineeForm
   validates :middle_names, length: { maximum: 50 }, allow_nil: true
   validates :date_of_birth, presence: true
   validate :date_of_birth_valid
-  validate :date_of_birth_not_in_future
-  validate :date_of_birth_year_is_four_digits
   validates :gender, presence: true, inclusion: { in: Trainee.genders.keys }
   validates :other_nationality1, :other_nationality2, :other_nationality3, autocomplete: true, allow_nil: true, if: :other_is_selected?
   validate :nationalities_cannot_be_empty
@@ -132,15 +130,15 @@ private
   end
 
   def date_of_birth_valid
-    errors.add(:date_of_birth, :invalid) unless date_of_birth.is_a?(Date)
-  end
-
-  def date_of_birth_not_in_future
-    errors.add(:date_of_birth, :future) if date_of_birth.is_a?(Date) && date_of_birth > Time.zone.today
-  end
-
-  def date_of_birth_year_is_four_digits
-    errors.add(:date_of_birth, :invalid_year) if date_of_birth.is_a?(Date) && date_of_birth.year.digits.length != 4
+    if !date_of_birth.is_a?(Date)
+      errors.add(:date_of_birth, :invalid)
+    elsif date_of_birth > Time.zone.today
+      errors.add(:date_of_birth, :future)
+    elsif date_of_birth.year.digits.length != 4
+      errors.add(:date_of_birth, :invalid_year)
+    elsif date_of_birth < 100.years.ago
+      errors.add(:date_of_birth, :past)
+    end
   end
 
   def calculate_other

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1200,10 +1200,11 @@ en:
               too_long: Middle name must be 50 characters or fewer
             date_of_birth:
               blank: Enter a date of birth
-              invalid: Enter a valid date
-              invalid_year: The year must include 4 numbers
               future: Enter a date of birth that is in the past, for example 31 3 1980
               hint_html: For example, 31 3 %{year}
+              invalid: Enter a valid date
+              invalid_year: The year must include 4 numbers
+              past: Enter a valid date of birth
             gender:
               blank: Select a gender
             nationality_names:

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -135,6 +135,22 @@ describe PersonalDetailsForm, type: :model do
           )
         end
       end
+
+      context "past date" do
+        let(:params) { { day: 1, month: 2, year: 1066 } }
+
+        before do
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date_of_birth]).to include(
+            I18n.t(
+              "activemodel.errors.models.personal_details_form.attributes.date_of_birth.past",
+            ),
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context

https://trello.com/c/rjoQD1ep/3362-add-date-of-birth-validation

### Changes proposed in this pull request

We've had an issue whereby a trainee was entered with a Medieval birthday - unsurprisingly the TRN request was rejected.

This PR adds an extra past-date validation.

### Guidance to review

Try to create a trainee with a birthdate more than 100 years ago. It should fail.