### PR TITLE
[xxx] Fix the funding component for draft trainees

### DIFF
--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -69,7 +69,7 @@ module Funding
     end
 
     def grant_funding_row
-      grant_text = if data_model.applying_for_grant?
+      grant_text = if data_model.applying_for_grant
                      t(".grant_applied_for") + "<br>#{tag.span("#{format_currency(grant_amount)} estimated grant", class: 'govuk-hint')}"
                    else
                      t(".no_grant_applied_for")

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 module Funding
   describe View do
+    let(:data_model) { Funding::FormValidator.new(trainee) }
+
     before { render_inline(View.new(data_model: trainee)) }
 
     context "with tieried bursary" do
@@ -44,7 +46,7 @@ module Funding
           create(:funding_method_subject,
                  funding_method: funding_method,
                  allocation_subject: subject_specialism.allocation_subject)
-          render_inline(View.new(data_model: trainee))
+          render_inline(View.new(data_model: data_model))
         end
 
         it "renders if the trainee selects mathematics" do
@@ -95,7 +97,7 @@ module Funding
 
         describe "has no bursary" do
           before do
-            render_inline(View.new(data_model: trainee))
+            render_inline(View.new(data_model: data_model))
           end
 
           it "doesnt not render bursary row" do
@@ -104,6 +106,10 @@ module Funding
 
           context "and it non-draft" do
             let(:state) { :trn_received }
+
+            before do
+              render_inline(View.new(data_model: trainee))
+            end
 
             it "renders bursary not available" do
               expect(rendered_component).to have_text("Not applicable")


### PR DESCRIPTION
### Context

The funding component did not render for draft trainees.
This is because it relied on a method `applying_for_grant?` only
available on trainees, and not on the stashed Funding form. The
method common to both is `applying_for_grant`.

### Changes proposed in this pull request

Sometimes a form object is passed into the component (when then trainee is in draft) and sometimes a trainee is passed into the form component.
Use the common `applying_for_grant` method.

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~