### PR TITLE
[3498] Fix: ITT start date labelled as missing even though it's present (but invalid)

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -236,7 +236,7 @@ private
 
   def new_date(date_hash)
     date_args = date_hash.values.map(&:to_i)
-    valid_date?(date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+    valid_date?(date_args) ? Date.new(*date_args) : InvalidDate.new(date_hash)
   end
 
   def primary_courses_valid

--- a/app/forms/multi_date_form.rb
+++ b/app/forms/multi_date_form.rb
@@ -74,7 +74,7 @@ private
     date_hash = { year: year, month: month, day: day }
     date_args = date_hash.values.map(&:to_i)
 
-    valid_date?(date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+    valid_date?(date_args) ? Date.new(*date_args) : InvalidDate.new(date_hash)
   end
 
   def date_valid

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -38,7 +38,7 @@ class PersonalDetailsForm < TraineeForm
     date_hash = { year: year, month: month, day: day }
     date_args = date_hash.values.map(&:to_i)
 
-    valid_date?(date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+    valid_date?(date_args) ? Date.new(*date_args) : InvalidDate.new(date_hash)
   end
 
   def save!

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -51,7 +51,11 @@ class TraineeForm
   def missing_fields
     return [] if valid?
 
-    [errors.attribute_names]
+    [
+      errors.attribute_names.filter_map do |attribute_name|
+        attribute_name if public_send(attribute_name).blank?
+      end,
+    ]
   end
 
   def clear_stash

--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -26,7 +26,7 @@ class TraineeStartDateForm < TraineeForm
     date_hash = { year: year, month: month, day: day }
     date_args = date_hash.values.map(&:to_i)
 
-    valid_date?(date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+    valid_date?(date_args) ? Date.new(*date_args) : InvalidDate.new(date_hash)
   end
 
   def deferring?

--- a/app/forms/trainee_start_status_form.rb
+++ b/app/forms/trainee_start_status_form.rb
@@ -40,7 +40,7 @@ class TraineeStartStatusForm < TraineeForm
       date_hash = { year: year, month: month, day: day }
       date_args = date_hash.values.map(&:to_i)
 
-      valid_date?(date_args) ? Date.new(*date_args) : OpenStruct.new(date_hash)
+      valid_date?(date_args) ? Date.new(*date_args) : InvalidDate.new(date_hash)
     end
   end
 

--- a/app/lib/invalid_date.rb
+++ b/app/lib/invalid_date.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+InvalidDate = Struct.new(:day, :month, :year, keyword_init: true) do
+  def blank?
+    members.all? { |date_field| public_send(date_field).blank? }
+  end
+
+  def future?
+    false
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/2XLwt9mE/3491-trainee-overview-missing-data-not-missing

### Changes proposed in this pull request
- Change `TraineeForm#missing_fields` to check if the attributes are actually empty
- Introduce new object `InvalidDate` so that invalid dates can checked for blank values by `TraineeForm#missing_fields` 

### Guidance to review
I've updated the following trainee to have the same dates as the trainee highlighted in the Trello card.

Visit https://register-pr-1965.london.cloudapps.digital/trainees/2b7JGBPdhN4PtWkTt7SAqX7f

There should be no message saying the start date is missing.

