### PR TITLE
[3465] Update the mapping for BA/Education

### DIFF
--- a/app/lib/dttp/code_sets/degree_types.rb
+++ b/app/lib/dttp/code_sets/degree_types.rb
@@ -59,7 +59,7 @@ module Dttp
         "BEd" => { entity_id: "c1695652-c197-e711-80d8-005056ac45bb", hesa_code: "1" },
         "BSc/Education" => { entity_id: "c5695652-c197-e711-80d8-005056ac45bb", hesa_code: "3" },
         "BTech/Education" => { entity_id: "c9695652-c197-e711-80d8-005056ac45bb", hesa_code: "5" },
-        "BA/Education" => { entity_id: "c9695652-c197-e711-80d8-005056ac45bb", hesa_code: "7" },
+        "BA/Education" => { entity_id: "cd695652-c197-e711-80d8-005056ac45bb", hesa_code: "7" },
         "BA Combined Studies/Education of the Deaf" => { entity_id: "d1695652-c197-e711-80d8-005056ac45bb", hesa_code: "9" },
         "BA with intercalated PGCE" => { entity_id: "d5695652-c197-e711-80d8-005056ac45bb", hesa_code: "12" },
         "Master of Arts" => {

--- a/db/data/20220107171921_update_ba_education_degrees_in_dttp.rb
+++ b/db/data/20220107171921_update_ba_education_degrees_in_dttp.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class UpdateBaEducationDegreesInDttp < ActiveRecord::Migration[6.1]
+  # We had accidentally mapped BA/Education to BTech/Education in DTTP.
+  # This migration finds all affected trainees (~65) and updates them in DTTP.
+  def up
+    degrees = Degree.where(uk_degree: "BA/Education")
+
+    Trainee.where(id: degrees.pluck(:trainee_id)).each do |trainee|
+      Dttp::UpdateTraineeJob.perform_later(trainee)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/Pq2pV4Ym/3465-investigate-degrees-not-imported-due-to-missing-degreetype

### Changes proposed in this pull request

- All degrees marked with `non_importable_missing_type` were due to one missing DTTP ID - for "BA/Education".
- We have "BA/Education" BUT with the wrong DTTP ID 🤦‍♀️ 
- This has always been wrong - it sends "BTech/Education" to DTTP

This PR:
- Update the entity ID in the codeset
- Adds a data migration to update affect trainees in DTTP

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
