### PR TITLE
[3671] Record completion filter hidden for users in lead school context

### DIFF
--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -21,31 +21,7 @@
     <% end %>
   <% end %>
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-        <% if trainee_search_path?(search_path) %>
-          <%= t("views.trainees.index.filters.record_completion") %>
-        <% else %>
-          <%= t("views.drafts.index.filters.record_completion") %>
-        <% end %>
-      </legend>
-      <div class="govuk-checkboxes govuk-checkboxes--small">
-        <% [:complete, :incomplete].map do |completion_status| %>
-          <div class="govuk-checkboxes__item">
-            <%= check_box_tag "record_completion[]",
-                              completion_status,
-                              checked?(filters, :record_completion, completion_status.to_s),
-                              id: "record_completion-#{completion_status}",
-                              class: "govuk-checkboxes__input" %>
-            <%= label_tag "record_completion-#{completion_status}",
-                          label_for("record_completion", completion_status),
-                          class: "govuk-label govuk-checkboxes__label" %>
-          </div>
-        <% end %>
-      </div>
-    </fieldset>
-  </div>
+  <%= render "trainees/record_completion_filter", search_path: search_path %>
 
   <% if filter_start_year_options(current_user).count > 2 %>
     <div class="govuk-form-group">

--- a/app/views/trainees/_record_completion_filter.html.erb
+++ b/app/views/trainees/_record_completion_filter.html.erb
@@ -1,0 +1,27 @@
+<% unless lead_school_user? %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+        <% if trainee_search_path?(search_path) %>
+          <%= t("views.trainees.index.filters.record_completion") %>
+        <% else %>
+          <%= t("views.drafts.index.filters.record_completion") %>
+        <% end %>
+      </legend>
+      <div class="govuk-checkboxes govuk-checkboxes--small">
+        <% [:complete, :incomplete].map do |completion_status| %>
+          <div class="govuk-checkboxes__item">
+            <%= check_box_tag "record_completion[]",
+                              completion_status,
+                              checked?(filters, :record_completion, completion_status.to_s),
+                              id: "record_completion-#{completion_status}",
+                              class: "govuk-checkboxes__input" %>
+            <%= label_tag "record_completion-#{completion_status}",
+                          label_for("record_completion", completion_status),
+                          class: "govuk-label govuk-checkboxes__label" %>
+          </div>
+        <% end %>
+      </div>
+    </fieldset>
+  </div>
+<% end %>

--- a/spec/views/trainees/record_completion.html.erb_spec.rb
+++ b/spec/views/trainees/record_completion.html.erb_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "trainees/_record_completion_filter.html.erb", "feature_routes.provider_led_postgrad": true do
+  before do
+    without_partial_double_verification do
+      allow(view).to receive(:search_path).and_return(trainees_path)
+      allow(view).to receive(:filters).and_return(nil)
+      allow(view).to receive(:lead_school_user?).and_return(lead_school_user?)
+      render
+    end
+  end
+
+  context "placements enabled", feature_placements: true do
+    context "with a lead school users" do
+      let(:lead_school_user?) { true }
+
+      it "does not render the record completion filter" do
+        expect(rendered).to be_empty
+      end
+    end
+
+    context "with a non lead school user" do
+      let(:lead_school_user?) { false }
+
+      it "does render the record completion filter" do
+        expect(rendered).not_to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Users in lead school context cannot 'complete' and 'incomplete' record so the concept is meaningless to them.

We have a filter on the registered trainees index page that filters for incomplete records. This should be hidden from lead school users.

### Changes proposed in this pull request

Hide Record completion filter from lead school users.
