### PR TITLE
Improve the display of autocomplete hints

### DIFF
--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -10,7 +10,7 @@ module DegreesHelper
         "data-synonyms" => synonyms.join("|"),
         "data-append" => attributes[:abbreviation] && tag.strong("(#{attributes[:abbreviation]})"),
         "data-boost" => (Dttp::CodeSets::DegreeTypes::COMMON.include?(name) ? 1.5 : 1),
-        "data-hint" => attributes[:hint],
+        "data-hint" => attributes[:hint]  && tag.span("#{attributes[:hint]}", class: "autocomplete__option--hint"),
       }.compact
       [name, name, data]
     end

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -10,7 +10,7 @@ module DegreesHelper
         "data-synonyms" => synonyms.join("|"),
         "data-append" => attributes[:abbreviation] && tag.strong("(#{attributes[:abbreviation]})"),
         "data-boost" => (Dttp::CodeSets::DegreeTypes::COMMON.include?(name) ? 1.5 : 1),
-        "data-hint" => attributes[:hint]  && tag.span("#{attributes[:hint]}", class: "autocomplete__option--hint"),
+        "data-hint" => attributes[:hint] && tag.span(attributes[:hint], class: "autocomplete__option--hint"),
       }.compact
       [name, name, data]
     end

--- a/app/lib/dttp/code_sets/degree_types.rb
+++ b/app/lib/dttp/code_sets/degree_types.rb
@@ -202,6 +202,7 @@ module Dttp
             "Level 6 NVQ",
             "Ordinary degree",
           ],
+          hint: "Including level 6 qualifications, graduate certificates and diplomas, degree apprenticeships and ordinary degrees",
           hesa_code: "402",
         },
         "Unknown" => { entity_id: "6f6a5652-c197-e711-80d8-005056ac45bb", abbreviation: nil },


### PR DESCRIPTION
The hints in the autocomplete are intended to be rendered in grey. This adjusts them to make that happen.

I also added a new hint for the `degree equivalent` option to give it parity with the `higher degree` option.
