### PR TITLE
[3340] Fix empty item shown in autocomplete

### DIFF
--- a/app/components/form_components/autocomplete/script.js
+++ b/app/components/form_components/autocomplete/script.js
@@ -43,8 +43,10 @@ const setupAutoComplete = (component) => {
     selectElement: selectEl,
     minLength: 2,
     source: (query, populateResults) => {
-      tracker.trackSearch(query)
-      populateResults(sort(query, options))
+      if (/\S/.test(query)) {
+        tracker.trackSearch(query)
+        populateResults(sort(query, options))
+      }
     },
     autoselect: true,
     templates: { suggestion: (value) => suggestion(value, options) },

--- a/app/webpacker/scripts/autocomplete/stop_words.spec.js
+++ b/app/webpacker/scripts/autocomplete/stop_words.spec.js
@@ -20,7 +20,7 @@ describe('removeStopWords', () => {
   })
 
   describe('last character has the potential to be a stop word', () => {
-    it("is kept in the text", () => {
+    it('is kept in the text', () => {
       expect(removeStopWords('bachelor o')).toEqual('bachelor o')
     })
   })

--- a/app/webpacker/scripts/live_filter.js
+++ b/app/webpacker/scripts/live_filter.js
@@ -16,7 +16,7 @@ export default class LiveFilter {
 
     if (!(this.form && this.resultsDiv && this.selectedFiltersDiv)) return
 
-    this.endpoint = this.form.attributes["data-search-endpoint"].value
+    this.endpoint = this.form.attributes['data-search-endpoint'].value
 
     this.saveState()
     this.setInitialStateToHistory()

--- a/app/webpacker/scripts/live_filter.spec.js
+++ b/app/webpacker/scripts/live_filter.spec.js
@@ -13,7 +13,7 @@ describe('LiveFilter', () => {
       <option value="applied biology">Applied biology</option>
       <option value="applied chemistry">Applied chemistry</option>
     </select>
-    </form>`);
+    </form>`)
 
     const $results = $('<div id="js-results"></div>')
     const $selectedFilters = $('<div id="js-selected-filters"></div>')


### PR DESCRIPTION
### Context
https://trello.com/c/90z3HP6Q/3340-empty-item-shown-in-autocomplete

### Changes proposed in this pull request
- Update autocomplete to not show results if the query string only has spaces 

### Guidance to review
- Visit a UK degree form page
- Enter multiple spaces into "Awarding institution"
- It should display "No results found"