### PR TITLE
[3525] Fix back links on User/Provider tab going to the wrong page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,7 +33,7 @@ module ApplicationHelper
     return unless current_user
 
     items = [{ name: t("header.items.sign_out"), url: sign_out_path }]
-    items.unshift({ name: t("header.items.system_admin"), url: providers_path }) if current_user.system_admin?
+    items.unshift({ name: t("header.items.system_admin"), url: users_path }) if current_user.system_admin?
     items
   end
 

--- a/app/views/system_admin/lead_schools/show.html.erb
+++ b/app/views/system_admin/lead_schools/show.html.erb
@@ -2,8 +2,8 @@
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
-    text: t("back"),
-    href: lead_schools_path,
+    text: t(:back),
+    href: params[:context] == "users" ? users_path : lead_schools_path,
   ) %>
 <% end %>
 

--- a/app/views/system_admin/providers/show.html.erb
+++ b/app/views/system_admin/providers/show.html.erb
@@ -2,8 +2,8 @@
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
-    text: t("back"),
-    href: providers_path,
+    text: t(:back),
+    href: params[:context] == "users" ? users_path : providers_path,
   ) %>
 <% end %>
 

--- a/app/views/system_admin/users/index.html.erb
+++ b/app/views/system_admin/users/index.html.erb
@@ -33,7 +33,9 @@
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
             <% user.lead_schools.each do |lead_school| %>
-              <%= govuk_link_to(lead_school.name, lead_school_path(lead_school), class: "govuk-!-display-block") %>
+              <%= govuk_link_to(lead_school.name,
+                                lead_school_path(lead_school, context: :users),
+                                class: "govuk-!-display-block") %>
             <% end %>
           </span>
         </td>
@@ -41,7 +43,9 @@
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
             <% user.providers.each do |provider| %>
-              <%= govuk_link_to provider.name, provider_path(provider), class: "govuk-!-display-block" %>
+              <%= govuk_link_to provider.name,
+                                provider_path(provider, context: :users),
+                                class: "govuk-!-display-block" %>
             <% end %>
           </span>
         </td>


### PR DESCRIPTION
### Context
https://trello.com/c/BP9QKYrl/3525-back-links-on-user-tab-going-to-the-wrong-page

### Changes proposed in this pull request
I explored using `PageTracker`, but decided not to fiddle with it to work with non-trainee pages. The simpler solution for now is to just add some context to the lead school and provider links so the backlink knows how to get back to the users page. 

### Guidance to review
- Visit system admin page
- Click on a lead school within the users tab
- Click back link
- Should go back to the users tab

Repeat for provider.