### PR TITLE
Add permissions for dependabot package push

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,6 +9,12 @@ on:
     - main
     types: [opened, reopened, synchronize, labeled]
 
+permissions:
+  contents: write
+  deployments: write
+  packages: write
+  pull-requests: write
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Dependabot can't push to GitHub packages because it does not have
enough permissions. Adding the permissions section to include write to
packages ensures dependabot can push properly.

### Context
An issue was raised around dependabot failing to push to GitHub packages. The logs were unavailable by the time the issue was looked at, however a similar issue was resolved by manually adding the permissions section in to the workflow file.

### Changes proposed in this pull request
Add permission section to workflow file to include packages.

### Guidance to review
Check review app process works as expected.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
