### PR TITLE
[3487] Add additional disability text if HESA multiple disabilities

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -11,6 +11,8 @@ module Trainees
                     "Wales", "Isle of Man",
                     "United Kingdom, not otherwise specified"].freeze
 
+    MULTIPLE_DISABILITIES_TEXT = "HESA multiple disabilities"
+
     def initialize(dttp_trainee:)
       @dttp_trainee = dttp_trainee
       @trainee = Trainee.new(mapped_attributes)
@@ -55,6 +57,8 @@ module Trainees
       end
 
       trainee.save!
+
+      add_multiple_disability_text!
 
       calculate_funding!
 
@@ -175,7 +179,6 @@ module Trainees
         }
       end
 
-      # TODO: This needs a decision, since DTTP may have 'multiple disabilities'
       if disability == Diversities::MULTIPLE_DISABILITIES
         return {
           disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled],
@@ -194,6 +197,12 @@ module Trainees
         dttp_trainee.response["_dfe_disibilityid_value"],
         Dttp::CodeSets::Disabilities::MAPPING,
       )
+    end
+
+    def add_multiple_disability_text!
+      return unless disability == Diversities::MULTIPLE_DISABILITIES
+
+      trainee.trainee_disabilities.last.update!(additional_disability: MULTIPLE_DISABILITIES_TEXT)
     end
 
     def ethnicity_attributes

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -413,6 +413,20 @@ module Trainees
         end
       end
 
+      context "when disability is 'MULTIPLE_DISABILITIES'" do
+        let(:multiple_disability_id) { "d398eae7-4ba5-e711-80da-005056ac45bb" }
+        let(:api_trainee) { create(:api_trainee, _dfe_disibilityid_value: multiple_disability_id) }
+
+        before { create(:disability, name: Diversities::OTHER) }
+
+        it "saves the disability as 'other' and sets the additional_diversity text" do
+          create_trainee_from_dttp
+          trainee_disability = Trainee.last.trainee_disabilities.last
+          expect(trainee_disability.additional_disability).to eq(Trainees::CreateFromDttp::MULTIPLE_DISABILITIES_TEXT)
+          expect(trainee_disability.disability.name).to eq(Diversities::OTHER)
+        end
+      end
+
       context "when just ethnicity is disclosed" do
         let(:api_trainee) do
           create(:api_trainee, _dfe_ethnicityid_value: Dttp::CodeSets::Ethnicities::MAPPING[Diversities::AFRICAN][:entity_id])


### PR DESCRIPTION
### Context

https://trello.com/c/mVnmPhgy/3487-s-for-multiple-disabilities-set-other-and-add-text-hesa-multiple-disabilities

Trainees coming from HESA have the option of 'Multiple disabilities' as a disabilities. We are not given the individual disabilities. Therefore we decided to save this as 'Other' and add a comment in the free text field.

### Changes proposed in this pull request

- If the trainee's disabilities is 'Multiple disabilities', then set the additional_disability text to "HESA multiple disabilities"

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
