### PR TITLE
Fix: review app not deleted

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -8,22 +8,10 @@ on:
 jobs:
   delete-review-app:
     name: Delete Review App ${{ github.event.pull_request.number }}
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for Deploy App Workflow for review
-        id: wait_for_deployment
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        with:
-         token: ${{ secrets.GITHUB_TOKEN }}
-         checkName: ${{ github.event.pull_request.number }} Deployment
-         ref: ${{ github.event.pull_request.head.sha }}
-         timeoutSeconds: 1800
-
-      - name: Exit whole workflow if wait was not successful
-        if: ${{ steps.wait_for_deployment.outputs.conclusion != '' && steps.wait_for_deployment.outputs.conclusion != 'success' }}
-        run: exit 1
-
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
### Context
Review apps are not deleted

### Changes proposed in this pull request
Replacing wait with native concurrency feature which is less brittle

### Guidance to review
Successful delete workflow run: https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/1992434548

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
