### PR TITLE
[3456] Draft records last updated sort is inaccurate

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -43,7 +43,7 @@ module ApplicationRecordCard
     end
 
     def last_updated_date
-      return record.updated_at || record.created_at if record.draft?
+      return record.updated_at if record.draft?
 
       record.timeline&.first&.date.presence || record.updated_at
     end

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -36,11 +36,16 @@ module ApplicationRecordCard
     end
 
     def updated_at
-      date_stamp = record.timeline&.first&.date.presence || record.created_at
-      date_text = tag.span(date_stamp.strftime("%-d %B %Y"))
+      date_text = tag.span(last_updated_date.strftime("%-d %B %Y"))
       class_list = "govuk-caption-m govuk-!-font-size-16 govuk-!-margin-top-2 govuk-!-margin-bottom-0 application-record-card__submitted"
 
       sanitize(tag.p(date_text.prepend("Updated: "), class: class_list))
+    end
+
+    def last_updated_date
+      return record.updated_at || record.created_at if record.draft?
+
+      record.timeline&.first&.date.presence || record.updated_at
     end
 
     def trainee_id

--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -96,7 +96,8 @@ private
   end
 
   def paginated_trainees
-    @paginated_trainees ||= filtered_trainees.ordered_by_drafts_then_by(field).page(params[:page] || 1)
+    @paginated_trainees ||= filtered_trainees.public_send("ordered_by_#{field}")
+                                             .page(params[:page] || 1)
   end
 
   def filters

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -104,10 +104,6 @@ private
     @trainee ||= Trainee.from_param(params[:id])
   end
 
-  def ordered_trainees
-    policy_scope(Trainee.includes(provider: [:courses]).ordered_by_drafts_then_by(field))
-  end
-
   def trainee_params
     params.fetch(:trainee, {}).permit(:training_route)
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -160,15 +160,8 @@ class Trainee < ApplicationRecord
                   against: %i[first_names middle_names last_name trainee_id trn],
                   using: { tsearch: { prefix: true } }
 
-  scope :ordered_by_drafts_then_by, (lambda do |field|
-    ordered_by_drafts.public_send("ordered_by_#{field}")
-  end)
-
   scope :ordered_by_updated_at, -> { order(updated_at: :desc) }
   scope :ordered_by_last_name, -> { order(last_name: :asc) }
-
-  # NOTE: Returns draft trainees first, then all trainees in any other state.
-  scope :ordered_by_drafts, -> { order(ordered_by_drafts_clause) }
 
   # NOTE: Enforce subquery to remove duplications and allow for chain-ability.
   scope :with_subject_or_allocation_subject, (lambda do |subject|
@@ -238,15 +231,6 @@ class Trainee < ApplicationRecord
 
   def sha
     Digest::SHA1.hexdigest(value_digest)
-  end
-
-  def self.ordered_by_drafts_clause
-    Arel.sql(<<~SQL)
-      CASE trainees.state
-      WHEN #{states.fetch('draft')} THEN 0
-      ELSE 1
-      END
-    SQL
   end
 
   def self.join_allocation_subjects_clause

--- a/spec/components/application_record_card/view_preview.rb
+++ b/spec/components/application_record_card/view_preview.rb
@@ -17,7 +17,7 @@ module ApplicationRecordCard
       end
 
       define_method "single_card_with_incomplete_data#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: Trainee.new(id: 1, created_at: Time.zone.now, provider: mock_provider), system_admin: system_admin))
+        render(ApplicationRecordCard::View.new(record: Trainee.new(id: 1, updated_at: Time.zone.now, provider: mock_provider), system_admin: system_admin))
       end
 
       define_method "single_card_with_two_subjects#{suffice}" do
@@ -34,7 +34,7 @@ module ApplicationRecordCard
     def mock_trainee
       Trainee.new(
         id: 1,
-        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
         first_names: "Tom",
         last_name: "Jones",
         training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
@@ -46,7 +46,7 @@ module ApplicationRecordCard
     def mock_trainee_with_trn_and_trainee_id
       Trainee.new(
         id: 1,
-        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
         first_names: "Tom",
         last_name: "Jones",
         training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
@@ -60,7 +60,7 @@ module ApplicationRecordCard
     def mock_trainee_with_two_subjects
       Trainee.new(
         id: 1,
-        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
         first_names: "Tom",
         last_name: "Jones",
         training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
@@ -73,7 +73,7 @@ module ApplicationRecordCard
     def mock_trainee_with_three_subjects
       Trainee.new(
         id: 1,
-        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
         first_names: "Tom",
         last_name: "Jones",
         training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
@@ -86,11 +86,11 @@ module ApplicationRecordCard
 
     def mock_multiple_trainees
       [
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Primary", course_subject_two: "Mathematics", course_subject_three: "Latin", provider: mock_provider),
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Paddington", last_name: "Bear", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Science", course_subject_two: "Mathematics", provider: mock_provider),
-        Trainee.new(id: 1, created_at: Time.zone.now, provider: mock_provider),
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Tim", last_name: "Knight", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Maths", provider: mock_provider),
-        Trainee.new(id: 1, created_at: Time.zone.now, first_names: "Toby", last_name: "Rocker", provider: mock_provider),
+        Trainee.new(id: 1, updated_at: Time.zone.now, first_names: "Tom", last_name: "Jones", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Primary", course_subject_two: "Mathematics", course_subject_three: "Latin", provider: mock_provider),
+        Trainee.new(id: 1, updated_at: Time.zone.now, first_names: "Paddington", last_name: "Bear", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Science", course_subject_two: "Mathematics", provider: mock_provider),
+        Trainee.new(id: 1, updated_at: Time.zone.now, provider: mock_provider),
+        Trainee.new(id: 1, updated_at: Time.zone.now, first_names: "Tim", last_name: "Knight", training_route: TRAINING_ROUTE_ENUMS[:assessment_only], course_subject_one: "Maths", provider: mock_provider),
+        Trainee.new(id: 1, updated_at: Time.zone.now, first_names: "Toby", last_name: "Rocker", provider: mock_provider),
       ]
     end
 

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -101,6 +101,8 @@ module ApplicationRecordCard
     end
 
     context "when a trainee with all their details filled in" do
+      let(:state) { "draft" }
+
       let(:trainee) do
         Timecop.freeze(Time.zone.local(2020, 1, 1)) do
           build(
@@ -114,6 +116,7 @@ module ApplicationRecordCard
             created_at: Time.zone.now,
             trn: "789456",
             provider: provider,
+            state: state,
           )
         end
       end
@@ -144,10 +147,6 @@ module ApplicationRecordCard
         expect(rendered_component).to have_text("TRN: 789456")
       end
 
-      it "renders updated at" do
-        expect(rendered_component).to have_text("Updated: #{Time.zone.now.strftime('%-d %B %Y')}")
-      end
-
       it "renders trainee name" do
         expect(rendered_component).to have_text("Teddy Smith")
       end
@@ -158,6 +157,22 @@ module ApplicationRecordCard
 
       it "renders route if there is no route" do
         expect(rendered_component).to have_text(t("activerecord.attributes.trainee.training_routes.assessment_only"))
+      end
+
+      describe "rendering updated at" do
+        context "when the trainee is in draft" do
+          it "renders updated at from the model" do
+            expect(rendered_component).to have_text("Updated: #{trainee.created_at.strftime('%-d %B %Y')}")
+          end
+        end
+
+        context "when the trainee is not draft" do
+          let(:state) { "trn_received" }
+
+          it "renders updated at from the timeline" do
+            expect(rendered_component).to have_text("Updated: #{Time.zone.now.strftime('%-d %B %Y')}")
+          end
+        end
       end
     end
   end

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -6,8 +6,8 @@ module ApplicationRecordCard
   describe View do
     let(:provider) { create(:provider, :with_courses) }
     let(:course) { provider.courses.first }
-    let(:trainee) { Trainee.new(created_at: Time.zone.now, course_uuid: course.uuid, provider: provider) }
     let(:system_admin) { false }
+    let(:trainee) { create(:trainee, first_names: nil, provider: provider, course_uuid: course.uuid, trainee_id: nil) }
 
     before do
       allow(trainee).to receive(:timeline).and_return([double(date: Time.zone.now)])
@@ -33,20 +33,12 @@ module ApplicationRecordCard
     end
 
     context "when the Trainee has no subject" do
-      let(:trainee) do
-        create(:trainee, provider: provider, course_uuid: course.uuid)
-      end
-
-      before do
-        trainee
-      end
-
       it "renders the course name" do
         expect(rendered_component).to have_text(course.name)
       end
 
       context "and is an Early Years trainee" do
-        let(:trainee) { Trainee.new(created_at: Time.zone.now, training_route: TRAINING_ROUTE_ENUMS[:early_years_undergrad]) }
+        let(:trainee) { create(:trainee, :early_years_undergrad) }
 
         it "renders 'Early years teaching'" do
           expect(rendered_component).to have_text("Early years teaching")
@@ -55,6 +47,8 @@ module ApplicationRecordCard
     end
 
     context "when the Trainee has no route" do
+      let(:trainee) { build(:trainee, training_route: nil, updated_at: Time.zone.now) }
+
       it "renders 'No route provided'" do
         expect(rendered_component).to have_text("No route provided")
       end
@@ -83,7 +77,7 @@ module ApplicationRecordCard
         { state: :withdrawn, colour: "red", text: "withdrawn" },
       ].each do |state_expectation|
         context "when state is #{state_expectation[:state]}" do
-          let(:trainee) { build(:trainee, state_expectation[:state], training_route: TRAINING_ROUTE_ENUMS[:assessment_only], created_at: Time.zone.now) }
+          let(:trainee) { create(:trainee, state_expectation[:state], training_route: TRAINING_ROUTE_ENUMS[:assessment_only]) }
 
           it "renders '#{state_expectation[:text]}'" do
             expect(rendered_component).to have_selector(".govuk-tag", text: state_expectation[:text])
@@ -102,26 +96,20 @@ module ApplicationRecordCard
 
     context "when a trainee with all their details filled in" do
       let(:state) { "draft" }
-
-      let(:trainee) do
-        Timecop.freeze(Time.zone.local(2020, 1, 1)) do
-          build(
-            :trainee,
-            id: 1,
-            first_names: "Teddy",
-            last_name: "Smith",
-            course_subject_one: "Designer",
-            training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
-            trainee_id: "132456",
-            created_at: Time.zone.now,
-            trn: "789456",
-            provider: provider,
-            state: state,
-          )
-        end
-      end
-
       let(:system_admin) { false }
+      let(:trainee) do
+        create(
+          :trainee,
+          first_names: "Teddy",
+          last_name: "Smith",
+          course_subject_one: "Design",
+          training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
+          trainee_id: "132456",
+          trn: "789456",
+          provider: provider,
+          state: state,
+        )
+      end
 
       before do
         render_inline(described_class.new(record: trainee, system_admin: system_admin))
@@ -152,10 +140,10 @@ module ApplicationRecordCard
       end
 
       it "renders subject" do
-        expect(rendered_component).to have_text("Designer")
+        expect(rendered_component).to have_text("Design")
       end
 
-      it "renders route if there is no route" do
+      it "renders route" do
         expect(rendered_component).to have_text(t("activerecord.attributes.trainee.training_routes.assessment_only"))
       end
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -465,59 +465,6 @@ describe Trainee do
         expect(Trainee.ordered_by_last_name).to eq(expected_order)
       end
     end
-
-    describe "#ordered_by_drafts" do
-      let(:expected_order) do
-        [
-          draft_trainee_c,
-          draft_trainee_d,
-          deferred_trainee_a,
-          submitted_for_trn_trainee_b,
-        ]
-      end
-
-      it "orders the trainees by drafts first, then any other state" do
-        expect(save_trainees).not_to eq(expected_order)
-
-        expect(Trainee.ordered_by_drafts.first(2)).to match_array([draft_trainee_d, draft_trainee_c])
-      end
-    end
-
-    describe "#ordered_by_drafts_then_by" do
-      context "last_name field" do
-        let(:expected_order) do
-          [
-            draft_trainee_d,
-            draft_trainee_c,
-            submitted_for_trn_trainee_b,
-            deferred_trainee_a,
-          ]
-        end
-
-        it "orders the trainees by drafts first, then any other state, then by last_name" do
-          expect(save_trainees).not_to eq(expected_order)
-
-          expect(Trainee.ordered_by_drafts_then_by(:last_name)).to eq(expected_order)
-        end
-      end
-
-      context "updated_at field" do
-        let(:expected_order) do
-          [
-            draft_trainee_c,
-            draft_trainee_d,
-            submitted_for_trn_trainee_b,
-            deferred_trainee_a,
-          ]
-        end
-
-        it "orders the trainees by drafts first, then any other state, then by updated_at" do
-          expect(save_trainees).not_to eq(expected_order)
-
-          expect(Trainee.ordered_by_drafts_then_by(:updated_at)).to eq(expected_order)
-        end
-      end
-    end
   end
 
   describe "#with_subject_or_allocation_subject" do


### PR DESCRIPTION
### Context

https://trello.com/c/TURjhLuH/3456-draft-records-last-updated-sort-is-inaccurate

### Changes proposed in this pull request

It _looked_ like the drafts weren't being ordered by last updated it.
They actually were. It was the 'Updated' timestamp on the trainee row that was wrong.
We decided to use the last entry on the timeline for this date so as not to confuse users with 'behind the scenes updates'.
But for draft trainees we don't _show_ any timeline events! So this date was always showing created_at, regardless of updates.

This PR:
- Uses the `updated_at` for drafts rather than the (empty) timeline
- Removes method `ordered_by_drafts_then_by` - relic from when drafts and registered were on same page
- Removes method `ordered_by_drafts` - as above
- Removes method `ordered_by_drafts_clause` - as above
- Removes unused method `ordered_trainees`
- Tidies up `application_record_card/view_spec.rb` to use factories and traits

### Guidance to review

- View the draft trainees
- Make a change to a trainee (not the first one)
- Save it and see that this is now first in the list AND the updated at is reflected on the card

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
