### PR TITLE
3832 Redirect users with no organisations yet

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,7 +7,7 @@ class PagesController < ApplicationController
     session[:requested_path] = root_path
     if authenticated?
       if FeatureService.enabled?(:user_can_have_multiple_organisations) && organisation_not_set?
-        redirect_to(organisation_contexts_path) && return
+        redirect_to(organisations_path) && return
       end
 
       @trainees = policy_scope(Trainee.all)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -25,6 +25,8 @@ class SessionsController < ApplicationController
 private
 
   def login_redirect_path
-    current_user.multiple_organisations? ? organisations_path : (session.delete(:requested_path) || root_path)
+    return organisations_path if current_user.multiple_organisations? || current_user.no_organisation?
+
+    (session.delete(:requested_path) || root_path)
   end
 end

--- a/app/lib/user_with_organisation_context.rb
+++ b/app/lib/user_with_organisation_context.rb
@@ -45,6 +45,12 @@ class UserWithOrganisationContext < SimpleDelegator
     organisation.is_a?(School)
   end
 
+  def no_organisation?
+    return false unless FeatureService.enabled?(:user_can_have_multiple_organisations)
+
+    user.providers.none? && user.lead_schools.none? && !user.system_admin?
+  end
+
 private
 
   attr_reader :session

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -34,5 +34,10 @@
         If you need to access a different organisation’s records, contact us at <%= support_email %>
       </p>
     <%- end -%>
+
+    <%- if current_user.no_organisation? -%>
+      <h2 class="govuk-heading-m"><%=t("pages.no_organisation.heading")%></h2>
+      <%= t("pages.no_organisation.body_html") %>
+    <%- end -%>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,6 +229,7 @@ en:
         not_found: Page not found
         internal_server_error: Sorry, something went wrong
         unprocessable_entity: Sorry, the change you wanted was rejected
+        no_organisation: You have not been linked to an organisation yet
       sign_in:
         index: Sign in
       trn_submissions:
@@ -822,6 +823,8 @@ en:
       heading: Check what data you need to provide
     privacy_policy:
       heading: Privacy Notice for the Register trainee teachers service (Register)
+    no_organisation: 
+      heading: You have not been linked to an organisation yet
   sign_in:
     new:
       heading: Ask for an account to register trainee teachers

--- a/config/locales/pages/no_organisation/en.yml
+++ b/config/locales/pages/no_organisation/en.yml
@@ -1,0 +1,17 @@
+en:
+  pages:
+    no_organisation:
+      body_html: "
+      <p class='govuk-body'>You’ve successfully signed in to Register, but your account has not been linked to an organisation yet.</p>
+
+      <p class='govuk-body'>Your account needs to be linked to an organisation so you can use Register.</p>
+
+      <p class='govuk-body'>To be added to an organisation, email us at <a class='govuk-link' href='mailto:becomingateacher@digital.education.gov.uk?subject=Accessibility%20issues%20'>becomingateacher@digital.education.gov.uk</a></p>
+
+      <p class='govuk-body'>In your email tell us:</p>
+
+      <ul class='govuk-list govuk-list--bullet'>
+        <li>the email address associated with your Register account</li>
+        <li>which organisation you’d like to be added to</li>
+      </ul>
+    "

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,5 +24,10 @@ FactoryBot.define do
       providers { [] }
       lead_schools { [build(:school, :lead)] }
     end
+
+    trait :with_no_organisation_in_db do
+      providers { [] }
+      lead_schools { [] }
+    end
   end
 end

--- a/spec/features/organisation_contexts_spec.rb
+++ b/spec/features/organisation_contexts_spec.rb
@@ -28,6 +28,19 @@ feature "setting a provider organisation context", feature_user_can_have_multipl
     end
   end
 
+  context "a user with no organisations in the DB" do
+    background { given_i_am_authenticated(user: no_organisation_user) }
+
+    before do
+      given_i_visit_the_organisations_page
+      then_i_am_redirected_to_the_organisations_page
+    end
+
+    scenario "display the content for a user with no organisation" do
+      then_i_see_the_content_for_a_user_with_no_organisation
+    end
+  end
+
 private
 
   attr_reader :provider, :lead_school
@@ -77,6 +90,10 @@ private
     expect(trainee_drafts_page.trainee_name.first).to have_text("Dave Provides")
   end
 
+  def then_i_see_the_content_for_a_user_with_no_organisation
+    expect(organisations_index_page).to have_text(I18n.t("pages.no_organisation.heading"))
+  end
+
   def multi_organisation_user
     @_multi_organisation_user ||= create(:user, :with_multiple_organisations)
   end
@@ -91,5 +108,9 @@ private
 
   def provider_trainee
     @_provider_trainee ||= create(:trainee, provider: provider, first_names: "Dave", last_name: "Provides")
+  end
+
+  def no_organisation_user
+    @_no_organisation_user ||= create(:user, :with_no_organisation_in_db)
   end
 end

--- a/spec/lib/user_with_organisation_context_spec.rb
+++ b/spec/lib/user_with_organisation_context_spec.rb
@@ -207,6 +207,58 @@ describe UserWithOrganisationContext do
     end
   end
 
+  describe "no_organisation?" do
+    subject { super().no_organisation? }
+
+    context "multi organisation feature is enabled" do
+      before do
+        enable_features(:user_can_have_multiple_organisations)
+      end
+
+      context "user has no organisations" do
+        let(:user) { create(:user, id: 1, lead_schools: [], providers: []) }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "user has an organisation" do
+        let(:user) { create(:user, id: 1, providers: [provider]) }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "user is system admin" do
+        let(:user) { create(:user, :system_admin) }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context "multi organisation feature is disabled" do
+      before do
+        disable_features(:user_can_have_multiple_organisations)
+      end
+
+      context "user has no organisations" do
+        let(:user) { create(:user, id: 1, lead_schools: [], providers: []) }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "user has an organisation" do
+        let(:user) { create(:user, id: 1, providers: [provider]) }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "user is system admin" do
+        let(:user) { create(:user, :system_admin) }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+
   describe "#user" do
     subject { super().user }
 


### PR DESCRIPTION
### Context

Trello ticket: https://trello.com/c/FINAuif9/3832-users-with-no-organisation-get-a-useful-message-when-they-try-to-login

When a user with no organisation set in the DB logs into Register, we redirect them to the organisations path and render the appropriate content to tell them they need to be added to an org.

### Changes proposed in this pull request

* Add `current_user.no_organisation?` into organisation path redirect (`login_redirect_path`) in sessions controller
* Users with no org will then be redirected on login to the organisations index, which shows them a helpful message

### Guidance to review

I've updated Annie Bell on the review app so they are not linked to an organisation.

- Log in as Annie Bell, check that you see the organisations page with the no org content
- Log in as a system admin, check you see the home page as expected
- Log in as a provider user (no lead school), check you see home page as expected
- Log in as a user with provider and lead school, check you are redirected to organisation page with correct content
- Make sure you can still switch between different providers correctly

### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
