### PR TITLE
[xxx] Allow updates to apply applications if not already imported

### DIFF
--- a/app/services/apply_api/import_application.rb
+++ b/app/services/apply_api/import_application.rb
@@ -11,7 +11,7 @@ module ApplyApi
     end
 
     def call
-      return unless application.new_record?
+      return unless application.new_record? || application.importable?
 
       ApplyApplication.transaction do
         application.update!(

--- a/app/services/apply_api/import_application.rb
+++ b/app/services/apply_api/import_application.rb
@@ -11,7 +11,7 @@ module ApplyApi
     end
 
     def call
-      return unless application.new_record? || application.importable?
+      return if application.persisted? && !application.importable?
 
       ApplyApplication.transaction do
         application.update!(

--- a/spec/services/apply_api/import_application_spec.rb
+++ b/spec/services/apply_api/import_application_spec.rb
@@ -23,16 +23,34 @@ module ApplyApi
         end
 
         context "and the apply application_data also exists in register" do
+          let(:existing_application) { ApiStubs::ApplyApi.application(degree_attributes: { subject: "different subject" }) }
+
           before do
-            create(:apply_application, :imported, apply_id: application_data["id"])
+            create(:apply_application, state, apply_id: application_data["id"], application: existing_application)
           end
 
-          it "does not create a duplicate" do
-            expect { subject }.not_to(change { ApplyApplication.count })
+          context "and is importable" do
+            let(:state) { :importable }
+
+            it "does not create a duplicate" do
+              expect { subject }.not_to(change { ApplyApplication.count })
+            end
+
+            it "updates old values" do
+              expect { subject }.to(change { ApplyApplication.last.application })
+            end
           end
 
-          it "does not update old values" do
-            expect { subject }.not_to(change { ApplyApplication.last.state })
+          context "and has already been imported" do
+            let(:state) { :imported }
+
+            it "does not create a duplicate" do
+              expect { subject }.not_to(change { ApplyApplication.count })
+            end
+
+            it "does not update old values" do
+              expect { subject }.not_to(change { ApplyApplication.last.application })
+            end
           end
         end
 


### PR DESCRIPTION
### Context

Currently we have this issue:

- An Apply application is not imported (and no trainee is created) because of some error in the data
- The Apply application is fixed upstream and we receive an updated application via the API
- However, we do not update our own Apply application in our database, because of a check `return unless application.new_record?`

The application remains in the 'importable' state and errors daily when trying to create a trainee.

### Changes proposed in this pull request

- Allow updates to our own Apply applications if the application is in the importable state i.e. no trainee has been created yet.

### Guidance to review

Any reason why this isn't sensible?
I think we may have blocked updates to applications in a bid to 'freeze' them at the point at which a trainee is created. This change doesn't invalidate that logic.

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
