### PR TITLE
[3657] Map HESA ethnicity and disability attributes

### DIFF
--- a/app/lib/dttp/code_sets/ethnicities.rb
+++ b/app/lib/dttp/code_sets/ethnicities.rb
@@ -3,50 +3,34 @@
 module Dttp
   module CodeSets
     module Ethnicities
-      WHITE = "white"
-      SCOTTISH = "scottish"
-      INFORMATION_REFUSED = "information_refused"
-      INFORMATION_NOT_YET_SOUGHT = "information_not_yet_sought"
-
-      NOT_PROVIDED_ETHNICITIES = [
-        Diversities::NOT_PROVIDED,
-        INFORMATION_REFUSED,
-        INFORMATION_NOT_YET_SOUGHT,
-      ].freeze
-
-      WHITE_ETHNICITIES = [
-        WHITE,
-        SCOTTISH,
-      ].freeze
-
       MAPPING = {
-        ::Diversities::AFRICAN => { ethnic_minority: true, entity_id: "c00bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::ANOTHER_ASIAN_BACKGROUND => { ethnic_minority: true, entity_id: "cc0bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::ANOTHER_BLACK_BACKGROUND => { ethnic_minority: true, entity_id: "c20bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::ANOTHER_ETHNIC_BACKGROUND => { ethnic_minority: true, entity_id: "d80bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::ANOTHER_MIXED_BACKGROUND => { ethnic_minority: true, entity_id: "d40bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::ANOTHER_WHITE_BACKGROUND => { ethnic_minority: false, entity_id: "bc0bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::ARAB => { ethnic_minority: true, entity_id: "d60bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::ASIAN_AND_WHITE => { ethnic_minority: true, entity_id: "d20bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::BANGLADESHI => { ethnic_minority: true, entity_id: "c80bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::BLACK_AFRICAN_AND_WHITE => { ethnic_minority: true, entity_id: "d00bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::BLACK_CARIBBEAN_AND_WHITE => { ethnic_minority: true, entity_id: "ce0bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::CARIBBEAN => { ethnic_minority: true, entity_id: "be0bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::CHINESE => { ethnic_minority: true, entity_id: "ca0bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::INDIAN => { ethnic_minority: true, entity_id: "c40bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::IRISH => { ethnic_minority: false, entity_id: "b40bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::IRISH_TRAVELLER => { ethnic_minority: true, entity_id: "b80bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::NOT_PROVIDED => { ethnic_minority: false, entity_id: "da0bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::PAKISTANI => { ethnic_minority: true, entity_id: "c60bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::TRAVELLER_OR_GYPSY => { ethnic_minority: false, entity_id: "ba0bb892-2b9d-e711-80d9-005056ac45bb" },
-        ::Diversities::WHITE_BRITISH => { ethnic_minority: false, entity_id: "b20bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::AFRICAN => { ethnic_minority: true, entity_id: "c00bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::ANOTHER_ASIAN_BACKGROUND => { ethnic_minority: true, entity_id: "cc0bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::ANOTHER_BLACK_BACKGROUND => { ethnic_minority: true, entity_id: "c20bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::ANOTHER_ETHNIC_BACKGROUND => { ethnic_minority: true, entity_id: "d80bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::ANOTHER_MIXED_BACKGROUND => { ethnic_minority: true, entity_id: "d40bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::ANOTHER_WHITE_BACKGROUND => { ethnic_minority: false, entity_id: "bc0bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::ARAB => { ethnic_minority: true, entity_id: "d60bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::ASIAN_AND_WHITE => { ethnic_minority: true, entity_id: "d20bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::BANGLADESHI => { ethnic_minority: true, entity_id: "c80bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::BLACK_AFRICAN_AND_WHITE => { ethnic_minority: true, entity_id: "d00bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::BLACK_CARIBBEAN_AND_WHITE => { ethnic_minority: true, entity_id: "ce0bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::CARIBBEAN => { ethnic_minority: true, entity_id: "be0bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::CHINESE => { ethnic_minority: true, entity_id: "ca0bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::INDIAN => { ethnic_minority: true, entity_id: "c40bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::IRISH => { ethnic_minority: false, entity_id: "b40bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::IRISH_TRAVELLER => { ethnic_minority: true, entity_id: "b80bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::NOT_PROVIDED => { ethnic_minority: false, entity_id: "da0bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::PAKISTANI => { ethnic_minority: true, entity_id: "c60bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::TRAVELLER_OR_GYPSY => { ethnic_minority: false, entity_id: "ba0bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::WHITE_BRITISH => { ethnic_minority: false, entity_id: "b20bb892-2b9d-e711-80d9-005056ac45bb" },
       }.freeze
 
       INACTIVE_MAPPING = {
-        WHITE => { entity_id: "b00bb892-2b9d-e711-80d9-005056ac45bb" },
-        SCOTTISH => { entity_id: "b60bb892-2b9d-e711-80d9-005056ac45bb" },
-        INFORMATION_REFUSED => { entity_id: "dc0bb892-2b9d-e711-80d9-005056ac45bb" },
-        INFORMATION_NOT_YET_SOUGHT => { entity_id: "de0bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::WHITE => { entity_id: "b00bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::SCOTTISH => { entity_id: "b60bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::INFORMATION_REFUSED => { entity_id: "dc0bb892-2b9d-e711-80d9-005056ac45bb" },
+        Diversities::INFORMATION_NOT_YET_SOUGHT => { entity_id: "de0bb892-2b9d-e711-80d9-005056ac45bb" },
       }.freeze
     end
   end

--- a/app/lib/hesa/code_sets/disabilities.rb
+++ b/app/lib/hesa/code_sets/disabilities.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Hesa
+  module CodeSets
+    module Disabilities
+      # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
+      MAPPING = {
+        "00" => Diversities::NO_KNOWN_DISABILITY,
+        "08" => Diversities::MULTIPLE_DISABILITIES,
+        "51" => Diversities::LEARNING_DIFFICULTY,
+        "53" => Diversities::SOCIAL_IMPAIRMENT,
+        "54" => Diversities::LONG_STANDING_ILLNESS,
+        "55" => Diversities::MENTAL_HEALTH_CONDITION,
+        "56" => Diversities::PHYSICAL_DISABILITY,
+        "57" => Diversities::DEAF,
+        "58" => Diversities::BLIND,
+        "96" => Diversities::OTHER,
+      }.freeze
+    end
+  end
+end

--- a/app/lib/hesa/code_sets/ethnicities.rb
+++ b/app/lib/hesa/code_sets/ethnicities.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Hesa
+  module CodeSets
+    module Ethnicities
+      # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
+      MAPPING = {
+        "10" => Diversities::WHITE_BRITISH,
+        "15" => Diversities::TRAVELLER_OR_GYPSY,
+        "21" => Diversities::CARIBBEAN,
+        "22" => Diversities::AFRICAN,
+        "29" => Diversities::ANOTHER_BLACK_BACKGROUND,
+        "31" => Diversities::INDIAN,
+        "32" => Diversities::PAKISTANI,
+        "33" => Diversities::BANGLADESHI,
+        "34" => Diversities::CHINESE,
+        "39" => Diversities::ANOTHER_ASIAN_BACKGROUND,
+        "41" => Diversities::BLACK_CARIBBEAN_AND_WHITE,
+        "42" => Diversities::BLACK_AFRICAN_AND_WHITE,
+        "43" => Diversities::ASIAN_AND_WHITE,
+        "49" => Diversities::ANOTHER_MIXED_BACKGROUND,
+        "50" => Diversities::ARAB,
+        "80" => Diversities::ANOTHER_ETHNIC_BACKGROUND,
+        "90" => Diversities::NOT_PROVIDED,
+        "98" => Diversities::INFORMATION_REFUSED,
+      }.freeze
+    end
+  end
+end

--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -4,8 +4,8 @@ module Hesa
   module Parsers
     class IttRecord
       class << self
-        def to_attributes(itt_record_doc:)
-          student_attributes = Hash.from_xml(itt_record_doc).dig("ITTRecord", "Student")
+        def to_attributes(student_node:)
+          student_attributes = Hash.from_xml(student_node.to_s)['Student']
           student_attributes = convert_all_null_values_to_nil(student_attributes)
 
           {

--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -5,7 +5,7 @@ module Hesa
     class IttRecord
       class << self
         def to_attributes(student_node:)
-          student_attributes = Hash.from_xml(student_node.to_s)['Student']
+          student_attributes = Hash.from_xml(student_node.to_s)["Student"]
           student_attributes = convert_all_null_values_to_nil(student_attributes)
 
           {
@@ -13,7 +13,7 @@ module Hesa
             last_name: student_attributes["F_PSURNAME"],
             email: student_attributes["F_NQTEMAIL"],
             date_of_birth: student_attributes["F_BIRTHDTE"],
-            ethnic_group: student_attributes["F_ETHNIC"],
+            ethnic_background: student_attributes["F_ETHNIC"],
             gender: student_attributes["F_SEXID"],
             ukprn: student_attributes["F_UKPRN"],
             trainee_id: student_attributes["F_OWNSTU"],
@@ -32,7 +32,7 @@ module Hesa
             applying_for_bursary: student_attributes["F_FUNDCODE"],
             international_address: student_attributes["F_DOMICILE"],
             withdraw_date: student_attributes["F_ENDDATE"],
-            disability_disclosure: student_attributes["F_DISABLE"],
+            disability: student_attributes["F_DISABLE"],
             bursary_tier: student_attributes["F_BURSLEV"],
             trn: student_attributes["F_TREFNO"],
             training_route: student_attributes["F_ENTRYRTE"],

--- a/app/services/concerns/diversity_attributes.rb
+++ b/app/services/concerns/diversity_attributes.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module DiversityAttributes
+  MULTIPLE_DISABILITIES_TEXT = "HESA multiple disabilities"
+
+  def add_multiple_disability_text!
+    return unless disability == Diversities::MULTIPLE_DISABILITIES
+
+    trainee.trainee_disabilities.last.update!(additional_disability: MULTIPLE_DISABILITIES_TEXT)
+  end
+
+  def ethnicity_and_disability_attributes
+    ethnicity_attributes.merge(disability_attributes)
+                        .merge({ diversity_disclosure: diversity_disclosure })
+  end
+
+  def disability_attributes
+    if disability.blank? || disability == Diversities::NOT_PROVIDED
+      return {
+        disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided],
+      }
+    end
+
+    if disability == Diversities::NO_KNOWN_DISABILITY
+      return {
+        disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability],
+      }
+    end
+
+    if disability == Diversities::MULTIPLE_DISABILITIES
+      return {
+        disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled],
+        disabilities: Disability.where(name: ::Diversities::OTHER),
+      }
+    end
+
+    {
+      disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled],
+      disabilities: Disability.where(name: disability),
+    }
+  end
+
+  def ethnicity_attributes
+    if Diversities::NOT_PROVIDED_ETHNICITIES.include?(ethnic_background)
+      return {
+        ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:not_provided],
+        ethnic_background: Diversities::NOT_PROVIDED,
+      }
+    end
+
+    if Diversities::WHITE_ETHNICITIES.include?(ethnic_background)
+      return {
+        ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:white],
+        ethnic_background: Diversities::NOT_PROVIDED,
+      }
+    end
+
+    if Diversities::BACKGROUNDS.values.flatten.include?(ethnic_background)
+      ethnic_group = Diversities::BACKGROUNDS.select { |_key, values| values.include?(ethnic_background) }&.keys&.first
+
+      return {
+        ethnic_group: ethnic_group,
+        ethnic_background: ethnic_background,
+      }
+    end
+
+    {
+      ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:not_provided],
+      ethnic_background: Diversities::NOT_PROVIDED,
+    }
+  end
+
+  def diversity_disclosure
+    if disability.present? || ethnicity_disclosed?
+      Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed]
+    else
+      Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed]
+    end
+  end
+
+  def ethnicity_disclosed?
+    ethnic_background.present? && ethnic_background != Diversities::INFORMATION_REFUSED
+  end
+end

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -4,14 +4,13 @@ module Trainees
   class CreateFromDttp
     include ServicePattern
     include HasDttpMapping
+    include DiversityAttributes
 
     TRN_REGEX = /^(\d{6,7})$/.freeze
 
     UK_COUNTRIES = ["England", "United Kingdom", "Scotland", "Northern Ireland",
                     "Wales", "Isle of Man",
                     "United Kingdom, not otherwise specified"].freeze
-
-    MULTIPLE_DISABILITIES_TEXT = "HESA multiple disabilities"
 
     def initialize(dttp_trainee:)
       @dttp_trainee = dttp_trainee
@@ -169,32 +168,6 @@ module Trainees
           find_by_entity_id(dttp_trainee.nationality, Dttp::CodeSets::Nationalities::INACTIVE_MAPPING)
     end
 
-    def disability_attributes
-      if disability.blank? || disability == Diversities::NOT_PROVIDED
-        return {
-          disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided],
-        }
-      end
-
-      if disability == Diversities::NO_KNOWN_DISABILITY
-        return {
-          disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability],
-        }
-      end
-
-      if disability == Diversities::MULTIPLE_DISABILITIES
-        return {
-          disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled],
-          disabilities: Disability.where(name: ::Diversities::OTHER),
-        }
-      end
-
-      {
-        disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled],
-        disabilities: Disability.where(name: disability),
-      }
-    end
-
     def disability
       @disability ||= find_by_entity_id(
         dttp_trainee.response["_dfe_disibilityid_value"],
@@ -202,63 +175,9 @@ module Trainees
       )
     end
 
-    def add_multiple_disability_text!
-      return unless disability == Diversities::MULTIPLE_DISABILITIES
-
-      trainee.trainee_disabilities.last.update!(additional_disability: MULTIPLE_DISABILITIES_TEXT)
-    end
-
-    def ethnicity_attributes
-      if Dttp::CodeSets::Ethnicities::NOT_PROVIDED_ETHNICITIES.include?(ethnic_background)
-        return {
-          ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:not_provided],
-          ethnic_background: Diversities::NOT_PROVIDED,
-        }
-      end
-
-      if Dttp::CodeSets::Ethnicities::WHITE_ETHNICITIES.include?(ethnic_background)
-        return {
-          ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:white],
-          ethnic_background: Diversities::NOT_PROVIDED,
-        }
-      end
-
-      if Diversities::BACKGROUNDS.values.flatten.include?(ethnic_background)
-        ethnic_group = Diversities::BACKGROUNDS.select { |_key, values| values.include?(ethnic_background) }&.keys&.first
-
-        return {
-          ethnic_group: ethnic_group,
-          ethnic_background: ethnic_background,
-        }
-      end
-
-      {
-        ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:not_provided],
-        ethnic_background: Diversities::NOT_PROVIDED,
-      }
-    end
-
     def ethnic_background
       find_by_entity_id(dttp_trainee.ethnicity, Dttp::CodeSets::Ethnicities::MAPPING) ||
         find_by_entity_id(dttp_trainee.ethnicity, Dttp::CodeSets::Ethnicities::INACTIVE_MAPPING)
-    end
-
-    def diversity_disclosure
-      if disability.present? || ethnicity_disclosed?
-        Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed]
-      else
-        Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed]
-      end
-    end
-
-    def ethnicity_disclosed?
-      ethnic_background.present? &&
-        ethnic_background != Dttp::CodeSets::Ethnicities::INFORMATION_REFUSED
-    end
-
-    def ethnicity_and_disability_attributes
-      ethnicity_attributes.merge(disability_attributes)
-                          .merge({ diversity_disclosure: diversity_disclosure })
     end
 
     def personal_details_attributes

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -3,6 +3,7 @@
 module Trainees
   class CreateFromHesa
     include ServicePattern
+    include DiversityAttributes
 
     def initialize(student_node:)
       @hesa_trainee = Hesa::Parsers::IttRecord.to_attributes(student_node: student_node)
@@ -13,6 +14,7 @@ module Trainees
       trainee.assign_attributes(mapped_attributes)
       trainee.save!
       trainee
+      add_multiple_disability_text!
     end
 
   private
@@ -27,6 +29,7 @@ module Trainees
       }.merge(personal_details_attributes)
        .merge(contact_attributes)
        .merge(provider_attributes)
+       .merge(ethnicity_and_disability_attributes)
     end
 
     def personal_details_attributes
@@ -62,6 +65,14 @@ module Trainees
 
     def training_route
       Hesa::CodeSets::TrainingRoutes::MAPPING[hesa_trainee[:training_route]]
+    end
+
+    def ethnic_background
+      Hesa::CodeSets::Ethnicities::MAPPING[hesa_trainee[:ethnic_background]]
+    end
+
+    def disability
+      Hesa::CodeSets::Disabilities::MAPPING[hesa_trainee[:disability]]
     end
   end
 end

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -4,8 +4,8 @@ module Trainees
   class CreateFromHesa
     include ServicePattern
 
-    def initialize(itt_record_doc:)
-      @hesa_trainee = Hesa::Parsers::IttRecord.to_attributes(itt_record_doc: itt_record_doc)
+    def initialize(student_node:)
+      @hesa_trainee = Hesa::Parsers::IttRecord.to_attributes(student_node: student_node)
       @trainee = Trainee.find_or_initialize_by(hesa_id: hesa_trainee[:hesa_id])
     end
 

--- a/config/initializers/diversity_enums.rb
+++ b/config/initializers/diversity_enums.rb
@@ -2,6 +2,11 @@
 
 module Diversities
   NOT_PROVIDED = "Not provided"
+  INFORMATION_REFUSED = "information_refused"
+  INFORMATION_NOT_YET_SOUGHT = "information_not_yet_sought"
+
+  WHITE = "white"
+  SCOTTISH = "scottish"
 
   BANGLADESHI = "Bangladeshi"
   CHINESE = "Chinese"
@@ -27,6 +32,17 @@ module Diversities
 
   ARAB = "Arab"
   ANOTHER_ETHNIC_BACKGROUND = "Another ethnic background"
+
+  NOT_PROVIDED_ETHNICITIES = [
+    NOT_PROVIDED,
+    INFORMATION_REFUSED,
+    INFORMATION_NOT_YET_SOUGHT,
+  ].freeze
+
+  WHITE_ETHNICITIES = [
+    WHITE,
+    SCOTTISH,
+  ].freeze
 
   DIVERSITY_DISCLOSURE_ENUMS = {
     diversity_disclosed: "diversity_disclosed",

--- a/spec/lib/hesa/parsers/itt_record_spec.rb
+++ b/spec/lib/hesa/parsers/itt_record_spec.rb
@@ -6,8 +6,7 @@ module Hesa
   module Parsers
     describe IttRecord do
       describe ".to_attributes" do
-        let(:xml_doc) { Nokogiri::XML(read_fixture_file("hesa/itt_record.xml")) }
-        let(:student_node) { xml_doc.xpath("//ITTRecord/Student").first }
+        let(:student_node) { ApiStubs::HesaApi.new.student_node }
 
         subject(:trainee_attributes) do
           described_class.to_attributes(student_node: student_node)
@@ -19,7 +18,7 @@ module Hesa
             last_name: "Geoorge",
             email: "student.name@email.com",
             date_of_birth: "1978-08-13",
-            ethnic_group: "80",
+            ethnic_background: "80",
             gender: "1",
             trn: nil,
             ukprn: "10007713",
@@ -37,7 +36,7 @@ module Hesa
             international_address: "XF",
             withdraw_reason: nil,
             withdraw_date: nil,
-            disability_disclosure: "00",
+            disability: "00",
             bursary_tier: "6",
             employing_school_id: "115795",
             lead_school_id: "115795",

--- a/spec/lib/hesa/parsers/itt_record_spec.rb
+++ b/spec/lib/hesa/parsers/itt_record_spec.rb
@@ -6,10 +6,11 @@ module Hesa
   module Parsers
     describe IttRecord do
       describe ".to_attributes" do
-        let(:itt_record_doc) { read_fixture_file("hesa/itt_record.xml") }
+        let(:xml_doc) { Nokogiri::XML(read_fixture_file("hesa/itt_record.xml")) }
+        let(:student_node) { xml_doc.xpath("//ITTRecord/Student").first }
 
         subject(:trainee_attributes) do
-          described_class.to_attributes(itt_record_doc: itt_record_doc)
+          described_class.to_attributes(student_node: student_node)
         end
 
         it "returns an hash with mapped trainee attributes" do

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 module Trainees
   describe CreateFromHesa do
-    let(:itt_record_doc) { read_fixture_file("hesa/itt_record.xml") }
-    let(:itt_record_xml_attributes) { Hesa::Parsers::IttRecord.to_attributes(itt_record_doc: itt_record_doc) }
+    let(:xml_doc) { Nokogiri::XML(read_fixture_file("hesa/itt_record.xml")) }
+    let(:student_node) { xml_doc.xpath("//ITTRecord/Student").first }
+    let(:itt_record_xml_attributes) { Hesa::Parsers::IttRecord.to_attributes(student_node: student_node) }
     let(:nationality_name) { ApplyApi::CodeSets::Nationalities::MAPPING[itt_record_xml_attributes[:nationality]] }
     let(:training_route) { Hesa::CodeSets::TrainingRoutes::MAPPING[itt_record_xml_attributes[:training_route]] }
     let(:trainee) { Trainee.first }
@@ -15,7 +16,7 @@ module Trainees
     context "trainee already exists and didn't come from HESA" do
       before do
         create(:trainee, hesa_id: itt_record_xml_attributes[:hesa_id])
-        described_class.call(itt_record_doc: itt_record_doc)
+        described_class.call(student_node: student_node)
       end
 
       it "updates the trainee from HESA XML document" do
@@ -37,7 +38,7 @@ module Trainees
     context "trainee doesn't exist" do
       before do
         create(:provider, ukprn: itt_record_xml_attributes[:ukprn])
-        described_class.call(itt_record_doc: itt_record_doc)
+        described_class.call(student_node: student_node)
       end
 
       it "creates the trainee from HESA XML document" do

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -4,57 +4,132 @@ require "rails_helper"
 
 module Trainees
   describe CreateFromHesa do
-    let(:xml_doc) { Nokogiri::XML(read_fixture_file("hesa/itt_record.xml")) }
-    let(:student_node) { xml_doc.xpath("//ITTRecord/Student").first }
-    let(:itt_record_xml_attributes) { Hesa::Parsers::IttRecord.to_attributes(student_node: student_node) }
-    let(:nationality_name) { ApplyApi::CodeSets::Nationalities::MAPPING[itt_record_xml_attributes[:nationality]] }
-    let(:training_route) { Hesa::CodeSets::TrainingRoutes::MAPPING[itt_record_xml_attributes[:training_route]] }
-    let(:trainee) { Trainee.first }
+    let(:nationality_name) { ApplyApi::CodeSets::Nationalities::MAPPING[student_attributes[:nationality]] }
+    let(:hesa_disability_codes) { Hesa::CodeSets::Disabilities::MAPPING.invert }
+    let(:hesa_ethnicity_codes) { Hesa::CodeSets::Ethnicities::MAPPING.invert }
+    let(:training_route) { Hesa::CodeSets::TrainingRoutes::MAPPING[student_attributes[:training_route]] }
+    let(:hesa_api_stub) { ApiStubs::HesaApi.new(hesa_stub_attributes) }
+    let(:student_node) { hesa_api_stub.student_node }
+    let(:student_attributes) { hesa_api_stub.student_attributes }
+    let(:create_custom_state) { "implemented where necessary" }
+    let(:hesa_stub_attributes) { {} }
 
-    before { create(:nationality, name: nationality_name) }
+    subject(:trainee) { Trainee.first }
 
-    context "trainee already exists and didn't come from HESA" do
-      before do
-        create(:trainee, hesa_id: itt_record_xml_attributes[:hesa_id])
-        described_class.call(student_node: student_node)
-      end
+    before do
+      create(:nationality, name: nationality_name)
+      create(:provider, ukprn: student_attributes[:ukprn])
+      create_custom_state
+      described_class.call(student_node: student_node)
+    end
 
-      it "updates the trainee from HESA XML document" do
-        expect(trainee.created_from_hesa).to be(false)
-        expect(trainee.hesa_id).to eq(itt_record_xml_attributes[:hesa_id])
-        expect(trainee.first_names).to eq(itt_record_xml_attributes[:first_names])
-        expect(trainee.last_name).to eq(itt_record_xml_attributes[:last_name])
-        expect(trainee.address_line_one).to eq(itt_record_xml_attributes[:address_line_one])
-        expect(trainee.address_line_two).to eq(itt_record_xml_attributes[:address_line_two])
-        expect(trainee.email).to eq(itt_record_xml_attributes[:email])
-        expect(trainee.date_of_birth).to eq(Date.parse(itt_record_xml_attributes[:date_of_birth]))
-        expect(trainee.gender).to eq("female")
-        expect(trainee.trainee_id).to eq(itt_record_xml_attributes[:trainee_id])
-        expect(trainee.nationalities.pluck(:name)).to include(nationality_name)
-        expect(trainee.trn).to eq(itt_record_xml_attributes[:trn])
-      end
+    it "updates the trainee from HESA XML document" do
+      expect(trainee.hesa_id).to eq(student_attributes[:hesa_id])
+      expect(trainee.first_names).to eq(student_attributes[:first_names])
+      expect(trainee.last_name).to eq(student_attributes[:last_name])
+      expect(trainee.address_line_one).to eq(student_attributes[:address_line_one])
+      expect(trainee.address_line_two).to eq(student_attributes[:address_line_two])
+      expect(trainee.email).to eq(student_attributes[:email])
+      expect(trainee.date_of_birth).to eq(Date.parse(student_attributes[:date_of_birth]))
+      expect(trainee.gender).to eq("female")
+      expect(trainee.trainee_id).to eq(student_attributes[:trainee_id])
+      expect(trainee.nationalities.pluck(:name)).to include(nationality_name)
+      expect(trainee.trn).to eq(student_attributes[:trn])
     end
 
     context "trainee doesn't exist" do
-      before do
-        create(:provider, ukprn: itt_record_xml_attributes[:ukprn])
-        described_class.call(student_node: student_node)
+      describe "#created_from_hesa" do
+        subject { trainee.created_from_hesa }
+
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    context "trainee already exists and didn't come from HESA" do
+      let(:create_custom_state) { create(:trainee, hesa_id: student_attributes[:hesa_id]) }
+
+      describe "#created_from_hesa" do
+        subject { trainee.created_from_hesa }
+
+        it { is_expected.to eq(false) }
       end
 
-      it "creates the trainee from HESA XML document" do
-        expect(trainee.created_from_hesa).to be(true)
-        expect(trainee.training_route).to eq(training_route)
-        expect(trainee.hesa_id).to eq(itt_record_xml_attributes[:hesa_id])
-        expect(trainee.first_names).to eq(itt_record_xml_attributes[:first_names])
-        expect(trainee.last_name).to eq(itt_record_xml_attributes[:last_name])
-        expect(trainee.address_line_one).to eq(itt_record_xml_attributes[:address_line_one])
-        expect(trainee.address_line_two).to eq(itt_record_xml_attributes[:address_line_two])
-        expect(trainee.email).to eq(itt_record_xml_attributes[:email])
-        expect(trainee.date_of_birth).to eq(Date.parse(itt_record_xml_attributes[:date_of_birth]))
-        expect(trainee.gender).to eq("female")
-        expect(trainee.trainee_id).to eq(itt_record_xml_attributes[:trainee_id])
-        expect(trainee.nationalities.pluck(:name)).to include(nationality_name)
-        expect(trainee.trn).to eq(itt_record_xml_attributes[:trn])
+      context "when ethnicity is missing" do
+        let(:hesa_stub_attributes) { { ethnic_background: nil } }
+
+        it "sets the ethnic_group and background to 'Not provided'" do
+          expect(trainee.ethnic_group).to eq(Diversities::ETHNIC_GROUP_ENUMS[:not_provided])
+          expect(trainee.ethnic_background).to eq(Diversities::NOT_PROVIDED)
+        end
+      end
+
+      context "when ethnicity is explicitly 'not provided'" do
+        let(:hesa_stub_attributes) do
+          { ethnic_background: hesa_disability_codes[Diversities::NOT_PROVIDED] }
+        end
+
+        it "sets the ethnic_group and background to 'Not provided'" do
+          expect(trainee.ethnic_group).to eq(Diversities::ETHNIC_GROUP_ENUMS[:not_provided])
+          expect(trainee.ethnic_background).to eq(Diversities::NOT_PROVIDED)
+        end
+      end
+
+      context "when neither ethnicity nor disabilities are disclosed" do
+        let(:hesa_stub_attributes) do
+          {
+            ethnic_background: hesa_disability_codes[Diversities::INFORMATION_REFUSED],
+            disability: nil,
+          }
+        end
+
+        it "sets the diversity disclosure to 'diversity_not_disclosed'" do
+          expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed])
+        end
+      end
+
+      context "when just disability is disclosed" do
+        let(:hesa_stub_attributes) do
+          {
+            ethnic_background: hesa_ethnicity_codes[Diversities::INFORMATION_REFUSED],
+            disability: hesa_disability_codes[Diversities::LEARNING_DIFFICULTY],
+          }
+        end
+
+        it "sets the diversity disclosure to 'diversity_disclosed'" do
+          expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed])
+        end
+      end
+
+      context "when disability is 'MULTIPLE_DISABILITIES'" do
+        let(:trainee_disability) { trainee.trainee_disabilities.last }
+        let(:create_custom_state) { create(:disability, name: Diversities::OTHER) }
+        let(:hesa_stub_attributes) do
+          {
+            ethnic_background: hesa_ethnicity_codes[Diversities::INFORMATION_REFUSED],
+            disability: hesa_disability_codes[Diversities::MULTIPLE_DISABILITIES],
+          }
+        end
+
+        it "saves the disability as 'other' and sets the additional_diversity text" do
+          expect(trainee_disability.additional_disability).to eq(Trainees::CreateFromHesa::MULTIPLE_DISABILITIES_TEXT)
+          expect(trainee_disability.disability.name).to eq(Diversities::OTHER)
+        end
+      end
+
+      context "when just ethnicity is disclosed" do
+        let(:hesa_stub_attributes) { { ethnic_background: hesa_ethnicity_codes[Diversities::AFRICAN] } }
+
+        it "sets the diversity disclosure to 'diversity_disclosed'" do
+          expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed])
+        end
+      end
+
+      context "when ethnicity is information_refused" do
+        let(:hesa_stub_attributes) { { ethnic_background: hesa_ethnicity_codes[Diversities::INFORMATION_REFUSED] } }
+
+        it "sets the ethnic_group to 'Not provided'" do
+          expect(trainee.ethnic_group).to eq(Diversities::ETHNIC_GROUP_ENUMS[:not_provided])
+        end
       end
     end
   end

--- a/spec/support/api_stubs/hesa_api.rb
+++ b/spec/support/api_stubs/hesa_api.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module ApiStubs
+  class HesaApi
+    TAG_MAP = {
+      first_names: "F_FNAMES",
+      last_name: "F_PSURNAME",
+      email: "F_NQTEMAIL",
+      date_of_birth: "F_BIRTHDTE",
+      ethnic_background: "F_ETHNIC",
+      gender: "F_SEXID",
+      ukprn: "F_UKPRN",
+      trainee_id: "F_OWNSTU",
+      course_subject_one: "F_SBJCA1",
+      course_subject_two: "F_SBJCA2",
+      course_subject_three: "F_SBJCA3",
+      itt_start_date: "F_PGAPPSTDT",
+      employing_school_id: "F_SDEMPLOY",
+      lead_school_id: "F_SDLEAD",
+      withdraw_reason: "F_RSNEND",
+      study_mode: "F_MODE",
+      course_min_age: "F_ITTPHSC",
+      commencement_date: "F_ITTCOMDATE",
+      training_initiative: "F_INITIATIVES1",
+      hesa_id: "F_HUSID",
+      applying_for_bursary: "F_FUNDCODE",
+      international_address: "F_DOMICILE",
+      withdraw_date: "F_ENDDATE",
+      disability: "F_DISABLE",
+      bursary_tier: "F_BURSLEV",
+      trn: "F_TREFNO",
+      training_route: "F_ENTRYRTE",
+      nationality: "F_NATION",
+    }.freeze
+
+    attr_reader :attributes, :student_node, :student_attributes
+
+    def initialize(attributes = {})
+      @attributes = attributes
+      xml_doc = Nokogiri::XML(read_fixture_file("hesa/itt_record.xml"))
+      @student_node = override_node_tags(xml_doc.xpath("//ITTRecord/Student").first)
+      @student_attributes = Hesa::Parsers::IttRecord.to_attributes(student_node: student_node)
+    end
+
+  private
+
+    def override_node_tags(student_node)
+      attributes.each do |key, value|
+        value = "NULL" if value.nil?
+        student_node.xpath("//#{TAG_MAP[key]}").first.content = value
+      end
+      student_node
+    end
+
+    def read_fixture_file(filename)
+      File.read(fixture_file_path(filename))
+    end
+
+    def fixture_file_path(filename)
+      Rails.root.join("spec/support/fixtures/#{filename}").to_s
+    end
+  end
+end

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-def fixture_file_path(filename)
-  Rails.root.join("spec/support/fixtures/#{filename}").to_s
-end
-
-def read_fixture_file(filename)
-  File.read(fixture_file_path(filename))
-end


### PR DESCRIPTION
### Context
https://trello.com/c/8SisYLpY/3657-hesa-map-ethnicity-and-disability-attributes

### Changes proposed in this pull request
- Extended `Trainees::CreateFromHesa` to extract and save ethnicity and disability data from the HESA XML
- Mapped HESA codes for ethnicities and disabilities
- New HESA stub API object to help with testing
- Extracted common diversity code between `Trainees::CreateFromHesa` and `Trainees::CreateFromDttp` into a module to get around Sonar's duplicated code warnings
- Changed `Hesa::Parsers::IttRecord` to accept a student node instead of the root node. The background job will loop through the student nodes and pass then to `Trainees::CreateFromHesa` 

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
