### PR TITLE
[3405] Add `hesa_id` field to trainees

### DIFF
--- a/app/models/dttp/trainee.rb
+++ b/app/models/dttp/trainee.rb
@@ -39,6 +39,10 @@ module Dttp
       non_importable_missing_initiative: 9,
     }
 
+    def hesa_id
+      response["dfe_husid"]
+    end
+
     def date_of_birth
       return if response["birthdate"].blank?
 

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -94,6 +94,7 @@ module Trainees
         submitted_for_trn_at: dttp_trainee.earliest_placement_assignment.response["dfe_trnassessmentdate"],
         dttp_id: dttp_trainee.dttp_id,
         placement_assignment_dttp_id: dttp_trainee.latest_placement_assignment.dttp_id,
+        hesa_id: dttp_trainee.hesa_id,
       }.merge(personal_details_attributes)
        .merge(contact_attributes)
        .merge(ethnicity_and_disability_attributes)

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -196,6 +196,7 @@ shared:
     - lead_school_not_applicable
     - region
     - submission_ready
+    - hesa_id
   users:
     - created_at
     - dfe_sign_in_uid

--- a/db/migrate/20220104113614_add_hesa_id_to_trainees.rb
+++ b/db/migrate/20220104113614_add_hesa_id_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHesaIdToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :hesa_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_16_171101) do
+ActiveRecord::Schema.define(version: 2022_01_04_113614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -441,6 +441,7 @@ ActiveRecord::Schema.define(version: 2021_12_16_171101) do
     t.integer "commencement_status"
     t.datetime "discarded_at"
     t.boolean "created_from_dttp", default: false, null: false
+    t.string "hesa_id"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"

--- a/spec/factories/dttp/api_trainee.rb
+++ b/spec/factories/dttp/api_trainee.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     dfe_trn { Faker::Number.number(digits: 7) }
     merged { false }
     _dfe_traineestatusid_value { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::AWARDED_QTS][:entity_id] }
+    dfe_husid { "1811499435078" }
 
     initialize_with { attributes.stringify_keys }
     to_create { |instance| instance }

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -95,6 +95,7 @@ module Trainees
         expect(trainee.nationalities).to be_empty
         expect(trainee.trn).to eq(api_trainee["dfe_trn"].to_s)
         expect(trainee.training_initiative).to eq("now_teach")
+        expect(trainee.hesa_id).to eq(api_trainee["dfe_husid"])
       end
 
       context "when the country is something other than England and has a non-uk postcode" do


### PR DESCRIPTION
### Context

https://trello.com/c/9o6CJJ7d/3405-link-the-trainees-created-from-hesa-records-back-to-hesa

### Changes proposed in this pull request

- Add a new field `hesa_id` to trainees
- Populate this field when we create Register trainees from DTTP

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
  - `hesa_id` added to the whitelist.
