### PR TITLE
[3744] Lead school user should not be able to see gender, nationality or diversity details

### DIFF
--- a/app/components/personal_details/view.rb
+++ b/app/components/personal_details/view.rb
@@ -4,25 +4,26 @@ module PersonalDetails
   class View < GovukComponent::Base
     include SanitizeHelper
 
-    def initialize(data_model:, has_errors: false, editable: false)
+    def initialize(data_model:, has_errors: false, editable: false, minimal: false)
       @data_model = data_model
       @nationalities = Nationality.where(id: data_model.nationality_ids)
       @has_errors = has_errors
       @editable = editable
+      @minimal = minimal
     end
 
     def personal_detail_rows
       [
         full_name_row,
         date_of_birth_row,
-        gender_row,
-        nationality_row,
+        (gender_row unless minimal),
+        (nationality_row unless minimal),
       ].compact
     end
 
   private
 
-    attr_accessor :data_model, :nationalities, :has_errors, :editable
+    attr_accessor :data_model, :nationalities, :has_errors, :editable, :minimal
 
     def trainee
       data_model.is_a?(Trainee) ? data_model : data_model.trainee

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -6,9 +6,4 @@ module OrganisationHelper
       current_user.multiple_organisations? &&
       current_user.organisation.present?
   end
-
-  def hide_draft_records?
-    defined?(current_user) && current_user.present? &&
-      current_user.lead_school?
-  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module UsersHelper
+  def lead_school_user?
+    defined?(current_user) && current_user&.lead_school?
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
       <%= render NavigationBar::View.new(
         items: [
           { name: "Home", url: root_path },
-          ({ name: "Draft trainees", url: drafts_path, current: active_link_for("drafts", @trainee) } unless hide_draft_records?),
+          ({ name: "Draft trainees", url: drafts_path, current: active_link_for("drafts", @trainee) } unless lead_school_user?),
           { name: "Registered trainees", url: trainees_path, current: active_link_for("trainees", @trainee) },
           ({ name: current_user.organisation.name, url: organisations_path, align_right: true } if show_organisation_link?),
         ],

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <%= render PageTitle::View.new(i18n_key: "pages.home") %>
 
-<% unless hide_draft_records? %>
+<% unless lead_school_user? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <% if current_user.organisation %>
@@ -45,7 +45,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <% if hide_draft_records? %>
+    <% if lead_school_user? %>
       <% if current_user.organisation %>
         <span class="govuk-caption-l"><%= current_user.organisation.name %></span>
       <% end %>

--- a/app/views/trainees/personal_details/show.html.erb
+++ b/app/views/trainees/personal_details/show.html.erb
@@ -1,14 +1,18 @@
 <div class="personal-details">
-  <%= render PersonalDetails::View.new(data_model: @trainee, editable: trainee_editable?) %>
+  <%= render PersonalDetails::View.new(data_model: @trainee,
+                                       editable: trainee_editable?,
+                                       minimal: lead_school_user?) %>
 </div>
 
 <div class="contact-details">
   <%= render ContactDetails::View.new(data_model: @trainee, editable: trainee_editable?) %>
 </div>
 
-<div class="diversity-details">
-  <%= render Diversity::View.new(data_model: @trainee, editable: trainee_editable?) %>
-</div>
+<% unless lead_school_user? %>
+  <div class="diversity-details">
+    <%= render Diversity::View.new(data_model: @trainee, editable: trainee_editable?) %>
+  </div>
+<% end %>
 
 <% if @trainee.requires_degree? %>
   <% if @trainee.degrees.any? %>

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -2,15 +2,15 @@
 
 require "rails_helper"
 
-describe OrganisationHelper do
-  include OrganisationHelper
+describe UsersHelper do
+  include UsersHelper
 
-  describe "#hide_draft_records?" do
+  describe "#lead_school_user?" do
     describe "lead school user" do
       let(:current_user) { double(UserWithOrganisationContext, lead_school?: true) }
 
       it "returns true" do
-        expect(hide_draft_records?).to be(true)
+        expect(lead_school_user?).to be(true)
       end
     end
 
@@ -18,7 +18,7 @@ describe OrganisationHelper do
       let(:current_user) { double(UserWithOrganisationContext, lead_school?: false) }
 
       it "returns false" do
-        expect(hide_draft_records?).to be(false)
+        expect(lead_school_user?).to be(false)
       end
     end
   end

--- a/spec/views/trainees/personal_details/show.html.erb_spec.rb
+++ b/spec/views/trainees/personal_details/show.html.erb_spec.rb
@@ -3,17 +3,19 @@
 require "rails_helper"
 
 describe "trainees/personal_details/show.html.erb" do
+  let(:lead_school_user?) { false }
+  let(:trainee) { create(:trainee) }
+
   before do
     assign(:trainee, trainee)
     without_partial_double_verification do
       allow(view).to receive(:trainee_editable?).and_return(true)
+      allow(view).to receive(:lead_school_user?).and_return(lead_school_user?)
     end
     render
   end
 
   context "with a trainee with no degree" do
-    let(:trainee) { create(:trainee) }
-
     it "renders the incomplete section component" do
       expect(rendered).to have_text("Add degree details")
     end
@@ -24,6 +26,19 @@ describe "trainees/personal_details/show.html.erb" do
 
     it "renders the confirmation component" do
       expect(rendered).to have_text("Add another degree")
+    end
+  end
+
+  context "minimal mode" do
+    let(:lead_school_user?) { true }
+
+    it "doesn't display gender or nationality" do
+      expect(rendered).not_to have_text("Gender")
+      expect(rendered).not_to have_text("Nationality")
+    end
+
+    it "doesn't display diversity information" do
+      expect(rendered).not_to have_text("Diversity")
     end
   end
 end


### PR DESCRIPTION
 ### Context
https://trello.com/c/Q1bD0HeP/3744-lead-school-user-should-not-be-able-to-see-gender-nationality-diversity-details

### Changes proposed in this pull request
- Add new boolean argument `minimal` to `PersonalDetails::View` to hide gender, nationality and diversity details

### Guidance to review
- Log in using the Denise Theominis persona
- Choose the lead school
- Visit non-draft trainee and their personal details
- Gender, nationality and diversity details information should not be displayed

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~0
