### PR TITLE
Remove db:seed and example_data:generate from review app start command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,7 +127,7 @@ jobs:
           CONFIRM_PRODUCTION:       yes
 
       - uses: DFE-Digital/keyvault-yaml-secret@v1
-        if: env.DEPLOY_ENV == 'staging' || env.DEPLOY_ENV == 'dttpimport' || env.DEPLOY_ENV == 'production'
+        if: env.DEPLOY_ENV == 'review' || env.DEPLOY_ENV == 'staging' || env.DEPLOY_ENV == 'dttpimport' || env.DEPLOY_ENV == 'production'
         id: get-secrets
         with:
           keyvault: ${{ env.key_vault_name }}
@@ -135,7 +135,7 @@ jobs:
           key: CF_USER,CF_PASSWORD
 
       - name: Setup cf cli
-        if: env.DEPLOY_ENV == 'staging' || env.DEPLOY_ENV == 'dttpimport' || env.DEPLOY_ENV == 'production'
+        if: env.DEPLOY_ENV == 'review' || env.DEPLOY_ENV == 'staging' || env.DEPLOY_ENV == 'dttpimport' || env.DEPLOY_ENV == 'production'
         uses: DFE-Digital/github-actions/setup-cf-cli@master
         with:
           CF_USERNAME:   ${{ steps.get-secrets.outputs.CF_USER }}
@@ -145,6 +145,10 @@ jobs:
       - name: Run data migrations
         if: env.DEPLOY_ENV == 'staging' || env.DEPLOY_ENV == 'dttpimport' || env.DEPLOY_ENV == 'production'
         run: cf run-task "register-${DEPLOY_ENV}" --command "cd /app && bundle exec rails data:migrate" --wait
+
+      - name: Generate example data
+        if: env.DEPLOY_ENV == 'review'
+        run: cf run-task "register-pr-${PR_NUMBER}" --command "cd /app && bundle exec rails db:seed example_data:generate" --wait
 
       - name: Trigger ${{ env.DEPLOY_ENV }} Smoke Tests
         uses: benc-uk/workflow-dispatch@v1.1

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,16 +24,31 @@ Disability.upsert_all(
   unique_by: :name,
 )
 
-ALLOCATION_SUBJECT_SPECIALISM_MAPPING.each do |allocation_subject, subject_specialisms|
-  allocation_subject = AllocationSubject.find_or_create_by!(name: allocation_subject)
-  if allocation_subject.name == AllocationSubjects::PRIMARY
-    allocation_subject.subject_specialisms.find_or_create_by!(name: CourseSubjects::PRIMARY_TEACHING)
-  else
-    subject_specialisms.each do |subject_specialism_name|
-      allocation_subject.subject_specialisms.find_or_create_by!(name: subject_specialism_name)
+allocation_subjects = AllocationSubject.upsert_all(
+  ALLOCATION_SUBJECT_SPECIALISM_MAPPING.keys.map do |allocation_subject|
+    {
+      name: allocation_subject,
+      created_at: Time.zone.now,
+      updated_at: Time.zone.now,
+    }
+  end,
+  unique_by: :name,
+  returning: %w[name id],
+)
+
+SubjectSpecialism.upsert_all(
+  allocation_subjects.rows.flat_map do |allocation_subject_name, allocation_subject_id|
+    ALLOCATION_SUBJECT_SPECIALISM_MAPPING[allocation_subject_name].map do |subject_specialism_name|
+      {
+        name: subject_specialism_name,
+        allocation_subject_id: allocation_subject_id,
+        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
+      }
     end
-  end
-end
+  end,
+  unique_by: :index_subject_specialisms_on_lower_name,
+)
 
 ACADEMIC_CYCLES.each do |academic_cycle|
   AcademicCycle.find_or_create_by!(start_date: academic_cycle[:start_date], end_date: academic_cycle[:end_date])

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -127,6 +127,8 @@ namespace :example_data do
       # Hpitt provider can only have trainees on the hpitt_postgrad route
       enabled_routes = [TRAINING_ROUTE_ENUMS[:hpitt_postgrad]] if provider.hpitt_postgrad?
 
+      nationalities = Nationality.all
+
       # For each route that's enabled...
       enabled_routes.each do |route|
         # And for all possible trainee states...
@@ -135,7 +137,11 @@ namespace :example_data do
           sample_size = rand(4...8)
 
           sample_size.times do |sample_index|
-            attrs = { randomise_subjects: true, created_at: Faker::Date.between(from: 100.days.ago, to: 50.days.ago) }
+            attrs = {
+              randomise_subjects: true,
+              created_at: Faker::Date.between(from: 100.days.ago, to: 50.days.ago),
+              nationalities: [],
+            }
             attrs.merge!(provider: provider) if provider
 
             # Some route-specific logic, but could move into factories too
@@ -187,10 +193,10 @@ namespace :example_data do
 
             trainee = FactoryBot.create(:trainee, route, state, attrs)
 
-            trainee.nationalities << Nationality.all.sample
+            trainee.nationalities << nationalities.sample
 
             if rand(10) < 2 # Give 20% of trainees an extra nationality and a non-uk degree
-              trainee.nationalities << Nationality.all.sample
+              trainee.nationalities << nationalities.sample
               degree_type = :non_uk_degree_with_details
             else
               degree_type = :uk_degree_with_details

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -112,7 +112,7 @@ FactoryBot.define do
       applying_for_bursary { false }
       applying_for_scholarship { false }
       applying_for_grant { false }
-      nationalities { [Nationality.offset(rand(Nationality.count)).first || build(:nationality)] }
+      nationalities { [Nationality.all.sample || build(:nationality)] }
       progress do
         Progress.new(
           personal_details: true,

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -40,8 +40,7 @@ locals {
     DATABASE_URL  = cloudfoundry_service_key.postgres-key.credentials.uri
     SETTINGS__BLAZER_DATABASE_URL = cloudfoundry_service_key.postgres-blazer-key.credentials.uri
   })
-  review_app_start_command = "bundle exec rake db:migrate db:seed example_data:generate && bundle exec rails server -b 0.0.0.0"
-  web_app_start_command    = var.app_environment == "review" ? local.review_app_start_command : "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
+  web_app_start_command    = "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "register-worker-${local.app_name_suffix}"
   logging_service_name     = "register-logit-${local.app_name_suffix}"


### PR DESCRIPTION
### Context
The `example_data:generate` seems to be running for a bit too long:

Local results
```bash
$ time bundle exec rails example_data:generate
bundle exec rails example_data:generate  114.26s user 5.63s system 89% cpu 2:13.28 total
```
This causes the data to not be generated correctly in review apps. This can be reproduced by raising a PR, which will seem to be missing the personas with multi-user accounts, (compare with this PR's review app)

### Changes proposed in this pull request

* Move `db:seed` and `example_data:generate` over to the deploy pipeline, similar to the way we do when running data migrations.
* Additionally, update some seeds to use `upsert_all`

### Guidance to review
:eyes: 

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
