### PR TITLE
[3600] Import extra entity sets from DTTP

### DIFF
--- a/app/jobs/dttp/sync_bursary_details_job.rb
+++ b/app/jobs/dttp/sync_bursary_details_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Dttp
+  class SyncBursaryDetailsJob < ApplicationJob
+    queue_as :dttp
+
+    def perform(request_uri = nil)
+      return unless FeatureService.enabled?(:sync_trainees_from_dttp)
+
+      @bursary_details = RetrieveBursaryDetails.call(request_uri: request_uri)
+
+      BursaryDetail.upsert_all(bursary_detail_attributes, unique_by: :dttp_id)
+
+      Dttp::SyncBursaryDetailsJob.perform_later(next_page_url) if next_page?
+    end
+
+  private
+
+    attr_reader :bursary_details
+
+    def bursary_detail_attributes
+      Parsers::BursaryDetail.to_attributes(bursary_details: bursary_details[:items])
+    end
+
+    def next_page_url
+      bursary_details[:meta][:next_page_url]
+    end
+
+    def next_page?
+      next_page_url.present?
+    end
+  end
+end

--- a/app/jobs/dttp/sync_training_initiatives_job.rb
+++ b/app/jobs/dttp/sync_training_initiatives_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Dttp
+  class SyncTrainingInitiativesJob < ApplicationJob
+    queue_as :dttp
+
+    def perform(request_uri = nil)
+      return unless FeatureService.enabled?(:sync_trainees_from_dttp)
+
+      @training_initiatives = RetrieveTrainingInitiatives.call(request_uri: request_uri)
+
+      TrainingInitiative.upsert_all(training_initiative_attributes, unique_by: :dttp_id)
+
+      Dttp::SyncTrainingInitiativesJob.perform_later(next_page_url) if next_page?
+    end
+
+  private
+
+    attr_reader :training_initiatives
+
+    def training_initiative_attributes
+      Parsers::TrainingInitiative.to_attributes(training_initiatives: training_initiatives[:items])
+    end
+
+    def next_page_url
+      training_initiatives[:meta][:next_page_url]
+    end
+
+    def next_page?
+      next_page_url.present?
+    end
+  end
+end

--- a/app/lib/dttp/parsers/bursary_detail.rb
+++ b/app/lib/dttp/parsers/bursary_detail.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Dttp
+  module Parsers
+    class BursaryDetail
+      class << self
+        def to_attributes(bursary_details:)
+          bursary_details.map do |bursary_detail|
+            {
+              dttp_id: bursary_detail["dfe_bursarydetailid"],
+              response: bursary_detail,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/dttp/parsers/training_initiative.rb
+++ b/app/lib/dttp/parsers/training_initiative.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Dttp
+  module Parsers
+    class TrainingInitiative
+      class << self
+        def to_attributes(training_initiatives:)
+          training_initiatives.map do |training_initiative|
+            {
+              dttp_id: training_initiative["dfe_initiativeid"],
+              response: training_initiative,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/dttp/bursary_detail.rb
+++ b/app/models/dttp/bursary_detail.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Dttp
+  class BursaryDetail < ApplicationRecord
+    self.table_name = "dttp_bursary_details"
+
+    validates :response, presence: true
+  end
+end

--- a/app/models/dttp/training_initiative.rb
+++ b/app/models/dttp/training_initiative.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Dttp
+  class TrainingInitiative < ApplicationRecord
+    self.table_name = "dttp_training_initiatives"
+
+    validates :response, presence: true
+  end
+end

--- a/app/services/dttp/retrieve_bursary_details.rb
+++ b/app/services/dttp/retrieve_bursary_details.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Dttp
+  class RetrieveBursaryDetails
+    include ServicePattern
+    include SyncPattern
+
+  private
+
+    def default_path
+      @default_path ||= "/dfe_bursarydetails"
+    end
+  end
+end

--- a/app/services/dttp/retrieve_training_initiatives.rb
+++ b/app/services/dttp/retrieve_training_initiatives.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Dttp
+  class RetrieveTrainingInitiatives
+    include ServicePattern
+    include SyncPattern
+
+  private
+
+    def default_path
+      @default_path ||= "/dfe_initiatives"
+    end
+  end
+end

--- a/db/migrate/20220207155623_create_dttp_bursary_details.rb
+++ b/db/migrate/20220207155623_create_dttp_bursary_details.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateDttpBursaryDetails < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dttp_bursary_details do |t|
+      t.jsonb :response
+      t.uuid :dttp_id, null: false
+      t.timestamps default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :dttp_bursary_details, :dttp_id, unique: true
+  end
+end

--- a/db/migrate/20220207155734_create_dttp_training_initiatives.rb
+++ b/db/migrate/20220207155734_create_dttp_training_initiatives.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateDttpTrainingInitiatives < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dttp_training_initiatives do |t|
+      t.jsonb :response
+      t.uuid :dttp_id, null: false
+      t.timestamps default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :dttp_training_initiatives, :dttp_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_04_132842) do
+ActiveRecord::Schema.define(version: 2022_02_07_155623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -208,6 +208,14 @@ ActiveRecord::Schema.define(version: 2022_02_04_132842) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_disabilities_on_name", unique: true
+  end
+
+  create_table "dttp_bursary_details", force: :cascade do |t|
+    t.jsonb "response"
+    t.uuid "dttp_id", null: false
+    t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.index ["dttp_id"], name: "index_dttp_bursary_details_on_dttp_id", unique: true
   end
 
   create_table "dttp_degree_qualifications", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_07_155623) do
+ActiveRecord::Schema.define(version: 2022_02_07_155734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -279,6 +279,14 @@ ActiveRecord::Schema.define(version: 2022_02_07_155623) do
     t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.uuid "status"
     t.index ["dttp_id"], name: "index_dttp_trainees_on_dttp_id", unique: true
+  end
+
+  create_table "dttp_training_initiatives", force: :cascade do |t|
+    t.jsonb "response"
+    t.uuid "dttp_id", null: false
+    t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.index ["dttp_id"], name: "index_dttp_training_initiatives_on_dttp_id", unique: true
   end
 
   create_table "dttp_users", force: :cascade do |t|

--- a/spec/factories/dttp/api_bursary_detail.rb
+++ b/spec/factories/dttp/api_bursary_detail.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :api_bursary_detail, class: Hash do
+    dfe_bursarydetailid { SecureRandom.uuid }
+    dfe_name do
+      [
+        "School direct salaried",
+        "Postgraduate Bursary",
+        "Top - 1st Equivalent",
+        "Middle - 2:1 Equivalent",
+        "Bottom - 2:2 Equivalent",
+        "Undergraduate bursary",
+      ].sample
+    end
+    initialize_with { attributes.stringify_keys }
+    to_create { |instance| instance }
+  end
+end

--- a/spec/factories/dttp/api_training_initiative.rb
+++ b/spec/factories/dttp/api_training_initiative.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :api_training_initiative, class: Hash do
+    dfe_initiativeid { SecureRandom.uuid }
+    dfe_name do
+      [
+        "Transition to Teach",
+        "Now Teach",
+        "Employer engagement co-funded students",
+      ].sample
+    end
+    initialize_with { attributes.stringify_keys }
+    to_create { |instance| instance }
+  end
+end

--- a/spec/factories/dttp/bursary_details.rb
+++ b/spec/factories/dttp/bursary_details.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dttp_bursary_detail, class: "Dttp::BursaryDetail" do
+    dttp_id { SecureRandom.uuid }
+    response {
+      create(
+        :api_bursary_detail,
+        dfe_bursarydetailid: dttp_id,
+      )
+    }
+  end
+end

--- a/spec/factories/dttp/training_initiatives.rb
+++ b/spec/factories/dttp/training_initiatives.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dttp_training_initiative, class: "Dttp::TrainingInitiative" do
+    dttp_id { SecureRandom.uuid }
+    response {
+      create(
+        :api_training_initiative,
+        dfe_initiativeid: dttp_id,
+      )
+    }
+  end
+end

--- a/spec/jobs/dttp/sync_bursary_details_job_spec.rb
+++ b/spec/jobs/dttp/sync_bursary_details_job_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe SyncBursaryDetailsJob do
+    include ActiveJob::TestHelper
+
+    let(:bursary_detail_one_hash) { create(:api_bursary_detail) }
+    let(:bursary_detail_two_hash) { create(:api_bursary_detail) }
+    let(:next_page_url) { "https://some-url.com" }
+
+    let(:trainee_list) do
+      {
+        items: [bursary_detail_one_hash, bursary_detail_two_hash],
+        meta: { next_page_url: next_page_url },
+      }
+    end
+
+    subject { described_class.perform_now }
+
+    before do
+      enable_features(:sync_trainees_from_dttp)
+      allow(RetrieveBursaryDetails).to receive(:call) { trainee_list }
+    end
+
+    it "enqueues job with the next_page_url" do
+      expect {
+        subject
+      }.to have_enqueued_job(described_class).with("https://some-url.com")
+    end
+
+    context "when the Dttp::BursaryDetail is not in register" do
+      it "creates a Dttp::BursaryDetail record for each unique trainee" do
+        expect {
+          subject
+        }.to change(Dttp::BursaryDetail, :count).by(2)
+      end
+    end
+
+    context "when a Dttp::BursaryDetail exists" do
+      let(:dttp_bursary_detail) { create(:dttp_bursary_detail, dttp_id: bursary_detail_one_hash["dfe_bursarydetailid"]) }
+
+      before do
+        dttp_bursary_detail
+      end
+
+      it "updates the existing record" do
+        subject
+        expect(dttp_bursary_detail.reload.response).to eq(bursary_detail_one_hash)
+      end
+    end
+
+    context "when next_page_url is not available" do
+      let(:next_page_url) { nil }
+
+      it "does not enqueue any further jobs" do
+        expect {
+          subject
+        }.not_to have_enqueued_job(described_class)
+      end
+    end
+  end
+end

--- a/spec/jobs/dttp/sync_training_initiatives_job_spec.rb
+++ b/spec/jobs/dttp/sync_training_initiatives_job_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe SyncTrainingInitiativesJob do
+    include ActiveJob::TestHelper
+
+    let(:training_initiative_one_hash) { create(:api_training_initiative) }
+    let(:training_initiative_two_hash) { create(:api_training_initiative) }
+    let(:next_page_url) { "https://some-url.com" }
+
+    let(:trainee_list) do
+      {
+        items: [training_initiative_one_hash, training_initiative_two_hash],
+        meta: { next_page_url: next_page_url },
+      }
+    end
+
+    subject { described_class.perform_now }
+
+    before do
+      enable_features(:sync_trainees_from_dttp)
+      allow(RetrieveTrainingInitiatives).to receive(:call) { trainee_list }
+    end
+
+    it "enqueues job with the next_page_url" do
+      expect {
+        subject
+      }.to have_enqueued_job(described_class).with("https://some-url.com")
+    end
+
+    context "when the Dttp::TrainingInitiative is not in register" do
+      it "creates a Dttp::TrainingInitiative record for each unique trainee" do
+        expect {
+          subject
+        }.to change(Dttp::TrainingInitiative, :count).by(2)
+      end
+    end
+
+    context "when a Dttp::TrainingInitiative exists" do
+      let(:dttp_training_initiative) do
+        create(:dttp_training_initiative, dttp_id: training_initiative_one_hash["dfe_initiativeid"])
+      end
+
+      before do
+        dttp_training_initiative
+      end
+
+      it "updates the existing record" do
+        subject
+        expect(dttp_training_initiative.reload.response).to eq(training_initiative_one_hash)
+      end
+    end
+
+    context "when next_page_url is not available" do
+      let(:next_page_url) { nil }
+
+      it "does not enqueue any further jobs" do
+        expect {
+          subject
+        }.not_to have_enqueued_job(described_class)
+      end
+    end
+  end
+end

--- a/spec/models/dttp/bursary_detail_spec.rb
+++ b/spec/models/dttp/bursary_detail_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe BursaryDetail do
+    subject { build(:dttp_bursary_detail) }
+
+    it { is_expected.to be_valid }
+
+    describe "validations" do
+      it { is_expected.to validate_presence_of(:response) }
+    end
+  end
+end

--- a/spec/services/dttp/retrieve_bursary_details_spec.rb
+++ b/spec/services/dttp/retrieve_bursary_details_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe RetrieveBursaryDetails do
+    subject { described_class.call }
+
+    let(:expected_path) { "/dfe_bursarydetails" }
+
+    it_behaves_like "dttp info retriever" do
+      let(:request_headers) { { headers: { "Prefer" => "odata.maxpagesize=5000" } } }
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/PrAg4L3F/3600-s-import-extra-entity-sets-from-dttp

### Changes proposed in this pull request
- New Sidekiq jobs to download and import DTTP entities from `/dfe_bursarydetails` and `/dfe_initiatives` 

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
