### PR TITLE
Update gmp in Dockerfile to fix vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN apk add --update --no-cache --virtual build-dependances \
     rm -rf /usr/local/bundle/cache && \
     apk del build-dependances
 
+# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest gmp
+RUN apk add --no-cache gmp=6.2.1-r1
+
 COPY package.json yarn.lock ./
 RUN  yarn install --frozen-lockfile && \
      yarn cache clean


### PR DESCRIPTION
### Context

SNYK has highlighted vulnerability in gmp 6.2.1-r0 in the base image
This is fixed in 6.2.1-r1

### Changes proposed in this pull request

Change to Dockerfile to update gmp to the new version

### Guidance to review

Check build completes successfully

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
