### PR TITLE
[xxxx] Order publish courses by name for manually added trainees

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -247,7 +247,7 @@ class Trainee < ApplicationRecord
   def available_courses
     return provider.courses.order(:name) if apply_application?
 
-    provider.courses.where(route: training_route) if TRAINING_ROUTES_FOR_COURSE.keys.include?(training_route)
+    provider.courses.where(route: training_route).order(:name) if TRAINING_ROUTES_FOR_COURSE.keys.include?(training_route)
   end
 
   def clear_disabilities

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -154,6 +154,29 @@ describe Trainee do
     end
   end
 
+  describe "#available_courses" do
+    let(:course_route) { TRAINING_ROUTES_FOR_COURSE.keys.first }
+    let!(:physics_course) { create(:course, route: course_route, name: "Physics", accredited_body_code: provider.code) }
+    let!(:citizenship_course) { create(:course, route: course_route, name: "Citizenship", accredited_body_code: provider.code) }
+    let!(:economics_course) { create(:course, route: TRAINING_ROUTES_FOR_COURSE.keys.last, name: "Economics", accredited_body_code: provider.code) }
+    let(:trainee) { create(:trainee, training_route: course_route) }
+    let(:provider) { trainee.provider }
+
+    subject { trainee.available_courses }
+
+    it "returns courses available for the route ordered by name" do
+      expect(subject).to eq([citizenship_course, physics_course])
+    end
+
+    context "with a trainee from apply" do
+      let(:trainee) { create(:trainee, :with_apply_application) }
+
+      it "returns all courses available from the provider ordered by name" do
+        expect(subject).to eq([citizenship_course, economics_course, physics_course])
+      end
+    end
+  end
+
   context "slug" do
     subject { create(:trainee) }
 


### PR DESCRIPTION
### Context
Ensure publish courses are ordered alphabetically for manually added trainees. Right now the order can change based on the last created/updated course.

### Guidance to review
:eyes: 

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
