### PR TITLE
Add dttp portal PaaS route for staging

### DIFF
--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -22,3 +22,7 @@ data cloudfoundry_service redis {
 data cloudfoundry_domain register_education_gov_uk {
   name = "register-trainee-teachers.education.gov.uk"
 }
+
+data cloudfoundry_domain education_gov_uk {
+  name = "education.gov.uk"
+}

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -54,7 +54,7 @@ resource cloudfoundry_app web_app {
   dynamic "routes" {
     for_each = local.web_app_routes
     content {
-      route = routes.value
+      route = routes.value.id
     }
   }
 
@@ -104,6 +104,13 @@ resource cloudfoundry_route web_app_service_gov_uk_route {
   domain   = data.cloudfoundry_domain.register_education_gov_uk.id
   space    = data.cloudfoundry_space.space.id
   hostname = var.web_app_hostname
+}
+
+resource cloudfoundry_route web_app_dttp_gov_uk_route {
+  for_each = toset(var.dttp_portal)
+  domain   = data.cloudfoundry_domain.education_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = each.value
 }
 
 resource cloudfoundry_user_provided_service logging {

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -14,6 +14,11 @@ variable deployment_strategy { default = "blue-green-v2" }
 
 variable web_app_hostname {}
 
+variable dttp_portal {
+  default = []
+  type = list
+}
+
 variable web_app_instances { default = 1 }
 
 variable web_app_memory { default = 512 }
@@ -44,7 +49,7 @@ locals {
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "register-worker-${local.app_name_suffix}"
   logging_service_name     = "register-logit-${local.app_name_suffix}"
-  web_app_routes           = [cloudfoundry_route.web_app_service_gov_uk_route.id, cloudfoundry_route.web_app_route.id]
+  web_app_routes           = flatten([cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_route, values(cloudfoundry_route.web_app_dttp_gov_uk_route)])
   noeviction_maxmemory_policy = {
     maxmemory_policy = "noeviction"
   }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -51,6 +51,7 @@ module paas {
   redis_service_plan    = var.paas_redis_service_plan
   space_name            = var.paas_space_name
   web_app_hostname      = var.paas_web_app_hostname
+  dttp_portal           = var.paas_dttp_portal
   deployment_strategy   = var.paas_deployment_strategy
   web_app_instances     = var.paas_web_app_instances
   web_app_memory        = var.paas_web_app_memory

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,6 +16,11 @@ variable paas_deployment_strategy { default = "blue-green-v2" }
 
 variable paas_web_app_hostname {}
 
+variable paas_dttp_portal {
+  default = []
+  type = list
+}
+
 variable paas_web_app_instances { default = 2 }
 
 variable paas_web_app_memory { default = 512 }

--- a/terraform/workspace-variables/staging.tfvars.json
+++ b/terraform/workspace-variables/staging.tfvars.json
@@ -10,6 +10,7 @@
   "paas_redis_service_plan": "tiny-ha-5_x",
   "paas_space_name": "bat-staging",
   "paas_web_app_hostname": "staging",
+  "paas_dttp_portal": ["traineeteacherportal-pp"],
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1024,
   "paas_worker_app_instances": 1,


### PR DESCRIPTION
### Context

Add DTTP portal route to PaaS for staging.
This is just adding the route, the DNS change will occur later.

https://trello.com/c/272NMS5W/3820-setup-dttp-portal-domains-on-govuk-paas

### Changes proposed in this pull request

Update terraform configuration to add route 

### Guidance to review

Confirm review deploys successfully
confirm in staging env

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
