### PR TITLE
[3764] Hook up the DQT TRN route

### DIFF
--- a/app/services/dqt/register_for_trn.rb
+++ b/app/services/dqt/register_for_trn.rb
@@ -33,7 +33,7 @@ module Dqt
     end
 
     def update_trainee
-      trainee.submit_for_trn!
+      trainee.submit_for_trn! if trainee.can_submit_for_trn?
     end
   end
 end

--- a/app/services/trainees/submit_for_trn.rb
+++ b/app/services/trainees/submit_for_trn.rb
@@ -11,8 +11,15 @@ module Trainees
 
     def call
       trainee.submit_for_trn!
-      Dttp::RegisterForTrnJob.perform_later(trainee, dttp_id)
-      Dttp::RetrieveTrnJob.perform_with_default_delay(trainee)
+
+      if FeatureService.enabled?(:persist_to_dttp)
+        Dttp::RegisterForTrnJob.perform_later(trainee, dttp_id)
+        Dttp::RetrieveTrnJob.perform_with_default_delay(trainee)
+      end
+
+      if FeatureService.enabled?(:integrate_with_dqt)
+        Dqt::RegisterForTrnJob.perform_later(trainee)
+      end
     end
 
   private

--- a/spec/services/trainees/submit_for_trn_spec.rb
+++ b/spec/services/trainees/submit_for_trn_spec.rb
@@ -9,18 +9,34 @@ module Trainees
 
     subject { described_class.call(trainee: trainee, dttp_id: dttp_id) }
 
-    it "queues a background job to register trainee for TRN" do
-      expect {
+    context "persist_to_dttp enabled", feature_persist_to_dttp: true do
+      it "queues a background job to register trainee for TRN" do
+        expect {
+          subject
+        }.to have_enqueued_job(Dttp::RegisterForTrnJob).with(trainee, dttp_id)
+      end
+
+      it "queues a background job to poll for the trainee's TRN" do
+        expect(Dttp::RetrieveTrnJob).to receive(:perform_with_default_delay).with(trainee)
         subject
-      }.to have_enqueued_job(Dttp::RegisterForTrnJob).with(trainee, dttp_id)
+      end
+
+      it "transitions the trainee state to submitted_for_trn" do
+        expect {
+          subject
+        }.to change {
+          trainee.state
+        }.from("draft").to("submitted_for_trn")
+      end
     end
 
-    it "queues a background job to poll for the trainee's TRN" do
-      expect(Dttp::RetrieveTrnJob).to receive(:perform_with_default_delay).with(trainee)
-      subject
-    end
+    context "integrate_with_dqt enabled", feature_integrate_with_dqt: true do
+      it "queues a background job to register trainee for TRN" do
+        expect {
+          subject
+        }.to have_enqueued_job(Dqt::RegisterForTrnJob).with(trainee)
+      end
 
-    context "trainee state" do
       it "transitions the trainee state to submitted_for_trn" do
         expect {
           subject


### PR DESCRIPTION
### Context

https://trello.com/c/8ZTMCFk7/3764-hook-up-the-dqt-trn-route

### Changes proposed in this pull request

* Updated `Trainees::SubmitForTrn` to also schedule `Dqt::RegisterForTrnJob`

### Guidance to review

* Backend

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
