### PR TITLE
Migrate to GitHub container registry

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: dfedigital/register-trainee-teachers
+      DOCKER_IMAGE: ghcr.io/dfe-digital/register-trainee-teachers
 
     steps:
       - name: Checkout
@@ -44,12 +44,13 @@ jobs:
           secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
           key: SNYK_TOKEN
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         if: github.actor != 'dependabot[bot]'
-        uses: docker/login-action@v1.9.0
+        uses: docker/login-action@v1.12.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker Image
         uses: docker/build-push-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: dfedigital/register-trainee-teachers
+      DOCKER_IMAGE: ghcr.io/dfe-digital/register-trainee-teachers
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
       DB_HOSTNAME: localhost
@@ -36,12 +36,13 @@ jobs:
         echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
         echo "IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
-    - name: Login to DockerHub
+    - name: Login to GitHub Container Registry
       if: github.actor != 'dependabot[bot]'
-      uses: docker/login-action@v1.9.0
+      uses: docker/login-action@v1.12.0
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build Docker Image
       uses: docker/build-push-action@v2

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ destroy: terraform-init
 
 terraform-init:
 	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=main))
-	$(eval export TF_VAR_paas_app_docker_image=dfedigital/register-trainee-teachers:$(IMAGE_TAG))
+	$(eval export TF_VAR_paas_app_docker_image=ghcr.io/dfe-digital/register-trainee-teachers:$(IMAGE_TAG))
 	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
 	$(eval export TF_VAR_paas_sso_passcode=$(PASSCODE))
 	az account set -s $(AZ_SUBSCRIPTION) && az account show \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     build:
       context: .
       cache_from:
-        - dfedigital/register-trainee-teachers:${IMAGE_TAG:-main}
-    image: dfedigital/register-trainee-teachers:${IMAGE_TAG:-main}
+        - ghcr.io/dfe-digital/register-trainee-teachers:${IMAGE_TAG:-main}
+    image: ghcr.io/dfe-digital/register-trainee-teachers:${IMAGE_TAG:-main}
     command: ash -c "bundle exec rails server -p 3001 -b '0.0.0.0'"
     ports:
       - 3001:3001
@@ -31,7 +31,7 @@ services:
       - REDIS_URL=redis://redis:6379
 
   bg-jobs:
-    image: dfedigital/register-trainee-teachers:${IMAGE_TAG:-main}
+    image: ghcr.io/dfe-digital/register-trainee-teachers:${IMAGE_TAG:-main}
     command: bundle exec sidekiq -c 5 -C config/sidekiq.yml
     depends_on:
       - web

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -50,7 +50,6 @@ resource cloudfoundry_app web_app {
   strategy                   = "blue-green-v2"
   timeout                    = var.app_start_timeout
   environment                = local.app_environment
-  docker_credentials         = var.docker_credentials
 
   dynamic "routes" {
     for_each = local.web_app_routes
@@ -82,7 +81,6 @@ resource cloudfoundry_app worker_app {
   strategy           = "blue-green-v2"
   timeout            = var.app_start_timeout
   environment        = local.app_environment
-  docker_credentials = var.docker_credentials
   stopped            = var.worker_app_stopped
 
   service_binding {

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -24,8 +24,6 @@ variable worker_app_memory { default = 512 }
 
 variable log_url {}
 
-variable docker_credentials { type = map }
-
 variable app_secrets_variable { type = map } #secrets from yml file
 
 variable app_config_variable { type = map } #from yml file

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -57,7 +57,6 @@ module paas {
   worker_app_instances  = var.paas_worker_app_instances
   worker_app_memory     = var.paas_worker_app_memory
   log_url               = local.infra_secrets.LOGSTASH_URL
-  docker_credentials    = local.docker_credentials
   app_secrets_variable  = local.app_secrets
   app_config_variable   = local.app_config
   worker_app_stopped    = var.paas_worker_app_stopped

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -51,10 +51,6 @@ locals {
   app_secrets   = yamldecode(data.azurerm_key_vault_secret.app_secrets.value)
   infra_secrets = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
   app_config    = yamldecode(file(var.paas_app_config_file))[var.env_config]
-  docker_credentials = {
-    username = local.infra_secrets.DOCKERHUB_USERNAME
-    password = local.infra_secrets.DOCKERHUB_PASSWORD
-  }
 
   azure_credentials = try(jsondecode(var.azure_credentials), null)
 }


### PR DESCRIPTION
### Context
Containers for this repo are currently published to Dockerhub. Publishing images to GitHub container registry is simpler and more secure.

### Changes proposed in this pull request
This commit migrates workflows from Dockerhub to the GitHub Container Packages registry.

### Guidance to review
- Confirm that image is being published as a GitHub Container Package
- Confirm that deployment is using the correct GitHub Container Package

### Trello card
https://trello.com/c/wVT0QcJ4

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
