### PR TITLE
[3345] Import trainees with placement assignments on multiple providers

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -107,7 +107,7 @@ module Trainees
     end
 
     def multiple_providers?
-      dttp_trainee.placement_assignments.map(&:provider_dttp_id).uniq != [dttp_trainee.provider_dttp_id]
+      dttp_trainee.latest_placement_assignment.provider_dttp_id != dttp_trainee.provider_dttp_id
     end
 
     def trainee_already_exists?

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -544,7 +544,22 @@ module Trainees
     end
 
     context "when placement assignments are from multiple providers" do
-      let(:dttp_trainee) { create(:dttp_trainee, :with_provider, placement_assignments: create_list(:dttp_placement_assignment, 2)) }
+      let(:placement_assignment_one) { create(:dttp_placement_assignment, :with_academic_year_twenty_twenty_one) }
+      let(:placement_assignment_two) { create(:dttp_placement_assignment, :with_academic_year_twenty_one_twenty_two, provider_dttp_id: provider.dttp_id) }
+      let(:dttp_trainee) { create(:dttp_trainee, placement_assignments: [placement_assignment_one, placement_assignment_two], provider: provider) }
+
+      it "imports the application" do
+        expect {
+          create_trainee_from_dttp
+        }.to change(Trainee, :count).by(1)
+        .and change(dttp_trainee, :state).to("imported")
+      end
+    end
+
+    context "when the latest placement assignment provider does not match the contact provider" do
+      let(:placement_assignment_one) { create(:dttp_placement_assignment, :with_academic_year_twenty_twenty_one, provider_dttp_id: provider.dttp_id) }
+      let(:placement_assignment_two) { create(:dttp_placement_assignment, :with_academic_year_twenty_one_twenty_two) }
+      let(:dttp_trainee) { create(:dttp_trainee, placement_assignments: [placement_assignment_one, placement_assignment_two], provider: provider) }
 
       it "marks the application as non importable" do
         expect {


### PR DESCRIPTION
### Context
Handle trainees with placement assignments on multiple providers.

### Changes proposed in this pull request
1. When the latest placement assignment provider matches the provider on the trainee record (contact), we have decided to import them as normal
2. When the latest placement assignment provider is different to the trainee/contact provider, we will defer it to dttp-ops for review.

### Guidance to review
:shipit:  

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
