### PR TITLE
[3416] Fix trainee_status method so that AWARDED_QTS trainees are correctly mapped

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -413,9 +413,9 @@ module Trainees
       when DttpStatuses::STANDARDS_MET then "recommended_for_award"
       when DttpStatuses::DEFERRED then "deferred"
       when DttpStatuses::YET_TO_COMPLETE_COURSE then "trn_received"
-      when (DttpStatuses::AWARDED_EYTS || DttpStatuses::AWARDED_QTS) then "awarded"
+      when DttpStatuses::AWARDED_EYTS, DttpStatuses::AWARDED_QTS then "awarded"
       when DttpStatuses::LEFT_COURSE_BEFORE_END then "withdrawn"
-      when (DttpStatuses::AWAITING_QTS || DttpStatuses::EYTS_REVOKED || DttpStatuses::QTS_REVOKED || DttpStatuses::STANDARDS_NOT_MET || DttpStatuses::DID_NOT_START || DttpStatuses::REJECTED) then nil
+      when DttpStatuses::AWAITING_QTS, DttpStatuses::EYTS_REVOKED, DttpStatuses::QTS_REVOKED, DttpStatuses::STANDARDS_NOT_MET, DttpStatuses::DID_NOT_START, DttpStatuses::REJECTED then nil
       end
     end
 

--- a/spec/factories/dttp/api_trainee.rb
+++ b/spec/factories/dttp/api_trainee.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     _dfe_nationality_value { "d17d640e-5c62-e711-80d1-005056ac45bb" }
     dfe_trn { Faker::Number.number(digits: 7) }
     merged { false }
+    _dfe_traineestatusid_value { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::AWARDED_QTS][:entity_id] }
 
     initialize_with { attributes.stringify_keys }
     to_create { |instance| instance }


### PR DESCRIPTION
### Context

https://trello.com/c/a1Rww7Je/3412-investigate-21-22-trainees-in-state-nonimportablemissingstate

### Changes proposed in this pull request

All dttp_trainees with the state `non_importable_missing_state` were actually QTS Awarded trainees.

This PR fixes the syntax in the case statement so that trainees with the `AWARDED_QTS` state are correctly mapped.

### Guidance to review

🚢 

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
