### PR TITLE
[3598] Add additional_dttp_data field to trainees

### DIFF
--- a/db/migrate/20220204132842_add_additional_dttp_data_to_trainees.rb
+++ b/db/migrate/20220204132842_add_additional_dttp_data_to_trainees.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddAdditionalDttpDataToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    change_table :trainees, bulk: true do |t|
+      t.jsonb :additional_dttp_data
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_171355) do
+ActiveRecord::Schema.define(version: 2022_02_04_132842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -471,6 +471,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_171355) do
     t.datetime "discarded_at"
     t.boolean "created_from_dttp", default: false, null: false
     t.string "hesa_id"
+    t.jsonb "additional_dttp_data"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"

--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -27,7 +27,8 @@ SET
   postcode = CASE WHEN postcode IS NULL THEN NULL ELSE 'SW1P 3BT' END,
   international_address = CASE WHEN international_address IS NULL THEN NULL ELSE 'International Address' END,
   trainee_id = concat('trainee-', id),
-  trn = CASE WHEN trn IS NULL THEN NULL ELSE id END;
+  trn = CASE WHEN trn IS NULL THEN NULL ELSE id END,
+  additional_dttp_data = NULL;
 
 -- Dttp Users
 UPDATE "dttp_users"


### PR DESCRIPTION
### Context

We have some data that comes in from DTTP but isn't currently supported with our functionality. e.g. TRNs that have state info in them rather than TRNs or initiatives that we don't recognise as initiatives.

To enable us to proceed with the imports without losing this we should store these things in a column that has a flexible schema. If we need them in the future we can make proper columns for them.

### Changes proposed in this pull request

- Add `additional_dttp_data` jsonb field into the trainees table

### Guidance to review

- Checkout the branch and run migration, see no errors
- Check the naming is correct i.e. no spelling error
- Check trainees table additional_dttp_data field looks as expected

### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
