### PR TITLE
[3700] add states to hesa collection request model

### DIFF
--- a/app/models/hesa_collection_request.rb
+++ b/app/models/hesa_collection_request.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class HesaCollectionRequest < ApplicationRecord
+
+  enum state: {
+    importable: 0,
+    imported: 1,
+    non_importable_missing_route: 2,
+    non_importable_provider: 3,
+    non_importable_missing_funding: 4,
+    non_importable_missing_initiative: 5,
+  }
+
   class << self
     def next_from_date
       current_collection_ref = Settings.hesa.current_collection_reference

--- a/db/migrate/20220224105736_add_state_to_hesa_collection_requests.rb
+++ b/db/migrate/20220224105736_add_state_to_hesa_collection_requests.rb
@@ -1,0 +1,5 @@
+class AddStateToHesaCollectionRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :hesa_collection_requests, :state, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_14_142008) do
+ActiveRecord::Schema.define(version: 2022_02_24_105736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -327,6 +327,7 @@ ActiveRecord::Schema.define(version: 2022_02_14_142008) do
     t.string "response_body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "state", default: 0
   end
 
   create_table "lead_school_users", force: :cascade do |t|

--- a/spec/factories/hesa_collection_requests.rb
+++ b/spec/factories/hesa_collection_requests.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :hesa_collection_request
+  factory :hesa_collection_request, class: "HesaCollectionRequest" do
+    state { "importable" }
+  end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/ikAxOSDE/3700-add-states-to-hesa-collection-request-model

Branched off https://github.com/DFE-Digital/register-trainee-teachers/pull/2038

### Changes proposed in this pull request

* Added new enum `state` column to `HesaCollectionRequest`
* Also included `importable` default state, similar to Dttp

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
