### PR TITLE
[3582] Pick statuses from placement assignments or contact

### DIFF
--- a/app/services/trainees/map_state_from_dttp.rb
+++ b/app/services/trainees/map_state_from_dttp.rb
@@ -21,14 +21,21 @@ module Trainees
     end
 
     def call
-      if dttp_statuses.empty? || status_not_determinable? || mapped_statuses.empty?
+      if sorted_dttp_statuses.empty? || mapped_statuses.empty?
         dttp_trainee.non_importable_missing_state!
         return
       end
 
-      # Specific rule
-      if dttp_statuses == [DttpStatuses::DEFERRED, DttpStatuses::STANDARDS_NOT_MET]
+      if trainee_deferred_but_placement_assignment_yet_to_complete?
+        return "trn_received"
+      end
+
+      if trainee_yet_to_complete_but_placement_assignment_deferred?
         return "deferred"
+      end
+
+      if awaiting_qts_or_standards_met?
+        return "trn_received"
       end
 
       most_progressed_state
@@ -38,29 +45,31 @@ module Trainees
 
     attr_reader :dttp_trainee, :placement_assignment
 
+    def trainee_deferred_but_placement_assignment_yet_to_complete?
+      dttp_statuses == [DttpStatuses::DEFERRED, DttpStatuses::YET_TO_COMPLETE_COURSE]
+    end
+
+    def trainee_yet_to_complete_but_placement_assignment_deferred?
+      dttp_statuses == [DttpStatuses::YET_TO_COMPLETE_COURSE, DttpStatuses::DEFERRED]
+    end
+
+    def awaiting_qts_or_standards_met?
+      sorted_dttp_statuses == [DttpStatuses::AWAITING_QTS, DttpStatuses::STANDARDS_MET]
+    end
+
+    def sorted_dttp_statuses
+      @sorted_dttp_statuses ||= dttp_statuses.sort
+    end
+
     def dttp_statuses
       @dttp_statuses ||= [
         find_by_entity_id(dttp_trainee.response["_dfe_traineestatusid_value"], Dttp::CodeSets::Statuses::MAPPING),
         find_by_entity_id(dttp_trainee.latest_placement_assignment.response["_dfe_traineestatusid_value"], Dttp::CodeSets::Statuses::MAPPING),
-      ].compact.sort
-    end
-
-    def status_not_determinable?
-      non_determinable_statuses.include?(dttp_statuses)
-    end
-
-    def non_determinable_statuses
-      [
-        [DttpStatuses::AWAITING_QTS, DttpStatuses::STANDARDS_MET],
-        [DttpStatuses::AWAITING_QTS, DttpStatuses::LEFT_COURSE_BEFORE_END],
-        [DttpStatuses::DEFERRED, DttpStatuses::AWAITING_QTS],
-        [DttpStatuses::DEFERRED, DttpStatuses::LEFT_COURSE_BEFORE_END],
-        [DttpStatuses::DEFERRED, DttpStatuses::YET_TO_COMPLETE_COURSE],
-      ].map(&:sort)
+      ].compact
     end
 
     def mapped_statuses
-      @mapped_statuses ||= dttp_statuses.map { |dttp_status| map_to_state(dttp_status) }.compact
+      @mapped_statuses ||= sorted_dttp_statuses.map { |dttp_status| map_to_state(dttp_status) }.compact
     end
 
     def most_progressed_state

--- a/app/services/trainees/map_state_from_dttp.rb
+++ b/app/services/trainees/map_state_from_dttp.rb
@@ -35,7 +35,7 @@ module Trainees
       end
 
       if awaiting_qts_or_standards_met?
-        return "trn_received"
+        return standards_met_to_state_mapping
       end
 
       most_progressed_state
@@ -80,7 +80,8 @@ module Trainees
       case dttp_status
       when DttpStatuses::DRAFT_RECORD then "draft"
       when DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED then "submitted_for_trn"
-      when DttpStatuses::STANDARDS_MET, DttpStatuses::AWAITING_QTS then "recommended_for_award"
+      when DttpStatuses::AWAITING_QTS then "recommended_for_award"
+      when DttpStatuses::STANDARDS_MET then standards_met_to_state_mapping
       when DttpStatuses::DEFERRED then "deferred"
       when DttpStatuses::YET_TO_COMPLETE_COURSE then "trn_received"
       when DttpStatuses::AWARDED_EYTS, DttpStatuses::AWARDED_QTS then "awarded"
@@ -89,6 +90,16 @@ module Trainees
         withdraw_date.present? ? "withdrawn" : "trn_received"
       when DttpStatuses::EYTS_REVOKED, DttpStatuses::QTS_REVOKED, DttpStatuses::DID_NOT_START, DttpStatuses::REJECTED then nil
       end
+    end
+
+    def standards_met_to_state_mapping
+      return "trn_received" if dttp_trainee.hesa_id.present?
+
+      recommended_for_award? ? "recommended_for_award" : "trn_received"
+    end
+
+    def recommended_for_award?
+      dttp_trainee.latest_placement_assignment.response["dfe_recommendtraineetonctl"] == true
     end
 
     def withdraw_date

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -203,7 +203,7 @@ module Trainees
       end
 
       context "when the trainee is in a recommended_for_award state" do
-        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: "1f5af972-9e1b-e711-80c7-0050568902d3") }
+        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: "1b5af972-9e1b-e711-80c7-0050568902d3") }
 
         before do
           allow(Dttp::RetrieveAwardJob).to receive(:perform_with_default_delay)

--- a/spec/services/trainees/map_state_from_dttp_spec.rb
+++ b/spec/services/trainees/map_state_from_dttp_spec.rb
@@ -7,7 +7,9 @@ module Trainees
     include SeedHelper
     let(:awaiting_qts_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::AWAITING_QTS][:entity_id] }
     let(:deferred_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::DEFERRED][:entity_id] }
+    let(:yet_to_complete_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::YET_TO_COMPLETE_COURSE][:entity_id] }
     let(:qts_revoked_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::QTS_REVOKED][:entity_id] }
+    let(:standards_met_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::STANDARDS_MET][:entity_id] }
     let(:standards_not_met_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::STANDARDS_NOT_MET][:entity_id] }
     let(:awarded_qts_id) { Dttp::CodeSets::Statuses::MAPPING[DttpStatuses::AWARDED_QTS][:entity_id] }
 
@@ -26,17 +28,6 @@ module Trainees
       it { is_expected.to be_nil }
     end
 
-    context "when the combination of statuses means the state is not determinable" do
-      let(:api_trainee) { create(:api_trainee, _dfe_traineestatusid_value: awaiting_qts_id) }
-      let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: deferred_id) }
-
-      it "marks the trainee as non importable" do
-        expect { subject }.to change(dttp_trainee, :state).to("non_importable_missing_state")
-      end
-
-      it { is_expected.to be_nil }
-    end
-
     context "the placement_assignment has a status but we don't have it in Register" do
       let(:api_trainee) { create(:api_trainee, _dfe_traineestatusid_value: qts_revoked_id) }
 
@@ -45,6 +36,27 @@ module Trainees
       end
 
       it { is_expected.to be_nil }
+    end
+
+    context "when the placement assignment status is STANDARDS_MET but the trainee status is AWAITING_QTS" do
+      let(:api_trainee) { create(:api_trainee, _dfe_traineestatusid_value: standards_met_id) }
+      let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: awaiting_qts_id) }
+
+      it { is_expected.to eq("trn_received") }
+    end
+
+    context "when the placement assignment status is YET_TO_COMPLETE_COURSE but the trainee status is DEFERRED" do
+      let(:api_trainee) { create(:api_trainee, _dfe_traineestatusid_value: deferred_id) }
+      let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: yet_to_complete_id) }
+
+      it { is_expected.to eq("trn_received") }
+    end
+
+    context "when the placement assignment status is DEFERRED but the trainee status is YET_TO_COMPLETE_COURSE" do
+      let(:api_trainee) { create(:api_trainee, _dfe_traineestatusid_value: yet_to_complete_id) }
+      let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: deferred_id) }
+
+      it { is_expected.to eq("deferred") }
     end
 
     context "when the placement assignment status is DEFERRED but the trainee status is STANDARDS_NOT_MET" do

--- a/spec/services/trainees/map_state_from_dttp_spec.rb
+++ b/spec/services/trainees/map_state_from_dttp_spec.rb
@@ -79,15 +79,35 @@ module Trainees
 
       context "and it is STANDARDS_NOT_MET" do
         context "and they have a 'dateleft'" do
-          let(:api_placement_assignment) { create(:api_placement_assignment, dfe_dateleft: Time.zone.today, _dfe_traineestatusid_value: "215af972-9e1b-e711-80c7-0050568902d3") }
+          let(:api_placement_assignment) { create(:api_placement_assignment, dfe_dateleft: Time.zone.today, _dfe_traineestatusid_value: standards_not_met_id) }
 
           it { is_expected.to eq("withdrawn") }
         end
 
         context "and they don't have a dateleft" do
-          let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: "215af972-9e1b-e711-80c7-0050568902d3") }
+          let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: standards_not_met_id) }
 
           it { is_expected.to eq("trn_received") }
+        end
+      end
+
+      context "and it is STANDARDS_MET" do
+        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: standards_met_id) }
+
+        context "and they are a hesa record" do
+          it { is_expected.to eq("trn_received") }
+        end
+
+        context "and they are a non hesa record" do
+          let(:api_trainee) { create(:api_trainee, dfe_husid: nil) }
+
+          it { is_expected.to eq("trn_received") }
+
+          context "and they have dfe_recommendtraineetonctl set to true" do
+            let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: standards_met_id, dfe_recommendtraineetonctl: true) }
+
+            it { is_expected.to eq("recommended_for_award") }
+          end
         end
       end
     end


### PR DESCRIPTION
### Context
Added a few tweaks based on further analysis.

### Changes proposed in this pull request
1. if the trainee record is yet to complete, but the placement assignment is deferred, we use deferred
2. if the placement assignment is yet to complete, but the trainee record is deferred, we stick with yet to complete. This is because DTTP does not always update statuses.
3. Clear out existing non_determinable_statuses, since we've agreed on logical mappings for them now!

4. Map STANDARDS_MET to recommended_for_award or trn received based on these two rules:
 - For hesa records, we need to map STANDARDS_MET to `trn_received`, as they do not use this status to signify that a trainee has been `recommended_for_award`.
 - For portal records, however, we need to rely on the value of `dfe_recommendtraineetonctl`, which is set to `true` when a record is recommended for award. This change will use the value of this boolean to determine if the register status should map to `recommended_for_award` or `trn_received`.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
