### PR TITLE
[3492] Fix ITT start date validation

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -260,7 +260,7 @@ private
       errors.add(:itt_start_date, :future)
     elsif !itt_start_date.is_a?(Date)
       errors.add(:itt_start_date, :invalid)
-    elsif itt_start_date < earliest_valid_start_date
+    elsif before_academic_cycle?(itt_start_date)
       errors.add(:itt_start_date, :too_old)
     end
   end
@@ -305,8 +305,18 @@ private
     next_year + MAX_END_YEARS
   end
 
-  def earliest_valid_start_date
-    Date.parse("1/8/2020")
+  def before_academic_cycle?(date)
+    return false unless date && academic_cycle
+
+    date < academic_cycle.start_date
+  end
+
+  def course
+    @course ||= trainee.available_courses&.find_by(uuid: course_uuid)
+  end
+
+  def academic_cycle
+    @academic_cycle ||= (AcademicCycle.for_year(course.recruitment_cycle_year) if course)
   end
 
   def sanitise_subjects

--- a/app/forms/itt_dates_form.rb
+++ b/app/forms/itt_dates_form.rb
@@ -98,8 +98,6 @@ private
       errors.add(:start_date, :future)
     elsif !start_date.is_a?(Date)
       errors.add(:start_date, :invalid)
-    elsif start_date < earliest_valid_start_date
-      errors.add(:start_date, :too_old)
     elsif outside_academic_cycle?(start_date)
       errors.add(:start_date, :not_within_academic_cycle)
     end
@@ -141,10 +139,6 @@ private
 
   def max_years
     next_year + MAX_END_YEARS
-  end
-
-  def earliest_valid_start_date
-    Date.parse("1/8/2020")
   end
 
   def copy_dates_to_course

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -232,10 +232,27 @@ describe CourseDetailsForm, type: :model do
 
         describe "#itt_start_date_valid" do
           let(:end_date_attributes) { {} }
+          let(:academic_cycle) { build(:academic_cycle, start_date: "2021-09-01", end_date: "2022-08-31") }
+
+          before do
+            # rubocop:disable RSpec/SubjectStub
+            allow(subject).to receive(:academic_cycle).and_return(academic_cycle)
+            # rubocop:enable RSpec/SubjectStub
+            subject.valid?
+          end
 
           context "the start date fields are 12/11/2020" do
             let(:start_date_attributes) do
               { start_day: "12", start_month: "11", start_year: "2020" }
+            end
+
+            let(:academic_cycle) { build(:academic_cycle, start_date: "2020-09-01", end_date: "2021-08-31") }
+
+            before do
+              # rubocop:disable RSpec/SubjectStub
+              allow(subject).to receive(:academic_cycle).and_return(academic_cycle)
+              # rubocop:enable RSpec/SubjectStub
+              subject.valid?
             end
 
             it "does not return an error message for itt start date" do
@@ -265,6 +282,15 @@ describe CourseDetailsForm, type: :model do
           context "the start date fields are too far in past" do
             let(:start_date_attributes) do
               { start_day: "12", start_month: "11", start_year: "2000" }
+            end
+
+            let(:academic_cycle) { build(:academic_cycle, start_date: "2021-09-01", end_date: "2022-08-31") }
+
+            before do
+              # rubocop:disable RSpec/SubjectStub
+              allow(subject).to receive(:academic_cycle).and_return(academic_cycle)
+              # rubocop:enable RSpec/SubjectStub
+              subject.valid?
             end
 
             it "returns an error message for itt start date" do


### PR DESCRIPTION
### Context

https://trello.com/c/6Lb3Ca9n/3492-fix-itt-start-date-validation

### Changes proposed in this pull request

* Updated validation for Course details form to use the academic year
* Removed validation from IttDates form as we're already checking date is within the academic cycle year

### Guidance to review

* Manually enter course, set date outside of current academic cycle year.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
