### PR TITLE
Add weekly cache refresh workflow

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -1,0 +1,89 @@
+name: Build No Cache
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '30 12 * * 0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE: dfedigital/register-trainee-teachers
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Environment variable
+        run: |
+          GIT_BRANCH=${GITHUB_REF##*/}
+          echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
+          # tag build to the review env for vars and secrets
+          tf_vars_file=terraform/workspace-variables/review.tfvars.json
+          echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "KEY_VAULT_INFRA_SECRET_NAME=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
+
+      - name: Validate Azure Key Vault secrets
+        uses: DFE-Digital/github-actions/validate-key-vault-secrets@master
+        with:
+          KEY_VAULT: ${{ env.KEY_VAULT_NAME }}
+          SECRETS: |
+            ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
+
+      - uses: DFE-Digital/keyvault-yaml-secret@v1
+        id: get-secret
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
+          key: SNYK_TOKEN
+
+      - name: Login to DockerHub
+        if: github.actor != 'dependabot[bot]'
+        uses: docker/login-action@v1.9.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          tags: |
+            ${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
+            ${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
+          load: true
+          cache-to: type=inline
+          push: false
+          build-args: COMMIT_SHA=${{ github.sha }}
+
+      - name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
+        with:
+          image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
+          args: --file=Dockerfile
+
+      - name: Push ${{ env.DOCKER_IMAGE }} images
+        if: ${{ success() }}
+        run: |
+          docker push ${{ env.DOCKER_IMAGE }}:${{env.IMAGE_TAG}}
+          docker push ${{ env.DOCKER_IMAGE }}:${{env.BRANCH_TAG}}
+
+      - name: Check for Failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: twd_publish_register_tech
+          SLACK_COLOR: '#ef5343'
+          SLACK_ICON_EMOJI: ':github-logo:'
+          SLACK_USERNAME: Register Trainee Teachers
+          SLACK_TITLE: Build failure on weekly rebuild cache workflow
+          SLACK_MESSAGE: ':alert: Build failure :sadparrot:'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

https://trello.com/c/UdUEnOJu/511-reload-docker-image-cache

Schedule a weekly refresh of the docker image cache, so that we pick up updates to the base images
Also runs a SNYK scan against the docker image

### Changes proposed in this pull request

New workflow for weekly docker image cache refresh

### Guidance to review

Ran workflow against branch to confirm it works as expected

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
