### PR TITLE
[xxx] Persona page should say trainees not users

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -484,8 +484,8 @@ en:
             pg_teaching_apprenticeship: Lead and employing schools
     personas:
       view:
-        provider_user: "Belongs to <strong>%{provider_name}</strong> and is responsible for managing users."
-        lead_school_user: "Associated with <strong>%{lead_school_name}</strong> and can view users assigned to that lead school."
+        provider_user: "Belongs to <strong>%{provider_name}</strong> and is responsible for managing trainees."
+        lead_school_user: "Associated with <strong>%{lead_school_name}</strong> and can view trainees assigned to that lead school."
   apply_applications:
     trainee_data:
       view:


### PR DESCRIPTION
### Context

We list the personas on review and QA.

### Changes proposed in this pull request

The description should say "responsible for... trainess" not "users"

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
