### PR TITLE
[3489] HESA records don’t have an ITT end date

### DIFF
--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -26,8 +26,12 @@ module CourseDetails
         age_range_row,
         study_mode_row,
         course_date_row(itt_start_date, :start),
-        course_date_row(itt_end_date, :end),
+        (course_date_row(itt_end_date, :end) if end_date_required?),
       ].compact
+    end
+
+    def end_date_required?
+      trainee.hesa_id.blank?
     end
 
   private

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -53,7 +53,7 @@ class CourseDetailsForm < TraineeForm
   validates :study_mode, inclusion: { in: TRAINEE_STUDY_MODE_ENUMS.keys }, if: :requires_study_mode?
 
   validate :itt_start_date_valid
-  validate :itt_end_date_valid
+  validate :itt_end_date_valid, if: :end_date_required?
 
   delegate :apply_application?, :requires_study_mode?, to: :trainee
 
@@ -75,7 +75,9 @@ class CourseDetailsForm < TraineeForm
   end
 
   def itt_end_date
-    new_date({ year: end_year, month: end_month, day: end_day })
+    if end_date_required?
+      new_date({ year: end_year, month: end_month, day: end_day })
+    end
   end
 
   def save!
@@ -127,6 +129,10 @@ class CourseDetailsForm < TraineeForm
       sum
     }
     assign_attributes_and_stash(opts)
+  end
+
+  def end_date_required?
+    trainee.hesa_id.blank?
   end
 
 private

--- a/app/forms/itt_dates_form.rb
+++ b/app/forms/itt_dates_form.rb
@@ -18,7 +18,8 @@ class IttDatesForm < TraineeForm
 
   attr_accessor(*FIELDS, :course)
 
-  validate :start_date_valid, :end_date_valid
+  validate :start_date_valid
+  validate :end_date_valid, if: :end_date_required?
 
   delegate :study_mode, to: :course_details_form
 
@@ -57,7 +58,13 @@ class IttDatesForm < TraineeForm
   end
 
   def end_date
-    compute_date({ year: end_year, month: end_month, day: end_day })
+    if end_date_required?
+      compute_date({ year: end_year, month: end_month, day: end_day })
+    end
+  end
+
+  def end_date_required?
+    trainee.hesa_id.blank?
   end
 
 private
@@ -80,6 +87,8 @@ private
   end
 
   def for_all_trainees?
+    return false unless end_date_required?
+
     ActiveModel::Type::Boolean.new.cast(is_for_all_trainees)
   end
 

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -59,11 +59,13 @@
                              legend: { text: t("publish_course_details.view.itt_start_date").html_safe, size: "s" },
                              hint: { text: t("activemodel.errors.models.course_details_form.attributes.itt_start_date.hint_html", year: Time.zone.now.year) }) %>
 
-       <%= f.govuk_date_field(:itt_end_date,
-                              date_of_birth: false,
-                              legend: { text: t("publish_course_details.view.itt_end_date").html_safe, size: "s" },
-                              hint: { text: t("activemodel.errors.models.course_details_form.attributes.itt_end_date.hint_html", year: Time.zone.now.next_year.year) }) %>
+        <% if @course_details_form.end_date_required? %>
+          <%= f.govuk_date_field(:itt_end_date,
+                                date_of_birth: false,
+                                legend: { text: t("publish_course_details.view.itt_end_date").html_safe, size: "s" },
+                                hint: { text: t("activemodel.errors.models.course_details_form.attributes.itt_end_date.hint_html", year: Time.zone.now.next_year.year) }) %>
 
+        <% end %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/trainees/itt_dates/edit.html.erb
+++ b/app/views/trainees/itt_dates/edit.html.erb
@@ -25,20 +25,22 @@
                                  text: t("activemodel.errors.models.course_details_form.attributes.itt_start_date.hint_html",
                                          year: Time.zone.now.year)
                                }) %>
-        <%= f.govuk_date_field(:end_date,
-                               date_of_birth: false,
-                               legend: { text: t("publish_course_details.view.itt_end_date").html_safe, size: "s" },
-                               hint: {
-                                 text: t("activemodel.errors.models.course_details_form.attributes.itt_end_date.hint_html",
-                                         year: Time.zone.now.next_year.year)
-                               }) %>
-        <%= f.govuk_check_box(:is_for_all_trainees, "1", "0", multiple: false,
-                              label: { text: t(".is_for_all_courses",
-                                               course_name: @itt_dates_form.course.name,
-                                               course_code: @itt_dates_form.course.code,
-                                               study_mode: t("activerecord.attributes.trainee.study_modes.#{@itt_dates_form.study_mode}").downcase,
-                                               cycle_year: @itt_dates_form.course.recruitment_cycle_year,
-                                               next_cycle_year: @itt_dates_form.course.recruitment_cycle_year + 1) }) %>
+        <% if @itt_dates_form.end_date_required? %>
+          <%= f.govuk_date_field(:end_date,
+                                 date_of_birth: false,
+                                 legend: { text: t("publish_course_details.view.itt_end_date").html_safe, size: "s" },
+                                 hint: {
+                                   text: t("activemodel.errors.models.course_details_form.attributes.itt_end_date.hint_html",
+                                           year: Time.zone.now.next_year.year)
+                                 }) %>
+          <%= f.govuk_check_box(:is_for_all_trainees, "1", "0", multiple: false,
+                                label: { text: t(".is_for_all_courses",
+                                                 course_name: @itt_dates_form.course.name,
+                                                 course_code: @itt_dates_form.course.code,
+                                                 study_mode: t("activerecord.attributes.trainee.study_modes.#{@itt_dates_form.study_mode}").downcase,
+                                                 cycle_year: @itt_dates_form.course.recruitment_cycle_year,
+                                                 next_cycle_year: @itt_dates_form.course.recruitment_cycle_year + 1) }) %>
+        <% end %>
       </div>
       <%= f.govuk_submit %>
     <% end %>

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -135,6 +135,40 @@ module CourseDetails
       end
     end
 
+    context "HESA trainee" do
+      context "with a publish course", feature_publish_course_details: true do
+        let(:trainee) { create(:trainee, :with_primary_education, :with_publish_course_details, hesa_id: "XXX", itt_end_date: Time.zone.today) }
+
+        before do
+          render_inline(View.new(data_model: trainee))
+        end
+
+        it "renders 6 rows" do
+          expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 6)
+        end
+
+        it "does not render the ITT end date" do
+          expect(rendered_component).not_to have_text("ITT end date")
+        end
+      end
+
+      context "without a publish course" do
+        let(:trainee) { create(:trainee, hesa_id: "XXX", itt_end_date: Time.zone.today) }
+
+        before do
+          render_inline(View.new(data_model: trainee))
+        end
+
+        it "renders 4 rows" do
+          expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 4)
+        end
+
+        it "does not render the ITT end date" do
+          expect(rendered_component).not_to have_text("ITT end date")
+        end
+      end
+    end
+
     context "early years route" do
       before do
         render_inline(View.new(data_model: trainee))

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -367,6 +367,55 @@ describe CourseDetailsForm, type: :model do
         end
       end
     end
+
+    context "HESA trainee record" do
+      let(:trainee) { build(:trainee, hesa_id: "XXX") }
+
+      context "itt_end_date not set" do
+        let(:params) { {} }
+
+        before do
+          subject.valid?
+        end
+
+        it "does not validate itt_end_date" do
+          expect(subject.errors[:itt_end_date]).to be_empty
+        end
+      end
+
+      context "itt_end_date is set" do
+        let(:valid_start_date) do
+          Faker::Date.between(from: 1.year.ago, to: 2.days.ago)
+        end
+
+        let(:valid_end_date) do
+          Faker::Date.between(from: valid_start_date + 1.day, to: Time.zone.today)
+        end
+
+        let(:params) do
+          {
+            start_day: valid_start_date.day.to_s,
+            start_month: valid_start_date.month.to_s,
+            start_year: valid_start_date.year.to_s,
+            end_day: valid_end_date.day.to_s,
+            end_month: valid_end_date.month.to_s,
+            end_year: valid_end_date.year.to_s,
+          }
+        end
+
+        before do
+          subject.valid?
+        end
+
+        it "does not validate itt_end_date" do
+          expect(subject.errors[:itt_end_date]).to be_empty
+        end
+
+        it "returns nil" do
+          expect(subject.itt_end_date).to be_nil
+        end
+      end
+    end
   end
 
   context "valid trainee" do


### PR DESCRIPTION
### Context

https://trello.com/c/f62gKF3L/3489-hesa-records-dont-have-an-itt-end-date

### Changes proposed in this pull request

* Updated `itt_dates` form and `course_details` form to hide ITT end date when HESA record
* Updated course details confirmation page to hide ITT end date row when HESA record

### Guidance to review

* Need HESA record, add course details
* HESA draft record: https://register-pr-1931.london.cloudapps.digital/trainees/4A9KBxfZAc1wkAEygZaPWF2v/course-details/itt-dates/edit
* HESA non-draft: https://register-pr-1931.london.cloudapps.digital/trainees/wj7t5f7NBPFKjEwzajkBLuuo/course-details/itt-dates/edit

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
