### PR TITLE
[3500] Do not prompt for missing data on completed records

### DIFF
--- a/app/helpers/mappable_field_helper.rb
+++ b/app/helpers/mappable_field_helper.rb
@@ -4,7 +4,7 @@ module MappableFieldHelper
   def non_editable
     return false if system_admin
 
-    trainee.recommended_for_award? || trainee.awarded? || trainee.withdrawn?
+    !trainee.awaiting_action?
   end
 
   def mappable_field(field_value, field_label, action_url)

--- a/app/view_objects/mappable_field_row.rb
+++ b/app/view_objects/mappable_field_row.rb
@@ -26,7 +26,7 @@ private
   attr_accessor :invalid_data, :record_id, :field_name, :field_value, :field_label, :text, :action_url, :has_errors, :apply_draft, :non_editable
 
   def value_attribute
-    return { value: unmapped_value.html_safe } if field_value.nil?
+    return { value: blank_field_value_content } if field_value.nil?
 
     { value: field_value }
   end
@@ -35,6 +35,16 @@ private
     return {} if field_value.nil? || action_url.nil? || non_editable
 
     { action_href: action_url, action_text: I18n.t(:change), action_visually_hidden_text: field_label.downcase }
+  end
+
+  def blank_field_value_content
+    return not_provided_text if non_editable
+
+    unmapped_value.html_safe
+  end
+
+  def not_provided_text
+    @not_provided_text ||= I18n.t("components.confirmation.not_provided")
   end
 
   def unmapped_value

--- a/app/view_objects/missing_data_banner_view.rb
+++ b/app/view_objects/missing_data_banner_view.rb
@@ -18,7 +18,7 @@ class MissingDataBannerView
   end
 
   def content
-    return unless missing_fields.any?
+    return unless can_render?
 
     tag.ul(class: "govuk-list app-notice-banner__list") do
       render_links
@@ -28,6 +28,10 @@ class MissingDataBannerView
 private
 
   attr_reader :trainee, :missing_fields
+
+  def can_render?
+    trainee.awaiting_action? && missing_fields.any?
+  end
 
   def render_links
     safe_join(

--- a/spec/components/mappable_summary/view_spec.rb
+++ b/spec/components/mappable_summary/view_spec.rb
@@ -53,8 +53,8 @@ module MappableSummary
       context "closed trainee records not editable" do
         let(:trainee) { create(:trainee, :withdrawn) }
 
-        it "renders missing data markup without edit links" do
-          expect(component).to have_text("Course is missing")
+        it "renders not provided text without edit links" do
+          expect(component).to have_text("Not provided")
           expect(component).not_to have_text("Enter an answer")
           expect(component).not_to have_css(".govuk-link")
           expect(component).not_to have_text("Change")

--- a/spec/view_objects/mappable_field_row_spec.rb
+++ b/spec/view_objects/mappable_field_row_spec.rb
@@ -119,7 +119,7 @@ describe MappableFieldRow do
     context "non editable" do
       subject do
         described_class.new(
-          field_value: "History",
+          field_value: field_value,
           field_label: field_label,
           action_url: action_url,
           apply_draft: false,
@@ -133,6 +133,15 @@ describe MappableFieldRow do
         expect(subject[:action_href]).to be_nil
         expect(subject[:action_text]).to be_nil
         expect(subject[:action_visually_hidden_text]).to be_nil
+        expect(subject[:value]).to eq("Not provided")
+      end
+
+      context "when field value exists" do
+        let(:field_value) { "History" }
+
+        it "renders the provided value" do
+          expect(subject[:value]).to eq("History")
+        end
       end
     end
   end

--- a/spec/view_objects/missing_data_banner_view_spec.rb
+++ b/spec/view_objects/missing_data_banner_view_spec.rb
@@ -26,6 +26,14 @@ describe MissingDataBannerView do
         "<ul class=\"govuk-list app-notice-banner__list\"><li><a class=\"govuk-notification-banner__link\" href=\"#{expected_path}\">#{expected_display_name} is missing</a></li></ul>"
       end
 
+      context "and the trainee is not awaiting action" do
+        let(:trainee) { create(:trainee, %i[recommended_for_award withdrawn awarded].sample, first_names: nil) }
+
+        it "returns nothing" do
+          expect(subject).to be_falsey
+        end
+      end
+
       context "first_names" do
         let(:field) { :first_names }
         let(:expected_path) { edit_trainee_personal_details_path(trainee) }


### PR DESCRIPTION
### Context
Once a trainee has been 'awarded', 'recommended for award', or 'withdrawn' we don't want to show the missing data UI.

### Changes proposed in this pull request
For trainees in 'awarded', 'recommended for award', or 'withdrawn' states:
1. Don't display the missing data banner even when data is missing
2. Don't show the change links on missing data fields, except if the user is an admin.

### Guidance to review
On the review app,
- as an admin, visit any of qualification recommended, qualification awarded or withdrawn trainnees, the missing data banner is not shown, but against each attribute that is missing, the missing text, and the change button is visible.
![image](https://user-images.githubusercontent.com/910019/151331902-47a70db4-240d-4f0a-9f41-959f4efe63bd.png)

- as a regular user, visit any of qualification recommended, qualification awarded or withdrawn trainnees, the missing data banner is not shown, the change button is not visible, and the text says "Not Provided"
![image](https://user-images.githubusercontent.com/910019/151332124-7acadb6f-ec69-4b80-b129-ef8f55d409ad.png)



### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
