### PR TITLE
Update disable browser autofill code to use data attribute

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
         autocomplete: :off,
         "data-js-disable-browser-autofill": :on,
         spellcheck: false,
-      }
+      },
     }
     form_with(*args << defaults.deep_merge(options), &block)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,10 +18,14 @@ module ApplicationHelper
 
   def register_form_with(*args, &block)
     options = args.extract_options!
-    defaults = { html: { novalidate: true,
-                         autocomplete: :off,
-                         "data-js-disable-browser-autofill": :on,
-                         spellcheck: false, } }
+    defaults = {
+      html: {
+        novalidate: true,
+        autocomplete: :off,
+        "data-js-disable-browser-autofill": :on,
+        spellcheck: false,
+      }
+    }
     form_with(*args << defaults.deep_merge(options), &block)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,8 +21,7 @@ module ApplicationHelper
     defaults = { html: { novalidate: true,
                          autocomplete: :off,
                          "data-js-disable-browser-autofill": :on,
-                         spellcheck: false,
-                       } }
+                         spellcheck: false, } }
     form_with(*args << defaults.deep_merge(options), &block)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,11 @@ module ApplicationHelper
 
   def register_form_with(*args, &block)
     options = args.extract_options!
-    defaults = { html: { novalidate: true, autocomplete: :off, spellcheck: false } }
+    defaults = { html: { novalidate: true,
+                         autocomplete: :off,
+                         "data-js-disable-browser-autofill": :on,
+                         spellcheck: false
+                       } }
     form_with(*args << defaults.deep_merge(options), &block)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
     defaults = { html: { novalidate: true,
                          autocomplete: :off,
                          "data-js-disable-browser-autofill": :on,
-                         spellcheck: false
+                         spellcheck: false,
                        } }
     form_with(*args << defaults.deep_merge(options), &block)
   end

--- a/app/views/system_admin/providers/edit.html.erb
+++ b/app/views/system_admin/providers/edit.html.erb
@@ -10,9 +10,9 @@
         Edit provider
       </h1>
 
-      <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20, autocomplete: :disabled %>
-      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :disabled %>
-      <%= f.govuk_text_field :code, label: { text: "Provider code", size: "s" }, width: 20, autocomplete: :disabled %>
+      <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :code, label: { text: "Provider code", size: "s" }, width: 20, autocomplete: :off %>
       <div class="govuk-form-group">
         <%= f.govuk_check_box :apply_sync_enabled, true, multiple: false, label: { text: "Import application data from Apply?", size: "s" } %>
       </div>

--- a/app/views/system_admin/providers/new.html.erb
+++ b/app/views/system_admin/providers/new.html.erb
@@ -10,9 +10,9 @@
         Add a provider
       </h1>
 
-      <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20, autocomplete: :disabled %>
-      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :disabled %>
-      <%= f.govuk_text_field :code, label: { text: "Provider code", size: "s" }, width: 20, autocomplete: :disabled %>
+      <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :code, label: { text: "Provider code", size: "s" }, width: 20, autocomplete: :off %>
       <div class="govuk-form-group">
         <%= f.govuk_check_box :apply_sync_enabled, true, multiple: false, label: { text: "Import application data from Apply?", size: "s" } %>
       </div>

--- a/app/views/system_admin/users/edit.html.erb
+++ b/app/views/system_admin/users/edit.html.erb
@@ -15,7 +15,7 @@
         Edit user <%= @user.name %>
       </h1>
 
-      <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: 20, autocomplete: :disabled %>
+      <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: 20, autocomplete: :off %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/system_admin/users/new.html.erb
+++ b/app/views/system_admin/users/new.html.erb
@@ -15,10 +15,10 @@
         Add a user for <%= @provider.name %>
       </h1>
 
-      <%= f.govuk_text_field :first_name, label: { text: "First Name", size: "s" }, width: 20, autocomplete: :disabled %>
-      <%= f.govuk_text_field :last_name, label: { text: "Last Name", size: "s" }, width: 20, autocomplete: :disabled %>
-      <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: 20, autocomplete: :disabled %>
-      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :disabled %>
+      <%= f.govuk_text_field :first_name, label: { text: "First Name", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :last_name, label: { text: "Last Name", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :email, label: { text: "Email address", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :off %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -17,7 +17,7 @@
           <%= f.govuk_text_area :international_address,
                                 width: "one-quarter",
                                 label: { text: "Home address" },
-                                autocomplete: :disabled %>
+                                autocomplete: :off %>
         <% end %>
 
         <%= f.govuk_radio_button :locale_code, :uk, label: { text: "In the UK" } do %>
@@ -25,19 +25,19 @@
             <%= f.govuk_text_field :address_line_one,
                                    width: "full",
                                    label: { text: "Building and street" },
-                                   autocomplete: :disabled %>
+                                   autocomplete: :off %>
 
             <%= f.govuk_text_field :address_line_two,
                                    width: "full",
                                    label: { text: "Address line 2", hidden: true },
-                                   autocomplete: :disabled %>
+                                   autocomplete: :off %>
 
             <%= f.govuk_text_field :town_city,
                                    width: "two-thirds",
                                    label: { text: "Town or city" },
-                                   autocomplete: :disabled %>
+                                   autocomplete: :off %>
 
-            <%= f.govuk_text_field :postcode, width: 10, label: { text: "Postal code" }, autocomplete: :disabled %>
+            <%= f.govuk_text_field :postcode, width: 10, label: { text: "Postal code" }, autocomplete: :off %>
           <% end %>
         <% end %>
       <% end %>
@@ -46,7 +46,7 @@
                               hint: { text: t(".email.hint")},
                               width: "two-thirds",
                               label: { text: "Email address", size: "s" },
-                              autocomplete: :disabled %>
+                              autocomplete: :off %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/trainees/degrees/_non_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_non_uk_degree_form.html.erb
@@ -52,7 +52,7 @@
   <%= f.govuk_text_field :graduation_year,
                          form_group: { class: invalid_data_class(form: @degree_form, field: "graduation_year"), id: :graduation_year },
                          width: "one-quarter",
-                         autocomplete: :disabled,
+                         autocomplete: :off,
                          label: { text: "Graduation year", size: "s" } do
                             render InvalidDataText::View.new(form_section: :graduation_year, degree_form: @degree_form)
                           end %>

--- a/app/views/trainees/diversity/disability_details/edit.html.erb
+++ b/app/views/trainees/diversity/disability_details/edit.html.erb
@@ -30,7 +30,7 @@
               <%= f.govuk_text_field :additional_disability,
                                      label: { text: "Describe their disability (optional)" },
                                      width: "two-thirds",
-                                     autocomplete: :disabled %>
+                                     autocomplete: :off %>
             <% end %>
           <% end %>
 

--- a/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
+++ b/app/views/trainees/diversity/ethnic_backgrounds/edit.html.erb
@@ -35,7 +35,7 @@
                 <%= f.govuk_text_field(
                   :additional_ethnic_background,
                   width: "two-thirds",
-                  autocomplete: :disabled,
+                  autocomplete: :off,
                   label: { text: I18n.t("views.forms.ethnic_backgrounds.another_ethnic_background_labels.#{@ethnic_background_form.ethnic_group}") },
                 ) %>
               <% end %>

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -15,7 +15,8 @@
       <%= f.govuk_text_field :first_names,
                              label: { text: "First names", size: "s" },
                              width: "three-quarters",
-                             autocomplete: :disabled %>
+                             autocomplete: :disabled,
+                             js_disable_browser_autofill: 'on' %>
 
       <%= f.govuk_text_field :middle_names,
                              label: { text: "Middle names", size: "s" },

--- a/app/views/trainees/personal_details/edit.html.erb
+++ b/app/views/trainees/personal_details/edit.html.erb
@@ -15,18 +15,17 @@
       <%= f.govuk_text_field :first_names,
                              label: { text: "First names", size: "s" },
                              width: "three-quarters",
-                             autocomplete: :disabled,
-                             js_disable_browser_autofill: 'on' %>
+                             autocomplete: :off %>
 
       <%= f.govuk_text_field :middle_names,
                              label: { text: "Middle names", size: "s" },
                              width: "three-quarters",
-                             autocomplete: :disabled %>
+                             autocomplete: :off %>
 
       <%= f.govuk_text_field :last_name,
                              label: { text: "Last names", size: "s" },
                              width: "three-quarters",
-                             autocomplete: :disabled %>
+                             autocomplete: :off %>
 
       <%= f.govuk_date_field :date_of_birth,
                              date_of_birth: true,

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -17,7 +17,7 @@
 
       <%= f.govuk_text_field :trainee_id, label: {
         text: t("views.forms.training_details.trainee_id.label"), tag: "h1", size: "l"
-      }, hint: { text: t("views.forms.training_details.trainee_id.hint").html_safe }, width: 20, autocomplete: :disabled %>
+      }, hint: { text: t("views.forms.training_details.trainee_id.hint").html_safe }, width: 20, autocomplete: :off %>
 
       <%= f.govuk_submit t(:continue) %>
     <% end %>

--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -58,7 +58,7 @@
                                  label: { text: t("views.forms.withdrawal_reasons.labels.for_another_reason") } do %>
           <%= f.govuk_text_field :additional_withdraw_reason,
                                  label: { text: t("views.forms.withdrawal_reasons.labels.additional_reason") },
-                                 autocomplete: :disabled %>
+                                 autocomplete: :off %>
         <% end %>
 
         <%= f.govuk_radio_button :withdraw_reason, WithdrawalReasons::UNKNOWN,

--- a/app/webpacker/scripts/global/disable-browser-autofill.js
+++ b/app/webpacker/scripts/global/disable-browser-autofill.js
@@ -9,13 +9,25 @@ function disableBrowserAutofill () {
 
   document.querySelectorAll('form').forEach(form => {
 
-    const inputs = [...form.querySelectorAll('input')]
+    let inputs = []
+
+    if (form.dataset['js-disable-browser-autofill'] == 'on'){
+      inputs = [...form.querySelectorAll('input')]
       .filter(input => inputTypes.includes(input.type))
-      .filter(input => input.dataset['js-disable-browser-autofill'] == 'true')
+      .filter(input => input.dataset['js-disable-browser-autofill'] !=== 'off')
+    }
+
+    else inputs = [...form.querySelectorAll('input')]
+      .filter(input => inputTypes.includes(input.type))
+      .filter(input => input.dataset['js-disable-browser-autofill'] === 'on')
+
+    console.log({inputs})
 
     if (inputs.length) {
 
       inputs.forEach(input => {
+        // The autocomplete attribute needs to be set to a non-standard attribute
+        // for the solution to work
         input.setAttribute('autocomplete', 'disabled')
         input.setAttribute(dataAttributeName, input.name)
         input.name = Math.random().toString(36).substring(7) // NOSONAR

--- a/app/webpacker/scripts/global/disable-browser-autofill.js
+++ b/app/webpacker/scripts/global/disable-browser-autofill.js
@@ -11,17 +11,17 @@ function disableBrowserAutofill () {
 
     let inputs = []
 
-    if (form.dataset['js-disable-browser-autofill'] == 'on'){
+    if (form.dataset.jsDisableBrowserAutofill === 'on'){
       inputs = [...form.querySelectorAll('input')]
       .filter(input => inputTypes.includes(input.type))
-      .filter(input => input.dataset['js-disable-browser-autofill'] !=== 'off')
+      .filter(input => input.dataset.jsDisableBrowserAutofill !== 'off')
     }
 
-    else inputs = [...form.querySelectorAll('input')]
+    else {
+      inputs = [...form.querySelectorAll('input')]
       .filter(input => inputTypes.includes(input.type))
-      .filter(input => input.dataset['js-disable-browser-autofill'] === 'on')
-
-    console.log({inputs})
+      .filter(input => input.dataset.jsDisableBrowserAutofill === 'on')
+    }
 
     if (inputs.length) {
 

--- a/app/webpacker/scripts/global/disable-browser-autofill.js
+++ b/app/webpacker/scripts/global/disable-browser-autofill.js
@@ -24,18 +24,13 @@ function disableBrowserAutofill () {
 
   document.querySelectorAll('form').forEach(form => {
 
-    let inputs = []
+    let inputs = [...form.querySelectorAll('input')]
+      .filter(input => inputTypes.includes(input.type))
 
     if (form.dataset.jsDisableBrowserAutofill === 'on'){
-      inputs = [...form.querySelectorAll('input')]
-      .filter(input => inputTypes.includes(input.type))
-      .filter(input => input.dataset.jsDisableBrowserAutofill !== 'off')
-    }
-
-    else {
-      inputs = [...form.querySelectorAll('input')]
-      .filter(input => inputTypes.includes(input.type))
-      .filter(input => input.dataset.jsDisableBrowserAutofill === 'on')
+      inputs = inputs.filter(input => input.dataset.jsDisableBrowserAutofill !== 'off')
+    } else {
+      inputs = inputs.filter(input => input.dataset.jsDisableBrowserAutofill === 'on')
     }
 
     if (inputs.length) {

--- a/app/webpacker/scripts/global/disable-browser-autofill.js
+++ b/app/webpacker/scripts/global/disable-browser-autofill.js
@@ -8,10 +8,15 @@ function disableBrowserAutofill () {
   }
 
   document.querySelectorAll('form').forEach(form => {
-    if (form.getAttribute('autocomplete') === 'off') {
-      const inputs = [...form.querySelectorAll('input[autocomplete]')].filter(input => inputTypes.includes(input.type))
+
+    const inputs = [...form.querySelectorAll('input')]
+      .filter(input => inputTypes.includes(input.type))
+      .filter(input => input.dataset['js-disable-browser-autofill'] == 'true')
+
+    if (inputs.length) {
 
       inputs.forEach(input => {
+        input.setAttribute('autocomplete', 'disabled')
         input.setAttribute(dataAttributeName, input.name)
         input.name = Math.random().toString(36).substring(7) // NOSONAR
       })
@@ -21,6 +26,7 @@ function disableBrowserAutofill () {
           input.name = input.getAttribute(dataAttributeName)
         })
       })
+
     }
   })
 }

--- a/app/webpacker/scripts/global/disable-browser-autofill.js
+++ b/app/webpacker/scripts/global/disable-browser-autofill.js
@@ -1,3 +1,18 @@
+// Disable browser autofill
+
+// This code is used to force the disabling of browser autofill. It’s needed
+// for browsers that ignore the `autocomplete="off"` attribute.
+
+// To use, add `data-js-disable-browser-autofill='on'` either on a form
+// element or on individual inputs where autofill should be disabled.
+
+// ## Accessibility
+// The solution relies on setting the `autocomplete` attribute to a
+// non-standard attribute. This may be considered a fail for WCAG 1.3.5 -
+// Identify Input Purpose. However, we accept this is a necessary and
+// worthwhile tradeoff for the benefits of preventing browser autofill on
+// inputs where it shouldn’t appear.
+
 function disableBrowserAutofill () {
   const dataAttributeName = 'data-nameoriginal'
   const inputTypes = ['text', 'tel', 'email', 'number']


### PR DESCRIPTION
This refactors the code to disable browser autofill to make it easier for other teams to use and to make the non-js code more standard.

Issues with previous code:
* It required inputs to have a specific `autocomplete` attribute, but this isn't documented anywhere
* The autocomplete attribute is technically invalid, and so may fail accessibility validators. With this solution, it's only applied when the js runs.