### PR TITLE
[3848] Backfill UKPRN on provider

### DIFF
--- a/db/data/20220322130704_backfill_provider_ukprns.rb
+++ b/db/data/20220322130704_backfill_provider_ukprns.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BackfillProviderUkprns < ActiveRecord::Migration[6.1]
+  def up
+    missing_ukprn_providers = Provider.where(ukprn: nil)
+    missing_ukprn_providers.each do |provider|
+      dttp_provider = Dttp::Provider.find_by(dttp_id: provider.dttp_id)
+      provider.update(ukprn: dttp_provider.ukprn) if dttp_provider.present?
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

We have a UKPRN field on `Provider` but not all providers currently have one. We need them to for the DQT API interaction.

### Changes proposed in this pull request

Copy over the UKPRNs from the DTTP table. Presence validation and DB contstraint hasn't been added here but will be as part of another ticket.

### Guidance to review

I ran this against a local sanitised production copy. You could do the same if you feel so inclined. Spoilers... it did fill in all of the missing ones. We are however relying on the DTTP data being correct which could be mildly contentious.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
