### PR TITLE
[3580] Map other DTTP study modes to either part time or full time

### DIFF
--- a/app/lib/dttp/code_sets/course_study_modes.rb
+++ b/app/lib/dttp/code_sets/course_study_modes.rb
@@ -3,6 +3,18 @@
 module Dttp
   module CodeSets
     module CourseStudyModes
+      OTHER_FULL_TIME_MODES = [
+        "11640d4b-82b4-ea11-a812-000d3ad82cac", # Change to dormant status - previously full-time
+        "177e1fe8-1113-e711-80c2-0050568902d3", # Dormant - previously full-time
+        "2deeadf5-aa70-e811-80f3-005056ac45bb", # Other full-time
+        "967ff3ef-1113-e711-80c2-0050568902d3", # Abridged
+      ].freeze
+
+      OTHER_PART_TIME_MODES = [
+        "db110557-82b4-ea11-a812-000d3ad82cac", # Change to dormant status - previously part-time
+        "25e5f293-aa70-e811-80f3-005056ac45bb", # Dormant - previously part-time
+      ].freeze
+
       MAPPING = {
         COURSE_STUDY_MODES[:part_time] => { entity_id: "97ba18db-1113-e711-80c2-0050568902d3" },
         COURSE_STUDY_MODES[:full_time] => { entity_id: "a7a68b82-1113-e711-80c2-0050568902d3" },

--- a/app/models/dttp/placement_assignment.rb
+++ b/app/models/dttp/placement_assignment.rb
@@ -21,5 +21,9 @@ module Dttp
     def employing_school_id
       response["_dfe_employingschoolid_value"]
     end
+
+    def study_mode_id
+      response["_dfe_studymodeid_value"]
+    end
   end
 end

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -348,10 +348,17 @@ module Trainees
     end
 
     def study_mode
-      find_by_entity_id(
-        dttp_trainee.latest_placement_assignment.response["_dfe_studymodeid_value"],
-        Dttp::CodeSets::CourseStudyModes::MAPPING,
-      )
+      study_mode_id = dttp_trainee.latest_placement_assignment.study_mode_id
+
+      if Dttp::CodeSets::CourseStudyModes::OTHER_FULL_TIME_MODES.include?(study_mode_id)
+        return COURSE_STUDY_MODES[:full_time]
+      end
+
+      if Dttp::CodeSets::CourseStudyModes::OTHER_PART_TIME_MODES.include?(study_mode_id)
+        return COURSE_STUDY_MODES[:part_time]
+      end
+
+      find_by_entity_id(study_mode_id, Dttp::CodeSets::CourseStudyModes::MAPPING)
     end
 
     def school_attributes

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -662,5 +662,25 @@ module Trainees
         expect(trainee.dormancy_dttp_id).to eq(dormant_period.dttp_id)
       end
     end
+
+    context "when the trainee has a study mode that's not part or full time" do
+      context "mappable to full time" do
+        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_studymodeid_value: "11640d4b-82b4-ea11-a812-000d3ad82cac") }
+
+        it "maps it to full time" do
+          create_trainee_from_dttp
+          expect(Trainee.last.study_mode).to eq(COURSE_STUDY_MODES[:full_time])
+        end
+      end
+
+      context "mappable to part time" do
+        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_studymodeid_value: "db110557-82b4-ea11-a812-000d3ad82cac") }
+
+        it "maps it to part time" do
+          create_trainee_from_dttp
+          expect(Trainee.last.study_mode).to eq(COURSE_STUDY_MODES[:part_time])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
To confirm: Should 'abridged' be mapped to part time or full time?
_-> confirmed it is full time._

### Context

https://trello.com/c/ejyupGqS/3580-trainees-missing-study-modes

### Changes proposed in this pull request

- Pull in all possible study mode entity_ids from DTTP and map them to either full time or part time in Register

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
