### PR TITLE
[3670] Hide incomplete badge on registered trainees from lead school users

### DIFF
--- a/app/components/application_record_card/view.html.erb
+++ b/app/components/application_record_card/view.html.erb
@@ -5,7 +5,7 @@
     </h<%= heading_level %>>
 
     <span class="application-record-card__tag-container">
-      <%= render StatusTag::View.new(trainee: record) %>
+      <%= render StatusTag::View.new(trainee: record,  hide_progress_tag: hide_progress_tag) %>
     </span>
   </div>
 

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -8,12 +8,13 @@ module ApplicationRecordCard
 
     with_collection_parameter :record
 
-    attr_reader :record, :heading_level, :system_admin
+    attr_reader :record, :heading_level, :system_admin, :hide_progress_tag
 
-    def initialize(heading_level = 3, record:, system_admin:)
+    def initialize(heading_level = 3, record:, system_admin:, hide_progress_tag: false)
       @record = record
       @heading_level = heading_level
       @system_admin = system_admin
+      @hide_progress_tag = hide_progress_tag
     end
 
     def trainee_name

--- a/app/components/record_header/view.html.erb
+++ b/app/components/record_header/view.html.erb
@@ -11,5 +11,5 @@
     <% end %>
   </div>
 
-  <%= render StatusTag::View.new(trainee: trainee) %>
+  <%= render StatusTag::View.new(trainee: trainee, hide_progress_tag: hide_progress_tag) %>
 </div>

--- a/app/components/record_header/view.rb
+++ b/app/components/record_header/view.rb
@@ -4,10 +4,11 @@ module RecordHeader
   class View < GovukComponent::Base
     include TraineeHelper
 
-    attr_reader :trainee
+    attr_reader :trainee, :hide_progress_tag
 
-    def initialize(trainee:)
+    def initialize(trainee:, hide_progress_tag: false)
       @trainee = trainee
+      @hide_progress_tag = hide_progress_tag
     end
 
     delegate :trn, to: :trainee

--- a/app/components/status_tag/view.rb
+++ b/app/components/status_tag/view.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class StatusTag::View < GovukComponent::Base
-  def initialize(trainee:, classes: "")
+  def initialize(trainee:, classes: "", hide_progress_tag: false)
     super(classes: classes, html_attributes: {})
     @trainee = trainee
+    @hide_progress_tag = hide_progress_tag
   end
 
   def tags
@@ -23,7 +24,7 @@ class StatusTag::View < GovukComponent::Base
 
 private
 
-  attr_accessor :trainee
+  attr_accessor :trainee, :hide_progress_tag
 
   def status_colour
     {
@@ -42,7 +43,8 @@ private
   end
 
   def record_progress_tag
-    return if @trainee.draft? || @trainee.submission_ready? || !@trainee.awaiting_action?
+    return if hide_progress_tag
+    return if trainee.draft? || trainee.submission_ready? || !trainee.awaiting_action?
 
     { status: "incomplete", status_colour: "grey", classes: classes.concat(%w[govuk-tag--white]) }
   end

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -8,7 +8,7 @@
     ) %>
   <% end %>
 
-  <%= render RecordHeader::View.new(trainee: @trainee) %>
+  <%= render RecordHeader::View.new(trainee: @trainee, hide_progress_tag: @current_user.lead_school?) %>
 
   <% if @missing_data_view %>
     <%= render NoticeBanner::View.new do |component| %>

--- a/app/views/trainees/_results.html.erb
+++ b/app/views/trainees/_results.html.erb
@@ -6,7 +6,7 @@
           <h2 class="govuk-heading-m"><%= search_primary_result_title %></h2>
         </div>
       </div>
-      <%= render ApplicationRecordCard::View.with_collection(search_primary_result_set, system_admin: @current_user.system_admin?) %>
+      <%= render ApplicationRecordCard::View.with_collection(search_primary_result_set, system_admin: @current_user.system_admin?, hide_progress_tag: @current_user.lead_school?) %>
     </div>
   <% end %>
 
@@ -19,7 +19,7 @@
           <% end  %>
         </div>
       </div>
-      <%= render ApplicationRecordCard::View.with_collection(search_secondary_result_set, system_admin: @current_user.system_admin?) %>
+      <%= render ApplicationRecordCard::View.with_collection(search_secondary_result_set, system_admin: @current_user.system_admin?, hide_progress_tag: @current_user.lead_school?) %>
     </div>
   <% end %>
 

--- a/spec/components/record_header/view_spec.rb
+++ b/spec/components/record_header/view_spec.rb
@@ -67,7 +67,7 @@ module RecordHeader
 
     describe "status tag" do
       before do
-        allow(StatusTag::View).to receive(:new).with(trainee: trainee).and_return(double(render_in: "liverpool"))
+        allow(StatusTag::View).to receive(:new).with(trainee: trainee, hide_progress_tag: false).and_return(double(render_in: "liverpool"))
         render_inline(described_class.new(trainee: trainee))
       end
 

--- a/spec/components/status_tag/view_spec.rb
+++ b/spec/components/status_tag/view_spec.rb
@@ -46,4 +46,16 @@ RSpec.describe StatusTag::View do
       expect(rendered_component).to have_text("incomplete")
     end
   end
+
+  context "when hide_progress_tag is true" do
+    before do
+      render_inline(described_class.new(trainee: trainee, hide_progress_tag: true))
+    end
+
+    let(:trainee) { build(:trainee, :trn_received, :not_submission_ready) }
+
+    it "does not render the incomplete progress tag" do
+      expect(rendered_component).not_to have_text("incomplete")
+    end
+  end
 end


### PR DESCRIPTION
### Context

When a record is 'incomplete' we label the record in the index and in the titles of various pages.

Users in a lead school context can't 'complete' records so they shouldn't get the 'incomplete' badge anywhere. 

## Success

* Incomplete records aren't labelled for lead school users

### Changes proposed in this pull request

- Add `hide_progress_tag` boolean into relevant components and views in the app to hide the badge from the record card and the record header
- `hide_progress_tag` defaults to false
- `hide_progress_tag` evaluates to true when `current_user.lead_school?` is true

### Guidance to review

- Log into the review app as Denise Theominis
- Make sure you are on the Provider B view (see top right)
- In registered trainees, look for trainee with name 'incomplete trainee'. You will see they have an incomplete badge
- Click on 'Provider B' in top right and switch to lead school account Kreiger Institute
- Go to registered trainees and find 'incomplete trainee', observe there is no incomplete badge
- Click through to the trainee details and observe there is no badge there either
- Check the record to make sure 'incomplete' isn't mentioned anywhere

(note removing incomplete/complete from the filters is in a separate ticket)


### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
