### PR TITLE
Explicitly set text colour on summary card headings

### DIFF
--- a/app/components/summary_card/style.scss
+++ b/app/components/summary_card/style.scss
@@ -7,6 +7,7 @@
     align-items: center;
     background-color: govuk-colour("light-grey");
     padding: govuk-spacing(3);
+    color: $govuk-text-colour;
 
     @include govuk-media-query($from: desktop) {
       display: flex;


### PR DESCRIPTION
Latest Chrome combined with MacOS dark mode and an acrobat extension is causing several issues with the design system (bug raised with GDS).

Additionally, our summary card headers don't have a colour set, and the result is that the header turns white. This copies @ralph-hawkins's fix from https://github.com/DFE-Digital/register-trainee-teachers-prototype/pull/458

Before:
![Screenshot 2022-02-24 at 13 18 39](https://user-images.githubusercontent.com/2204224/155531606-e8aa3e1c-747c-431e-bcf1-b92d4dd4a27c.png)

After:
![Screenshot 2022-02-24 at 15 00 46](https://user-images.githubusercontent.com/2204224/155565115-97c190b2-9375-4dfa-971c-abcd8e55dbed.png)

