### PR TITLE
[3860] Handle undergrad routes not having degrees

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -61,7 +61,7 @@ module Dqt
           "genderCode" => GENDER_CODES[trainee.gender.to_sym],
           "initialTeacherTraining" => initial_teacher_training_params,
           "qualification" => qualification_params,
-        }
+        }.compact
       end
 
       def address_params
@@ -101,6 +101,8 @@ module Dqt
       end
 
       def qualification_params
+        return if trainee.degrees.empty?
+
         {
           "providerUkprn" => nil,
           "countryCode" => country_codes[degree.uk? ? UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED : degree.country],

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -88,6 +88,14 @@ module Dqt
             })
           end
         end
+
+        context "when trainee has no degree" do
+          let(:trainee) { create(:trainee, :early_years_undergrad) }
+
+          it "doesn't include qualification" do
+            expect(subject["qualification"]).to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/rR3r5N1Z/3860-s-handle-undergrad-routes-not-having-degrees

### Changes proposed in this pull request
- Change `Dqt::Params::TrnRequest` to not include `qualification` params if there's no degree

### Important business
~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
