### PR TITLE
[xxx] Add `created_from_dttp` to trainees

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -77,6 +77,7 @@ module Trainees
       return if latest_placement_assignment.blank?
 
       {
+        created_from_dttp: true,
         state: trainee_status,
         provider: dttp_trainee.provider,
         trainee_id: trainee_id,

--- a/db/migrate/20211216145323_add_created_from_dttp_to_trainees.rb
+++ b/db/migrate/20211216145323_add_created_from_dttp_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCreatedFromDttpToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :created_from_dttp, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_14_144114) do
+ActiveRecord::Schema.define(version: 2021_12_16_145323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -437,6 +437,7 @@ ActiveRecord::Schema.define(version: 2021_12_14_144114) do
     t.boolean "submission_ready", default: false
     t.integer "commencement_status"
     t.datetime "discarded_at"
+    t.boolean "created_from_dttp", default: false, null: false
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -69,6 +69,7 @@ module Trainees
       it "creates a trainee with the dttp_trainee attributes" do
         create_trainee_from_dttp
         trainee = Trainee.last
+        expect(trainee.created_from_dttp).to be true
         expect(trainee.first_names).to eq(api_trainee["firstname"])
         expect(trainee.last_name).to eq(api_trainee["lastname"])
         expect(trainee.locale_code).to eq("uk")


### PR DESCRIPTION
### Context

We want to be able to distinguish trainees created via the import from DTTP from trainees created by users in Register.
This will help us running test runs of the import, and also may be used in the future (different UI? blocking updates to DTTP?)

### Changes proposed in this pull request

Add boolean field `created_from_dttp` to trainees so we can easily distinguish
them from trainees created by users on Register.

### Guidance to review

🚢 