### PR TITLE
[3601] Update 403/forbidden page content

### DIFF
--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,8 +1,8 @@
 <%= extends_layout :error do %>
   <%= render PageTitle::View.new(i18n_key: "pages.forbidden") %>
 
-  <h1 class="govuk-heading-l">You do not have access to view details for this trainee</h1>
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
 
-  <p class="govuk-body">If you think you should have access, contact: <%= support_email(subject: "Register trainee teachers support") %>.</p>
+  <p class="govuk-body"><%= t(".support_message_html", link: support_email(subject: "Register trainee teachers support")) %></p>
 
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,7 +223,7 @@ en:
         cookie_policy: Cookies on Register trainee teachers
         guidance: Data requirements
         privacy_policy: Privacy Notice for the Register trainee teachers service (Register)
-        forbidden: You do not have access to view details for this trainee
+        forbidden: &forbidden You do not have permission to perform this action
         home: Home
         request_an_account: Request an account
         not_found: Page not found
@@ -823,6 +823,9 @@ en:
       dfe_sign_in_button: Sign in using DfE Sign-in
       persona_sign_in_button: Sign in using Persona
   errors:
+    forbidden:
+      heading: *forbidden
+      support_message_html: "If you think you should have access, contact: %{link}."
     not_found:
       heading: Page not found
       body: Check the web address and try again.


### PR DESCRIPTION
### Context
Update 403 page
![image](https://user-images.githubusercontent.com/910019/155001278-584e9604-cb8a-4447-94b0-5c84c3c58b1c.png)

### Changes proposed in this pull request
Update 403 page title to read "You do not have permission to perform this action" 

### Guidance to review
On the review app, login as a user with Lead School access, and try performing an edit action against a trainee, eg
https://register-pr-2058.london.cloudapps.digital/trainees/sCCpHen2mgh2CFMFnoisFLnW/training-routes/edit
You will be presented with the new forbidden page content

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
