### PR TITLE
[3436] Validation on missing data seems slightly broken

### DIFF
--- a/app/components/collapsed_section/view.html.erb
+++ b/app/components/collapsed_section/view.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-inset-text app-inset-text--narrow-border app-inset-text--<%= @has_errors ? "error" : "important" %>">
   <p class="app-inset-text__title"><%= title %></p>
   <% if url.present? %>
-    <%= govuk_link_to link_text, url %>
+    <%= govuk_link_to link_text, url, name: name %>
   <% end %>
   <% if hint_text.present? %>
     <span class="govuk-hint">

--- a/app/components/collapsed_section/view.rb
+++ b/app/components/collapsed_section/view.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class CollapsedSection::View < ViewComponent::Base
-  attr_accessor :title, :url, :link_text, :hint_text, :has_errors
+  attr_accessor :title, :url, :link_text, :hint_text, :has_errors, :name
 
-  def initialize(title:, link_text: nil, url: nil, hint_text: nil, has_errors: false)
+  def initialize(title:, link_text: nil, url: nil, hint_text: nil, has_errors: false, name: nil)
     @url = url
     @link_text = link_text
     @title = title
     @hint_text = hint_text
     @has_errors = has_errors
+    @name = name
   end
 end

--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -43,7 +43,7 @@ module Sections
       if section == :funding && funding_options(trainee) == :funding_inactive
         collapsed_funding_inactive_section_args
       else
-        { title: title, link_text: link_text, url: url, has_errors: form_has_errors? }
+        { title: title, link_text: link_text, url: url, has_errors: form_has_errors?, name: section }
       end
     end
 

--- a/app/view_objects/apply_invalid_data_view.rb
+++ b/app/view_objects/apply_invalid_data_view.rb
@@ -23,23 +23,13 @@ class ApplyInvalidDataView
   end
 
   def summary_content
-    I18n.t("views.apply_invalid_data_view.invalid_answers_summary", count: invalid_fields.flatten.size)
+    if invalid_data?
+      I18n.t("views.apply_invalid_data_view.invalid_answers_summary", count: invalid_fields.flatten.size)
+    end
   end
 
   def summary_items_content
-    @summary_items_content ||= safe_join(
-      invalid_fields.map.with_index(1) do |fieldset, index|
-        fieldset.map do |field|
-          tag.li(
-            link_to(
-              I18n.t("views.apply_invalid_data_view.unrecognised_field_text", invalid_field: get_field_name(field).humanize.upcase_first),
-              get_link_anchor(get_field_name(field), index),
-              class: "govuk-notification-banner__link",
-            ),
-          )
-        end
-      end,
-    )
+    @summary_items_content ||= safe_join(invalid_fields_list)
   end
 
   def invalid_data?
@@ -49,6 +39,28 @@ class ApplyInvalidDataView
 private
 
   attr_reader :apply_application, :invalid_fields, :degree, :on_form_page, :degrees_sort_order
+
+  def invalid_fields_list
+    items = invalid_fields.map.with_index(1) do |fieldset, index|
+      fieldset.map do |field|
+        tag.li(
+          link_to(
+            I18n.t("views.apply_invalid_data_view.unrecognised_field_text",
+                   invalid_field: get_field_name(field).humanize.upcase_first),
+            get_link_anchor(get_field_name(field), index),
+            class: "govuk-notification-banner__link",
+          ),
+        )
+      end
+    end
+
+    if degrees_sort_order.empty?
+      link_text = I18n.t("views.apply_invalid_data_view.invalid_answers_summary.degree_missing")
+      items << tag.li(link_to(link_text, "#degrees", class: "govuk-notification-banner__link"))
+    end
+
+    items
+  end
 
   def get_link_anchor(field, index)
     return get_form_page_link_anchor(field) if on_form_page

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -483,6 +483,7 @@ en:
       invalid_answers_summary:
         one: This application contains 1 answer that you need to amend. This is because it was entered in a free text format.
         other: This application contains %{count} answers that you need to amend. This is because they were entered in a free text format.
+        degree_missing: Degree details not provided
       unrecognised_field_text: "%{invalid_field} is not recognised"
     mappable_field_row:
       default_hint_text_html: 'Enter an answer <span class="govuk-visually-hidden"> for %{field_label}</span>'

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -200,8 +200,16 @@ namespace :example_data do
 
             trainee = FactoryBot.create(:trainee, route, state, attrs)
 
-            # Add an extra nationality 20% of the time
-            trainee.nationalities << Nationality.all.sample if rand(10) < 2
+            trainee.nationalities << Nationality.all.sample
+
+            if rand(10) < 2 # Give 20% of trainees an extra nationality and a non-uk degree
+              trainee.nationalities << Nationality.all.sample
+              degree_type = :non_uk_degree_with_details
+            else
+              degree_type = :uk_degree_with_details
+            end
+
+            FactoryBot.create(:degree, degree_type, trainee: trainee)
           end
         end
       end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -99,7 +99,7 @@ FactoryBot.define do
       applying_for_bursary { false }
       applying_for_scholarship { false }
       applying_for_grant { false }
-      nationalities { [build(:nationality)] }
+      nationalities { [Nationality.offset(rand(Nationality.count)).first || build(:nationality)] }
       progress do
         Progress.new(
           personal_details: true,

--- a/spec/view_objects/apply_invalid_data_view_spec.rb
+++ b/spec/view_objects/apply_invalid_data_view_spec.rb
@@ -28,7 +28,11 @@ describe ApplyInvalidDataView do
   end
 
   describe "#invalid_data?" do
-    subject { described_class.new(application, degree: degree, degrees_sort_order: application.invalid_data["degrees"].keys).invalid_data? }
+    subject do
+      described_class.new(application,
+                          degree: degree,
+                          degrees_sort_order: application.invalid_data["degrees"].keys).invalid_data?
+    end
 
     let(:degree) { nil }
 
@@ -57,6 +61,15 @@ describe ApplyInvalidDataView do
     it "returns the invalid answer summary items" do
       expected_markup = "<li><a class=\"govuk-notification-banner__link\" href=\"#awarding-institution\">Awarding institution is not recognised</a></li>"
       expect(subject.summary_items_content).to include(expected_markup)
+    end
+
+    context "no errors but no degrees" do
+      subject { described_class.new(application, degrees_sort_order: []) }
+
+      it "returns a link anchored to the degrees section" do
+        expected_markup = "<li><a class=\"govuk-notification-banner__link\" href=\"#degrees\">Degree details not provided</a></li>"
+        expect(subject.summary_items_content).to include(expected_markup)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/YPJgSwuj/3436-validation-on-missing-data-seems-slightly-broken


### Changes proposed in this pull request
- Fix error summary when attempting to mark Trainee Data from Apply applications with no degrees
- Fix the example data so trainee's with an Apply application always have a nationality and degree

### Before
<img width="531" alt="Screenshot 2022-01-07 at 16 58 04" src="https://user-images.githubusercontent.com/28728/148578909-2a354e8f-1846-4e75-a9ce-ee34836c1103.png">

### After

<img width="582" alt="Screenshot 2022-01-07 at 16 59 43" src="https://user-images.githubusercontent.com/28728/148579166-d6fd8d1f-efed-4649-b830-e6809fb1937e.png">

