### PR TITLE
[3678] SPIKE DQT API integration

### DIFF
--- a/app/jobs/dqt/register_for_trn_job.rb
+++ b/app/jobs/dqt/register_for_trn_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Dqt
+  class RegisterForTrnJob < ApplicationJob
+    sidekiq_options retry: 0
+    queue_as :default
+
+    def perform(trainee)
+      return unless FeatureService.enabled?(:integrate_with_dqt)
+
+      RegisterForTrn.call(trainee: trainee)
+
+      ChangeTraineeStatusJob.perform_later(
+        trainee,
+        DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED,
+        UpdateTraineeStatus::CONTACT_ENTITY_TYPE,
+      )
+
+      ChangeTraineeStatusJob.perform_later(
+        trainee,
+        DttpStatuses::PROSPECTIVE_TRAINEE_TRN_REQUESTED,
+        UpdateTraineeStatus::PLACEMENT_ASSIGNMENT_ENTITY_TYPE,
+      )
+    end
+  end
+end

--- a/app/jobs/dqt/retrieve_trn_job.rb
+++ b/app/jobs/dqt/retrieve_trn_job.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Dttp
+  class RetrieveTrnJob < ApplicationJob
+    queue_as :default
+    retry_on Client::HttpError
+    include NotifyOnTimeout
+
+    class TraineeAttributeError < StandardError; end
+
+    def perform(trainee, timeout_after = nil)
+      return unless FeatureService.enabled?(:sync_from_dttp)
+
+      @timeout_after = timeout_after
+      @trainee = trainee
+
+      if @timeout_after.nil?
+        self.class.perform_later(trainee, trainee.submitted_for_trn_at + Settings.jobs.max_poll_duration_days.days)
+        return
+      end
+
+      trn = Dttp::RetrieveTrn.call(trainee: trainee)
+
+      if trn
+        trainee.trn_received!(trn)
+      elsif continue_polling?
+        requeue
+      else
+        send_message_to_slack(trainee, self.class.name)
+      end
+    end
+
+    class << self
+      def perform_with_default_delay(trainee)
+        set(wait: Settings.jobs.poll_delay_hours.hours)
+          .perform_later(trainee, Settings.jobs.max_poll_duration_days.days.from_now)
+      end
+    end
+
+  private
+
+    attr_reader :trainee, :timeout_after
+
+    def continue_polling?
+      if trainee.submitted_for_trn_at.nil?
+        raise(TraineeAttributeError, "Trainee#submitted_for_trn_at is nil - it should be timestamped (id: #{trainee.id})")
+      end
+
+      Time.zone.now.utc < timeout_after
+    end
+
+    def requeue
+      self.class.set(wait: Settings.jobs.poll_delay_hours.hours).perform_later(trainee, timeout_after)
+    end
+  end
+end

--- a/app/models/dqt/trn_request.rb
+++ b/app/models/dqt/trn_request.rb
@@ -1,0 +1,5 @@
+module Dqt
+  class TrnRequest < ApplicationRecord
+    enum state: [ :requested, :received ]
+  end
+end

--- a/app/services/dqt/register_for_trn.rb
+++ b/app/services/dqt/register_for_trn.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Dqt
+  class RegisterForTrn
+    include ServicePattern
+
+    attr_reader :trainee
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      return unless FeatureService.enabled?(:integrate_with_dqt)
+
+      submit_trn_request
+      update_trainee
+    end
+
+  private
+
+    def submit_trn_request
+      # https://github.com/DFE-Digital/qualified-teachers-api/blob/main/docs/api-specs/v2.json#L289
+      # put request to ^
+      request_id = SecureRandom.uuid
+      path = "/v2/trn-requests/#{request_id}"
+
+      # with params https://github.com/DFE-Digital/qualified-teachers-api/blob/main/docs/api-specs/v2.json#L503
+
+          # "firstName":
+          # "middleName":
+          # "lastName":
+          # "birthDate": #yyyy-mm-dd
+          # "emailAddress":
+          # "address": { # https://github.com/DFE-Digital/qualified-teachers-api/blob/main/docs/api-specs/v2.json#L547
+          #   "addressLine1":
+          #   "addressLine2":
+          #   "addressLine3":
+          #   "city":
+          #   "postalCode":
+          #   "country":
+          # },
+          # "genderCode": # "Male", "Female", "Other" https://github.com/DFE-Digital/qualified-teachers-api/blob/main/docs/api-specs/v2.json#L483
+          # "initialTeacherTraining": {
+          #   "providerUkprn":
+          #   "programmeStartDate":
+          #   "programmeEndDate":
+          #   "programmeType": # https://github.com/DFE-Digital/qualified-teachers-api/blob/main/docs/api-specs/v2.json#L659
+          #   "subject1":
+          #   "subject2":
+          #   "ageRangeFrom":
+          #   "ageRangeTo":
+          # },
+          # "qualification": { #https://github.com/DFE-Digital/qualified-teachers-api/blob/main/docs/api-specs/v2.json#L621
+          #   "providerUkprn":
+          #   "countryCode":
+          #   "subject":
+          #   "class": #{ https://github.com/DFE-Digital/qualified-teachers-api/blob/main/docs/api-specs/v2.json#L411
+          #   "date":
+          # }
+    end
+
+
+    def update_trainee
+      trainee.trn_requested!(contact_dttp_id, placement_assignment_dttp_id)
+    end
+  end
+end

--- a/app/services/dqt/submit_for_trn.rb
+++ b/app/services/dqt/submit_for_trn.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module Dqt
+  class SubmitForTrn
+    include ServicePattern
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      trainee.submit_for_trn!
+      Dqt::RegisterForTrnJob.perform_later(trainee)
+      Dqt::RetrieveTrnJob.perform_with_default_delay(trainee)
+    end
+
+    private
+
+    attr_reader :trainee, :dttp_id
+  end
+end

--- a/db/migrate/20220217162803_create_trn_requests.rb
+++ b/db/migrate/20220217162803_create_trn_requests.rb
@@ -1,0 +1,13 @@
+class CreateTrnRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :trn_requests do |t|
+      t.references :trainee, null: false, foreign_key: true
+      t.uuid :request_id
+      t.integer :state
+      t.timestamps
+    end
+
+    add_index :trn_requests, :request_id
+    add_index :trn_requests, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_08_155419) do
+ActiveRecord::Schema.define(version: 2022_02_17_162803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -320,6 +320,15 @@ ActiveRecord::Schema.define(version: 2022_02_08_155419) do
     t.index ["academic_cycle_id"], name: "index_funding_methods_on_academic_cycle_id"
   end
 
+  create_table "hesa_collection_requests", force: :cascade do |t|
+    t.string "collection_reference"
+    t.datetime "requested_at"
+    t.datetime "updates_since"
+    t.string "response_body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "lead_school_users", force: :cascade do |t|
     t.bigint "lead_school_id", null: false
     t.bigint "user_id", null: false
@@ -507,6 +516,17 @@ ActiveRecord::Schema.define(version: 2022_02_08_155419) do
     t.index ["training_route"], name: "index_trainees_on_training_route"
   end
 
+  create_table "trn_requests", force: :cascade do |t|
+    t.bigint "trainee_id", null: false
+    t.uuid "request_id"
+    t.integer "state"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["request_id"], name: "index_trn_requests_on_request_id"
+    t.index ["state"], name: "index_trn_requests_on_state"
+    t.index ["trainee_id"], name: "index_trn_requests_on_trainee_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
@@ -552,4 +572,5 @@ ActiveRecord::Schema.define(version: 2022_02_08_155419) do
   add_foreign_key "trainees", "providers"
   add_foreign_key "trainees", "schools", column: "employing_school_id"
   add_foreign_key "trainees", "schools", column: "lead_school_id"
+  add_foreign_key "trn_requests", "trainees"
 end


### PR DESCRIPTION
### Context

We are going to use the DQT API for directly requesting and retrieving TRNs and submitting outcomes.

### Changes proposed in this pull request

Sketching out the bits that we'll need. Very WIP but I think we can pretty much create renamed DQT versions of the services and jobs we have and add parsers and params presenters following the patterns we've already established.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
