### PR TITLE
[3798] Bugs with school picking flows part 1/3

### DIFF
--- a/app/controllers/trainees/employing_schools_controller.rb
+++ b/app/controllers/trainees/employing_schools_controller.rb
@@ -49,7 +49,7 @@ module Trainees
     end
 
     def index_or_edit_page
-      @employing_school_form.search_results_found? || @employing_school_form.no_results_searching_again?? :index : :edit
+      @employing_school_form.search_results_found? || @employing_school_form.no_results_searching_again? ? :index : :edit
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/employing_schools_controller.rb
+++ b/app/controllers/trainees/employing_schools_controller.rb
@@ -49,7 +49,7 @@ module Trainees
     end
 
     def index_or_edit_page
-      @employing_school_form.search_results_found? ? :index : :edit
+      @employing_school_form.search_results_found? || @employing_school_form.no_results_searching_again?? :index : :edit
     end
 
     def authorize_trainee

--- a/app/forms/schools/employing_school_form.rb
+++ b/app/forms/schools/employing_school_form.rb
@@ -9,6 +9,8 @@ module Schools
 
     attr_accessor(*FIELDS)
 
+    validates :employing_school_id, presence: true, if: :school_validation_required?
+
     alias_method :school_id, :employing_school_id
     alias_method :school_not_applicable, :employing_school_not_applicable
 

--- a/app/forms/schools/form.rb
+++ b/app/forms/schools/form.rb
@@ -95,7 +95,7 @@ module Schools
     end
 
     def both_fields_are_not_selected
-      if school_id.present? && params[:query].present? && school_not_applicable?
+      if params[:query].present? && school_not_applicable?
         errors.add(:query, :both_fields_are_present)
       end
     end

--- a/app/forms/schools/form.rb
+++ b/app/forms/schools/form.rb
@@ -12,8 +12,6 @@ module Schools
 
     attr_accessor(*NON_TRAINEE_FIELDS)
 
-    validates :school_id, presence: true, if: :school_validation_required?
-
     validate :both_fields_are_not_selected
 
     validates :query,

--- a/app/forms/schools/lead_school_form.rb
+++ b/app/forms/schools/lead_school_form.rb
@@ -9,6 +9,8 @@ module Schools
 
     attr_accessor(*FIELDS)
 
+    validates :lead_school_id, presence: true, if: :school_validation_required?
+
     alias_method :school_id, :lead_school_id
     alias_method :school_not_applicable, :lead_school_not_applicable
 

--- a/app/views/trainees/employing_schools/_no_results.html.erb
+++ b/app/views/trainees/employing_schools/_no_results.html.erb
@@ -1,18 +1,21 @@
+<%= f.govuk_error_summary %>
+
+<%= render TraineeName::View.new(@trainee) %>
+
 <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
   <%= t("components.page_titles.search_schools.page_title_no_results") %>
 </h1>
 
-<div class="govuk-inset-text">
-  <p class="govuk-body"><%= t("components.page_titles.search_schools.sub_text_no_results") %>
-    <span class="govuk-!-font-weight-bold"><%= query %></span>.
-  </p>
-</div>
-
-<%= f.govuk_error_summary %>
+<% if f.object.valid? %>
+  <div class="govuk-inset-text">
+    <p class="govuk-body"><%= t("components.page_titles.search_schools.sub_text_no_results") %>
+      <span class="govuk-!-font-weight-bold"><%= query %></span>.
+    </p>
+  </div>
+<% end %>
 
 <%= f.hidden_field :employing_school_id, value: :no_results_search_again %>
 
-<%= render TraineeName::View.new(@trainee) %>
 <%= f.govuk_text_field :no_results_search_again_query,
                        label: { text: t("components.page_titles.search_schools.search_hint") },
                        width: "three-quarters" %>

--- a/app/views/trainees/employing_schools/_results.html.erb
+++ b/app/views/trainees/employing_schools/_results.html.erb
@@ -1,6 +1,7 @@
 <%= f.govuk_error_summary %>
 
 <%= f.hidden_field :employing_school_id, value: nil %>
+<%= f.hidden_field :employing_school_not_applicable, value: "false" %>
 <%= f.hidden_field :search_results_found, value: "true" %>
 
 <%= render TraineeName::View.new(@trainee) %>

--- a/app/views/trainees/lead_schools/_no_results.html.erb
+++ b/app/views/trainees/lead_schools/_no_results.html.erb
@@ -1,16 +1,18 @@
-<% if f.object.valid? %>
-  <h1 class="govuk-heading-l govuk-!-margin-bottom-1">
-    <%= t("components.page_titles.search_schools.page_title_no_results") %>
-  </h1>
+<%= f.govuk_error_summary %>
 
+<%= render TraineeName::View.new(@trainee) %>
+
+<h1 class="govuk-heading-l govuk-!-margin-bottom-1">
+  <%= t("components.page_titles.search_schools.page_title_no_results") %>
+</h1>
+
+<% if f.object.valid? %>
   <div class="govuk-inset-text">
     <p class="govuk-body"><%= t("components.page_titles.search_schools.sub_text_no_results") %>
       <span class="govuk-!-font-weight-bold"><%= query %></span>.
     </p>
   </div>
 <% end %>
-
-<%= f.govuk_error_summary %>
 
 <%= f.hidden_field :lead_school_id, value: :no_results_search_again %>
 

--- a/app/views/trainees/lead_schools/_results.html.erb
+++ b/app/views/trainees/lead_schools/_results.html.erb
@@ -1,6 +1,7 @@
 <%= f.govuk_error_summary %>
 
 <%= f.hidden_field :lead_school_id, value: nil %>
+<%= f.hidden_field :lead_school_not_applicable, value: "false" %>
 <%= f.hidden_field :search_results_found, value: "true" %>
 
 <%= render TraineeName::View.new(@trainee) %>

--- a/app/views/trainees/lead_schools/_results.html.erb
+++ b/app/views/trainees/lead_schools/_results.html.erb
@@ -3,6 +3,7 @@
 <%= f.hidden_field :lead_school_id, value: nil %>
 <%= f.hidden_field :search_results_found, value: "true" %>
 
+<%= render TraineeName::View.new(@trainee) %>
 <%= f.govuk_radio_buttons_fieldset :lead_school_id,
   legend: { text: t("components.page_titles.trainees.lead_schools.index"), tag: "h1", size: "l" },
   hint: { text: "#{t('components.page_titles.search_schools.sub_text_results')} ‘#{query}’" } do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1181,7 +1181,6 @@ en:
           attributes:
             query:
               blank: Enter a school unique reference number (URN), name or postcode
-              both_fields_are_present: Select a lead school or select lead school not applicable
             lead_school_id:
               blank: Select a lead school or search again
             results_search_again_query:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1430,7 +1430,7 @@ en:
             query:
               blank: Enter a school unique reference number (URN), name or postcode
               both_fields_are_present: Select a lead school or select lead school not applicable
-            school_id:
+            lead_school_id:
               blank: Select a lead school or search again
             results_search_again_query:
               blank: Enter a school unique reference number (URN), name or postcode
@@ -1441,7 +1441,7 @@ en:
             query:
               blank: Enter a school unique reference number (URN), name or postcode
               both_fields_are_present: Select an employing school or select employing school not applicable
-            school_id:
+            employing_school_id:
               blank: Select an employing school or search again
             results_search_again_query:
               blank: Enter a school unique reference number (URN), name or postcode

--- a/spec/support/shared_examples/school_form_validations.rb
+++ b/spec/support/shared_examples/school_form_validations.rb
@@ -40,4 +40,15 @@ RSpec.shared_examples "school form validations" do |school_id_key|
       )
     end
   end
+
+  context "school not chosen, but query present and also marked as not applicable" do
+    let(:form_name) { school_id_key.sub("id", "form") }
+    let(:params) { { school_id_key.sub("id", "not_applicable") => "1", query: "school" } }
+
+    it "returns an error" do
+      expect(subject.errors[:query]).to include(
+        I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.query.both_fields_are_present"),
+      )
+    end
+  end
 end

--- a/spec/support/shared_examples/school_form_validations.rb
+++ b/spec/support/shared_examples/school_form_validations.rb
@@ -24,8 +24,8 @@ RSpec.shared_examples "school form validations" do |school_id_key|
     let(:params) { { "results_search_again_query" => "", school_id_key => "", "search_results_found" => "true" } }
 
     it "returns an error" do
-      expect(subject.errors[:school_id]).to include(
-        I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.school_id.blank"),
+      expect(subject.errors[school_id_key]).to include(
+        I18n.t("activemodel.errors.models.schools/#{form_name}.attributes.#{school_id_key}.blank"),
       )
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/wMpA9i2G/3798-bugs-with-school-picking-flows-part-1-3

### Changes proposed in this pull request

As per the numbering (and 'before' screenshots on the ticket:

1. Show error on lead and employing schools form if query entered, no query selected and not applicable selected

<img width="671" alt="Screenshot 2022-03-23 at 09 29 10" src="https://user-images.githubusercontent.com/18436946/159667282-f5b0df05-b836-4445-962f-4ca289d29866.png">

2. Cannot reproduce

3. Validation styling on server-side search. Error message now linked to the no-JS results checkboxes.

<img width="679" alt="Screenshot 2022-03-23 at 09 29 49" src="https://user-images.githubusercontent.com/18436946/159667423-ea890ff4-70f4-4b84-842f-dd4abb968e6d.png">

4. Trainee name caption moved to correct place above h1 on no-JS no results pages

<img width="681" alt="Screenshot 2022-03-23 at 09 30 28" src="https://user-images.githubusercontent.com/18436946/159667549-bffd2d84-d377-456e-aa7e-49ed0414386e.png">

5. Fixed redirect after searching again with an empty search on the no-results no-JS employing school page

### Guidance to review

- Reproduce steps in Trello card, check all are fixed.

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~