### PR TITLE
[3766] Enqueue TRN request when creating hesa records that do not have one

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -7,6 +7,8 @@ module Trainees
 
     USERNAME = "HESA"
 
+    TRN_REGEX = /^(\d{6,7})$/.freeze
+
     class HesaImportError < StandardError; end
 
     def initialize(student_node:)
@@ -21,6 +23,7 @@ module Trainees
         if trainee.save!
           create_degrees!
           add_multiple_disability_text!
+          enqueue_background_jobs!
         end
       end
     rescue ActiveRecord::RecordInvalid
@@ -37,6 +40,7 @@ module Trainees
         created_from_hesa: trainee.id.blank?,
         trainee_id: hesa_trainee[:trainee_id],
         training_route: training_route,
+        trn: trn,
       }.merge(personal_details_attributes)
        .merge(provider_attributes)
        .merge(ethnicity_and_disability_attributes)
@@ -163,6 +167,16 @@ module Trainees
 
     def disability
       Hesa::CodeSets::Disabilities::MAPPING[hesa_trainee[:disability]]
+    end
+
+    def trn
+      hesa_trainee[:trn] if TRN_REGEX.match?(hesa_trainee[:trn])
+    end
+
+    def enqueue_background_jobs!
+      if FeatureService.enabled?(:integrate_with_dqt) && trainee.trn.blank?
+        Dqt::RegisterForTrnJob.perform_later(trainee)
+      end
     end
 
     def training_initiative

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -9,12 +9,13 @@ module Trainees
     let(:student_node) { hesa_api_stub.student_node }
     let(:student_attributes) { hesa_api_stub.student_attributes }
     let(:create_custom_state) { "implemented where necessary" }
-    let(:hesa_stub_attributes) { {} }
+    let(:hesa_stub_attributes) { { trn: "8080808" } }
     let(:trainee_degree) { trainee.degrees.first }
 
     subject(:trainee) { Trainee.first }
 
     before do
+      allow(Dqt::RegisterForTrnJob).to receive(:perform_later)
       create(:nationality, name: nationality_name)
       create(:provider, ukprn: student_attributes[:ukprn])
       create(:school, urn: student_attributes[:lead_school_urn])
@@ -77,6 +78,14 @@ module Trainees
         expect(trainee_degree.grade).to eq("First-class honours")
         expect(trainee_degree.other_grade).to be_nil
         expect(trainee_degree.country).to eq("Canada")
+      end
+
+      context "when the trn does not exist", feature_integrate_with_dqt: true do
+        let(:hesa_stub_attributes) { {} }
+
+        it "enqueues Dqt::RegisterForTrnJob" do
+          expect(Dqt::RegisterForTrnJob).to have_received(:perform_later).with(Trainee.last)
+        end
       end
     end
 


### PR DESCRIPTION
### Context
Enqueue a TRN request by using the `Dqt::RegisterForTrnJob` job.

### Changes proposed in this pull request
When a trn is available, use it, and when it isn't available, enqueue the `Dqt::RegisterForTrnJob` job. This job will take care of setting the trainee's state to `submitted_for_trn`.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
