### PR TITLE
[3861] DTTP import uses the DQT QPI for TRNs

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -384,8 +384,7 @@ module Trainees
     end
 
     def enqueue_background_jobs!
-      Dttp::RetrieveTrnJob.perform_with_default_delay(trainee) if trainee.submitted_for_trn?
-      Dttp::RetrieveAwardJob.perform_with_default_delay(trainee) if trainee.recommended_for_award?
+      Dqt::RetrieveTrnJob.perform_later(trainee) if trainee.submitted_for_trn?
     end
 
     def funding_attributes

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -187,25 +187,12 @@ module Trainees
         let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: "275af972-9e1b-e711-80c7-0050568902d3") }
 
         before do
-          allow(Dttp::RetrieveTrnJob).to receive(:perform_with_default_delay)
+          allow(Dqt::RetrieveTrnJob).to receive(:perform_later)
         end
 
-        it "enqueues Dttp::RetrieveTrnJob job" do
+        it "enqueues Dqt::RetrieveTrnJob job" do
           create_trainee_from_dttp
-          expect(Dttp::RetrieveTrnJob).to have_received(:perform_with_default_delay).with(Trainee.last)
-        end
-      end
-
-      context "when the trainee is in a recommended_for_award state" do
-        let(:api_placement_assignment) { create(:api_placement_assignment, _dfe_traineestatusid_value: "1b5af972-9e1b-e711-80c7-0050568902d3") }
-
-        before do
-          allow(Dttp::RetrieveAwardJob).to receive(:perform_with_default_delay)
-        end
-
-        it "enqueues Dttp::RetrieveAwardJob job" do
-          create_trainee_from_dttp
-          expect(Dttp::RetrieveAwardJob).to have_received(:perform_with_default_delay).with(Trainee.last)
+          expect(Dqt::RetrieveTrnJob).to have_received(:perform_later).with(Trainee.last)
         end
       end
 


### PR DESCRIPTION
### Context

https://trello.com/c/KLw8C5WS/3861-m-dttp-import-uses-the-dqt-api-for-trns

### Changes proposed in this pull request

- Swap `Dttp::RetrieveTrnJob` out for `Dqt::RetrieveTrnJob` to poll for trainees' trns who are `submitted_for_trn`
- Remove `Dttp::RetrieveAwardJob`. We don't poll for awards via DQT. We will solve these manually (there were only 19 of these when we ran the latest test).

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~