### PR TITLE
[3711] HESA records in Register - View only state for HESA records

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -8,13 +8,12 @@ module ApplicationRecordCard
 
     with_collection_parameter :record
 
-    attr_reader :record, :heading_level, :show_provider, :hide_progress_tag
+    attr_reader :record, :heading_level, :current_user
 
-    def initialize(heading_level = 3, record:, show_provider: false, hide_progress_tag: false)
+    def initialize(heading_level = 3, record:, current_user:)
       @record = record
       @heading_level = heading_level
-      @show_provider = show_provider
-      @hide_progress_tag = hide_progress_tag
+      @current_user = current_user
     end
 
     def trainee_name
@@ -73,6 +72,14 @@ module ApplicationRecordCard
 
       year_text = "#{academic_cycle.start_year} to #{academic_cycle.start_year + 1}"
       tag.p("Start year: #{year_text}", class: "govuk-caption-m govuk-!-font-size-16 application-record-card__start_year govuk-!-margin-top-1 govuk-!-margin-bottom-1")
+    end
+
+    def show_provider
+      current_user.system_admin? || current_user.lead_school?
+    end
+
+    def hide_progress_tag
+      TraineePolicy.new(current_user, record).hide_progress_tag?
     end
 
   private

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -83,6 +83,10 @@ class TraineePolicy
     user_is_system_admin? || user.provider?
   end
 
+  def hide_progress_tag?
+    user.lead_school? || hesa_record?
+  end
+
   alias_method :index?, :show?
 
   alias_method :edit?, :update?
@@ -96,7 +100,11 @@ private
   end
 
   def write?
-    user_is_system_admin? || (user_in_provider_context? && trainee.awaiting_action?)
+    user_is_system_admin? || (!hesa_record? && user_in_provider_context? && trainee.awaiting_action?)
+  end
+
+  def hesa_record?
+    trainee.hesa_id.present?
   end
 
   def user_in_provider_context?

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -8,7 +8,7 @@
     ) %>
   <% end %>
 
-  <%= render RecordHeader::View.new(trainee: @trainee, hide_progress_tag: @current_user.lead_school?) %>
+  <%= render RecordHeader::View.new(trainee: @trainee, hide_progress_tag: policy(@trainee).hide_progress_tag?) %>
 
   <% if @missing_data_view %>
     <%= render NoticeBanner::View.new do |component| %>

--- a/app/views/trainees/_results.html.erb
+++ b/app/views/trainees/_results.html.erb
@@ -8,8 +8,7 @@
       </div>
       <%= render ApplicationRecordCard::View.with_collection(
         search_primary_result_set,
-        hide_progress_tag: @current_user.lead_school?,
-        show_provider: @current_user.system_admin? || @current_user.lead_school?
+        current_user: @current_user,
         ) %>
     </div>
   <% end %>
@@ -25,8 +24,7 @@
       </div>
       <%= render ApplicationRecordCard::View.with_collection(
         search_secondary_result_set,
-        hide_progress_tag: @current_user.lead_school?,
-        show_provider: @current_user.system_admin? || @current_user.lead_school?
+        current_user: @current_user,
         ) %>
     </div>
   <% end %>

--- a/spec/components/application_record_card/view_preview.rb
+++ b/spec/components/application_record_card/view_preview.rb
@@ -4,28 +4,33 @@ module ApplicationRecordCard
   class ViewPreview < ViewComponent::Preview
     [true, false].each do |system_admin|
       suffice = system_admin ? "_as_system_admin" : ""
+      user = if system_admin
+               Struct.new(:system_admin?, :lead_school?).new(true, false)
+             else
+               Struct.new(:system_admin?, :lead_school?).new(false, false)
+             end
       define_method "single_card#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: mock_trainee, show_provider: system_admin))
+        render(ApplicationRecordCard::View.new(record: mock_trainee, current_user: user))
       end
 
       define_method "single_card_with_trn_and_trainee_id#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: mock_trainee_with_trn_and_trainee_id, show_provider: system_admin))
+        render(ApplicationRecordCard::View.new(record: mock_trainee_with_trn_and_trainee_id, current_user: user))
       end
 
       define_method "multiple_cards#{suffice}" do
-        render(ApplicationRecordCard::View.with_collection(mock_multiple_trainees, show_provider: system_admin))
+        render(ApplicationRecordCard::View.with_collection(mock_multiple_trainees, current_user: user))
       end
 
       define_method "single_card_with_incomplete_data#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: Trainee.new(id: 1, updated_at: Time.zone.now, provider: mock_provider), show_provider: system_admin))
+        render(ApplicationRecordCard::View.new(record: Trainee.new(id: 1, updated_at: Time.zone.now, provider: mock_provider), current_user: user))
       end
 
       define_method "single_card_with_two_subjects#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: mock_trainee_with_two_subjects, show_provider: system_admin))
+        render(ApplicationRecordCard::View.new(record: mock_trainee_with_two_subjects, current_user: user))
       end
 
       define_method "single_card_with_three_subjects#{suffice}" do
-        render(ApplicationRecordCard::View.new(record: mock_trainee_with_three_subjects, show_provider: system_admin))
+        render(ApplicationRecordCard::View.new(record: mock_trainee_with_three_subjects, current_user: user))
       end
     end
 

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -14,6 +14,7 @@ describe TraineePolicy do
 
   let(:provider_trainee) { create(:trainee, provider: provider) }
   let(:lead_school_trainee) { create(:trainee, lead_school: lead_school) }
+  let(:hesa_trainee) { create(:trainee, provider: provider, hesa_id: "XXX123") }
 
   subject { described_class }
 
@@ -46,6 +47,7 @@ describe TraineePolicy do
 
   permissions :update?, :edit?, :destroy?, :confirm? do
     it { is_expected.to permit(provider_user, provider_trainee) }
+    it { is_expected.not_to permit(provider_user, hesa_trainee) }
     it { is_expected.not_to permit(lead_school_user, lead_school_trainee) }
 
     it { is_expected.to permit(system_admin_user, provider_trainee) }
@@ -237,6 +239,12 @@ describe TraineePolicy do
     context "when the user is a lead school user" do
       it { is_expected.not_to permit(lead_school_user) }
     end
+  end
+
+  permissions :hide_progress_tag? do
+    it { is_expected.not_to permit(provider_user, provider_trainee) }
+    it { is_expected.to permit(provider_user, hesa_trainee) }
+    it { is_expected.to permit(lead_school_user, lead_school_trainee) }
   end
 
   describe TraineePolicy::Scope do


### PR DESCRIPTION
### Context

https://trello.com/c/EYqO3fg8/3711-l-hesa-records-in-register-view-only-state-for-hesa-records

### Changes proposed in this pull request

* Updated `TraineePolicy` to check for hesa record
* Hiding incomplete tag now uses `TraineePolicy`

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
