### PR TITLE
[3516] Handle dttp trainees with "Primary Mathematics Specialism" as initiative

### DIFF
--- a/app/lib/dttp/code_sets/course_subjects.rb
+++ b/app/lib/dttp/code_sets/course_subjects.rb
@@ -84,6 +84,10 @@ module Dttp
         ::CourseSubjects::UK_GOVERNMENT_PARLIAMENTARY_STUDIES => { entity_id: "96a12838-b3cf-e911-a860-000d3ab1da01" },
         ::CourseSubjects::WELSH_LANGUAGE => { entity_id: "98a12838-b3cf-e911-a860-000d3ab1da01" },
       }.freeze
+
+      INACTIVE_MAPPING = {
+        ::CourseSubjects::SPECIALIST_TEACHING_PRIMARY_WITH_MATHEMETICS => { entity_id: "f88274df-181e-e711-80c8-0050568902d3" },
+      }.freeze
     end
   end
 end

--- a/app/lib/dttp/code_sets/training_initiatives.rb
+++ b/app/lib/dttp/code_sets/training_initiatives.rb
@@ -4,6 +4,7 @@ module Dttp
   module CodeSets
     module TrainingInitiatives
       EBACC = "883398f8-0d89-e811-80f7-005056ac45bb"
+      PRIMARY_MATHEMATICS_SPECIALISM = "5808fd3f-276e-e711-80d2-005056ac45bb"
 
       # DTTP recognise future_teaching_scholars as a route not an initiative,
       # hence there is no mapping. See Dttp::CodeSets::Routes.

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -327,10 +327,8 @@ module Trainees
     end
 
     def course(dttp_course_uuid)
-      find_by_entity_id(
-        dttp_course_uuid,
-        Dttp::CodeSets::CourseSubjects::MAPPING,
-      )
+      find_by_entity_id(dttp_course_uuid, Dttp::CodeSets::CourseSubjects::MAPPING) ||
+        find_by_entity_id(dttp_course_uuid, Dttp::CodeSets::CourseSubjects::INACTIVE_MAPPING)
     end
 
     def course_education_phase(subject_name)

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -387,11 +387,21 @@ module Trainees
         return ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars]
       end
 
+      return if primary_mathematics_specialism?
+
       find_by_entity_id(dttp_initiative_id, Dttp::CodeSets::TrainingInitiatives::MAPPING)
     end
 
     def unmapped_training_initiative?
-      dttp_initiative_id.present? && !ebacc? && training_initiative.blank?
+      dttp_initiative_id.present? && !special_initiatives? && training_initiative.blank?
+    end
+
+    def special_initiatives?
+      ebacc? || primary_mathematics_specialism?
+    end
+
+    def primary_mathematics_specialism?
+      dttp_initiative_id == Dttp::CodeSets::TrainingInitiatives::PRIMARY_MATHEMATICS_SPECIALISM
     end
 
     def ebacc?

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -235,6 +235,19 @@ module Trainees
         end
       end
 
+      context "with 'Primary Mathematics Specialist' as course subject" do
+        let(:api_placement_assignment) do
+          create(:api_placement_assignment,
+                 _dfe_ittsubject1id_value: Dttp::CodeSets::CourseSubjects::INACTIVE_MAPPING[::CourseSubjects::SPECIALIST_TEACHING_PRIMARY_WITH_MATHEMETICS][:entity_id])
+        end
+
+        it "sets the course subject one to Specialist Teaching" do
+          create_trainee_from_dttp
+          trainee = Trainee.last
+          expect(trainee.course_subject_one).to eq(CourseSubjects::SPECIALIST_TEACHING_PRIMARY_WITH_MATHEMETICS)
+        end
+      end
+
       context "with multiple placement_assignments" do
         let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_ittsubject1id_value: Dttp::CodeSets::CourseSubjects::MODERN_LANGUAGES_DTTP_ID) }
         let(:placement_assignment_one) { create(:dttp_placement_assignment, :with_academic_year_twenty_twenty_one, provider_dttp_id: provider.dttp_id, response: api_placement_assignment) }

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -574,6 +574,18 @@ module Trainees
       end
     end
 
+    context "when training_initiative is Primary mathematics specialism" do
+      let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_initiative1id_value: Dttp::CodeSets::TrainingInitiatives::PRIMARY_MATHEMATICS_SPECIALISM) }
+
+      before do
+        create_trainee_from_dttp
+      end
+
+      it "sets no initiative" do
+        expect(Trainee.last.training_initiative).to eq(ROUTE_INITIATIVES_ENUMS[:no_initiative])
+      end
+    end
+
     context "when training_initiative is not mapped" do
       let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_initiative1id_value: SecureRandom.uuid) }
 


### PR DESCRIPTION
### Context
Handle dttp trainees with "Primary Mathematics Specialism" as initiative.

### Changes proposed in this pull request
When a trainee has a Primary mathematics specialism initiative, ignore it and map it to `no_initiative`.
Similarly, add an INACTIVE_MAPPING to handle trainees having a duplicate subject entity id of Primary Mathematics Specialist.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
