### PR TITLE
Use 1st October as academic year start date

### DIFF
--- a/spec/support/date_helpers.rb
+++ b/spec/support/date_helpers.rb
@@ -3,7 +3,7 @@
 def current_recruitment_cycle_year
   current_date = Time.zone.now
   current_year = current_date.year
-  return current_year - 1 if current_date < Date.new(current_year, 1, 10)
+  return current_year - 1 if current_date < Date.new(current_year, 10, 1)
 
   current_year
 end


### PR DESCRIPTION
### Context
Fixes a typo in a spec helper from 10/1 to 1/10 (academic year start date) which breaks our test suite from today.
