### PR TITLE
[3619] Hide year filters

### DIFF
--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -47,27 +47,29 @@
     </fieldset>
   </div>
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-        <%= t("views.trainees.index.filters.trainee_start_year") %>
-      </legend>
-      <div class="govuk-checkboxes govuk-checkboxes--small">
-        <% AcademicCycle.trainees_filter.map do |academic_cycle| %>
-          <div class="govuk-checkboxes__item">
-            <%= check_box_tag "trainee_start_year[]",
-                              academic_cycle.start_year,
-                              checked?(filters, :trainee_start_year, academic_cycle.start_year.to_s),
-                              id: "trainee_start_year-#{academic_cycle.start_year}",
-                              class: "govuk-checkboxes__input" %>
-            <%= label_tag "trainee_start_year-#{academic_cycle.start_year}",
-                          academic_cycle.label,
-                          class: "govuk-label govuk-checkboxes__label" %>
-          </div>
-        <% end %>
-      </div>
-    </fieldset>
-  </div>
+  <% if FeatureService.enabled?("filters.show_start_year_filter") %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          <%= t("views.trainees.index.filters.trainee_start_year") %>
+        </legend>
+        <div class="govuk-checkboxes govuk-checkboxes--small">
+          <% AcademicCycle.trainees_filter.map do |academic_cycle| %>
+            <div class="govuk-checkboxes__item">
+              <%= check_box_tag "trainee_start_year[]",
+                                academic_cycle.start_year,
+                                checked?(filters, :trainee_start_year, academic_cycle.start_year.to_s),
+                                id: "trainee_start_year-#{academic_cycle.start_year}",
+                                class: "govuk-checkboxes__input" %>
+              <%= label_tag "trainee_start_year-#{academic_cycle.start_year}",
+                            academic_cycle.label,
+                            class: "govuk-label govuk-checkboxes__label" %>
+            </div>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+  <% end %>
 
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,6 +55,8 @@ features:
     pg_teaching_apprenticeship: false
   google:
     send_data_to_big_query: false
+  filters:
+    show_start_year_filter: false
 
 dfe_sign_in:
   # Our service name


### PR DESCRIPTION
### Context

The start year filter is currently not working. However there is some design work being done currently that will overlap with this, so for now it is agreed to hide the filters.

We need to currently hide the filters instead of fix them due to the mentioned design work but also to ensure out users aren't seeing broken elements in the UI.

### Changes proposed in this pull request

- Feature flag added in `config/settings.yml` to switch start years filter on or off (currently set to `false` in this PR)
- Conditional flag added to the filter view to stop start year filter from rendering

### Guidance to review

As any user (provider or admin):
- given I am on the draft or registered trainee pages, then I do not see the 'Start year filter'

### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
