### PR TITLE
[3746] Obscure some usernames from the timeline

### DIFF
--- a/app/controllers/trainees/timelines_controller.rb
+++ b/app/controllers/trainees/timelines_controller.rb
@@ -3,7 +3,7 @@
 module Trainees
   class TimelinesController < BaseController
     def show
-      @timeline_events = trainee.timeline
+      @timeline_events = Trainees::CreateTimeline.call(trainee: trainee, current_user: current_user)
       render(layout: "trainee_record")
     end
   end

--- a/app/services/trainees/create_timeline.rb
+++ b/app/services/trainees/create_timeline.rb
@@ -4,8 +4,9 @@ module Trainees
   class CreateTimeline
     include ServicePattern
 
-    def initialize(trainee:)
+    def initialize(trainee:, current_user: nil)
       @trainee = trainee
+      @current_user = current_user
     end
 
     def call
@@ -14,10 +15,10 @@ module Trainees
 
   private
 
-    attr_reader :trainee
+    attr_reader :trainee, :current_user
 
     def events
-      filtered_audits.map { |audit| CreateTimelineEvents.call(audit: audit) }
+      filtered_audits.map { |audit| CreateTimelineEvents.call(audit: audit, current_user: current_user) }
     end
 
     def filtered_audits

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -55,8 +55,9 @@ module Trainees
 
     delegate :user, :created_at, :auditable_type, :audited_changes, :auditable, to: :audit
 
-    def initialize(audit:)
+    def initialize(audit:, current_user: nil)
       @audit = audit
+      @current_user = current_user
     end
 
     def call
@@ -113,7 +114,7 @@ module Trainees
 
   private
 
-    attr_reader :audit
+    attr_reader :audit, :current_user
 
     # An action can be one of "create", "destroy" or "update". Here, we're
     # creating a new "state_change" action as they're displayed differently.
@@ -172,14 +173,26 @@ module Trainees
       title
     end
 
+    # The `user` is the user associated with the audit. The `current_user` is
+    # the logged in user.
     def username
       return unless user && !user.is_a?(String)
 
-      user.system_admin? ? "DfE administrator" : user.name
+      return "DfE administrator" if user.system_admin?
+
+      return "#{user.name} (#{provider_name})" if current_user&.system_admin?
+
+      return provider_name if current_user != user
+
+      user.name
     end
 
     def hesa_or_dttp_user?
       IMPORT_SOURCES.include?(user)
+    end
+
+    def provider_name
+      Provider.find(audit.associated_id).name
     end
   end
 end

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -192,7 +192,7 @@ module Trainees
     end
 
     def provider_name
-      Provider.find(audit.associated_id).name
+      Provider.find_by(id: audit.associated_id)&.name
     end
   end
 end

--- a/spec/services/trainees/create_timeline_spec.rb
+++ b/spec/services/trainees/create_timeline_spec.rb
@@ -7,7 +7,7 @@ module Trainees
     let(:trainee) { create(:trainee) }
     let(:audits) { trainee.own_and_associated_audits }
 
-    subject { described_class.call(trainee: trainee) }
+    subject { described_class.call(trainee: trainee, current_user: nil) }
 
     describe "#call" do
       context "when a trainee is updated but not yet submitted for trn" do
@@ -70,7 +70,7 @@ module Trainees
 
     def reload_audits
       trainee.own_and_associated_audits.each do |audit|
-        allow(CreateTimelineEvents).to receive(:call).with(audit: audit).and_return(double(title: "title", date: audit.created_at))
+        allow(CreateTimelineEvents).to receive(:call).with(audit: audit, current_user: nil).and_return(double(title: "title", date: audit.created_at))
       end
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/3XvRgc1C/3746-obscure-names-from-timeline-if-its-not-the-same-user-viewing-it

### Changes proposed in this pull request

- If the user viewing the timeline is not the same as the user who
  made the audit, then only show provider name
- If the user viewing the timeline is a system admin, show the user
  name and the provider name

### Guidance to review

This is kinda funky because there's a cached version of a trainee's timeline on the trainee model, which should not rely on a current_user in the session. We used this cached version to read off the latest updated timestamp in various places across the app.

So, I've left this part of the code untouched:
https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/trainee.rb#L287

And updated the _actual_ timeline as generated in the timelines controller to pass in `current_user`.

**Product review**
- Sign in as a provider user, make a change to a trainee
- View the timeline and see that the user name is shown
- Sign in as the lead school user related to that same trainees
- View the timeline and see that the provider user name is obscured, but the provider name is shown
- Sign in as a system admin
- View the timeline and see that the user name and the provider name is shown in brackets

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
