### PR TITLE
[3496] Add deferral/reinstatement information from DTTP Dormancy Periods

### DIFF
--- a/app/jobs/dttp/sync_dormant_periods_job.rb
+++ b/app/jobs/dttp/sync_dormant_periods_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Dttp
+  class SyncDormantPeriodsJob < ApplicationJob
+    queue_as :dttp
+
+    def perform(request_uri = nil)
+      return unless FeatureService.enabled?(:sync_trainees_from_dttp)
+
+      @dormant_periods = RetrieveDormantPeriods.call(request_uri: request_uri)
+
+      DormantPeriod.upsert_all(dormant_period_attributes, unique_by: :dttp_id)
+
+      Dttp::SyncDormantPeriodsJob.perform_later(next_page_url) if next_page?
+    end
+
+  private
+
+    attr_reader :dormant_periods
+
+    def dormant_period_attributes
+      Parsers::DormantPeriod.to_attributes(dormant_periods: dormant_periods[:items])
+    end
+
+    def next_page_url
+      dormant_periods[:meta][:next_page_url]
+    end
+
+    def next_page?
+      next_page_url.present?
+    end
+  end
+end

--- a/app/lib/dttp/parsers/dormant_period.rb
+++ b/app/lib/dttp/parsers/dormant_period.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Dttp
+  module Parsers
+    class DormantPeriod
+      class << self
+        def to_attributes(dormant_periods:)
+          dormant_periods.map do |dormant_period|
+            {
+              dttp_id: dormant_period["dfe_dormantperiodid"],
+              placement_assignment_dttp_id: dormant_period["_dfe_trainingrecordid_value"],
+              response: dormant_period,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/dttp/dormant_period.rb
+++ b/app/models/dttp/dormant_period.rb
@@ -7,5 +7,13 @@ module Dttp
     belongs_to :placement_assignment, foreign_key: :placement_assignment_dttp_id, primary_key: :dttp_id, inverse_of: :dormant_period, optional: true
 
     validates :response, presence: true
+
+    def date_left
+      response["dfe_dateleftcourse"]
+    end
+
+    def date_returned
+      response["dfe_datereturnedtocourse"]
+    end
   end
 end

--- a/app/models/dttp/dormant_period.rb
+++ b/app/models/dttp/dormant_period.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Dttp
+  class DormantPeriod < ApplicationRecord
+    self.table_name = "dttp_dormant_periods"
+
+    belongs_to :placement_assignment, foreign_key: :placement_assignment_dttp_id, primary_key: :dttp_id, inverse_of: :dormant_period, optional: true
+
+    validates :response, presence: true
+  end
+end

--- a/app/models/dttp/placement_assignment.rb
+++ b/app/models/dttp/placement_assignment.rb
@@ -6,6 +6,8 @@ module Dttp
 
     belongs_to :trainee, foreign_key: :contact_dttp_id, primary_key: :dttp_id, inverse_of: :placement_assignments, optional: true
 
+    has_one :dormant_period, foreign_key: :placement_assignment_dttp_id, primary_key: :dttp_id, inverse_of: :placement_assignment
+
     validates :response, presence: true
 
     def route_dttp_id

--- a/app/services/dttp/retrieve_dormant_periods.rb
+++ b/app/services/dttp/retrieve_dormant_periods.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Dttp
+  class RetrieveDormantPeriods
+    include ServicePattern
+    include SyncPattern
+
+    MAX_PAGE_SIZE = 100
+
+  private
+
+    def default_path
+      @default_path ||= "/dfe_dormantperiods"
+    end
+
+    def response
+      @response ||= Client.get(request_uri, headers: { "Prefer" => "odata.maxpagesize=#{MAX_PAGE_SIZE}" })
+    end
+  end
+end

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -99,6 +99,7 @@ module Trainees
        .merge(school_attributes)
        .merge(training_initiative_attributes)
        .merge(withdrawal_attributes)
+       .merge(deferral_attributes)
     end
 
     def create_degrees!
@@ -482,6 +483,16 @@ module Trainees
       {
         withdraw_date: withdraw_date,
         withdraw_reason: withdraw_reason || WithdrawalReasons::FOR_ANOTHER_REASON,
+      }
+    end
+
+    def deferral_attributes
+      return {} if dttp_trainee.latest_placement_assignment.dormant_period.blank?
+
+      {
+        defer_date: dttp_trainee.latest_placement_assignment.dormant_period.date_left,
+        reinstate_date: dttp_trainee.latest_placement_assignment.dormant_period.date_returned,
+        dormancy_dttp_id: dttp_trainee.latest_placement_assignment.dormant_period.dttp_id,
       }
     end
 

--- a/db/migrate/20220119171355_create_dttp_dormant_periods.rb
+++ b/db/migrate/20220119171355_create_dttp_dormant_periods.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateDttpDormantPeriods < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dttp_dormant_periods do |t|
+      t.jsonb :response
+      t.uuid :dttp_id, null: false
+      t.uuid :placement_assignment_dttp_id
+      t.timestamps default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :dttp_dormant_periods, :dttp_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_06_101133) do
+ActiveRecord::Schema.define(version: 2022_01_19_171355) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -218,6 +218,15 @@ ActiveRecord::Schema.define(version: 2022_01_06_101133) do
     t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["dttp_id"], name: "index_dttp_degree_qualifications_on_dttp_id", unique: true
+  end
+
+  create_table "dttp_dormant_periods", force: :cascade do |t|
+    t.jsonb "response"
+    t.uuid "dttp_id", null: false
+    t.uuid "placement_assignment_dttp_id"
+    t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.index ["dttp_id"], name: "index_dttp_dormant_periods_on_dttp_id", unique: true
   end
 
   create_table "dttp_placement_assignments", force: :cascade do |t|

--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -55,3 +55,7 @@ SET
 UPDATE "dttp_degree_qualifications"
 SET
   response = NULL;
+
+UPDATE "dttp_dormant_periods"
+SET
+  response = NULL;

--- a/spec/factories/dttp/api_dormant_period.rb
+++ b/spec/factories/dttp/api_dormant_period.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :api_dormant_period, class: Hash do
+    dfe_dormantperiodid { SecureRandom.uuid }
+    _dfe_trainingrecordid_value { SecureRandom.uuid }
+
+    initialize_with { attributes.stringify_keys }
+    to_create { |instance| instance }
+  end
+end

--- a/spec/factories/dttp/dormant_periods.rb
+++ b/spec/factories/dttp/dormant_periods.rb
@@ -2,6 +2,10 @@
 
 FactoryBot.define do
   factory :dttp_dormant_period, class: "Dttp::DormantPeriod" do
+    transient do
+      defer_date { Faker::Date.in_date_period }
+      reinstate_date { Faker::Date.in_date_period }
+    end
     dttp_id { SecureRandom.uuid }
     placement_assignment_dttp_id { SecureRandom.uuid }
     response {
@@ -9,6 +13,8 @@ FactoryBot.define do
         :api_dormant_period,
         dfe_dormantperiodid: dttp_id,
         _dfe_trainingrecordid_value: placement_assignment_dttp_id,
+        dfe_dateleftcourse: defer_date,
+        dfe_datereturnedtocourse: reinstate_date,
       )
     }
   end

--- a/spec/factories/dttp/dormant_periods.rb
+++ b/spec/factories/dttp/dormant_periods.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dttp_dormant_period, class: "Dttp::DormantPeriod" do
+    dttp_id { SecureRandom.uuid }
+    placement_assignment_dttp_id { SecureRandom.uuid }
+    response {
+      create(
+        :api_dormant_period,
+        dfe_dormantperiodid: dttp_id,
+        _dfe_trainingrecordid_value: placement_assignment_dttp_id,
+      )
+    }
+  end
+end

--- a/spec/jobs/dttp/sync_dormant_periods_job_spec.rb
+++ b/spec/jobs/dttp/sync_dormant_periods_job_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe SyncDormantPeriodsJob do
+    include ActiveJob::TestHelper
+
+    let(:dormant_period_one_hash) { create(:api_dormant_period) }
+    let(:dormant_period_two_hash) { create(:api_dormant_period) }
+    let(:next_page_url) { "https://some-url.com" }
+
+    let(:trainee_list) do
+      {
+        items: [dormant_period_one_hash, dormant_period_two_hash],
+        meta: { next_page_url: next_page_url },
+      }
+    end
+
+    subject { described_class.perform_now }
+
+    before do
+      enable_features(:sync_trainees_from_dttp)
+      allow(RetrieveDormantPeriods).to receive(:call) { trainee_list }
+    end
+
+    it "enqueues job with the next_page_url" do
+      expect {
+        subject
+      }.to have_enqueued_job(described_class).with("https://some-url.com")
+    end
+
+    context "when the Dttp::DormantPeriod is not in register" do
+      it "creates a Dttp::DormantPeriod record for each unique trainee" do
+        expect {
+          subject
+        }.to change(Dttp::DormantPeriod, :count).by(2)
+      end
+    end
+
+    context "when a Dttp::DormantPeriod exists" do
+      let(:dttp_dormant_period) { create(:dttp_dormant_period, dttp_id: dormant_period_one_hash["dfe_dormantperiodid"]) }
+
+      before do
+        dttp_dormant_period
+      end
+
+      it "updates the existing record" do
+        subject
+        expect(dttp_dormant_period.reload.response).to eq(dormant_period_one_hash)
+      end
+    end
+
+    context "when next_page_url is not available" do
+      let(:next_page_url) { nil }
+
+      it "does not enqueue any further jobs" do
+        expect {
+          subject
+        }.not_to have_enqueued_job(described_class)
+      end
+    end
+  end
+end

--- a/spec/models/dttp/dormant_period_spec.rb
+++ b/spec/models/dttp/dormant_period_spec.rb
@@ -3,13 +3,13 @@
 require "rails_helper"
 
 module Dttp
-  describe PlacementAssignment do
-    subject { build(:dttp_placement_assignment) }
+  describe DormantPeriod do
+    subject { build(:dttp_dormant_period) }
 
     it { is_expected.to be_valid }
 
     describe "relationships" do
-      it { is_expected.to have_one(:dormant_period) }
+      it { is_expected.to belong_to(:placement_assignment).optional }
     end
 
     describe "validations" do

--- a/spec/services/dttp/retrieve_dormant_periods_spec.rb
+++ b/spec/services/dttp/retrieve_dormant_periods_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe RetrieveDormantPeriods do
+    subject { described_class.call }
+
+    let(:expected_path) { "/dfe_dormantperiods" }
+
+    it_behaves_like "dttp info retriever" do
+      let(:request_headers) { { headers: { "Prefer" => "odata.maxpagesize=100" } } }
+    end
+  end
+end


### PR DESCRIPTION
### Context
Deferred trainees are missing a deferral date, we need to fetch `dfe_dormant_periods` to be able to populate this information.

### Changes proposed in this pull request
1. Add a job and related bits to retreive Dormant Periods
2. Fetch defer_date, reinstate_date, and dormancy_dttp_id to a trainee if they have a dormant period record available.

### Guidance to review
Preferably commit by commit.

### Important business

* [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
