### PR TITLE
[3669] Draft records link and section aren't visible

### DIFF
--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -4,6 +4,11 @@ class DraftsController < BaseTraineeController
   include TraineeHelper
   include ActivityTracker
 
+  def index
+    authorize(current_user, :drafts?)
+    super
+  end
+
 private
 
   def search_path(filter_params = nil)

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -6,4 +6,9 @@ module OrganisationHelper
       current_user.multiple_organisations? &&
       current_user.organisation.present?
   end
+
+  def hide_draft_records?
+    defined?(current_user) && current_user.present? &&
+      current_user.lead_school?
+  end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -8,4 +8,8 @@ class UserPolicy < ProviderPolicy
   def permitted_attributes_for_update
     [:email]
   end
+
+  def drafts?
+    !user.lead_school?
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
       <%= render NavigationBar::View.new(
         items: [
           { name: "Home", url: root_path },
-          { name: "Draft records", url: drafts_path, current: active_link_for("drafts", @trainee) },
+          ({ name: "Draft records", url: drafts_path, current: active_link_for("drafts", @trainee) } unless hide_draft_records?),
           { name: "Registered trainees", url: trainees_path, current: active_link_for("trainees", @trainee) },
           ({ name: current_user.organisation.name, url: organisations_path, align_right: true } if show_organisation_link?),
         ],

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,48 +1,56 @@
 <%= render PageTitle::View.new(i18n_key: "pages.home") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
-    <% if current_user.organisation %>
-      <span class="govuk-caption-l"><%= current_user.organisation.name %></span>
-    <% end %>
-    <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
-    <h2 class="govuk-heading-l"><%= t(".draft_heading") %></h2>
-    <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
-      <% if @home_view.draft_trainees_count > @home_view.draft_apply_trainees_count %>
-        <li>
-          <%= govuk_link_to(
-            t(".draft_trainees_link", count: @home_view.draft_trainees_count),
-            drafts_path,
-            { class: "govuk-link--no-visited-state" }
-          )%>
-        </li>
+<% unless hide_draft_records? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <% if current_user.organisation %>
+        <span class="govuk-caption-l"><%= current_user.organisation.name %></span>
       <% end %>
-      <% if @home_view.draft_apply_trainees_count > 0 %>
-        <li>
-          <%= govuk_link_to(
-            t(".draft_apply_trainees_link", count: @home_view.draft_apply_trainees_count),
-            drafts_path("record_source[]": :apply),
-            { class: "govuk-link--no-visited-state" }
-          )%>
-        </li>
-      <% end %>
-      <% if policy(Trainee).new? %>
-        <li class="govuk-!-margin-bottom-0">
-          <%= govuk_link_to(
-            t(".new_trainee_link"),
-            new_trainee_path,
-            { class: "govuk-link--no-visited-state" }
-          ) %>
-        </li>
-      <% end %>
-    </ul>
+      <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+      <h2 class="govuk-heading-l"><%= t(".draft_heading") %></h2>
+      <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
+        <% if @home_view.draft_trainees_count > @home_view.draft_apply_trainees_count %>
+          <li>
+            <%= govuk_link_to(
+              t(".draft_trainees_link", count: @home_view.draft_trainees_count),
+              drafts_path,
+              { class: "govuk-link--no-visited-state" }
+            )%>
+          </li>
+        <% end %>
+        <% if @home_view.draft_apply_trainees_count > 0 %>
+          <li>
+            <%= govuk_link_to(
+              t(".draft_apply_trainees_link", count: @home_view.draft_apply_trainees_count),
+              drafts_path("record_source[]": :apply),
+              { class: "govuk-link--no-visited-state" }
+            )%>
+          </li>
+        <% end %>
+        <% if policy(Trainee).new? %>
+          <li class="govuk-!-margin-bottom-0">
+            <%= govuk_link_to(
+              t(".new_trainee_link"),
+              new_trainee_path,
+              { class: "govuk-link--no-visited-state" }
+            ) %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
   </div>
-</div>
 
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
+    <% if hide_draft_records? %>
+      <% if current_user.organisation %>
+        <span class="govuk-caption-l"><%= current_user.organisation.name %></span>
+      <% end %>
+      <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+    <% end %>
     <h2 class="govuk-heading-l"><%= t(".registered_heading") %></h2>
     <ul class="govuk-list govuk-list--spaced">
       <% if @home_view.registered_trainees_count > 0 %>

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -15,6 +15,7 @@ features:
     pg_teaching_apprenticeship: true
     provider_led_undergrad: true
     opt_in_undergrad: true
+  user_can_have_multiple_organisations: true
 
 pagination:
   records_per_page: 30

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -32,5 +32,19 @@ describe PagesController, type: :controller do
       expect(session[:requested_path]).to eq "/"
       expect(response).to render_template("home")
     end
+
+    context "lead school user" do
+      render_views
+
+      before do
+        allow(current_user).to receive(:lead_school?).and_return(true)
+      end
+
+      it "renders home page" do
+        get :start
+        expect(response.body).not_to match("Draft records")
+        expect(response.body).not_to match("Draft trainees")
+      end
+    end
   end
 end

--- a/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
+++ b/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
@@ -34,7 +34,7 @@ feature "View trainees" do
     end
   end
 
-  context "when i am a lead school user" do
+  context "when i am a lead school user", feature_user_can_have_multiple_organisations: true do
     let(:trainee) { create(:trainee, :submitted_for_trn, commencement_date: nil, lead_school: @current_user.lead_schools.first) }
 
     background { given_i_am_authenticated_as_a_lead_school_user }

--- a/spec/helpers/organisation_helper_spec.rb
+++ b/spec/helpers/organisation_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe OrganisationHelper do
+  include OrganisationHelper
+
+  describe "#hide_draft_records?" do
+    describe "lead school user" do
+      let(:current_user) { double(UserWithOrganisationContext, lead_school?: true) }
+
+      it "returns true" do
+        expect(hide_draft_records?).to be(true)
+      end
+    end
+
+    describe "non-lead school user" do
+      let(:current_user) { double(UserWithOrganisationContext, lead_school?: false) }
+
+      it "returns false" do
+        expect(hide_draft_records?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe UserPolicy do
+  subject { described_class }
+
+  let(:lead_school) { create(:school, :lead) }
+  let(:provider) { create(:provider) }
+
+  let(:provider_user) { create(:user, providers: [provider]) }
+  let(:provider_user_context) { UserWithOrganisationContext.new(user: provider_user, session: {}) }
+
+  let(:lead_school_user) { create(:user, lead_schools: [lead_school]) }
+  let(:lead_school_user_context) { UserWithOrganisationContext.new(user: lead_school_user, session: {}) }
+
+  before do
+    allow(lead_school_user_context).to receive(:lead_school?).and_return(true)
+  end
+
+  permissions :drafts? do
+    it { is_expected.to permit(provider_user_context) }
+    it { is_expected.not_to permit(lead_school_user_context) }
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/OCdiDgyG/3669-draft-records-link-and-section-arent-visible

### Changes proposed in this pull request

* Helper to hide the link and content on start page
* Updated `UserPolicy` to authorise `drafts#index`

### Guidance to review

* Login with persona Denise Theominis and choose org Western Flatley University
* See start page
* Go directly to `/drafts` as a lead school user, it should error

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
