### PR TITLE
Update StatusCake contact groups

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -20,7 +20,7 @@
       "website_url": "https://www.register-trainee-teachers.education.gov.uk/ping",
       "test_type": "HTTP",
       "check_rate": 60,
-      "contact_group": [188603],
+      "contact_group": [151103],
       "trigger_rate": 0,
       "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
     }

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -20,7 +20,7 @@
       "website_url": "https://qa.register-trainee-teachers.education.gov.uk/ping",
       "test_type": "HTTP",
       "check_rate": 60,
-      "contact_group": [188603],
+      "contact_group": [151103],
       "trigger_rate": 0,
       "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
     }

--- a/terraform/workspace-variables/sandbox.tfvars.json
+++ b/terraform/workspace-variables/sandbox.tfvars.json
@@ -20,7 +20,7 @@
       "website_url": "https://sandbox.register-trainee-teachers.education.gov.uk/ping",
       "test_type": "HTTP",
       "check_rate": 60,
-      "contact_group": [188603],
+      "contact_group": [151103],
       "trigger_rate": 0,
       "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
     }

--- a/terraform/workspace-variables/staging.tfvars.json
+++ b/terraform/workspace-variables/staging.tfvars.json
@@ -20,7 +20,7 @@
       "website_url": "https://staging.register-trainee-teachers.education.gov.uk/ping",
       "test_type": "HTTP",
       "check_rate": 60,
-      "contact_group": [188603],
+      "contact_group": [151103],
       "trigger_rate": 0,
       "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
     }


### PR DESCRIPTION
### Context

Alerts are currently routed to StatusCake Contact group BAT-DevOps-Slack-All which only forwards to email.

### Changes proposed in this pull request

The contact group will be changed to BAT-DevOps-Slack-Prod which will be routed to Slack, email and mobile alerts instead of just email.  Email and mobile alerts are a limited subset of users.  Updated contact groups in workspace variable files for production, qa, sandbox and staging.  

https://trello.com/c/q3F2WvuS

### Guidance to review

Do the channels match the expected channels.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
