### PR TITLE
[xxxx] Remove explicit ordering on SchoolPolicy spec

### DIFF
--- a/spec/policies/school_policy_spec.rb
+++ b/spec/policies/school_policy_spec.rb
@@ -16,15 +16,10 @@ describe SchoolPolicy do
   describe SchoolPolicy::Scope do
     let!(:school1) { create(:school, name: "AAA") }
     let!(:school2) { create(:school, name: "BBB") }
+    let(:user) { system_admin_user }
 
     subject { described_class.new(user, School).resolve }
 
-    context "ordered by name" do
-      let(:user) { system_admin_user }
-      let(:trainee) { create(:trainee, :discarded) }
-
-      it { expect(subject[0]).to eql(school1) }
-      it { expect(subject[1]).to eql(school2) }
-    end
+    it { expect(subject).to match_array([school1, school2]) }
   end
 end


### PR DESCRIPTION
### Context
Fixes https://github.com/DFE-Digital/register-trainee-teachers/runs/5318503141?check_suite_focus=true

We don't have a need for a explicit order by name spec in the `SchoolPolicy` specs, since the `order_by_name` bit is taken care of by the `School.order_by_name` scope rather than any policy specific logic.

### Guidance to review
:shipit: 

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
