### PR TITLE
[3374] Provider users many to many

### DIFF
--- a/app/components/personas/view.html.erb
+++ b/app/components/personas/view.html.erb
@@ -7,7 +7,7 @@
     <% if persona.system_admin? %>
       <%= persona.first_name %> has <strong>administrator</strong> access.
     <% else %>
-      Belongs to <strong><%= persona.provider.name %></strong> and is responsible for managing users.
+      Belongs to <strong><%= persona.primary_provider.name %></strong> and is responsible for managing users.
     <% end %>
     </p>
   </div>

--- a/app/controllers/system_admin/imports/users_controller.rb
+++ b/app/controllers/system_admin/imports/users_controller.rb
@@ -4,7 +4,8 @@ module SystemAdmin
   module Imports
     class UsersController < ApplicationController
       def create
-        authorize(provider.users.create!(user_params))
+        user = authorize(provider.users.create!(user_params))
+        ProviderUser.find_or_create_by!(provider: provider, user: user)
         redirect_to(provider_path(provider))
       end
 

--- a/app/controllers/system_admin/users_controller.rb
+++ b/app/controllers/system_admin/users_controller.rb
@@ -9,6 +9,7 @@ module SystemAdmin
     def create
       @user = authorize(provider.users.build(permitted_attributes(User)))
       if @user.save
+        ProviderUser.find_or_create_by!(provider: provider, user: @user)
         redirect_to(provider_path(provider), flash: { success: t(".success") })
       else
         render(:new)
@@ -17,12 +18,12 @@ module SystemAdmin
 
     def edit
       user
-      @provider = user.provider
+      @provider = user.primary_provider
     end
 
     def update
       user
-      @provider = user.provider
+      @provider = user.primary_provider
       if user.update(permitted_attributes(@user))
         redirect_to(provider_path(provider), flash: { success: t(".success") })
       else
@@ -32,12 +33,12 @@ module SystemAdmin
 
     def delete
       user
-      @provider = user.provider
+      @provider = user.primary_provider
     end
 
     def destroy
       user.discard
-      @provider = user.provider
+      @provider = user.primary_provider
       redirect_to(provider_path(@provider))
     end
 

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -23,7 +23,7 @@ class TraineesController < BaseTraineeController
     if trainee_params[:training_route] == "other"
       redirect_to(trainees_not_supported_route_path)
     else
-      authorize(@trainee = Trainee.new(trainee_params.merge(provider_id: current_user.provider_id)))
+      authorize(@trainee = Trainee.new(trainee_params.merge(provider_id: current_user.primary_provider.id)))
       trainee.set_early_years_course_details
       if trainee.save
         redirect_to(trainee_review_drafts_path(trainee))

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Provider < ApplicationRecord
-  has_many :users
+  has_many :provider_users, inverse_of: :provider
+  has_many :users, through: :provider_users
   has_many :trainees
 
   validates :name, presence: true

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ProviderUser < ApplicationRecord
+  belongs_to :provider
+  belongs_to :user
+
+  validates :provider, presence: true
+  validates :user, presence: true, uniqueness: { scope: :provider_id }
+
+  audited associated_with: :provider
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,8 @@
 class User < ApplicationRecord
   include Discard::Model
 
-  belongs_to :provider, optional: true
-
-  has_many :trainees, through: :provider
+  has_many :provider_users, inverse_of: :user
+  has_many :providers, through: :provider_users
 
   has_many :lead_school_users
   has_many :lead_schools, through: :lead_school_users
@@ -24,7 +23,11 @@ class User < ApplicationRecord
     EmailFormatValidator.new(record).validate
   end
 
-  audited associated_with: :provider
+  audited associated_with: :primary_provider
+
+  def primary_provider
+    providers.first
+  end
 
   def name
     "#{first_name} #{last_name}"

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -10,7 +10,7 @@ class TraineePolicy
     end
 
     def resolve
-      user.system_admin? ? scope.all : scope.where(provider_id: user.provider_id).kept
+      user.system_admin? ? scope.all : scope.where(provider_id: user.primary_provider.id).kept
     end
   end
 
@@ -63,6 +63,6 @@ class TraineePolicy
 private
 
   def allowed_user?
-    user&.system_admin? || user&.provider == trainee.provider
+    user&.system_admin? || user&.primary_provider == trainee.provider
   end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,8 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <% if current_user.provider %>
-      <span class="govuk-caption-l"><%= current_user.provider.name %></span>
+    <% if current_user.primary_provider %>
+      <span class="govuk-caption-l"><%= current_user.primary_provider.name %></span>
     <% end %>
     <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
     <h2 class="govuk-heading-l"><%= t(".draft_heading") %></h2>

--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "l", text: t("components.page_titles.trainees.training_routes.edit"), tag: "h1" }) do %>
 
-  <% if current_user.provider&.hpitt_postgrad? %>
+  <% if current_user.primary_provider.hpitt_postgrad? %>
     <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:hpitt_postgrad], label: { text: t("activerecord.attributes.trainee.training_routes.hpitt_postgrad") } %>
   <% else %>
     <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:assessment_only], label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>

--- a/db/data/20220104160549_update_provider_users.rb
+++ b/db/data/20220104160549_update_provider_users.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class UpdateProviderUsers < ActiveRecord::Migration[6.1]
+  def up
+    User.where.not(provider_id: nil).find_each do |user|
+      ProviderUser.find_or_create_by!(
+        provider_id: user.provider_id,
+        user_id: user.id,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20220104155959_create_provider_users.rb
+++ b/db/migrate/20220104155959_create_provider_users.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateProviderUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :provider_users do |t|
+      t.references :provider, null: false, foreign_key: true, index: true
+      t.references :user, null: false, foreign_key: true, index: true
+
+      t.timestamps
+    end
+
+    add_index :provider_users, %i[provider_id user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -320,6 +320,16 @@ ActiveRecord::Schema.define(version: 2022_01_05_173543) do
     t.index ["name"], name: "index_nationalities_on_name", unique: true
   end
 
+  create_table "provider_users", force: :cascade do |t|
+    t.bigint "provider_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider_id", "user_id"], name: "index_provider_users_on_provider_id_and_user_id", unique: true
+    t.index ["provider_id"], name: "index_provider_users_on_provider_id"
+    t.index ["user_id"], name: "index_provider_users_on_user_id"
+  end
+
   create_table "providers", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -508,6 +518,8 @@ ActiveRecord::Schema.define(version: 2022_01_05_173543) do
   add_foreign_key "lead_school_users", "users"
   add_foreign_key "nationalisations", "nationalities"
   add_foreign_key "nationalisations", "trainees"
+  add_foreign_key "provider_users", "providers"
+  add_foreign_key "provider_users", "users"
   add_foreign_key "subject_specialisms", "allocation_subjects"
   add_foreign_key "trainee_disabilities", "disabilities"
   add_foreign_key "trainee_disabilities", "trainees"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -79,10 +79,12 @@ namespace :example_data do
     # For each persona...
     PERSONAS.each do |persona_attributes|
       # Create the persona
-      persona = Persona.create_with(dttp_id: SecureRandom.uuid).find_or_create_by!(first_name: persona_attributes[:first_name],
-                                                                                   last_name: persona_attributes[:last_name],
-                                                                                   email: persona_attributes[:email],
-                                                                                   system_admin: persona_attributes[:system_admin])
+      persona = Persona.create_with(dttp_id: SecureRandom.uuid).find_or_create_by!(
+        first_name: persona_attributes[:first_name],
+        last_name: persona_attributes[:last_name],
+        email: persona_attributes[:email],
+        system_admin: persona_attributes[:system_admin],
+      )
 
       next unless persona_attributes[:provider]
 
@@ -92,7 +94,7 @@ namespace :example_data do
         code: persona_attributes[:provider_code].presence || Faker::Alphanumeric.alphanumeric(number: 3).upcase,
       )
 
-      persona.update!(provider: provider)
+      ProviderUser.find_or_create_by!(user: persona, provider: provider)
 
       # For each of the course routes enabled...
       enabled_course_routes.each do |route|

--- a/spec/components/personas/view_preview.rb
+++ b/spec/components/personas/view_preview.rb
@@ -9,7 +9,8 @@ module Personas
   private
 
     def mock_persona
-      User.new(id: 1, first_name: "Tom", last_name: "Jones", provider: Provider.new(name: "Provider A"))
+      provider = FactoryBot.create(:provider, name: "Provider A")
+      FactoryBot.create(:user, first_name: "Tom", last_name: "Jones", providers: [provider])
     end
   end
 end

--- a/spec/components/personas/view_spec.rb
+++ b/spec/components/personas/view_spec.rb
@@ -7,7 +7,7 @@ module Personas
     alias_method :component, :page
 
     let(:persona_id) { 1 }
-    let(:persona) { build(:user, id: persona_id, provider: build(:provider)) }
+    let(:persona) { create(:user, id: persona_id, providers: [create(:provider)]) }
 
     before do
       render_inline(described_class.new(persona: persona))
@@ -18,7 +18,7 @@ module Personas
     end
 
     it "renders the persona's provider name" do
-      expect(component).to have_text(persona.provider.name)
+      expect(component).to have_text(persona.primary_provider.name)
     end
 
     it "renders a sign-in button to login as the persona" do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -21,7 +21,7 @@ describe PagesController, type: :controller do
   end
 
   context "when signed in and navigate to start page" do
-    let(:current_user) { build(:user) }
+    let(:current_user) { create(:user) }
 
     before do
       allow(controller).to receive(:current_user).and_return(current_user)

--- a/spec/controllers/trainees/award_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/award_recommendations_controller_spec.rb
@@ -6,7 +6,7 @@ describe Trainees::AwardRecommendationsController do
   include ActiveJob::TestHelper
 
   let(:current_user) { create(:user) }
-  let(:trainee) { create(:trainee, :trn_received, provider: current_user.provider) }
+  let(:trainee) { create(:trainee, :trn_received, provider: current_user.primary_provider) }
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)

--- a/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
@@ -6,7 +6,7 @@ describe Trainees::ConfirmDeferralsController do
   include ActiveJob::TestHelper
 
   let(:current_user) { create(:user) }
-  let(:trainee) { create(:trainee, :trn_received, provider: current_user.provider) }
+  let(:trainee) { create(:trainee, :trn_received, provider: current_user.primary_provider) }
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)

--- a/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
@@ -6,7 +6,7 @@ describe Trainees::ConfirmReinstatementsController do
   include ActiveJob::TestHelper
 
   let(:current_user) { create(:user) }
-  let(:trainee) { create(:trainee, :deferred, trn: trn, provider: current_user.provider) }
+  let(:trainee) { create(:trainee, :deferred, trn: trn, provider: current_user.primary_provider) }
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)

--- a/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
@@ -6,7 +6,7 @@ describe Trainees::ConfirmWithdrawalsController do
   include ActiveJob::TestHelper
 
   let(:current_user) { create(:user) }
-  let(:trainee) { create(:trainee, :trn_received, provider: current_user.provider) }
+  let(:trainee) { create(:trainee, :trn_received, provider: current_user.primary_provider) }
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)

--- a/spec/controllers/trainees/degrees/type_controller_spec.rb
+++ b/spec/controllers/trainees/degrees/type_controller_spec.rb
@@ -4,12 +4,13 @@ require "rails_helper"
 
 RSpec.describe Trainees::Degrees::TypeController, type: :controller do
   describe "#create" do
-    let(:user) { create(:user, provider: trainee.provider) }
+    let(:user) { create(:user, providers: [trainee.provider]) }
     let(:trainee) { create(:trainee) }
     let(:response) do
-      post(:create, params: { trainee_id: trainee,
-                              degree:
-      { locale_code: locale_code } })
+      post(:create, params: {
+        trainee_id: trainee,
+        degree: { locale_code: locale_code },
+      })
     end
 
     before do

--- a/spec/controllers/trainees/degrees_controller_spec.rb
+++ b/spec/controllers/trainees/degrees_controller_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Trainees::DegreesController, type: :controller do
   describe "#create" do
-    let(:user) { create(:user, provider: trainee.provider) }
+    let(:user) { create(:user, providers: [trainee.provider]) }
     let(:trainee) { create(:trainee) }
     let(:degree) { build(:degree, :uk_degree_with_details) }
 

--- a/spec/controllers/trainees/lead_schools_controller_spec.rb
+++ b/spec/controllers/trainees/lead_schools_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Trainees::LeadSchoolsController, type: :controller do
 
     context "when school direct salaried trainee" do
       let(:trainee) { create(:trainee, :school_direct_salaried) }
-      let(:user) { create(:user, provider: trainee.provider) }
+      let(:user) { create(:user, providers: [trainee.provider]) }
 
       before do
         allow(controller).to receive(:current_user).and_return(user)
@@ -28,7 +28,7 @@ RSpec.describe Trainees::LeadSchoolsController, type: :controller do
 
     context "when school direct tuition fee trainee" do
       let(:trainee) { create(:trainee, :school_direct_tuition_fee) }
-      let(:user) { create(:user, provider: trainee.provider) }
+      let(:user) { create(:user, providers: [trainee.provider]) }
 
       before do
         allow(controller).to receive(:current_user).and_return(user)

--- a/spec/controllers/trainees/personal_details_controller_spec.rb
+++ b/spec/controllers/trainees/personal_details_controller_spec.rb
@@ -11,7 +11,7 @@ describe Trainees::PersonalDetailsController do
 
   describe "#show" do
     context "with a non-draft trainee" do
-      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.provider) }
+      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.primary_provider) }
 
       before do
         get(:show, params: { trainee_id: trainee })
@@ -23,7 +23,7 @@ describe Trainees::PersonalDetailsController do
     end
 
     context "with a draft trainee" do
-      let(:trainee) { create(:trainee, :draft, provider: user.provider) }
+      let(:trainee) { create(:trainee, :draft, provider: user.primary_provider) }
 
       it "redirects to /review-draft" do
         expect(get(:show, params: { trainee_id: trainee })).to redirect_to(trainee_review_drafts_path(trainee))
@@ -33,7 +33,7 @@ describe Trainees::PersonalDetailsController do
 
   describe "#update" do
     context "with an apply draft trainee" do
-      let(:trainee) { create(:trainee, :draft, :with_apply_application, provider: user.provider) }
+      let(:trainee) { create(:trainee, :draft, :with_apply_application, provider: user.primary_provider) }
 
       before do
         allow(PersonalDetailsForm).to receive(:new).and_return(double(stash_or_save!: true))

--- a/spec/controllers/trainees/subject_specialisms_controller_spec.rb
+++ b/spec/controllers/trainees/subject_specialisms_controller_spec.rb
@@ -8,7 +8,7 @@ describe Trainees::SubjectSpecialismsController do
     create(:trainee,
            :provider_led_postgrad,
            :submitted_for_trn,
-           provider: user.provider,
+           provider: user.primary_provider,
            course_subject_one: nil,
            course_subject_two: nil,
            course_subject_three: nil)

--- a/spec/controllers/trainees/training_details_controller_spec.rb
+++ b/spec/controllers/trainees/training_details_controller_spec.rb
@@ -11,7 +11,7 @@ describe Trainees::TrainingDetailsController do
 
   describe "#update" do
     context "with an apply draft trainee" do
-      let(:trainee) { create(:trainee, :draft, :with_apply_application, provider: user.provider) }
+      let(:trainee) { create(:trainee, :draft, :with_apply_application, provider: user.primary_provider) }
 
       before do
         allow(TrainingDetailsForm).to receive(:new).and_return(double(save: true))

--- a/spec/controllers/trainees_controller_spec.rb
+++ b/spec/controllers/trainees_controller_spec.rb
@@ -49,7 +49,7 @@ describe TraineesController do
     end
 
     context "csv export" do
-      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.provider) }
+      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.primary_provider) }
 
       before do
         trainee
@@ -67,7 +67,7 @@ describe TraineesController do
 
   describe "#show" do
     context "with a non-draft trainee" do
-      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.provider) }
+      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.primary_provider) }
 
       before do
         get(:show, params: { id: trainee })
@@ -89,7 +89,7 @@ describe TraineesController do
 
   describe "#destroy" do
     context "with a non-draft trainee" do
-      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.provider) }
+      let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.primary_provider) }
 
       it "redirects to the trainee index page" do
         expect(get(:destroy, params: { id: trainee })).to redirect_to(trainees_path)

--- a/spec/controllers/trn_submissions_controller_spec.rb
+++ b/spec/controllers/trn_submissions_controller_spec.rb
@@ -19,7 +19,7 @@ describe TrnSubmissionsController do
             :trainee,
             :completed,
             :with_study_mode_and_future_course_dates,
-            provider: current_user.provider,
+            provider: current_user.primary_provider,
           )
         end
 
@@ -30,7 +30,7 @@ describe TrnSubmissionsController do
       end
 
       context "and the itt start date is in the past" do
-        let(:trainee) { create(:trainee, :completed, provider: current_user.provider) }
+        let(:trainee) { create(:trainee, :completed, provider: current_user.primary_provider) }
 
         it "redirects to the trainee start status page" do
           expect(post(:create, params: { trainee_id: trainee }))

--- a/spec/factories/provider_users.rb
+++ b/spec/factories/provider_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :provider_user do
+    provider
+    user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,16 @@
 
 FactoryBot.define do
   factory :user, class: "User" do
+    transient do
+      providers { [build(:provider)] }
+    end
+
+    after(:create) do |user, evaluator|
+      evaluator.providers.each do |provider|
+        create(:provider_user, provider: provider, user: user)
+      end
+    end
+
     dfe_sign_in_uid { SecureRandom.uuid }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
@@ -9,10 +19,8 @@ FactoryBot.define do
     dttp_id { SecureRandom.uuid }
     welcome_email_sent_at { Faker::Time.backward(days: 1).utc }
 
-    provider
-
     trait :system_admin do
-      provider { nil }
+      providers { [] }
       system_admin { true }
     end
   end

--- a/spec/features/end_to_end/teach_first_journey_spec.rb
+++ b/spec/features/end_to_end/teach_first_journey_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 feature "teach-first end-to-end journey", type: :feature do
-  let(:user) { create(:user, provider: create(:provider, code: TEACH_FIRST_PROVIDER_CODE)) }
+  let(:user) { create(:user, providers: [create(:provider, code: TEACH_FIRST_PROVIDER_CODE)]) }
 
   background { given_i_am_authenticated(user: user) }
 

--- a/spec/features/form_sections/personal_and_education_details/degrees/delete_degree_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/degrees/delete_degree_spec.rb
@@ -54,13 +54,13 @@ private
   end
 
   def uk_trainee
-    @uk_trainee ||= create(:trainee, provider: current_user.provider).tap do |t|
+    @uk_trainee ||= create(:trainee, provider: current_user.primary_provider).tap do |t|
       t.degrees << build(:degree, :uk_degree_with_details)
     end
   end
 
   def non_uk_trainee
-    @non_uk_trainee ||= create(:trainee, provider: current_user.provider).tap do |t|
+    @non_uk_trainee ||= create(:trainee, provider: current_user.primary_provider).tap do |t|
       t.degrees << build(:degree, :non_uk_degree_with_details)
     end
   end

--- a/spec/features/form_sections/personal_and_education_details/degrees/editing_degree_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/degrees/editing_degree_spec.rb
@@ -76,7 +76,7 @@ private
   end
 
   def given_a_non_draft_trainee_with_a_uk_degree
-    @uk_trainee ||= create(:trainee, :submitted_for_trn, provider: current_user.provider)
+    @uk_trainee ||= create(:trainee, :submitted_for_trn, provider: current_user.primary_provider)
   end
 
   def given_a_trainee_with_a_non_uk_degree
@@ -147,13 +147,13 @@ private
   end
 
   def uk_trainee(trait: :draft)
-    @uk_trainee ||= create(:trainee, trait, provider: current_user.provider).tap do |t|
+    @uk_trainee ||= create(:trainee, trait, provider: current_user.primary_provider).tap do |t|
       t.degrees << build(:degree, :uk_degree_type)
     end
   end
 
   def non_uk_trainee
-    @non_uk_trainee ||= create(:trainee, provider: current_user.provider).tap do |t|
+    @non_uk_trainee ||= create(:trainee, provider: current_user.primary_provider).tap do |t|
       t.degrees << build(:degree, :non_uk_degree_type)
     end
   end

--- a/spec/features/form_sections/personal_and_education_details/diversities/edit_ethnic_background_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/diversities/edit_ethnic_background_spec.rb
@@ -39,7 +39,7 @@ feature "edit ethnic background", type: :feature do
   end
 
   def given_a_trainee_exists(group = Diversities::ETHNIC_GROUP_ENUMS[:asian])
-    @trainee = create(:trainee, :diversity_disclosed, ethnic_group: group, provider: current_user.provider)
+    @trainee = create(:trainee, :diversity_disclosed, ethnic_group: group, provider: current_user.primary_provider)
   end
 
   def with_an_additional_background_provided

--- a/spec/features/form_sections/personal_and_education_details/diversities/edit_ethnic_group_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/diversities/edit_ethnic_group_spec.rb
@@ -52,7 +52,7 @@ feature "edit ethnic group", type: :feature do
   end
 
   def given_a_trainee_exists
-    @trainee = create(:trainee, :diversity_disclosed, :disability_not_provided, provider: current_user.provider)
+    @trainee = create(:trainee, :diversity_disclosed, :disability_not_provided, provider: current_user.primary_provider)
   end
 
   def given_a_trainee_with_a_background_exists
@@ -61,7 +61,7 @@ feature "edit ethnic group", type: :feature do
       :diversity_disclosed,
       ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:mixed],
       ethnic_background: Diversities::BACKGROUNDS[Diversities::ETHNIC_GROUP_ENUMS[:mixed]].sample,
-      provider: current_user.provider,
+      provider: current_user.primary_provider,
     )
   end
 

--- a/spec/features/system_admin/users/creating_a_new_user_spec.rb
+++ b/spec/features/system_admin/users/creating_a_new_user_spec.rb
@@ -45,7 +45,7 @@ private
   end
 
   def then_i_am_taken_to_the_provider_show_page
-    expect(provider_show_page).to be_displayed(id: user.provider.id)
+    expect(provider_show_page).to be_displayed(id: user.primary_provider.id)
   end
 
   def and_i_click_on_add_a_user

--- a/spec/features/system_admin/users/deleting_a_user_spec.rb
+++ b/spec/features/system_admin/users/deleting_a_user_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 feature "Creating a new user" do
-  let(:user) { create(:user, provider: system_admin.provider) }
-  let(:system_admin) { create(:user, system_admin: true) }
+  let(:provider) { create(:provider) }
+  let(:user) { create(:user, providers: [provider]) }
+  let(:system_admin) { create(:user, system_admin: true, providers: [provider]) }
 
   before do
     given_there_is_a_user(user)
@@ -38,7 +39,7 @@ private
   end
 
   def then_i_am_taken_to_the_provider_show_page
-    provider_show_page.load(id: system_admin.provider.id)
+    provider_show_page.load(id: system_admin.primary_provider.id)
   end
 
   def and_i_see_the_registered_users
@@ -58,7 +59,7 @@ private
   end
 
   def then_i_am_redirected_to_the_provider_show_page
-    provider_show_page.load(id: system_admin.provider.id)
+    provider_show_page.load(id: system_admin.primary_provider.id)
   end
 
   def and_the_user_has_been_deleted

--- a/spec/features/system_admin/users/updating_a_user_spec.rb
+++ b/spec/features/system_admin/users/updating_a_user_spec.rb
@@ -35,7 +35,7 @@ feature "Creating a new user" do
 private
 
   def when_i_visit_the_provider_show_page
-    provider_show_page.load(id: user.provider.id)
+    provider_show_page.load(id: user.primary_provider.id)
   end
 
   def and_i_click_on_edit_user_link
@@ -67,7 +67,7 @@ private
   end
 
   def then_i_am_taken_to_the_provider_show_page
-    expect(provider_show_page).to be_displayed(id: user.provider.id)
+    expect(provider_show_page).to be_displayed(id: user.primary_provider.id)
   end
 
   def edit_user_page

--- a/spec/features/system_admin/users/viewing_users_spec.rb
+++ b/spec/features/system_admin/users/viewing_users_spec.rb
@@ -35,7 +35,7 @@ feature "View users" do
   end
 
   def and_there_is_a_dttp_user
-    create(:dttp_user, provider_dttp_id: user.provider.dttp_id)
+    create(:dttp_user, provider_dttp_id: user.primary_provider.dttp_id)
   end
 
   def and_i_click_on_a_provider
@@ -43,7 +43,7 @@ feature "View users" do
   end
 
   def then_i_am_taken_to_the_provider_show_page
-    expect(provider_show_page).to be_displayed(id: user.provider.id)
+    expect(provider_show_page).to be_displayed(id: user.primary_provider.id)
   end
 
   def then_i_see_the_registered_users

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -143,7 +143,7 @@ private
     @early_years_trainee ||= create(:trainee, :submitted_for_trn, :early_years_undergrad)
     @primary_trainee ||= create(:trainee, :submitted_for_trn, course_age_range: AgeRange::THREE_TO_EIGHT)
     @apply_non_draft_trainee ||= create(:trainee, :submitted_for_trn, :with_apply_application)
-    Trainee.update_all(provider_id: @current_user.provider.id)
+    Trainee.update_all(provider_id: @current_user.primary_provider.id)
   end
 
   def given_all_trainees_are_from_a_single_source

--- a/spec/features/trainee_actions/submit_for_trn_spec.rb
+++ b/spec/features/trainee_actions/submit_for_trn_spec.rb
@@ -16,7 +16,7 @@ feature "submit for TRN" do
         create(
           :trainee,
           :completed,
-          provider: current_user.provider,
+          provider: current_user.primary_provider,
           course_uuid: nil,
         )
       end
@@ -37,7 +37,7 @@ feature "submit for TRN" do
             :trainee,
             :completed,
             :with_study_mode_and_future_course_dates,
-            provider: current_user.provider,
+            provider: current_user.primary_provider,
             course_uuid: nil,
           )
         end
@@ -76,7 +76,7 @@ feature "submit for TRN" do
   end
 
   describe "content" do
-    let(:trainee) { create(:trainee, :with_apply_application, provider: current_user.provider) }
+    let(:trainee) { create(:trainee, :with_apply_application, provider: current_user.primary_provider) }
 
     context "with an apply-draft-trainee" do
       scenario "has a trainee data section" do

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProviderUser, type: :model do
+  subject { create(:provider_user) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:provider) }
+    it { is_expected.to validate_presence_of(:user) }
+
+    it { is_expected.to validate_uniqueness_of(:user).scoped_to(:provider_id) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:provider) }
+    it { is_expected.to belong_to(:user) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,7 +58,7 @@ describe User do
   end
 
   describe "associations" do
-    it { is_expected.to belong_to(:provider).optional }
+    it { is_expected.to have_many(:providers) }
   end
 
   describe "indexes" do
@@ -67,7 +67,7 @@ describe User do
   end
 
   describe "auditing" do
-    it { is_expected.to be_audited.associated_with(:provider) }
+    it { is_expected.to be_audited.associated_with(:primary_provider) }
   end
 
   describe "#discard" do
@@ -117,6 +117,14 @@ describe User do
       it "is not returned" do
         expect(User.system_admins).to be_empty
       end
+    end
+  end
+
+  describe ".primary_provider" do
+    subject { create(:user) }
+
+    context "returns first provider" do
+      it { expect(subject.primary_provider).to eq(subject.providers.first) }
     end
   end
 end

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 describe TraineePolicy do
-  let(:system_admin_user) { build(:user, :system_admin) }
+  let(:system_admin_user) { create(:user, :system_admin) }
   let(:provider) { create(:provider) }
-  let(:provider_user) { build(:user, provider: provider) }
-  let(:other_provider_user) { build(:user) }
+  let(:provider_user) { create(:user, providers: [provider]) }
+  let(:other_provider_user) { create(:user) }
   let(:trainee) { create(:trainee, provider: provider) }
   let(:deferred_trainee) { create(:trainee, :deferred, provider: provider) }
 
@@ -27,7 +27,7 @@ describe TraineePolicy do
   end
 
   describe TraineePolicy::Scope do
-    let(:user) { create(:user, provider: provider) }
+    let(:user) { create(:user, providers: [provider]) }
     let(:provider) { create(:provider) }
 
     subject { described_class.new(user, Trainee).resolve }

--- a/spec/support/features/trainee_steps.rb
+++ b/spec/support/features/trainee_steps.rb
@@ -5,7 +5,7 @@ module Features
     attr_reader :trainee
 
     def given_a_trainee_exists(*traits, **overrides)
-      @trainee ||= create(:trainee, *traits, **overrides, provider: current_user.provider)
+      @trainee ||= create(:trainee, *traits, **overrides, provider: current_user.primary_provider)
     end
 
     def trainee_from_url

--- a/spec/view_objects/system_admin/users_view_spec.rb
+++ b/spec/view_objects/system_admin/users_view_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe SystemAdmin::UsersView do
   let(:provider) { create(:provider) }
   let(:dttp_user) { create(:dttp_user, provider_dttp_id: provider.dttp_id) }
-  let(:user) { create(:user, provider: provider) }
+  let(:user) { create(:user, providers: [provider]) }
 
   subject { described_class.new(provider) }
 


### PR DESCRIPTION
### Context

https://trello.com/c/Qzaf2eBf/3374-l-provider-users

There's also a migration PR to remove old provider column from users:
https://github.com/DFE-Digital/register-trainee-teachers/pull/1874

### Changes proposed in this pull request

* Many to many relation added for `Provider` and `User` using model `ProviderUser`
* Data migration added to copy over `User.provider_id` to `ProviderUser` relationships.
* Added `User.primary_provider`, returns first provider
* `User.primary_provider` is used instead of old `User.provider`, will need to be updated when we have worked out how to choose current provider.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
