### PR TITLE
3484 s imported trainee filter

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -188,8 +188,9 @@ class Trainee < ApplicationRecord
     )
   end)
 
-  scope :with_manual_application, -> { where(apply_application: nil) }
+  scope :with_manual_application, -> { where(apply_application: nil, created_from_dttp: false) }
   scope :with_apply_application, -> { where.not(apply_application: nil) }
+  scope :created_from_dttp, -> { where(created_from_dttp: true) }
 
   scope :on_early_years_routes, -> { where(training_route: EARLY_YEARS_TRAINING_ROUTES.keys) }
 

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -4,7 +4,7 @@ class TraineeFilter
   AWARD_STATES = %w[qts_recommended qts_awarded eyts_recommended eyts_awarded].freeze
   STATES = Trainee.states.keys.excluding("recommended_for_award", "awarded") + AWARD_STATES
 
-  RECORD_SOURCES = %w[apply manual].freeze
+  RECORD_SOURCES = %w[apply manual dttp].freeze
 
   def initialize(params:)
     @params = params

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -30,12 +30,25 @@ module Trainees
       trainees.with_education_phase(*levels)
     end
 
-    def record_source(trainees, record_source)
-      return trainees if record_source.blank? || record_source.size > 1
+    def record_source(trainees, record_source_values)
+      scope_map = {
+        "dttp" => :created_from_dttp,
+        "manual" => :with_manual_application,
+        "apply" => :with_apply_application,
+      }
+      scoped_trainees = trainees
 
-      return trainees.with_manual_application if record_source.include?("manual")
+      Array(record_source_values).each_with_index do |source, i|
+        scope_name = scope_map[source]
 
-      trainees.with_apply_application
+        if i.zero?
+          scoped_trainees = scoped_trainees.send(scope_name)
+        else
+          scoped_trainees = scoped_trainees.or(trainees.send(scope_name))
+        end
+      end
+
+      scoped_trainees
     end
 
     def training_route(trainees, training_route)

--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -91,21 +91,26 @@
     </fieldset>
   </div>
 
-  <% if multiple_record_sources? %>
+  <% if show_source_filters? %>
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
           Record source
         </legend>
         <div class="govuk-checkboxes govuk-checkboxes--small">
+            <% available_record_sources.map do |source| %>
+              <% next if source == "dttp" && !current_user.system_admin? %>
             <div class="govuk-checkboxes__item">
-              <%= check_box_tag "record_source[]", "apply", checked?(filters, :record_source, "apply"), id: "record_source-apply", class: "govuk-checkboxes__input" %>
-              <%= label_tag "record_source-apply", label_for("record_source", "apply"), class: "govuk-label govuk-checkboxes__label" %>
+              <%= check_box_tag "record_source[]",
+                                source,
+                                checked?(filters, :record_source, source.to_s),
+                                id: "record_source-#{source}",
+                                class: "govuk-checkboxes__input" %>
+              <%= label_tag "record_source-#{source}",
+                            label_for("record_source", source),
+                            class: "govuk-label govuk-checkboxes__label" %>
             </div>
-            <div class="govuk-checkboxes__item">
-              <%= check_box_tag "record_source[]", "manual", checked?(filters, :record_source, "manual"), id: "record_source-manual", class: "govuk-checkboxes__input" %>
-              <%= label_tag "record_source-manual", label_for("record_source", "manual"), class: "govuk-label govuk-checkboxes__label" %>
-            </div>
+            <% end %>
         </div>
       </fieldset>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1010,6 +1010,7 @@ en:
         record_sources:
           apply: Imported from Apply
           manual: Added manually
+          dttp: Imported from DTTP
         trainee_id: *trainee_id
         training_routes:
           assessment_only: Assessment only

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -491,5 +491,9 @@ FactoryBot.define do
     trait :discarded do
       discarded_at { Time.zone.now }
     end
+
+    trait :created_from_dttp do
+      created_from_dttp { true }
+    end
   end
 end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -72,7 +72,7 @@ describe Trainee do
     end
   end
 
-  context "scopes" do
+  describe "scopes" do
     describe "with_award_states" do
       it "returns trainees with the correct training route and state" do
         create(:trainee, :trn_received)
@@ -115,9 +115,19 @@ describe Trainee do
     describe ".with_manual_application" do
       let!(:manual_trainee) { create(:trainee) }
       let!(:apply_trainee) { create(:trainee, :with_apply_application) }
+      let!(:dttp_trainee) { create(:trainee, :created_from_dttp) }
 
-      it "returns trainees from apply" do
+      it "returns manually entered trainees" do
         expect(described_class.with_manual_application).to contain_exactly(manual_trainee)
+      end
+    end
+
+    describe ".created_from_dttp" do
+      let!(:draft_trainee) { create(:trainee) }
+      let!(:dttp_trainee) { create(:trainee, :created_from_dttp) }
+
+      it "returns trainees created from dttp" do
+        expect(described_class.created_from_dttp).to contain_exactly(dttp_trainee)
       end
     end
   end

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -6,8 +6,8 @@ module Trainees
   describe Filter do
     subject { described_class.call(trainees: trainees, filters: filters) }
 
-    let!(:draft_trainee) { create(:trainee, :draft) }
-    let!(:apply_draft_trainee) { create(:trainee, :with_apply_application) }
+    let!(:draft_trainee) { create(:trainee, :draft, first_names: "Draft") }
+    let!(:apply_draft_trainee) { create(:trainee, :with_apply_application, first_names: "Apply") }
     let(:filters) { nil }
     let(:trainees) { Trainee.all }
 
@@ -130,22 +130,51 @@ module Trainees
       end
     end
 
-    context "with record_source filter set to apply" do
-      let(:filters) { { record_source: %w[apply] } }
+    describe "record source filter" do
+      let!(:dttp_trainee) { create(:trainee, :created_from_dttp, first_names: "DTTP") }
+      let(:filters) { { record_source: filter_value } }
 
-      it { is_expected.to contain_exactly(apply_draft_trainee) }
-    end
+      context "with record_source filter set to apply" do
+        let(:filter_value) { %w[apply] }
 
-    context "with record_source filter set to manual" do
-      let(:filters) { { record_source: %w[manual] } }
+        it { is_expected.to contain_exactly(apply_draft_trainee) }
+      end
 
-      it { is_expected.to contain_exactly(draft_trainee) }
-    end
+      context "with record_source filter set to manual" do
+        let(:filter_value) { %w[manual] }
 
-    context "with record_source filter set to both manual and apply" do
-      let(:filters) { { record_source: %w[apply manual] } }
+        it { is_expected.to contain_exactly(draft_trainee) }
+      end
 
-      it { is_expected.to contain_exactly(apply_draft_trainee, draft_trainee) }
+      context "with record_source filter set to dttp" do
+        let(:filter_value) { %w[dttp] }
+
+        it { is_expected.to contain_exactly(dttp_trainee) }
+      end
+
+      context "with record_source filter set to both manual and apply" do
+        let(:filter_value) { %w[apply manual] }
+
+        it { is_expected.to match_array([apply_draft_trainee, draft_trainee]) }
+      end
+
+      context "with record_source filter set to both dttp and apply" do
+        let(:filter_value) { %w[apply dttp] }
+
+        it { is_expected.to match_array([apply_draft_trainee, dttp_trainee]) }
+      end
+
+      context "with record_source filter set to both dttp and manual" do
+        let(:filter_value) { %w[manual dttp] }
+
+        it { is_expected.to match_array([draft_trainee, dttp_trainee]) }
+      end
+
+      context "with record_source filter set to both dttp, apply and manual" do
+        let(:filter_value) { %w[apply dttp manual] }
+
+        it { is_expected.to match_array([apply_draft_trainee, dttp_trainee, draft_trainee]) }
+      end
     end
 
     context "with study_mode filter set to full time" do

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -21,6 +21,7 @@ module PageObjects
       element :incomplete_checkbox, "#record_completion-incomplete"
       element :assessment_only_checkbox, "#training_route-assessment_only"
       element :imported_from_apply_checkbox, "#record_source-apply"
+      element :imported_from_dttp_checkbox, "#record_source-dttp"
       element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"
       element :subject, "#subject"
       element :provider_filter, "#provider"


### PR DESCRIPTION
### Context

The PR adds the functionality to filter by 'Imported from DTTP' on draft and registered trainee pages, under 'Record Source'. This filter option is only available to admins and does not render for non-admin users.

### Changes proposed in this pull request

- `created_from_dttp` scope added to Trainee model
- dttp added to `RECORD_SOURCES` in TraineeFilter model
- `record_source` modified in `filter.rb` to return DTTP trainees correctly
- changes made in `base_trainee_controller.rb` and `_filters.html.erb` so that the DTTP filter renders conditionally

### Guidance to review

For provider A, we have created one DTTP trainee. Check the below.

Given I am an admin user:
-  when I visit the index page and there is a DTTP trainee, then I can see the 'Imported from DTTP' record source filter
-  when I click on 'Imported from DTTP', then I can see the trainee
-  when I click on multiple or all record source filter options, then I can see the relevant trainees
- when I click on the different record source filter options, then the total trainee counts look correct
- when I filter to Provider A, then I can click on 'Imported from DTTP' and see the trainee
- when I filter to Provider B, then I cannot click on 'Imported from DTTP' and see the trainee

Given I am a non-admin user:
- when I visit the index page and there is a DTTP trainee, then I cannot see the 'Imported from DTTP' record source filter
- when I visit the index page and there is a DTTP trainee, I can see the trainee in the list/search for the trainee

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
