### PR TITLE
[3416] Investigate and handle un-imported degrees 21/22

### DIFF
--- a/app/lib/dttp/code_sets/degree_types.rb
+++ b/app/lib/dttp/code_sets/degree_types.rb
@@ -206,6 +206,11 @@ module Dttp
         },
         "Unknown" => { entity_id: "6f6a5652-c197-e711-80d8-005056ac45bb", abbreviation: nil },
       }.freeze
+
+      INACTIVE_MAPPING = {
+        "BA (Hons) education" => { entity_id: "cf695652-c197-e711-80d8-005056ac45bb" },
+        "BSc (Hons) with intercalated PGCE" => { entity_id: "d7695652-c197-e711-80d8-005056ac45bb" },
+      }.freeze
     end
   end
 end

--- a/app/lib/dttp/code_sets/institutions.rb
+++ b/app/lib/dttp/code_sets/institutions.rb
@@ -194,7 +194,7 @@ module Dttp
         "Point Blank Music School" => { entity_id: "b73e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "309" },
         "Prestolee SCITT" => { entity_id: "027bf34a-2887-e711-80d8-005056ac45bb" },
         "Queen Margaret University, Edinburgh" => { entity_id: "40f3791d-7042-e811-80ff-3863bb3640b8", hesa_code: "100" },
-        "Queen Mary University of London" => { entity_id: "47f3791d-7042-e811-80ff-3863bb3640b8", hesa_code: "139" },
+        "Queen Mary University of London" => { entity_id: "b93e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "139" },
         "Raindance Educational Services Limited" => { entity_id: "bb3e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "429" },
         "Ravensbourne" => { entity_id: "4ff3791d-7042-e811-80ff-3863bb3640b8", hesa_code: "30" },
         "Regent College" => { entity_id: "bd3e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "278" },
@@ -357,6 +357,10 @@ module Dttp
         "Winchester School of Art" => { entity_id: "d123a753-7042-e811-80ff-3863bb3640b8", hesa_code: "45" },
         "Writtle College" => { entity_id: "d723a753-7042-e811-80ff-3863bb3640b8", hesa_code: "189" },
         "York St John University" => { entity_id: "4c71f34a-2887-e711-80d8-005056ac45bb", hesa_code: "13" },
+      }.freeze
+
+      INACTIVE_MAPPING = {
+        "Queen Mary University of London" => { entity_id: "47f3791d-7042-e811-80ff-3863bb3640b8" },
       }.freeze
     end
   end

--- a/app/models/dttp/degree_qualification.rb
+++ b/app/models/dttp/degree_qualification.rb
@@ -32,5 +32,9 @@ module Dttp
     def institution
       response["_dfe_awardinginstitutionid_value"]
     end
+
+    def degree_type
+      response["_dfe_degreetypeid_value"]
+    end
   end
 end

--- a/app/models/dttp/degree_qualification.rb
+++ b/app/models/dttp/degree_qualification.rb
@@ -28,5 +28,9 @@ module Dttp
 
       Date.parse(response["dfe_degreeenddate"]).year
     end
+
+    def institution
+      response["_dfe_awardinginstitutionid_value"]
+    end
   end
 end

--- a/app/services/degrees/map_from_dttp.rb
+++ b/app/services/degrees/map_from_dttp.rb
@@ -31,10 +31,8 @@ module Degrees
       {
         locale_code: Trainee.locale_codes[:uk],
         uk_degree: qualification_type,
-        institution: institution || inactive_institution,
+        institution: institution,
         grade: grade.presence || Dttp::CodeSets::Grades::OTHER,
-        # Maybe?
-        # other_grade: dttp_degree.response["dfe_name"]
       }
     end
 
@@ -63,18 +61,13 @@ module Degrees
     end
 
     def qualification_type
-      find_by_entity_id(
-        dttp_degree.response["_dfe_degreetypeid_value"],
-        Dttp::CodeSets::DegreeTypes::MAPPING,
-      )
+      find_by_entity_id(dttp_degree.degree_type, Dttp::CodeSets::DegreeTypes::MAPPING) ||
+        find_by_entity_id(dttp_degree.degree_type, Dttp::CodeSets::DegreeTypes::INACTIVE_MAPPING)
     end
 
     def institution
-      find_by_entity_id(dttp_degree.institution, Dttp::CodeSets::Institutions::MAPPING)
-    end
-
-    def inactive_institution
-      find_by_entity_id(dttp_degree.institution, Dttp::CodeSets::Institutions::INACTIVE_MAPPING)
+      find_by_entity_id(dttp_degree.institution, Dttp::CodeSets::Institutions::MAPPING) ||
+        find_by_entity_id(dttp_degree.institution, Dttp::CodeSets::Institutions::INACTIVE_MAPPING)
     end
 
     def grade

--- a/spec/services/degrees/map_from_dttp_spec.rb
+++ b/spec/services/degrees/map_from_dttp_spec.rb
@@ -65,6 +65,20 @@ module Degrees
 
         it { is_expected.to include(uk_degree_attributes) }
       end
+
+      context "with an inactive degree type" do
+        let(:degree_type) { "BA (Hons) education" }
+        let(:api_degree_qualification) do
+          create(
+            :api_degree_qualification,
+            _dfe_awardinginstitutionid_value: Dttp::CodeSets::Institutions::MAPPING[institution][:entity_id],
+            _dfe_degreetypeid_value: Dttp::CodeSets::DegreeTypes::INACTIVE_MAPPING[degree_type][:entity_id],
+            _dfe_classofdegreeid_value: Dttp::CodeSets::Grades::MAPPING[grade][:entity_id],
+          )
+        end
+
+        it { is_expected.to include(uk_degree_attributes) }
+      end
     end
 
     context "with a non-uk degree" do

--- a/spec/services/degrees/map_from_dttp_spec.rb
+++ b/spec/services/degrees/map_from_dttp_spec.rb
@@ -51,6 +51,20 @@ module Degrees
       end
 
       it { is_expected.to include(uk_degree_attributes) }
+
+      context "with an inactive institution" do
+        let(:institution) { "Queen Mary University of London" }
+        let(:api_degree_qualification) do
+          create(
+            :api_degree_qualification,
+            _dfe_awardinginstitutionid_value: Dttp::CodeSets::Institutions::INACTIVE_MAPPING[institution][:entity_id],
+            _dfe_degreetypeid_value: Dttp::CodeSets::DegreeTypes::MAPPING[degree_type][:entity_id],
+            _dfe_classofdegreeid_value: Dttp::CodeSets::Grades::MAPPING[grade][:entity_id],
+          )
+        end
+
+        it { is_expected.to include(uk_degree_attributes) }
+      end
     end
 
     context "with a non-uk degree" do


### PR DESCRIPTION
### Context

https://trello.com/c/mhCEJYII/3416-investigate-handle-un-imported-degrees-21-22

### Changes proposed in this pull request

Looking at the un-imported degrees from 21/22 the following issues were unearthed:

**Things I haven't solved because we can't immediately save the degree**
- No subject
- No institution
- No end date and/or no start date

**Things I have solved:**
- Missing mapping for degree type "BA (Hons) education" (cf695652-c197-e711-80d8-005056ac45bb)
  **Added in an inactive mapping which is searched after the active one. Inactive mappings don't appear in the UI**
- Missing mapping for degree type "BSc (Hons) with intercalated PGCE" (d7695652-c197-e711-80d8-005056ac45bb)
  **Added in an inactive mapping as above**
- International degrees with no dfe_name
  **Fell back on degree_type when this is not present**
- Unmapped institution "Queen Mary University of London" (b93e182c-1425-ec11-b6e6-000d3adf095a)
  **We were actually missing the active mapping for this institution. I swapped the old one into an inactive mapping which works as above.**

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
