### PR TITLE
[3578] Use programme start date where the trainee is missing a commencent date

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -317,7 +317,7 @@ module Trainees
         course_min_age: age_range && age_range[0],
         course_max_age: age_range && age_range[1],
         study_mode: study_mode,
-        commencement_date: dttp_trainee.latest_placement_assignment.response["dfe_commencementdate"],
+        commencement_date: commencement_date,
         itt_start_date: dttp_trainee.latest_placement_assignment.programme_start_date,
         itt_end_date: dttp_trainee.latest_placement_assignment.programme_end_date,
       }
@@ -327,6 +327,10 @@ module Trainees
       return CourseSubjects::SPECIALIST_TEACHING_PRIMARY_WITH_MATHEMETICS if primary_mathematics_specialism?
 
       course(dttp_trainee.latest_placement_assignment.response["_dfe_ittsubject1id_value"])
+    end
+
+    def commencement_date
+      dttp_trainee.latest_placement_assignment.response["dfe_commencementdate"] || dttp_trainee.latest_placement_assignment.programme_start_date
     end
 
     def course(dttp_course_uuid)

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -99,6 +99,15 @@ module Trainees
         end
       end
 
+      context "when the commencement_date is missing" do
+        let(:api_placement_assignment) { create(:api_placement_assignment, dfe_commencementdate: nil) }
+
+        it "uses the programme start date" do
+          create_trainee_from_dttp
+          expect(Trainee.last.commencement_date).to eq(placement_assignment.programme_start_date)
+        end
+      end
+
       context "when neither address line one or postcode is present" do
         let(:api_trainee) { create(:api_trainee, address1_line1: nil, address1_postalcode: nil) }
 


### PR DESCRIPTION
### Context
We have decided to use programme start date as a fallback for when commencement date is missing as some hesa records have commencement date missing.

### Changes proposed in this pull request
Fallback to the programme_start_date if dfe_commencementdate is null.


### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
