### PR TITLE
[3462] Map other gender from DTTP to other in register

### DIFF
--- a/app/models/dttp/trainee.rb
+++ b/app/models/dttp/trainee.rb
@@ -67,6 +67,10 @@ module Dttp
       response["_dfe_ethnicityid_value"]
     end
 
+    def gender_code
+      response["gendercode"].to_i
+    end
+
     def nationality
       response["_dfe_nationality_value"]
     end

--- a/app/models/dttp/trainee.rb
+++ b/app/models/dttp/trainee.rb
@@ -68,7 +68,7 @@ module Dttp
     end
 
     def gender_code
-      response["gendercode"].to_i
+      response["gendercode"]
     end
 
     def nationality

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -136,9 +136,11 @@ module Trainees
     end
 
     def trainee_gender
-      return :other if Dttp::Params::Contact::OTHER_GENDER_CODE == dttp_trainee.gender_code
+      return :gender_not_provided if dttp_trainee.gender_code.blank?
 
-      Dttp::Params::Contact::GENDER_CODES.invert[dttp_trainee.gender_code]
+      return :other if Dttp::Params::Contact::OTHER_GENDER_CODE == dttp_trainee.gender_code.to_i
+
+      Dttp::Params::Contact::GENDER_CODES.invert[dttp_trainee.gender_code.to_i]
     end
 
     def trainee_id

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -136,9 +136,9 @@ module Trainees
     end
 
     def trainee_gender
-      # TODO: Need to take a decision on mapping gender other/not provided
-      # Hash#invert might not be desirable as we lose one of the duplicated values
-      Dttp::Params::Contact::GENDER_CODES.invert[dttp_trainee.response["gendercode"].to_i]
+      return :other if Dttp::Params::Contact::OTHER_GENDER_CODE == dttp_trainee.gender_code
+
+      Dttp::Params::Contact::GENDER_CODES.invert[dttp_trainee.gender_code]
     end
 
     def trainee_id

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -467,11 +467,11 @@ module Trainees
       end
 
       context "when gender is other" do
-        let(:api_trainee) { create(:api_trainee, gendercode: "389040000") }
+        let(:api_trainee) { create(:api_trainee, gendercode: Dttp::Params::Contact::OTHER_GENDER_CODE) }
 
-        it "maps gender to not provided" do
+        it "maps gender to other" do
           create_trainee_from_dttp
-          expect(Trainee.last.gender).to eq("gender_not_provided")
+          expect(Trainee.last.gender).to eq("other")
         end
       end
 

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -475,6 +475,15 @@ module Trainees
         end
       end
 
+      context "when gender is nil" do
+        let(:api_trainee) { create(:api_trainee, gendercode: nil) }
+
+        it "maps gender to gender_not_provided" do
+          create_trainee_from_dttp
+          expect(Trainee.last.gender).to eq("gender_not_provided")
+        end
+      end
+
       context "when trainee_id is NOTPROVIDED" do
         let(:api_trainee) { create(:api_trainee, dfe_traineeid: "NOTPROVIDED") }
 


### PR DESCRIPTION
### Context
The current implementation was mapping a value of "other" gender in DTTP to "gender_not_provided" in register.

### Changes proposed in this pull request
Prefer `:other` if gendercode is 389040000. This conversion is lossless in this context, since any update to dttp would map it to the same gendercode.


### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
