### PR TITLE
[3403] Add AcademicYears codeset from DTTP

### DIFF
--- a/app/lib/dttp/code_sets/academic_years.rb
+++ b/app/lib/dttp/code_sets/academic_years.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Dttp
+  module CodeSets
+    module AcademicYears
+      ACADEMIC_YEAR_2008_2009_FIRST = "1757b5c4-2bd1-e711-80df-005056ac45bb"
+      ACADEMIC_YEAR_2008_2009_SECOND = "77f80620-680f-ea11-a811-000d3ab5d037"
+      ACADEMIC_YEAR_2020_2021 = "76bcaeca-2bd1-e711-80df-005056ac45bb"
+      ACADEMIC_YEAR_2021_2022 = "21196925-17b9-e911-a863-000d3ab0dc71"
+      ACADEMIC_YEAR_2022_2023 = "ed0db9f4-eff5-eb11-94ef-000d3ab1e900"
+
+      MAPPING = {
+        "1996/97" => { entity_id: "63fc6019-2cd1-e711-80df-005056ac45bb" },
+        "1997/98" => { entity_id: "64fc6019-2cd1-e711-80df-005056ac45bb" },
+        "1998/99" => { entity_id: "0d57b5c4-2bd1-e711-80df-005056ac45bb" },
+        "1999/00" => { entity_id: "0e57b5c4-2bd1-e711-80df-005056ac45bb" },
+        "2000/01" => { entity_id: "0f57b5c4-2bd1-e711-80df-005056ac45bb" },
+        "2001/02" => { entity_id: "1057b5c4-2bd1-e711-80df-005056ac45bb" },
+        "2002/03" => { entity_id: "1157b5c4-2bd1-e711-80df-005056ac45bb" },
+        "2003/04" => { entity_id: "1257b5c4-2bd1-e711-80df-005056ac45bb" },
+        "2004/05" => { entity_id: "1357b5c4-2bd1-e711-80df-005056ac45bb" },
+        "2005/06" => { entity_id: "1457b5c4-2bd1-e711-80df-005056ac45bb" },
+        "2006/07" => { entity_id: "1557b5c4-2bd1-e711-80df-005056ac45bb" },
+        "2007/08" => { entity_id: "1657b5c4-2bd1-e711-80df-005056ac45bb" },
+        "2008/09" => { entity_id: ACADEMIC_YEAR_2008_2009_FIRST },
+        "2008/09 (DUPE)" => { entity_id: ACADEMIC_YEAR_2008_2009_SECOND },
+        "2009/10" => { entity_id: "71bcaeca-2bd1-e711-80df-005056ac45bb" },
+        "2010/11" => { entity_id: "72bcaeca-2bd1-e711-80df-005056ac45bb" },
+        "2011/12" => { entity_id: "73bcaeca-2bd1-e711-80df-005056ac45bb" },
+        "2012/13" => { entity_id: "74bcaeca-2bd1-e711-80df-005056ac45bb" },
+        "2013/14" => { entity_id: "75bcaeca-2bd1-e711-80df-005056ac45bb" },
+        "2014/15" => { entity_id: "dc4fe179-bc46-e711-80c8-0050568902d3" },
+        "2015/16" => { entity_id: "e5694d69-bc46-e711-80c8-0050568902d3" },
+        "2016/17" => { entity_id: "22320514-b646-e711-80c8-0050568902d3" },
+        "2017/18" => { entity_id: "8289012b-2487-e711-80e7-3863bb3640b8" },
+        "2018/19" => { entity_id: "0f8ee3cd-bc46-e711-80c8-0050568902d3" },
+        "2019/20" => { entity_id: "00469dd9-bc46-e711-80c8-0050568902d3" },
+        "2020/21" => { entity_id: ACADEMIC_YEAR_2020_2021 },
+        "2021/22" => { entity_id: ACADEMIC_YEAR_2021_2022 },
+        "2022/23" => { entity_id: ACADEMIC_YEAR_2022_2023 },
+      }.freeze
+    end
+  end
+end

--- a/app/lib/dttp/params/placement_assignment.rb
+++ b/app/lib/dttp/params/placement_assignment.rb
@@ -5,10 +5,6 @@ module Dttp
     class PlacementAssignment
       include Mappable
 
-      ACADEMIC_YEAR_2020_2021 = "76bcaeca-2bd1-e711-80df-005056ac45bb"
-      ACADEMIC_YEAR_2021_2022 = "21196925-17b9-e911-a863-000d3ab0dc71"
-      ACADEMIC_YEAR_2022_2023 = "ed0db9f4-eff5-eb11-94ef-000d3ab1e900"
-
       SCHOOL_NOT_APPLICABLE = "9e7fcac0-4a37-e811-80ef-005056ac45bb"
 
       COURSE_LEVEL_PG = 12
@@ -190,10 +186,10 @@ module Dttp
       end
 
       def academic_year
-        return ACADEMIC_YEAR_2020_2021 if itt_start_date_between?("1/8/2020", "31/7/2021")
-        return ACADEMIC_YEAR_2021_2022 if itt_start_date_between?("1/8/2021", "31/7/2022")
+        return CodeSets::AcademicYears::ACADEMIC_YEAR_2020_2021 if itt_start_date_between?("1/8/2020", "31/7/2021")
+        return CodeSets::AcademicYears::ACADEMIC_YEAR_2021_2022 if itt_start_date_between?("1/8/2021", "31/7/2022")
 
-        ACADEMIC_YEAR_2022_2023 if course_starting_in_2022?
+        CodeSets::AcademicYears::ACADEMIC_YEAR_2022_2023 if course_starting_in_2022?
       end
 
       def training_route

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -19,7 +19,7 @@ module Trainees
     def call
       return if dttp_trainee.imported?
       return if dttp_trainee.provider.blank?
-      return if dttp_trainee.latest_placement_assignment.blank?
+      return if dttp_trainee.placement_assignments.blank?
       return if dttp_trainee.response["merged"]
 
       if trainee_already_exists?
@@ -82,7 +82,7 @@ module Trainees
     attr_reader :dttp_trainee, :trainee
 
     def mapped_attributes
-      return if dttp_trainee.latest_placement_assignment.blank?
+      return if dttp_trainee.placement_assignments.blank?
 
       {
         created_from_dttp: true,

--- a/spec/factories/dttp/placement_assignments.rb
+++ b/spec/factories/dttp/placement_assignments.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     dttp_id { SecureRandom.uuid }
     contact_dttp_id { SecureRandom.uuid }
     provider_dttp_id { SecureRandom.uuid }
-    academic_year { SecureRandom.uuid }
+    academic_year { Dttp::Trainee::ACADEMIC_YEAR_ENTITY_IDS.sample }
     programme_start_date { Faker::Date.in_date_period(month: 9) }
     programme_end_date { Faker::Date.in_date_period(month: 8, year: Faker::Date.in_date_period.year + 1) }
     trainee_status { SecureRandom.uuid }
@@ -20,5 +20,13 @@ FactoryBot.define do
         dfe_programmeenddate: programme_end_date.strftime("%Y-%m-%d"),
       )
     }
+
+    trait :with_academic_year_twenty_twenty_one do
+      academic_year { Dttp::CodeSets::AcademicYears::ACADEMIC_YEAR_2020_2021 }
+    end
+
+    trait :with_academic_year_twenty_one_twenty_two do
+      academic_year { Dttp::CodeSets::AcademicYears::ACADEMIC_YEAR_2021_2022 }
+    end
   end
 end

--- a/spec/lib/dttp/params/placement_assignment_spec.rb
+++ b/spec/lib/dttp/params/placement_assignment_spec.rb
@@ -68,7 +68,7 @@ module Dttp
           end
 
           context "trainee with course in 20/21" do
-            let(:expected_year) { Dttp::Params::PlacementAssignment::ACADEMIC_YEAR_2020_2021 }
+            let(:expected_year) { Dttp::CodeSets::AcademicYears::ACADEMIC_YEAR_2020_2021 }
 
             context "1/8/2020" do
               let(:start_date) { "1/8/2020" }
@@ -84,7 +84,7 @@ module Dttp
           end
 
           context "trainee with course in 21/22" do
-            let(:expected_year) { Dttp::Params::PlacementAssignment::ACADEMIC_YEAR_2021_2022 }
+            let(:expected_year) { Dttp::CodeSets::AcademicYears::ACADEMIC_YEAR_2021_2022 }
 
             context "1/8/2021" do
               let(:start_date) { "1/8/2021" }
@@ -100,7 +100,7 @@ module Dttp
           end
 
           context "trainee with course in 22/23" do
-            let(:expected_year) { Dttp::Params::PlacementAssignment::ACADEMIC_YEAR_2022_2023 }
+            let(:expected_year) { Dttp::CodeSets::AcademicYears::ACADEMIC_YEAR_2022_2023 }
 
             context "1/8/2022" do
               let(:start_date) { "1/8/2022" }
@@ -137,7 +137,7 @@ module Dttp
                 "dfe_AwardingInstitutionId@odata.bind" => "/accounts(#{dttp_degree_institution_entity_id})",
                 "dfe_ClassofUGDegreeId@odata.bind" => "/dfe_classofdegrees(#{dttp_degree_grade_entity_id})",
                 "dfe_traineeid" => trainee.trainee_id,
-                "dfe_AcademicYearId@odata.bind" => "/dfe_academicyears(#{Dttp::Params::PlacementAssignment::ACADEMIC_YEAR_2020_2021})",
+                "dfe_AcademicYearId@odata.bind" => "/dfe_academicyears(#{Dttp::CodeSets::AcademicYears::ACADEMIC_YEAR_2020_2021})",
                 "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_PG,
                 "dfe_sendforregistration" => true,
                 "dfe_ProviderId@odata.bind" => "/accounts(#{dttp_provider_id})",
@@ -167,7 +167,7 @@ module Dttp
                 "dfe_commencementdate" => trainee.commencement_date.in_time_zone.iso8601,
                 "dfe_CountryofStudyId@odata.bind" => "/dfe_countries(#{dttp_country_entity_id})",
                 "dfe_traineeid" => trainee.trainee_id,
-                "dfe_AcademicYearId@odata.bind" => "/dfe_academicyears(#{Dttp::Params::PlacementAssignment::ACADEMIC_YEAR_2020_2021})",
+                "dfe_AcademicYearId@odata.bind" => "/dfe_academicyears(#{Dttp::CodeSets::AcademicYears::ACADEMIC_YEAR_2020_2021})",
                 "dfe_courselevel" => Dttp::Params::PlacementAssignment::COURSE_LEVEL_PG,
                 "dfe_sendforregistration" => true,
                 "dfe_ProviderId@odata.bind" => "/accounts(#{dttp_provider_id})",

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -306,21 +306,23 @@ module Trainees
       context "with multiple placement_assignments" do
         let(:placement_assignment_one) do
           create(:dttp_placement_assignment,
+                 :with_academic_year_twenty_twenty_one,
                  provider_dttp_id: provider.dttp_id,
-                 programme_start_date: Faker::Date.in_date_period(year: Time.zone.now.year - 1, month: 9).strftime("%Y-%m-%d"),
                  response: create(:api_placement_assignment,
                                   _dfe_ittsubject1id_value: Dttp::CodeSets::CourseSubjects::MODERN_LANGUAGES_DTTP_ID))
         end
 
         let(:placement_assignment_two) do
           create(:dttp_placement_assignment,
+                 :with_academic_year_twenty_one_twenty_two,
                  provider_dttp_id: provider.dttp_id,
-                 programme_start_date: Faker::Date.in_date_period(year: Time.zone.now.year, month: 9).strftime("%Y-%m-%d"),
                  response: create(:api_placement_assignment,
                                   _dfe_ittsubject1id_value: Dttp::CodeSets::CourseSubjects::MODERN_LANGUAGES_DTTP_ID))
         end
 
         let(:dttp_trainee) { create(:dttp_trainee, provider: provider, placement_assignments: [placement_assignment_one, placement_assignment_two]) }
+
+        before { dttp_trainee.reload }
 
         it "sets the course details from the latest placement assignment" do
           create_trainee_from_dttp


### PR DESCRIPTION
### Context
Adding this codeset in will enable us to refine records imported from dttp by matching them to the correct academic year. Currently, we are fetching based on the `programme_start_date` attribute, which in some cases may be missing against a trainee's placement assignment.

### Changes proposed in this pull request
1. Add `Dttp::CodeSets::AcademicYears`, which contains all known entity ids.
2. Use this codeset to set the sort order for placement assignments, as opposed to `programme_start_date`.

### Guidance to review
One bit that stands out: There are [two dttp academic years for 2008/09](https://github.com/DFE-Digital/register-trainee-teachers/compare/3403-investigate-handle-dttptrainees-with-missing-programmestartdate?expand=1#diff-2e20301c1132fe4438b19737319d8cb3e70e28bffe0f0d780d1d5477346ba301R25-R26), both seem to be in use. That said, it doesn't appear to be an issue for us.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
