### PR TITLE
[3319] Improve handling of addresses

### DIFF
--- a/app/models/dttp/trainee.rb
+++ b/app/models/dttp/trainee.rb
@@ -48,5 +48,13 @@ module Dttp
     def trn
       response["dfe_trn"]
     end
+
+    def country
+      response["address1_country"]
+    end
+
+    def postcode
+      response["address1_postalcode"]
+    end
   end
 end

--- a/app/models/dttp/trainee.rb
+++ b/app/models/dttp/trainee.rb
@@ -56,7 +56,7 @@ module Dttp
     def postcode
       response["address1_postalcode"]
     end
-    
+
     def earliest_placement_assignment
       @earliest_placement_assignment ||= sorted_placement_assignments.first
     end

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -97,6 +97,37 @@ module Trainees
         expect(trainee.training_initiative).to eq("now_teach")
       end
 
+      context "when the country is something other than England and has a non-uk postcode" do
+        let(:api_trainee) { create(:api_trainee, address1_postalcode: nil, address1_country: "France") }
+
+        it "sets the locale to non_uk" do
+          create_trainee_from_dttp
+          expect(Trainee.last.locale_code).to eq("non_uk")
+        end
+      end
+
+      context "when neither address line one or postcode is present" do
+        let(:api_trainee) { create(:api_trainee, address1_line1: nil, address1_postalcode: nil) }
+
+        before do
+          create_trainee_from_dttp
+        end
+
+        it "does not set the local to UK" do
+          expect(Trainee.last.locale_code).to be nil
+        end
+
+        context "but the country is set to England" do
+          let(:api_trainee) do
+            create(:api_trainee, address1_line1: nil, address1_postalcode: nil, address1_country: "England")
+          end
+
+          it "sets the local to UK" do
+            expect(Trainee.last.locale_code).to eq("uk")
+          end
+        end
+      end
+
       context "when the trainee is on future_teaching_scholars" do
         let(:placement_assignment) do
           create(:dttp_placement_assignment,


### PR DESCRIPTION
### Context

https://trello.com/c/0OczNMS6/3319-investigate-trainees-with-no-addresses-international-addresses

### Changes proposed in this pull request

- Set the locale_code to uk if the country is explicitly set to a UK country OR postcode is a valid UK postcode
- Set the locale_code to non_uk if the country is present and not in the UK country life
- Otherwise, set nothing.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
