### PR TITLE
Fix nationality related flaky spec

### DIFF
--- a/spec/features/form_sections/personal_and_education_details/edit_personal_details_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/edit_personal_details_spec.rb
@@ -121,9 +121,9 @@ private
   end
 
   def and_nationalities_exist_in_the_system
-    @british ||= create(:nationality, name: "british")
-    @french ||= create(:nationality, name: "french")
-    @south_african ||= create(:nationality, name: "south african")
+    @british ||= Nationality.find_or_create_by(name: "british")
+    @french ||= Nationality.find_or_create_by(name: "french")
+    @south_african ||= Nationality.find_or_create_by(name: "south african")
   end
 
   def when_i_visit_the_personal_details_page

--- a/spec/support/features/personal_details_steps.rb
+++ b/spec/support/features/personal_details_steps.rb
@@ -31,8 +31,8 @@ module Features
     end
 
     def and_nationalities_exist_in_the_system
-      @british ||= create(:nationality, name: "british")
-      @french ||= create(:nationality, name: "french")
+      @british ||= Nationality.find_or_create_by(name: "british")
+      @french ||= Nationality.find_or_create_by(name: "french")
     end
 
     def and_the_personal_details_is_marked_completed


### PR DESCRIPTION
### Context
Fixes https://github.com/DFE-Digital/register-trainee-teachers/runs/5035494381?check_suite_focus=true
Since we have added a code change to ensure we have real/known
nationalities to the factory, this can sometimes raise an exception:
ActiveRecord::RecordNotUnique:
PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_nationalities_on_name"
This change uses find_or_create by to get avoid triggering the
exception.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
