### PR TITLE
[3777] Hide 'incomplete' tags for HESA records

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -316,7 +316,7 @@ class Trainee < ApplicationRecord
   end
 
   def awaiting_action?
-    !%w[recommended_for_award withdrawn awarded].include?(state)
+    !%w[recommended_for_award withdrawn awarded].include?(state) && hesa_id.blank?
   end
 
   def short_name

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -627,4 +627,26 @@ describe Trainee do
       expect(trainee.duplicate?).to be(true)
     end
   end
+
+  describe "#awaiting_action?" do
+    let(:trainee) { create(:trainee, awaiting_states.sample) }
+    let(:awaiting_states) { %i[submitted_for_trn trn_received deferred] }
+    let(:non_awaiting_states) { %i[recommended_for_award withdrawn awarded] }
+
+    subject { trainee.awaiting_action? }
+
+    it { is_expected.to be_truthy }
+
+    context "with a trainee in a non awaiting_action state" do
+      let(:trainee) { create(:trainee, non_awaiting_states.sample) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "with a trainee is a hesa record" do
+      let(:trainee) { create(:trainee, awaiting_states.sample, hesa_id: "0310261553101") }
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
### Context
Because we are pulling updates from HESA we don't want records with conflicts.
To prevent this records that are still going to receive updates from HESA need to be view only.

### Changes proposed in this pull request
Extend Trainee#awaiting_action? to check the presence of hesa_id

### Guidance to review
<TBC>

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
