### PR TITLE
[3862] Fix timeline event double entries

### DIFF
--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -61,6 +61,8 @@ module Trainees
     end
 
     def call
+      return if trainee_association_imported_from_dttp?
+
       if action == "create"
         creation_events = [
           TimelineEvent.new(
@@ -189,6 +191,14 @@ module Trainees
 
     def hesa_or_dttp_user?
       IMPORT_SOURCES.include?(user)
+    end
+
+    def dttp_user?
+      user == "DTTP"
+    end
+
+    def trainee_association_imported_from_dttp?
+      auditable_type != "Trainee" && action == "create" && dttp_user?
     end
 
     def provider_name

--- a/spec/services/trainees/create_timeline_events_spec.rb
+++ b/spec/services/trainees/create_timeline_events_spec.rb
@@ -19,7 +19,7 @@ module Trainees
 
         context "when the creation audit was from a DTTP or HESA import" do
           before do
-            trainee.own_and_associated_audits.first.update(user: "HESA")
+            trainee.own_and_associated_audits.first.update!(user: "HESA")
           end
 
           it "returns an array including a creation timeline event with that user in the title" do
@@ -35,7 +35,7 @@ module Trainees
           let(:trainee_created_at) { Time.zone.yesterday }
 
           before do
-            trainee.update(created_at: trainee_created_at)
+            trainee.update!(created_at: trainee_created_at)
           end
 
           it "returns a timeline event with the earlier created_at" do
@@ -51,7 +51,7 @@ module Trainees
 
         context "made by a provider user" do
           before do
-            trainee.own_and_associated_audits.first.update(user: provider_user)
+            trainee.own_and_associated_audits.first.update!(user: provider_user)
           end
 
           it "returns a timeline event that reflects the update" do
@@ -91,7 +91,7 @@ module Trainees
 
         context "made by a system admin" do
           before do
-            trainee.own_and_associated_audits.first.update(user: system_admin)
+            trainee.own_and_associated_audits.first.update!(user: system_admin)
           end
 
           it "returns a timeline event that reflects the update" do
@@ -105,7 +105,7 @@ module Trainees
 
         context "made in HESA" do
           before do
-            trainee.own_and_associated_audits.first.update(username: "HESA")
+            trainee.own_and_associated_audits.first.update!(username: "HESA")
           end
 
           it "returns a timeline event that reflects the update" do
@@ -174,6 +174,17 @@ module Trainees
         it "returns a 'creation' timeline event" do
           degree.reload
           expect(subject.first.title).to eq(t("components.timeline.titles.degree.create"))
+        end
+
+        context "when imported from dttp" do
+          before do
+            degree.save!
+            trainee.own_and_associated_audits.first.update!(user: "DTTP")
+          end
+
+          it "returns empty timeline event" do
+            expect(subject).to be_nil
+          end
         end
       end
 


### PR DESCRIPTION
### Context
For DTTP imported records, this change will ensure that we do not show timeline entries for associations, eg: when a new degree or nationality is addded.

Furthermore, this fixes a duplicate entry that was being rendered for the imported from DTTP event.

### Changes proposed in this pull request
return early if a trainee association creation `audit` is passed to the `Trainees::CreateTimelineEvents` with the import user set to `DTTP`

Before:
![image](https://user-images.githubusercontent.com/910019/159728675-c7355d80-139f-4a9c-9934-3adf5485666a.png)

After:
![image](https://user-images.githubusercontent.com/910019/159728750-d709635b-b04f-4081-9112-dbcfe88e865e.png)

### Guidance to review
<TBC>

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
