### PR TITLE
[3530] Improve seed data pt 2

### DIFF
--- a/config/initializers/mappings/allocation_subject_to_specialism_mapping.rb
+++ b/config/initializers/mappings/allocation_subject_to_specialism_mapping.rb
@@ -107,8 +107,8 @@ ALLOCATION_SUBJECT_SPECIALISM_MAPPING = {
     CourseSubjects::SPORT_AND_EXERCISE_SCIENCES,
   ],
   AllocationSubjects::PHYSICS => [
-    CourseSubjects::APPLIED_PHYSICS,
     CourseSubjects::PHYSICS,
+    CourseSubjects::APPLIED_PHYSICS,
   ],
   AllocationSubjects::RELIGIOUS_EDUCATION => [
     CourseSubjects::PHILOSOPHY,

--- a/config/initializers/mappings/publish_to_allocation_subject_mapping.rb
+++ b/config/initializers/mappings/publish_to_allocation_subject_mapping.rb
@@ -68,7 +68,6 @@ PUBLISH_SECONDARY_SUBJECT_SPECIALISM_MAPPING = {
   "History" => [CourseSubjects::HISTORY],
   "Music" => [CourseSubjects::MUSIC_EDUCATION_AND_TEACHING],
   "Philosophy" => [CourseSubjects::PHILOSOPHY],
-  "Physics" => [CourseSubjects::PHYSICS],
   "Psychology" => [CourseSubjects::PSYCHOLOGY],
   "Religious education" => [CourseSubjects::RELIGIOUS_STUDIES],
   "Science" => [CourseSubjects::GENERAL_SCIENCES],
@@ -98,6 +97,7 @@ PUBLISH_SECONDARY_SUBJECT_SPECIALISM_MAPPING = {
   "Drama" => ALLOCATION_SUBJECT_SPECIALISM_MAPPING[AllocationSubjects::DRAMA],
   "Mathematics" => ALLOCATION_SUBJECT_SPECIALISM_MAPPING[AllocationSubjects::MATHEMATICS],
   "Physical education" => ALLOCATION_SUBJECT_SPECIALISM_MAPPING[AllocationSubjects::PHYSICAL_EDUCATION],
+  "Physics" => ALLOCATION_SUBJECT_SPECIALISM_MAPPING[AllocationSubjects::PHYSICS],
 }.freeze
 
 PUBLISH_SUBJECT_SPECIALISM_MAPPING = PUBLISH_SECONDARY_SUBJECT_SPECIALISM_MAPPING.merge(PUBLISH_PRIMARY_SUBJECT_SPECIALISM_MAPPING).freeze

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -221,7 +221,7 @@ namespace :example_data do
               attrs.merge!(
                 course_subject_one: CourseSubjects::EARLY_YEARS_TEACHING,
                 course_age_range: AgeRange::ZERO_TO_FIVE,
-                course_education_phase: COURSE_EDUCATION_PHASE_ENUMS[:primary],
+                course_education_phase: nil,
               )
             end
 

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -221,10 +221,21 @@ namespace :example_data do
               attrs.merge!(
                 course_subject_one: CourseSubjects::EARLY_YEARS_TEACHING,
                 course_age_range: AgeRange::ZERO_TO_FIVE,
+                course_education_phase: COURSE_EDUCATION_PHASE_ENUMS[:primary],
               )
             end
 
-            FactoryBot.create(:trainee, route, state, attrs)
+            trainee = FactoryBot.create(:trainee, route, state, attrs)
+
+            if sample_index < sample_size * 80.0 / 100
+              funding_manager = FundingManager.new(trainee)
+
+              trainee.applying_for_bursary = true if funding_manager.can_apply_for_bursary?
+              trainee.applying_for_grant = true if funding_manager.can_apply_for_grant?
+              trainee.applying_for_scholarship = true if funding_manager.can_apply_for_scholarship?
+            end
+
+            trainee.save!
           end
         end
       end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     transient do
       age_range do
         Dttp::CodeSets::AgeRanges::MAPPING.select do |_, v|
-          v[:levels]&.include?(level)
+          v[:option] == :main && v[:levels]&.include?(level)
         end.keys.sample
       end
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -280,6 +280,7 @@ FactoryBot.define do
     trait :with_early_years_course_details do
       course_subject_one { CourseSubjects::EARLY_YEARS_TEACHING }
       course_age_range { AgeRange::ZERO_TO_FIVE }
+      with_primary_education
       with_study_mode_and_course_dates
     end
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -161,7 +161,7 @@ FactoryBot.define do
       course_subject_three { primary_specialism_subjects.third }
       course_age_range do
         Dttp::CodeSets::AgeRanges::MAPPING.select do |_, v|
-          v[:levels]&.include?(course_education_phase.to_sym)
+          v[:option] == :main && v[:levels]&.include?(course_education_phase.to_sym)
         end.keys.sample
       end
       with_study_mode_and_course_dates
@@ -180,7 +180,7 @@ FactoryBot.define do
       course_subject_three { nil }
       course_age_range do
         Dttp::CodeSets::AgeRanges::MAPPING.select do |_, v|
-          v[:levels]&.include?(course_education_phase.to_sym)
+          v[:option] == :main && v[:levels]&.include?(course_education_phase.to_sym)
         end.keys.sample
       end
       with_study_mode_and_course_dates

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -280,7 +280,6 @@ FactoryBot.define do
     trait :with_early_years_course_details do
       course_subject_one { CourseSubjects::EARLY_YEARS_TEACHING }
       course_age_range { AgeRange::ZERO_TO_FIVE }
-      with_primary_education
       with_study_mode_and_course_dates
     end
 


### PR DESCRIPTION
### Context

https://trello.com/c/8v7sSyFk/3530-snags-with-seed-data-part-2

### Changes proposed in this pull request

- Set education phase for primary trainees to primary
- Map physics to physics and applied physics specialisms
- Choose common age ranges for courses
- Set 80% of trainees to funded if funding available

See ticket for explanation of checklist items not addressed here (i.e. already fixed, or not reproducible) 

Historical data seeds pulled out into separate ticket https://trello.com/c/N972jc7z/3814-historical-data-seeds

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
