### PR TITLE
Removed condition from GHCR login step of build

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -47,7 +47,6 @@ jobs:
         echo "IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
     - name: Login to GitHub Container Registry
-      if: github.actor != 'dependabot[bot]'
       uses: docker/login-action@v1.12.0
       with:
         registry: ghcr.io

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -45,7 +45,6 @@ jobs:
           key: SNYK_TOKEN
 
       - name: Login to GitHub Container Registry
-        if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@v1.12.0
         with:
           registry: ghcr.io


### PR DESCRIPTION
### Context
The GitHub Container Registry login step has a condition that stops Dependabot PRs from trying to login to GHCR.

### Changes proposed in this pull request
As the workflow can now login when running with the Dependabot identity the condition has been removed.

### Guidance to review

- Check for conditions that will prevent a Dependabot triggered build from pushing the container image

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
