### PR TITLE
[3712] hesa records in register content change

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -346,6 +346,10 @@ class Trainee < ApplicationRecord
     Trainee.where(first_names: first_names, last_name: last_name, date_of_birth: date_of_birth, email: email).count > 1
   end
 
+  def hesa_record?
+    hesa_id.present?
+  end
+
 private
 
   def value_digest

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -84,7 +84,7 @@ class TraineePolicy
   end
 
   def hide_progress_tag?
-    user.lead_school? || hesa_record?
+    user.lead_school? || trainee.hesa_record?
   end
 
   alias_method :index?, :show?
@@ -100,11 +100,7 @@ private
   end
 
   def write?
-    user_is_system_admin? || (!hesa_record? && user_in_provider_context? && trainee.awaiting_action?)
-  end
-
-  def hesa_record?
-    trainee.hesa_id.present?
+    user_is_system_admin? || (!trainee.hesa_record? && user_in_provider_context? && trainee.awaiting_action?)
   end
 
   def user_in_provider_context?

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -10,6 +10,17 @@
 
   <%= render RecordHeader::View.new(trainee: @trainee, hide_progress_tag: policy(@trainee).hide_progress_tag?) %>
 
+  <% if @trainee.hesa_record? %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <%= render GovukComponent::InsetTextComponent.new(classes: "govuk-!-padding-top-0 govuk-!-padding-bottom-0") do %>
+          <h3 class="govuk-heading-s"><%= t(".hesa_uneditable_heading") %></h3>
+          <%= t(".body_html", award_level: @trainee.early_years_route? ? t(".eyts_award_level") : t(".qts_award_level")).html_safe %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
   <% if @missing_data_view %>
     <%= render NoticeBanner::View.new do |component| %>
       <% component.header { @missing_data_view.header } %>

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -14,7 +14,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <%= render GovukComponent::InsetTextComponent.new(classes: "govuk-!-padding-top-0 govuk-!-padding-bottom-0") do %>
-          <h3 class="govuk-heading-s"><%= t(".hesa_uneditable_heading") %></h3>
+          <h2 class="govuk-heading-s"><%= t(".hesa_uneditable_heading") %></h2>
           <%= t(".body_html", award_level: @trainee.early_years_route? ? t(".eyts_award_level") : t(".qts_award_level")).html_safe %>
         <% end %>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1472,3 +1472,10 @@ en:
     schools:
       errors:
         bad_request: The query param needs to be at least %{length} characters
+  layouts:
+    trainee_record:
+      hesa_uneditable_heading: This record was imported from HESA and cannot be edited
+      body_html: <p class="govuk-body">Updates from HESA are imported regularly.</p>
+            <p class="govuk-body">You will be able to recommend the trainee for %{award_level} at the end of the academic year.</p>
+      qts_award_level: QTS
+      eyts_award_level: EYTS


### PR DESCRIPTION
### Context
https://trello.com/c/Cj6PM6Au/3712-hesa-records-in-register-content-telling-users-theyre-record-is-from-hesa-an-cannot-be-edited

### Changes proposed in this pull request
- Based on https://github.com/DFE-Digital/register-trainee-teachers/pull/2114
- moved the `hesa_record?` from `TraineePolicy` to `Trainee` to be able to reuse it in the view.
- Add the inset text.

### Guidance to review
Only https://github.com/DFE-Digital/register-trainee-teachers/pull/2118/commits/fdfd2bc4b8e369d9be17a66af068d533aef7da77 forms part of this PR.
Visit any non-draft trainee on Provider A, to view the content  (i've marked them all as HESA imports)
![image](https://user-images.githubusercontent.com/910019/158163320-742f08e9-0227-4d5e-9ec0-62d60bc0779f.png)


### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
