### PR TITLE
[3397] Set dttp_update_sha when importing from dttp 

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -74,6 +74,8 @@ module Trainees
 
       dttp_trainee.imported!
 
+      trainee.update!(dttp_update_sha: trainee.sha)
+
       trainee
     end
 

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -96,6 +96,7 @@ module Trainees
         expect(trainee.trn).to eq(api_trainee["dfe_trn"].to_s)
         expect(trainee.training_initiative).to eq("now_teach")
         expect(trainee.hesa_id).to eq(api_trainee["dfe_husid"])
+        expect(trainee.dttp_update_sha).to eq(trainee.sha)
       end
 
       context "when the country is something other than England and has a non-uk postcode" do


### PR DESCRIPTION
### Context
Adding the dttp_update_sha prevents the nightly job from syncing these records to dttp.
The advantage of this approach is that, it will trigger an update to dttp if some data is changed from within register, while still preventing a sync on initial import.

### Changes proposed in this pull request
Set dttp_update_sha when importing from dttp 

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
