### PR TITLE
[3577] 'Address is missing' is showing for HESA trainees

### DIFF
--- a/app/forms/contact_details_form.rb
+++ b/app/forms/contact_details_form.rb
@@ -19,9 +19,9 @@ class ContactDetailsForm < TraineeForm
   before_validation :sanitise_email
 
   validates :locale_code, presence: true, if: :address_required?
-  validate :uk_address_valid, if: -> { uk? }
-  validate :international_address_valid, if: -> { non_uk? }
-  validates :postcode, postcode: true, if: ->(attr) { attr.postcode.present? }
+  validate :uk_address_valid, if: -> { address_required? && uk? }
+  validate :international_address_valid, if: -> { address_required? && non_uk? }
+  validates :postcode, postcode: true, if: -> { address_required? && postcode.present? }
   validates :email, presence: true
 
   validate do |record|


### PR DESCRIPTION
### Context

https://trello.com/c/vMjKzkNx/3577-address-is-missing-is-showing-for-hesa-trainees

### Changes proposed in this pull request

* Seems like imported records have some partial data.
* Updated `ContactDetailsForm` to ignore all address fields if hesa record.

### Guidance to review

* Need HESA trainee with some partial address info
* non-HESA trainee with partial address: https://register-pr-1979.london.cloudapps.digital/trainees/Vtbrin94U3Btm1F1M4GxqpQo/personal-details
* HESA trainee with partial address: https://register-pr-1979.london.cloudapps.digital/trainees/P5RfmiCwVNn5goFtKf8bbTUn/personal-details

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
