### PR TITLE
[3572] trainee id validation allows duplicates if trainee inactive

### DIFF
--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -42,7 +42,8 @@ private
 
   def trainee_id_uniqueness
     return if trainee_id.blank?
-    return unless existing_trainee_with_id
+    return if existing_trainee_with_id.blank?
+    return if existing_trainee_with_id.inactive?
 
     errors.add(:trainee_id, duplicate_error_message)
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -342,6 +342,14 @@ class Trainee < ApplicationRecord
     ].select(&:present?).join(" ").presence
   end
 
+  def inactive?
+    if state == "awarded"
+      AcademicCycle.for_date(awarded_at) != AcademicCycle.for_date(Time.zone.now)
+    else
+      state == "withdrawn"
+    end
+  end
+
   def full_name
     [
       first_names,

--- a/spec/forms/training_details_form_spec.rb
+++ b/spec/forms/training_details_form_spec.rb
@@ -48,15 +48,35 @@ describe TrainingDetailsForm, type: :model do
         end
       end
 
-      context "duplicate" do
+      context "duplicate active trainee" do
         let!(:existing_trainee) { create(:trainee, trainee_id: "Test123") }
-        let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: "TEST123") }
+        let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: existing_trainee.trainee_id) }
+
+        it "existing trainee remains active" do
+          expect(existing_trainee.inactive?).to be(false)
+        end
 
         it "returns a duplicate error message" do
           expect(subject.errors[:trainee_id]).to include(
             I18n.t("#{error_attr}.trainee_id.uniqueness"),
           )
           expect(subject.duplicate_error?).to be_truthy
+        end
+      end
+
+      context "duplicate inactive trainee" do
+        let!(:existing_trainee) { create(:trainee, trainee_id: "Test123", state: "withdrawn") }
+        let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: existing_trainee.trainee_id) }
+
+        it "existing trainee is inactive" do
+          expect(existing_trainee.inactive?).to be(true)
+        end
+
+        it "returns a duplicate error message" do
+          expect(subject.errors[:trainee_id]).not_to include(
+            I18n.t("#{error_attr}.trainee_id.uniqueness"),
+          )
+          expect(subject.duplicate_error?).to be(false)
         end
       end
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -625,6 +625,52 @@ describe Trainee do
     end
   end
 
+  describe "#inactive?" do
+    context "when a trainee is withdrawn" do
+      let(:trainee) { create(:trainee, state: "withdrawn") }
+
+      it "returns true" do
+        expect(trainee.inactive?).to be(true)
+      end
+    end
+
+    context "when a trainee is awarded in a previous cycle" do
+      let(:trainee) { create(:trainee, state: "awarded", awarded_at: "31/02/2020") }
+
+      before do
+        create(:academic_cycle, start_date: "01/9/2021", end_date: "31/8/2022")
+        create(:academic_cycle, start_date: "01/9/2020", end_date: "31/8/2021")
+        create(:academic_cycle, start_date: "01/9/2019", end_date: "31/8/2020")
+      end
+
+      it "returns true" do
+        expect(trainee.inactive?).to be(true)
+      end
+    end
+
+    context "when a trainee is awarded in a current cycle" do
+      let(:trainee) { create(:trainee, state: "awarded", awarded_at: 2.days.ago) }
+
+      before do
+        create(:academic_cycle, start_date: "01/9/2021", end_date: Time.zone.now)
+        create(:academic_cycle, start_date: "01/9/2020", end_date: "31/8/2021")
+        create(:academic_cycle, start_date: "01/9/2019", end_date: "31/8/2020")
+      end
+
+      it "returns false" do
+        expect(trainee.inactive?).to be(false)
+      end
+    end
+
+    context "when a trainee is awaiting a trn" do
+      let(:trainee) { create(:trainee, state: "awarded", awarded_at: 2.days.ago) }
+
+      it "returns false" do
+        expect(trainee.inactive?).to be(false)
+      end
+    end
+  end
+
   describe "#duplicate?" do
     let(:trainee) { create(:trainee) }
 


### PR DESCRIPTION
### Context

If a trainee is inactive (withdrawn or awarded in a previous cycle) we should be able to create a duplicate of it using the same trainee_id.
