### PR TITLE
[3377] Add existing user to lead school & provider

### DIFF
--- a/app/controllers/system_admin/user_lead_schools_controller.rb
+++ b/app/controllers/system_admin/user_lead_schools_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class UserLeadSchoolsController < ApplicationController
+    def new
+      @user = User.find(params[:user_id])
+      @lead_schools = School.lead_only
+    end
+
+    def create
+      @user = User.find(params[:user_id])
+      @lead_school = School.find_by(name: params[:school][:lead_school])
+      LeadSchoolUser.find_or_create_by!(lead_school: @lead_school, user: @user)
+      redirect_to(user_path(@user), flash: { success: "Lead school added" })
+    end
+  end
+end

--- a/app/controllers/system_admin/user_providers_controller.rb
+++ b/app/controllers/system_admin/user_providers_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class UserProvidersController < ApplicationController
+    def new
+      @user = User.find(params[:user_id])
+      @providers = Provider.all
+    end
+
+    def create
+      @user = User.find(params[:user_id])
+      @provider = Provider.find_by(name: params.require(:provider).permit(:provider)[:provider])
+      ProviderUser.find_or_create_by!(provider: @provider, user: @user)
+      redirect_to(user_path(@user), flash: { success: "Provider added" })
+    end
+  end
+end

--- a/app/views/system_admin/user_lead_schools/new.html.erb
+++ b/app/views/system_admin/user_lead_schools/new.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-form-group">
+  <label class="govuk-label" for="sort">
+    <%= "Select lead school to add to #{@user.name}" %>
+  </label>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <%= register_form_with model: [@user, School.new], url: user_lead_schools_path(@user), local: true do |f| %>
+
+        <%= f.govuk_error_summary %>
+
+        <h1 class="govuk-heading-l">
+          Add a lead school for <%= @user.name %>
+        </h1>
+
+        <p><%= f.govuk_select(:lead_school, @lead_schools.map(&:name), label: { text: "Add lead school", size: "s" }, width: 20, autocomplete: :enabled, class: 'lead-school-select') %></p>
+
+        <%= f.govuk_submit %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/system_admin/user_providers/new.html.erb
+++ b/app/views/system_admin/user_providers/new.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-form-group">
+  <label class="govuk-label" for="sort">
+    <%= "Select provider to add to #{@user.name}" %>
+  </label>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <%= register_form_with model: [@user, Provider.new], url: user_providers_path(@user), local: true do |f| %>
+
+        <%= f.govuk_error_summary %>
+
+        <h1 class="govuk-heading-l">
+          Add a provider for <%= @user.name %>
+        </h1>
+
+        <p><%= f.govuk_select(:provider, @providers.map(&:name), label: { text: "Add provider", size: "s" }, width: 20, autocomplete: :enabled, class: 'provider-select') %></p>
+
+        <%= f.govuk_submit %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/system_admin/users/index.html.erb
+++ b/app/views/system_admin/users/index.html.erb
@@ -16,11 +16,11 @@
 
   <tbody class="govuk-table__body">
     <% @users.each do |user| %>
-      <tr class="govuk-table__row qa-user_row">
+      <tr class="govuk-table__row user-row">
 
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= govuk_link_to(user.name, user_path(user), class: "govuk-!-display-block") %>
+            <%= govuk_link_to(user.name, user_path(user), class: "govuk-!-display-block user-link") %>
           </span>
         </td>
 

--- a/app/views/system_admin/users/show.html.erb
+++ b/app/views/system_admin/users/show.html.erb
@@ -34,17 +34,18 @@
       <%= @user.email %>
     </dd>
   </div>
-  <div class="govuk-summary-list__row">
+  <div class="govuk-summary-list__row lead-school-rows">
     <dt class="govuk-summary-list__key">
       Lead schools
     </dt>
     <dd class="govuk-summary-list__value">
       <% @user.lead_schools.each do |lead_school| %>
-        <%= govuk_link_to(lead_school.name, lead_school_path(lead_school), class: "govuk-!-display-block") %>
+        <%= govuk_link_to("#{lead_school.name} - #{lead_school.urn}", lead_school_path(lead_school), class: "govuk-!-display-block") %>
       <% end %>
+
     </dd>
   </div>
-  <div class="govuk-summary-list__row">
+  <div class="govuk-summary-list__row provider-row">
     <dt class="govuk-summary-list__key">
       Providers
     </dt>
@@ -52,6 +53,9 @@
       <% @user.providers.each do |provider| %>
         <%= govuk_link_to provider.name, provider_path(provider), class: "govuk-!-display-block" %>
       <% end %>
+      <%= govuk_link_to("Add provider", new_user_provider_path(@user), class: "govuk-!-display-block add-provider-to-user") %>
+      </div>
+
     </dd>
   </div>
 </dl>

--- a/app/views/system_admin/users/show.html.erb
+++ b/app/views/system_admin/users/show.html.erb
@@ -34,7 +34,7 @@
       <%= @user.email %>
     </dd>
   </div>
-  <div class="govuk-summary-list__row lead-school-rows">
+  <div class="govuk-summary-list__row lead-school-row">
     <dt class="govuk-summary-list__key">
       Lead schools
     </dt>
@@ -42,7 +42,7 @@
       <% @user.lead_schools.each do |lead_school| %>
         <%= govuk_link_to("#{lead_school.name} - #{lead_school.urn}", lead_school_path(lead_school), class: "govuk-!-display-block") %>
       <% end %>
-
+      <%= govuk_link_to("Add lead school", new_user_lead_school_path(@user), class: "govuk-!-display-block add-lead-school-to-user") %>
     </dd>
   </div>
   <div class="govuk-summary-list__row provider-row">
@@ -51,7 +51,7 @@
     </dt>
     <dd class="govuk-summary-list__value">
       <% @user.providers.each do |provider| %>
-        <%= govuk_link_to provider.name, provider_path(provider), class: "govuk-!-display-block" %>
+        <%= govuk_link_to "#{provider.name} - #{provider.code}", provider_path(provider), class: "govuk-!-display-block" %>
       <% end %>
       <%= govuk_link_to("Add provider", new_user_provider_path(@user), class: "govuk-!-display-block add-provider-to-user") %>
       </div>

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -26,7 +26,9 @@ module SystemAdminRoutes
           end
         end
 
-        resources :users, only: %i[index]
+        resources :users, only: %i[index] do
+          resources :providers, controller: "user_providers",  only: [:new, :create]
+        end
         resources :dttp_providers, only: %i[index show create]
         resources :validation_errors, only: %i[index]
         resources :schools, only: %i[index]

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -27,7 +27,8 @@ module SystemAdminRoutes
         end
 
         resources :users, only: %i[index] do
-          resources :providers, controller: "user_providers",  only: [:new, :create]
+          resources :providers, controller: "user_providers", only: %i[new create]
+          resources :lead_schools, controller: "user_lead_schools", only: %i[new create]
         end
         resources :dttp_providers, only: %i[index show create]
         resources :validation_errors, only: %i[index]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -491,6 +491,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_171355) do
 
   create_table "users", force: :cascade do |t|
     t.string "first_name", null: false
+    t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "email", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -491,7 +491,6 @@ ActiveRecord::Schema.define(version: 2022_01_19_171355) do
 
   create_table "users", force: :cascade do |t|
     t.string "first_name", null: false
-    t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "email", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/features/system_admin/users/add_a_lead_school_to_user_spec.rb
+++ b/spec/features/system_admin/users/add_a_lead_school_to_user_spec.rb
@@ -2,28 +2,28 @@
 
 require "rails_helper"
 
-feature "creating a new user" do
+feature "creating a new lead school for a user" do
   let(:user) { create(:user, system_admin: true) }
   let(:dttp_id) { SecureRandom.uuid }
   let!(:user_to_be_updated) { create(:user, first_name: "James", last_name: "Rodney") }
-  let!(:new_provider) { create(:provider, name: "Richards Provider Supreme") }
+  let!(:new_lead_school) { create(:school, :lead, name: "Richards School Supreme") }
 
   before do
     given_i_am_authenticated(user: user)
     when_i_visit_the_user_index_page
     and_i_click_on_the_user_name_link
     then_i_am_taken_to_the_user_show_page
-    and_i_click_on_add_provider
-    then_i_am_taken_to_the_add_provider_to_user_page
+    and_i_click_on_add_lead_school
+    then_i_am_taken_to_the_add_lead_school_to_user_page
   end
 
   describe "adding a provider to a user" do
     context "valid details" do
       scenario "adding a new user record associated with a provider" do
-        and_i_select_a_provider_from_the_dropdown
+        and_i_select_a_lead_school_from_the_dropdown
         and_i_click_submit
         then_i_am_taken_to_the_user_show_page
-        and_i_see_the_new_provider
+        and_i_see_the_new_lead_school
       end
     end
   end
@@ -42,23 +42,23 @@ private
     expect(users_show_page.current_path).to eq("/system-admin/users/#{user_to_be_updated.id}")
   end
 
-  def and_i_click_on_add_provider
-    users_show_page.add_provider.click
+  def and_i_click_on_add_lead_school
+    users_show_page.add_lead_school.click
   end
 
-  def then_i_am_taken_to_the_add_provider_to_user_page
-    expect(add_provider_to_user_page).to be_displayed(id: user_to_be_updated.id)
+  def then_i_am_taken_to_the_add_lead_school_to_user_page
+    expect(add_lead_school_to_user_page.current_path).to eq("/system-admin/users/#{user_to_be_updated.id}/lead_schools/new")
   end
 
-  def and_i_select_a_provider_from_the_dropdown
-    add_provider_to_user_page.provider_select.select("Richards Provider Supreme")
+  def and_i_select_a_lead_school_from_the_dropdown
+    add_lead_school_to_user_page.lead_school_select.select("Richards School Supreme")
   end
 
   def and_i_click_submit
-    add_provider_to_user_page.submit.click
+    add_lead_school_to_user_page.submit.click
   end
 
-  def and_i_see_the_new_provider
-    expect(users_show_page.providers.map(&:text)).to include("#{new_provider.name} - #{new_provider.code}")
+  def and_i_see_the_new_lead_school
+    expect(users_show_page.lead_schools.map(&:text)).to include("#{new_lead_school.name} - #{new_lead_school.urn}")
   end
 end

--- a/spec/features/system_admin/users/add_a_provider_to_user_spec.rb
+++ b/spec/features/system_admin/users/add_a_provider_to_user_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Creating a new user" do
+  let(:user) { create(:user, system_admin: true) }
+  let(:dttp_id) { SecureRandom.uuid }
+  let!(:user_to_be_updated) { create(:user, first_name: 'James', last_name: 'Rodney') }
+  let!(:new_provider) { create(:provider, name: 'Richards Provider Supreme')}
+
+  before do
+    given_i_am_authenticated(user: user)
+    when_i_visit_the_user_index_page
+    and_i_click_on_the_user_name_link
+    then_i_am_taken_to_the_user_show_page
+    and_i_click_on_add_provider
+    then_i_am_taken_to_the_add_provider_to_user_page
+  end
+
+  describe "Adding a provider to a user" do
+    context "Valid details" do
+      scenario "Adding a new user record associated with a provider" do
+        and_i_select_a_provider_from_the_dropdown
+        and_i_click_submit
+        then_i_am_taken_to_the_user_show_page
+        and_i_see_the_new_provider
+      end
+    end
+  end
+
+  private
+
+  def when_i_visit_the_user_index_page
+    users_index_page.load
+  end
+
+  def and_i_click_on_the_user_name_link
+    users_index_page.users.find{ |user| user.link.text == user_to_be_updated.name }.link.click
+  end
+
+  def then_i_am_taken_to_the_user_show_page
+    expect(users_show_page.current_path).to eq("/system-admin/users/#{user_to_be_updated.id}")
+  end
+
+  def and_i_click_on_add_provider
+    users_show_page.add_provider.click
+  end
+
+  def then_i_am_taken_to_the_add_provider_to_user_page
+    expect(add_provider_to_user_page).to be_displayed(id: user_to_be_updated.id)
+  end
+
+  def and_i_select_a_provider_from_the_dropdown
+    add_provider_to_user_page.provider_select.select('Richards Provider Supreme')
+  end
+
+  def and_i_click_submit
+    add_provider_to_user_page.submit.click
+  end
+
+  def and_i_see_the_new_provider
+    expect(users_show_page.providers.map(&:text)).to include('Richards Provider Supreme')
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -102,8 +102,20 @@ module Features
       @users_index_page ||= PageObjects::Users::Index.new
     end
 
+    def users_show_page
+      @users_show_page ||= PageObjects::Users::Show.new
+    end
+
     def new_user_page
       @new_user_page ||= PageObjects::Users::New.new
+    end
+
+    def show_user_page
+      @new_user_page ||= PageObjects::Users::Show.new
+    end
+
+    def add_provider_to_user_page
+      @add_provider_to_user_page ||= PageObjects::Users::AddProvider.new
     end
 
     def provider_show_page

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -118,6 +118,10 @@ module Features
       @add_provider_to_user_page ||= PageObjects::Users::AddProvider.new
     end
 
+    def add_lead_school_to_user_page
+      @add_provider_to_user_page ||= PageObjects::Users::AddLeadSchool.new
+    end
+
     def provider_show_page
       @provider_show_page ||= PageObjects::Providers::Show.new
     end

--- a/spec/support/page_objects/users/add_lead_school.rb
+++ b/spec/support/page_objects/users/add_lead_school.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Users
+    class AddLeadSchool < PageObjects::Base
+      set_url "/system-admin/users{/id}/lead-schools/new"
+      element :lead_school_select, ".lead-school-select"
+      element :submit, 'button.govuk-button[type="submit"]'
+    end
+  end
+end

--- a/spec/support/page_objects/users/add_provider.rb
+++ b/spec/support/page_objects/users/add_provider.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 module PageObjects
   module Users
-
     class AddProvider < PageObjects::Base
       set_url "/system-admin/users{/id}/providers/new"
       element :provider_select, ".provider-select"

--- a/spec/support/page_objects/users/add_provider.rb
+++ b/spec/support/page_objects/users/add_provider.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module Users
+
+    class AddProvider < PageObjects::Base
+      set_url "/system-admin/users{/id}/providers/new"
+      element :provider_select, ".provider-select"
+      element :submit, 'button.govuk-button[type="submit"]'
+    end
+  end
+end

--- a/spec/support/page_objects/users/index.rb
+++ b/spec/support/page_objects/users/index.rb
@@ -2,8 +2,13 @@
 
 module PageObjects
   module Users
+    class UserRow < SitePrism::Section
+      element :link, ".user-link"
+    end
+
     class Index < PageObjects::Base
       set_url "/system-admin/users"
+      sections :users, UserRow, ".user-row"
     end
   end
 end

--- a/spec/support/page_objects/users/show.rb
+++ b/spec/support/page_objects/users/show.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Users
+    class AddProviderLink < SitePrism::Section
+      element :link, ".add-provider-to-user"
+    end
+
+    class Show < PageObjects::Base
+      set_url "/system-admin/users{/id}"
+      element :add_provider, "a", text: "Add provider"
+      elements :providers, '.provider-row dd a'
+      # sections :add_provider, AddProviderLink, ".provider-row"
+    end
+  end
+end

--- a/spec/support/page_objects/users/show.rb
+++ b/spec/support/page_objects/users/show.rb
@@ -6,11 +6,16 @@ module PageObjects
       element :link, ".add-provider-to-user"
     end
 
+    class AddLeadSchoolLink < SitePrism::Section
+      element :link, ".add-lead-school-to-user"
+    end
+
     class Show < PageObjects::Base
       set_url "/system-admin/users{/id}"
       element :add_provider, "a", text: "Add provider"
-      elements :providers, '.provider-row dd a'
-      # sections :add_provider, AddProviderLink, ".provider-row"
+      element :add_lead_school, "a", text: "Add lead school"
+      elements :providers, ".provider-row dd a"
+      elements :lead_schools, ".lead-school-row dd a"
     end
   end
 end


### PR DESCRIPTION
### Context

Add dropdowns to add providers and lead schools to a user in the system admin section of the application.

### Guidance to review

Go to /system-admin/users
click on a user
test the 'add a provider' and 'add a lead school' link


### Changes proposed in this pull request

New dropdown select screen added to create associations between users and lead schools/ providers

