### PR TITLE
[3778] Set HESA states correctly

### DIFF
--- a/app/lib/hesa/code_sets/fund_codes.rb
+++ b/app/lib/hesa/code_sets/fund_codes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Hesa
+  module CodeSets
+    module FundCodes
+      # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
+      # https://www.hesa.ac.uk/collection/c21053/e/fundcode
+      MAPPING = {
+        "2" => "Not fundable by funding council/body",
+        "7" => "Eligible for funding from the DfE",
+      }.freeze
+    end
+  end
+end

--- a/app/lib/hesa/code_sets/genders.rb
+++ b/app/lib/hesa/code_sets/genders.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Hesa
+  module CodeSets
+    module Genders
+      # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
+      # https://www.hesa.ac.uk/collection/c21053/e/sexid
+      MAPPING = {
+        "1" => Trainee.genders[:male],
+        "2" => Trainee.genders[:female],
+        "3" => Trainee.genders[:other],
+      }.freeze
+    end
+  end
+end

--- a/app/lib/hesa/code_sets/itt_aims.rb
+++ b/app/lib/hesa/code_sets/itt_aims.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Hesa
+  module CodeSets
+    module IttAims
+      # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
+      # https://www.hesa.ac.uk/collection/c21053/e/ittaim
+      MAPPING = {
+        "201" => "Professional status only",
+        "202" => "Both professional status and academic award",
+      }.freeze
+    end
+  end
+end

--- a/app/lib/hesa/code_sets/itt_qualification_aims.rb
+++ b/app/lib/hesa/code_sets/itt_qualification_aims.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Hesa
+  module CodeSets
+    module IttQualificationAims
+      # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
+      # https://www.hesa.ac.uk/collection/c21053/e/qlaim
+      MAPPING = {
+        "007" => "BA",
+        "008" => "BA (Hons)",
+        "001" => "BEd",
+        "002" => "BEd (Hons)",
+        "003" => "BSc",
+        "004" => "BSc (Hons)",
+        "020" => "Postgraduate Certificate in Education",
+        "021" => "Postgraduate Diploma in Education",
+        "028" => "Undergraduate Master of Teaching",
+        "031" => "Professional Graduate Certificate in Education",
+        "032" => "Masters, not by research",
+      }.freeze
+    end
+  end
+end

--- a/app/lib/hesa/code_sets/service_leavers.rb
+++ b/app/lib/hesa/code_sets/service_leavers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Hesa
+  module CodeSets
+    module ServiceLeavers
+      # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
+      # https://www.hesa.ac.uk/collection/c21053/e/serleave
+      MAPPING = {
+        "01" => "Trainee has not left full time employment in the British Army, Royal Air Force or Royal Navy within 5 years of beginning the programme",
+        "02" => "Trainee left full time employment in the British Army, Royal Air Force or Royal Navy within 5 years of beginning the programme",
+        "03" => "Prefer not to say",
+        "09" => "Unknown",
+      }.freeze
+    end
+  end
+end

--- a/app/lib/hesa/code_sets/study_length_units.rb
+++ b/app/lib/hesa/code_sets/study_length_units.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Hesa
+  module CodeSets
+    module StudyLengthUnits
+      # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
+      # https://www.hesa.ac.uk/collection/c21053/e/unitlgth
+      MAPPING = {
+        "1" =>	"years",
+        "2" =>	"months",
+        "3" =>	"weeks",
+        "4" =>	"days",
+        "5" =>	"hours",
+      }.freeze
+    end
+  end
+end

--- a/app/lib/hesa/code_sets/study_modes.rb
+++ b/app/lib/hesa/code_sets/study_modes.rb
@@ -4,10 +4,13 @@ module Hesa
   module CodeSets
     module StudyModes
       # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
-      # https://www.hesa.ac.uk/collection/c21053/e/crmode
+      # https://www.hesa.ac.uk/collection/c21053/e/mode
       MAPPING = {
-        "1" => TRAINEE_STUDY_MODE_ENUMS["full_time"],
-        "2" => TRAINEE_STUDY_MODE_ENUMS["part_time"],
+        "01" => TRAINEE_STUDY_MODE_ENUMS["full_time"],
+        "02" => TRAINEE_STUDY_MODE_ENUMS["full_time"],
+        "31" => TRAINEE_STUDY_MODE_ENUMS["part_time"],
+        "63" => TRAINEE_STUDY_MODE_ENUMS["full_time"],
+        "64" => TRAINEE_STUDY_MODE_ENUMS["part_time"],
       }.freeze
     end
   end

--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -3,52 +3,61 @@
 module Hesa
   module Parsers
     class IttRecord
+      TAG_MAP = {
+        first_names: "F_FNAMES",
+        last_name: "F_SURNAME",
+        email: "F_NQTEMAIL",
+        date_of_birth: "F_BIRTHDTE",
+        ethnic_background: "F_ETHNIC",
+        gender: "F_SEXID",
+        ukprn: "F_UKPRN",
+        trainee_id: "F_OWNSTU",
+        course_subject_one: "F_SBJCA1",
+        course_subject_two: "F_SBJCA2",
+        course_subject_three: "F_SBJCA3",
+        itt_start_date: "F_COMDATE",
+        itt_end_date: "F_ENDDATE",
+        employing_school_urn: "F_SDEMPLOY",
+        lead_school_urn: "F_SDLEAD",
+        mode: "F_MODE",
+        course_age_range: "F_ITTPHSC",
+        commencement_date: "F_ITTCOMDATE",
+        training_initiative: "F_INITIATIVES1",
+        hesa_id: "F_HUSID",
+        disability: "F_DISABLE",
+        end_date: "F_ENDDATE",
+        reason_for_leaving: "F_RSNEND",
+        bursary_level: "F_BURSLEV",
+        trn: "F_TREFNO",
+        training_route: "F_ENTRYRTE",
+        nationality: "F_NATION",
+        hesa_updated_at: "F_STATUS_TIMESTAMP",
+        itt_aim: "F_ITTAIM",
+        itt_qualification_aim: "F_QLAIM",
+        fund_code: "F_FUNDCODE",
+        study_length: "F_SPLENGTH",
+        study_length_unit: "F_UNITLGTH",
+        service_leaver: "F_SERLEAVE",
+        course_programme_title: "F_CTITLE",
+        pg_apprenticeship_start_date: "F_PGAPPSTDT",
+        year_of_course: "F_YEARPRG",
+        degrees: "PREVIOUSQUALIFICATIONS",
+        placements: "PLACEMENTS",
+      }.freeze
+
       class << self
         def to_attributes(student_node:)
           student_attributes = Hash.from_xml(student_node.to_s)["Student"]
           student_attributes = convert_all_null_values_to_nil(student_attributes)
-
-          {
-            first_names: student_attributes["F_FNAMES"],
-            last_name: student_attributes["F_SURNAME"],
-            email: student_attributes["F_NQTEMAIL"],
-            date_of_birth: student_attributes["F_BIRTHDTE"],
-            ethnic_background: student_attributes["F_ETHNIC"],
-            gender: student_attributes["F_SEXID"],
-            ukprn: student_attributes["F_UKPRN"],
-            trainee_id: student_attributes["F_OWNSTU"],
-            course_subject_one: student_attributes["F_SBJCA1"],
-            course_subject_two: student_attributes["F_SBJCA2"],
-            course_subject_three: student_attributes["F_SBJCA3"],
-            itt_start_date: student_attributes["F_COMDATE"],
-            itt_end_date: student_attributes["F_ENDDATE"],
-            employing_school_urn: student_attributes["F_SDEMPLOY"],
-            lead_school_urn: student_attributes["F_SDLEAD"],
-            mode: student_attributes["F_MODE"],
-            course_age_range: student_attributes["F_ITTPHSC"],
-            commencement_date: student_attributes["F_ITTCOMDATE"],
-            training_initiative: student_attributes["F_INITIATIVES1"],
-            hesa_id: student_attributes["F_HUSID"],
-            disability: student_attributes["F_DISABLE"],
-            end_date: student_attributes["F_ENDDATE"],
-            reason_for_leaving: student_attributes["F_RSNEND"],
-            bursary_level: student_attributes["F_BURSLEV"],
-            trn: student_attributes["F_TREFNO"],
-            training_route: student_attributes["F_ENTRYRTE"],
-            nationality: student_attributes["F_NATION"],
-            hesa_updated_at: student_attributes["F_STATUS_TIMESTAMP"],
-            itt_aim: student_attributes["F_ITTAIM"],
-            itt_qualification_aim: student_attributes["F_QLAIM"],
-            fund_code: student_attributes["F_FUNDCODE"],
-            study_length: student_attributes["F_SPLENGTH"],
-            study_length_unit: student_attributes["F_UNITLGTH"],
-            service_leaver: student_attributes["F_SERLEAVE"],
-            course_programme_title: student_attributes["F_CTITLE"],
-            pg_apprenticeship_start_date: student_attributes["F_PGAPPSTDT"],
-            year_of_course: student_attributes["F_YEARPRG"],
-            degrees: to_degrees_attributes(student_attributes["PREVIOUSQUALIFICATIONS"]),
-            placements: to_placement_attributes(student_attributes["PLACEMENTS"]),
-          }
+          TAG_MAP.inject({}) do |hash, (attribute_name, xml_tag_name)|
+            tag_value = student_attributes[xml_tag_name]
+            hash[attribute_name] = case attribute_name
+                                   when :degrees then to_degrees_attributes(tag_value)
+                                   when :placements then to_placement_attributes(tag_value)
+                                   else tag_value
+                                   end
+            hash
+          end
         end
 
         def to_degrees_attributes(qualifications)

--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -29,7 +29,6 @@ module Hesa
             commencement_date: student_attributes["F_ITTCOMDATE"],
             training_initiative: student_attributes["F_INITIATIVES1"],
             hesa_id: student_attributes["F_HUSID"],
-            international_address: student_attributes["F_DOMICILE"],
             disability: student_attributes["F_DISABLE"],
             end_date: student_attributes["F_ENDDATE"],
             reason_for_leaving: student_attributes["F_RSNEND"],

--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -25,7 +25,6 @@ module Hesa
             employing_school_urn: student_attributes["F_SDEMPLOY"],
             lead_school_urn: student_attributes["F_SDLEAD"],
             mode: student_attributes["F_MODE"],
-            study_mode: student_attributes["F_CRMODE"],
             course_age_range: student_attributes["F_ITTPHSC"],
             commencement_date: student_attributes["F_ITTCOMDATE"],
             training_initiative: student_attributes["F_INITIATIVES1"],

--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -38,6 +38,7 @@ module Hesa
             trn: student_attributes["F_TREFNO"],
             training_route: student_attributes["F_ENTRYRTE"],
             nationality: student_attributes["F_NATION"],
+            hesa_updated_at: student_attributes["F_STATUS_TIMESTAMP"],
             degrees: to_degrees_attributes(student_attributes["PREVIOUSQUALIFICATIONS"]),
           }
         end

--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -37,7 +37,17 @@ module Hesa
             training_route: student_attributes["F_ENTRYRTE"],
             nationality: student_attributes["F_NATION"],
             hesa_updated_at: student_attributes["F_STATUS_TIMESTAMP"],
+            itt_aim: student_attributes["F_ITTAIM"],
+            itt_qualification_aim: student_attributes["F_QLAIM"],
+            fund_code: student_attributes["F_FUNDCODE"],
+            study_length: student_attributes["F_SPLENGTH"],
+            study_length_unit: student_attributes["F_UNITLGTH"],
+            service_leaver: student_attributes["F_SERLEAVE"],
+            course_programme_title: student_attributes["F_CTITLE"],
+            pg_apprenticeship_start_date: student_attributes["F_PGAPPSTDT"],
+            year_of_course: student_attributes["F_YEARPRG"],
             degrees: to_degrees_attributes(student_attributes["PREVIOUSQUALIFICATIONS"]),
+            placements: to_placement_attributes(student_attributes["PLACEMENTS"]),
           }
         end
 
@@ -53,6 +63,14 @@ module Hesa
               institution: qualification["F_DEGEST"],
               grade: qualification["F_DEGCLSS"],
               country: qualification["F_DEGCTRY"],
+            }
+          end
+        end
+
+        def to_placement_attributes(placements)
+          [placements&.values].flatten.compact.map do |placement|
+            {
+              school_urn: placement["F_PLMNTSCH"],
             }
           end
         end

--- a/app/models/hesa/metadatum.rb
+++ b/app/models/hesa/metadatum.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Hesa
+  class Metadatum < ApplicationRecord
+    self.table_name = "hesa_metadata"
+
+    belongs_to :trainee
+  end
+end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -31,6 +31,8 @@ class Trainee < ApplicationRecord
   has_many :trainee_disabilities, dependent: :destroy, inverse_of: :trainee
   has_many :disabilities, through: :trainee_disabilities
 
+  has_one :hesa_metadatum, class_name: "Hesa::Metadatum"
+
   attribute :progress, Progress.to_type
 
   delegate :award_type,

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -43,7 +43,7 @@ module Trainees
         return
       end
 
-      if trainee_status.blank?
+      if trainee_state.blank?
         dttp_trainee.non_importable_missing_state!
         return
       end
@@ -75,7 +75,7 @@ module Trainees
 
       {
         created_from_dttp: true,
-        state: trainee_status,
+        state: trainee_state,
         provider: dttp_trainee.provider,
         trainee_id: trainee_id,
         training_route: training_route,
@@ -349,12 +349,12 @@ module Trainees
       Dttp::School.find_by(dttp_id: dttp_trainee.latest_placement_assignment.employing_school_id)&.urn
     end
 
-    def trainee_status
-      @trainee_status ||= MapStateFromDttp.call(dttp_trainee: dttp_trainee)
+    def trainee_state
+      @trainee_state ||= MapStateFromDttp.call(dttp_trainee: dttp_trainee)
     end
 
     def withdrawal_attributes
-      return {} unless trainee_status == "withdrawn"
+      return {} unless trainee_state == "withdrawn"
 
       {
         withdraw_date: withdraw_date,

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -185,7 +185,7 @@ module Trainees
 
     # This field indicates the mode the student was reported on for the DfE census in their first year.
     def study_mode
-      Hesa::CodeSets::StudyModes::MAPPING[hesa_trainee[:study_mode]]
+      Hesa::CodeSets::StudyModes::MAPPING[hesa_trainee[:mode]]
     end
 
     def age_range

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -58,7 +58,7 @@ module Trainees
         first_names: hesa_trainee[:first_names],
         last_name: hesa_trainee[:last_name],
         date_of_birth: hesa_trainee[:date_of_birth],
-        gender: hesa_trainee[:gender].to_i,
+        gender: gender,
         nationalities: nationalities,
         email: hesa_trainee[:email],
       }
@@ -148,6 +148,10 @@ module Trainees
 
     def training_initiative_attributes
       { training_initiative: training_initiative || ROUTE_INITIATIVES_ENUMS[:no_initiative] }
+    end
+
+    def gender
+      Hesa::CodeSets::Genders::MAPPING[hesa_trainee[:gender]]
     end
 
     def nationalities

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -47,7 +47,6 @@ module Trainees
        .merge(provider_attributes)
        .merge(ethnicity_and_disability_attributes)
        .merge(course_attributes)
-       .merge(deferral_attributes)
        .merge(withdrawal_attributes)
        .merge(funding_attributes)
        .merge(school_attributes)
@@ -84,16 +83,6 @@ module Trainees
         itt_end_date: hesa_trainee[:itt_end_date],
         commencement_date: hesa_trainee[:commencement_date] || hesa_trainee[:itt_start_date],
       }
-    end
-
-    def deferral_attributes
-      return { defer_date: nil } unless trainee_status == :deferred
-
-      # It's possible that the HESA record gets updated even though the record remains deferred. We don't
-      # want change the defer_date if it's
-      return {} if trainee.defer_date.present?
-
-      { defer_date: hesa_trainee[:hesa_updated_at] } # hesa_trainee[:end_date] is not applicable in this scenario
     end
 
     def withdrawal_attributes

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -41,7 +41,7 @@ module Trainees
         trainee_id: hesa_trainee[:trainee_id],
         training_route: training_route,
         trn: trn,
-        state: trainee_status,
+        state: trainee_state,
         hesa_updated_at: hesa_trainee[:hesa_updated_at],
       }.merge(created_from_hesa_attribute)
        .merge(personal_details_attributes)
@@ -97,7 +97,7 @@ module Trainees
     end
 
     def withdrawal_attributes
-      return {} unless trainee_status == :withdrawn
+      return {} unless trainee_state == :withdrawn
 
       { withdraw_date: hesa_trainee[:end_date], withdraw_reason: reason_for_leaving }
     end
@@ -231,8 +231,8 @@ module Trainees
       Hesa::CodeSets::ServiceLeavers::MAPPING[hesa_trainee[:service_leaver]]
     end
 
-    def trainee_status
-      @trainee_status ||= MapStateFromHesa.call(hesa_trainee: hesa_trainee)
+    def trainee_state
+      @trainee_state ||= MapStateFromHesa.call(hesa_trainee: hesa_trainee)
     end
   end
 end

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -37,13 +37,13 @@ module Trainees
 
     def mapped_attributes
       {
-        created_from_hesa: trainee.id.blank?,
         trainee_id: hesa_trainee[:trainee_id],
         training_route: training_route,
         trn: trn,
         state: trainee_status,
         hesa_updated_at: hesa_trainee[:hesa_updated_at],
-      }.merge(personal_details_attributes)
+      }.merge(created_from_hesa_attribute)
+       .merge(personal_details_attributes)
        .merge(provider_attributes)
        .merge(ethnicity_and_disability_attributes)
        .merge(course_attributes)
@@ -52,6 +52,16 @@ module Trainees
        .merge(school_attributes)
        .merge(training_initiative_attributes)
        .compact
+    end
+
+    def trn
+      hesa_trainee[:trn] if TRN_REGEX.match?(hesa_trainee[:trn])
+    end
+
+    def created_from_hesa_attribute
+      return {} if trainee.id.present?
+
+      { created_from_hesa: true }
     end
 
     def personal_details_attributes
@@ -133,10 +143,6 @@ module Trainees
 
     def disability
       Hesa::CodeSets::Disabilities::MAPPING[hesa_trainee[:disability]]
-    end
-
-    def trn
-      hesa_trainee[:trn] if TRN_REGEX.match?(hesa_trainee[:trn])
     end
 
     def enqueue_background_jobs!

--- a/app/services/trainees/map_state_from_hesa.rb
+++ b/app/services/trainees/map_state_from_hesa.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Trainees
+  class MapStateFromHesa
+    include ServicePattern
+
+    def initialize(hesa_trainee:)
+      @hesa_trainee = hesa_trainee
+      @trn = hesa_trainee[:trn]
+    end
+
+    def call
+      return :submitted_for_trn if submitted_for_trn?
+      return :trn_received if trn_received?
+      return :withdrawn if withdrawn?
+      return :deferred if trainee_dormant?
+
+      :awarded if successful_completion_of_course?
+    end
+
+  private
+
+    attr_reader :hesa_trainee, :trn
+
+    def submitted_for_trn?
+      reason_for_leaving.blank? && trn.blank? && !trainee_dormant?
+    end
+
+    def trn_received?
+      reason_for_leaving.blank? && trn.present? && !trainee_dormant?
+    end
+
+    def withdrawn?
+      reason_for_leaving.present? && course_not_completed? && hesa_trainee[:end_date].present?
+    end
+
+    def course_not_completed?
+      [
+        successful_completion_of_course?,
+        completion_of_course_result_unknown?,
+      ].none?
+    end
+
+    def successful_completion_of_course?
+      reason_for_leaving == Hesa::CodeSets::ReasonsForLeavingCourse::SUCCESSFUL_COMPLETION
+    end
+
+    def completion_of_course_result_unknown?
+      reason_for_leaving == Hesa::CodeSets::ReasonsForLeavingCourse::UNKNOWN_COMPLETION
+    end
+
+    def reason_for_leaving
+      Hesa::CodeSets::ReasonsForLeavingCourse::MAPPING[hesa_trainee[:reason_for_leaving]]
+    end
+
+    def trainee_dormant?
+      [
+        Hesa::CodeSets::Modes::DORMANT_FULL_TIME,
+        Hesa::CodeSets::Modes::DORMANT_PART_TIME,
+      ].include?(mode)
+    end
+
+    def mode
+      Hesa::CodeSets::Modes::MAPPING[hesa_trainee[:mode]]
+    end
+  end
+end

--- a/app/services/trainees/map_state_from_hesa.rb
+++ b/app/services/trainees/map_state_from_hesa.rb
@@ -27,7 +27,7 @@ module Trainees
     end
 
     def trn_received?
-      reason_for_leaving.blank? && trn.present? && !trainee_dormant?
+      (reason_for_leaving.blank? || completion_of_course_result_unknown?) && trn.present? && !trainee_dormant?
     end
 
     def withdrawn?

--- a/db/migrate/20220318111733_add_hesa_updated_at_to_trainees.rb
+++ b/db/migrate/20220318111733_add_hesa_updated_at_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHesaUpdatedAtToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :hesa_updated_at, :datetime
+  end
+end

--- a/db/migrate/20220318112417_create_hesa_metadata.rb
+++ b/db/migrate/20220318112417_create_hesa_metadata.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateHesaMetadata < ActiveRecord::Migration[6.1]
+  def change
+    create_table :hesa_metadata do |t|
+      t.belongs_to :trainee
+      t.column :study_length, :integer
+      t.column :study_length_unit, :string
+      t.column :itt_aim, :string
+      t.column :itt_qualification_aim, :string
+      t.column :fundability, :string
+      t.column :service_leaver, :string
+      t.column :course_programme_title, :string
+      t.column :placement_school_urn, :integer
+      t.column :pg_apprenticeship_start_date, :date
+      t.column :year_of_course, :string
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_18_111733) do
+ActiveRecord::Schema.define(version: 2022_03_18_112417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -341,6 +341,23 @@ ActiveRecord::Schema.define(version: 2022_03_18_111733) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "state"
     t.index ["state"], name: "index_hesa_collection_requests_on_state"
+  end
+
+  create_table "hesa_metadata", force: :cascade do |t|
+    t.bigint "trainee_id"
+    t.integer "study_length"
+    t.string "study_length_unit"
+    t.string "itt_aim"
+    t.string "itt_qualification_aim"
+    t.string "fundability"
+    t.string "service_leaver"
+    t.string "course_programme_title"
+    t.integer "placement_school_urn"
+    t.date "pg_apprenticeship_start_date"
+    t.string "year_of_course"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["trainee_id"], name: "index_hesa_metadata_on_trainee_id"
   end
 
   create_table "lead_school_users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_15_113557) do
+ActiveRecord::Schema.define(version: 2022_03_18_111733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
+  enable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "academic_cycles", force: :cascade do |t|
     t.date "start_date", null: false
@@ -160,9 +162,9 @@ ActiveRecord::Schema.define(version: 2022_03_15_113557) do
     t.integer "duration_in_years", null: false
     t.string "course_length"
     t.integer "qualification", null: false
+    t.integer "level", null: false
     t.integer "route", null: false
     t.string "summary", null: false
-    t.integer "level", null: false
     t.string "accredited_body_code", null: false
     t.integer "min_age", null: false
     t.integer "max_age", null: false
@@ -381,8 +383,8 @@ ActiveRecord::Schema.define(version: 2022_03_15_113557) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.boolean "apply_sync_enabled", default: false
     t.string "code"
+    t.boolean "apply_sync_enabled", default: false
     t.string "ukprn"
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
@@ -491,14 +493,14 @@ ActiveRecord::Schema.define(version: 2022_03_15_113557) do
     t.text "course_subject_two"
     t.text "course_subject_three"
     t.datetime "awarded_at"
-    t.boolean "applying_for_bursary"
     t.integer "training_initiative"
+    t.boolean "applying_for_bursary"
     t.integer "bursary_tier"
     t.integer "study_mode"
     t.boolean "ebacc", default: false
     t.string "region"
-    t.integer "course_education_phase"
     t.boolean "applying_for_scholarship"
+    t.integer "course_education_phase"
     t.boolean "applying_for_grant"
     t.uuid "course_uuid"
     t.boolean "lead_school_not_applicable", default: false
@@ -511,6 +513,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_113557) do
     t.jsonb "additional_dttp_data"
     t.boolean "created_from_hesa", default: false, null: false
     t.string "dqt_update_sha"
+    t.datetime "hesa_updated_at"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"

--- a/spec/lib/hesa/parsers/itt_record_spec.rb
+++ b/spec/lib/hesa/parsers/itt_record_spec.rb
@@ -33,7 +33,6 @@ module Hesa
             commencement_date: nil,
             training_initiative: "C",
             hesa_id: "0310261553101",
-            international_address: "XF",
             reason_for_leaving: nil,
             end_date: nil,
             disability: "00",

--- a/spec/lib/hesa/parsers/itt_record_spec.rb
+++ b/spec/lib/hesa/parsers/itt_record_spec.rb
@@ -43,6 +43,7 @@ module Hesa
             lead_school_urn: "115795",
             training_route: "02",
             nationality: "NZ",
+            hesa_updated_at: "17/10/2016 14:27:04",
             degrees: [{
               country: "CA",
               grade: "01",

--- a/spec/lib/hesa/parsers/itt_record_spec.rb
+++ b/spec/lib/hesa/parsers/itt_record_spec.rb
@@ -28,7 +28,6 @@ module Hesa
             course_subject_three: nil,
             itt_start_date: "2016-09-27",
             itt_end_date: nil,
-            study_mode: "1",
             mode: "01",
             course_age_range: "71",
             commencement_date: nil,

--- a/spec/lib/hesa/parsers/itt_record_spec.rb
+++ b/spec/lib/hesa/parsers/itt_record_spec.rb
@@ -42,6 +42,15 @@ module Hesa
             training_route: "02",
             nationality: "NZ",
             hesa_updated_at: "17/10/2016 14:27:04",
+            itt_aim: "202",
+            itt_qualification_aim: "032",
+            course_programme_title: "FE Course 1",
+            pg_apprenticeship_start_date: nil,
+            fund_code: "7",
+            service_leaver: "01",
+            study_length: "3",
+            study_length_unit: "1",
+            year_of_course: "0",
             degrees: [{
               country: "CA",
               grade: "01",
@@ -50,6 +59,7 @@ module Hesa
               subject: nil,
               degree_type: "999",
             }],
+            placements: [{ school_urn: "900000" }],
           })
         end
       end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -253,7 +253,6 @@ module Trainees
 
           let(:hesa_stub_attributes) do
             {
-              end_date: date,
               reason_for_leaving: hesa_reasons_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::UNKNOWN_COMPLETION],
               mode: hesa_modes[Hesa::CodeSets::Modes::DORMANT_FULL_TIME],
             }
@@ -261,7 +260,6 @@ module Trainees
 
           it "creates a deferred trainee with the relevant details" do
             expect(trainee.state).to eq("deferred")
-            expect(trainee.defer_date).to eq(Date.parse(date))
           end
         end
       end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -9,8 +9,8 @@ module Trainees
     let(:student_node) { hesa_api_stub.student_node }
     let(:student_attributes) { hesa_api_stub.student_attributes }
     let(:create_custom_state) { "implemented where necessary" }
-    let(:hesa_stub_attributes) { { trn: trn } }
-    let(:trn) { Faker::Number.number(digits: 7) }
+    let(:hesa_stub_attributes) { { trn: hesa_trn } }
+    let(:hesa_trn) { Faker::Number.number(digits: 7).to_s }
     let(:trainee_degree) { trainee.degrees.first }
 
     subject(:trainee) { Trainee.first }
@@ -99,9 +99,10 @@ module Trainees
     end
 
     context "trainee already exists and didn't come from HESA" do
+      let(:existing_trn) { Faker::Number.number(digits: 7).to_s }
       let(:hesa_disability_codes) { Hesa::CodeSets::Disabilities::MAPPING.invert }
       let(:hesa_ethnicity_codes) { Hesa::CodeSets::Ethnicities::MAPPING.invert }
-      let(:create_custom_state) { create(:trainee, hesa_id: student_attributes[:hesa_id], trn: "5050505") }
+      let(:create_custom_state) { create(:trainee, hesa_id: student_attributes[:hesa_id], trn: existing_trn) }
 
       describe "#created_from_hesa" do
         subject { trainee.created_from_hesa }
@@ -109,18 +110,18 @@ module Trainees
         it { is_expected.to be(false) }
       end
 
-      context "when the trainee had a previously saved trn" do
-        context "and the trn exists" do
-          it "updates the trn" do
-            expect(trainee.trn).to eq("8080808")
+      context "when the trainee has a previously saved TRN" do
+        context "HESA has a different TRN" do
+          it "updates the trainee TRN with the HESA TRN" do
+            expect(trainee.trn).to eq(hesa_trn)
           end
         end
 
-        context "and the trn does not exist" do
-          let(:hesa_stub_attributes) { {} }
+        context "HESA TRN is nil" do
+          let(:hesa_stub_attributes) { { trn: nil } }
 
-          it "does not overwrite the trn" do
-            expect(trainee.trn).to eq("5050505")
+          it "does not overwrite the existing trainee TRN" do
+            expect(trainee.trn).to eq(existing_trn)
           end
         end
       end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -33,7 +33,7 @@ module Trainees
       it "updates the trainee's personal details" do
         expect(trainee.first_names).to eq(student_attributes[:first_names])
         expect(trainee.last_name).to eq(student_attributes[:last_name])
-        expect(trainee.gender).to eq("female")
+        expect(trainee.gender).to eq("male")
         expect(trainee.date_of_birth).to eq(Date.parse(student_attributes[:date_of_birth]))
         expect(trainee.nationalities.pluck(:name)).to include(nationality_name)
         expect(trainee.email).to eq(student_attributes[:email])

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -81,6 +81,18 @@ module Trainees
         expect(trainee_degree.country).to eq("Canada")
       end
 
+      it "creates a trainee HESA metadata record" do
+        expect(trainee.hesa_metadatum.study_length).to eq(3)
+        expect(trainee.hesa_metadatum.study_length_unit).to eq("years")
+        expect(trainee.hesa_metadatum.itt_aim).to eq("Both professional status and academic award")
+        expect(trainee.hesa_metadatum.itt_qualification_aim).to eq("Masters, not by research")
+        expect(trainee.hesa_metadatum.fundability).to eq("Eligible for funding from the DfE")
+        expect(trainee.hesa_metadatum.service_leaver).to eq("Trainee has not left full time employment in the British Army, Royal Air Force or Royal Navy within 5 years of beginning the programme")
+        expect(trainee.hesa_metadatum.course_programme_title).to eq("FE Course 1")
+        expect(trainee.hesa_metadatum.placement_school_urn).to eq(900000)
+        expect(trainee.hesa_metadatum.year_of_course).to eq("0")
+      end
+
       context "when the trn does not exist", feature_integrate_with_dqt: true do
         let(:hesa_stub_attributes) { {} }
 

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -9,7 +9,8 @@ module Trainees
     let(:student_node) { hesa_api_stub.student_node }
     let(:student_attributes) { hesa_api_stub.student_attributes }
     let(:create_custom_state) { "implemented where necessary" }
-    let(:hesa_stub_attributes) { { trn: "8080808" } }
+    let(:hesa_stub_attributes) { { trn: trn } }
+    let(:trn) { Faker::Number.number(digits: 7) }
     let(:trainee_degree) { trainee.degrees.first }
 
     subject(:trainee) { Trainee.first }
@@ -224,7 +225,7 @@ module Trainees
 
           it "creates a withdrawn trainee with the relevant details" do
             expect(trainee.state).to eq("withdrawn")
-            expect(trainee.withdraw_date).to eq(Date.parse(date))
+            expect(trainee.withdraw_date).to eq(date)
             expect(trainee.withdraw_reason).to eq(WithdrawalReasons::HEALTH_REASONS)
           end
         end
@@ -237,10 +238,13 @@ module Trainees
             }
           end
 
-          it "does not create a withdrawn trainee" do
-            expect(trainee.state).not_to eq("withdrawn")
+          it "does not set the withdraw fields" do
             expect(trainee.withdraw_date).to be_nil
             expect(trainee.withdraw_reason).to be_nil
+          end
+
+          it "creates a awarded trainee with the relevant details" do
+            expect(trainee.state).to eq("awarded")
           end
         end
 

--- a/spec/services/trainees/map_state_from_hesa_spec.rb
+++ b/spec/services/trainees/map_state_from_hesa_spec.rb
@@ -10,7 +10,7 @@ module Trainees
     let(:hesa_trainee) { Hesa::Parsers::IttRecord.to_attributes(student_node: hesa_api_stub.student_node) }
     let(:hesa_reason_for_leaving_codes) { Hesa::CodeSets::ReasonsForLeavingCourse::MAPPING.invert }
     let(:hesa_mode_codes) { Hesa::CodeSets::Modes::MAPPING.invert }
-    let(:trn) { Faker::Number.number(digits: 7) }
+    let(:hesa_trn) { Faker::Number.number(digits: 7) }
     let(:date_today) { Time.zone.today }
 
     subject { described_class.call(hesa_trainee: hesa_trainee) }
@@ -25,10 +25,22 @@ module Trainees
 
     context "trn_received" do
       let(:hesa_stub_attributes) do
-        { reason_for_leaving: nil, mode: nil, trn: trn }
+        { reason_for_leaving: nil, mode: nil, trn: hesa_trn }
       end
 
       it { is_expected.to eq(:trn_received) }
+
+      context "course completed - result unknown" do
+        let(:hesa_stub_attributes) do
+          {
+            mode: nil,
+            trn: hesa_trn,
+            reason_for_leaving: hesa_mode_codes[Hesa::CodeSets::ReasonsForLeavingCourse::UNKNOWN_COMPLETION],
+          }
+        end
+
+        it { is_expected.to eq(:trn_received) }
+      end
     end
 
     context "withdrawn" do
@@ -41,7 +53,10 @@ module Trainees
 
     context "awarded" do
       let(:hesa_stub_attributes) do
-        { reason_for_leaving: hesa_reason_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::SUCCESSFUL_COMPLETION], end_date: date_today }
+        {
+          end_date: date_today,
+          reason_for_leaving: hesa_reason_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::SUCCESSFUL_COMPLETION],
+        }
       end
 
       it { is_expected.to eq(:awarded) }

--- a/spec/services/trainees/map_state_from_hesa_spec.rb
+++ b/spec/services/trainees/map_state_from_hesa_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe MapStateFromHesa do
+    let(:hesa_stub_attributes) { {} }
+    let(:hesa_api_stub) { ApiStubs::HesaApi.new(hesa_stub_attributes) }
+    let(:hesa_xml) { hesa_api_stub.raw_xml }
+    let(:hesa_trainee) { Hesa::Parsers::IttRecord.to_attributes(student_node: hesa_api_stub.student_node) }
+    let(:hesa_reason_for_leaving_codes) { Hesa::CodeSets::ReasonsForLeavingCourse::MAPPING.invert }
+    let(:hesa_mode_codes) { Hesa::CodeSets::Modes::MAPPING.invert }
+    let(:trn) { Faker::Number.number(digits: 7) }
+    let(:date_today) { Time.zone.today }
+
+    subject { described_class.call(hesa_trainee: hesa_trainee) }
+
+    context "submitted_for_trn" do
+      let(:hesa_stub_attributes) do
+        { reason_for_leaving: nil, mode: nil, trn: nil }
+      end
+
+      it { is_expected.to eq(:submitted_for_trn) }
+    end
+
+    context "trn_received" do
+      let(:hesa_stub_attributes) do
+        { reason_for_leaving: nil, mode: nil, trn: trn }
+      end
+
+      it { is_expected.to eq(:trn_received) }
+    end
+
+    context "withdrawn" do
+      let(:hesa_stub_attributes) do
+        { reason_for_leaving: hesa_reason_for_leaving_codes[WithdrawalReasons::HEALTH_REASONS], end_date: date_today }
+      end
+
+      it { is_expected.to eq(:withdrawn) }
+    end
+
+    context "awarded" do
+      let(:hesa_stub_attributes) do
+        { reason_for_leaving: hesa_reason_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::SUCCESSFUL_COMPLETION], end_date: date_today }
+      end
+
+      it { is_expected.to eq(:awarded) }
+    end
+  end
+end

--- a/spec/support/api_stubs/hesa_api.rb
+++ b/spec/support/api_stubs/hesa_api.rb
@@ -2,37 +2,6 @@
 
 module ApiStubs
   class HesaApi
-    TAG_MAP = {
-      first_names: "F_FNAMES",
-      last_name: "F_SURNAME",
-      email: "F_NQTEMAIL",
-      date_of_birth: "F_BIRTHDTE",
-      ethnic_background: "F_ETHNIC",
-      gender: "F_SEXID",
-      ukprn: "F_UKPRN",
-      trainee_id: "F_OWNSTU",
-      course_subject_one: "F_SBJCA1",
-      course_subject_two: "F_SBJCA2",
-      course_subject_three: "F_SBJCA3",
-      itt_start_date: "F_PGAPPSTDT",
-      employing_school_urn: "F_SDEMPLOY",
-      lead_school_urn: "F_SDLEAD",
-      reason_for_leaving: "F_RSNEND",
-      mode: "F_MODE",
-      study_mode: "F_CRMODE",
-      course_min_age: "F_ITTPHSC",
-      commencement_date: "F_ITTCOMDATE",
-      training_initiative: "F_INITIATIVES1",
-      hesa_id: "F_HUSID",
-      international_address: "F_DOMICILE",
-      end_date: "F_ENDDATE",
-      disability: "F_DISABLE",
-      bursary_level: "F_BURSLEV",
-      trn: "F_TREFNO",
-      training_route: "F_ENTRYRTE",
-      nationality: "F_NATION",
-    }.freeze
-
     attr_reader :raw_xml, :attributes, :student_node, :student_attributes
 
     def initialize(attributes = {})
@@ -48,7 +17,7 @@ module ApiStubs
     def override_node_tags(student_node)
       attributes.each do |key, value|
         value = "NULL" if value.nil?
-        student_node.xpath("//#{TAG_MAP[key]}").first.content = value
+        student_node.xpath("//#{Hesa::Parsers::IttRecord::TAG_MAP[key]}").first.content = value
       end
       student_node
     end


### PR DESCRIPTION
### Context
https://trello.com/c/Csx5hMPq/3778-l-hesa-set-states-correctly

### Changes proposed in this pull request
- Fix gender mapping
- Fix state mapping
- Add missing TRN attribute
- Add new field `hesa_updated_at` to trainees to help with data analysis
- Fix `study_mode` mapping
- Remove deferral atributes (there is no defer date or reinstate date in HESA)
- Change the way `created_from_hesa` is set (it shouldn't be touched in future updates)
- Add new table `hesa_metadata` to store important information that can be use dby the funding department later on

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
