### PR TITLE
[2581] Use a canonical list of nationalities in seed data

### DIFF
--- a/spec/factories/nationalities.rb
+++ b/spec/factories/nationalities.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :nationality do
-    sequence(:name) { |n| "nationality #{n}" }
+    name { Dttp::CodeSets::Nationalities::MAPPING.keys.sample }
 
     trait :british do
       name { Dttp::CodeSets::Nationalities::BRITISH }


### PR DESCRIPTION
### Context

Bug ticket raised to fix the nationalities mapping in `specs/factories/nationalities.rb`, so that it uses real nationalities from DTTP and not generic sequenced ones i.e. 'Nationality01'.

### Changes proposed in this pull request

- Use `Dttp::CodeSets::Nationalities::MAPPING` to seed nationalities

### Guidance to review

I think you need to re-seed to be able to check this, so may need to check locally.

- git checkout this branch
- Drop db and set up db with `bin/rails db:drop` and `bin/rails db:setup`
- Re-seed your db with `rake example_data:generate`
- On your localhost, visit http://localhost:5000/trainees/new
- Select any route and go to personal details 
- Scroll down to 'Nationality', click 'other', and type 'na'
- Observe there is no 'Nationality01', 'Nationality02' etc

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
