### PR TITLE
[3785] Add search by user last name and email

### DIFF
--- a/app/controllers/system_admin/users_controller.rb
+++ b/app/controllers/system_admin/users_controller.rb
@@ -3,7 +3,7 @@
 module SystemAdmin
   class UsersController < ApplicationController
     def index
-      @users = policy_scope(User.kept, policy_scope_class: UserPolicy).order_by_last_name.page(params[:page] || 1)
+      @users = filtered_users(policy_scope(User.kept, policy_scope_class: UserPolicy).order_by_last_name.page(params[:page] || 1))
     end
 
     def new
@@ -28,6 +28,14 @@ module SystemAdmin
 
     def user
       @user ||= authorize(User.find(params[:id]))
+    end
+
+    def filtered_users(users)
+      if params[:search]
+        users.where("last_name like ? or email like ?", "%#{params[:search]}%", "%#{params[:search]}%")
+      else
+        users
+      end
     end
   end
 end

--- a/app/views/system_admin/users/index.html.erb
+++ b/app/views/system_admin/users/index.html.erb
@@ -1,64 +1,86 @@
-<%= render PageTitle::View.new(i18n_key: "users.index") %>
+<div class="govuk-grid-row">
+  <div class ="govuk-grid-column-two-thirds-from-desktop">
+    <%= render PageTitle::View.new(i18n_key: "users.index") %>
 
-<h1 class="govuk-heading-l">Users</h1>
+    <h1 class="govuk-heading-l">Users</h1>
+  </div>
+</div>
 
-<%= render "system_admin/tab_nav" %>
+<div class="govuk-grid-row">
+  <div class ="govuk-grid-column-full">
+    <%= render "system_admin/tab_nav" %>
 
-<p class="govuk-body">
-  <%= render GovukComponent::StartButtonComponent.new(
-  text: "Add a user",
-  href: new_user_path,
-) %>
-</p>
+    <p class="govuk-body">
+      <%= render GovukComponent::StartButtonComponent.new(
+      text: "Add a user",
+      href: new_user_path,
+    ) %>
+    </p>
 
-<table class="govuk-table" summary="Users list">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Email</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Lead Schools</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Providers</th>
-    </tr>
-  </thead>
+    <div class="govuk-grid-row">
+      <div class ="govuk-grid-column-full">
+        <%= register_form_with url: users_path, method: :get do |f| %>
+          <%= f.govuk_text_field :search,
+                                 label: { text: "Search for a user"},
+                                 hint: { text: "Search using the person’s email address or surname", size: "s" },
+                                 value: params[:search],
+                                 width: "two-thirds" %>
+          <%= f.govuk_submit "Search", class: "submit-search" %>
+        <% end %>
+      </div>
+    </div>
 
-  <tbody class="govuk-table__body">
-    <% @users.each do |user| %>
-      <tr class="govuk-table__row user-row">
-
-        <td class="govuk-table__cell">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= govuk_link_to(user.name, user_path(user), class: "govuk-!-display-block user-link") %>
-          </span>
-        </td>
-
-        <td class="govuk-table__cell">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= user.email %>
-          </span>
-        </td>
-
-        <td class="govuk-table__cell">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <% user.lead_schools.each do |lead_school| %>
-              <%= govuk_link_to(lead_school.name,
-                                lead_school_path(lead_school, context: :users),
-                                class: "govuk-!-display-block") %>
-            <% end %>
-          </span>
-        </td>
-
-        <td class="govuk-table__cell">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <% user.providers.each do |provider| %>
-              <%= govuk_link_to provider.name,
-                                provider_path(provider, context: :users),
-                                class: "govuk-!-display-block" %>
-            <% end %>
-          </span>
-        </td>
+  <table class="govuk-table" summary="Users list">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Name</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Email</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Lead Schools</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-fifth no-wrap">Providers</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
 
-<%= render Paginator::View.new(scope: @users) %>
+    <tbody class="govuk-table__body">
+      <% @users.each do |user| %>
+        <tr class="govuk-table__row user-row">
+
+          <td class="govuk-table__cell">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+              <%= govuk_link_to(user.name, user_path(user), class: "govuk-!-display-block user-link") %>
+            </span>
+          </td>
+
+          <td class="govuk-table__cell">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+              <%= user.email %>
+            </span>
+          </td>
+
+          <td class="govuk-table__cell">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+              <% user.lead_schools.each do |lead_school| %>
+                <%= govuk_link_to(lead_school.name,
+                                  lead_school_path(lead_school, context: :users),
+                                  class: "govuk-!-display-block") %>
+              <% end %>
+            </span>
+          </td>
+
+          <td class="govuk-table__cell">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+              <% user.providers.each do |provider| %>
+                <%= govuk_link_to provider.name,
+                                  provider_path(provider, context: :users),
+                                  class: "govuk-!-display-block" %>
+              <% end %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= render Paginator::View.new(scope: @users) %>
+  </div>
+</div>
+

--- a/spec/features/system_admin/users/search_users_spec.rb
+++ b/spec/features/system_admin/users/search_users_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Search users" do
+  context "as a system admin" do
+    let(:user) { create(:user, system_admin: true) }
+    let!(:second_user) { create(:user, system_admin: true) }
+
+    before do
+      given_i_am_authenticated(user: user)
+    end
+
+    scenario "search users" do
+      when_i_visit_the_user_index_page
+      then_i_see_the_users
+      then_i_enter_the_first_users_last_name_into_the_search_field
+      then_i_click_search
+      then_i_see_only_the_first_user
+      then_i_enter_the_second_users_email_address_into_the_search_field
+      then_i_click_search
+      then_i_see_only_the_second_user
+    end
+  end
+
+  def when_i_visit_the_user_index_page
+    users_index_page.load
+  end
+
+  def then_i_see_the_users
+    index_page_has_first_user_details
+    index_page_has_second_user_details
+  end
+
+  def index_page_has_first_user_details
+    expect(users_index_page).to have_text(user.first_name)
+    expect(users_index_page).to have_text(user.last_name)
+    expect(users_index_page).to have_text(user.email)
+  end
+
+  def index_page_has_second_user_details
+    expect(users_index_page).to have_text(second_user.first_name)
+    expect(users_index_page).to have_text(second_user.last_name)
+    expect(users_index_page).to have_text(second_user.email)
+  end
+
+  def then_i_enter_the_first_users_last_name_into_the_search_field
+    users_index_page.search.set(user.last_name)
+  end
+
+  def then_i_click_search
+    users_index_page.submit_search.click
+  end
+
+  def then_i_see_only_the_first_user
+    index_page_has_first_user_details
+    expect(users_index_page).not_to have_text(second_user.first_name)
+  end
+
+  def then_i_enter_the_second_users_email_address_into_the_search_field
+    users_index_page.search.set(second_user.email)
+  end
+
+  def then_i_see_only_the_second_user
+    index_page_has_second_user_details
+    expect(users_index_page).not_to have_text(user.first_name)
+  end
+end

--- a/spec/support/page_objects/users/index.rb
+++ b/spec/support/page_objects/users/index.rb
@@ -8,9 +8,9 @@ module PageObjects
 
     class Index < PageObjects::Base
       set_url "/system-admin/users"
-
       element :add_a_user, "a", text: "Add a user"
-
+      element :search, 'input[name="search"]'
+      element :submit_search, ".submit-search"
       sections :users, UserRow, ".user-row"
     end
   end


### PR DESCRIPTION
### Context

Large user lists might be overwhelming for a system admin, so the option to search for users by last name/email address has been added 

### Changes proposed in this pull request

New search box under system-admin/users that will filter the list down. 
