### PR TITLE
[3412] Handle trainees on an EBACC initiative

### DIFF
--- a/app/lib/dttp/code_sets/training_initiatives.rb
+++ b/app/lib/dttp/code_sets/training_initiatives.rb
@@ -3,6 +3,8 @@
 module Dttp
   module CodeSets
     module TrainingInitiatives
+      EBACC = "883398f8-0d89-e811-80f7-005056ac45bb"
+
       # DTTP recognise future_teaching_scholars as a route not an initiative,
       # hence there is no mapping. See Dttp::CodeSets::Routes.
       MAPPING = {

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -347,6 +347,7 @@ module Trainees
     def training_initiative_attributes
       {
         training_initiative: training_initiative.presence || ROUTE_INITIATIVES_ENUMS[:no_initiative],
+        ebacc: ebacc?,
       }
     end
 
@@ -355,14 +356,19 @@ module Trainees
         return ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars]
       end
 
-      find_by_entity_id(
-        dttp_trainee.latest_placement_assignment.response["_dfe_initiative1id_value"],
-        Dttp::CodeSets::TrainingInitiatives::MAPPING,
-      )
+      find_by_entity_id(dttp_initiative_id, Dttp::CodeSets::TrainingInitiatives::MAPPING)
     end
 
     def unmapped_training_initiative?
-      dttp_trainee.latest_placement_assignment.response["_dfe_initiative1id_value"].present? && training_initiative.blank?
+      dttp_initiative_id.present? && !ebacc? && training_initiative.blank?
+    end
+
+    def ebacc?
+      dttp_initiative_id == Dttp::CodeSets::TrainingInitiatives::EBACC
+    end
+
+    def dttp_initiative_id
+      @dttp_initiative_id ||= dttp_trainee.latest_placement_assignment.response["_dfe_initiative1id_value"]
     end
 
     def lead_school_urn

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -468,6 +468,23 @@ module Trainees
       end
     end
 
+    context "when training_initiative is EBACC" do
+      let(:api_placement_assignment) { create(:dttp_placement_assignment, provider_dttp_id: provider.dttp_id, response: create(:api_placement_assignment, _dfe_initiative1id_value: Dttp::CodeSets::TrainingInitiatives::EBACC)) }
+      let(:dttp_trainee) { create(:dttp_trainee, provider: provider, placement_assignments: [api_placement_assignment]) }
+
+      before do
+        create_trainee_from_dttp
+      end
+
+      it "sets ebaac to true" do
+        expect(Trainee.last.ebacc).to be true
+      end
+
+      it "sets no initiative" do
+        expect(Trainee.last.training_initiative).to eq(ROUTE_INITIATIVES_ENUMS[:no_initiative])
+      end
+    end
+
     context "when training_initiative is not mapped" do
       let(:api_placement_assignment) { create(:dttp_placement_assignment, provider_dttp_id: provider.dttp_id, response: create(:api_placement_assignment, _dfe_initiative1id_value: SecureRandom.uuid)) }
       let(:dttp_trainee) { create(:dttp_trainee, provider: provider, placement_assignments: [api_placement_assignment]) }


### PR DESCRIPTION
### Context

https://trello.com/c/2fus5V0x/3413-investigate-21-22-trainees-in-state-nonimportablemissinginitiative

### Changes proposed in this pull request

If a trainees is on the "Additional ITT place for PE with a priority subject" initiative, it actually means they're on PE with Ebacc. So set our ebacc field to true for these trainees and import them with no initiative.

The other missing initiative was "Primary mathematics specialism" but these needs more analysis https://trello.com/c/ceGyQHVL/2621-investigate-primary-with-mathematics-and-specialist-teaching so we'll continue skipping these trainees.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
