### PR TITLE
Add the DQT queue to sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,6 +2,7 @@
 :concurrency: 5
 :queues:
   - default
+  - dqt
   - dttp
   - mailers
   - low_priority


### PR DESCRIPTION
### Context

To fix missing DQT queue which is preventing smoke tests from passing.

### Changes proposed in this pull request

* Add DQT queue to Sidekiq

### Guidance to review

### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
