### PR TITLE
[3486] Fallback to placement assignment for degree grad date

### DIFF
--- a/app/services/degrees/create_from_dttp.rb
+++ b/app/services/degrees/create_from_dttp.rb
@@ -23,7 +23,7 @@ module Degrees
 
     def create_degrees!
       dttp_trainee.degree_qualifications.each do |dttp_degree|
-        attrs = ::Degrees::MapFromDttp.call(dttp_degree: dttp_degree)
+        attrs = ::Degrees::MapFromDttp.call(dttp_degree: dttp_degree, dttp_trainee: dttp_trainee)
         next unless attrs
 
         trainee.degrees.build(attrs)

--- a/spec/factories/dttp/placement_assignments.rb
+++ b/spec/factories/dttp/placement_assignments.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
         _dfe_academicyearid_value: academic_year,
         dfe_programmestartdate: programme_start_date.strftime("%Y-%m-%d"),
         dfe_programmeenddate: programme_end_date.strftime("%Y-%m-%d"),
+        dfe_undergraddegreedateobtained: Faker::Date.between(from: 2.years.ago, to: 1.year.ago),
       )
     }
 

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -650,27 +650,5 @@ module Trainees
         expect(trainee.dormancy_dttp_id).to eq(dormant_period.dttp_id)
       end
     end
-
-    context "when the trainee is 'Standards not met'" do
-      before do
-        create_trainee_from_dttp
-      end
-
-      context "and they have a 'dateleft'" do
-        let(:api_placement_assignment) { create(:api_placement_assignment, dfe_dateleft: Time.zone.today, _dfe_traineestatusid_value: "215af972-9e1b-e711-80c7-0050568902d3") }
-
-        it "creates the trainee as withdrawn" do
-          expect(Trainee.last.state).to eq("withdrawn")
-        end
-      end
-
-      context "and they don't have a dateleft" do
-        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: "215af972-9e1b-e711-80c7-0050568902d3") }
-
-        it "creates the trainee as trn_received" do
-          expect(Trainee.last.state).to eq("trn_received")
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
### Context

If the degree is bursary-related, the graduation year is saved onto
the latest placement assignment.
Fall back to this date if there's no degree end date and the degree
is bursary related.

https://trello.com/c/mSdBYJV5/3486-graduation-year-is-incorrectly-set

### Changes proposed in this pull request

* Pull the graduation year from the latest placement assignment if the degree has no end date and it's bursary-related.

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
