### PR TITLE
[3780] show record source for admins

### DIFF
--- a/app/components/application_record_card/view.html.erb
+++ b/app/components/application_record_card/view.html.erb
@@ -16,6 +16,7 @@
         <%= trn %>
         <%= start_year %>
         <%= provider_name %>
+        <%= record_source %>
       </div>
 
       <div>

--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -60,6 +60,14 @@ module ApplicationRecordCard
       tag.p(record.provider.name.to_s, class: "govuk-caption-m govuk-!-font-size-16 application-record-card__provider_name govuk-!-margin-bottom-0 govuk-!-margin-top-2")
     end
 
+    def record_source
+      return unless show_record_source
+
+      title = I18n.t("components.application_record_card.record_source.title")
+      record_source_text = I18n.t("components.application_record_card.record_source.#{record.record_source}")
+      tag.p("#{title}: #{record_source_text}", class: "govuk-caption-m govuk-!-font-size-16 application-record-card__record_source govuk-!-margin-bottom-0 govuk-!-margin-top-2")
+    end
+
     def trn
       return if record.trn.blank?
 
@@ -76,6 +84,10 @@ module ApplicationRecordCard
 
     def show_provider
       current_user.system_admin? || current_user.lead_school?
+    end
+
+    def show_record_source
+      current_user.system_admin?
     end
 
     def hide_progress_tag

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -5,18 +5,20 @@ module RecordDetails
     include SanitizeHelper
     include SummaryHelper
 
-    attr_reader :trainee, :last_updated_event, :not_provided_copy, :show_provider, :editable
+    attr_reader :trainee, :last_updated_event, :not_provided_copy, :show_provider, :show_record_source, :editable
 
-    def initialize(trainee:, last_updated_event:, show_provider: false, editable: false)
+    def initialize(trainee:, last_updated_event:, show_provider: false, show_record_source: false, editable: false)
       @trainee = trainee
       @last_updated_event = last_updated_event
       @show_provider = show_provider
       @editable = editable
+      @show_record_source = show_record_source
     end
 
     def record_detail_rows
       [
         provider_row,
+        record_source_row,
         trainee_id_row,
         region,
         trn_row,
@@ -35,6 +37,13 @@ module RecordDetails
 
       { field_label: t(".provider"),
         field_value: trainee.provider.name_and_code }
+    end
+
+    def record_source_row
+      return unless show_record_source
+
+      { field_label: t(".record_source.title"),
+        field_value: t(".record_source.#{trainee.record_source}") }
     end
 
     def trainee_id_row

--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -133,9 +133,10 @@ private
 
   def available_record_sources
     sources = {
-      "apply" => records_contain_apply_source?,
       "manual" => records_contain_manual_source?,
+      "apply" => records_contain_apply_source?,
       "dttp" => records_contain_dttp_source?,
+      "hesa" => records_contain_hesa_source?,
     }.select { |_key, value| value == true }.keys
 
     sources.delete("dttp") unless current_user.system_admin?
@@ -147,15 +148,19 @@ private
   end
 
   def records_contain_manual_source?
-    policy_scope(Trainee).with_manual_application.count.positive?
+    policy_scope(trainee_search_scope).with_manual_application.count.positive?
   end
 
   def records_contain_dttp_source?
-    policy_scope(Trainee).created_from_dttp.count.positive?
+    policy_scope(trainee_search_scope).created_from_dttp.count.positive?
   end
 
   def records_contain_apply_source?
-    policy_scope(Trainee).with_apply_application.count.positive?
+    policy_scope(trainee_search_scope).with_apply_application.count.positive?
+  end
+
+  def records_contain_hesa_source?
+    policy_scope(trainee_search_scope).imported_from_hesa.count.positive?
   end
 
   def save_filter

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -181,9 +181,10 @@ class Trainee < ApplicationRecord
     )
   end)
 
-  scope :with_manual_application, -> { where(apply_application: nil, created_from_dttp: false) }
+  scope :with_manual_application, -> { where(apply_application: nil, created_from_dttp: false, hesa_id: nil) }
   scope :with_apply_application, -> { where.not(apply_application: nil) }
   scope :created_from_dttp, -> { where(created_from_dttp: true) }
+  scope :imported_from_hesa, -> { where.not(hesa_id: nil) }
 
   scope :on_early_years_routes, -> { where(training_route: EARLY_YEARS_TRAINING_ROUTES.keys) }
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -351,6 +351,16 @@ class Trainee < ApplicationRecord
     hesa_id.present?
   end
 
+  def record_source
+    return "hesa" if hesa_record?
+
+    return "apply" if apply_application?
+
+    return "dttp" if  created_from_dttp?
+
+    "manual"
+  end
+
 private
 
   def value_digest

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -4,7 +4,7 @@ class TraineeFilter
   AWARD_STATES = %w[qts_recommended qts_awarded eyts_recommended eyts_awarded].freeze
   STATES = Trainee.states.keys.excluding("recommended_for_award", "awarded") + AWARD_STATES
 
-  RECORD_SOURCES = %w[apply manual dttp].freeze
+  RECORD_SOURCES = %w[apply manual dttp hesa].freeze
 
   def initialize(params:)
     @params = params

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -35,6 +35,7 @@ module Trainees
         "dttp" => :created_from_dttp,
         "manual" => :with_manual_application,
         "apply" => :with_apply_application,
+        "hesa" => :imported_from_hesa,
       }
       scoped_trainees = trainees
 

--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -18,6 +18,7 @@
           class: "govuk-select"
         ) %>
       </div>
+      <%= render "trainees/record_source_filter" if current_page?(:trainees) %>
     <% end %>
   <% end %>
 
@@ -57,30 +58,7 @@
     </fieldset>
   </div>
 
-  <% if show_source_filters? %>
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-          Record source
-        </legend>
-        <div class="govuk-checkboxes govuk-checkboxes--small">
-            <% available_record_sources.map do |source| %>
-              <% next if source == "dttp" && !current_user.system_admin? %>
-            <div class="govuk-checkboxes__item">
-              <%= check_box_tag "record_source[]",
-                                source,
-                                checked?(filters, :record_source, source.to_s),
-                                id: "record_source-#{source}",
-                                class: "govuk-checkboxes__input" %>
-              <%= label_tag "record_source-#{source}",
-                            label_for("record_source", source),
-                            class: "govuk-label govuk-checkboxes__label" %>
-            </div>
-            <% end %>
-        </div>
-      </fieldset>
-    </div>
-  <% end %>
+  <%= render "trainees/record_source_filter" if current_page?(:drafts) %>
 
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">

--- a/app/views/trainees/_record_source_filter.html.erb
+++ b/app/views/trainees/_record_source_filter.html.erb
@@ -1,0 +1,24 @@
+<% if show_source_filters? %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+        <%= t('components.filter.record_source') %>
+      </legend>
+      <div class="govuk-checkboxes govuk-checkboxes--small">
+          <% available_record_sources.map do |source| %>
+            <% next if source == "dttp" && !current_user.system_admin? %>
+          <div class="govuk-checkboxes__item">
+            <%= check_box_tag "record_source[]",
+                              source,
+                              checked?(filters, :record_source, source.to_s),
+                              id: "record_source-#{source}",
+                              class: "govuk-checkboxes__input" %>
+            <%= label_tag "record_source-#{source}",
+                          label_for("record_source", source),
+                          class: "govuk-label govuk-checkboxes__label" %>
+          </div>
+          <% end %>
+      </div>
+    </fieldset>
+  </div>
+<% end %>

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -5,7 +5,11 @@
 <% end %>
 
 <div class="record-details">
-  <%= render RecordDetails::View.new(trainee: @trainee, last_updated_event: @trainee.timeline.first, show_provider: @current_user.system_admin? || @current_user.lead_school?, editable: trainee_editable?) %>
+  <%= render RecordDetails::View.new(trainee: @trainee, 
+      last_updated_event: @trainee.timeline.first, 
+      show_provider: @current_user.system_admin? || @current_user.lead_school?, 
+      show_record_source: @current_user.system_admin?, 
+      editable: trainee_editable?) %>
 </div>
 
 <div class="course-details">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1034,8 +1034,9 @@ en:
       trainee:
         record_sources:
           apply: Imported from Apply
-          manual: Added manually
           dttp: Imported from DTTP
+          hesa: Imported from HESA
+          manual: Added manually
         trainee_id: *trainee_id
         training_routes:
           assessment_only: Assessment only

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,7 +99,7 @@ en:
       reinstated_before_starting: Trainee returned before their <abbr title="initial teacher training">ITT</abbr> started
   components:
     admin_feature:
-      title: Admin feature
+      title: Admin
     heading:
       apply_draft:
         registration_data_from_apply: Registration data from Apply

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,12 @@ en:
       trainee_status: Trainee status
       last_updated: Last updated
       record_created: Record created
+      record_source: 
+        title: Record source
+        apply: Imported from Apply
+        dttp: Imported from DTTP
+        hesa: Imported from HESA
+        manual: Added manually
       trainee_start_date: &trainee_start_date Trainee start date
       trn: TRN
       progress_date_prefix:
@@ -105,6 +111,12 @@ en:
       subject:
         early_years: Early years teaching
         blank: No subject provided
+      record_source: 
+        title: Record source
+        apply: Apply
+        dttp: DTTP
+        hesa: HESA
+        manual: Manual
       route:
         blank: No route provided
       trainee_name:
@@ -1033,6 +1045,7 @@ en:
     attributes:
       trainee:
         record_sources:
+          title: Record source
           apply: Imported from Apply
           dttp: Imported from DTTP
           hesa: Imported from HESA

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -29,6 +29,10 @@ module ApplicationRecordCard
       it "renders provider name" do
         expect(rendered_component).to have_selector(".application-record-card__provider_name", text: provider.name.to_s)
       end
+
+      it "renders the record source" do
+        expect(rendered_component).to have_selector(".application-record-card__record_source", text: I18n.t("components.application_record_card.record_source.title"))
+      end
     end
 
     context "when lead school user" do

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -35,6 +35,26 @@ module RecordDetails
       end
     end
 
+    context "when :show_record_source is true" do
+      before do
+        render_inline(View.new(trainee: trainee, last_updated_event: timeline_event, show_record_source: true))
+      end
+
+      it "renders the record source" do
+        expect(rendered_component).to have_text(I18n.t("record_details.view.record_source.title"))
+      end
+    end
+
+    context "when :show_record_source is false" do
+      before do
+        render_inline(View.new(trainee: trainee, last_updated_event: timeline_event, show_record_source: false))
+      end
+
+      it "does not render the record source" do
+        expect(rendered_component).not_to have_text(I18n.t(".record_details.view.record_source"))
+      end
+    end
+
     context "when any data has not been provided" do
       before do
         trainee.trainee_id = nil

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -517,5 +517,9 @@ FactoryBot.define do
     trait :created_from_dttp do
       created_from_dttp { true }
     end
+
+    trait :imported_from_hesa do
+      hesa_id { Faker::Number.number(digits: 5) }
+    end
   end
 end

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -3,150 +3,166 @@
 require "rails_helper"
 
 RSpec.feature "Filtering trainees" do
-  before do
-    given_i_am_authenticated
-    given_trainees_exist_in_the_system
-    given_a_subject_specialism_is_available_for_selection
-    when_i_visit_the_trainee_index_page
-    then_i_see_my_provider_name
-    then_all_trainees_are_visible
-  end
-
-  scenario "can filter by complete records" do
-    when_i_filter_by_complete
-    then_only_complete_records_are_visible
-  end
-
-  scenario "can filter by incomplete records" do
-    when_i_filter_by_incomplete
-    then_only_incomplete_records_are_visible
-  end
-
-  scenario "can filter by subject" do
-    when_i_filter_by_subject("Biology")
-    then_only_biology_trainees_are_visible
-    then_the_tag_is_visible_for("Biology")
-    then_the_select_should_still_show("Biology")
-    when_i_remove_a_tag_for("Biology")
-    then_all_trainees_are_visible
-    when_i_filter_by_subject("All subjects")
-    then_all_trainees_are_visible
-  end
-
-  scenario "can filter by apply_drafts" do
-    when_i_filter_by_apply_draft_status
-    then_only_the_apply_non_draft_trainee_is_visible
-  end
-
-  scenario "cannot filter by dttp import as record source" do
-    then_i_should_not_see_imported_from_dttp_as_record_source
-  end
-
-  scenario "when all trainees are from a single source" do
-    given_all_trainees_are_from_a_single_source
-    when_i_visit_the_trainee_index_page
-    then_the_record_source_filter_is_not_visible
-  end
-
-  scenario "can filter by status" do
-    when_i_filter_by_trn_received_status
-    then_only_the_trn_received_trainee_is_visible
-  end
-
-  scenario "can filter by level" do
-    when_i_filter_by_early_years_level
-    then_only_the_early_years_trainee_is_visible
-  end
-
-  scenario "can filter by training route" do
-    when_i_filter_by_assessment_only
-    then_only_assessment_only_trainee_is_visible
-  end
-
-  scenario "can clear filters" do
-    when_i_filter_by_subject("Biology")
-    then_only_biology_trainees_are_visible
-    when_i_clear_filters
-    then_all_trainees_are_visible
-  end
-
-  scenario "no matches" do
-    when_i_filter_by_a_subject_which_returns_no_matches
-    then_i_see_a_no_records_found_message
-    then_i_should_not_see_sort_links
-  end
-
-  scenario "cannot filter by provider" do
-    then_i_should_not_see_the_provider_filter
-  end
-
-  context "as a system-admin" do
+  context "registered trainees" do
     before do
-      given_i_am_authenticated_as_system_admin
+      given_i_am_authenticated
+      given_registered_trainees_exist_in_the_system
+      given_a_subject_specialism_is_available_for_selection
       when_i_visit_the_trainee_index_page
+      then_i_see_my_provider_name
+      then_all_registered_trainees_are_visible
     end
 
-    scenario "can filter by provider" do
-      then_i_should_see_the_provider_filter
+    scenario "can filter by complete records" do
+      when_i_filter_by_complete
+      then_only_complete_records_are_visible
     end
 
-    scenario "can filter by dttp import as record source" do
-      when_i_filter_by_dttp_import
-      then_only_the_trainee_imported_from_dttp_is_visible
+    scenario "can filter by incomplete records" do
+      when_i_filter_by_incomplete
+      then_only_incomplete_records_are_visible
     end
 
-    scenario "cannot see dttp import filter when dttp trainees do not exist" do
-      when_dttp_trainees_do_not_exist
-      when_i_visit_the_trainee_index_page
-      then_i_should_not_see_imported_from_dttp_as_record_source
+    scenario "can filter by subject" do
+      when_i_filter_by_subject("Biology")
+      then_only_biology_trainees_are_visible
+      then_the_tag_is_visible_for("Biology")
+      then_the_select_should_still_show("Biology")
+      when_i_remove_a_tag_for("Biology")
+      then_all_registered_trainees_are_visible
+      when_i_filter_by_subject("All subjects")
+      then_all_registered_trainees_are_visible
     end
-  end
 
-  context "searching" do
-    before { when_i_search_for(search_term) }
+    scenario "cannot filter by record source" do
+      then_the_record_source_filter_is_not_visible
+    end
 
-    shared_examples_for "a working search" do
-      it "returns the correct trainee" do
-        then_only_the_searchable_trainee_is_visible
-        then_the_tag_is_visible_for(search_term)
+    scenario "can filter by status" do
+      when_i_filter_by_trn_received_status
+      then_only_the_trn_received_trainee_is_visible
+    end
+
+    scenario "can filter by level" do
+      when_i_filter_by_early_years_level
+      then_only_the_early_years_trainee_is_visible
+    end
+
+    scenario "can filter by training route" do
+      when_i_filter_by_assessment_only
+      then_only_assessment_only_trainee_is_visible
+    end
+
+    scenario "can clear filters" do
+      when_i_filter_by_subject("Biology")
+      then_only_biology_trainees_are_visible
+      when_i_clear_filters
+      then_all_registered_trainees_are_visible
+    end
+
+    scenario "no matches" do
+      when_i_filter_by_a_subject_which_returns_no_matches
+      then_i_see_a_no_records_found_message
+      then_i_should_not_see_sort_links
+    end
+
+    scenario "cannot filter by provider" do
+      then_i_should_not_see_the_provider_filter
+    end
+
+    context "as a system-admin" do
+      before do
+        given_i_am_authenticated_as_system_admin
+        when_i_visit_the_trainee_index_page
+      end
+
+      scenario "can filter by provider" do
+        then_i_should_see_the_provider_filter
+      end
+
+      scenario "can filter by record source" do
+        then_i_should_see_record_source_filter
+      end
+
+      scenario "when all trainees are from a single source" do
+        given_all_trainees_are_from_a_single_source
+        when_i_visit_the_trainee_index_page
+        then_the_record_source_filter_is_not_visible
+      end
+
+      scenario "can filter by dttp import as record source" do
+        when_i_filter_by_dttp_import
+        then_only_the_trainee_imported_from_dttp_is_visible
+      end
+
+      scenario "cannot see dttp import filter when dttp trainees do not exist" do
+        when_dttp_trainees_do_not_exist
+        when_i_visit_the_trainee_index_page
+        then_i_should_not_see_imported_from_dttp_as_record_source
       end
     end
 
-    context "by name" do
-      let(:search_term) { @searchable_trainee.first_names }
+    context "searching" do
+      before { when_i_search_for(search_term) }
 
-      it_behaves_like "a working search"
+      shared_examples_for "a working search" do
+        it "returns the correct trainee" do
+          then_only_the_searchable_trainee_is_visible
+          then_the_tag_is_visible_for(search_term)
+        end
+      end
+
+      context "by name" do
+        let(:search_term) { @searchable_trainee.first_names }
+
+        it_behaves_like "a working search"
+      end
+
+      context "by trn" do
+        let(:search_term) { @searchable_trainee.trn }
+
+        it_behaves_like "a working search"
+      end
+
+      context "by trainee_id" do
+        let(:search_term) { @searchable_trainee.trainee_id }
+
+        it_behaves_like "a working search"
+      end
     end
 
-    context "by trn" do
-      let(:search_term) { @searchable_trainee.trn }
+    context "exporting", feature_trainee_export: true do
+      scenario "exporting with no filter" do
+        and_i_export_the_results
+        then_i_see_my_trainee_search_results
+      end
 
-      it_behaves_like "a working search"
-    end
-
-    context "by trainee_id" do
-      let(:search_term) { @searchable_trainee.trainee_id }
-
-      it_behaves_like "a working search"
+      scenario "exporting with a filter" do
+        when_i_filter_by_subject("Biology")
+        and_i_export_the_results
+        then_i_see_my_filtered_trainee_search_results
+      end
     end
   end
 
-  context "exporting", feature_trainee_export: true do
-    scenario "exporting with no filter" do
-      and_i_export_the_results
-      then_i_see_my_trainee_search_results
+  context "draft trainees" do
+    before do
+      given_i_am_authenticated
+      given_draft_trainees_exist_in_the_system
+      when_i_visit_the_drafts_index_page
+      then_i_see_my_provider_name
+      then_all_draft_trainees_are_visible
     end
 
-    scenario "exporting with a filter" do
-      when_i_filter_by_subject("Biology")
-      and_i_export_the_results
-      then_i_see_my_filtered_trainee_search_results
+    scenario "can filter by apply_drafts" do
+      when_i_filter_by_apply_draft_status
+      then_only_the_apply_draft_trainees_are_visible
     end
   end
 
 private
 
-  def given_trainees_exist_in_the_system
+  def given_registered_trainees_exist_in_the_system
     @assessment_only_trainee ||= create(:trainee, :submitted_for_trn, training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
     @provider_led_postgrad_trainee ||= create(:trainee, :submitted_for_trn, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
     @biology_trainee ||= create(:trainee, :submitted_for_trn, :with_subject_specialism, subject_name: CourseSubjects::BIOLOGY)
@@ -163,13 +179,23 @@ private
     Trainee.update_all(provider_id: @current_user.organisation.id)
   end
 
+  def given_draft_trainees_exist_in_the_system
+    @manual_draft_trainee ||= create(:trainee, provider: current_provider)
+    @apply_draft_trainee ||= create(:trainee, :with_apply_application, provider: current_provider)
+    @dttp_draft_trainee ||= create(:trainee, :created_from_dttp, provider: current_provider)
+  end
+
+  def current_provider
+    @current_provider ||= @current_user.organisation
+  end
+
   def given_all_trainees_are_from_a_single_source
     Trainee.with_apply_application.destroy_all
     Trainee.created_from_dttp.destroy_all
   end
 
   def then_the_record_source_filter_is_not_visible
-    expect(trainee_index_page).not_to have_text("Record source")
+    expect(trainee_index_page).not_to have_text(I18n.t("components.filter.record_source"))
   end
 
   def given_a_subject_specialism_is_available_for_selection
@@ -179,6 +205,11 @@ private
   def when_i_visit_the_trainee_index_page
     trainee_index_page.load
     expect(trainee_index_page).to be_displayed
+  end
+
+  def when_i_visit_the_drafts_index_page
+    trainee_drafts_page.load
+    expect(trainee_drafts_page).to be_displayed
   end
 
   def when_i_filter_by_assessment_only
@@ -266,8 +297,12 @@ private
     expect(select.value.upcase_first).to eq value
   end
 
-  def then_all_trainees_are_visible
+  def then_all_registered_trainees_are_visible
     Trainee.where.not(state: "draft").each { |trainee| expect(trainee_index_page).to have_text(full_name(trainee)) }
+  end
+
+  def then_all_draft_trainees_are_visible
+    Trainee.draft.each { |trainee| expect(trainee_drafts_page).to have_text(full_name(trainee)) }
   end
 
   def then_only_biology_trainees_are_visible
@@ -295,12 +330,16 @@ private
     end
   end
 
-  def then_only_the_apply_non_draft_trainee_is_visible
-    expect(trainee_index_page).to have_text(full_name(@apply_non_draft_trainee))
+  def then_only_the_apply_draft_trainees_are_visible
+    expect(trainee_drafts_page).to have_text(full_name(@apply_draft_trainee))
   end
 
   def then_i_should_not_see_imported_from_dttp_as_record_source
     expect(trainee_index_page).not_to have_text("Imported from DTTP")
+  end
+
+  def then_i_should_see_record_source_filter
+    expect(trainee_index_page).to have_text(I18n.t("components.filter.record_source"))
   end
 
   def then_only_the_trn_received_trainee_is_visible

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -195,7 +195,7 @@ private
   end
 
   def then_the_record_source_filter_is_not_visible
-    expect(trainee_index_page).not_to have_text(I18n.t("components.filter.record_source"))
+    expect(trainee_index_page).not_to have_text(I18n.t("activerecord.attributes.trainee.record_sources.manual"))
   end
 
   def given_a_subject_specialism_is_available_for_selection

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -116,6 +116,7 @@ describe Trainee do
       let!(:manual_trainee) { create(:trainee) }
       let!(:apply_trainee) { create(:trainee, :with_apply_application) }
       let!(:dttp_trainee) { create(:trainee, :created_from_dttp) }
+      let!(:hesa_trainee) { create(:trainee, :imported_from_hesa) }
 
       it "returns manually entered trainees" do
         expect(described_class.with_manual_application).to contain_exactly(manual_trainee)
@@ -128,6 +129,15 @@ describe Trainee do
 
       it "returns trainees created from dttp" do
         expect(described_class.created_from_dttp).to contain_exactly(dttp_trainee)
+      end
+    end
+
+    describe ".imported_from_hesa" do
+      let!(:draft_trainee) { create(:trainee) }
+      let!(:hesa_trainee) { create(:trainee, :imported_from_hesa) }
+
+      it "returns trainees created from hesa" do
+        expect(described_class.imported_from_hesa).to contain_exactly(hesa_trainee)
       end
     end
   end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -373,6 +373,42 @@ describe Trainee do
         end
       end
     end
+
+    describe "#record_source" do
+      subject { trainee.record_source }
+
+      context "manual record source" do
+        let(:trainee) { create(:trainee) }
+
+        it "returns manual record source" do
+          expect(subject).to eql("manual")
+        end
+      end
+
+      context "dttp record source" do
+        let(:trainee) { create(:trainee, :created_from_dttp) }
+
+        it "returns dttp record source" do
+          expect(subject).to eql("dttp")
+        end
+      end
+
+      context "apply record source" do
+        let(:trainee) { create(:trainee, :with_apply_application) }
+
+        it "returns apply record source" do
+          expect(subject).to eql("apply")
+        end
+      end
+
+      context "hesa record source" do
+        let(:trainee) { create(:trainee, :imported_from_hesa) }
+
+        it "returns hesa record source" do
+          expect(subject).to eql("hesa")
+        end
+      end
+    end
   end
 
   describe "#with_name_trainee_id_or_trn_like" do


### PR DESCRIPTION
### Context

For admin users we want to display the 'source' of each trainee record, it can be one of 
```
Manually entered
Imported from Apply
Imported from HESA
Imported from DTTP
```

### Changes proposed in this pull request
1. For all users, show the filter on `/drafts`. 
![image](https://user-images.githubusercontent.com/910019/159041048-57acb4f9-9988-4e90-8e6b-fca54b3afbc2.png)

2. Only for system-admin users, show the filter as an "Admin feature" 
![image](https://user-images.githubusercontent.com/910019/159040863-d4ebdca2-6afe-49aa-8122-8181a4122589.png)

3. For system admin users, on the trainee listing page, show the record source like so:
![image](https://user-images.githubusercontent.com/910019/159041171-80143250-5ad6-4a0a-9262-a6e2e79a3741.png)

4. For system admin users, on the trainee show page, show the record source:
![image](https://user-images.githubusercontent.com/910019/159041357-014cba0d-f3f3-4f75-8dfa-fe2c8938bdc8.png)


### Guidance to review

We've created the four types of trainee (manual, apply, DTTP, HESA) under Annie Bell, Provider A. With the current implementation, DTTP as a record source is hidden for non-admins. This was a previous design decision.

As Annie Bell:
- Navigate to draft trainees
- Observe you can see three record source filter types (manual, apply, HESA)
- Test that these filters work as expected
- Navigate to registered trainees
- Observe you cannot see the record source filter
- On registered trainees, click through to the details page for an individual trainee of each record type, and check that the record type **does not** display on the trainee details
- Observe on both the drafts and registered trainee lists, the record source **does not** display on the trainee card

As an admin:
- Navigate to draft trainees
- Observe you can see all four record source filter types (manual, apply, HESA, DTTP)
- Test that these filters work as expected
- Navigate to registered trainees
- Observe you can see the record source filter in the admin section of the filter (purple section under providers)
- Test that you can interact with the filters as expected
- On registered trainees, click through to the details page for an individual trainee of each record type, and check that the record type **does** display on the trainee details beneath the provider row
- Observe on both the drafts and registered trainee lists, the record source **does** display on the trainee card

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
