### PR TITLE
[3787] Fix recommend for award path

### DIFF
--- a/app/lib/dqt/params/award.rb
+++ b/app/lib/dqt/params/award.rb
@@ -23,7 +23,6 @@ module Dqt
           "ittProviderUkprn" => trainee.provider.ukprn,
           "outcome" => PASS,
           "assessmentDate" => trainee.outcome_date.iso8601,
-          "birthDate" => trainee.date_of_birth.iso8601,
         }
       end
     end

--- a/app/services/dqt/recommend_for_award.rb
+++ b/app/services/dqt/recommend_for_award.rb
@@ -23,7 +23,7 @@ module Dqt
     end
 
     def path
-      @path ||= "/v2/teachers/#{trainee.trn}/itt-outcome"
+      @path ||= "/v2/teachers/#{trainee.trn}/itt-outcome?birthDate=#{trainee.date_of_birth.iso8601}"
     end
 
     def params

--- a/spec/lib/dqt/params/award_spec.rb
+++ b/spec/lib/dqt/params/award_spec.rb
@@ -15,7 +15,6 @@ module Dqt
             "ittProviderUkprn" => trainee.provider.ukprn,
             "outcome" => "Pass",
             "assessmentDate" => trainee.outcome_date.iso8601,
-            "birthDate" => trainee.date_of_birth.iso8601,
           })
         end
       end

--- a/spec/services/dqt/recommend_for_award_spec.rb
+++ b/spec/services/dqt/recommend_for_award_spec.rb
@@ -12,6 +12,8 @@ module Dqt
         "qtsDate" => award_date,
       }
     }
+    let(:expected_path) { "/v2/teachers/#{trainee.trn}/itt-outcome?birthDate=#{trainee.date_of_birth.iso8601}" }
+    let(:json_body_params) { "JSON Donovan" }
 
     subject { described_class.call(trainee: trainee) }
 
@@ -19,10 +21,20 @@ module Dqt
       before do
         enable_features(:integrate_with_dqt)
         allow(Dqt::Client).to receive(:put).and_return(dqt_response)
+        allow(Dqt::Params::Award).to receive(:new).with(trainee: trainee).and_return(award_params = double)
+        allow(award_params).to receive(:to_json).and_return(json_body_params)
       end
 
       it "returns the award date" do
         expect(subject).to eq(award_date)
+      end
+
+      it "makes the correct request" do
+        expect(Dqt::Client).to receive(:put).with(
+          expected_path,
+          body: json_body_params,
+        ).and_return(dqt_response)
+        subject
       end
     end
   end


### PR DESCRIPTION
### Context

Small change in the DQT API that we hadn't picked up.

### Changes proposed in this pull request

birthDate is a URL querystring parameter. We were passing it in the body payload.

### Guidance to review

The docs haven't been updated yet but I've discussed this with @gunndabad


