### PR TITLE
[3574] Save `ethnic_background` as "Not provided" for white ethnicities

### DIFF
--- a/app/lib/dttp/code_sets/ethnicities.rb
+++ b/app/lib/dttp/code_sets/ethnicities.rb
@@ -8,6 +8,17 @@ module Dttp
       INFORMATION_REFUSED = "information_refused"
       INFORMATION_NOT_YET_SOUGHT = "information_not_yet_sought"
 
+      NOT_PROVIDED_ETHNICITIES = [
+        Diversities::NOT_PROVIDED,
+        INFORMATION_REFUSED,
+        INFORMATION_NOT_YET_SOUGHT,
+      ].freeze
+
+      WHITE_ETHNICITIES = [
+        WHITE,
+        SCOTTISH,
+      ].freeze
+
       MAPPING = {
         ::Diversities::AFRICAN => { ethnic_minority: true, entity_id: "c00bb892-2b9d-e711-80d9-005056ac45bb" },
         ::Diversities::ANOTHER_ASIAN_BACKGROUND => { ethnic_minority: true, entity_id: "cc0bb892-2b9d-e711-80d9-005056ac45bb" },

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -213,22 +213,17 @@ module Trainees
     end
 
     def ethnicity_attributes
-      if [
-        Diversities::NOT_PROVIDED,
-        Dttp::CodeSets::Ethnicities::INFORMATION_NOT_YET_SOUGHT,
-        Dttp::CodeSets::Ethnicities::INFORMATION_REFUSED,
-      ].include?(ethnic_background)
+      if Dttp::CodeSets::Ethnicities::NOT_PROVIDED_ETHNICITIES.include?(ethnic_background)
         return {
           ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:not_provided],
+          ethnic_background: Diversities::NOT_PROVIDED,
         }
       end
 
-      if [
-        Dttp::CodeSets::Ethnicities::WHITE,
-        Dttp::CodeSets::Ethnicities::SCOTTISH,
-      ].include?(ethnic_background)
+      if Dttp::CodeSets::Ethnicities::WHITE_ETHNICITIES.include?(ethnic_background)
         return {
           ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:white],
+          ethnic_background: Diversities::NOT_PROVIDED,
         }
       end
 
@@ -241,7 +236,10 @@ module Trainees
         }
       end
 
-      {}
+      {
+        ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:not_provided],
+        ethnic_background: Diversities::NOT_PROVIDED,
+      }
     end
 
     def ethnic_background

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -408,9 +408,10 @@ module Trainees
         context "when ethnicity is #{name}" do
           let(:api_trainee) { create(:api_trainee, _dfe_ethnicityid_value: Dttp::CodeSets::Ethnicities::INACTIVE_MAPPING[name][:entity_id]) }
 
-          it "sets the ethnic_group to white" do
+          it "sets the ethnic_group to white and the ethnic_background to 'Not provided'" do
             create_trainee_from_dttp
             expect(Trainee.last.ethnic_group).to eq(Diversities::ETHNIC_GROUP_ENUMS[:white])
+            expect(Trainee.last.ethnic_background).to eq(Diversities::NOT_PROVIDED)
           end
         end
       end
@@ -426,12 +427,23 @@ module Trainees
         end
       end
 
-      context "when ethnicity is 'not provided'" do
-        let(:api_trainee) { create(:api_trainee, _dfe_ethnicityid_value: Dttp::CodeSets::Ethnicities::MAPPING[Diversities::NOT_PROVIDED][:entity_id]) }
+      context "when ethnicity is missing" do
+        let(:api_trainee) { create(:api_trainee, _dfe_ethnicityid_value: nil) }
 
-        it "sets the ethnic_group to 'Not provided'" do
+        it "sets the ethnic_group and background to 'Not provided'" do
           create_trainee_from_dttp
           expect(Trainee.last.ethnic_group).to eq(Diversities::ETHNIC_GROUP_ENUMS[:not_provided])
+          expect(Trainee.last.ethnic_background).to eq(Diversities::NOT_PROVIDED)
+        end
+      end
+
+      context "when ethnicity is explicitly 'not provided'" do
+        let(:api_trainee) { create(:api_trainee, _dfe_ethnicityid_value: Dttp::CodeSets::Ethnicities::MAPPING[Diversities::NOT_PROVIDED][:entity_id]) }
+
+        it "sets the ethnic_group and background to 'Not provided'" do
+          create_trainee_from_dttp
+          expect(Trainee.last.ethnic_group).to eq(Diversities::ETHNIC_GROUP_ENUMS[:not_provided])
+          expect(Trainee.last.ethnic_background).to eq(Diversities::NOT_PROVIDED)
         end
       end
 


### PR DESCRIPTION
### Context

If the DTTP ethnicity is White or Scottish, then we save ethnic_group
as White.
But we also need to save ethnic_background to Not provided, otherwise
the section is incomplete.
I've also fallen back on Not provided for both ethnic_group and
ethnic_background if the DTTP ethnicities is completely missing.

https://trello.com/c/YatgY0qT/3574-ethnicity-sections-for-trainees-with-white-ethnicity-not-showing-as-completed

### Changes proposed in this pull request

- Save ethnic_background as "Not provided" in cases where we only have the 'White' ethnicity or it is explicitly not provided in DTTP
- Fall back on ethnic_background and ethnic_group as "Not provided" if the DTTP ethnicity is missing.

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
