### PR TITLE
[3756] Add email uniqueness validation and db constraint

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,8 @@ class User < ApplicationRecord
   validates :last_name, presence: true
   validates :email, presence: true
   validates :dttp_id, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }, unless: :system_admin?
-  validates :dttp_id, uniqueness: true, if: :active_user?
+  validates :dttp_id, uniqueness: true, if: :active_user_by_dttp_id?
+  validates :email, uniqueness: { case_sensitive: false }, if: :active_user?
 
   validate do |record|
     EmailFormatValidator.new(record).validate
@@ -29,10 +30,14 @@ class User < ApplicationRecord
   end
 
   def active_user?
-    User.exists?(dttp_id: dttp_id, discarded_at: nil)
+    User.kept.exists?(email: email)
   end
 
 private
+
+  def active_user_by_dttp_id?
+    User.kept.exists?(dttp_id: dttp_id)
+  end
 
   def sanitise_email
     self.email = email.gsub(/\s+/, "") unless email.nil?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1111,6 +1111,7 @@ en:
               blank: Enter the user’s last name
             email:
               blank: Enter the user’s email address
+              taken: Enter a unique email address
             dttp_id:
               invalid: Enter a DTTP ID in the correct format, like 6a61d94f-5060-4d57-8676-bdb265a5b949
               taken: Enter a unique DTTP ID

--- a/db/migrate/20220302160415_add_uniqueness_to_user_email.rb
+++ b/db/migrate/20220302160415_add_uniqueness_to_user_email.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUniquenessToUserEmail < ActiveRecord::Migration[6.1]
+  def change
+    rename_index :users, "index_unique_active_users", "index_unique_active_dttp_users"
+    remove_index :users, :email
+    add_index :users, %i[email], unique: true, where: "discarded_at IS NULL", name: "index_unique_active_users"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_25_152144) do
+ActiveRecord::Schema.define(version: 2022_03_02_160415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -543,8 +543,8 @@ ActiveRecord::Schema.define(version: 2022_02_25_152144) do
     t.datetime "discarded_at"
     t.index ["dfe_sign_in_uid"], name: "index_users_on_dfe_sign_in_uid", unique: true
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
-    t.index ["dttp_id"], name: "index_unique_active_users", unique: true, where: "(discarded_at IS NULL)"
-    t.index ["email"], name: "index_users_on_email"
+    t.index ["dttp_id"], name: "index_unique_active_dttp_users", unique: true, where: "(discarded_at IS NULL)"
+    t.index ["email"], name: "index_unique_active_users", unique: true, where: "(discarded_at IS NULL)"
   end
 
   create_table "validation_errors", force: :cascade do |t|

--- a/spec/components/user_card/view_preview.rb
+++ b/spec/components/user_card/view_preview.rb
@@ -24,7 +24,6 @@ module UserCard
         :user,
         first_name: "Luke",
         last_name: "Skywalker",
-        email: "luke@email.com",
         created_at: Time.zone.now,
         dttp_id: SecureRandom.uuid,
         providers: [provider],

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,11 +20,15 @@ describe User do
     end
   end
 
-  context "validates dttp_id" do
+  context "uniqueness validations" do
     subject { create(:user) }
 
-    it "validates uniqueness" do
+    it "validates uniqueness of dttp_id" do
       expect(subject).to validate_uniqueness_of(:dttp_id).case_insensitive.with_message("Enter a unique DTTP ID")
+    end
+
+    it "validates uniqueness of email" do
+      expect(subject).to validate_uniqueness_of(:email).with_message("Enter a unique email address")
     end
   end
 
@@ -33,26 +37,26 @@ describe User do
 
     subject { build(:user) }
 
-    context "user with same dttp_id as active user" do
+    context "user with same email as active user" do
       before do
-        subject.dttp_id = first_user.dttp_id
+        subject.email = first_user.email
         subject.save
       end
 
       it "errors" do
-        expect(subject.errors[:dttp_id]).to include(I18n.t("activerecord.errors.models.user.attributes.dttp_id.taken"))
+        expect(subject.errors[:email]).to include(I18n.t("activerecord.errors.models.user.attributes.email.taken"))
       end
     end
 
-    context "user with same dttp_id as inactive user" do
+    context "user with same email as inactive user" do
       before do
-        subject.dttp_id = first_user.dttp_id
+        subject.email = first_user.email
         first_user.discard
         subject.save
       end
 
       it "allows user to be saved" do
-        expect(subject.errors[:dttp_id]).not_to include(I18n.t("activerecord.errors.models.user.attributes.dttp_id.taken"))
+        expect(subject.errors[:email]).not_to include(I18n.t("activerecord.errors.models.user.attributes.email.taken"))
       end
     end
   end
@@ -64,6 +68,7 @@ describe User do
   describe "indexes" do
     it { is_expected.to have_db_index(:dfe_sign_in_uid).unique(true) }
     it { is_expected.to have_db_index(:dttp_id).unique(true) }
+    it { is_expected.to have_db_index(:email).unique(true) }
   end
 
   describe "#discard" do


### PR DESCRIPTION
### Context
Ensure email addresses are unique when creating a user.

### Changes proposed in this pull request
Add a migration to change the index on `users.email` to be unique.
Add a uniqueness validation.
Tweak the existing definition of `User#active_user?` to compare users by email as opposed to dttp ids.
Define a private method `active_user_by_dttp_id?` on `User` to ensure that existing dttp_id uniqueness validation works as before.

### Guidance to review
Visit the review app as a system admin, and try to create a user with the same email address.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
