### PR TITLE
add maintenance mode for traineeteacherportal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,13 @@ qa:
 	$(eval DEPLOY_ENV=qa)
 	$(eval SPACE=bat-qa)
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-development)
+	$(eval DTTP_HOSTNAME=traineeteacherportal-dv)
 
 staging:
 	$(eval DEPLOY_ENV=staging)
 	$(eval SPACE=bat-staging)
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-test)
+	$(eval DTTP_HOSTNAME=traineeteacherportal-pp)
 
 production:
 	$(if $(CONFIRM_PRODUCTION), , $(error Can only run with CONFIRM_PRODUCTION))
@@ -60,6 +62,7 @@ production:
 	$(eval SPACE=bat-prod)
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-production)
 	$(eval HOST_NAME=www)
+	$(eval DTTP_HOSTNAME=traineeteacherportal)
 
 dttpimport:
 	$(if $(CONFIRM_PRODUCTION), , $(error Can only run with CONFIRM_PRODUCTION))
@@ -126,13 +129,17 @@ enable-maintenance: ## make qa enable-maintenance / make production enable-maint
 	cf target -s ${SPACE}
 	cd service_unavailable_page && cf push
 	cf map-route register-unavailable register-trainee-teachers.education.gov.uk --hostname ${REAL_HOSTNAME}
+	cf map-route register-unavailable education.gov.uk --hostname ${DTTP_HOSTNAME}
 	echo Waiting 5s for route to be registered... && sleep 5
 	cf unmap-route register-${DEPLOY_ENV} register-trainee-teachers.education.gov.uk --hostname ${REAL_HOSTNAME}
+	cf unmap-route register-${DEPLOY_ENV} education.gov.uk --hostname ${DTTP_HOSTNAME}
 
 disable-maintenance: ## make qa disable-maintenance / make production disable-maintenance CONFIRM_PRODUCTION=y
 	$(if $(HOST_NAME), $(eval REAL_HOSTNAME=${HOST_NAME}), $(eval REAL_HOSTNAME=${DEPLOY_ENV}))
 	cf target -s ${SPACE}
 	cf map-route register-${DEPLOY_ENV} register-trainee-teachers.education.gov.uk --hostname ${REAL_HOSTNAME}
+	cf map-route register-${DEPLOY_ENV} education.gov.uk --hostname ${DTTP_HOSTNAME}
 	echo Waiting 5s for route to be registered... && sleep 5
 	cf unmap-route register-unavailable register-trainee-teachers.education.gov.uk --hostname ${REAL_HOSTNAME}
+	cf unmap-route register-unavailable education.gov.uk --hostname ${DTTP_HOSTNAME}
 	cf delete register-unavailable -r -f

--- a/service_unavailable_page/web/nginx.conf
+++ b/service_unavailable_page/web/nginx.conf
@@ -16,15 +16,34 @@ http {
   keepalive_timeout 30;
   port_in_redirect off; # Ensure that redirects don't include the internal container PORT - 8080
 
+
   server {
     listen {{port}};
-    root public;
+    root   public;
 
     # Request to / returns 403 (directory index forbidden)
     # Request to anything else than /internal return 404 not found
     # The maintenance page is served as error page
     # And the response code is changed to 500
     error_page 403 404 =500 /internal/index.html;
+
+    # Assets are relative to the URL. We capture the prefix and filename
+    # and serve them from the right files
+    location ~ /(stylesheets|assets|javascript)/(.*)$ {
+      alias public/internal/$1/$2;
+    }
+  }
+
+  server {
+    listen       {{port}};
+    server_name  traineeteacherportal-dv.education.gov.uk traineeteacherportal-pp.education.gov.uk traineeteacherportal.education.gov.uk;
+    root         public;
+
+    # Request to / returns 403 (directory index forbidden)
+    # Request to anything else than /internal return 404 not found
+    # The maintenance page is served as error page
+    # And the response code is changed to 500
+    error_page 403 404 =500 /internal/traineeteacherportal.html;
 
     # Assets are relative to the URL. We capture the prefix and filename
     # and serve them from the right files

--- a/service_unavailable_page/web/public/internal/traineeteacherportal.html
+++ b/service_unavailable_page/web/public/internal/traineeteacherportal.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>This service is temporarily unavailable</title>
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="assets/images/favicon.ico" type="image/x-icon">
+    <link rel="mask-icon" href="assets/images/govuk-mask-icon.svg" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/images/govuk-apple-touch-icon-180x180.png">
+    <link rel="apple-touch-icon" sizes="167x167" href="assets/images/govuk-apple-touch-icon-167x167.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="assets/images/govuk-apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" href="assets/images/govuk-apple-touch-icon.png">
+    <meta property="og:image" content="assets/govuk-opengraph-image.png">
+    <link rel="stylesheet" media="all" href="stylesheets/govuk-frontend-3.13.1.min.css">
+    <link rel="stylesheet" media="all" href="stylesheets/style.css">
+  </head>
+  <body class="govuk-template__body">
+    <header class="govuk-header govuk-!-display-none-print app-header--production app-header--full-border app-header--wide-logo" role="banner" data-module="govuk-header">
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+          <a class="govuk-header__link govuk-header__link--homepage" href="https://www.gov.uk/">
+            <span class="govuk-header__logotype">
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                <image src="assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">GOV.UK</span>
+            </span>
+          </a>
+        </div>
+        <div class="govuk-header__product-name">
+          DTTP trainee teacher portal
+        </div>
+      </div>
+    </header>
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper" id="main-content" role="main">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">The DTTP trainee teacher portal is temporarily unavailable</h1>
+            <p class="govuk-body">You cannot access this service right now because there is scheduled maintenance work happening. This work will end at 8am on <span class="no-wrap">Saturday 19 March.</span></p>
+            <p class="govuk-body">You can try accessing the service again after this time. </p>
+            <p class="govuk-body">If you have any questions, email us at<br>
+            <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+          </div>
+        </div>
+      </main>
+    </div>
+    <footer class="govuk-footer govuk-!-display-none-print" role="contentinfo">
+      <div class="govuk-width-container">
+        <div class="govuk-footer__meta">
+          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+            <h2 class="govuk-heading-m">Get help</h2>
+            <div class="govuk-grid-row govuk-!-margin-bottom-5">
+              <div class=" govuk-grid-column-one-half">
+                <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Email</h2>
+                <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
+                  <li><a class="govuk-footer__link" href=" mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> </li>
+                  <li>You’ll get a response within 5 working days, or one working day for urgent requests.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="govuk-footer__meta-item">
+            <a class="govuk-footer__link govuk-footer__copyright-logo govuk-!-margin-bottom-1" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
### Context

When Register is down for the DTTP migration, we want to ensure that users accessing the DTTP portal get an appropriate message that may be different from Registers.

### Changes proposed in this pull request

Add another maintenance page for the traineeteacherportal hosts.

### Guidance to review

This has been tested in `qa` using the Makefile recipe.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
