### PR TITLE
Revert "Bump puma from 5.5.2 to 5.6.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "rails", "~> 6.1.4"
 gem "pg", ">= 0.18", "< 2.0"
 
 # Use Puma as the app server
-gem "puma", "~> 5.6"
+gem "puma", "~> 5.5"
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem "webpacker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,7 +353,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (5.6.0)
+    puma (5.5.2)
       nio4r (~> 2.0)
     pundit (2.1.1)
       activesupport (>= 3.0.0)
@@ -617,7 +617,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pg_search (~> 2.3)
   pry-byebug
-  puma (~> 5.6)
+  puma (~> 5.5)
   pundit
   rails (~> 6.1.4)
   rails-controller-testing


### PR DESCRIPTION
### Context
Puma 5.6.0 isn't playing nicely with our test suite. This PR reverts it back to 5.5.2 so that we can go about BAU.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
