### PR TITLE
[3618] Users not prevented from starting funding section as they should be

### DIFF
--- a/app/lib/funding_manager.rb
+++ b/app/lib/funding_manager.rb
@@ -49,9 +49,8 @@ class FundingManager
   end
 
   def funding_available?
-    funding_methods = academic_cycle.nil? ? FundingMethod.all : academic_cycle.funding_methods
-
-    Rails.cache.fetch("FundingManager.funding_available?/#{training_route}", expires_in: 1.day) do
+    Rails.cache.fetch("FundingManager.funding_available?/#{training_route}/#{academic_cycle&.id}", expires_in: 1.day) do
+      funding_methods = academic_cycle.nil? ? FundingMethod.all : academic_cycle.funding_methods
       funding_methods.includes(:funding_method_subjects)
                     .where.not(funding_method_subjects: { id: nil })
                     .where(training_route: training_route).present?

--- a/app/lib/funding_manager.rb
+++ b/app/lib/funding_manager.rb
@@ -49,10 +49,10 @@ class FundingManager
   end
 
   def funding_available?
-    return false if academic_cycle.nil?
+    funding_methods = academic_cycle.nil? ? FundingMethod.all : academic_cycle.funding_methods
 
     Rails.cache.fetch("FundingManager.funding_available?/#{training_route}", expires_in: 1.day) do
-      academic_cycle.funding_methods.includes(:funding_method_subjects)
+      funding_methods.includes(:funding_method_subjects)
                     .where.not(funding_method_subjects: { id: nil })
                     .where(training_route: training_route).present?
     end

--- a/spec/lib/funding_manager_spec.rb
+++ b/spec/lib/funding_manager_spec.rb
@@ -166,6 +166,38 @@ describe FundingManager do
         end
       end
     end
+
+    context "when academic year is nil for trainee" do
+      let(:trainee_without_start_dates) { create(:trainee) }
+      let(:route) { trainee_without_start_dates.training_route }
+      let(:subject_specialism) { create(:subject_specialism) }
+      let(:academic_cycle) { create(:academic_cycle, previous_cycle: true) }
+      let(:funding_manager) { described_class.new(trainee_without_start_dates) }
+
+      before do
+        create(:funding_method_subject, funding_method: funding_method, allocation_subject: subject_specialism.allocation_subject)
+      end
+
+      context "and the route is funded in a another academic year" do
+        let(:funding_method) { create(:funding_method, training_route: route, academic_cycle: academic_cycle) }
+
+        it "returns true" do
+          expect(subject).to be_truthy
+        end
+      end
+
+      TRAINING_ROUTE_ENUMS.keys.reject { |x| x == :assessment_only }.map do |route|
+        let(:training_route) { route }
+
+        context "and the route is not funded in another academic year" do
+          let(:funding_method) { create(:funding_method, training_route: training_route, academic_cycle: academic_cycle) }
+
+          it "returns false" do
+            expect(subject).to be_falsey
+          end
+        end
+      end
+    end
   end
 
   describe "#can_apply_for_bursary?" do


### PR DESCRIPTION
### Context

We use academic cycle to determine whether funding should be available for a trainee. 

If there is no academic cycle for that trainee (because they don't have a start date yet), we aren't correctly restricting entering funding information before course information on the view. This means they can incorrectly complete their funding section without having course details added.

This PR relaxes the `funding_available?` check by allowing us to look for existing funding methods for the relevant route for other academic years, when `academic_year` is nil. This means we can restrict the entry of funding information better on the UI, which looks for `funding_available?` to be true and `trainee.course_subject_one.blank?` in order to work.

### Changes proposed in this pull request

- Update `funding_available?` to look through all previous funding methods when academic_year is nil and return true if any exist

### Guidance to review

Log in as Provider A

Bug repo steps:
- In the review app, start to create a new trainee
- Select 'provider led postgrad' and continue
- Observe the Funding section has no link and has status 'Cannot start yet'
- Complete course details section adding Maths as the course
- Observe Funding section can now be started and has status 'Incomplete'
- Complete funding section, observe that you see the bursary page, select yes for bursary
- Observe success

For assessment-only:
- In the review app, start to create a new trainee
- Select 'assessment only' and continue
- Observe Funding section can be completed without course details added and has status 'Incomplete
- Complete funding section, observe that you do not see the bursary page and only see the training initiative options
- Observe success

### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
