### PR TITLE
[3452] ApplicationController#current_user returns UserWithOrganisationContext

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,12 @@ private
   end
 
   def current_user
-    @current_user ||= User.kept.find_by("LOWER(email) = ?", dfe_sign_in_user&.email)
+    return if dfe_sign_in_user.blank?
+
+    @current_user ||= begin
+      user = User.kept.find_by("LOWER(email) = ?", dfe_sign_in_user.email)
+      UserWithOrganisationContext.new(user: user, session: session) if user.present?
+    end
   end
 
   def authenticated?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
 
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
 
-  helper_method :current_user, :authenticated?
+  helper_method :current_user, :authenticated?, :audit_user
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
@@ -44,6 +44,10 @@ private
       user = User.kept.find_by("LOWER(email) = ?", dfe_sign_in_user.email)
       UserWithOrganisationContext.new(user: user, session: session) if user.present?
     end
+  end
+
+  def audit_user
+    current_user&.user
   end
 
   def authenticated?

--- a/app/lib/user_with_organisation_context.rb
+++ b/app/lib/user_with_organisation_context.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class UserWithOrganisationContext < SimpleDelegator
+  attr_reader :user
+
+  def initialize(user:, session:)
+    __setobj__(user)
+    @user = user
+    @session = session
+  end
+
+  def organisation
+    # TODO: placeholder behaviour. Should return the lead school or
+    # provider set in the session
+    user.providers.first
+  end
+
+private
+
+  attr_reader :session
+end

--- a/app/lib/user_with_organisation_context.rb
+++ b/app/lib/user_with_organisation_context.rb
@@ -9,6 +9,20 @@ class UserWithOrganisationContext < SimpleDelegator
     @session = session
   end
 
+  class << self
+    def primary_key
+      "id"
+    end
+  end
+
+  def is_a?(value)
+    value == User
+  end
+
+  def class_name
+    "User"
+  end
+
   def organisation
     # TODO: placeholder behaviour. Should return the lead school or
     # provider set in the session

--- a/config/initializers/audited.rb
+++ b/config/initializers/audited.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Audited.current_user_method = :audit_user

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -13,7 +13,7 @@ describe SessionsController, type: :controller do
   describe "#callback" do
     context "existing database user" do
       it "calls send welcome email service" do
-        expect(SendWelcomeEmailService).to receive(:call).with(current_user: user).once
+        expect(SendWelcomeEmailService).to receive(:call).once
         request_callback
       end
 

--- a/spec/controllers/trainees/award_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/award_recommendations_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe Trainees::AwardRecommendationsController do
   include ActiveJob::TestHelper
 
-  let(:current_user) { create(:user) }
+  let(:current_user) { build_current_user }
   let(:trainee) { create(:trainee, :trn_received, provider: current_user.primary_provider) }
 
   before do

--- a/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe Trainees::ConfirmDeferralsController do
   include ActiveJob::TestHelper
 
-  let(:current_user) { create(:user) }
+  let(:current_user) { build_current_user }
   let(:trainee) { create(:trainee, :trn_received, provider: current_user.primary_provider) }
 
   before do

--- a/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe Trainees::ConfirmReinstatementsController do
   include ActiveJob::TestHelper
 
-  let(:current_user) { create(:user) }
+  let(:current_user) { build_current_user }
   let(:trainee) { create(:trainee, :deferred, trn: trn, provider: current_user.primary_provider) }
 
   before do

--- a/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_withdrawals_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe Trainees::ConfirmWithdrawalsController do
   include ActiveJob::TestHelper
 
-  let(:current_user) { create(:user) }
+  let(:current_user) { build_current_user }
   let(:trainee) { create(:trainee, :trn_received, provider: current_user.primary_provider) }
 
   before do

--- a/spec/controllers/trainees/degrees_controller_spec.rb
+++ b/spec/controllers/trainees/degrees_controller_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Trainees::DegreesController, type: :controller do
   describe "#create" do
-    let(:user) { create(:user, providers: [trainee.provider]) }
+    let(:user) { build_current_user(user: create(:user, providers: [trainee.provider])) }
     let(:trainee) { create(:trainee) }
     let(:degree) { build(:degree, :uk_degree_with_details) }
 

--- a/spec/controllers/trainees/lead_schools_controller_spec.rb
+++ b/spec/controllers/trainees/lead_schools_controller_spec.rb
@@ -12,12 +12,15 @@ RSpec.describe Trainees::LeadSchoolsController, type: :controller do
       }
     end
 
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
     context "when school direct salaried trainee" do
       let(:trainee) { create(:trainee, :school_direct_salaried) }
-      let(:user) { create(:user, providers: [trainee.provider]) }
+      let(:user) { build_current_user(user: create(:user, providers: [trainee.provider])) }
 
       before do
-        allow(controller).to receive(:current_user).and_return(user)
         post(:update, params: { trainee_id: trainee, schools_lead_school_form: params })
       end
 
@@ -28,10 +31,9 @@ RSpec.describe Trainees::LeadSchoolsController, type: :controller do
 
     context "when school direct tuition fee trainee" do
       let(:trainee) { create(:trainee, :school_direct_tuition_fee) }
-      let(:user) { create(:user, providers: [trainee.provider]) }
+      let(:user) { build_current_user(user: create(:user, providers: [trainee.provider])) }
 
       before do
-        allow(controller).to receive(:current_user).and_return(user)
         post(:update, params: { trainee_id: trainee, schools_lead_school_form: params })
       end
 

--- a/spec/controllers/trainees/start_statuses_controller_spec.rb
+++ b/spec/controllers/trainees/start_statuses_controller_spec.rb
@@ -6,7 +6,7 @@ describe Trainees::StartStatusesController, type: :controller do
   include ActiveJob::TestHelper
 
   describe "#update" do
-    let(:current_user) { create(:user) }
+    let(:current_user) { build_current_user }
     let(:page_context) { nil }
 
     let(:send_request) do

--- a/spec/controllers/trainees_controller_spec.rb
+++ b/spec/controllers/trainees_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe TraineesController do
-  let(:user) { create(:user) }
+  let(:user) { build_current_user }
 
   before do
     allow(controller).to receive(:current_user).and_return(user)

--- a/spec/lib/user_with_organisation_context_spec.rb
+++ b/spec/lib/user_with_organisation_context_spec.rb
@@ -32,4 +32,22 @@ describe UserWithOrganisationContext do
 
     it { is_expected.to eq(user) }
   end
+
+  describe "#is_a?" do
+    it "pretends to be a user" do
+      expect(subject.is_a?(User)).to eq(true)
+    end
+  end
+
+  describe "#class_name" do
+    it "pretends to be a user" do
+      expect(subject.class_name).to eq("User")
+    end
+  end
+
+  describe ".primary_key" do
+    it "returns 'id'" do
+      expect(described_class.primary_key).to eq("id")
+    end
+  end
 end

--- a/spec/lib/user_with_organisation_context_spec.rb
+++ b/spec/lib/user_with_organisation_context_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe UserWithOrganisationContext do
+  let(:user) { double(id: 1, boo: "yah", providers: ["first"]) }
+  let(:session) { {} }
+
+  subject do
+    described_class.new(user: user, session: session)
+  end
+
+  it "delegates missing methods to user" do
+    expect(subject.boo).to eq("yah")
+    expect(subject.id).to eq(1)
+  end
+
+  describe "#organisation" do
+    subject { super().organisation }
+    # TODO: this is placeholder behaviour until we
+    # start setting the current organisation context in the
+    # session
+
+    it { is_expected.to eq(user.providers.first) }
+
+    # The correct behaviour. Return the provider or lead school
+    it "returns the current organisation as set in the session"
+  end
+
+  describe "#user" do
+    subject { super().user }
+
+    it { is_expected.to eq(user) }
+  end
+end

--- a/spec/support/current_user.rb
+++ b/spec/support/current_user.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+def build_current_user(user: create(:user), session: {})
+  UserWithOrganisationContext.new(user: user, session: session)
+end

--- a/spec/support/features/authentication_steps.rb
+++ b/spec/support/features/authentication_steps.rb
@@ -5,7 +5,7 @@ module Features
     attr_reader :current_user
 
     def given_i_am_authenticated(user: nil)
-      @current_user = user || create(:user)
+      @current_user = UserWithOrganisationContext.new(user: (user || create(:user)), session: {})
       user_exists_in_dfe_sign_in(user: @current_user)
 
       visit_sign_in_page


### PR DESCRIPTION
### Context

We are working towards supporting users with multiple providers and lead schools. To implement this we're going to decorate the current_user to include an 'organisation context'. This is some initial work on that based on [the spike](https://github.com/DFE-Digital/register-trainee-teachers/pull/1815).

### Changes proposed in this pull request

* Add `UserWithOrganisationContext` - a decorator to expose the 'current organisation' and ultimately handle the logic for deriving that in the session. This PR is just to wrap the `providers.first` logic that we are currently using
* Return that from `current_user`
* Add `audit_user`. The audited gem handles non ActiveRecord 'current_user'-ses differently and doesn't attribute the audits correctly so return the AR version as `audit_user` and configure Audited to use that.
* Add a `build_current_user` spec helper that will handle setting the organisation etc for specs

### Guidance to review

This is essentially a refactor so all existing functionality should still work as before.

Bit controversial is making the `UserWithOrganisationContext` class pretend to be a `User`. Doing this means it can still be passed as a parameter when creating associations e.g. `ProviderUser.create(user: current_user, provider: provider)`. This saves having to do `ProviderUser.create(user: current_user.user, provider: provider)` all over the place. Might be a bit 🤮 though so I'd be interested to hear opinions on that.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
