### PR TITLE
[3581] Trainees with invalid TRNs

### DIFF
--- a/app/models/dttp/trainee.rb
+++ b/app/models/dttp/trainee.rb
@@ -76,7 +76,7 @@ module Dttp
     end
 
     def trn
-      response["dfe_trn"]
+      response["dfe_trn"]&.strip
     end
 
     def country

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -5,7 +5,8 @@ module Trainees
     include ServicePattern
     include HasDttpMapping
 
-    INVALID_TRN = "999999999"
+    TRN_REGEX = /^(\d{6,7})$/.freeze
+
     UK_COUNTRIES = ["England", "United Kingdom", "Scotland", "Northern Ireland",
                     "Wales", "Isle of Man",
                     "United Kingdom, not otherwise specified"].freeze
@@ -136,7 +137,7 @@ module Trainees
     end
 
     def trn
-      dttp_trainee.trn == INVALID_TRN ? nil : dttp_trainee.trn
+      dttp_trainee.trn if TRN_REGEX.match?(dttp_trainee.trn)
     end
 
     def trainee_gender

--- a/spec/factories/dttp/api_trainee.rb
+++ b/spec/factories/dttp/api_trainee.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     address1_postalcode { Faker::Address.postcode }
     dfe_traineeid { "#{firstname}.#{lastname}.#{birthdate}" }
     _dfe_nationality_value { Dttp::CodeSets::Nationalities::MAPPING[nationality_name][:entity_id] }
-    dfe_trn { Faker::Number.number(digits: 7) }
+    dfe_trn { Faker::Number.number(digits: 7).to_s }
     merged { false }
     dfe_husid { "1811499435078" }
 
@@ -36,6 +36,10 @@ FactoryBot.define do
         Dttp::CodeSets::Nationalities::MAPPING.dig(nationality_name, :entity_id).presence ||
         Dttp::CodeSets::Nationalities::INACTIVE_MAPPING.dig(nationality_name, :entity_id)
       end
+    end
+
+    trait :with_invalid_trn do
+      dfe_trn { "Not Registered" }
     end
   end
 end

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -84,7 +84,7 @@ module Trainees
         expect(trainee.gender).to eq("male")
         expect(trainee.trainee_id).to eq(api_trainee["dfe_traineeid"])
         expect(trainee.nationalities).to be_empty
-        expect(trainee.trn).to eq(api_trainee["dfe_trn"].to_s)
+        expect(trainee.trn).to eq(api_trainee["dfe_trn"])
         expect(trainee.training_initiative).to eq("now_teach")
         expect(trainee.hesa_id).to eq(api_trainee["dfe_husid"])
         expect(trainee.dttp_update_sha).to eq(trainee.sha)
@@ -215,12 +215,30 @@ module Trainees
         end
       end
 
-      context "when the trainee has an invalid TRN" do
+      context "when the trainee has an invalid non-digit TRN" do
+        let(:api_trainee) { create(:api_trainee, :with_invalid_trn) }
+
+        it "does not save the TRN" do
+          create_trainee_from_dttp
+          expect(Trainee.last.trn).to be nil
+        end
+      end
+
+      context "when the trainee has an invalid TRN of 999999999" do
         let(:api_trainee) { create(:api_trainee, dfe_trn: "999999999") }
 
         it "does not save the TRN" do
           create_trainee_from_dttp
           expect(Trainee.last.trn).to be nil
+        end
+      end
+
+      context "when the trainee has a valid TRN with whitespace" do
+        let(:api_trainee) { create(:api_trainee, dfe_trn: "1065267 ") }
+
+        it "trims whitespace and saves the TRN" do
+          create_trainee_from_dttp
+          expect(Trainee.last.trn).to eq("1065267")
         end
       end
 


### PR DESCRIPTION
### Context

It was picked up during the DTTP imports that there were some additional invalid TRNs coming from DTTP that needed to be set as nil in Register. Arlston found these with a regexp and I've implemented that in the code.

We have discussed creating a new metadata column to store the invalid TRNs as these are sometimes used by Ops team as an indication of why a trainee is missing a TRN e.g. `999999999` indicates the trainee came from HESA without a TRN.

Research for which TRNs to include is linked to this trello card: https://trello.com/c/6wuGuyu6/3579-check-do-all-post-submission-trainees-have-trns

### Changes proposed in this pull request

* Add TRN_REGEX rule so that we only accept TRNs that are 6 or 7 digits
* Invalid TRNs are saved as nil
* Remove INVALID_TRN constant as this is now covered by the regex rule
* Trim whitespace in `trn` method in `models/dttp/trainee.rb`
* Add `:with_invalid_trn` as a trait to the `api_trainee` factory

### Guidance to review

* Look at the implementation of the regex and see if you think I've missed any edge cases! 
* Test DTTP import on this?

### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
