### PR TITLE
[3826] Send HECoS codes instead of subject names

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -92,8 +92,9 @@ module Dqt
           "programmeStartDate" => trainee.itt_start_date.iso8601,
           "programmeEndDate" => trainee.itt_end_date.iso8601,
           "programmeType" => PROGRAMME_TYPE[trainee.training_route],
-          "subject1" => trainee.course_subject_one,
-          "subject2" => trainee.course_subject_two,
+          "subject1" => course_subject_code(trainee.course_subject_one),
+          "subject2" => course_subject_code(trainee.course_subject_two),
+          "subject3" => course_subject_code(trainee.course_subject_three),
           "ageRangeFrom" => trainee.course_min_age,
           "ageRangeTo" => trainee.course_max_age,
         }
@@ -103,14 +104,22 @@ module Dqt
         {
           providerUkprn: nil,
           countryCode: country_codes[degree.uk? ? UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED : degree.country],
-          subject: degree.subject,
+          subject: degree_subject,
           class: DEGREE_CLASSES[degree.grade],
           date: Date.parse("01-01-#{degree.graduation_year}").iso8601,
         }
       end
 
+      def course_subject_code(subject_name)
+        Hesa::CodeSets::CourseSubjects::MAPPING.invert[subject_name]
+      end
+
       def degree
         trainee.degrees.first
+      end
+
+      def degree_subject
+        Hesa::CodeSets::DegreeSubjects::MAPPING.invert[degree.subject]
       end
 
       def country_codes

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -7,6 +7,7 @@ module Dqt
     describe TrnRequest do
       let(:trainee) { create(:trainee, :completed, gender: "female") }
       let(:degree) { trainee.degrees.first }
+      let(:degree_subject) { Hesa::CodeSets::DegreeSubjects::MAPPING.invert[degree.subject] }
 
       describe "#params" do
         subject { described_class.new(trainee: trainee).params }
@@ -41,8 +42,9 @@ module Dqt
             "programmeStartDate" => trainee.itt_start_date.iso8601,
             "programmeEndDate" => trainee.itt_end_date.iso8601,
             "programmeType" => "AssessmentOnlyRoute",
-            "subject1" => trainee.course_subject_one,
+            "subject1" => "100403",
             "subject2" => trainee.course_subject_two,
+            "subject3" => trainee.course_subject_three,
             "ageRangeFrom" => trainee.course_min_age,
             "ageRangeTo" => trainee.course_max_age,
           })
@@ -52,7 +54,7 @@ module Dqt
           expect(subject["qualification"]).to eq({
             providerUkprn: nil,
             countryCode: "XK",
-            subject: degree.subject,
+            subject: degree_subject,
             class: described_class::DEGREE_CLASSES[degree.grade],
             date: Date.new(degree.graduation_year).iso8601,
           })


### PR DESCRIPTION
### Context
The DQT API needs HECoS codes for ITT subjects and qualification subject.
Also add in support for subject3/course_subject_three.

### Changes proposed in this pull request
Use the `Hesa::CodeSets::CourseSubjects` and `Hesa::CodeSets::DegreeSubjects` mappings to determine the HECoS Codes. 

### Guidance to review

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
