### PR TITLE
[3861] Add data migration to add missing providers for DTTP import

### DIFF
--- a/db/data/20220323125945_add_missing_dttp_import_providers.rb
+++ b/db/data/20220323125945_add_missing_dttp_import_providers.rb
@@ -3,9 +3,9 @@
 class AddMissingDttpImportProviders < ActiveRecord::Migration[6.1]
   def up
     [
-      { name: "Consilium SCITT", dttp_id: "d470f34a-2887-e711-80d8-005056ac45bb", code: "1MS" },
-      { name: "Newcastle University", dttp_id: "ea70f34a-2887-e711-80d8-005056ac45bb", code: "N21" },
-      { name: "St Mary's University", dttp_id: "f670f34a-2887-e711-80d8-005056ac45bb", code: "S64" },
+      { ukprn: 10061209, name: "Consilium SCITT", dttp_id: "d470f34a-2887-e711-80d8-005056ac45bb", code: "1MS" },
+      { ukprn: 10007799, name: "Newcastle University", dttp_id: "ea70f34a-2887-e711-80d8-005056ac45bb", code: "N21" },
+      { ukprn: 10007843, name: "St Mary's University", dttp_id: "f670f34a-2887-e711-80d8-005056ac45bb", code: "S64" },
     ].each do |attributes|
       Provider.find_or_create_by(attributes)
     end

--- a/db/data/20220323125945_add_missing_dttp_import_providers.rb
+++ b/db/data/20220323125945_add_missing_dttp_import_providers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddMissingDttpImportProviders < ActiveRecord::Migration[6.1]
+  def up
+    [
+      { name: "Consilium SCITT", dttp_id: "d470f34a-2887-e711-80d8-005056ac45bb", code: "1MS" },
+      { name: "Newcastle University", dttp_id: "ea70f34a-2887-e711-80d8-005056ac45bb", code: "N21" },
+      { name: "St Mary's University", dttp_id: "f670f34a-2887-e711-80d8-005056ac45bb", code: "S64" },
+    ].each do |attributes|
+      Provider.find_or_create_by(attributes)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/HWfETSWT/3851-s-add-missing-providers-to-production

### Changes proposed in this pull request

- Add three new providers to Register needed for the import of a number of trainees from DTTP.

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
