### PR TITLE
[3575] Improve trainee index page loading time

### DIFF
--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -65,7 +65,7 @@ private
   end
 
   def total_trainees_count
-    filtered_trainees.count(:id)
+    filtered_trainees.count
   end
 
   def providers


### PR DESCRIPTION
### Context
https://trello.com/c/AkaOjAmN/3575-spike-trainee-index-loading-slow-for-admins

### Changes proposed in this pull request
- Remove column name from `count()`. It doesn't seem to add anything apart from the extra 3-4s it takes to make the calculation.

### Guidance to review
It won't be possible to test this until it's deployed to the DTTP import app.


