### PR TITLE
[3839] Fix undefined method 'recruitment_cycle_year' for nil:NilClass

### DIFF
--- a/app/controllers/trainees/itt_dates_controller.rb
+++ b/app/controllers/trainees/itt_dates_controller.rb
@@ -60,6 +60,7 @@ module Trainees
           end_day: course_end_date.day,
           end_month: course_end_date.month,
           end_year: course_end_date.year,
+          course_uuid: course_uuid,
         }, user: current_user).stash_or_save!
 
         redirect_to(course_confirmation_path)

--- a/spec/controllers/trainees/itt_dates_controller_spec.rb
+++ b/spec/controllers/trainees/itt_dates_controller_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Trainees::IttDatesController do
+  let(:user) { build_current_user }
+  let(:trainee) { create(:trainee, :school_direct_salaried, provider: user.organisation) }
+
+  let(:course) {
+    create(:course,
+           :with_full_time_dates,
+           accredited_body_code: trainee.provider.code,
+           route: trainee.training_route)
+  }
+
+  before do
+    PublishCourseDetailsForm.new(trainee).assign_attributes_and_stash({ course_uuid: course.uuid })
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#edit" do
+    context "with a course having full time itt dates" do
+      it "redirects to the course confirmation page" do
+        get :edit, params: { trainee_id: trainee.slug }
+        expect(response).to redirect_to(trainee_publish_course_details_confirm_path(trainee))
+      end
+    end
+  end
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -35,6 +35,11 @@ FactoryBot.define do
       name { PUBLISH_SECONDARY_SUBJECT_SPECIALISM_MAPPING.keys.sample }
     end
 
+    trait :with_full_time_dates do
+      full_time_start_date { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year) }
+      full_time_end_date { Faker::Date.in_date_period(month: 8, year: current_recruitment_cycle_year + 1) }
+    end
+
     factory :course_with_unmappable_subject do
       transient do
         subjects_count { 1 }


### PR DESCRIPTION
### Context
Fixes https://sentry.io/organizations/dfe-teacher-services/issues/2967214933

This was getting triggered when a user tries to create a trainee on a course
where previously the full time/part time dates have been set globally.

The exception was being triggered due to the course_uuid not being sent
through to the form.

### Changes proposed in this pull request

### Guidance to review
Stolen from @edwardhorsford 
1. add a new draft trainee for Provider A
2. school direct salaried
3. add course details
4. pick any publish course.
5. Ensure you add the ITT start and end dates, and check the box which starts with "Use these dates for all full time trainees on ..." (see screenshot)
![image](https://user-images.githubusercontent.com/910019/159257066-1d546443-862e-4b54-8cd8-37ff20876468.png)
6. Observe success.

Repeat steps for a new trainee, and it should success now. Compare with [QA](qa.register-trainee-teachers.education.gov.uk)

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
