### PR TITLE
[3575] Fix: line breaks in service updates yaml don't output line breaks or paragraphs when rendered

### DIFF
--- a/app/components/service_update/view.rb
+++ b/app/components/service_update/view.rb
@@ -19,6 +19,7 @@ class ServiceUpdate::View < GovukComponent::Base
   end
 
   def content_html
-    Markdown.new(content).to_html.html_safe
+    custom_render = Redcarpet::Render::HTML.new(link_attributes: { class: "govuk-link" })
+    Redcarpet::Markdown.new(custom_render).render(content).html_safe
   end
 end

--- a/db/service_updates.yml
+++ b/db/service_updates.yml
@@ -1,33 +1,39 @@
 - date: '2022-01-20'
   title: When you need to provide trainee start dates has changed
-  content: >-
-   When registering a trainee, we were always asking when the trainee started, even if their course had not started. Now, we will only ask when the trainee started, after their course has started.
-    
-    
+  content: |
+    When registering a trainee, we were always asking when the trainee started, even if their course had not started.
+    Now, we will only ask when the trainee started, after their course has started.
+
     You’ll need to provide a start date before you can recommend a trainee for QTS or EYTS.
 
 - date: '2022-01-04'
   title: Draft records are now separate from the list of registered records
-  content: >-
-    Instead of having a single list with all of your records, there are now separate lists for draft and registered records.
+  content: |
+    Instead of having a single list with all of your records, there are now separate lists for draft and
+    registered records.
 
 - date: '2021-12-21'
   title: Support during the Christmas period
-  content: >-
+  content: |
     The support desk will close at 2pm on Friday 24 December 2021. It will open again on Tuesday 4 January 2022.
 
-
-    If you have an urgent problem during this time, you can still contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+    If you have an urgent problem during this time, you can still contact us at
+    [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 
 - date: '2021-12-03'
   title: The Department for Education (DfE) has published the provisional data for the 2021 initial teacher training (ITT) census
-  content: >-
-    DfE has published the provisional data for the ITT census for September and October 2021. The publication provides national and provider-level information about the numbers and characteristics of new entrants to <span class="no-wrap">initial teacher training</span> in England in the academic year <span class="no-wrap">2021 to 2022</span>.
-
+  content: |
+    DfE has published the provisional data for the ITT census for September and October 2021. The publication
+    provides national and provider-level information about the numbers and characteristics of new entrants to
+    <span class="no-wrap">initial teacher training</span> in England in the academic year
+    <span class="no-wrap">2021 to 2022</span>.
 
     [Read the provisional 2021 census data publication](https://www.gov.uk/government/statistics/initial-teacher-training-trainee-number-census-2021-to-2022)
 
 - date: '2021-09-01'
   title: You no longer need to provide a lead or employing school for trainees who are employed or funded privately
-  content: >-
-    When you’re registering a trainee, we were asking for a lead or employing school in all cases. If a trainee is employed or funded privately, we do not need this information so we’ve added a ‘not applicable’ option to the lead and employing schools sections. You do not need to provide lead or employing schools if the trainee is employed or funded privately.
+  content: |
+    When you’re registering a trainee, we were asking for a lead or employing school in all cases. If a trainee is
+    employed or funded privately, we do not need this information so we’ve added a ‘not applicable’ option to the lead
+    and employing schools sections. You do not need to provide lead or employing schools if the trainee is employed or
+    funded privately.


### PR DESCRIPTION
### Context
https://trello.com/c/0oVDDKXr/3431-line-breaks-in-service-updates-yaml-dont-output-line-breaks-or-paragraphs-when-rendered

### Changes proposed in this pull request
- Use `|` instead of `>-` to preserve linebreaks
- Markdown links to include `govuk-link` class