### PR TITLE
[xxx] Replace Redis.current

### DIFF
--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -38,22 +38,26 @@ class FormStore
 
   class << self
     def get(trainee_id, key)
-      value = Redis.current.get("#{trainee_id}_#{key}")
+      value = redis.get("#{trainee_id}_#{key}")
       JSON.parse(value) if value.present?
     end
 
     def set(trainee_id, key, values)
       raise(InvalidKeyError) unless FORM_SECTION_KEYS.include?(key)
 
-      Redis.current.set("#{trainee_id}_#{key}", values.to_json)
+      redis.set("#{trainee_id}_#{key}", values.to_json)
 
       true
     end
 
     def clear_all(trainee_id)
       FORM_SECTION_KEYS.each do |key|
-        Redis.current.set("#{trainee_id}_#{key}", nil)
+        redis.set("#{trainee_id}_#{key}", nil)
       end
+    end
+
+    def redis
+      RedisClient.current
     end
   end
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -27,4 +27,8 @@ private
   end
 end
 
-Redis.current = Redis.new(url: RedisSetting.new(ENV["VCAP_SERVICES"]).url)
+class RedisClient
+  def self.current
+    @current ||= Redis.new(url: RedisSetting.new(ENV["VCAP_SERVICES"]).url)
+  end
+end


### PR DESCRIPTION
### Context

Redis.current has been deprecated.

### Changes proposed in this pull request

Add `RedisClient#current` to memoize a `Redis` instance.

### Guidance to review

Check FormStore is still functioning

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
