### PR TITLE
[3783] Add autocomplete to the user's lead school form

### DIFF
--- a/app/controllers/system_admin/user_lead_schools_controller.rb
+++ b/app/controllers/system_admin/user_lead_schools_controller.rb
@@ -22,7 +22,7 @@ module SystemAdmin
         return redirect_to(user_lead_schools_path(query: query))
       end
 
-      if @lead_school_form.save!
+      if @lead_school_form.save
         redirect_to(user_path(@user), flash: { success: "Lead school added" })
       else
         @school_search = SchoolSearch.call(query: params[:query], lead_schools_only: true)

--- a/app/controllers/system_admin/user_lead_schools_controller.rb
+++ b/app/controllers/system_admin/user_lead_schools_controller.rb
@@ -4,6 +4,13 @@ module SystemAdmin
   class UserLeadSchoolsController < ApplicationController
     before_action :set_user
 
+    helper_method :query
+
+    def index
+      @lead_school_form = UserLeadSchoolsForm.new
+      @school_search = SchoolSearch.call(query: query, lead_schools_only: true)
+    end
+
     def new
       @lead_school_form = UserLeadSchoolsForm.new
     end
@@ -11,21 +18,35 @@ module SystemAdmin
     def create
       @lead_school_form = UserLeadSchoolsForm.new(lead_school_params.merge(user: @user))
 
+      if @lead_school_form.school_not_selected? && @lead_school_form.valid?
+        return redirect_to(user_lead_schools_path(query: query))
+      end
+
       if @lead_school_form.save!
         redirect_to(user_path(@user), flash: { success: "Lead school added" })
       else
-        render(:new)
+        @school_search = SchoolSearch.call(query: params[:query], lead_schools_only: true)
+        render(index_or_new_page)
       end
     end
 
   private
 
     def lead_school_params
-      params.require(:system_admin_user_lead_schools_form).permit(:lead_school_id)
+      params.fetch(:system_admin_user_lead_schools_form, {})
+            .permit(UserLeadSchoolsForm::FIELDS)
     end
 
     def set_user
       @user = User.find(params[:user_id])
+    end
+
+    def query
+      lead_school_params[:results_search_again_query].presence || lead_school_params[:no_results_search_again_query] || lead_school_params[:query] || params[:query]
+    end
+
+    def index_or_new_page
+      @lead_school_form.search_results_found? || @lead_school_form.no_results_searching_again? ? :index : :new
     end
   end
 end

--- a/app/controllers/system_admin/user_lead_schools_controller.rb
+++ b/app/controllers/system_admin/user_lead_schools_controller.rb
@@ -2,16 +2,30 @@
 
 module SystemAdmin
   class UserLeadSchoolsController < ApplicationController
+    before_action :set_user
+
     def new
-      @user = User.find(params[:user_id])
-      @lead_schools = School.lead_only
+      @lead_school_form = UserLeadSchoolsForm.new
     end
 
     def create
+      @lead_school_form = UserLeadSchoolsForm.new(lead_school_params.merge(user: @user))
+
+      if @lead_school_form.save!
+        redirect_to(user_path(@user), flash: { success: "Lead school added" })
+      else
+        render(:new)
+      end
+    end
+
+  private
+
+    def lead_school_params
+      params.require(:system_admin_user_lead_schools_form).permit(:lead_school_id)
+    end
+
+    def set_user
       @user = User.find(params[:user_id])
-      @lead_school = School.find_by(name: params[:school][:lead_school])
-      LeadSchoolUser.find_or_create_by!(lead_school: @lead_school, user: @user)
-      redirect_to(user_path(@user), flash: { success: "Lead school added" })
     end
   end
 end

--- a/app/forms/system_admin/user_lead_schools_form.rb
+++ b/app/forms/system_admin/user_lead_schools_form.rb
@@ -4,22 +4,75 @@ module SystemAdmin
   class UserLeadSchoolsForm
     include ActiveModel::Model
 
-    validates :lead_school_id, presence: true
+    FIELDS = %i[
+      query
+      lead_school_id
+      search_results_found
+      results_search_again_query
+      no_results_search_again_query
+    ].freeze
 
-    attr_accessor :lead_school_id, :user
+    validates :lead_school_id, presence: true, if: :school_validation_required?
+
+    validates :query,
+              presence: true,
+              length: {
+                minimum: SchoolSearch::MIN_QUERY_LENGTH,
+                message: I18n.t("activemodel.errors.models.user_lead_schools_form.attributes.query.length"),
+              },
+              if: -> { initial_search? }
+
+    validates :results_search_again_query,
+              presence: true,
+              length: {
+                minimum: SchoolSearch::MIN_QUERY_LENGTH,
+                message: I18n.t("activemodel.errors.models.user_lead_schools_form.attributes.query.length"),
+              },
+              if: -> { results_searching_again? }
+
+    validates :no_results_search_again_query,
+              presence: true,
+              length: {
+                minimum: SchoolSearch::MIN_QUERY_LENGTH,
+                message: I18n.t("activemodel.errors.models.user_lead_schools_form.attributes.query.length"),
+              },
+              if: -> { no_results_searching_again? }
+
+    attr_accessor(*FIELDS, :user)
 
     def save!
       if valid?
+        lead_school = School.find(lead_school_id)
         LeadSchoolUser.find_or_create_by!(lead_school: lead_school, user: user)
       else
         false
       end
     end
 
+    def search_results_found?
+      search_results_found == "true"
+    end
+
+    def school_not_selected?
+      lead_school_id.to_i.zero?
+    end
+
+    def no_results_searching_again?
+      lead_school_id == "no_results_search_again"
+    end
+
   private
 
-    def lead_school
-      School.find_by(id: lead_school_id)
+    def initial_search?
+      !query.nil?
+    end
+
+    def results_searching_again?
+      lead_school_id == "results_search_again"
+    end
+
+    def school_validation_required?
+      search_results_found? && results_search_again_query.blank?
     end
   end
 end

--- a/app/forms/system_admin/user_lead_schools_form.rb
+++ b/app/forms/system_admin/user_lead_schools_form.rb
@@ -42,7 +42,7 @@ module SystemAdmin
 
     attr_accessor(*FIELDS, :user)
 
-    def save!
+    def save
       if valid?
         lead_school = School.find(lead_school_id)
         LeadSchoolUser.find_or_create_by!(lead_school: lead_school, user: user)

--- a/app/forms/system_admin/user_lead_schools_form.rb
+++ b/app/forms/system_admin/user_lead_schools_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class UserLeadSchoolsForm
+    include ActiveModel::Model
+
+    validates :lead_school_id, presence: true
+
+    attr_accessor :lead_school_id, :user
+
+    def save!
+      if valid?
+        LeadSchoolUser.find_or_create_by!(lead_school: lead_school, user: user)
+      else
+        false
+      end
+    end
+
+  private
+
+    def lead_school
+      School.find_by(id: lead_school_id)
+    end
+  end
+end

--- a/app/forms/system_admin/user_lead_schools_form.rb
+++ b/app/forms/system_admin/user_lead_schools_form.rb
@@ -12,13 +12,15 @@ module SystemAdmin
       no_results_search_again_query
     ].freeze
 
+    QUERY_ERROR = I18n.t("activemodel.errors.models.user_lead_schools_form.attributes.query.length")
+
     validates :lead_school_id, presence: true, if: :school_validation_required?
 
     validates :query,
               presence: true,
               length: {
                 minimum: SchoolSearch::MIN_QUERY_LENGTH,
-                message: I18n.t("activemodel.errors.models.user_lead_schools_form.attributes.query.length"),
+                message: QUERY_ERROR,
               },
               if: -> { initial_search? }
 
@@ -26,7 +28,7 @@ module SystemAdmin
               presence: true,
               length: {
                 minimum: SchoolSearch::MIN_QUERY_LENGTH,
-                message: I18n.t("activemodel.errors.models.user_lead_schools_form.attributes.query.length"),
+                message: QUERY_ERROR,
               },
               if: -> { results_searching_again? }
 
@@ -34,7 +36,7 @@ module SystemAdmin
               presence: true,
               length: {
                 minimum: SchoolSearch::MIN_QUERY_LENGTH,
-                message: I18n.t("activemodel.errors.models.user_lead_schools_form.attributes.query.length"),
+                message: QUERY_ERROR,
               },
               if: -> { no_results_searching_again? }
 

--- a/app/views/system_admin/user_lead_schools/_no_results.html.erb
+++ b/app/views/system_admin/user_lead_schools/_no_results.html.erb
@@ -1,0 +1,19 @@
+<h1 class="govuk-heading-l govuk-!-margin-bottom-1">
+  <%= t("components.page_titles.search_schools.page_title_no_results") %>
+</h1>
+
+<div class="govuk-inset-text">
+  <p class="govuk-body"><%= t("components.page_titles.search_schools.sub_text_no_results") %>
+    <span class="govuk-!-font-weight-bold"><%= query %></span>.
+  </p>
+</div>
+
+<%= f.govuk_error_summary %>
+
+<%= f.hidden_field :lead_school_id, value: :no_results_search_again %>
+
+<%= f.govuk_text_field :no_results_search_again_query,
+                       label: { text: t("components.page_titles.search_schools.search_hint") },
+                       width: "three-quarters" %>
+
+<%= f.govuk_submit t("components.page_titles.search_schools.search_button") %>

--- a/app/views/system_admin/user_lead_schools/_results.html.erb
+++ b/app/views/system_admin/user_lead_schools/_results.html.erb
@@ -1,0 +1,34 @@
+<%= f.govuk_error_summary %>
+
+<%= f.hidden_field :lead_school_id, value: nil %>
+<%= f.hidden_field :search_results_found, value: "true" %>
+
+<%= f.govuk_radio_buttons_fieldset :lead_school_id,
+  legend: { text: t("components.page_titles.trainees.lead_schools.index"), tag: "h1", size: "l" },
+  hint: { text: "#{t('components.page_titles.search_schools.sub_text_results')} ‘#{query}’" } do %>
+    <% @school_search.schools.each_with_index do |school, index| %>
+      <%= f.govuk_radio_button :lead_school_id, school.id,
+                              checked: false,
+                              label: { text: school.name },
+                              link_errors: index.zero?,
+                              hint: { text: school_urn_and_location(school) } %>
+    <% end %>
+
+  <%= f.govuk_radio_divider %>
+
+  <%= f.govuk_radio_button :lead_school_id,
+                          :results_search_again,
+                          label: { text: t("components.page_titles.search_schools.search_button") } do %>
+    <%= f.govuk_text_field :results_search_again_query,
+                          label: { text: t("components.page_titles.search_schools.search_hint") },
+                          width: "three-quarters" %>
+  <% end %>
+<% end %>
+
+<%= render SchoolResultNotice::View.new(
+  search_query: query,
+  search_limit: @school_search.limit,
+  search_count: @school_search.schools.unscope(:limit).count,
+) %>
+
+<%= f.govuk_submit %>

--- a/app/views/system_admin/user_lead_schools/index.html.erb
+++ b/app/views/system_admin/user_lead_schools/index.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: @lead_school_form,
+                           url: user_lead_schools_path(@user, query: params[:query]),
+                           method: :post,
+                           local: true) do |f| %>
+      <% render (@school_search.schools.empty? ? "no_results" : "results"), f: f %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/system_admin/user_lead_schools/new.html.erb
+++ b/app/views/system_admin/user_lead_schools/new.html.erb
@@ -1,19 +1,22 @@
 <div class="govuk-form-group">
-  <label class="govuk-label" for="sort">
-    <%= "Select lead school to add to #{@user.name}" %>
-  </label>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= register_form_with model: [@user, School.new], url: user_lead_schools_path(@user), local: true do |f| %>
-
+      <%= register_form_with model: @lead_school_form, url: user_lead_schools_path(@user), local: true,
+                             html: { data: { module: "app-schools-autocomplete" } } do |f| %>
         <%= f.govuk_error_summary %>
+        <%= f.hidden_field :lead_school_id, id: "school-id" %>
 
-        <h1 class="govuk-heading-l">
-          Add a lead school for <%= @user.name %>
-        </h1>
+        <%= f.govuk_text_field(
+          :query,
+          label: { text: "Add a lead school for #{@user.name}", size: "l", tag: "h1" },
+          hint: { text: "Search for a school by its unique reference number (URN), name or postcode" },
+          value: params[:query],
+          "data-field" => "schools-autocomplete",
+          width: "three-quarters",
+        ) %>
 
-        <p><%= f.govuk_select(:lead_school, @lead_schools.map(&:name), label: { text: "Add lead school", size: "s" }, width: 20, autocomplete: :enabled, class: 'lead-school-select') %></p>
+        <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-only-lead-schools=true
+            data-default-value="<%= params[:query] %>" data-field-name="system_admin_user_lead_schools_form[query]"></div>
 
         <%= f.govuk_submit %>
       <% end %>

--- a/app/views/system_admin/user_lead_schools/new.html.erb
+++ b/app/views/system_admin/user_lead_schools/new.html.erb
@@ -18,7 +18,7 @@
         <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-only-lead-schools=true
             data-default-value="<%= params[:query] %>" data-field-name="system_admin_user_lead_schools_form[query]"></div>
 
-        <%= f.govuk_submit %>
+        <%= f.govuk_submit(t(:continue), class: "govuk-!-margin-top-4") %>
       <% end %>
     </div>
   </div>

--- a/app/views/system_admin/users/show.html.erb
+++ b/app/views/system_admin/users/show.html.erb
@@ -39,8 +39,12 @@
       Lead schools
     </dt>
     <dd class="govuk-summary-list__value">
-      <% @user.lead_schools.each do |lead_school| %>
-        <%= govuk_link_to("#{lead_school.name} - #{lead_school.urn}", lead_school_path(lead_school), class: "govuk-!-display-block") %>
+      <% if @user.lead_schools.any? %>
+        <div class="govuk-!-margin-bottom-3">
+          <% @user.lead_schools.each do |lead_school| %>
+            <%= govuk_link_to("#{lead_school.name} - #{lead_school.urn}", lead_school_path(lead_school), class: "govuk-!-display-block") %>
+          <% end %>
+        </div>
       <% end %>
       <%= govuk_link_to("Add lead school", new_user_lead_school_path(@user), class: "govuk-!-display-block add-lead-school-to-user") %>
     </dd>
@@ -50,8 +54,12 @@
       Providers
     </dt>
     <dd class="govuk-summary-list__value">
-      <% @user.providers.each do |provider| %>
-        <%= govuk_link_to "#{provider.name} - #{provider.code}", provider_path(provider), class: "govuk-!-display-block" %>
+      <% if @user.providers.any? %>
+        <div class="govuk-!-margin-bottom-3">
+          <% @user.providers.each do |provider| %>
+            <%= govuk_link_to "#{provider.name} - #{provider.code}", provider_path(provider), class: "govuk-!-display-block" %>
+          <% end %>
+        </div>
       <% end %>
       <%= govuk_link_to("Add provider", new_user_provider_path(@user), class: "govuk-!-display-block add-provider-to-user") %>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1153,6 +1153,10 @@ en:
           attributes:
             reviewed:
               blank: Select yes if this is the correct course
+        system_admin/user_lead_schools_form:
+          attributes:
+            lead_school_id:
+              blank: Select a lead school
         contact_details_form:
           attributes:
             locale_code:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1155,8 +1155,15 @@ en:
               blank: Select yes if this is the correct course
         system_admin/user_lead_schools_form:
           attributes:
+            query:
+              blank: Enter a school unique reference number (URN), name or postcode
+              both_fields_are_present: Select a lead school or select lead school not applicable
             lead_school_id:
-              blank: Select a lead school
+              blank: Select a lead school or search again
+            results_search_again_query:
+              blank: Enter a school unique reference number (URN), name or postcode
+            no_results_search_again_query:
+              blank: Enter a school unique reference number (URN), name or postcode
         contact_details_form:
           attributes:
             locale_code:

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -28,7 +28,7 @@ module SystemAdminRoutes
 
         resources :users do
           resources :providers, controller: "user_providers", only: %i[new create]
-          resources :lead_schools, controller: "user_lead_schools", only: %i[new create]
+          resources :lead_schools, controller: "user_lead_schools", only: %i[index new create]
         end
         resources :users
         resources :dttp_providers, only: %i[index show create]

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -28,7 +28,7 @@ module SystemAdminRoutes
 
         resources :users do
           resources :providers, controller: "user_providers", only: %i[new create]
-          resources :lead_schools, controller: "user_lead_schools", only: %i[index new create]
+          resources :lead_schools, controller: "user_lead_schools", only: %i[index new create], path: "lead-schools"
         end
         resources :users
         resources :dttp_providers, only: %i[index show create]

--- a/spec/features/system_admin/users/add_a_lead_school_to_user_spec.rb
+++ b/spec/features/system_admin/users/add_a_lead_school_to_user_spec.rb
@@ -21,7 +21,7 @@ feature "creating a new lead school for a user" do
       scenario "works", js: true do
         and_i_fill_in_my_lead_school
         and_i_click_the_first_item_in_the_list
-        and_i_click_submit
+        and_i_continue
         then_i_am_taken_to_the_user_show_page
         and_i_see_the_new_lead_school
       end
@@ -29,7 +29,7 @@ feature "creating a new lead school for a user" do
       context "when a lead school is not selected" do
         it "works", js: true do
           and_i_fill_in_my_lead_school
-          and_i_click_submit
+          and_i_continue
           then_i_am_redirected_to_the_lead_schools_page
         end
       end
@@ -38,7 +38,7 @@ feature "creating a new lead school for a user" do
     context "without javascript" do
       scenario "works" do
         and_i_fill_in_my_lead_school_without_js
-        and_i_click_submit
+        and_i_continue
         then_i_am_redirected_to_the_lead_schools_page
       end
     end
@@ -67,7 +67,7 @@ private
   end
 
   def then_i_am_taken_to_the_add_lead_school_to_user_page
-    expect(add_lead_school_to_user_page.current_path).to eq("/system-admin/users/#{user_to_be_updated.id}/lead_schools/new")
+    expect(add_lead_school_to_user_page.current_path).to eq("/system-admin/users/#{user_to_be_updated.id}/lead-schools/new")
   end
 
   def my_lead_school_name
@@ -90,8 +90,8 @@ private
     click(add_lead_school_to_user_page.autocomplete_list_item)
   end
 
-  def and_i_click_submit
-    add_lead_school_to_user_page.submit.click
+  def and_i_continue
+    click(add_lead_school_to_user_page.submit)
   end
 
   def and_i_see_the_new_lead_school

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -119,7 +119,11 @@ module Features
     end
 
     def add_lead_school_to_user_page
-      @add_provider_to_user_page ||= PageObjects::Users::AddLeadSchool.new
+      @add_lead_school_to_user_page ||= PageObjects::Users::AddLeadSchool.new
+    end
+
+    def user_lead_schools_page
+      @user_lead_schools_page ||= PageObjects::Users::LeadSchools.new
     end
 
     def provider_show_page

--- a/spec/support/page_objects/users/add_lead_school.rb
+++ b/spec/support/page_objects/users/add_lead_school.rb
@@ -4,7 +4,10 @@ module PageObjects
   module Users
     class AddLeadSchool < PageObjects::Base
       set_url "/system-admin/users{/id}/lead-schools/new"
-      element :lead_school_select, ".lead-school-select"
+
+      element :lead_school, "#system-admin-user-lead-schools-form-query-field"
+      element :no_js_lead_school, "#system-admin-user-lead-schools-form-query-field"
+      element :autocomplete_list_item, "#system-admin-user-lead-schools-form-query-field__listbox li:first-child"
       element :submit, 'button.govuk-button[type="submit"]'
     end
   end

--- a/spec/support/page_objects/users/lead_schools.rb
+++ b/spec/support/page_objects/users/lead_schools.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Users
+    class LeadSchools < PageObjects::Base
+      set_url "/system-admin/users/{id}/lead_schools"
+
+      element :search_again_option, "input#system-admin-user-lead-schools-form-lead-school-id-results-search-again-field"
+      element :results_search_again_input, "input#system-admin-user-lead-schools-form-results-search-again-query-field"
+      element :no_results_search_again_input, "input#system-admin-user-lead-schools-form-no-results-search-again-query-field"
+      element :continue, "button[type='submit']"
+
+      def choose_school(id:)
+        find("#system-admin-user-lead-schools-form-lead-school-id-#{id}-field").choose
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/users/lead_schools.rb
+++ b/spec/support/page_objects/users/lead_schools.rb
@@ -3,16 +3,7 @@
 module PageObjects
   module Users
     class LeadSchools < PageObjects::Base
-      set_url "/system-admin/users/{id}/lead_schools"
-
-      element :search_again_option, "input#system-admin-user-lead-schools-form-lead-school-id-results-search-again-field"
-      element :results_search_again_input, "input#system-admin-user-lead-schools-form-results-search-again-query-field"
-      element :no_results_search_again_input, "input#system-admin-user-lead-schools-form-no-results-search-again-query-field"
-      element :continue, "button[type='submit']"
-
-      def choose_school(id:)
-        find("#system-admin-user-lead-schools-form-lead-school-id-#{id}-field").choose
-      end
+      set_url "/system-admin/users/{id}/lead-schools"
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/y9iFHwee/3783-m-add-autocomplete-to-the-add-lead-school-form

### Changes proposed in this pull request

- Based on the lead school's search for trainees, add a JS autocomplete to the lead school search for users.
- Add a non-JS backup route (checkboxes filtered by the user's query)
- Small styling fixes
- Route name change from `lead_schools` to `lead-schools` to match rest of app

### Guidance to review

- Sign in as a system admin
- Click the system admin link in the top right hand corner
- Click on the name of a user
- Click 'Add lead school'
- Search for a school (hint: there's lots of 'academy's)
- Search for a school by URN
- Search for a school by postcode
- Try submitting an empty field
- Try submitting a field with a search that returns no schools
- Select a school from the list and see that it saves to the user
- **Now turn JS off**
- Search for another school
- See that you are redirected to the JS checkbox page
- Try submitting without selecting a school
- Try searching again (at the bottom)
- Select a school and see that it saves to the user

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~