### PR TITLE
Remove message about how trainees can be recommended for QTS/EYTS

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1476,6 +1476,5 @@ en:
     trainee_record:
       hesa_uneditable_heading: This record was imported from HESA and cannot be edited
       body_html: <p class="govuk-body">Updates from HESA are imported regularly.</p>
-            <p class="govuk-body">You will be able to recommend the trainee for %{award_level} at the end of the academic year.</p>
       qts_award_level: QTS
       eyts_award_level: EYTS


### PR DESCRIPTION
This might not be true, we should remove it to avoid confusion. When we know how users recommend trainees we can update the message.