### PR TITLE
Fix check on smoke test outcome

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -118,14 +118,14 @@ runs:
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
         token: ${{ github.token }}
-        ref:   ${{ github.ref }}
+        ref:   ${{ env.DEPLOY_REF }}
         checkName: smoke-tests-${{ inputs.environment }}
         timeoutSeconds:  300
         intervalSeconds: 15
 
     - name: Stop when smoke tests fail
       shell: bash
-      if: steps.wait_for_smoke_tests.outputs.conclusion == 'failure'
+      if: steps.wait_for_smoke_tests.outputs.conclusion != 'success'
       run: exit 1
 
     - name: Update ${{ env.DEPLOY_ENV }} status


### PR DESCRIPTION
  ### Context

The wait for step wasn't locating the dispatched smoke test workflow so was timing out.  This wasn't failing the workflow because the condition only checked for failures and not timeouts.

### Changes proposed in this pull request

Changed the ref used to track the dispatched workflow and altered the condition to fail the workflow if smoke tests not successful.

### Guidance to review

- Check that the smoke tests are reporting as expected in the build and deploy workflow

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
