### PR TITLE
[3444] Enable HPITT route against all providers

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -50,9 +50,6 @@ class Trainee < ApplicationRecord
     message: I18n.t("activerecord.errors.models.trainee.attributes.training_route"),
   }
 
-  validates :training_route, inclusion: { in: [TRAINING_ROUTE_ENUMS[:hpitt_postgrad]] }, if: :hpitt_provider?
-  validates :training_route, exclusion: { in: [TRAINING_ROUTE_ENUMS[:hpitt_postgrad]] }, unless: :hpitt_provider?
-
   enum training_route: TRAINING_ROUTES
 
   enum training_initiative: ROUTE_INITIATIVES

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -52,11 +52,6 @@ module Trainees
         return
       end
 
-      if training_route == TRAINING_ROUTE_ENUMS[:hpitt_postgrad]
-        dttp_trainee.non_importable_hpitt!
-        return
-      end
-
       trainee.set_early_years_course_details
 
       if funding_not_yet_mapped?

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -144,49 +144,22 @@ describe Trainee do
     end
   end
 
-  context "validations" do
-    context "training route" do
-      let(:provider) { build(:provider, code: TEACH_FIRST_PROVIDER_CODE) }
-      let(:training_route) { TRAINING_ROUTE_ENUMS[:hpitt_postgrad] }
+  context "slug" do
+    subject { create(:trainee) }
 
-      subject { build(:trainee, provider: provider, training_route: training_route) }
+    it { is_expected.to validate_uniqueness_of(:slug).case_insensitive }
 
-      it "can only have trainees on the hpitt_postgrad route" do
-        expect(subject).to be_valid
+    context "immutability" do
+      let(:original_slug) { subject.slug.dup }
+
+      before do
+        original_slug
+        subject.regenerate_slug
+        subject.reload
       end
 
-      context "with trainees on any other route" do
-        let(:training_route) { TRAINING_ROUTE_ENUMS[:early_years_undergrad] }
-
-        it { is_expected.not_to be_valid }
-      end
-
-      context "when the provider is not an hpitt provider" do
-        let(:provider) { build(:provider) }
-
-        it "cannot have trainees on the hpitt_postgrad route" do
-          expect(subject).not_to be_valid
-        end
-      end
-    end
-
-    context "slug" do
-      subject { create(:trainee) }
-
-      it { is_expected.to validate_uniqueness_of(:slug).case_insensitive }
-
-      context "immutability" do
-        let(:original_slug) { subject.slug.dup }
-
-        before do
-          original_slug
-          subject.regenerate_slug
-          subject.reload
-        end
-
-        it "is immutable once created" do
-          expect(subject.slug).to eq(original_slug)
-        end
+      it "is immutable once created" do
+        expect(subject.slug).to eq(original_slug)
       end
     end
   end

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -51,17 +51,6 @@ module Trainees
       end
     end
 
-    context "when the trainee is hpitt" do
-      let(:dttp_trainee) { create(:dttp_trainee, :with_provider, :with_hpitt_placement_assignment) }
-
-      it "marks the application as non importable" do
-        expect {
-          create_trainee_from_dttp
-        }.to change(Trainee, :count).by(0)
-        .and change(dttp_trainee, :state).to("non_importable_hpitt")
-      end
-    end
-
     context "when a provider exists" do
       let(:dttp_trainee) { create(:dttp_trainee, :with_placement_assignment, :with_provider, api_trainee_hash: api_trainee) }
 


### PR DESCRIPTION
### Context
In the 21/22 cycle we addded the HPITT trainees under a single Teach First SCITT.
However, in previous years, DTTP contains trainees on the HPITT route
against various providers. This change will enable us to import these
trainees into register.

### Changes proposed in this pull request
Remove a bit of code, to enable all providers to have an HPITT trainee created against them. This does not change the UI for now.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
