### PR TITLE
[3485] Created at and Updated at is set from dttp fields

### DIFF
--- a/app/models/dttp/trainee.rb
+++ b/app/models/dttp/trainee.rb
@@ -57,6 +57,14 @@ module Dttp
       response["dfe_husid"]
     end
 
+    def created_at
+      response["createdon"]
+    end
+
+    def updated_at
+      response["modifiedon"]
+    end
+
     def date_of_birth
       return if response["birthdate"].blank?
 

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -67,8 +67,9 @@ module Trainees
 
       dttp_trainee.imported!
 
-      trainee.update!(dttp_update_sha: trainee.sha)
+      update_dttp_sha!
 
+      set_created_at_and_updated_at!
       trainee
     end
 
@@ -526,6 +527,17 @@ module Trainees
 
     def funding_manager
       @funding_manager ||= FundingManager.new(trainee)
+    end
+
+    def update_dttp_sha!
+      trainee.dttp_update_sha = trainee.sha
+
+      trainee.save!
+    end
+
+    def set_created_at_and_updated_at!
+      trainee.update!(created_at: dttp_trainee.created_at)
+      trainee.update!(updated_at: dttp_trainee.updated_at)
     end
   end
 end

--- a/spec/factories/dttp/api_trainee.rb
+++ b/spec/factories/dttp/api_trainee.rb
@@ -22,6 +22,8 @@ FactoryBot.define do
     _dfe_nationality_value { Dttp::CodeSets::Nationalities::MAPPING[nationality_name][:entity_id] }
     dfe_trn { Faker::Number.number(digits: 7) }
     merged { false }
+    createdon { Faker::Date.between(from: 2.years.ago, to: 2.days.ago).iso8601 }
+    modifiedon { Faker::Date.between(from: 2.years.ago, to: 2.days.ago).iso8601 }
     dfe_husid { "1811499435078" }
 
     initialize_with { attributes.stringify_keys }

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -87,6 +87,8 @@ module Trainees
         expect(trainee.trn).to eq(api_trainee["dfe_trn"].to_s)
         expect(trainee.training_initiative).to eq("now_teach")
         expect(trainee.hesa_id).to eq(api_trainee["dfe_husid"])
+        expect(trainee.created_at).to eq(api_trainee["createdon"])
+        expect(trainee.updated_at).to eq(api_trainee["modifiedon"])
         expect(trainee.dttp_update_sha).to eq(trainee.sha)
       end
 


### PR DESCRIPTION
### Context

When a record is imported it currently has created_at and updated_at set to the date of import. This is misleading and causes the records to appear at the top of the lists of trainees. This PR will change the created_at and updated_at fields to be set from the createdon and modifiedon ddtp fields instead.

