### PR TITLE
[3787] DQT manual testing snags

### DIFF
--- a/app/lib/dqt/client.rb
+++ b/app/lib/dqt/client.rb
@@ -28,7 +28,7 @@ module Dqt
     end
 
     def self.handle_response(response:, statuses:)
-      return JSON.parse(response) if statuses.include?(response.code)
+      return JSON.parse(response.body) if statuses.include?(response.code)
 
       raise(HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}")
     end

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -4,6 +4,7 @@ module Dqt
   module Params
     class TrnRequest
       UNITED_KINGDOM = "United Kingdom"
+      UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED = "United Kingdom, not otherwise specified"
 
       GENDER_CODES = {
         male: "Male",
@@ -101,7 +102,7 @@ module Dqt
       def qualification_params
         {
           providerUkprn: nil,
-          countryCode: degree.uk? ? UNITED_KINGDOM : degree.country,
+          countryCode: country_codes[degree.uk? ? UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED : degree.country],
           subject: degree.subject,
           class: DEGREE_CLASSES[degree.grade],
           date: Date.parse("01-01-#{degree.graduation_year}").iso8601,
@@ -110,6 +111,10 @@ module Dqt
 
       def degree
         trainee.degrees.first
+      end
+
+      def country_codes
+        @country_codes ||= Hesa::CodeSets::Countries::MAPPING.invert
       end
     end
   end

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -51,7 +51,7 @@ module Dqt
         it "returns a hash including degree attributes" do
           expect(subject["qualification"]).to eq({
             providerUkprn: nil,
-            countryCode: described_class::UNITED_KINGDOM,
+            countryCode: "XK",
             subject: degree.subject,
             class: described_class::DEGREE_CLASSES[degree.grade],
             date: Date.new(degree.graduation_year).iso8601,
@@ -77,12 +77,12 @@ module Dqt
         end
 
         context "when trainee has an international degree" do
-          let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details) }
+          let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details, country: "Albania") }
           let(:trainee) { create(:trainee, :completed, degrees: [non_uk_degree]) }
 
-          it "maps the degree country to countryCode" do
+          it "maps the degree country to HESA countryCode" do
             expect(subject["qualification"]).to include({
-              countryCode: degree.country,
+              countryCode: "AL",
             })
           end
         end


### PR DESCRIPTION
### Context

We've been testing the DQT API for TRNs. A few small issues were identified. This PR addresses them.

### Changes proposed in this pull request

* Fix issue in the client `request.body`
* Send HESA country codes for degrees

### Guidance to review

This has been succesfully tested against the API and is currently feature flagged. We'll be doing more manual testing so just a quick once over would be good. We need these changes for other work that is in flight so it'll be good to get them into main.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
