### PR TITLE
[3490] HESA records don’t have an address

### DIFF
--- a/app/components/contact_details/view.rb
+++ b/app/components/contact_details/view.rb
@@ -12,7 +12,7 @@ module ContactDetails
 
     def contact_detail_rows
       [
-        address_row,
+        (address_row if address_required?),
         email_row,
       ].compact
     end
@@ -23,6 +23,10 @@ module ContactDetails
 
     def trainee
       data_model.is_a?(Trainee) ? data_model : data_model.trainee
+    end
+
+    def address_required?
+      trainee.hesa_id.blank?
     end
 
     def address_row

--- a/app/forms/contact_details_form.rb
+++ b/app/forms/contact_details_form.rb
@@ -18,7 +18,7 @@ class ContactDetailsForm < TraineeForm
 
   before_validation :sanitise_email
 
-  validates :locale_code, presence: true
+  validates :locale_code, presence: true, if: :address_required?
   validate :uk_address_valid, if: -> { uk? }
   validate :international_address_valid, if: -> { non_uk? }
   validates :postcode, postcode: true, if: ->(attr) { attr.postcode.present? }
@@ -42,6 +42,10 @@ class ContactDetailsForm < TraineeForm
     end
   end
 
+  def address_required?
+    trainee.hesa_id.blank?
+  end
+
 private
 
   def compute_fields
@@ -63,10 +67,24 @@ private
   end
 
   def nullify_unused_address_fields!
-    if uk?
+    if !address_required?
+      fields.merge!(
+        locale_code: nil,
+        international_address: nil,
+        address_line_one: nil,
+        address_line_two: nil,
+        town_city: nil,
+        postcode: nil,
+      )
+    elsif uk?
       fields.merge!(international_address: nil)
     else
-      fields.merge!(address_line_one: nil, address_line_two: nil, town_city: nil, postcode: nil)
+      fields.merge!(
+        address_line_one: nil,
+        address_line_two: nil,
+        town_city: nil,
+        postcode: nil,
+      )
     end
   end
 

--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -12,32 +12,34 @@
     <%= register_form_with(model: @contact_details_form, url: trainee_contact_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset(:locale_code, legend: { text: "Where does the trainee live?", size: "s" }, classes: "locale") do %>
-        <%= f.govuk_radio_button :locale_code, :non_uk, label: { text: "Outside the UK" }, link_errors: true  do %>
-          <%= f.govuk_text_area :international_address,
-                                width: "one-quarter",
-                                label: { text: "Home address" },
-                                autocomplete: :off %>
-        <% end %>
+      <% if @contact_details_form.address_required? %>
+        <%= f.govuk_radio_buttons_fieldset(:locale_code, legend: { text: "Where does the trainee live?", size: "s" }, classes: "locale") do %>
+          <%= f.govuk_radio_button :locale_code, :non_uk, label: { text: "Outside the UK" }, link_errors: true  do %>
+            <%= f.govuk_text_area :international_address,
+                                  width: "one-quarter",
+                                  label: { text: "Home address" },
+                                  autocomplete: :off %>
+          <% end %>
 
-        <%= f.govuk_radio_button :locale_code, :uk, label: { text: "In the UK" } do %>
-          <%= f.govuk_fieldset legend: { text: "Home address", size: "s" } do %>
-            <%= f.govuk_text_field :address_line_one,
-                                   width: "full",
-                                   label: { text: "Building and street" },
-                                   autocomplete: :off %>
+          <%= f.govuk_radio_button :locale_code, :uk, label: { text: "In the UK" } do %>
+            <%= f.govuk_fieldset legend: { text: "Home address", size: "s" } do %>
+              <%= f.govuk_text_field :address_line_one,
+                                     width: "full",
+                                     label: { text: "Building and street" },
+                                     autocomplete: :off %>
 
-            <%= f.govuk_text_field :address_line_two,
-                                   width: "full",
-                                   label: { text: "Address line 2", hidden: true },
-                                   autocomplete: :off %>
+              <%= f.govuk_text_field :address_line_two,
+                                     width: "full",
+                                     label: { text: "Address line 2", hidden: true },
+                                     autocomplete: :off %>
 
-            <%= f.govuk_text_field :town_city,
-                                   width: "two-thirds",
-                                   label: { text: "Town or city" },
-                                   autocomplete: :off %>
+              <%= f.govuk_text_field :town_city,
+                                     width: "two-thirds",
+                                     label: { text: "Town or city" },
+                                     autocomplete: :off %>
 
-            <%= f.govuk_text_field :postcode, width: 10, label: { text: "Postal code" }, autocomplete: :off %>
+              <%= f.govuk_text_field :postcode, width: 10, label: { text: "Postal code" }, autocomplete: :off %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/spec/components/contact_details/view_spec.rb
+++ b/spec/components/contact_details/view_spec.rb
@@ -72,6 +72,27 @@ RSpec.describe ContactDetails::View do
     end
   end
 
+  context "HESA trainee" do
+    before do
+      mock_trainee.hesa_id = "XXX"
+      mock_trainee.locale_code = "uk"
+      @result ||= render_inline(ContactDetails::View.new(data_model: mock_trainee))
+    end
+
+    it "does not renders rows for address, only email" do
+      expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 1)
+    end
+
+    it "does not render the address" do
+      expect(rendered_component).not_to have_text(mock_trainee.address_line_one)
+    end
+
+    it "renders the email address" do
+      expect(rendered_component)
+        .to have_text(mock_trainee.email)
+    end
+  end
+
 private
 
   def mock_trainee

--- a/spec/forms/contact_details_form_spec.rb
+++ b/spec/forms/contact_details_form_spec.rb
@@ -82,6 +82,39 @@ describe ContactDetailsForm, type: :model do
         expect(subject.errors[:address_line_two]).to be_empty
       end
     end
+
+    context "HESA trainee record" do
+      let(:trainee) { build(:trainee, locale_code: nil, hesa_id: "XXX") }
+      let(:params) do
+        {
+          "locale_code" => "uk",
+          "address_line_one" => "test",
+          "address_line_two" => "test",
+          "international_address" => "test",
+          "town_city" => "test",
+          "postcode" => "E1 5DJ",
+        }
+      end
+
+      before do
+        subject.valid?
+      end
+
+      it "does not show address validation errors" do
+        expect(subject.errors[:international_address]).to be_empty
+        expect(subject.errors[:address_line_two]).to be_empty
+        ContactDetailsForm::MANDATORY_UK_ADDRESS_FIELDS.each do |field|
+          expect(subject.errors[field]).to be_empty
+        end
+      end
+
+      it "nullifies all the address fields" do
+        subject.send(:nullify_unused_address_fields!)
+        params.each do |k, _v|
+          expect(subject.fields[k.to_sym]).to be_nil
+        end
+      end
+    end
   end
 
   describe "#stash" do


### PR DESCRIPTION
### Context

https://trello.com/c/rrfqtX4n/3490-m-hesa-records-dont-have-an-address

### Changes proposed in this pull request

* Contact details section removed address validation for HESA records
* Confirmation page, address row removed for HESA records

### Guidance to review

* HESA trainee go to contact details section.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
