### PR TITLE
[3375] Add system admin users tab

### DIFF
--- a/app/controllers/system_admin/users_controller.rb
+++ b/app/controllers/system_admin/users_controller.rb
@@ -2,6 +2,10 @@
 
 module SystemAdmin
   class UsersController < ApplicationController
+    def index
+      @users = policy_scope(User, policy_scope_class: UserPolicy).order_by_last_name.page(params[:page] || 1)
+    end
+
     def new
       @user = authorize(provider.users.build)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :lead_school_users
   has_many :lead_schools, through: :lead_school_users
 
+  scope :order_by_last_name, -> { order(:last_name) }
   scope :system_admins, -> { where(system_admin: true) }
 
   before_validation :sanitise_email

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 class ProviderPolicy
-  attr_reader :user
+  attr_reader :user, :scope
 
-  def initialize(user, provider)
+  def initialize(user, scope)
     @user = user
-    @provider = provider
+    @scope = scope
+  end
+
+  def resolve
+    scope
   end
 
   def show?

--- a/app/views/system_admin/_tab_nav.html.erb
+++ b/app/views/system_admin/_tab_nav.html.erb
@@ -1,4 +1,5 @@
 <%= render TabNavigation::View.new(items: [
+  { name: "Users", url: users_path },
   { name: "Providers", url: providers_path },
   { name: "Dttp providers", url: dttp_providers_path },
   { name: "Validation errors", url: validation_errors_path },

--- a/app/views/system_admin/users/index.html.erb
+++ b/app/views/system_admin/users/index.html.erb
@@ -1,0 +1,60 @@
+<%= render PageTitle::View.new(i18n_key: "users.index") %>
+
+<h1 class="govuk-heading-l">Users</h1>
+
+<%= render "system_admin/tab_nav" %>
+
+<table class="govuk-table" summary="Users list">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">First name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Last name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Email</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Lead Schools</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Providers</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @users.each do |user| %>
+      <tr class="govuk-table__row qa-user_row">
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= user.first_name %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= user.last_name %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= user.email %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <% user.lead_schools.each do |lead_school| %>
+              <%= govuk_link_to(lead_school.name, lead_school_path(lead_school), class: "govuk-!-display-block") %>
+            <% end %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <% user.providers.each do |provider| %>
+              <%= govuk_link_to provider.name, provider_path(provider), class: "govuk-!-display-block" %>
+            <% end %>
+          </span>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= render Paginator::View.new(scope: @users) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,6 +347,7 @@ en:
       dttp_providers:
         index: Dttp Providers
       users:
+        index: Users
         new: Add a user
         edit: Edit user
         delete: Remove a user

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -26,6 +26,7 @@ module SystemAdminRoutes
           end
         end
 
+        resources :users, only: %i[index]
         resources :dttp_providers, only: %i[index show create]
         resources :validation_errors, only: %i[index]
         resources :schools, only: %i[index]

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -95,6 +95,7 @@ namespace :example_data do
       )
 
       ProviderUser.find_or_create_by!(user: persona, provider: provider)
+      LeadSchoolUser.create!(user: persona, lead_school: School.lead_only.sample)
 
       # For each of the course routes enabled...
       enabled_course_routes.each do |route|

--- a/spec/features/system_admin/users/list_users_spec.rb
+++ b/spec/features/system_admin/users/list_users_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "List users" do
+  context "as a system admin" do
+    let(:user) { create(:user, system_admin: true) }
+    let(:lead_school) { create(:school, :lead) }
+    let(:provider) { create(:provider) }
+
+    before do
+      user.lead_schools << lead_school
+      user.providers << provider
+      given_i_am_authenticated(user: user)
+    end
+
+    scenario "list users" do
+      when_i_visit_the_user_index_page
+      then_i_see_the_user
+    end
+  end
+
+  def when_i_visit_the_user_index_page
+    users_index_page.load
+  end
+
+  def then_i_see_the_user
+    expect(users_index_page).to have_text(user.first_name)
+    expect(users_index_page).to have_text(user.last_name)
+    expect(users_index_page).to have_text(user.email)
+    expect(users_index_page).to have_text(lead_school.name)
+    expect(users_index_page).to have_text(provider.name)
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -98,6 +98,10 @@ module Features
       @lead_school_show_page ||= PageObjects::LeadSchools::Show.new
     end
 
+    def users_index_page
+      @users_index_page ||= PageObjects::Users::Index.new
+    end
+
     def new_user_page
       @new_user_page ||= PageObjects::Users::New.new
     end

--- a/spec/support/page_objects/users/index.rb
+++ b/spec/support/page_objects/users/index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Users
+    class Index < PageObjects::Base
+      set_url "/system-admin/users"
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/W41YJZPI/3373-s-lead-school-page

### Changes proposed in this pull request
- Add users tab to system admin

### Note
The providers column will be added when #1868 is merged.

<img width="973" alt="Screenshot 2022-01-12 at 17 32 25" src="https://user-images.githubusercontent.com/28728/149191783-a05f1a5f-eb79-4618-b83a-d4227a408356.png">

