### PR TITLE
Stop deployment status marking deployment inactive

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -139,6 +139,7 @@ runs:
         deployment_id: ${{ steps.deployment.outputs.deployment_id }}
         env_url: ${{ env.DEPLOY_URL }}
         ref: ${{ env.DEPLOY_REF }}
+        override: false
 
     - name: Check for Failure
       if: ${{ failure() && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
### Context

The deployment status update task by default (in version 1.1.0) actively marks previous deployments as inactive, this results in a large number of API calls which in turn causes a rate limiting failure.

### Changes proposed in this pull request

This change disables that function, this will leave deployments showing as Active in the deployments page.  An issue has been raised to fix this in the action.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
