### PR TITLE
Add DTTP portal route to PaaS for register-production

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -10,6 +10,7 @@
   "paas_redis_service_plan": "tiny-ha-5_x",
   "paas_space_name": "bat-prod",
   "paas_web_app_hostname": "www",
+  "paas_dttp_portal": ["traineeteacherportal"],
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1536,
   "paas_worker_app_instances": 2,


### PR DESCRIPTION
### Context
Add DTTP portal route to PaaS for production, traineeteacherportal.education.gov.uk.
This is just adding the route, the DNS change will occur later.

https://trello.com/c/272NMS5W/3820-setup-dttp-portal-domains-on-govuk-paas

### Changes proposed in this pull request
Add variable to production.tfvars.json

### Guidance to review
Confirm json & parameter value correct

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
