### PR TITLE
[3636] Scheduled task to retrieve HESA data

### DIFF
--- a/app/jobs/hesa/retrieve_collection_job.rb
+++ b/app/jobs/hesa/retrieve_collection_job.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Hesa
+  class RetrieveCollectionJob < ApplicationJob
+    def perform
+      return unless FeatureService.enabled?(:sync_from_hesa)
+
+      request_time = Time.zone.now
+      xml_response = Hesa::Client.get(url: url)
+
+      # TODO: when we try to import the trainees we're going to mark
+      # the collection success/failure and include any failure in the subsequent run of this job
+      # This will prevent a failure here e.g. an error repsonse from incrementing the
+      # date and skipping a portion of the updates
+
+      HesaCollectionRequest.create(
+        requested_at: request_time,
+        collection_reference: collection_reference,
+        updates_since: updates_since,
+        response_body: xml_response,
+      )
+    end
+
+    def url
+      "#{base_url}#{collection_reference}/#{updates_since}"
+    end
+
+    def collection_reference
+      Settings.hesa.current_collection_reference
+    end
+
+    def base_url
+      Settings.hesa.collection_base_url
+    end
+
+    def updates_since
+      @updates_since ||= HesaCollectionRequest.next_from_date
+    end
+  end
+end

--- a/app/models/hesa_collection_request.rb
+++ b/app/models/hesa_collection_request.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class HesaCollectionRequest < ApplicationRecord
+  class << self
+    def next_from_date
+      current_collection_ref = Settings.hesa.current_collection_reference
+      latest_request = where(collection_reference: current_collection_ref).order(:created_at).last
+
+      return DateTime.parse(Settings.hesa.current_collection_start_date).utc.iso8601 if latest_request.nil?
+
+      latest_request.requested_at.utc.iso8601
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,7 @@ dttp:
 
 hesa:
   auth_url: "https://identity.hesa.ac.uk/Account/RemoteLogOn?ReturnDomain=https://datacollection.hesa.ac.uk&ReturnUrl=%2f"
+  collection_base_url: "https://datacollection.hesa.ac.uk/apis/itt/1.1/CensusData/"
   current_collection_reference: "C22053"
   current_collection_start_date: "2022-04-01"
   username: <get from secrets>
@@ -65,6 +66,7 @@ features:
   filters:
     show_start_year_filter: false
   user_can_have_multiple_organisations: false
+  sync_from_hesa: false
 
 dfe_sign_in:
   # Our service name

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,8 +26,10 @@ dttp:
 
 hesa:
   auth_url: "https://identity.hesa.ac.uk/Account/RemoteLogOn?ReturnDomain=https://datacollection.hesa.ac.uk&ReturnUrl=%2f"
-  username: "email@example.com"
-  password: "1234"
+  current_collection_reference: "C22053"
+  current_collection_start_date: "2022-04-01"
+  username: <get from secrets>
+  password: <get from secrets>
 
 # Used to add feature flags in the app to control access to certain features.
 features:

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -38,3 +38,7 @@ delete_empty_trainees:
   cron: "0 0 * * *"
   class: "DeleteEmptyTraineesJob"
   queue: default
+import_collection_from_hesa:
+  cron: "0 */2 * * *"
+  class: "Hesa::RetrieveCollectionJob"
+  queue: default

--- a/db/migrate/20220214142008_create_hesa_collection_requests.rb
+++ b/db/migrate/20220214142008_create_hesa_collection_requests.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateHesaCollectionRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :hesa_collection_requests do |t|
+      t.string :collection_reference
+      t.datetime :requested_at
+      t.datetime :updates_since
+      t.text :response_body
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_08_155419) do
+ActiveRecord::Schema.define(version: 2022_02_14_142008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -318,6 +318,15 @@ ActiveRecord::Schema.define(version: 2022_02_08_155419) do
     t.integer "funding_type"
     t.bigint "academic_cycle_id"
     t.index ["academic_cycle_id"], name: "index_funding_methods_on_academic_cycle_id"
+  end
+
+  create_table "hesa_collection_requests", force: :cascade do |t|
+    t.string "collection_reference"
+    t.datetime "requested_at"
+    t.datetime "updates_since"
+    t.text "response_body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "lead_school_users", force: :cascade do |t|

--- a/spec/factories/hesa_collection_requests.rb
+++ b/spec/factories/hesa_collection_requests.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :hesa_collection_request
+end

--- a/spec/jobs/hesa/retrieve_collection_job_spec.rb
+++ b/spec/jobs/hesa/retrieve_collection_job_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Hesa
+  describe RetrieveCollectionJob do
+    context "feature flag is off" do
+      before { disable_features :sync_from_hesa }
+
+      it "doesn't create a HesaCollectionRequest" do
+        expect { described_class.new.perform }.not_to change { HesaCollectionRequest.count }
+      end
+
+      it "doesn't call the HESA API" do
+        expect(Hesa::Client).not_to receive(:get)
+        described_class.new.perform
+      end
+    end
+
+    context "feature flag is on" do
+      let(:current_reference) { "C123" }
+      let(:next_date) { DateTime.parse("10/01/2022").utc.iso8601 }
+      let(:expected_url) { "https://datacollection.hesa.ac.uk/apis/itt/1.1/CensusData/#{current_reference}/#{next_date}" }
+      let(:shouty_xml) { "<SHOUTYXML></SHOUTYXML>" }
+
+      before do
+        enable_features :sync_from_hesa
+        allow(Settings.hesa).to receive(:current_collection_reference).and_return("C123")
+        allow(HesaCollectionRequest).to receive(:next_from_date).and_return(next_date)
+        allow(Hesa::Client).to receive(:get).and_return(shouty_xml)
+      end
+
+      it "creates a HesaCollectionRequest" do
+        expect { described_class.new.perform }.to change { HesaCollectionRequest.count }.by(1)
+      end
+
+      it "calls the HESA API" do
+        expect(Hesa::Client).to receive(:get).with(url: expected_url)
+        described_class.new.perform
+      end
+
+      def created_hesa_collection_request
+        described_class.new.perform
+        HesaCollectionRequest.last
+      end
+
+      it "stores the xml" do
+        expect(created_hesa_collection_request.response_body).to eq(shouty_xml)
+      end
+
+      it "stores the requested_at" do
+        Timecop.freeze do
+          expected_time = Time.zone.now
+          expect(created_hesa_collection_request.requested_at.tv_sec).to eq(expected_time.tv_sec)
+        end
+      end
+
+      it "stores updates_since" do
+        expect(created_hesa_collection_request.updates_since).to eq(next_date)
+      end
+    end
+  end
+end

--- a/spec/models/hesa_collection_request_spec.rb
+++ b/spec/models/hesa_collection_request_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe HesaCollectionRequest do
+  describe ".next_from_date" do
+    before do
+      allow(Settings.hesa).to receive(:current_collection_reference).and_return("C123")
+      allow(Settings.hesa).to receive(:current_collection_start_date).and_return("2022-10-01")
+    end
+
+    subject { described_class.next_from_date }
+
+    context "where there is no previous request for the current collection" do
+      it "returns the current collection start date" do
+        expect(subject).to eq(DateTime.parse("2022-10-01").utc.iso8601)
+      end
+    end
+
+    context "where there is a previous request for the current collection" do
+      let!(:previous_request) { create(:hesa_collection_request, collection_reference: "C123", requested_at: "10/01/2022 13:00:00") }
+
+      it "returns the last request run datetime" do
+        expect(subject).to eq(previous_request.requested_at.utc.iso8601)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We want to run two hourly updates from HESA when a collection is open. The update will request XML from the HESA API containing updates since the last request.

### Changes proposed in this pull request

* Add Hesa::RetrieveCollectionJob - this job will request the XML, store it and then pass it into the service(s) currently being built to create or update the trainee. Currently it just requests and stores. [Trello ticket for the next bit](https://trello.com/c/pEaVj82M/3689-hook-up-the-hesaretrievecollectionjob-to-create-update-trainees)
* Add HesaCollectionRequest to log the requests and store the XML. We'll store the raw XML in the DB currently as this is the pattern we've adopted for all other integrations. If it turns out these responses are big we can reconsider.
* Use cron sidekiq to schedule the job to run two hourly
* Add a sync_from_hesa feature flag, currently set to false
* Add config for the collection reference and start date

### Guidance to review

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
