### PR TITLE
[3382] redirect to confirm page when commencement date before withdra…

### DIFF
--- a/app/components/withdrawal_details/view.rb
+++ b/app/components/withdrawal_details/view.rb
@@ -13,7 +13,7 @@ module WithdrawalDetails
     end
 
     def trainee_commencement_date
-      date_for_summary_view(trainee.commencement_date)
+      date_for_summary_view(data_model.commencement_date)
     end
 
     def withdraw_date

--- a/app/controllers/trainees/confirm_withdrawals_controller.rb
+++ b/app/controllers/trainees/confirm_withdrawals_controller.rb
@@ -3,7 +3,6 @@
 module Trainees
   class ConfirmWithdrawalsController < BaseController
     def show
-      TraineeStartStatusForm.new(trainee).save!
       page_tracker.save_as_origin!
       withdrawal
     end

--- a/app/controllers/trainees/confirm_withdrawals_controller.rb
+++ b/app/controllers/trainees/confirm_withdrawals_controller.rb
@@ -3,6 +3,7 @@
 module Trainees
   class ConfirmWithdrawalsController < BaseController
     def show
+      TraineeStartStatusForm.new(trainee).save!
       page_tracker.save_as_origin!
       withdrawal
     end

--- a/app/controllers/trainees/start_statuses_controller.rb
+++ b/app/controllers/trainees/start_statuses_controller.rb
@@ -41,6 +41,8 @@ module Trainees
     def relevant_redirect_path
       return trainee_forbidden_deletes_path(trainee) if @trainee_start_status_form.deleting?
 
+      return trainee_confirm_withdrawal_path(trainee) if trainee_commencement_date_before_withdrawal_date?
+
       return trainee_withdrawal_path(trainee) if @trainee_start_status_form.withdrawing?
 
       if @trainee_start_status_form.deferring?
@@ -50,6 +52,15 @@ module Trainees
       end
 
       trainee_start_status_confirm_path(trainee)
+    end
+
+    def trainee_commencement_date_before_withdrawal_date?
+      withdrawal_date = WithdrawalForm.new(trainee).date
+      if withdrawal_date.present?
+        @trainee_start_status_form.withdrawing? && @trainee_start_status_form.commencement_date < withdrawal_date
+      else
+        false
+      end
     end
   end
 end

--- a/app/forms/withdrawal_form.rb
+++ b/app/forms/withdrawal_form.rb
@@ -7,6 +7,10 @@ class WithdrawalForm < MultiDateForm
   validate :withdraw_reason_valid
   validate :additional_withdraw_reason_valid
 
+  def commencement_date
+    @commencement_date ||= ::TraineeStartStatusForm.new(trainee).commencement_date
+  end
+
 private
 
   def compute_fields

--- a/spec/components/withdrawal_details/view_spec.rb
+++ b/spec/components/withdrawal_details/view_spec.rb
@@ -5,13 +5,13 @@ require "rails_helper"
 describe WithdrawalDetails::View do
   include SummaryHelper
 
-  let(:trainee) { build(:trainee, :with_withdrawal_date, :with_start_date, id: 1) }
+  let(:trainee) { build(:trainee, withdraw_date: 2.days.ago, commencement_date: 3.days.ago, id: 1) }
   let(:withdraw_date) { trainee.withdraw_date }
   let(:withdraw_reason) { nil }
   let(:additional_withdraw_reason) { nil }
 
   let(:data_model) do
-    OpenStruct.new(trainee: trainee, date: withdraw_date, withdraw_reason: withdraw_reason, additional_withdraw_reason: additional_withdraw_reason)
+    OpenStruct.new(trainee: trainee, commencement_date: trainee.commencement_date, date: withdraw_date, withdraw_reason: withdraw_reason, additional_withdraw_reason: additional_withdraw_reason)
   end
 
   before do

--- a/spec/controllers/trainees/start_statuses_controller_spec.rb
+++ b/spec/controllers/trainees/start_statuses_controller_spec.rb
@@ -70,11 +70,33 @@ describe Trainees::StartStatusesController, type: :controller do
         end
       end
 
-      context "withdraw" do
+      context "withdrawal form has not started and contains no date" do
         let(:page_context) { :withdraw }
 
         it "redirects to the withdrawal page" do
           expect(response).to redirect_to(trainee_withdrawal_path(trainee))
+        end
+      end
+
+      context "withdrawal form has started and contains a withdrawal date before the commencement date" do
+        let(:trainee) { create(:trainee, :submitted_for_trn, withdraw_date: Date.new(2022, 1, 1)) }
+        let(:page_context) { :withdraw }
+        let(:send_request) do
+          post(:update,
+               params: {
+                 trainee_id: trainee,
+                 trainee_start_status_form: {
+                   "commencement_status" => "itt_started_on_time",
+                   "commencement_date(3i)" => "2",
+                   "commencement_date(2i)" => "1",
+                   "commencement_date(1i)" => "2022",
+                   context: page_context,
+                 },
+               })
+        end
+
+        it "redirects to the withdrawal page" do
+          expect(response).to redirect_to(trainee_confirm_withdrawal_path(trainee))
         end
       end
     end

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -137,6 +137,42 @@ feature "Withdrawing a trainee", type: :feature do
     then_the_duplicate_record_text_should_be_shown
   end
 
+  scenario "trainee is withdrawn and changes their start date to a date before the withdrawal date" do
+    when_i_am_on_the_withdrawal_page
+    and_i_choose_today
+    and_i_choose_a_specific_reason
+    and_i_continue
+    then_i_am_redirected_to_withdrawal_confirmation_page
+    and_i_click_change_start_date
+    and_i_choose_they_have_started
+    and_i_continue
+    and_i_select_no_they_started_later
+    and_i_fill_in_a_new_start_date(2.days.ago)
+    and_i_continue
+    then_i_am_redirected_to_withdrawal_confirmation_page
+    and_i_see_my_date(2.days.ago)
+  end
+
+  scenario "trainee is withdrawn and changes their start date to a date after the withdrawal date" do
+    when_i_am_on_the_withdrawal_page
+    when_i_choose_yesterday
+    and_i_choose_a_specific_reason
+    and_i_continue
+    then_i_am_redirected_to_withdrawal_confirmation_page
+    and_i_click_change_start_date
+    and_i_choose_they_have_started
+    and_i_continue
+    and_i_select_no_they_started_later
+    and_i_fill_in_a_new_start_date(1.hour.ago)
+    and_i_continue
+    then_i_should_be_on_the_withdrawal_page
+    and_i_choose_today
+    and_i_choose_a_specific_reason
+    and_i_continue
+    then_i_am_redirected_to_withdrawal_confirmation_page
+    and_i_see_my_date(1.hour.ago)
+  end
+
   def when_i_am_on_the_withdrawal_page
     given_i_am_authenticated
     given_a_trainee_exists_to_be_withdrawn
@@ -320,5 +356,21 @@ feature "Withdrawing a trainee", type: :feature do
 
   def then_i_am_taken_to_the_forbidden_withdrawal_page
     expect(withdrawal_forbidden_page).to be_displayed
+  end
+
+  def and_i_click_change_start_date
+    withdrawal_confirmation_page.start_date_change_link.click
+  end
+
+  def then_i_am_redirected_to_start_date_verification_page
+    expect(start_date_verification_page).to be_displayed(id: trainee.slug)
+  end
+
+  def and_i_select_no_they_started_later
+    trainee_start_status_edit_page.commencement_status_started_later.choose
+  end
+
+  def and_i_fill_in_a_new_start_date(date)
+    trainee_start_status_edit_page.set_date_fields("commencement_date", date.strftime("%d/%m/%Y"))
   end
 end

--- a/spec/support/page_objects/trainees/confirm_withdrawal.rb
+++ b/spec/support/page_objects/trainees/confirm_withdrawal.rb
@@ -5,6 +5,7 @@ module PageObjects
     class ConfirmWithdrawal < PageObjects::Base
       set_url "/trainees/{id}/withdraw/confirm"
 
+      element :start_date_change_link, "#trainee-start-date .govuk-link"
       element :withdraw, "button[type='submit']"
       element :cancel, ".govuk-link.qa-cancel-link"
     end


### PR DESCRIPTION
Error in previous pull request, if a commencement date is before the wirthdrawal date the user will now correctly be directed to the confirm page.
