### PR TITLE
Fix libretls vulnerability CVE-2022-0778

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apk add --update --no-cache --virtual build-dependances \
     rm -rf /usr/local/bundle/cache && \
     apk del build-dependances
 
-# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest gmp
-RUN apk add --no-cache gmp=6.2.1-r1
+# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest libretls
+RUN apk add --no-cache libretls=3.3.4-r3
 
 COPY package.json yarn.lock ./
 RUN  yarn install --frozen-lockfile && \


### PR DESCRIPTION
### Context
Fix base image vulnerability for libretls, https://github.com/advisories/GHSA-x3mh-jvjw-3xwx.
Info: https://snyk.io/vuln/SNYK-ALPINE315-LIBRETLS-2428776

### Changes proposed in this pull request
Bump libretls from 3.3.4-r2 to 3.3.4-r3
Also remove gmp bump to 6.2.1-r1 as this is now in the base image

### Guidance to review
Check build completes successfully
Run build-no-cache workflow against branch

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
