### PR TITLE
[xxx] Temporarily change unavailable page

### DIFF
--- a/service_unavailable_page/web/public/internal/index.html
+++ b/service_unavailable_page/web/public/internal/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Sorry, there’s a problem with the service - Register trainee teachers - GOV.UK</title>
+    <title>This service is temporarily unavailable</title>
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -15,6 +15,7 @@
     <link rel="apple-touch-icon" href="assets/images/govuk-apple-touch-icon.png">
     <meta property="og:image" content="assets/govuk-opengraph-image.png">
     <link rel="stylesheet" media="all" href="stylesheets/govuk-frontend-3.13.1.min.css">
+    <link rel="stylesheet" media="all" href="stylesheets/style.css">
   </head>
   <body class="govuk-template__body">
     <header class="govuk-header govuk-!-display-none-print app-header--production app-header--full-border app-header--wide-logo" role="banner" data-module="govuk-header">
@@ -39,9 +40,9 @@
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
-            <p class="govuk-body">Try again later.</p>
-            <p class="govuk-body">If you reached this page after submitting information then it has not been saved. You’ll need to enter it again when the service is available.</p>
+            <h1 class="govuk-heading-l">This service is temporarily unavailable</h1>
+            <p class="govuk-body">You cannot access this service right now because there is scheduled maintenance work happening. This work will end at 8am on <span class="no-wrap">Saturday 19 March.</span></p>
+            <p class="govuk-body">You can try accessing the service again after this time. </p>
             <p class="govuk-body">If you have any questions, email us at<br>
             <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
           </div>

--- a/service_unavailable_page/web/public/internal/stylesheets/style.css
+++ b/service_unavailable_page/web/public/internal/stylesheets/style.css
@@ -1,0 +1,3 @@
+.no-wrap {
+  white-space: nowrap;
+}


### PR DESCRIPTION
We have scheduled downtime tonight. Update the content on the service unavailable page so as we can enable that.

We have work planned to make this content more configurable so we'll update this soon.

### Guidance to review

<img width="1192" alt="Screenshot 2022-03-18 at 14 03 39" src="https://user-images.githubusercontent.com/5216/159017427-ecdf7d98-857a-4c1c-93ce-064d19c31bf3.png">


### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
