### PR TITLE
[3827] Do not overwrite trn if present in register, and the hesa update has a blank trn.

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -50,6 +50,7 @@ module Trainees
        .merge(funding_attributes)
        .merge(school_attributes)
        .merge(training_initiative_attributes)
+       .compact
     end
 
     def personal_details_attributes

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -100,12 +100,28 @@ module Trainees
     context "trainee already exists and didn't come from HESA" do
       let(:hesa_disability_codes) { Hesa::CodeSets::Disabilities::MAPPING.invert }
       let(:hesa_ethnicity_codes) { Hesa::CodeSets::Ethnicities::MAPPING.invert }
-      let(:create_custom_state) { create(:trainee, hesa_id: student_attributes[:hesa_id]) }
+      let(:create_custom_state) { create(:trainee, hesa_id: student_attributes[:hesa_id], trn: "5050505") }
 
       describe "#created_from_hesa" do
         subject { trainee.created_from_hesa }
 
         it { is_expected.to be(false) }
+      end
+
+      context "when the trainee had a previously saved trn" do
+        context "and the trn exists" do
+          it "updates the trn" do
+            expect(trainee.trn).to eq("8080808")
+          end
+        end
+
+        context "and the trn does not exist" do
+          let(:hesa_stub_attributes) { {} }
+
+          it "does not overwrite the trn" do
+            expect(trainee.trn).to eq("5050505")
+          end
+        end
       end
 
       context "when ethnicity is missing" do


### PR DESCRIPTION
### Context
From the HESA data it appears that a TRN might not always be submitted with an update,
even though a TRN has previously been submitted.

### Changes proposed in this pull request
This change prevents a blank TRN in the HESA update from overwriting an existing TRN in register by `compact`ing the attributes.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
