### PR TITLE
[3447] Handle missing degrees from recent 21/22 trainee test import

### DIFF
--- a/app/lib/dttp/code_sets/degree_types.rb
+++ b/app/lib/dttp/code_sets/degree_types.rb
@@ -208,8 +208,13 @@ module Dttp
       }.freeze
 
       INACTIVE_MAPPING = {
-        "BA (Hons) education" => { entity_id: "cf695652-c197-e711-80d8-005056ac45bb" },
+        "BA (Hons) /Education" => { entity_id: "cf695652-c197-e711-80d8-005056ac45bb" },
+        "BEd (Hons)" => { entity_id: "c3695652-c197-e711-80d8-005056ac45bb" },
+        "BSc (Hons) /Education" => { entity_id: "c7695652-c197-e711-80d8-005056ac45bb" },
+        "BTech (Hons) /Education" => { entity_id: "cb695652-c197-e711-80d8-005056ac45bb" },
+        "BA (Hons) with intercalated PGCE" => { entity_id: "d9695652-c197-e711-80d8-005056ac45bb" },
         "BSc (Hons) with intercalated PGCE" => { entity_id: "d7695652-c197-e711-80d8-005056ac45bb" },
+        "BA (Hons) Combined Studies/Education of the Deaf" => { entity_id: "d3695652-c197-e711-80d8-005056ac45bb" },
       }.freeze
     end
   end

--- a/app/lib/dttp/code_sets/institutions.rb
+++ b/app/lib/dttp/code_sets/institutions.rb
@@ -7,14 +7,20 @@ module Dttp
       BISHOP_GROSSETESTE_UNIVERSITY = "Bishop Grosseteste University"
       BRUNEL_UNIVERSITY_LONDON = "Brunel University London"
       GOLDSMITHS_COLLEGE = "Goldsmiths College"
+      GUILDHALL_SCHOOL_OF_MUSIC_AND_DRAMA = "Guildhall School of Music and Drama"
       HARPER_ADAMS_UNIVERSITY = "Harper Adams University"
       HERIOT_WATT_UNIVERSITY = "Heriot-Watt University"
+      HEYTHROP_COLLEGE = "Heythrop College"
       IMPERIAL_COLLEGE_OF_SCIENCE_TECHNOLOGY_AND_MEDICINE = "Imperial College of Science, Technology and Medicine"
       NEWMAN_UNIVERSITY = "Newman University"
       OTHER_UK = "Other UK"
       PLYMOUTH_MARJON_UNIVERSITY = "Plymouth Marjon University"
+      QUEEN_MARY_UNIVERSITY_OF_LONDON = "Queen Mary University of London"
+      ROSE_BRUFORD_COLLEGE = "Rose Bruford College"
       ROYAL_HOLLOWAY_AND_BEDFORD_NEW_COLLEGE = "Royal Holloway and Bedford New College"
+      ROYAL_NORTHERN_COLLEGE_OF_MUSIC = "Royal Northern College of Music"
       ST_GEORGES_HOSPITAL_MEDICAL_SCHOOL = "St George's Hospital Medical School"
+      THE_ARTS_UNIVERSITY_BOURNEMOUTH = "The Arts University Bournemouth"
       THE_QUEENS_UNIVERSITY_OF_BELFAST = "The Queen's University of Belfast"
       THE_UNIVERSITY_OF_KEELE = "The University of Keele"
       UNIVERSITY_CAMPUS_SUFFOLK = "University Campus Suffolk"
@@ -24,7 +30,7 @@ module Dttp
       UNIVERSITY_OF_NORTHUMBRIA_AT_NEWCASTLE = "University of Northumbria at Newcastle"
 
       MAPPING = {
-        BIRKBECK_COLLEGE => { entity_id: "9fc53e05-7042-e811-80ff-3863bb3640b8", hesa_code: "127" },
+        BIRKBECK_COLLEGE => { entity_id: "d6d0c9d6-e897-e711-80d8-005056ac45bb", hesa_code: "127" },
         BISHOP_GROSSETESTE_UNIVERSITY => { entity_id: "ca70f34a-2887-e711-80d8-005056ac45bb", hesa_code: "7" },
         BRUNEL_UNIVERSITY_LONDON => { entity_id: "cc70f34a-2887-e711-80d8-005056ac45bb", hesa_code: "113" },
         GOLDSMITHS_COLLEGE => { entity_id: "d270f34a-2887-e711-80d8-005056ac45bb", hesa_code: "131" },
@@ -38,7 +44,7 @@ module Dttp
         ST_GEORGES_HOSPITAL_MEDICAL_SCHOOL => { entity_id: "94407223-7042-e811-80ff-3863bb3640b8", hesa_code: "145" },
         THE_QUEENS_UNIVERSITY_OF_BELFAST => { entity_id: "a7db7129-7042-e811-80ff-3863bb3640b8", hesa_code: "184" },
         THE_UNIVERSITY_OF_KEELE => { entity_id: "3a7af34a-2887-e711-80d8-005056ac45bb", hesa_code: "121" },
-        UNIVERSITY_CAMPUS_SUFFOLK => { entity_id: "154b9247-7042-e811-80ff-3863bb3640b8", hesa_code: "210" },
+        UNIVERSITY_CAMPUS_SUFFOLK => { entity_id: "e93522b4-49a2-e811-812b-5065f38ba241", hesa_code: "210" },
         UNIVERSITY_OF_DURHAM => { entity_id: "1071f34a-2887-e711-80d8-005056ac45bb", hesa_code: "116" },
         UNIVERSITY_OF_LANCASTER => { entity_id: "a4eb7735-7042-e811-80ff-3863bb3640b8", hesa_code: "123" },
         UNIVERSITY_OF_NEWCASTLE_UPON_TYNE => { entity_id: "ea70f34a-2887-e711-80d8-005056ac45bb", hesa_code: "154" },
@@ -110,9 +116,9 @@ module Dttp
         "Gower College Swansea" => { entity_id: "4b3e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "336" },
         "Grŵp Llandrillo Menai" => { entity_id: "4d3e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "334" },
         "Grŵp NPTC Group" => { entity_id: "4f3e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "335" },
-        "Guildhall School of Music and Drama" => { entity_id: "076e5e11-7042-e811-80ff-3863bb3640b8", hesa_code: "208" },
+        GUILDHALL_SCHOOL_OF_MUSIC_AND_DRAMA => { entity_id: "513e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "208" },
         "Hartpury University" => { entity_id: "533e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "352" },
-        "Heythrop College" => { entity_id: "1b6e5e11-7042-e811-80ff-3863bb3640b8", hesa_code: "205" },
+        HEYTHROP_COLLEGE => { entity_id: "56bfbf8a-eb97-e711-80d8-005056ac45bb", hesa_code: "205" },
         "Hult International Business School Ltd" => { entity_id: "553e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "406" },
         "ICOM" => { entity_id: "573e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "297" },
         "ICON College of Technology and Management" => { entity_id: "593e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "236" },
@@ -194,7 +200,7 @@ module Dttp
         "Point Blank Music School" => { entity_id: "b73e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "309" },
         "Prestolee SCITT" => { entity_id: "027bf34a-2887-e711-80d8-005056ac45bb" },
         "Queen Margaret University, Edinburgh" => { entity_id: "40f3791d-7042-e811-80ff-3863bb3640b8", hesa_code: "100" },
-        "Queen Mary University of London" => { entity_id: "b93e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "139" },
+        QUEEN_MARY_UNIVERSITY_OF_LONDON => { entity_id: "b93e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "139" },
         "Raindance Educational Services Limited" => { entity_id: "bb3e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "429" },
         "Ravensbourne" => { entity_id: "4ff3791d-7042-e811-80ff-3863bb3640b8", hesa_code: "30" },
         "Regent College" => { entity_id: "bd3e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "278" },
@@ -204,13 +210,13 @@ module Dttp
         "Richmond, The American International University in London" => { entity_id: "c73e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "219" },
         "Robert Gordon University" => { entity_id: "c93e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "104" },
         "Roehampton University" => { entity_id: "f270f34a-2887-e711-80d8-005056ac45bb", hesa_code: "31" },
-        "Rose Bruford College" => { entity_id: "5af3791d-7042-e811-80ff-3863bb3640b8", hesa_code: "32" },
+        ROSE_BRUFORD_COLLEGE => { entity_id: "1882cdd0-e897-e711-80d8-005056ac45bb", hesa_code: "32" },
         "Royal Academy of Dance" => { entity_id: "cb3e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "263" },
         "Royal Academy of Dramatic Art" => { entity_id: "cd3e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "402" },
         "Royal Academy of Music" => { entity_id: "61f3791d-7042-e811-80ff-3863bb3640b8", hesa_code: "33" },
         "Royal College of Art" => { entity_id: "64407223-7042-e811-80ff-3863bb3640b8", synonyms: ["RCA"], hesa_code: "3" },
         "Royal College of Music" => { entity_id: "49e01caa-a141-e811-80ff-3863bb351d40", hesa_code: "34" },
-        "Royal Northern College of Music" => { entity_id: "74407223-7042-e811-80ff-3863bb3640b8", hesa_code: "35" },
+        ROYAL_NORTHERN_COLLEGE_OF_MUSIC => { entity_id: "cf3e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "35" },
         "Royal School of Needlework (The)" => { entity_id: "d13e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "404" },
         "Royal Welsh College of Music and Drama" => { entity_id: "7b407223-7042-e811-80ff-3863bb3640b8", hesa_code: "182" },
         "SAE Education Limited" => { entity_id: "d33e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "265" },
@@ -232,7 +238,7 @@ module Dttp
         "Tavistock and Portman NHS Foundation Trust" => { entity_id: "e33e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "433" },
         "Teach First" => { entity_id: "5a3385b1-2506-ea11-a811-000d3ab4df6c" },
         "Teesside University" => { entity_id: "2a96fc9d-a141-e811-80ff-3863bb351d40", hesa_code: "79" },
-        "The Arts University Bournemouth" => { entity_id: "c6407223-7042-e811-80ff-3863bb3640b8", hesa_code: "197" },
+        THE_ARTS_UNIVERSITY_BOURNEMOUTH => { entity_id: "91ea2521-3fa2-e811-812b-5065f38ba241", hesa_code: "197" },
         "The Cambridge Theological Federation" => { entity_id: "e73e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "288" },
         "The City College" => { entity_id: "e93e182c-1425-ec11-b6e6-000d3adf095a", hesa_code: "271" },
         "The City University" => { entity_id: "7bdb7129-7042-e811-80ff-3863bb3640b8", hesa_code: "115" },
@@ -332,8 +338,8 @@ module Dttp
         "University of Huddersfield" => { entity_id: "1e71f34a-2887-e711-80d8-005056ac45bb", hesa_code: "61" },
         "University of Kent" => { entity_id: "99eb7735-7042-e811-80ff-3863bb3640b8", hesa_code: "122" },
         "University of London" => { entity_id: "0d791c39-3fa2-e811-812b-5065f38ba241" },
-        "University of Manchester" => { entity_id: "5b43a44d-7042-e811-80ff-3863bb3640b8", hesa_code: "204" },
         "University of Nottingham" => { entity_id: "2c71f34a-2887-e711-80d8-005056ac45bb", hesa_code: "155" },
+        "University of Manchester" => { entity_id: "5b43a44d-7042-e811-80ff-3863bb3640b8", hesa_code: "204" },
         "University of Plymouth" => { entity_id: "3071f34a-2887-e711-80d8-005056ac45bb", hesa_code: "73" },
         "University of South Wales" => { entity_id: "8723a753-7042-e811-80ff-3863bb3640b8", hesa_code: "90" },
         "University of Southampton" => { entity_id: "4f5b7f3b-7042-e811-80ff-3863bb3640b8", hesa_code: "160" },
@@ -360,7 +366,14 @@ module Dttp
       }.freeze
 
       INACTIVE_MAPPING = {
-        "Queen Mary University of London" => { entity_id: "47f3791d-7042-e811-80ff-3863bb3640b8" },
+        QUEEN_MARY_UNIVERSITY_OF_LONDON => { entity_id: "47f3791d-7042-e811-80ff-3863bb3640b8" },
+        BIRKBECK_COLLEGE => { entity_id: "9fc53e05-7042-e811-80ff-3863bb3640b8" },
+        UNIVERSITY_CAMPUS_SUFFOLK => { entity_id: "154b9247-7042-e811-80ff-3863bb3640b8" },
+        GUILDHALL_SCHOOL_OF_MUSIC_AND_DRAMA => { entity_id: "076e5e11-7042-e811-80ff-3863bb3640b8" },
+        HEYTHROP_COLLEGE => { entity_id: "1b6e5e11-7042-e811-80ff-3863bb3640b8" },
+        ROSE_BRUFORD_COLLEGE => { entity_id: "5af3791d-7042-e811-80ff-3863bb3640b8" },
+        ROYAL_NORTHERN_COLLEGE_OF_MUSIC => { entity_id: "74407223-7042-e811-80ff-3863bb3640b8" },
+        THE_ARTS_UNIVERSITY_BOURNEMOUTH => { entity_id: "c6407223-7042-e811-80ff-3863bb3640b8" },
       }.freeze
     end
   end

--- a/app/models/dttp/degree_qualification.rb
+++ b/app/models/dttp/degree_qualification.rb
@@ -17,10 +17,18 @@ module Dttp
       importable: 0,
       imported: 1,
       non_importable_invalid_data: 2,
+      non_importable_missing_country: 3,
+      non_importable_missing_institution: 4,
+      non_importable_missing_subject: 5,
+      non_importable_missing_type: 6,
     }
 
-    def country_id
+    def country
       response["_dfe_degreecountryid_value"]
+    end
+
+    def degree_type
+      response["_dfe_degreetypeid_value"]
     end
 
     def end_year
@@ -29,12 +37,16 @@ module Dttp
       Date.parse(response["dfe_degreeenddate"]).year
     end
 
+    def grade
+      response["_dfe_classofdegreeid_value"]
+    end
+
     def institution
       response["_dfe_awardinginstitutionid_value"]
     end
 
-    def degree_type
-      response["_dfe_degreetypeid_value"]
+    def subject
+      response["_dfe_degreesubjectid_value"]
     end
   end
 end

--- a/app/services/degrees/create_from_dttp.rb
+++ b/app/services/degrees/create_from_dttp.rb
@@ -7,7 +7,7 @@ module Degrees
     class DttpTraineeNotFound < StandardError; end
 
     def initialize(trainee:)
-      @degrees_form = DegreesForm.new(trainee)
+      @trainee = trainee
       @dttp_trainee = trainee.dttp_trainee
     end
 
@@ -19,14 +19,16 @@ module Degrees
 
   private
 
-    attr_reader :dttp_trainee, :degrees_form
+    attr_reader :dttp_trainee, :trainee
 
     def create_degrees!
       dttp_trainee.degree_qualifications.each do |dttp_degree|
-        degree = degrees_form.build_degree(
-          ::Degrees::MapFromDttp.call(dttp_degree: dttp_degree),
-        )
-        if degree.save!
+        attrs = ::Degrees::MapFromDttp.call(dttp_degree: dttp_degree)
+        next unless attrs
+
+        trainee.degrees.build(attrs)
+
+        if trainee.save
           dttp_degree.imported!
         else
           dttp_degree.non_importable_invalid_data!

--- a/spec/services/degrees/create_from_dttp_spec.rb
+++ b/spec/services/degrees/create_from_dttp_spec.rb
@@ -5,10 +5,17 @@ require "rails_helper"
 module Degrees
   describe CreateFromDttp do
     let(:dttp_trainee) { create(:dttp_trainee) }
-    let!(:dttp_degree_qualification) { create(:dttp_degree_qualification, dttp_trainee: dttp_trainee) }
+    let(:api_degree_qualification) { create(:api_degree_qualification) }
+    let!(:dttp_degree_qualification) { create(:dttp_degree_qualification, dttp_trainee: dttp_trainee, response: api_degree_qualification) }
     let(:trainee) { create(:trainee, dttp_trainee: dttp_trainee) }
 
     subject(:create_from_dttp) { described_class.call(trainee: trainee) }
+
+    shared_examples "invalid" do
+      it "does not save the degree" do
+        expect { create_from_dttp }.not_to change(trainee.degrees, :count)
+      end
+    end
 
     it "creates a degree against the provided trainee" do
       expect {
@@ -34,23 +41,81 @@ module Degrees
       end
     end
 
-    context "when the degree fails to save" do
-      let(:invalid_subject) { "Creative accounting" }
-      let(:api_degree_qualification) { create(:api_degree_qualification, _dfe_degreesubjectid_value: invalid_subject) }
-      let!(:dttp_degree_qualification) do
+    context "when details are missing (not unmapped)" do
+      let(:api_degree_qualification) do
         create(
-          :dttp_degree_qualification,
-          dttp_trainee: dttp_trainee,
-          response: api_degree_qualification,
+          :api_degree_qualification,
+          _dfe_degreesubjectid_value: nil,
+          _dfe_degreetypeid_value: nil,
+          _dfe_awardinginstitutionid_value: nil,
         )
       end
+      let!(:dttp_degree_qualification) { create(:dttp_degree_qualification, dttp_trainee: dttp_trainee, response: api_degree_qualification) }
 
-      it "changes the state to non_importable_invalid_data" do
+      it "creates a degree with missing data" do
+        expect {
+          create_from_dttp
+        }.to change(trainee.degrees, :count).by(1)
+      end
+    end
+
+    context "when the degree has an unmapped subject" do
+      let(:unmapped_subject) { "Creative accounting" }
+      let(:api_degree_qualification) { create(:api_degree_qualification, _dfe_degreesubjectid_value: unmapped_subject) }
+
+      include_examples "invalid"
+
+      it "changes the state to non_importable_missing_subject" do
         expect {
           create_from_dttp
         }.to change {
           dttp_degree_qualification.reload.state
-        }.from("importable").to("non_importable_invalid_data")
+        }.from("importable").to("non_importable_missing_subject")
+      end
+    end
+
+    context "when the degree has an unmapped country" do
+      let(:unmapped_country) { "Isle of Woman" }
+      let(:api_degree_qualification) { create(:api_degree_qualification, _dfe_degreecountryid_value: unmapped_country) }
+
+      include_examples "invalid"
+
+      it "changes the state to non_importable_missing_country" do
+        expect {
+          create_from_dttp
+        }.to change {
+          dttp_degree_qualification.reload.state
+        }.from("importable").to("non_importable_missing_country")
+      end
+    end
+
+    context "when the degree has an unmapped degree type" do
+      let(:unmapped_type) { "Triple first class plus" }
+      let(:api_degree_qualification) { create(:api_degree_qualification, _dfe_degreetypeid_value: unmapped_type) }
+
+      include_examples "invalid"
+
+      it "changes the state to non_importable_missing_type" do
+        expect {
+          create_from_dttp
+        }.to change {
+          dttp_degree_qualification.reload.state
+        }.from("importable").to("non_importable_missing_type")
+      end
+    end
+
+    context "when the degree has an unmapped institution" do
+      let(:unmapped_institution) { "University of Foxford" }
+      let(:api_degree_qualification) { create(:api_degree_qualification, _dfe_awardinginstitutionid_value: unmapped_institution) }
+
+      include_examples "invalid"
+
+      it "changes the state to non_importable_missing_institution" do
+        expect {
+          create_from_dttp
+        }.to change {
+          dttp_degree_qualification.reload.state
+        }.from("importable").to("non_importable_missing_institution")
       end
     end
   end

--- a/spec/services/degrees/map_from_dttp_spec.rb
+++ b/spec/services/degrees/map_from_dttp_spec.rb
@@ -67,7 +67,7 @@ module Degrees
       end
 
       context "with an inactive degree type" do
-        let(:degree_type) { "BA (Hons) education" }
+        let(:degree_type) { "BA (Hons) /Education" }
         let(:api_degree_qualification) do
           create(
             :api_degree_qualification,


### PR DESCRIPTION
### Context

We failed to import a third of degrees. This was mainly due to degrees missing fields in DTTP.

https://trello.com/c/xNpaH7r4/3447-investigate-handle-missing-degrees-from-recent-21-22-trainee-import

### Changes proposed in this pull request

1. If a degree is missing a field (i.e. institution/country/type/subject is NULL) don't skip importing it. This more accurately reflects the data in DTTP and the user is presented with a missing data prompt:
<img width="1006" alt="Screenshot 2022-01-05 at 12 30 55" src="https://user-images.githubusercontent.com/18436946/148218118-970dba0a-1ee8-4bd6-b13b-57e8a3710915.png">

2. If a degrees has an unmapped field (i.e. institution/country/type/subject is NOT NULL but we don't have it in Register) skip importing it and flag the reason. This is the same as we do for DTTP trainees and will allow us to add missing mappings as we go back in time.

3. Add missing mappings for degree types, but don't surface them in the UI.

4. Add some missing institutions - these are institutions we have the inactive version for in Register. We need to keep the inactive mapping around for older records.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
