### PR TITLE
Allow Login to GitHub Container Registry for dependabot PRs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -41,7 +41,6 @@ jobs:
         echo "IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
     - name: Login to GitHub Container Registry
-      if: github.actor != 'dependabot[bot]'
       uses: docker/login-action@v1.12.0
       with:
         registry: ghcr.io


### PR DESCRIPTION
### Context
Dependabot pull requests are failing to build as they are not included in the allow list for the github container registry credentials

eg: https://github.com/DFE-Digital/register-trainee-teachers/pull/2117

### Changes proposed in this pull request
Initialise the registry credentials for pull requests created by dependabot.


### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
