### PR TITLE
[xxx] Enable mult-organisation feature

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -69,7 +69,7 @@ features:
     send_data_to_big_query: false
   filters:
     show_start_year_filter: false
-  user_can_have_multiple_organisations: false
+  user_can_have_multiple_organisations: true
   sync_from_hesa: false
   integrate_with_dqt: false
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -29,7 +29,6 @@ features:
     opt_in_undergrad: true
   google:
     send_data_to_big_query: true
-  user_can_have_multiple_organisations: true
 
 pagination:
   records_per_page: 30


### PR DESCRIPTION
### Context

We have a feature allowing users to belong to more than one organisation. It is currently turned off as we haven't 'launched' it yet.

### Changes proposed in this pull request

* Turn it on

### Guidance to review

Poke about on the review app and make sure it's working. As the feature was already enabled in review this doesn't really test much. Ideally we need to confirm in production once this is merged.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
