### PR TITLE
[3708] Add Dqt::Params::TrnRequest params presenter

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Dqt
+  module Params
+    class TrnRequest
+      UNITED_KINGDOM = "United Kingdom"
+
+      GENDER_CODES = {
+        male: "Male",
+        female: "Female",
+        other: "Other",
+        gender_not_provided: "Other",
+      }.freeze
+
+      PROGRAMME_TYPE = {
+        TRAINING_ROUTE_ENUMS[:assessment_only] => "AssessmentOnlyRoute",
+        TRAINING_ROUTE_ENUMS[:early_years_assessment_only] => "EYITTAssessmentOnly",
+        TRAINING_ROUTE_ENUMS[:early_years_postgrad] => "EYITTGraduateEntry",
+        TRAINING_ROUTE_ENUMS[:early_years_salaried] => "EYITTGraduateEmploymentBased",
+        TRAINING_ROUTE_ENUMS[:early_years_undergrad] => "EYITTUndergraduate",
+        TRAINING_ROUTE_ENUMS[:hpitt_postgrad] => "TeachFirstProgramme",
+        TRAINING_ROUTE_ENUMS[:opt_in_undergrad] => "UndergraduateOptIn",
+        TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => "Apprenticeship",
+        TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => "Core",
+        TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => "Core",
+        TRAINING_ROUTE_ENUMS[:school_direct_salaried] => "SchoolDirectTrainingProgrammeSalaried",
+        TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => "SchoolDirectTrainingProgrammeSelfFunded",
+      }.freeze
+
+      DEGREE_CLASSES = {
+        Dttp::CodeSets::Grades::FIRST_CLASS_HONOURS => "FirstClassHonours",
+        Dttp::CodeSets::Grades::UPPER_SECOND_CLASS_HONOURS => "UpperSecondClassHonours",
+        Dttp::CodeSets::Grades::LOWER_SECOND_CLASS_HONOURS => "LowerSecondClassHonours",
+        Dttp::CodeSets::Grades::THIRD_CLASS_HONOURS => "ThirdClassHonours",
+        Dttp::CodeSets::Grades::OTHER => "NotKnown",
+        Dttp::CodeSets::Grades::PASS => "Pass",
+      }.freeze
+
+      attr_reader :trainee, :params
+
+      def initialize(trainee:)
+        @trainee = trainee
+        @params = build_params
+      end
+
+      def to_json(*_args)
+        params.to_json
+      end
+
+    private
+
+      def build_params
+        {
+          "firstName" => trainee.first_names,
+          "middleName" => trainee.middle_names,
+          "lastName" => trainee.last_name,
+          "birthDate" => trainee.date_of_birth.iso8601,
+          "emailAddress" => trainee.email,
+          "address" => address_params,
+          "genderCode" => GENDER_CODES[trainee.gender.to_sym],
+          "initialTeacherTraining" => initial_teacher_training_params,
+          "qualification" => qualification_params,
+        }
+      end
+
+      def address_params
+        trainee.uk? ? uk_address : non_uk_address
+      end
+
+      def uk_address
+        {
+
+          "addressLine1" => trainee.address_line_one,
+          "addressLine2" => trainee.address_line_two,
+          "addressLine3" => nil,
+          "city" => trainee.town_city,
+          "postalCode" => trainee.postcode,
+          "country" => UNITED_KINGDOM,
+        }
+      end
+
+      def non_uk_address
+        {
+          "addressLine1" => trainee.international_address,
+        }
+      end
+
+      def initial_teacher_training_params
+        {
+          "providerUkprn" => trainee.provider.ukprn,
+          "programmeStartDate" => trainee.itt_start_date.iso8601,
+          "programmeEndDate" => trainee.itt_end_date.iso8601,
+          "programmeType" => PROGRAMME_TYPE[trainee.training_route],
+          "subject1" => trainee.course_subject_one,
+          "subject2" => trainee.course_subject_two,
+          "ageRangeFrom" => trainee.course_min_age,
+          "ageRangeTo" => trainee.course_max_age,
+        }
+      end
+
+      def qualification_params
+        {
+          providerUkprn: nil,
+          countryCode: degree.uk? ? UNITED_KINGDOM : degree.country,
+          subject: degree.subject,
+          class: DEGREE_CLASSES[degree.grade],
+          date: Date.parse("01-01-#{degree.graduation_year}").iso8601,
+        }
+      end
+
+      def degree
+        trainee.degrees.first
+      end
+    end
+  end
+end

--- a/app/lib/dttp/code_sets/grades.rb
+++ b/app/lib/dttp/code_sets/grades.rb
@@ -6,6 +6,9 @@ module Dttp
       # Do not make any changes to the keys. If necessary, change Degree#grade to enum type first
       FIRST_CLASS_HONOURS = "First-class honours"
       UPPER_SECOND_CLASS_HONOURS = "Upper second-class honours (2:1)"
+      LOWER_SECOND_CLASS_HONOURS = "Lower second-class honours (2:2)"
+      THIRD_CLASS_HONOURS = "Third-class honours"
+      PASS = "Pass"
       OTHER = "Other"
 
       MAPPING = {
@@ -17,15 +20,15 @@ module Dttp
           entity_id: "0030ca5f-766d-e711-80d2-005056ac45bb",
           hesa_code: "02",
         },
-        "Lower second-class honours (2:2)" => {
+        LOWER_SECOND_CLASS_HONOURS => {
           entity_id: "0230ca5f-766d-e711-80d2-005056ac45bb",
           hesa_code: "03",
         },
-        "Third-class honours" => {
+        THIRD_CLASS_HONOURS => {
           entity_id: "0630ca5f-766d-e711-80d2-005056ac45bb",
           hesa_code: "05",
         },
-        "Pass" => {
+        PASS => {
           entity_id: "0e30ca5f-766d-e711-80d2-005056ac45bb",
           hesa_code: "14",
         },

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -29,12 +29,7 @@ FactoryBot.define do
     additional_ethnic_background { nil }
     disability_disclosure { nil }
 
-    address_line_one { Faker::Address.street_address }
-    address_line_two { Faker::Address.street_name }
-    town_city { Faker::Address.city }
-    postcode { Faker::Address.postcode }
-    international_address { nil }
-    locale_code { :uk }
+    with_uk_address
     email { "#{first_names}.#{last_name}@example.com" }
     applying_for_bursary { nil }
 
@@ -49,6 +44,24 @@ FactoryBot.define do
       add_attribute("date_of_birth(3i)") { form_dob.day.to_s }
       add_attribute("date_of_birth(2i)") { form_dob.month.to_s }
       add_attribute("date_of_birth(1i)") { form_dob.year.to_s }
+    end
+
+    trait :with_uk_address do
+      address_line_one { Faker::Address.street_address }
+      address_line_two { Faker::Address.street_name }
+      town_city { Faker::Address.city }
+      postcode { Faker::Address.postcode }
+      international_address { nil }
+      locale_code { :uk }
+    end
+
+    trait :with_non_uk_address do
+      address_line_one { nil }
+      address_line_two { nil }
+      town_city { nil }
+      postcode { nil }
+      international_address { Faker::Address.full_address }
+      locale_code { :non_uk }
     end
 
     trait :incomplete do

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dqt
+  module Params
+    describe TrnRequest do
+      let(:trainee) { create(:trainee, :completed, gender: "female") }
+      let(:degree) { trainee.degrees.first }
+
+      describe "#params" do
+        subject { described_class.new(trainee: trainee).params }
+
+        let(:uk_address_hash) do
+          {
+
+            "addressLine1" => trainee.address_line_one,
+            "addressLine2" => trainee.address_line_two,
+            "addressLine3" => nil,
+            "city" => trainee.town_city,
+            "postalCode" => trainee.postcode,
+            "country" => described_class::UNITED_KINGDOM,
+          }
+        end
+
+        it "returns a hash including personal attributes" do
+          expect(subject).to include({
+            "firstName" => trainee.first_names,
+            "middleName" => trainee.middle_names,
+            "lastName" => trainee.last_name,
+            "birthDate" => trainee.date_of_birth.iso8601,
+            "emailAddress" => trainee.email,
+            "genderCode" => "Female",
+            "address" => uk_address_hash,
+          })
+        end
+
+        it "returns a hash including course attributes" do
+          expect(subject["initialTeacherTraining"]).to eq({
+            "providerUkprn" => trainee.provider.ukprn,
+            "programmeStartDate" => trainee.itt_start_date.iso8601,
+            "programmeEndDate" => trainee.itt_end_date.iso8601,
+            "programmeType" => "AssessmentOnlyRoute",
+            "subject1" => trainee.course_subject_one,
+            "subject2" => trainee.course_subject_two,
+            "ageRangeFrom" => trainee.course_min_age,
+            "ageRangeTo" => trainee.course_max_age,
+          })
+        end
+
+        it "returns a hash including degree attributes" do
+          expect(subject["qualification"]).to eq({
+            providerUkprn: nil,
+            countryCode: described_class::UNITED_KINGDOM,
+            subject: degree.subject,
+            class: described_class::DEGREE_CLASSES[degree.grade],
+            date: Date.new(degree.graduation_year).iso8601,
+          })
+        end
+
+        context "when gender is gender_not_provided" do
+          let(:trainee) { create(:trainee, :completed, gender: "gender_not_provided") }
+
+          it "maps gender to other" do
+            expect(subject["genderCode"]).to eq("Other")
+          end
+        end
+
+        context "when trainee has an international address" do
+          let(:trainee) { create(:trainee, :completed, :with_non_uk_address) }
+
+          it "maps international address to addressLine1" do
+            expect(subject["address"]).to eq({
+              "addressLine1" => trainee.international_address,
+            })
+          end
+        end
+
+        context "when trainee has an international degree" do
+          let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details) }
+          let(:trainee) { create(:trainee, :completed, degrees: [non_uk_degree]) }
+
+          it "maps the degree country to countryCode" do
+            expect(subject["qualification"]).to include({
+              countryCode: degree.country,
+            })
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Add a `Dqt::Params::TrnRequest` presenter

### Changes proposed in this pull request
Add a presenter similar to [the ones we already have](https://github.com/DFE-Digital/register-trainee-teachers/tree/main/app/lib/dttp/params).
This presenter receives a trainee record and outputs json in the format defined in the [DQT api](https://github.com/DFE-Digital/qualified-teachers-api/blob/d847781b438ce4962fb54558067772b149ea1c60/docs/api-specs/v2.json#L563).

### Guidance to review
There are a couple of areas that might need a bit of attention: 
1. Training Route mappings (`programmeType` in DQT), and
2. Degree grade mappings (`qualification->class` in DQT). 
Please see notes added in the PR against those two areas. 

### Important business
* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
