### PR TITLE
[xxx] Pull out trainee status into separate column on dttp_trainees

### DIFF
--- a/app/lib/dttp/parsers/contact.rb
+++ b/app/lib/dttp/parsers/contact.rb
@@ -21,6 +21,7 @@ module Dttp
             {
               dttp_id: contact["contactid"],
               provider_dttp_id: contact["_parentcustomerid_value"],
+              status: contact["_dfe_traineestatusid_value"],
               response: contact,
             }
           end

--- a/db/migrate/20220105173543_add_status_to_dttp_trainees.rb
+++ b/db/migrate/20220105173543_add_status_to_dttp_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStatusToDttpTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :dttp_trainees, :status, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_05_113142) do
+ActiveRecord::Schema.define(version: 2022_01_05_173543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -260,6 +260,7 @@ ActiveRecord::Schema.define(version: 2022_01_05_113142) do
     t.uuid "provider_dttp_id"
     t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.uuid "status"
     t.index ["dttp_id"], name: "index_dttp_trainees_on_dttp_id", unique: true
   end
 

--- a/spec/lib/dttp/parsers/contact_spec.rb
+++ b/spec/lib/dttp/parsers/contact_spec.rb
@@ -32,6 +32,7 @@ module Dttp
           {
             dttp_id: contact["contactid"],
             provider_dttp_id: contact["_parentcustomerid_value"],
+            status: contact["_dfe_traineestatusid_value"],
             response: contact,
           }
         end


### PR DESCRIPTION
### Context

We pull out the trainee status on the placement assignment, but not from the trainee.

### Changes proposed in this pull request

Extract the status from the dttp trainee and store it in a separate column. This will make querying and analysis easier.

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

  Yes, but we don't send the dttp_trainee entity to BigQuery.