### PR TITLE
[3319] Handle when the trainee is merged or has an invalid TRN

### DIFF
--- a/app/models/dttp/trainee.rb
+++ b/app/models/dttp/trainee.rb
@@ -44,5 +44,9 @@ module Dttp
 
       Date.parse(response["birthdate"])
     end
+
+    def trn
+      response["dfe_trn"]
+    end
   end
 end

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -6,6 +6,8 @@ module Trainees
 
     class UnrecognisedStatusError < StandardError; end
 
+    INVALID_TRN = "999999999"
+
     def initialize(dttp_trainee:)
       @dttp_trainee = dttp_trainee
       @trainee = Trainee.new(mapped_attributes)
@@ -15,6 +17,7 @@ module Trainees
       return if dttp_trainee.imported?
       return if dttp_trainee.provider.blank?
       return if latest_placement_assignment.blank?
+      return if dttp_trainee.response["merged"]
 
       if multiple_providers?
         dttp_trainee.non_importable_multi_provider!
@@ -82,7 +85,7 @@ module Trainees
         provider: dttp_trainee.provider,
         trainee_id: trainee_id,
         training_route: training_route,
-        trn: dttp_trainee.response["dfe_trn"],
+        trn: trn,
         submitted_for_trn_at: earliest_placement_assignment.response["dfe_trnassessmentdate"],
         dttp_id: dttp_trainee.dttp_id,
         placement_assignment_dttp_id: latest_placement_assignment.dttp_id,
@@ -141,6 +144,10 @@ module Trainees
 
     def undergrad_level?
       latest_placement_assignment.response["dfe_courselevel"] == Dttp::Params::PlacementAssignment::COURSE_LEVEL_UG
+    end
+
+    def trn
+      dttp_trainee.trn == INVALID_TRN ? nil : dttp_trainee.trn
     end
 
     def trainee_gender

--- a/spec/factories/dttp/api_trainee.rb
+++ b/spec/factories/dttp/api_trainee.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     dfe_traineeid { "#{firstname}.#{lastname}.#{birthdate}" }
     _dfe_nationality_value { "d17d640e-5c62-e711-80d1-005056ac45bb" }
     dfe_trn { Faker::Number.number(digits: 7) }
+    merged { false }
 
     initialize_with { attributes.stringify_keys }
     to_create { |instance| instance }


### PR DESCRIPTION
### Context

https://trello.com/c/0OczNMS6/3319-investigate-trainees-with-no-addresses-international-addresses

TRN's are set to 999999999 if they never received a TRN for some reason. We think this would be because they didn't start the course. If that's the case, the trainee would be skipped over since we do not map that "DID_NOT_START" status.

Trainee records can be merged into other (more complete) records in DTTP. Don't import these ones.

### Changes proposed in this pull request

- Don't set the our trainee's TRN to an invalid one from DTTP.
- Don't try to import merged trainees

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
