### PR TITLE
show start date when trainee withdraws

### DIFF
--- a/app/components/withdrawal_details/view.html.erb
+++ b/app/components/withdrawal_details/view.html.erb
@@ -1,17 +1,4 @@
 <%= render SummaryCard::View.new(
   title: t("components.confirmation.withdrawal_details.summary_title"),
-  rows: [
-    {
-      key: t("components.confirmation.withdrawal_details.withdraw_date_label"),
-      value: withdraw_date,
-      action_href: deferred ? nil : trainee_withdrawal_path(data_model.trainee),
-      action_text: deferred ? nil : t(:change),
-    },
-    {
-      key: t("components.confirmation.withdrawal_details.withdraw_reason_label"),
-      value: withdraw_reason,
-      action_href: trainee_withdrawal_path(data_model.trainee),
-      action_text: t(:change),
-    },
-  ],
+  rows: rows
 ) %>

--- a/app/components/withdrawal_details/view.rb
+++ b/app/components/withdrawal_details/view.rb
@@ -4,11 +4,16 @@ module WithdrawalDetails
   class View < GovukComponent::Base
     include SummaryHelper
 
-    attr_reader :data_model, :deferred
+    attr_reader :data_model, :deferred, :trainee
 
     def initialize(data_model)
       @data_model = data_model
+      @trainee = data_model.trainee
       @deferred = data_model.trainee.deferred?
+    end
+
+    def trainee_commencement_date
+      date_for_summary_view(trainee.commencement_date)
     end
 
     def withdraw_date
@@ -21,6 +26,10 @@ module WithdrawalDetails
       I18n.t("components.confirmation.withdrawal_details.reasons.#{data_model.withdraw_reason}")
     end
 
+    def rows
+      [start_date_row, withdrawal_date_row, reason_for_withdrawal_row]
+    end
+
   private
 
     def date_with_deferral_text
@@ -29,6 +38,33 @@ module WithdrawalDetails
 
     def withdrawal_date
       date_for_summary_view(data_model.date)
+    end
+
+    def start_date_row
+      {
+        key: t("components.confirmation.withdrawal_details.trainee_start_date_label"),
+        value: trainee_commencement_date,
+        action_href: deferred ? nil : trainee_start_date_verification_path(data_model.trainee, context: :withdraw),
+        action_text: deferred ? nil : t(:change),
+      }
+    end
+
+    def withdrawal_date_row
+      {
+        key: t("components.confirmation.withdrawal_details.withdraw_date_label"),
+        value: withdraw_date,
+        action_href: deferred ? nil : trainee_withdrawal_path(data_model.trainee),
+        action_text: deferred ? nil : t(:change),
+      }
+    end
+
+    def reason_for_withdrawal_row
+      {
+        key: t("components.confirmation.withdrawal_details.withdraw_reason_label"),
+        value: withdraw_reason,
+        action_href: trainee_withdrawal_path(data_model.trainee),
+        action_text: t(:change),
+      }
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,6 +151,7 @@ en:
       withdrawal_details:
         summary_title: Withdrawal details
         withdrawal_date: "%{date} (date of deferral)"
+        trainee_start_date_label: Trainee start date
         withdraw_date_label: Date of withdrawal
         withdraw_reason_label: Reason for withdrawal
         reasons: &withdrawal_reasons

--- a/spec/components/withdrawal_details/view_spec.rb
+++ b/spec/components/withdrawal_details/view_spec.rb
@@ -19,6 +19,10 @@ describe WithdrawalDetails::View do
   end
 
   context "withdrawn on another day" do
+    it "renders commencement date" do
+      expect(rendered_component).to have_text(date_for_summary_view(trainee.commencement_date))
+    end
+
     it "renders the date of withdrawal" do
       expect(rendered_component).to have_text(date_for_summary_view(data_model.date))
     end


### PR DESCRIPTION
### Context

For clarity (and consistency with deferral) we should show the user the commencement date when the user withdraws a trainee and allow them to change it

### Changes proposed in this pull request

Add commencement date to withdraw flow with change link
