### PR TITLE
[3673] Show provider details if a user is in a lead school context

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -8,12 +8,12 @@ module ApplicationRecordCard
 
     with_collection_parameter :record
 
-    attr_reader :record, :heading_level, :system_admin, :hide_progress_tag
+    attr_reader :record, :heading_level, :show_provider, :hide_progress_tag
 
-    def initialize(heading_level = 3, record:, system_admin:, hide_progress_tag: false)
+    def initialize(heading_level = 3, record:, show_provider: false, hide_progress_tag: false)
       @record = record
       @heading_level = heading_level
-      @system_admin = system_admin
+      @show_provider = show_provider
       @hide_progress_tag = hide_progress_tag
     end
 
@@ -56,7 +56,7 @@ module ApplicationRecordCard
     end
 
     def provider_name
-      return unless system_admin
+      return unless show_provider
 
       tag.p(record.provider.name.to_s, class: "govuk-caption-m govuk-!-font-size-16 application-record-card__provider_name govuk-!-margin-bottom-0 govuk-!-margin-top-2")
     end

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -5,12 +5,12 @@ module RecordDetails
     include SanitizeHelper
     include SummaryHelper
 
-    attr_reader :trainee, :last_updated_event, :not_provided_copy, :system_admin, :editable
+    attr_reader :trainee, :last_updated_event, :not_provided_copy, :show_provider, :editable
 
-    def initialize(trainee:, last_updated_event:, system_admin: false, editable: false)
+    def initialize(trainee:, last_updated_event:, show_provider: false, editable: false)
       @trainee = trainee
       @last_updated_event = last_updated_event
-      @system_admin = system_admin
+      @show_provider = show_provider
       @editable = editable
     end
 
@@ -31,7 +31,7 @@ module RecordDetails
   private
 
     def provider_row
-      return unless system_admin
+      return unless show_provider
 
       { field_label: t(".provider"),
         field_value: trainee.provider.name_and_code }

--- a/app/views/trainees/_results.html.erb
+++ b/app/views/trainees/_results.html.erb
@@ -6,7 +6,11 @@
           <h2 class="govuk-heading-m"><%= search_primary_result_title %></h2>
         </div>
       </div>
-      <%= render ApplicationRecordCard::View.with_collection(search_primary_result_set, system_admin: @current_user.system_admin?, hide_progress_tag: @current_user.lead_school?) %>
+      <%= render ApplicationRecordCard::View.with_collection(
+        search_primary_result_set,
+        hide_progress_tag: @current_user.lead_school?,
+        show_provider: @current_user.system_admin? || @current_user.lead_school?
+        ) %>
     </div>
   <% end %>
 
@@ -19,7 +23,11 @@
           <% end  %>
         </div>
       </div>
-      <%= render ApplicationRecordCard::View.with_collection(search_secondary_result_set, system_admin: @current_user.system_admin?, hide_progress_tag: @current_user.lead_school?) %>
+      <%= render ApplicationRecordCard::View.with_collection(
+        search_secondary_result_set,
+        hide_progress_tag: @current_user.lead_school?,
+        show_provider: @current_user.system_admin? || @current_user.lead_school?
+        ) %>
     </div>
   <% end %>
 

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <div class="record-details">
-  <%= render RecordDetails::View.new(trainee: @trainee, last_updated_event: @trainee.timeline.first, system_admin: @current_user.system_admin?, editable: trainee_editable?) %>
+  <%= render RecordDetails::View.new(trainee: @trainee, last_updated_event: @trainee.timeline.first, show_provider: @current_user.system_admin? || @current_user.lead_school?, editable: trainee_editable?) %>
 </div>
 
 <div class="course-details">

--- a/spec/components/application_record_card/view_preview.rb
+++ b/spec/components/application_record_card/view_preview.rb
@@ -5,27 +5,27 @@ module ApplicationRecordCard
     [true, false].each do |system_admin|
       suffice = system_admin ? "_as_system_admin" : ""
       define_method "single_card#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: mock_trainee, system_admin: system_admin))
+        render(ApplicationRecordCard::View.new(record: mock_trainee, show_provider: system_admin))
       end
 
       define_method "single_card_with_trn_and_trainee_id#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: mock_trainee_with_trn_and_trainee_id, system_admin: system_admin))
+        render(ApplicationRecordCard::View.new(record: mock_trainee_with_trn_and_trainee_id, show_provider: system_admin))
       end
 
       define_method "multiple_cards#{suffice}" do
-        render(ApplicationRecordCard::View.with_collection(mock_multiple_trainees, system_admin: system_admin))
+        render(ApplicationRecordCard::View.with_collection(mock_multiple_trainees, show_provider: system_admin))
       end
 
       define_method "single_card_with_incomplete_data#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: Trainee.new(id: 1, updated_at: Time.zone.now, provider: mock_provider), system_admin: system_admin))
+        render(ApplicationRecordCard::View.new(record: Trainee.new(id: 1, updated_at: Time.zone.now, provider: mock_provider), show_provider: system_admin))
       end
 
       define_method "single_card_with_two_subjects#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: mock_trainee_with_two_subjects, system_admin: system_admin))
+        render(ApplicationRecordCard::View.new(record: mock_trainee_with_two_subjects, show_provider: system_admin))
       end
 
       define_method "single_card_with_three_subjects#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: mock_trainee_with_three_subjects, system_admin: system_admin))
+        render(ApplicationRecordCard::View.new(record: mock_trainee_with_three_subjects, show_provider: system_admin))
       end
     end
 

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -6,20 +6,20 @@ module ApplicationRecordCard
   describe View do
     let(:provider) { create(:provider, :with_courses) }
     let(:course) { provider.courses.first }
-    let(:system_admin) { false }
+    let(:show_provider) { false }
     let(:trainee) { create(:trainee, first_names: nil, provider: provider, course_uuid: course.uuid, trainee_id: nil) }
 
     before do
       allow(trainee).to receive(:timeline).and_return([double(date: Time.zone.now)])
-      render_inline(described_class.new(record: trainee, system_admin: system_admin))
+      render_inline(described_class.new(record: trainee, show_provider: show_provider))
     end
 
     it "does not render provider name" do
       expect(rendered_component).not_to have_selector(".application-record-card__provider_name")
     end
 
-    context "when system admin is true" do
-      let(:system_admin) { true }
+    context "when :show_provider is true" do
+      let(:show_provider) { true }
 
       it "renders provider name" do
         expect(rendered_component).to have_selector(".application-record-card__provider_name", text: provider.name.to_s)
@@ -96,7 +96,7 @@ module ApplicationRecordCard
 
     context "when a trainee with all their details filled in" do
       let(:state) { "draft" }
-      let(:system_admin) { false }
+      let(:show_provider) { false }
       let(:trainee) do
         create(
           :trainee,
@@ -112,15 +112,15 @@ module ApplicationRecordCard
       end
 
       before do
-        render_inline(described_class.new(record: trainee, system_admin: system_admin))
+        render_inline(described_class.new(record: trainee, show_provider: show_provider))
       end
 
       it "does not render provider name" do
         expect(rendered_component).not_to have_selector(".application-record-card__provider_name")
       end
 
-      context "when system admin is true" do
-        let(:system_admin) { true }
+      context "when :show_provider is true" do
+        let(:show_provider) { true }
 
         it "renders provider name" do
           expect(rendered_component).to have_selector(".application-record-card__provider_name", text: provider.name.to_s)

--- a/spec/components/record_details/view_preview.rb
+++ b/spec/components/record_details/view_preview.rb
@@ -18,7 +18,7 @@ module RecordDetails
     end
 
     def as_system_admin
-      render(View.new(trainee: mock_trainee(nil), last_updated_event: last_updated_event, system_admin: true))
+      render(View.new(trainee: mock_trainee(nil), last_updated_event: last_updated_event, show_provider: true))
     end
 
     def with_no_trainee_id

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -15,9 +15,9 @@ module RecordDetails
     let(:trainee_progress) { "trainee-progress" }
     let(:timeline_event) { double(date: Time.zone.today) }
 
-    context "when system admin is true" do
+    context "when :show_provider is true" do
       before do
-        render_inline(View.new(trainee: trainee, last_updated_event: timeline_event, system_admin: true))
+        render_inline(View.new(trainee: trainee, last_updated_event: timeline_event, show_provider: true))
       end
 
       it "renders the provider name and code" do
@@ -25,9 +25,9 @@ module RecordDetails
       end
     end
 
-    context "when system admin is false" do
+    context "when :show_provider is not true" do
       before do
-        render_inline(View.new(trainee: trainee, last_updated_event: timeline_event, system_admin: false))
+        render_inline(View.new(trainee: trainee, last_updated_event: timeline_event))
       end
 
       it "renders the provider name and code" do


### PR DESCRIPTION
### Context

https://trello.com/c/4x8q1sXy/3673-add-accrediting-provider-for-lead-school-users

### Changes proposed in this pull request

In `RecordDetails::View` and `ApplicationRecordCard::View`:
- Re-purposes the `system_admin` boolean to be a `show_provider` boolean since this is what is actually means for the 'dumb' components.
- Sets `show_provider` to true if the user is a system admin, or in a lead school context.

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~