### PR TITLE
[3374] Provider users many to many - remove old provider column from users

### DIFF
--- a/db/migrate/20220106101133_remove_provider_from_users.rb
+++ b/db/migrate/20220106101133_remove_provider_from_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveProviderFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :users, :provider, index: true, null: false, foreign_key: { to_table: :providers }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_05_173543) do
+ActiveRecord::Schema.define(version: 2022_01_06_101133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -484,7 +484,6 @@ ActiveRecord::Schema.define(version: 2022_01_05_173543) do
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "email", null: false
-    t.bigint "provider_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "dfe_sign_in_uid"
@@ -497,7 +496,6 @@ ActiveRecord::Schema.define(version: 2022_01_05_173543) do
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["dttp_id"], name: "index_unique_active_users", unique: true, where: "(discarded_at IS NULL)"
     t.index ["email"], name: "index_users_on_email"
-    t.index ["provider_id"], name: "index_users_on_provider_id"
   end
 
   create_table "validation_errors", force: :cascade do |t|
@@ -527,5 +525,4 @@ ActiveRecord::Schema.define(version: 2022_01_05_173543) do
   add_foreign_key "trainees", "providers"
   add_foreign_key "trainees", "schools", column: "employing_school_id"
   add_foreign_key "trainees", "schools", column: "lead_school_id"
-  add_foreign_key "users", "providers"
 end

--- a/spec/components/user_card/view_preview.rb
+++ b/spec/components/user_card/view_preview.rb
@@ -14,14 +14,20 @@ module UserCard
   private
 
     def mock_user
-      User.new(
-        id: 1,
+      provider = FactoryBot.create(
+        :provider,
+        name: "Provider A",
+        dttp_id: SecureRandom.uuid,
+      )
+
+      FactoryBot.create(
+        :user,
         first_name: "Luke",
         last_name: "Skywalker",
         email: "luke@email.com",
         created_at: Time.zone.now,
-        provider_id: Provider.new(name: "Provider A", dttp_id: SecureRandom.uuid),
         dttp_id: SecureRandom.uuid,
+        providers: [provider],
       )
     end
 


### PR DESCRIPTION
### Context

https://trello.com/c/Qzaf2eBf/3374-l-provider-users

For PR:
https://github.com/DFE-Digital/register-trainee-teachers/pull/1868

### Changes proposed in this pull request

* Migration to remove old provider column from users

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
