### PR TITLE
[3833] add start_traineeteacherportal page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -30,6 +30,10 @@ class PagesController < ApplicationController
     render(:guidance)
   end
 
+  def start_traineeteacherportal
+    render(:start_traineeteacherportal)
+  end
+
 private
 
   def organisation_not_set?

--- a/app/views/pages/start_traineeteacherportal.html.erb
+++ b/app/views/pages/start_traineeteacherportal.html.erb
@@ -1,0 +1,9 @@
+<%= render PageTitle::View.new %>
+
+<div class="govuk-grid-row govuk-main-wrapper--auto-spacing">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    Welcome to Register, Trainee Teacher Portal user!
+
+  </div>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,4 +55,8 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = Settings.features.use_ssl
+
+  if Settings.dttp.portal_host.present?
+    config.hosts << Settings.dttp.portal_host
+  end
 end

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -9,7 +9,7 @@ CanonicalRails.setup do |config|
 
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
-  config.host = "www.register-trainee-teachers.education.gov.uk"
+  config.host = ENV.fetch("APPLICATION_HOST", "www.register-trainee-teachers.education.gov.uk")
   config.port # = '3000'
 
   # http://en.wikipedia.org/wiki/URL_normalization

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,15 @@ Rails.application.routes.draw do
   extend SystemAdminRoutes
   extend ApiRoutes
 
+  if Settings.dttp.portal_host.present?
+    constraints(->(req) { req.host == Settings.dttp.portal_host }) do
+      start_traineeteacherportal_url = "#{CanonicalRails.protocol}#{CanonicalRails.host}/start_traineeteacherportal"
+
+      root to: redirect(start_traineeteacherportal_url), as: :traineeteacherportal_root
+      get "/*ttp_path", to: redirect(start_traineeteacherportal_url), as: :traineeteacherportal
+    end
+  end
+
   get :ping, controller: :heartbeat
   get :healthcheck, controller: :heartbeat
   get :sha, controller: :heartbeat
@@ -12,6 +21,7 @@ Rails.application.routes.draw do
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
   get "/guidance", to: "pages#guidance"
   get "/check-data", to: "pages#check_data"
+  get "/start_traineeteacherportal", to: "pages#start_traineeteacherportal"
 
   get "/404", to: "errors#not_found", via: :all, as: :not_found
   get "/422", to: "errors#unprocessable_entity", via: :all

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,5 +1,6 @@
 dttp:
   api_base_url: "https://dttp-dev.api.crm4.dynamics.com"
+  portal_host: traineeteacherportal-local.education.gov.uk
 
 features:
   use_dfe_sign_in: false

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -14,6 +14,7 @@ dttp:
   back_office_url: https://dttp.crm4.dynamics.com/
   scope: https://dttp.crm4.dynamics.com/.default
   api_base_url: https://dttp.crm4.dynamics.com/api/data/v9.1
+  portal_host: traineeteacherportal.education.gov.uk
 
 dfe_sign_in:
   # URL that the users are redirected to for signing in

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -5,6 +5,7 @@ dttp:
   back_office_url: https://dttp-test.crm4.dynamics.com/
   scope: https://dttp-test.crm4.dynamics.com/.default
   api_base_url: https://dttp-test.crm4.dynamics.com/api/data/v9.1
+  portal_host: traineeteacherportal-dv.education.gov.uk
 
 features:
   home_text: true

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -5,6 +5,7 @@ dttp:
   back_office_url: https://dttp-ppad.crm4.dynamics.com/
   scope: https://dttp-ppad.crm4.dynamics.com/.default
   api_base_url: https://dttp-ppad.crm4.dynamics.com/api/data/v9.1
+  portal_host: traineeteacherportal-pp.education.gov.uk
 
 dfe_sign_in:
   # URL that the users are redirected to for signing in

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,5 +1,7 @@
 dttp:
   api_base_url: "https://test-api-base-uri.com"
+  portal_host: traineeteacherportal-test.education.gov.uk
+
 slack:
   default_channel: "test-channel"
   webhook_url: "https://test-slack-webhook-url.com"

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -46,4 +46,18 @@ describe PagesController, type: :controller do
       end
     end
   end
+
+  describe "GET #start_traineeteacherportal" do
+    it "returns a 200 status code" do
+      get :start_traineeteacherportal
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the start_traineeteacherportal page" do
+      get :start_traineeteacherportal
+
+      expect(response).to have_rendered("start_traineeteacherportal")
+    end
+  end
 end

--- a/spec/requests/traineeteacherportal_requests_spec.rb
+++ b/spec/requests/traineeteacherportal_requests_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "requests to traineeteacherportal-test.education.gov.uk" do
   it "redirects / to register" do
-    get "/", headers: { host: "traineeteacherportal-test.education.gov.uk"}
+    get "/", headers: { host: "traineeteacherportal-test.education.gov.uk" }
 
     expect(response).to redirect_to("https://www.register-trainee-teachers.education.gov.uk/start_traineeteacherportal")
   end
@@ -13,7 +13,7 @@ RSpec.describe "requests to traineeteacherportal-test.education.gov.uk" do
     # Example URL:
     #
     # https://traineeteacherportal.education.gov.uk/default.aspx#!/app/partials/dfeAppHome&id=0C1A66E4-0B9A-4C83-A0CB-4F902E76496E
-    get "/default.aspx#!/app/partials/dfeAppHome&id=0C1A66E4-0B9A-4C83-A0CB-4F902E76496E", headers: { host: "traineeteacherportal-test.education.gov.uk"}
+    get "/default.aspx#!/app/partials/dfeAppHome&id=0C1A66E4-0B9A-4C83-A0CB-4F902E76496E", headers: { host: "traineeteacherportal-test.education.gov.uk" }
 
     expect(response).to redirect_to("https://www.register-trainee-teachers.education.gov.uk/start_traineeteacherportal")
   end

--- a/spec/requests/traineeteacherportal_requests_spec.rb
+++ b/spec/requests/traineeteacherportal_requests_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "requests to traineeteacherportal-test.education.gov.uk" do
+  it "redirects / to register" do
+    get "/", headers: { host: "traineeteacherportal-test.education.gov.uk"}
+
+    expect(response).to redirect_to("https://www.register-trainee-teachers.education.gov.uk/start_traineeteacherportal")
+  end
+
+  it "redirects other paths typically used by portal to register" do
+    # Example URL:
+    #
+    # https://traineeteacherportal.education.gov.uk/default.aspx#!/app/partials/dfeAppHome&id=0C1A66E4-0B9A-4C83-A0CB-4F902E76496E
+    get "/default.aspx#!/app/partials/dfeAppHome&id=0C1A66E4-0B9A-4C83-A0CB-4F902E76496E", headers: { host: "traineeteacherportal-test.education.gov.uk"}
+
+    expect(response).to redirect_to("https://www.register-trainee-teachers.education.gov.uk/start_traineeteacherportal")
+  end
+end


### PR DESCRIPTION
### Context

When users go to `traineeteacherportal.education.gov.uk` we will redirect them to Register to keep their journey as seemless as possible. We've decided we'll give them their own start page before they view the main Register start page, the change here is flexible enough to accommodate this or be changed to send them to the normal Register start page.

### Changes proposed in this pull request

Accept requests to the `traineeteacherportal.education.gov.uk` (this can be different in different environments), and redirect those users to a custom landing page (`start_traineeteacherportal`).

### Guidance to review

The redirect mechanism is tricky to test locally, and may only really be testible in a deployed environment. I also tried to create a feature test but for some reason it went into a redirect loop, I think the routing constraint wasn't working correctly in test mode.

Also, the design for the custom start page isn't finalised, so this PR has a stand-in that will need replacement.

If you want to test this out locally, you'll need to add an entry to your `hosts` file:

```
127.0.0.1     traineeteacherportal-local.education.gov.uk
```

And you'll need to run the Rails server like so:

```
APPLICATION_HOST=localhost:5000 rails s
```

### Important business

We should aim to test this in qa by changing the DNS for the dev portal `traineeteacherportal-dv.education.gov.uk` to point to `qa.register-trainee-teachers.education.gov.uk`, which will also imply merging this PR to `main` I believe. Unless we want to play around with the DNS to point the dev portal to a preview app.

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql? _No_
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events? _No_
