### PR TITLE
[3682] Improve seeded Apply drafts

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -173,8 +173,14 @@ namespace :example_data do
               sample_course = courses.offset(rand(courses.count)).first
               attrs.merge!(course_uuid: sample_course.uuid,
                            course_education_phase: sample_course.level,
+                           study_mode: TRAINEE_STUDY_MODE_ENUMS[sample_course.study_mode],
+                           course_min_age: sample_course.min_age,
+                           course_max_age: sample_course.max_age,
                            itt_start_date: nil,
                            itt_end_date: nil,
+                           trainee_id: nil,
+                           lead_school_id: nil,
+                           employing_school_id: nil,
                            apply_application: FactoryBot.create(:apply_application, accredited_body_code: provider.code))
             end
 


### PR DESCRIPTION
### Context

https://trello.com/c/1rx8S5Wx/3682-snags-with-apply-seed-data

### Changes proposed in this pull request

- [x] ~Apply drafts don't necessarily have study mode pre-set on dual study mode courses~
  - Explicitly set study mode from sampled course
- [x] ~Apply drafts seem to have trainee-id pre-populated~
  - Set trainee_id to nil
- [x] ~Apply drafts seem to have schools pre-populated~
  - Set lead_school_id and employing_school_id to nil
- [x] When opening course details section, users should be asked to confirm the course, then followup questions. Instead they are taken to a confirmation page with missing data
  - I can't replicate this, I'm always asked to confirm the course, then the ITT start dates now
- [x] Apply drafts - When confirming a course the dates are shown as missing data on a confirm page rather than asking for the dates - this may be related to above issue of not confirming course and asking for data needed.
  - Sounds like this would have been related to the above issue, which now doesn't seem to be happening
- [x] ~Funding section isn't prevented from being started even if course details aren't confirmed.~
  - This was a bug fixed here: https://github.com/DFE-Digital/register-trainee-teachers/pull/2036
  
### Guidance to review

- Review the imported from Apply trainees seeded in the review app

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
