### PR TITLE
[3528] Add H1 provider name to draft and registered trainee index pages 

### DIFF
--- a/app/views/drafts/index.html.erb
+++ b/app/views/drafts/index.html.erb
@@ -6,6 +6,10 @@
   </span>
 <% end %>
 
+<% if current_user.primary_provider %>
+    <span class="govuk-caption-l"><%= current_user.primary_provider.name %></span>
+<% end %>
+
 <h1 class="govuk-heading-xl" aria-live="polite">
   Draft records (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
 </h1>

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -6,6 +6,10 @@
   </span>
 <% end %>
 
+<% if current_user.primary_provider %>
+    <span class="govuk-caption-l"><%= current_user.primary_provider.name %></span>
+<% end %>
+
 <h1 class="govuk-heading-xl" aria-live="polite">
   Registered trainees (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
 </h1>

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Filtering trainees" do
     given_trainees_exist_in_the_system
     given_a_subject_specialism_is_available_for_selection
     when_i_visit_the_trainee_index_page
+    then_i_see_my_provider_name
     then_all_trainees_are_visible
   end
 
@@ -249,6 +250,10 @@ private
 
   def then_i_should_not_see_sort_links
     expect(trainee_index_page).not_to have_content("Sort by")
+  end
+
+  def then_i_see_my_provider_name
+    expect(trainee_index_page).to have_text(current_user.primary_provider.name)
   end
 
   def then_the_checkbox_should_still_be_checked_for(value)


### PR DESCRIPTION
Add provider name to index and drafts

* Use primary_provider method to add provider name
* This may need amending once we support multi org users

### Context

This was a medium priority bug ticket raised by Design, to add the provider name to the trainee draft and index pages. 

I think this functionality will need to change when we allow for multi org users, as currently primary_provider only picks the first provider. This is also the case for the homepage where we expose the provider name.

### Changes proposed in this pull request

* Add logic to `views/drafts/index.html.erb` and `views/trainees/index.html.erb` to show the provider name.

### Guidance to review

Given I am an admin: 
* when I visit the drafts page, then I cannot see provider name
* when I visit the index page, then I cannot see provider name

Given I am provider A user:
* when I visit the drafts page, then I can see Provider A
* when I visit the index page, then I can see Provider A

Try this for Provider B user as well.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
