### PR TITLE
[3781] DQT QTS submission

### DIFF
--- a/app/controllers/trainees/award_recommendations_controller.rb
+++ b/app/controllers/trainees/award_recommendations_controller.rb
@@ -6,8 +6,14 @@ module Trainees
       if OutcomeDateForm.new(trainee).save! && trainee.submission_ready?
         trainee.recommend_for_award!
 
-        Dttp::RecommendForAwardJob.perform_later(trainee)
-        Dttp::RetrieveAwardJob.perform_with_default_delay(trainee)
+        if FeatureService.enabled?(:persist_to_dttp)
+          Dttp::RecommendForAwardJob.perform_later(trainee)
+          Dttp::RetrieveAwardJob.perform_with_default_delay(trainee)
+        end
+
+        if FeatureService.enabled?(:integrate_with_dqt)
+          Dqt::RecommendForAwardJob.perform_later(trainee)
+        end
 
         redirect_to(recommended_trainee_outcome_details_path(trainee))
       end

--- a/app/jobs/dqt/recommend_for_award_job.rb
+++ b/app/jobs/dqt/recommend_for_award_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Dqt
+  class RecommendForAwardJob < ApplicationJob
+    queue_as :default
+    retry_on Client::HttpError
+
+    def perform(trainee)
+      return unless FeatureService.enabled?(:integrate_with_dqt)
+
+      award_date = RecommendForAward.call(trainee: trainee)
+
+      if award_date
+        trainee.award_qts!(award_date)
+      else
+        raise(
+          DqtNoAwardDateError,
+          "failed to retrieve award date from DQT for trainee: #{trainee.id}",
+        )
+      end
+    end
+  end
+end

--- a/app/lib/dqt/params/award.rb
+++ b/app/lib/dqt/params/award.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Dqt
+  module Params
+    class Award
+      PASS = "Pass"
+
+      attr_reader :trainee, :params
+
+      def initialize(trainee:)
+        @trainee = trainee
+        @params = build_params
+      end
+
+      def to_json(*_args)
+        params.to_json
+      end
+
+    private
+
+      def build_params
+        {
+          "ittProviderUkprn" => trainee.provider.ukprn,
+          "outcome" => PASS,
+          "assessmentDate" => trainee.outcome_date.iso8601,
+          "birthDate" => trainee.date_of_birth.iso8601,
+        }
+      end
+    end
+  end
+end

--- a/app/models/dqt_no_award_date_error.rb
+++ b/app/models/dqt_no_award_date_error.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class DqtNoAwardDateError < StandardError; end

--- a/app/services/dqt/recommend_for_award.rb
+++ b/app/services/dqt/recommend_for_award.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Dqt
+  class RecommendForAward
+    include ServicePattern
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      return unless FeatureService.enabled?(:integrate_with_dqt)
+
+      response["qtsDate"]
+    end
+
+  private
+
+    attr_reader :trainee
+
+    def response
+      @response ||= Client.put(path, body: params.to_json)
+    end
+
+    def path
+      @path ||= "/v2/teachers/#{trainee.trn}/itt-outcome"
+    end
+
+    def params
+      @params ||= Params::Award.new(trainee: trainee)
+    end
+  end
+end

--- a/spec/controllers/trainees/award_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/award_recommendations_controller_spec.rb
@@ -13,30 +13,42 @@ describe Trainees::AwardRecommendationsController do
     allow(OutcomeDateForm).to receive(:new).with(trainee).and_return(double(save!: true))
   end
 
-  describe "#create" do
-    it "updates the placement assignment in DTTP to mark it ready for QTS" do
-      expect {
-        post :create, params: { trainee_id: trainee }
-      }.to have_enqueued_job(Dttp::RecommendForAwardJob).with(trainee)
-    end
+  context "when the DTTP feature flag is enabled", feature_persist_to_dttp: true do
+    describe "#create" do
+      it "updates the placement assignment in DTTP to mark it ready for QTS" do
+        expect {
+          post :create, params: { trainee_id: trainee }
+        }.to have_enqueued_job(Dttp::RecommendForAwardJob).with(trainee)
+      end
 
-    it "queues a background job to poll for the trainee's QTS" do
-      expect(Dttp::RetrieveAwardJob).to receive(:perform_with_default_delay).with(trainee)
-      post :create, params: { trainee_id: trainee }
-    end
-
-    it "redirects user to the recommended page" do
-      post :create, params: { trainee_id: trainee }
-      expect(response).to redirect_to(recommended_trainee_outcome_details_path(trainee))
-    end
-
-    context "trainee state" do
-      before do
+      it "queues a background job to poll for the trainee's QTS" do
+        expect(Dttp::RetrieveAwardJob).to receive(:perform_with_default_delay).with(trainee)
         post :create, params: { trainee_id: trainee }
       end
 
-      it "transitions the trainee state to recommended_for_award" do
-        expect(trainee.reload).to be_recommended_for_award
+      it "redirects user to the recommended page" do
+        post :create, params: { trainee_id: trainee }
+        expect(response).to redirect_to(recommended_trainee_outcome_details_path(trainee))
+      end
+
+      context "trainee state" do
+        before do
+          post :create, params: { trainee_id: trainee }
+        end
+
+        it "transitions the trainee state to recommended_for_award" do
+          expect(trainee.reload).to be_recommended_for_award
+        end
+      end
+    end
+  end
+
+  context "when the DQT feature flag is enabled", feature_integrate_with_dqt: true do
+    describe "#create" do
+      it "sends the ITT outcome to DQT" do
+        expect {
+          post :create, params: { trainee_id: trainee }
+        }.to have_enqueued_job(Dqt::RecommendForAwardJob).with(trainee)
       end
     end
   end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -343,6 +343,7 @@ FactoryBot.define do
 
     trait :recommended_for_award do
       trn_received
+      outcome_date { Time.zone.now }
       recommended_for_award_at { Time.zone.now }
       state { "recommended_for_award" }
     end

--- a/spec/jobs/dqt/recommend_for_award_job_spec.rb
+++ b/spec/jobs/dqt/recommend_for_award_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dqt
+  describe RecommendForAwardJob do
+    let(:award_date) { nil }
+    let(:trainee) { create(:trainee, :recommended_for_award) }
+
+    before do
+      enable_features(:integrate_with_dqt)
+      allow(RecommendForAward).to receive(:call).with(trainee: trainee).and_return(award_date)
+      allow(SlackNotifierService).to receive(:call)
+    end
+
+    context "we receive an award date" do
+      let(:award_date) { Time.zone.today.iso8601 }
+
+      it "updates the trainee awarded_at attribute" do
+        expect {
+          described_class.perform_now(trainee)
+          trainee.reload
+        }.to change(trainee, :awarded_at).to(Time.zone.parse(award_date))
+      end
+    end
+
+    context "we don't receive an award date" do
+      it "raises an error" do
+        expect {
+          described_class.perform_now(trainee)
+        }.to raise_error(DqtNoAwardDateError)
+      end
+    end
+  end
+end

--- a/spec/lib/dqt/params/award_spec.rb
+++ b/spec/lib/dqt/params/award_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dqt
+  module Params
+    describe Award do
+      let(:trainee) { create(:trainee, :recommended_for_award) }
+
+      subject { described_class.new(trainee: trainee).params }
+
+      describe "#params" do
+        it "returns a hash with all required values" do
+          expect(subject).to include({
+            "ittProviderUkprn" => trainee.provider.ukprn,
+            "outcome" => "Pass",
+            "assessmentDate" => trainee.outcome_date.iso8601,
+            "birthDate" => trainee.date_of_birth.iso8601,
+          })
+        end
+      end
+    end
+  end
+end

--- a/spec/services/dqt/recommend_for_award_spec.rb
+++ b/spec/services/dqt/recommend_for_award_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dqt
+  describe RecommendForAward do
+    let(:trainee) { create(:trainee, :recommended_for_award) }
+    let(:award_date) { Time.zone.today.iso8601 }
+    let(:dqt_response) {
+      {
+        "trn" => trainee.trn,
+        "qtsDate" => award_date,
+      }
+    }
+
+    subject { described_class.call(trainee: trainee) }
+
+    describe "#call" do
+      before do
+        enable_features(:integrate_with_dqt)
+        allow(Dqt::Client).to receive(:put).and_return(dqt_response)
+      end
+
+      it "returns the award date" do
+        expect(subject).to eq(award_date)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/DnKaKQRZ/3781-m-dqt-qts-submission

### Changes proposed in this pull request

- Update `AwardRecommendationsController` to send to DTTP/DQT depending on which
  feature flags are enabled.
- Create `RecommendForAward` service which makes the put request to DQT with the
  relevant parameters and returns the award date received in the response.
- Create `RecommendForAwardJob` which calls the services and sets the awarded_at
  date on the trainee.
- Create `Dqt::Params::Award` params for formatting the request parameters

### Guidance to review

DQT API specs:
https://github.com/DFE-Digital/qualified-teachers-api/blob/main/docs/api-specs/v2.json#L8

See `/v2/teachers/{trn}/itt-outcome`

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
