### PR TITLE
[3393] Handle dttp trainees with multiple placement assignments on different courses

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -32,11 +32,6 @@ module Trainees
         return
       end
 
-      if multiple_courses?
-        dttp_trainee.non_importable_multi_course!
-        return
-      end
-
       if training_route.blank?
         dttp_trainee.non_importable_missing_route!
         return
@@ -109,10 +104,6 @@ module Trainees
 
     def multiple_providers?
       dttp_trainee.placement_assignments.map(&:provider_dttp_id).uniq != [dttp_trainee.provider_dttp_id]
-    end
-
-    def multiple_courses?
-      dttp_trainee.placement_assignments.map { |placement_assignment| placement_assignment.response["_dfe_ittsubject1id_value"] }.uniq.count > 1
     end
 
     def trainee_already_exists?

--- a/spec/models/dttp/trainee_spec.rb
+++ b/spec/models/dttp/trainee_spec.rb
@@ -8,8 +8,46 @@ module Dttp
 
     it { is_expected.to be_valid }
 
+    it { is_expected.to have_many(:placement_assignments) }
+
     describe "validations" do
       it { is_expected.to validate_presence_of(:response) }
+    end
+
+    describe "latest_placement_assignment" do
+      let(:dttp_trainee) { create(:dttp_trainee) }
+      let(:first_placement_assignment) do
+        create(:dttp_placement_assignment,
+               :with_academic_year_twenty_twenty_one,
+               response: create(:api_placement_assignment, modifiedon: 3.hours.ago))
+      end
+      let(:second_placement_assignment) do
+        create(:dttp_placement_assignment,
+               :with_academic_year_twenty_twenty_one,
+               response: create(:api_placement_assignment, modifiedon: 2.hours.ago))
+      end
+
+      before do
+        dttp_trainee.placement_assignments << [first_placement_assignment, second_placement_assignment]
+      end
+
+      context "in the same academic year" do
+        it "sorts by academic year and response->'modifiedon'" do
+          expect(dttp_trainee.latest_placement_assignment).to eq(second_placement_assignment)
+        end
+      end
+
+      context "in different academic years" do
+        let(:first_placement_assignment) do
+          create(:dttp_placement_assignment,
+                 :with_academic_year_twenty_one_twenty_two,
+                 response: create(:api_placement_assignment, modifiedon: 1.hour.ago))
+        end
+
+        it "sorts by academic year" do
+          expect(dttp_trainee.latest_placement_assignment).to eq(first_placement_assignment)
+        end
+      end
     end
   end
 end

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -599,11 +599,11 @@ module Trainees
                provider_dttp_id: provider.dttp_id)
       }
 
-      it "marks the application as non importable" do
+      it "imports the application" do
         expect {
           create_trainee_from_dttp
-        }.to change(Trainee, :count).by(0)
-        .and change(dttp_trainee, :state).to("non_importable_multi_course")
+        }.to change(Trainee, :count).by(1)
+        .and change(dttp_trainee, :state).to("imported")
       end
     end
 


### PR DESCRIPTION
### Context
For trainees with multiple placement assignments on multiple courses, we have opted to import the data contained in the 'latest' placement assignment. The latest is determined by the academic year. In case of trainees where multiple placement assignments are available against a trainee in a single academic year, we use the latest one based on the value of `modifiedon`.

### Changes proposed in this pull request
1. Update the sort order for placement assignments, and add a has_one relationship for `latest_placement_assignment`
**Note that the sort order for first/last is being changed against `trainee.placement_assignments`**
2. Remove the `non_importable_multi_course` state check, so that these trainee records can be imported by using the latest placement assignment.

### Guidance to review
Important bit to note: this will change the placement assignment order, i.e, the `earliest_placement_assignment` was `placement_assignments.first` before, but will be `placement_assignment.last` now.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
