### PR TITLE
deploy_all job uses output from test job

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -77,6 +77,8 @@ jobs:
   test:
     name: Test
     needs: [build]
+    outputs: 
+      image_tag: ${{ needs.build.outputs.image_tag }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -171,5 +173,5 @@ jobs:
         arm-access-key: ${{ secrets[format('ARM_ACCESS_KEY_{0}', matrix.environment)] }}
         azure-credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
         environment: ${{ matrix.environment }}
-        sha: ${{ needs.build.outputs.image_tag }}
+        sha: ${{ needs.test.outputs.image_tag }}
         slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

This fixes an issue where the docker image tag wasn't getting passed to the deploy_all job in the build-and-deploy workflow which was then defaulting to the main tag.

### Changes proposed in this pull request

- Add out to test job
- Use output from test job in deploy_all instead of output from build

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
