### PR TITLE
[3591] Map Primary General (with Maths) initiative to specialist teaching

### DIFF
--- a/app/lib/dttp/code_sets/training_initiatives.rb
+++ b/app/lib/dttp/code_sets/training_initiatives.rb
@@ -5,6 +5,7 @@ module Dttp
     module TrainingInitiatives
       EBACC = "883398f8-0d89-e811-80f7-005056ac45bb"
       PRIMARY_MATHEMATICS_SPECIALISM = "5808fd3f-276e-e711-80d2-005056ac45bb"
+      PRIMARY_GENERAL_WITH_MATHS = "6808fd3f-276e-e711-80d2-005056ac45bb"
 
       # DTTP recognise future_teaching_scholars as a route not an initiative,
       # hence there is no mapping. See Dttp::CodeSets::Routes.

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -309,8 +309,6 @@ module Trainees
     end
 
     def course_attributes
-      course_subject_one_name = course(dttp_trainee.latest_placement_assignment.response["_dfe_ittsubject1id_value"])
-
       {
         course_education_phase: course_education_phase(course_subject_one_name),
         course_subject_one: course_subject_one_name,
@@ -323,6 +321,12 @@ module Trainees
         itt_start_date: dttp_trainee.latest_placement_assignment.programme_start_date,
         itt_end_date: dttp_trainee.latest_placement_assignment.programme_end_date,
       }
+    end
+
+    def course_subject_one_name
+      return CourseSubjects::SPECIALIST_TEACHING_PRIMARY_WITH_MATHEMETICS if primary_mathematics_specialism?
+
+      course(dttp_trainee.latest_placement_assignment.response["_dfe_ittsubject1id_value"])
     end
 
     def course(dttp_course_uuid)
@@ -405,7 +409,10 @@ module Trainees
     end
 
     def primary_mathematics_specialism?
-      dttp_initiative_id == Dttp::CodeSets::TrainingInitiatives::PRIMARY_MATHEMATICS_SPECIALISM
+      [
+        Dttp::CodeSets::TrainingInitiatives::PRIMARY_MATHEMATICS_SPECIALISM,
+        Dttp::CodeSets::TrainingInitiatives::PRIMARY_GENERAL_WITH_MATHS,
+      ].include?(dttp_initiative_id)
     end
 
     def ebacc?

--- a/spec/factories/dttp/api_placement_assignment.rb
+++ b/spec/factories/dttp/api_placement_assignment.rb
@@ -66,5 +66,14 @@ FactoryBot.define do
       _dfe_ittsubject1id_value { Dttp::CodeSets::CourseSubjects::MODERN_LANGUAGES_DTTP_ID }
       _dfe_bursarydetailsid_value { Dttp::CodeSets::BursaryDetails::NO_BURSARY_AWARDED }
     end
+
+    trait :primary_mathematics_specialism do
+      _dfe_initiative1id_value do
+        [
+          Dttp::CodeSets::TrainingInitiatives::PRIMARY_MATHEMATICS_SPECIALISM,
+          Dttp::CodeSets::TrainingInitiatives::PRIMARY_GENERAL_WITH_MATHS,
+        ].sample
+      end
+    end
   end
 end

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -632,15 +632,16 @@ module Trainees
       end
     end
 
-    context "when training_initiative is Primary mathematics specialism" do
-      let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_initiative1id_value: Dttp::CodeSets::TrainingInitiatives::PRIMARY_MATHEMATICS_SPECIALISM) }
+    context "when training_initiative is a primary mathematics specialism" do
+      let(:api_placement_assignment) { create(:api_placement_assignment, :primary_mathematics_specialism) }
 
       before do
         create_trainee_from_dttp
       end
 
-      it "sets no initiative" do
+      it "sets no initiative and course subject to primary_mathematics_specialism" do
         expect(Trainee.last.training_initiative).to eq(ROUTE_INITIATIVES_ENUMS[:no_initiative])
+        expect(Trainee.last.course_subject_one).to eq(CourseSubjects::SPECIALIST_TEACHING_PRIMARY_WITH_MATHEMETICS)
       end
     end
 


### PR DESCRIPTION
### Context
We have decided to map initiatives which are like "Primary General/Specialist Teaching" to "Specialist Teaching, Primary with Maths" course subject in register.

### Changes proposed in this pull request
When this initiative is encountered, override the course subject one to match "Specialist Teaching"

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
