### PR TITLE
[3526] Remove H2 from registered trainees page

### DIFF
--- a/app/views/trainees/_results.html.erb
+++ b/app/views/trainees/_results.html.erb
@@ -14,7 +14,9 @@
     <div class="govuk-!-margin-bottom-8">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-          <h2 class="govuk-heading-m"><%= search_secondary_result_title %></h2>
+          <% if current_page?(:drafts) %>
+            <h2 class="govuk-heading-m"><%= search_secondary_result_title %></h2>
+          <% end  %>
         </div>
       </div>
       <%= render ApplicationRecordCard::View.with_collection(search_secondary_result_set, system_admin: @current_user.system_admin?) %>


### PR DESCRIPTION
### Context
https://trello.com/c/o61FRvIt/3526-h2-should-be-removed-on-registered-trainees-page

### Changes proposed in this pull request
- Remove `H2` tag from registered trianees page
 
### Guidance to review
- Visit registered trainees page
- "Registered trainees" under Sort by heading is not present
