### PR TITLE
[xxx] Strip leading and trailing spaces from postcodes

### DIFF
--- a/app/forms/contact_details_form.rb
+++ b/app/forms/contact_details_form.rb
@@ -58,7 +58,7 @@ private
 
   def update_trainee_attributes
     nullify_unused_address_fields!
-    # Need to save the email attribute formatted by the ContactDetailsForm.
+    # Need to save the email attributes formatted by the ContactDetailsForm.
     trainee.assign_attributes(fields.merge(email: email))
   end
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -198,7 +198,7 @@ class Trainee < ApplicationRecord
   audited associated_with: :provider
   has_associated_audits
 
-  auto_strip_attributes :first_names, :last_name, squish: true
+  auto_strip_attributes :first_names, :last_name, :postcode, squish: true
 
   before_save :clear_employing_school_id, if: :employing_school_not_applicable?
   before_save :clear_lead_school_id, if: :lead_school_not_applicable?

--- a/spec/forms/contact_details_form_spec.rb
+++ b/spec/forms/contact_details_form_spec.rb
@@ -136,6 +136,7 @@ describe ContactDetailsForm, type: :model do
       allow(form_store).to receive(:get).and_return({
         "address_line_one" => address_line_one,
         "email" => "test @example.com",
+        "postcode" => " SW1P 3BT ",
       })
       allow(form_store).to receive(:set).with(trainee.id, :contact_details, nil)
     end
@@ -144,8 +145,12 @@ describe ContactDetailsForm, type: :model do
       expect { subject.save! }.to change(trainee, :address_line_one).to(address_line_one)
     end
 
-    it "strips whitespace from emails" do
+    it "strips all whitespace from emails" do
       expect { subject.save! }.to change(trainee, :email).to("test@example.com")
+    end
+
+    it "strips leading and trailing whitespace from postcodes" do
+      expect { subject.save! }.to change(trainee, :postcode).to("SW1P 3BT")
     end
   end
 end


### PR DESCRIPTION
### Context

A trainee was failing to update to DTTP because the postcode was longer than 20 characters. It passed our postcode validation because it was correctly formatted but with leading and trailing whitespace.

This probably happens when people copy and paste from another document.

https://sentry.io/organizations/dfe-teacher-services/issues/2777405619/?project=5552118&referrer=slack

### Changes proposed in this pull request

- Strip leading and trailing whitespace from postcodes before saving

### Guidance to review

- Try saving a trainee with a postcode `"    SW1P 3BT   "`
- See that it is actually saved `"SW1P 3BT"`

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
