### PR TITLE
[3406] Map trainees not on any initiatives

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -333,7 +333,7 @@ module Trainees
 
     def training_initiative_attributes
       {
-        training_initiative: training_initiative,
+        training_initiative: training_initiative.presence || ROUTE_INITIATIVES_ENUMS[:no_initiative],
       }
     end
 

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -104,6 +104,23 @@ module Trainees
         end
       end
 
+      context "when the trainee is not on any initiative" do
+        let(:placement_assignment) do
+          create(:dttp_placement_assignment,
+                 provider_dttp_id: provider.dttp_id,
+                 response: create(:api_placement_assignment,
+                                  _dfe_initiative1id_value: nil))
+        end
+
+        let(:dttp_trainee) { create(:dttp_trainee, placement_assignments: [placement_assignment], provider_dttp_id: provider.dttp_id) }
+
+        it "creates a trainee with no training_initiative" do
+          create_trainee_from_dttp
+          trainee = Trainee.last
+          expect(trainee.training_initiative).to eq(ROUTE_INITIATIVES_ENUMS[:no_initiative])
+        end
+      end
+
       context "when the trainee is provider_led_postgrad" do
         let(:placement_assignment) do
           create(:dttp_placement_assignment,

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -92,7 +92,7 @@ module Trainees
       let!(:trainee_with_physics) { create(:trainee, course_subject_one: "Physics") }
       let(:filters) { { subject: subject_name } }
 
-      it { is_expected.to eq([trainee_with_biology, trainee_with_chemistry, trainee_with_physics]) }
+      it { is_expected.to match_array([trainee_with_biology, trainee_with_chemistry, trainee_with_physics]) }
     end
 
     context "with text_search filter" do


### PR DESCRIPTION
### Context
We are [already flagging](https://github.com/DFE-Digital/register-trainee-teachers/blob/4e65e70c7657312644e116e320c9a77b93f3b496/app/services/trainees/create_from_dttp.rb#L34-L37) for cases when we do not recognise the initiative.
This PR completes initiative handling for when no information is available

### Guidance to review
:shipit: 
