### PR TITLE
[xxx] Add missing translations for primary subjects

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -544,6 +544,7 @@ en:
         commencement_date_radio_option: *commencement_date_path
         trainee_id: edit_trainee_training_details_path
         study_mode: *course_path
+        primary_course_subjects: *course_path
     missing_data_view:
       degrees_form: degree
       missing_fields_summary:
@@ -591,6 +592,7 @@ en:
         commencement_date_radio_option: *commencement_date
         trainee_id: *trainee_id
         study_mode: *study_mode
+        primary_course_subjects: *course_subject
     drafts:
       index:
         results:


### PR DESCRIPTION
### Context

https://sentry.io/organizations/dfe-teacher-services/issues/3083374458/?project=5552118&referrer=slack

### Changes proposed in this pull request

We were missing some translations for primary course subjects in the missing details banner.
This PR adds them.

### Guidance to review

Recreating the issue on dev, with the new translations:

<img width="1052" alt="Screenshot 2022-03-09 at 14 19 36" src="https://user-images.githubusercontent.com/18436946/157459975-392e8598-ae6c-4c30-aceb-ce33315ccecf.png">

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
