### PR TITLE
[3603] Trainee Policy edits

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
 
-  helper_method :current_user, :authenticated?, :audit_user
+  helper_method :current_user, :authenticated?, :audit_user, :trainee_editable?
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
@@ -82,6 +82,10 @@ private
 
   def ensure_trainee_is_draft!
     redirect_to(trainee_path(trainee)) unless trainee.draft?
+  end
+
+  def trainee_editable?
+    @trainee_editable ||= policy(trainee).update?
   end
 
   def ensure_trainee_is_not_draft!

--- a/app/controllers/concerns/publishable.rb
+++ b/app/controllers/concerns/publishable.rb
@@ -3,10 +3,6 @@
 module Publishable
   delegate :course_uuid, to: :publish_course_details_form
 
-  def trainee
-    @trainee ||= Trainee.from_param(params[:trainee_id])
-  end
-
   def course
     @course ||= trainee.available_courses.find_by!(uuid: course_uuid)
   end

--- a/app/controllers/trainees/check_details_controller.rb
+++ b/app/controllers/trainees/check_details_controller.rb
@@ -7,7 +7,6 @@ module Trainees
     def show
       page_tracker.save_as_origin!
       @form = Submissions::TrnValidator.new(trainee: trainee)
-      @editable = policy(trainee).update?
     end
   end
 end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -17,7 +17,7 @@ module Trainees
         @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.public_send(trainee_progress_key))
       end
 
-      @confirmation_component = view_component.new(data_model: data_model, editable: policy(trainee).update?)
+      @confirmation_component = view_component.new(data_model: data_model, editable: trainee_editable?)
     end
 
     def update
@@ -28,7 +28,7 @@ module Trainees
 
         redirect_to(page_tracker.last_origin_page_path || trainee_path(trainee))
       else
-        @confirmation_component = view_component.new(data_model: data_model, has_errors: true, editable: policy(trainee).update?)
+        @confirmation_component = view_component.new(data_model: data_model, has_errors: true, editable: trainee_editable?)
 
         render(:show)
       end

--- a/app/controllers/trainees/degrees/confirm_details_controller.rb
+++ b/app/controllers/trainees/degrees/confirm_details_controller.rb
@@ -18,7 +18,7 @@ module Trainees
                                       has_errors: false,
                                     )
                                   else
-                                    ::Degrees::View.new(data_model: data_model, editable: policy(@trainee).update?)
+                                    ::Degrees::View.new(data_model: data_model, editable: trainee_editable?)
                                   end
       end
 

--- a/app/controllers/trainees/diversity/confirm_details_controller.rb
+++ b/app/controllers/trainees/diversity/confirm_details_controller.rb
@@ -13,7 +13,7 @@ module Trainees
           @confirm_detail_form = ConfirmDetailForm.new(mark_as_completed: trainee.progress.diversity)
         end
 
-        @confirmation_component = ::Diversity::View.new(data_model: data_model, editable: policy(trainee).update?)
+        @confirmation_component = ::Diversity::View.new(data_model: data_model, editable: trainee_editable?)
       end
 
       def update
@@ -28,7 +28,7 @@ module Trainees
 
           redirect_to(page_tracker.last_origin_page_path || trainee_path(trainee))
         else
-          @confirmation_component = ::Diversity::View.new(data_model: data_model, has_errors: true, editable: policy(trainee).update?)
+          @confirmation_component = ::Diversity::View.new(data_model: data_model, has_errors: true, editable: trainee_editable?)
 
           render(:show)
         end

--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -41,7 +41,7 @@ module Trainees
   private
 
     def load_missing_data_view
-      return unless policy(trainee).update?
+      return unless trainee_editable?
 
       @missing_data_view = MissingDataBannerView.new(
         Submissions::MissingDataValidator.new(trainee: trainee).missing_fields, trainee

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -91,7 +91,7 @@ private
   end
 
   def load_missing_data_view
-    return unless policy(trainee).update?
+    return unless trainee_editable?
 
     @missing_data_view = MissingDataBannerView.new(missing_fields, trainee)
   end

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -47,8 +47,12 @@ class TraineePolicy
     read?
   end
 
-  def create?
+  def new?
     user.provider?
+  end
+
+  def create?
+    user_in_provider_context?
   end
 
   def update?
@@ -76,8 +80,6 @@ class TraineePolicy
   end
 
   alias_method :index?, :show?
-
-  alias_method :new?, :create?
 
   alias_method :edit?, :update?
   alias_method :destroy?, :update?

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -48,6 +48,10 @@ class TraineePolicy
   end
 
   def create?
+    user.provider?
+  end
+
+  def update?
     write?
   end
 
@@ -73,11 +77,11 @@ class TraineePolicy
 
   alias_method :index?, :show?
 
-  alias_method :update?, :create?
-  alias_method :edit?, :create?
   alias_method :new?, :create?
-  alias_method :destroy?, :create?
-  alias_method :confirm?, :create?
+
+  alias_method :edit?, :update?
+  alias_method :destroy?, :update?
+  alias_method :confirm?, :update?
 
 private
 

--- a/app/views/drafts/index.html.erb
+++ b/app/views/drafts/index.html.erb
@@ -14,7 +14,7 @@
   Draft records (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
 </h1>
 
-<% if policy(Trainee).create? %>
+<% if policy(Trainee).new? %>
   <p class="govuk-body">
     <%= render GovukComponent::StartButtonComponent.new(
     text: "Create a trainee record",

--- a/app/views/drafts/index.html.erb
+++ b/app/views/drafts/index.html.erb
@@ -14,7 +14,7 @@
   Draft records (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
 </h1>
 
-<% if current_user.provider? %>
+<% if policy(Trainee).create? %>
   <p class="govuk-body">
     <%= render GovukComponent::StartButtonComponent.new(
     text: "Create a trainee record",

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -26,7 +26,7 @@
           )%>
         </li>
       <% end %>
-      <% if current_user.provider? %>
+      <% if policy(Trainee).create? %>
         <li class="govuk-!-margin-bottom-0">
           <%= govuk_link_to(
             t(".new_trainee_link"),

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -26,7 +26,7 @@
           )%>
         </li>
       <% end %>
-      <% if policy(Trainee).create? %>
+      <% if policy(Trainee).new? %>
         <li class="govuk-!-margin-bottom-0">
           <%= govuk_link_to(
             t(".new_trainee_link"),

--- a/app/views/trainees/apply_applications/confirm_courses/show.html.erb
+++ b/app/views/trainees/apply_applications/confirm_courses/show.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-full">
     <%= render TraineeName::View.new(@trainee) %>
     <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
-    <%= render CourseDetails::View.new(data_model: @confirm_course_form, editable: policy(@trainee).update?) %>
+    <%= render CourseDetails::View.new(data_model: @confirm_course_form, editable: trainee_editable?) %>
 
     <%= register_form_with(model: @confirm_course_form,
                            url: trainee_apply_applications_confirm_courses_path(@trainee),

--- a/app/views/trainees/apply_applications/trainee_data/edit.html.erb
+++ b/app/views/trainees/apply_applications/trainee_data/edit.html.erb
@@ -27,7 +27,7 @@
         </h1>
       </div>
     </div>
-    <%= render ApplyApplications::TraineeData::View.new(trainee_data_form: @trainee_data_form, editable: policy(@trainee).update?) %>
+    <%= render ApplyApplications::TraineeData::View.new(trainee_data_form: @trainee_data_form, editable: trainee_editable?) %>
 
     <%= register_form_with(model: @trainee_data_form, builder: GOVUKDesignSystemFormBuilder::FormBuilder,
                            url: trainee_apply_applications_trainee_data_path(@trainee),

--- a/app/views/trainees/check_details/_apply_draft_trainee_check_details.html.erb
+++ b/app/views/trainees/check_details/_apply_draft_trainee_check_details.html.erb
@@ -2,18 +2,18 @@
   Registration data from Apply
 </h2>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :course_details, editable: @editable) %>
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :course_details, editable: @trainee_editable) %>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :trainee_data, editable: @editable) %>
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :trainee_data, editable: @trainee_editable) %>
 
 <h2 class="govuk-heading-m">
   About their teacher training
 </h2>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :training_details, editable: @editable) %>
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :training_details, editable: @trainee_editable) %>
 
 <% if @trainee.requires_schools? %>
-  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :schools, editable: @editable) %>
+  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :schools, editable: @trainee_editable) %>
 <% end %>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :funding, editable: @editable) %>
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :funding, editable: @trainee_editable) %>

--- a/app/views/trainees/check_details/_draft_trainee_check_details.html.erb
+++ b/app/views/trainees/check_details/_draft_trainee_check_details.html.erb
@@ -2,26 +2,26 @@
   <%= t("components.heading.draft.#{@trainee.requires_degree? ? "personal_details_and_education" : "personal_details"}") %>
 </h2>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :personal_details, editable: @editable) %>
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :personal_details, editable: @trainee_editable) %>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :contact_details, editable: @editable) %>
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :contact_details, editable: @trainee_editable) %>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :diversity, editable: @editable) %>
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :diversity, editable: @trainee_editable) %>
 
 <% if @trainee.requires_degree? %>
-  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :degrees, editable: @editable) %>
+  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :degrees, editable: @trainee_editable) %>
 <% end %>
 
 <h2 class="govuk-heading-m">
   About their teacher training
 </h2>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :course_details, editable: @editable) %>
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :course_details, editable: @trainee_editable) %>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :training_details, editable: @editable) %>
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :training_details, editable: @trainee_editable) %>
 
 <% if @trainee.requires_schools? %>
-  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :schools, editable: @editable) %>
+  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :schools, editable: @trainee_editable) %>
 <% end %>
 
-<%= render Sections::View.new(trainee: @trainee, form: @form, section: :funding, editable: @editable) %>
+<%= render Sections::View.new(trainee: @trainee, form: @form, section: :funding, editable: @trainee_editable) %>

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -14,7 +14,7 @@
   Registered trainees (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
 </h1>
 
-<% if policy(Trainee).create? %>
+<% if policy(Trainee).new? %>
   <p class="govuk-body">
     <%= render GovukComponent::StartButtonComponent.new(
     text: "Create a trainee record",

--- a/app/views/trainees/index.html.erb
+++ b/app/views/trainees/index.html.erb
@@ -14,7 +14,7 @@
   Registered trainees (<span id="js-trainee-count"><%= total_trainees_count %></span><span class="govuk-visually-hidden"> <%= "record".pluralize(total_trainees_count) %></span>)
 </h1>
 
-<% if current_user.provider? %>
+<% if policy(Trainee).create? %>
   <p class="govuk-body">
     <%= render GovukComponent::StartButtonComponent.new(
     text: "Create a trainee record",

--- a/app/views/trainees/personal_details/show.html.erb
+++ b/app/views/trainees/personal_details/show.html.erb
@@ -1,19 +1,19 @@
 <div class="personal-details">
-  <%= render PersonalDetails::View.new(data_model: @trainee, editable: policy(@trainee).update?) %>
+  <%= render PersonalDetails::View.new(data_model: @trainee, editable: trainee_editable?) %>
 </div>
 
 <div class="contact-details">
-  <%= render ContactDetails::View.new(data_model: @trainee, editable: policy(@trainee).update?) %>
+  <%= render ContactDetails::View.new(data_model: @trainee, editable: trainee_editable?) %>
 </div>
 
 <div class="diversity-details">
-  <%= render Diversity::View.new(data_model: @trainee, editable: policy(@trainee).update?) %>
+  <%= render Diversity::View.new(data_model: @trainee, editable: trainee_editable?) %>
 </div>
 
 <% if @trainee.requires_degree? %>
   <% if @trainee.degrees.any? %>
     <div class="degree-details">
-      <%= render Degrees::View.new(data_model: @trainee, show_delete_button: true, editable: policy(@trainee).update?) %>
+      <%= render Degrees::View.new(data_model: @trainee, show_delete_button: true, editable: trainee_editable?) %>
     </div>
   <% else %>
     <%= render CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), has_errors: false) %>

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -1,29 +1,29 @@
-<% if policy(@trainee).update? %>
+<% if trainee_editable? %>
   <div class="record-outcome-action-bar">
     <%= render RecordActions::View.new(@trainee, has_missing_fields: @missing_fields.present?) %>
   </div>
 <% end %>
 
 <div class="record-details">
-  <%= render RecordDetails::View.new(trainee: @trainee, last_updated_event: @trainee.timeline.first, system_admin: @current_user.system_admin?, editable: policy(@trainee).update?) %>
+  <%= render RecordDetails::View.new(trainee: @trainee, last_updated_event: @trainee.timeline.first, system_admin: @current_user.system_admin?, editable: trainee_editable?) %>
 </div>
 
 <div class="course-details">
-  <%= render CourseDetails::View.new(data_model: @trainee, editable: policy(@trainee).update?) %>
+  <%= render CourseDetails::View.new(data_model: @trainee, editable: trainee_editable?) %>
 </div>
 
 <% if @trainee.requires_schools? %>
   <div class="school-details">
-    <%= render SchoolDetails::View.new(trainee: @trainee, editable: policy(@trainee).update?)  %>
+    <%= render SchoolDetails::View.new(trainee: @trainee, editable: trainee_editable?)  %>
   </div>
 <% end %>
 
 <% if @trainee.requires_placement_details? %>
   <div class="placement-details">
-    <%= render PlacementDetails::View.new(trainee: @trainee, editable: policy(@trainee).update?) %>
+    <%= render PlacementDetails::View.new(trainee: @trainee, editable: trainee_editable?) %>
   </div>
 <% end %>
 
 <div class="funding">
-  <%= render Funding::View.new(data_model: @trainee, editable: policy(@trainee).update?) %>
+  <%= render Funding::View.new(data_model: @trainee, editable: trainee_editable?) %>
 </div>

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -15,7 +15,7 @@ module Pages
             @trainee = trainee(sections)
 
             @form = Submissions::TrnValidator.new(trainee: @trainee)
-            render template: template, locals: { "@trainee": @trainee, "@form": @form }
+            render template: template, locals: { "@trainee": @trainee, "@form": @form, "@trainee_editable": true }
           end
 
           define_method "#{sections}_validated" do
@@ -23,14 +23,14 @@ module Pages
 
             @form = Submissions::TrnValidator.new(trainee: @trainee)
             @form.validate
-            render template: template, locals: { "@trainee": @trainee, "@form": @form }
+            render template: template, locals: { "@trainee": @trainee, "@form": @form, "@trainee_editable": true }
           end
 
           define_method "#{sections}_itt" do
             @trainee = itt_trainee(sections)
 
             @form = Submissions::TrnValidator.new(trainee: @trainee)
-            render template: template, locals: { "@trainee": @trainee, "@form": @form }
+            render template: template, locals: { "@trainee": @trainee, "@form": @form, "@trainee_editable": true }
           end
 
           define_method "#{sections}_itt_validated" do
@@ -38,7 +38,7 @@ module Pages
 
             @form = Submissions::TrnValidator.new(trainee: @trainee)
             @form.validate
-            render template: template, locals: { "@trainee": @trainee, "@form": @form }
+            render template: template, locals: { "@trainee": @trainee, "@form": @form, "@trainee_editable": true }
           end
         end
 

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -33,11 +33,15 @@ describe TraineePolicy do
     it { is_expected.not_to permit(other_provider_user, provider_trainee) }
   end
 
-  permissions :create?, :new? do
+  permissions :new?, :create? do
     it { is_expected.to permit(provider_user, provider_trainee) }
 
     it { is_expected.not_to permit(lead_school_user, lead_school_trainee) }
     it { is_expected.not_to permit(system_admin_user, provider_trainee) }
+  end
+
+  permissions :create? do
+    it { is_expected.not_to permit(other_provider_user, provider_trainee) }
   end
 
   permissions :update?, :edit?, :destroy?, :confirm? do

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe TraineePolicy do
-  let(:system_admin_user) { create(:user, :system_admin) }
+  let(:system_admin_user) { user_with_organisation(create(:user, :system_admin), nil) }
   let(:provider) { create(:provider) }
   let(:other_provider) { create(:provider) }
   let(:provider_user) { user_with_organisation(create(:user, providers: [provider]), provider) }
@@ -33,7 +33,14 @@ describe TraineePolicy do
     it { is_expected.not_to permit(other_provider_user, provider_trainee) }
   end
 
-  permissions :create?, :update?, :edit?, :new?, :destroy?, :confirm? do
+  permissions :create?, :new? do
+    it { is_expected.to permit(provider_user, provider_trainee) }
+
+    it { is_expected.not_to permit(lead_school_user, lead_school_trainee) }
+    it { is_expected.not_to permit(system_admin_user, provider_trainee) }
+  end
+
+  permissions :update?, :edit?, :destroy?, :confirm? do
     it { is_expected.to permit(provider_user, provider_trainee) }
     it { is_expected.not_to permit(lead_school_user, lead_school_trainee) }
 

--- a/spec/views/trainees/personal_details/show.html.erb_spec.rb
+++ b/spec/views/trainees/personal_details/show.html.erb_spec.rb
@@ -4,17 +4,15 @@ require "rails_helper"
 
 describe "trainees/personal_details/show.html.erb" do
   before do
-    assign(:current_user, current_user)
     assign(:trainee, trainee)
     without_partial_double_verification do
-      allow(view).to receive(:policy).and_return(double(update?: true))
+      allow(view).to receive(:trainee_editable?).and_return(true)
     end
     render
   end
 
   context "with a trainee with no degree" do
     let(:trainee) { create(:trainee) }
-    let(:current_user) { create(:user, :system_admin) }
 
     it "renders the incomplete section component" do
       expect(rendered).to have_text("Add degree details")
@@ -23,7 +21,6 @@ describe "trainees/personal_details/show.html.erb" do
 
   context "with a trainee with a degree" do
     let(:trainee) { create(:trainee, :in_progress) }
-    let(:current_user) { create(:user, :system_admin) }
 
     it "renders the confirmation component" do
       expect(rendered).to have_text("Add another degree")

--- a/spec/views/trainees/show.html.erb_spec.rb
+++ b/spec/views/trainees/show.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe "trainees/show.html.erb", "feature_routes.provider_led_postgrad": true 
     assign(:trainee, trainee)
     assign(:current_user, current_user)
     without_partial_double_verification do
-      allow(view).to receive(:policy).and_return(double(update?: true))
+      allow(view).to receive(:trainee_editable?).and_return(true)
     end
   end
 


### PR DESCRIPTION
### Context
Adresses feedback from https://github.com/DFE-Digital/register-trainee-teachers/pull/2011

### Changes proposed in this pull request
1. Update `TraineePolicy#create?` to only allow users in a provider context.
2. Change template checks from `current_user.provider?` to `policy(Trainee).create?` when rendering buttons to add a new trainee.
3. Adds a `trainee_editable?` helper in `ApplicationController`, instead of duplicated checks all over the codebase.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
