### PR TITLE
[3787] DQT update config and enable on staging

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -7,6 +7,9 @@ dttp:
   api_base_url: https://dttp-test.crm4.dynamics.com/api/data/v9.1
   portal_host: traineeteacherportal-dv.education.gov.uk
 
+dqt:
+  base_url: https://test-teacher-qualifications-api.education.gov.uk/
+
 features:
   home_text: true
   use_dfe_sign_in: false

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -1,3 +1,6 @@
+dqt:
+  base_url: https://test-teacher-qualifications-api.education.gov.uk/
+
 features:
   home_text: true
   use_dfe_sign_in: false

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -36,6 +36,7 @@ features:
     school_direct_tuition_fee: true
   google:
     send_data_to_big_query: true
+  integrate_with_dqt: true
 
 environment:
   name: staging

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -13,6 +13,9 @@ dfe_sign_in:
   # URL of the users profile
   profile: https://pp-profile.signin.education.gov.uk
 
+dqt:
+  base_url: https://qualified-teachers-api-preprod.london.cloudapps.digital/
+
 features:
   basic_auth: false
   sync_from_dttp: true


### PR DESCRIPTION
### Context

We're inching ever forward towards enabling the DQT integration.

### Changes proposed in this pull request

* Add the URLs for the three environments
* Enable in staging for testing

### Guidance to review

* The keys have already been added to the secrets in each environment.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
