### PR TITLE
[3710] Fix snags with seed data

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -139,7 +139,7 @@ namespace :example_data do
           sample_size.times do |sample_index|
             nationalities = [nationalities.sample]
 
-            if sample_index < sample_size / 5 # Give 20% of trainees an extra nationality and a non-uk degree
+            if sample_index < sample_size * 20.0 / 100 # Give 20% of trainees an extra nationality and a non-uk degree
               nationalities << nationalities.sample
               degree_type = :non_uk_degree_with_details
             else
@@ -164,7 +164,7 @@ namespace :example_data do
 
               if state == :draft
                 # Make *roughly* half of draft trainees apply drafts
-                if sample_index < sample_size / 2
+                if sample_index >= sample_size / 2
                   # Create apply drafts for *next* academic cycle
                   courses = courses.where(recruitment_cycle_year: Settings.current_default_course_year + 1)
 
@@ -200,12 +200,12 @@ namespace :example_data do
             end
 
             # Make *roughly* 25% of submitted_for_trn trainees not have a commencement date
-            if state == :submitted_for_trn && sample_index < sample_size / 4
+            if state == :submitted_for_trn && sample_index < sample_size * 25.0 / 100
               attrs.merge!(commencement_date: nil)
             end
 
-            # Make 25% of drafts (both apply and manual) incomplete
-            if state == :draft && (sample_index < sample_size / 4)
+            # Make 75% of drafts (both apply and manual) incomplete
+            if state == :draft && (sample_index < sample_size * 75.0 / 100)
               attrs.merge!(
                 progress: Progress.new,
                 submission_ready: false,

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -137,10 +137,20 @@ namespace :example_data do
           sample_size = rand(4...8)
 
           sample_size.times do |sample_index|
+            nationalities = [nationalities.sample]
+
+            if sample_index < sample_size / 5 # Give 20% of trainees an extra nationality and a non-uk degree
+              nationalities << nationalities.sample
+              degree_type = :non_uk_degree_with_details
+            else
+              degree_type = :uk_degree_with_details
+            end
+
             attrs = {
               randomise_subjects: true,
               created_at: Faker::Date.between(from: 100.days.ago, to: 50.days.ago),
-              nationalities: [],
+              nationalities: nationalities,
+              degrees: [FactoryBot.build(:degree, degree_type)],
             }
             attrs.merge!(provider: provider) if provider
 
@@ -148,10 +158,29 @@ namespace :example_data do
             attrs.merge!(lead_school: lead_schools.sample) if LEAD_SCHOOL_ROUTES.include?(route)
             attrs.merge!(employing_school: employing_schools.sample) if EMPLOYING_SCHOOL_ROUTES.include?(route)
 
-            if state != :draft
-              course = provider.courses.where(route: TRAINING_ROUTES_FOR_COURSE[route.to_s]).sample
+            if enabled_course_routes.include?(route)
 
-              if course
+              courses = provider.courses.where(route: route)
+
+              if state == :draft
+                # Make *roughly* half of draft trainees apply drafts
+                if sample_index < sample_size / 2
+                  # Create apply drafts for *next* academic cycle
+                  courses = courses.where(recruitment_cycle_year: Settings.current_default_course_year + 1)
+
+                  attrs.merge!(
+                    apply_application: FactoryBot.build(:apply_application,
+                                                        accredited_body_code: provider.code),
+                  )
+                else
+                  # Create manual drafts for *current* academic cycle
+                  courses = courses.where(recruitment_cycle_year: Settings.current_default_course_year)
+                end
+              end
+
+              course = courses.sample
+
+              if course.present?
                 course_subject_one, course_subject_two, course_subject_three = CalculateSubjectSpecialisms.call(subjects: course.subjects.pluck(:name)).values.map(&:first).compact
 
                 attrs.merge!(
@@ -160,17 +189,14 @@ namespace :example_data do
                   course_subject_one: course_subject_one,
                   course_subject_two: course_subject_two,
                   course_subject_three: course_subject_three,
-                  study_mode: TRAINEE_STUDY_MODE_ENUMS[course.study_mode],
+                  study_mode: TRAINEE_STUDY_MODE_ENUMS[course.study_mode] || TRAINEE_STUDY_MODE_ENUMS.keys.sample,
                   course_min_age: course.min_age,
                   course_max_age: course.max_age,
                   itt_start_date: course.published_start_date,
                   itt_end_date: course.published_start_date + 9.months,
                 )
-
-                if (rand(10) < 2) && (state == :submitted_for_trn)
-                  attrs.merge!(commencement_date: nil)
-                end
               end
+
             end
 
             # Make *roughly* half of draft trainees apply drafts
@@ -188,6 +214,22 @@ namespace :example_data do
                            lead_school_id: nil,
                            employing_school_id: nil,
                            apply_application: FactoryBot.create(:apply_application, accredited_body_code: provider.code))
+
+            end
+
+            # Make *roughly* 25% of submitted_for_trn trainees not have a commencement date
+            if state == :submitted_for_trn && sample_index < sample_size / 4
+              attrs.merge!(commencement_date: nil)
+            end
+
+            # Make 25% of drafts (both apply and manual) incomplete
+            if state == :draft && (sample_index < sample_size / 4)
+              attrs.merge!(
+                progress: Progress.new,
+                submission_ready: false,
+                itt_start_date: nil,
+                itt_end_date: nil,
+              )
             end
 
             if route.to_s.include?(EARLY_YEARS_ROUTE_NAME_PREFIX)
@@ -197,18 +239,7 @@ namespace :example_data do
               )
             end
 
-            trainee = FactoryBot.create(:trainee, route, state, attrs)
-
-            trainee.nationalities << nationalities.sample
-
-            if rand(10) < 2 # Give 20% of trainees an extra nationality and a non-uk degree
-              trainee.nationalities << nationalities.sample
-              degree_type = :non_uk_degree_with_details
-            else
-              degree_type = :uk_degree_with_details
-            end
-
-            FactoryBot.create(:degree, degree_type, trainee: trainee)
+            FactoryBot.create(:trainee, route, state, attrs)
           end
         end
       end

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -199,24 +199,6 @@ namespace :example_data do
 
             end
 
-            # Make *roughly* half of draft trainees apply drafts
-            if state == :draft && sample_index < sample_size / 2 && enabled_course_routes.include?(route)
-              courses = provider.courses.where(route: route)
-              sample_course = courses.offset(rand(courses.count)).first
-              attrs.merge!(course_uuid: sample_course.uuid,
-                           course_education_phase: sample_course.level,
-                           study_mode: TRAINEE_STUDY_MODE_ENUMS[sample_course.study_mode],
-                           course_min_age: sample_course.min_age,
-                           course_max_age: sample_course.max_age,
-                           itt_start_date: nil,
-                           itt_end_date: nil,
-                           trainee_id: nil,
-                           lead_school_id: nil,
-                           employing_school_id: nil,
-                           apply_application: FactoryBot.create(:apply_application, accredited_body_code: provider.code))
-
-            end
-
             # Make *roughly* 25% of submitted_for_trn trainees not have a commencement date
             if state == :submitted_for_trn && sample_index < sample_size / 4
               attrs.merge!(commencement_date: nil)
@@ -229,6 +211,9 @@ namespace :example_data do
                 submission_ready: false,
                 itt_start_date: nil,
                 itt_end_date: nil,
+                trainee_id: nil,
+                lead_school: nil,
+                employing_school: nil,
               )
             end
 

--- a/spec/controllers/trainees/personal_details_controller_spec.rb
+++ b/spec/controllers/trainees/personal_details_controller_spec.rb
@@ -33,7 +33,7 @@ describe Trainees::PersonalDetailsController do
 
   describe "#update" do
     context "with an apply draft trainee" do
-      let(:trainee) { create(:trainee, :draft, :with_apply_application, provider: user.organisation) }
+      let(:trainee) { create(:trainee, :incomplete_draft, :with_apply_application, provider: user.organisation) }
 
       before do
         allow(PersonalDetailsForm).to receive(:new).and_return(double(stash_or_save!: true))

--- a/spec/controllers/trainees/training_details_controller_spec.rb
+++ b/spec/controllers/trainees/training_details_controller_spec.rb
@@ -11,7 +11,7 @@ describe Trainees::TrainingDetailsController do
 
   describe "#update" do
     context "with an apply draft trainee" do
-      let(:trainee) { create(:trainee, :draft, :with_apply_application, provider: user.organisation) }
+      let(:trainee) { create(:trainee, :incomplete_draft, :with_apply_application, provider: user.organisation) }
 
       before do
         allow(TrainingDetailsForm).to receive(:new).and_return(double(save: true))

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -280,6 +280,7 @@ FactoryBot.define do
     trait :with_early_years_course_details do
       course_subject_one { CourseSubjects::EARLY_YEARS_TEACHING }
       course_age_range { AgeRange::ZERO_TO_FIVE }
+      with_study_mode_and_course_dates
     end
 
     trait :early_years_assessment_only do
@@ -314,6 +315,12 @@ FactoryBot.define do
 
     trait :opt_in_undergrad do
       training_route { TRAINING_ROUTE_ENUMS[:opt_in_undergrad] }
+    end
+
+    trait :draft do
+      completed
+      state { "draft" }
+      submission_ready
     end
 
     trait :submitted_for_trn do

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -323,6 +323,10 @@ FactoryBot.define do
       submission_ready
     end
 
+    trait :incomplete_draft do
+      state { "draft" }
+    end
+
     trait :submitted_for_trn do
       completed
       dttp_id { SecureRandom.uuid }

--- a/spec/features/form_sections/personal_and_education_details/degrees/editing_degree_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/degrees/editing_degree_spec.rb
@@ -146,7 +146,7 @@ private
     (@uk_trainee || @non_uk_trainee)
   end
 
-  def uk_trainee(trait: :draft)
+  def uk_trainee(trait: :incomplete_draft)
     @uk_trainee ||= create(:trainee, trait, provider: current_user.organisation).tap do |t|
       t.degrees << build(:degree, :uk_degree_type)
     end

--- a/spec/forms/submissions/trn_validator_spec.rb
+++ b/spec/forms/submissions/trn_validator_spec.rb
@@ -242,8 +242,8 @@ module Submissions
         end
       end
 
-      context "when trainee is draft" do
-        let(:trainee) { build(:trainee, :draft) }
+      context "when trainee is incomplete draft" do
+        let(:trainee) { build(:trainee, :incomplete_draft) }
 
         it "returns false" do
           expect(subject.all_sections_complete?).to be(false)

--- a/spec/services/find_empty_trainees_spec.rb
+++ b/spec/services/find_empty_trainees_spec.rb
@@ -37,7 +37,7 @@ describe FindEmptyTrainees do
 
   context "for early year routes" do
     let!(:draft_trainee_with_no_data) do
-      create(:trainee, :incomplete, :early_years_salaried)
+      create(:trainee, :incomplete, :early_years_salaried, study_mode: nil, itt_start_date: nil, itt_end_date: nil)
     end
 
     subject { described_class.call }

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -6,7 +6,7 @@ module Trainees
   describe Filter do
     subject { described_class.call(trainees: trainees, filters: filters) }
 
-    let!(:draft_trainee) { create(:trainee, :draft, first_names: "Draft") }
+    let!(:draft_trainee) { create(:trainee, :incomplete_draft, first_names: "Draft") }
     let!(:apply_draft_trainee) { create(:trainee, :with_apply_application, first_names: "Apply") }
     let(:filters) { nil }
     let(:trainees) { Trainee.all }

--- a/spec/support/shared_examples/rendering_the_funding_section.rb
+++ b/spec/support/shared_examples/rendering_the_funding_section.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples "rendering the funding section" do
   context "when a trainee on a route with a bursary" do
     let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
-    let(:trainee) { create(:trainee, :with_start_date, :with_study_mode_and_course_dates, :draft, route) }
+    let(:trainee) { create(:trainee, :with_start_date, :with_study_mode_and_course_dates, :incomplete_draft, route) }
 
     before { create(:funding_method, :with_subjects, training_route: route) }
 
@@ -25,7 +25,7 @@ RSpec.shared_examples "rendering the funding section" do
   end
 
   context "when a trainee on a route with no bursary" do
-    let(:trainee) { create(:trainee, :draft, TRAINING_ROUTE_ENUMS[:assessment_only]) }
+    let(:trainee) { create(:trainee, :incomplete_draft, TRAINING_ROUTE_ENUMS[:assessment_only]) }
 
     before { create(:funding_method, :with_subjects, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad]) }
 


### PR DESCRIPTION
### Context
Fix snags listed in [this trello card](https://trello.com/c/2mKZD7EA/3710-snags-with-seed-data-drafts-trn-start-date).
I've created a separate base PR for the sake of the CI pipeline https://github.com/DFE-Digital/register-trainee-teachers/pull/2070
Also adds the functionality from https://github.com/DFE-Digital/register-trainee-teachers/pull/2073, since this PR moves things around a bit.

### Changes proposed in this pull request

- Ensure that ~25% of `submitted_for_trn` trainees do not have a `commencement_date`
- Also use `x/2` instead of `rand` for more explicit percentage calculation
- Move nationality, degree creation *before* creating trainee to allow creation of completed records.
- ~Ensure that 25% of drafts are incomplete.~
- Ensure that  ~75% of drafts are incomplete.
- Update draft trainee factory to contain complete attributes.
- Manual drafts that include course details: course is set to current academic year
- Apply drafts - course is set to *next* academic year.

### Guidance to review
Have a look at the various conditions listed in the card in the review app.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
