### PR TITLE
[3520] Add mappings for missing countries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    google-apis-bigquery_v2 (0.21.0)
+    google-apis-bigquery_v2 (0.23.0)
       google-apis-core (>= 0.4, < 2.a)
     google-apis-core (0.4.1)
       addressable (~> 2.5, >= 2.5.1)
@@ -231,7 +231,7 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-cloud-bigquery (1.38.0)
+    google-cloud-bigquery (1.38.1)
       concurrent-ruby (~> 1.0)
       google-apis-bigquery_v2 (~> 0.1)
       google-cloud-core (~> 1.6)

--- a/app/lib/dttp/code_sets/countries.rb
+++ b/app/lib/dttp/code_sets/countries.rb
@@ -4,6 +4,11 @@ module Dttp
   module CodeSets
     module Countries
       UNITED_KINGDOM = "United Kingdom"
+      ENGLAND = "England"
+      NORTHERN_IRELAND = "Northern Ireland"
+      SCOTLAND = "Scotland"
+      UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED = "United Kingdom, not otherwise specified"
+      WALES = "Wales"
 
       # country_code is used to regenerate public/location-autocomplete-graph.json - see rake task
       MAPPING = {
@@ -202,6 +207,30 @@ module Dttp
         "Yemen" => { entity_id: "7d7c4b74-ea28-e711-80c8-0050568902d3", country_code: "YE" },
         "Zambia" => { entity_id: "837c4b74-ea28-e711-80c8-0050568902d3", country_code: "ZM" },
         "Zimbabwe" => { entity_id: "857c4b74-ea28-e711-80c8-0050568902d3", country_code: "ZW" },
+      }.freeze
+
+      INACTIVE_MAPPING = {
+        "Not known" => { entity_id: "877c4b74-ea28-e711-80c8-0050568902d3" },
+        ENGLAND => { entity_id: "597c4b74-ea28-e711-80c8-0050568902d3" },
+        NORTHERN_IRELAND => { entity_id: "5b7c4b74-ea28-e711-80c8-0050568902d3" },
+        SCOTLAND => { entity_id: "5d7c4b74-ea28-e711-80c8-0050568902d3" },
+        UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED => { entity_id: "617c4b74-ea28-e711-80c8-0050568902d3" },
+        WALES => { entity_id: "5f7c4b74-ea28-e711-80c8-0050568902d3" },
+        "French Guiana" => { entity_id: "097b4b74-ea28-e711-80c8-0050568902d3" },
+        "Guadeloupe" => { entity_id: "177b4b74-ea28-e711-80c8-0050568902d3" },
+        "Hong Kong" => { entity_id: "277b4b74-ea28-e711-80c8-0050568902d3" },
+        "Isle of Man" => { entity_id: "397b4b74-ea28-e711-80c8-0050568902d3" },
+        "Jersey" => { entity_id: "477b4b74-ea28-e711-80c8-0050568902d3" },
+        "Martinique" => { entity_id: "957b4b74-ea28-e711-80c8-0050568902d3" },
+        "Occupied Palestinian Territories" => { entity_id: "d77b4b74-ea28-e711-80c8-0050568902d3" },
+        "Réunion" => { entity_id: "957b4b74-ea28-e711-80c8-0050568902d3" },
+        "Taiwan" => { entity_id: "337c4b74-ea28-e711-80c8-0050568902d3" },
+        "Africa not otherwise specified" => { entity_id: "6d7c4b74-ea28-e711-80c8-0050568902d3" },
+        "Asia (Except Middle East) not otherwise specified" => { entity_id: "717c4b74-ea28-e711-80c8-0050568902d3" },
+        "Caribbean not otherwise specified" => { entity_id: "797c4b74-ea28-e711-80c8-0050568902d3" },
+        "Europe not otherwise specified" => { entity_id: "6b7c4b74-ea28-e711-80c8-0050568902d3" },
+        "European Union not otherwise specified" => { entity_id: "f37a4b74-ea28-e711-80c8-0050568902d3" },
+        "North America not otherwise specified" => { entity_id: "737c4b74-ea28-e711-80c8-0050568902d3" },
       }.freeze
     end
   end

--- a/app/services/degrees/map_from_dttp.rb
+++ b/app/services/degrees/map_from_dttp.rb
@@ -65,7 +65,18 @@ module Degrees
     end
 
     def non_uk_degree?
-      country && country != Dttp::CodeSets::Countries::UNITED_KINGDOM
+      country && united_kingdom_countries.exclude?(country)
+    end
+
+    def united_kingdom_countries
+      [
+        Dttp::CodeSets::Countries::UNITED_KINGDOM,
+        Dttp::CodeSets::Countries::ENGLAND,
+        Dttp::CodeSets::Countries::NORTHERN_IRELAND,
+        Dttp::CodeSets::Countries::SCOTLAND,
+        Dttp::CodeSets::Countries::UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED,
+        Dttp::CodeSets::Countries::WALES,
+      ]
     end
 
     def non_uk_degree
@@ -104,7 +115,8 @@ module Degrees
     end
 
     def country
-      @country ||= find_by_entity_id(dttp_degree.country, Dttp::CodeSets::Countries::MAPPING)
+      find_by_entity_id(dttp_degree.country, Dttp::CodeSets::Countries::MAPPING) ||
+        find_by_entity_id(dttp_degree.country, Dttp::CodeSets::Countries::INACTIVE_MAPPING)
     end
 
     def unmapped_country?

--- a/spec/services/degrees/map_from_dttp_spec.rb
+++ b/spec/services/degrees/map_from_dttp_spec.rb
@@ -79,6 +79,21 @@ module Degrees
 
         it { is_expected.to include(uk_degree_attributes) }
       end
+
+      context "with a country that is part of the UK" do
+        let(:country) { "Wales" }
+        let(:api_degree_qualification) do
+          create(
+            :api_degree_qualification,
+            _dfe_degreecountryid_value: Dttp::CodeSets::Countries::INACTIVE_MAPPING[country][:entity_id],
+            _dfe_awardinginstitutionid_value: Dttp::CodeSets::Institutions::MAPPING[institution][:entity_id],
+            _dfe_degreetypeid_value: Dttp::CodeSets::DegreeTypes::MAPPING[degree_type][:entity_id],
+            _dfe_classofdegreeid_value: Dttp::CodeSets::Grades::MAPPING[grade][:entity_id],
+          )
+        end
+
+        it { is_expected.to include(uk_degree_attributes) }
+      end
     end
 
     context "with a non-uk degree" do
@@ -99,6 +114,18 @@ module Degrees
       end
 
       it { is_expected.to include(non_uk_degree_attributes) }
+
+      context "with an country not included in our dropdown" do
+        let(:country) { "Guadeloupe" }
+        let(:api_degree_qualification) do
+          create(
+            :api_degree_qualification,
+            _dfe_degreecountryid_value: Dttp::CodeSets::Countries::INACTIVE_MAPPING[country][:entity_id],
+          )
+        end
+
+        it { is_expected.to include(non_uk_degree_attributes) }
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/mOY06ML2/3520-m-non-importable-dttp-degrees-missing-country

### Changes proposed in this pull request

- Add inactive mapping for countries we're seeing in DTTP but not included in Register
- Expand our list of countries we classify as 'UK degree' (see `united_kingdom_countries` method)

If a trainee has a degree with a country included in the `INACTIVE` mapping, it will still be saved onto the degree, but not available for users to select in the dropdown.

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
