### PR TITLE
[3499] Add old funding rules to Register and import trainees from DTTP

### DIFF
--- a/app/lib/dttp/code_sets/bursary_details.rb
+++ b/app/lib/dttp/code_sets/bursary_details.rb
@@ -3,6 +3,8 @@
 module Dttp
   module CodeSets
     module BursaryDetails
+      NO_BURSARY_AWARDED = "1c8375c2-7722-e711-80c8-0050568902d3"
+
       POSTGRADUATE_BURSARY = "8c629dd7-bfc3-eb11-bacc-000d3addca7a"
       UNDERGRADUATE_BURSARY = "96756cc6-6041-e811-80f2-005056ac45bb"
       SCHOOL_DIRECT_SALARIED = "3036b79f-9fc7-eb11-bacc-000d3ab7dcfe"
@@ -10,7 +12,32 @@ module Dttp
 
       SCHOLARSHIP = "188375c2-7722-e711-80c8-0050568902d3"
 
-      NO_BURSARY_AWARDED = "1c8375c2-7722-e711-80c8-0050568902d3"
+      NEW_TIER_ONE_BURSARY = "001bf834-33ff-eb11-94ef-00224899ca99"
+      NEW_TIER_TWO_BURSARY = "66671547-33ff-eb11-94ef-00224899ca99"
+      NEW_TIER_THREE_BURSARY = "c5521159-33ff-eb11-94ef-00224899ca99"
+
+      OLD_TIER_ONE_BURSARY = "1e8375c2-7722-e711-80c8-0050568902d3"
+      OLD_TIER_TWO_BURSARY = "208375c2-7722-e711-80c8-0050568902d3"
+      OLD_TIER_THREE_BURSARY = "228375c2-7722-e711-80c8-0050568902d3"
+
+      BURSARIES = [
+        POSTGRADUATE_BURSARY,
+        UNDERGRADUATE_BURSARY,
+        OLD_TIER_ONE_BURSARY,
+        OLD_TIER_TWO_BURSARY,
+        OLD_TIER_THREE_BURSARY,
+      ].freeze
+
+      NEW_TIERS = [
+        NEW_TIER_ONE_BURSARY,
+        NEW_TIER_TWO_BURSARY,
+        NEW_TIER_THREE_BURSARY,
+      ].freeze
+
+      GRANTS = [
+        EARLY_YEARS_SALARIED,
+        SCHOOL_DIRECT_SALARIED,
+      ].freeze
 
       MAPPING = {
         # Postgraduate bursary
@@ -24,11 +51,11 @@ module Dttp
         TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => { entity_id: SCHOOL_DIRECT_SALARIED },
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => { entity_id: SCHOOL_DIRECT_SALARIED },
         # Tier one
-        BURSARY_TIER_ENUMS[:tier_one] => { entity_id: "001bf834-33ff-eb11-94ef-00224899ca99" },
+        BURSARY_TIER_ENUMS[:tier_one] => { entity_id: NEW_TIER_ONE_BURSARY },
         # Tier two
-        BURSARY_TIER_ENUMS[:tier_two] => { entity_id: "66671547-33ff-eb11-94ef-00224899ca99" },
+        BURSARY_TIER_ENUMS[:tier_two] => { entity_id: NEW_TIER_TWO_BURSARY },
         # Tier three
-        BURSARY_TIER_ENUMS[:tier_three] => { entity_id: "c5521159-33ff-eb11-94ef-00224899ca99" },
+        BURSARY_TIER_ENUMS[:tier_three] => { entity_id: NEW_TIER_THREE_BURSARY },
       }.freeze
     end
   end

--- a/app/models/dttp/placement_assignment.rb
+++ b/app/models/dttp/placement_assignment.rb
@@ -25,5 +25,9 @@ module Dttp
     def study_mode_id
       response["_dfe_studymodeid_value"]
     end
+
+    def funding_id
+      response["_dfe_bursarydetailsid_value"]
+    end
   end
 end

--- a/app/services/trainees/map_funding_from_dttp.rb
+++ b/app/services/trainees/map_funding_from_dttp.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Trainees
+  class MapFundingFromDttp
+    include ServicePattern
+    include HasDttpMapping
+
+    def initialize(dttp_trainee:)
+      @dttp_trainee = dttp_trainee
+    end
+
+    def call
+      return {} unless dttp_trainee
+
+      funding_attributes.compact
+    end
+
+  private
+
+    attr_reader :dttp_trainee
+
+    def funding_attributes
+      return {} if funding_entity_id.blank?
+
+      if funding_entity_id == Dttp::CodeSets::BursaryDetails::NO_BURSARY_AWARDED
+        return {
+          applying_for_grant: false,
+          applying_for_bursary: false,
+          applying_for_scholarship: false,
+        }
+      end
+
+      if applying_for_new_tier?
+        return {
+          applying_for_grant: false,
+          applying_for_bursary: true,
+          applying_for_scholarship: false,
+          bursary_tier: tier_for_funding,
+        }
+      end
+
+      {
+        applying_for_grant: applying_for_grant?,
+        applying_for_scholarship: applying_for_scholarship?,
+        applying_for_bursary: applying_for_bursary?,
+      }
+    end
+
+    def applying_for_bursary?
+      Dttp::CodeSets::BursaryDetails::BURSARIES.include?(funding_entity_id)
+    end
+
+    def applying_for_grant?
+      Dttp::CodeSets::BursaryDetails::GRANTS.include?(funding_entity_id)
+    end
+
+    def applying_for_new_tier?
+      Dttp::CodeSets::BursaryDetails::NEW_TIERS.include?(funding_entity_id)
+    end
+
+    def applying_for_scholarship?
+      funding_entity_id == Dttp::CodeSets::BursaryDetails::SCHOLARSHIP
+    end
+
+    def tier_for_funding
+      find_by_entity_id(funding_entity_id, Dttp::CodeSets::BursaryDetails::MAPPING)
+    end
+
+    def funding_entity_id
+      @funding_entity_id ||= dttp_trainee.latest_placement_assignment.funding_id
+    end
+  end
+end

--- a/db/data/20220207122830_add_old_funding_methods.rb
+++ b/db/data/20220207122830_add_old_funding_methods.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+class AddOldFundingMethods < ActiveRecord::Migration[6.1]
+  ACADEMIC_CYCLE = AcademicCycle.find_by(start_date: "2019-09-01")
+
+  BURSARIES_2019 = [
+    OpenStruct.new(
+      amount: 26_000,
+      allocation_subjects: [
+        AllocationSubjects::PHYSICS,
+        AllocationSubjects::COMPUTING,
+        AllocationSubjects::MODERN_LANGUAGES,
+        AllocationSubjects::GEOGRAPHY,
+        AllocationSubjects::CHEMISTRY,
+        AllocationSubjects::CLASSICS,
+        AllocationSubjects::BIOLOGY,
+      ],
+    ),
+    OpenStruct.new(
+      amount: 20_000,
+      allocation_subjects: [
+        AllocationSubjects::MATHEMATICS,
+      ],
+    ),
+    OpenStruct.new(
+      amount: 15_000,
+      allocation_subjects: [
+        AllocationSubjects::ENGLISH,
+      ],
+    ),
+    OpenStruct.new(
+      amount: 12_000,
+      allocation_subjects: [
+        AllocationSubjects::DESIGN_AND_TECHNOLOGY,
+        AllocationSubjects::HISTORY,
+      ],
+    ),
+    OpenStruct.new(
+      amount: 9_000,
+      allocation_subjects: [
+        AllocationSubjects::RELIGIOUS_EDUCATION,
+        AllocationSubjects::MUSIC,
+      ],
+    ),
+    OpenStruct.new(
+      amount: 6_000,
+      allocation_subjects: [
+        AllocationSubjects::PRIMARY_WITH_MATHEMATICS,
+      ],
+    ),
+  ].freeze
+
+  SCHOLARSHIPS_2019 = [
+    OpenStruct.new(
+      amount: 28_000,
+      allocation_subjects: [
+        AllocationSubjects::PHYSICS,
+        AllocationSubjects::COMPUTING,
+        AllocationSubjects::MODERN_LANGUAGES,
+        AllocationSubjects::GEOGRAPHY,
+        AllocationSubjects::CHEMISTRY,
+      ],
+    ),
+    OpenStruct.new(
+      amount: 22_000,
+      allocation_subjects: [
+        AllocationSubjects::MATHEMATICS,
+      ],
+    ),
+  ].freeze
+
+  def up
+    TRAINING_ROUTE_ENUMS.each_value do |route|
+      BURSARIES_2019.each do |bursary|
+        b = FundingMethod.find_or_create_by!(
+          training_route: route,
+          amount: bursary.amount,
+          academic_cycle: ACADEMIC_CYCLE,
+          funding_type: FUNDING_TYPE_ENUMS[:bursary],
+        )
+        bursary.allocation_subjects.map do |subject|
+          allocation_subject = AllocationSubject.find_by!(name: subject)
+          b.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
+        end
+      end
+
+      SCHOLARSHIPS_2019.each do |scholarship|
+        s = FundingMethod.find_or_create_by!(
+          training_route: route,
+          amount: scholarship.amount,
+          funding_type: FUNDING_TYPE_ENUMS[:scholarship],
+          academic_cycle: ACADEMIC_CYCLE,
+        )
+        scholarship.allocation_subjects.map do |subject|
+          allocation_subject = AllocationSubject.find_by!(name: subject)
+          s.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/trainees/map_funding_from_dttp_spec.rb
+++ b/spec/services/trainees/map_funding_from_dttp_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe MapFundingFromDttp do
+    include SeedHelper
+
+    let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: nil) }
+    let(:placement_assignment) { create(:dttp_placement_assignment, response: api_placement_assignment) }
+    let(:dttp_trainee) { create(:dttp_trainee, placement_assignments: [placement_assignment]) }
+
+    subject { described_class.call(dttp_trainee: dttp_trainee) }
+
+    context "with funding information available" do
+      context "when bursary is NO_BURSARY_AWARDED" do
+        let(:api_placement_assignment) { create(:api_placement_assignment, :with_no_bursary_awarded) }
+
+        it "sets bursary to false" do
+          expect(subject[:applying_for_bursary]).to eq(false)
+        end
+      end
+
+      context "when the trainee has a scholarship" do
+        let(:api_placement_assignment) { create(:api_placement_assignment, :with_scholarship) }
+
+        it "sets scholarship" do
+          expect(subject[:applying_for_scholarship]).to eq(true)
+        end
+      end
+
+      context "when the trainee has a bursary" do
+        let(:api_placement_assignment) { create(:api_placement_assignment, :with_provider_led_bursary) }
+
+        it "sets funding" do
+          expect(subject[:applying_for_bursary]).to eq(true)
+        end
+      end
+
+      context "when the trainee has a grant" do
+        let(:api_placement_assignment) { create(:api_placement_assignment, :with_early_years_salaried_bursary) }
+
+        it "sets funding" do
+          expect(subject[:applying_for_grant]).to eq(true)
+        end
+      end
+    end
+
+    context "with tiered bursary funding" do
+      let(:api_placement_assignment) { create(:api_placement_assignment, :with_tiered_bursary) }
+
+      it "sets bursary tier" do
+        expect(subject[:applying_for_bursary]).to eq(true)
+        expect(subject[:bursary_tier]).to eq(BURSARY_TIER_ENUMS[:tier_two])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/PznmhKZJ/3499-handle-trainees-with-funding-from-older-years

### Changes proposed in this pull request

- Adds 2019/20 funding rules to our DB via data migration. I haven't found nor added any previous to this and I don't know how many trainees this would affect.
- Splits the funding mapping into a separate file for clarity and testing
- Removes the checks we were making on whether funding was appropriate via the `FundingManager` and simply save the correct booleans based on what DTTP is telling us.
- The UI still uses the `FundingManager`. This means that unless there's a matching `FundingMethod` in the DB, the funding section will show "Not applicable".

This is the funding manual for 2019/20: https://www.gov.uk/government/publications/initial-teacher-training-itt-bursary-funding-manual/initial-teacher-training-bursaries-funding-manual-2019-to-2020-academic-year

Note: We did discuss an approach where we save the funding amounts directly to the trainee. However, I don't think we receive the actual funding amounts from DTTP, so we'd always need some way of storing the rules in Register (i.e. `FundingMethod`)

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
