### PR TITLE
[3531] Add `MapStateFromDttp` service

### DIFF
--- a/app/services/concerns/has_dttp_mapping.rb
+++ b/app/services/concerns/has_dttp_mapping.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module HasDttpMapping
+  def find_by_entity_id(id, mapping)
+    mapping.select { |_key, value| value[:entity_id] == id }.keys&.first
+  end
+end

--- a/app/services/degrees/map_from_dttp.rb
+++ b/app/services/degrees/map_from_dttp.rb
@@ -3,6 +3,7 @@
 module Degrees
   class MapFromDttp
     include ServicePattern
+    include HasDttpMapping
 
     def initialize(dttp_degree:)
       @dttp_degree = dttp_degree
@@ -121,10 +122,6 @@ module Degrees
 
     def unmapped_country?
       dttp_degree.country.present? && country.blank?
-    end
-
-    def find_by_entity_id(id, mapping)
-      mapping.select { |_key, value| value[:entity_id] == id }.keys&.first
     end
   end
 end

--- a/app/services/trainees/map_state_from_dttp.rb
+++ b/app/services/trainees/map_state_from_dttp.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Trainees
+  class MapStateFromDttp
+    include ServicePattern
+    include HasDttpMapping
+
+    # This is not the same order as the enum definition in the Trainee model
+    STATUS_PROGRESS_ORDER = %w[
+      draft
+      submitted_for_trn
+      trn_received
+      recommended_for_award
+      deferred
+      withdrawn
+      awarded
+    ].freeze
+
+    def initialize(dttp_trainee:)
+      @dttp_trainee = dttp_trainee
+    end
+
+    def call
+      if dttp_statuses.empty? || status_not_determinable? || mapped_statuses.empty?
+        dttp_trainee.non_importable_missing_state!
+        return
+      end
+
+      # Specific rule
+      if dttp_statuses == [DttpStatuses::DEFERRED, DttpStatuses::STANDARDS_NOT_MET]
+        return "deferred"
+      end
+
+      most_progressed_state
+    end
+
+  private
+
+    attr_reader :dttp_trainee, :placement_assignment
+
+    def dttp_statuses
+      @dttp_statuses ||= [
+        find_by_entity_id(dttp_trainee.response["_dfe_traineestatusid_value"], Dttp::CodeSets::Statuses::MAPPING),
+        find_by_entity_id(dttp_trainee.latest_placement_assignment.response["_dfe_traineestatusid_value"], Dttp::CodeSets::Statuses::MAPPING),
+      ].compact.sort
+    end
+
+    def status_not_determinable?
+      non_determinable_statuses.include?(dttp_statuses)
+    end
+
+    def non_determinable_statuses
+      [
+        [DttpStatuses::AWAITING_QTS, DttpStatuses::STANDARDS_MET],
+        [DttpStatuses::AWAITING_QTS, DttpStatuses::LEFT_COURSE_BEFORE_END],
+        [DttpStatuses::DEFERRED, DttpStatuses::AWAITING_QTS],
+        [DttpStatuses::DEFERRED, DttpStatuses::LEFT_COURSE_BEFORE_END],
+        [DttpStatuses::DEFERRED, DttpStatuses::YET_TO_COMPLETE_COURSE],
+      ].map(&:sort)
+    end
+
+    def mapped_statuses
+      @mapped_statuses ||= dttp_statuses.map { |dttp_status| map_to_state(dttp_status) }.compact
+    end
+
+    def most_progressed_state
+      mapped_statuses.max_by(&STATUS_PROGRESS_ORDER.method(:index))
+    end
+
+    def map_to_state(dttp_status)
+      case dttp_status
+      when DttpStatuses::DRAFT_RECORD then "draft"
+      when DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED then "submitted_for_trn"
+      when DttpStatuses::STANDARDS_MET, DttpStatuses::AWAITING_QTS then "recommended_for_award"
+      when DttpStatuses::DEFERRED then "deferred"
+      when DttpStatuses::YET_TO_COMPLETE_COURSE then "trn_received"
+      when DttpStatuses::AWARDED_EYTS, DttpStatuses::AWARDED_QTS then "awarded"
+      when DttpStatuses::LEFT_COURSE_BEFORE_END then "withdrawn"
+      when DttpStatuses::STANDARDS_NOT_MET
+        withdraw_date.present? ? "withdrawn" : "trn_received"
+      when DttpStatuses::EYTS_REVOKED, DttpStatuses::QTS_REVOKED, DttpStatuses::DID_NOT_START, DttpStatuses::REJECTED then nil
+      end
+    end
+
+    def withdraw_date
+      dttp_trainee.latest_placement_assignment.response["dfe_dateleft"]
+    end
+  end
+end

--- a/spec/factories/dttp/api_trainee.rb
+++ b/spec/factories/dttp/api_trainee.rb
@@ -21,7 +21,6 @@ FactoryBot.define do
     _dfe_nationality_value { "d17d640e-5c62-e711-80d1-005056ac45bb" }
     dfe_trn { Faker::Number.number(digits: 7) }
     merged { false }
-    _dfe_traineestatusid_value { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::AWARDED_QTS][:entity_id] }
     dfe_husid { "1811499435078" }
 
     initialize_with { attributes.stringify_keys }

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -474,17 +474,6 @@ module Trainees
       end
     end
 
-    context "when training state is not mapped" do
-      let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: nil) }
-
-      it "marks the application as non importable" do
-        expect {
-          create_trainee_from_dttp
-        }.to change(Trainee, :count).by(0)
-        .and change(dttp_trainee, :state).to("non_importable_missing_state")
-      end
-    end
-
     context "when placement assignments are from multiple providers" do
       let(:dttp_trainee) { create(:dttp_trainee, :with_provider, placement_assignments: create_list(:dttp_placement_assignment, 2)) }
 
@@ -549,28 +538,6 @@ module Trainees
         trainee = Trainee.last
         expect(trainee.withdraw_date).to eq date
         expect(trainee.withdraw_reason).to eq WithdrawalReasons::FOR_ANOTHER_REASON
-      end
-    end
-
-    context "when the trainee is 'Standards not met'" do
-      before do
-        create_trainee_from_dttp
-      end
-
-      context "and they have a 'dateleft'" do
-        let(:api_placement_assignment) { create(:api_placement_assignment, dfe_dateleft: Time.zone.today, _dfe_traineestatusid_value: "215af972-9e1b-e711-80c7-0050568902d3") }
-
-        it "creates the trainee as withdrawn" do
-          expect(Trainee.last.state).to eq("withdrawn")
-        end
-      end
-
-      context "and they don't have a dateleft" do
-        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: "215af972-9e1b-e711-80c7-0050568902d3") }
-
-        it "creates the trainee as trn_received" do
-          expect(Trainee.last.state).to eq("trn_received")
-        end
       end
     end
   end

--- a/spec/services/trainees/map_state_from_dttp_spec.rb
+++ b/spec/services/trainees/map_state_from_dttp_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe MapStateFromDttp do
+    include SeedHelper
+    let(:awaiting_qts_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::AWAITING_QTS][:entity_id] }
+    let(:deferred_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::DEFERRED][:entity_id] }
+    let(:qts_revoked_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::QTS_REVOKED][:entity_id] }
+    let(:standards_not_met_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::STANDARDS_NOT_MET][:entity_id] }
+    let(:awarded_qts_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::AWARDED_QTS][:entity_id] }
+
+    let(:api_trainee) { create(:api_trainee) }
+    let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: nil) }
+    let(:placement_assignment) { create(:dttp_placement_assignment, response: api_placement_assignment) }
+    let(:dttp_trainee) { create(:dttp_trainee, placement_assignments: [placement_assignment], api_trainee_hash: api_trainee) }
+
+    subject { described_class.call(dttp_trainee: dttp_trainee) }
+
+    context "when neither trainee nor placement_assignment have a status" do
+      it "marks the trainee as non importable" do
+        expect { subject }.to change(dttp_trainee, :state).to("non_importable_missing_state")
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the combination of statuses means the state is not determinable" do
+      let(:api_trainee) { create(:api_trainee, _dfe_traineestatusid_value: awaiting_qts_id) }
+      let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: deferred_id) }
+
+      it "marks the trainee as non importable" do
+        expect { subject }.to change(dttp_trainee, :state).to("non_importable_missing_state")
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "the placement_assignment has a status but we don't have it in Register" do
+      let(:api_trainee) { create(:api_trainee, _dfe_traineestatusid_value: qts_revoked_id) }
+
+      it "marks the trainee as non importable" do
+        expect { subject }.to change(dttp_trainee, :state).to("non_importable_missing_state")
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the placement assignment status is DEFERRED but the trainee status is STANDARDS_NOT_MET" do
+      let(:api_trainee) { create(:api_trainee, _dfe_traineestatusid_value: standards_not_met_id) }
+      let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: deferred_id) }
+
+      it { is_expected.to eq("deferred") }
+    end
+
+    context "when there is a placement assignment state but no trainee state" do
+      let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: awarded_qts_id) }
+
+      it { is_expected.to eq("awarded") }
+
+      context "and it is AWAITING_QTS" do
+        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: awaiting_qts_id) }
+
+        it { is_expected.to eq("recommended_for_award") }
+      end
+
+      context "and it is STANDARDS_NOT_MET" do
+        context "and they have a 'dateleft'" do
+          let(:api_placement_assignment) { create(:api_placement_assignment, dfe_dateleft: Time.zone.today, _dfe_traineestatusid_value: "215af972-9e1b-e711-80c7-0050568902d3") }
+
+          it { is_expected.to eq("withdrawn") }
+        end
+
+        context "and they don't have a dateleft" do
+          let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: "215af972-9e1b-e711-80c7-0050568902d3") }
+
+          it { is_expected.to eq("trn_received") }
+        end
+      end
+    end
+
+    context "when there is a placement assignment state and a trainee state" do
+      context "when there no mismatch" do
+        let(:api_trainee) { create(:api_trainee, _dfe_traineestatusid_value: deferred_id) }
+        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: deferred_id) }
+
+        it { is_expected.to eq("deferred") }
+      end
+
+      context "when there is a mismatch" do
+        let(:api_trainee) { create(:api_trainee, _dfe_traineestatusid_value: standards_not_met_id) }
+        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: awarded_qts_id) }
+
+        it "returns the 'most' progressed state" do
+          expect(subject).to eq("awarded")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/1Ec4keKs/3531-pick-statuses-from-placement-assignments-or-trainee-contacts-when-there-is-a-mismatch

### Changes proposed in this pull request

This service:
- Takes a `dttp_trainee` and returns the state to be saved on our trainee
- This is in most cases the 'most progressed' state, i.e. `awarded` wins over all other states, `trn_received` wins over `draft` etc etc
- Adds an error state to the `dttp_trainee` if it cannot determine the state (this is as per the spreadsheet attached to the Trello ticket)

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~