### PR TITLE
Increase worker memory

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -13,7 +13,7 @@
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1536,
   "paas_worker_app_instances": 2,
-  "paas_worker_app_memory": 512,
+  "paas_worker_app_memory": 1024,
   "statuscake_alerts": {
     "alert": {
       "website_name": "register-production",


### PR DESCRIPTION
### Context
Workers seem to crash under some of our nightly jobs.

### Changes proposed in this pull request
Double memory allocation from 512 to 1GB