### PR TITLE
[xxx] Fix autoloading deprecation warning

### DIFF
--- a/config/initializers/big_query.rb
+++ b/config/initializers/big_query.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "google/cloud/bigquery"
+require_relative "../../app/services/feature_service"
 
 if FeatureService.enabled?("google.send_data_to_big_query")
   Google::Cloud::Bigquery.configure do |config|


### PR DESCRIPTION
### Context

Constant reloading on init is deprecated and causes a mahoosive warning when the app initializes.

### Changes proposed in this pull request

* Explicitly require `FeatureService` in BigQuery initializer

### Guidance to review

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
