### PR TITLE
[xxx] Fix data migration

### DIFF
--- a/db/data/20220224150322_backfill_missing_provider_ukprns.rb
+++ b/db/data/20220224150322_backfill_missing_provider_ukprns.rb
@@ -56,12 +56,12 @@ class BackfillMissingProviderUkprns < ActiveRecord::Migration[6.1]
       119 => 10057399,
       121 => 10054033,
     }.each do |provider_id, ukprn|
-      Provider.find(provider_id).update(ukprn: ukprn)
+      Provider.find_by(id: provider_id)&.update(ukprn: ukprn)
     end
 
     # Fix data for existing provider.
     # It's currently pointing to St Mary's University, Belfast instead of St Mary's University, Twickenham
-    Provider.find_by(ukprn: 10008026).update(dttp_id: "9b407223-7042-e811-80ff-3863bb3640b8", ukprn: 10007843)
+    Provider.find_by(ukprn: 10008026)&.update(dttp_id: "9b407223-7042-e811-80ff-3863bb3640b8", ukprn: 10007843)
   end
 
   def down


### PR DESCRIPTION
### Context
Staging deployment failed because it doesn't have the provider data expected to run this data migration.

### Changes proposed in this pull request
- Make the migration run even if the expected records don't exist