### PR TITLE
[3495] Save withdrawal details and awarded dates

### DIFF
--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -47,6 +47,8 @@ module RecordDetails
     end
 
     def trn_row
+      return nil unless [trainee.trn, trainee.submitted_for_trn_at].any?(&:present?)
+
       if trainee.trn.present?
         {
           field_label: t(".trn"),

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -63,6 +63,14 @@ module RecordDetails
         expect(rendered_component).to have_text(date_for_summary_view(trainee.created_at))
       end
 
+      context "but the trainee has no trn or submitted_for_trn_at" do
+        let(:trainee) { create(:trainee, :withdrawn, trn: nil, submitted_for_trn_at: nil) }
+
+        it "renders the page" do
+          expect(rendered_component).to have_text("withdrawn")
+        end
+      end
+
       context "when trainee state is submitted_for_trn" do
         let(:trainee) { create(:trainee, :submitted_for_trn) }
 

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -635,5 +635,26 @@ module Trainees
         .and change(dttp_trainee, :state).to("non_importable_missing_initiative")
       end
     end
+
+    context "when the trainee is withdrawn" do
+      let(:date) { Time.zone.today }
+      let(:placement_assignment) do
+        create(:dttp_placement_assignment,
+               provider_dttp_id: provider.dttp_id,
+               response: create(:api_placement_assignment,
+                                _dfe_traineestatusid_value: "235af972-9e1b-e711-80c7-0050568902d3",
+                                dfe_dateleft: date,
+                                _dfe_reasonforleavingid_value: "436a46ad-11c2-e611-80be-00155d010316"))
+      end
+
+      let(:dttp_trainee) { create(:dttp_trainee, placement_assignments: [placement_assignment], provider_dttp_id: provider.dttp_id) }
+
+      it "saves the withdraw date and reason" do
+        create_trainee_from_dttp
+        trainee = Trainee.last
+        expect(trainee.withdraw_date).to eq date
+        expect(trainee.withdraw_reason).to eq WithdrawalReasons::FOR_ANOTHER_REASON
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/AZhT7Rkb/3495-m-withdrawn-trainees-error-due-to-nil-submittedfortrn-date

DTTP trainees can be withdrawn before they, so they end up with no `trn` and no `submitted_for_trn` at. This was breaking our trainee record page since we assumed submitted for trn would always be present.

https://trello.com/c/kIlpwOLS/3497-m-qts-and-eyts-awarded-trainees-are-missing-an-awarded-date

We also were not saving any dates to do with the trainee's award, or withdrawal. I've addressed these in this PR too.

### Changes proposed in this pull request

- Fix the view such that it loads without a `submitted_for_trn` date.
- Pull out `outcome_date` and `awarded_at` from the payload and save to trainees
- Pull out `withdraw_date` and `withdraw_reason` from the payload and save the trainee if they are withdrawn

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
