### PR TITLE
[3865] Add UKPRN field to provider forms

### DIFF
--- a/app/controllers/system_admin/providers_controller.rb
+++ b/app/controllers/system_admin/providers_controller.rb
@@ -39,7 +39,7 @@ module SystemAdmin
   private
 
     def provider_params
-      params.require(:provider).permit(:name, :dttp_id, :code, :apply_sync_enabled)
+      params.require(:provider).permit(:name, :dttp_id, :code, :ukprn, :apply_sync_enabled)
     end
 
     def set_provider

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -8,6 +8,7 @@ class Provider < ApplicationRecord
   validates :name, presence: true
   validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
   validates :code, format: { with: /\A[A-Z0-9]+\z/i }, allow_blank: true
+  validates :ukprn, format: { with: /\A[0-9]{8}\z/ }
 
   has_many :courses, class_name: "Course", foreign_key: :accredited_body_code, primary_key: :code, inverse_of: :provider
   has_many :apply_applications, ->(provider) { unscope(:where).where(accredited_body_code: provider.code) }

--- a/app/views/system_admin/providers/edit.html.erb
+++ b/app/views/system_admin/providers/edit.html.erb
@@ -12,6 +12,7 @@
 
       <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :ukprn, label: { text: "UKPRN", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :code, label: { text: "Provider code", size: "s" }, width: 20, autocomplete: :off %>
       <div class="govuk-form-group">
         <%= f.govuk_check_box :apply_sync_enabled, true, multiple: false, label: { text: "Import application data from Apply?", size: "s" } %>

--- a/app/views/system_admin/providers/new.html.erb
+++ b/app/views/system_admin/providers/new.html.erb
@@ -12,6 +12,7 @@
 
       <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :ukprn, label: { text: "UKPRN", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :code, label: { text: "Provider code", size: "s" }, width: 20, autocomplete: :off %>
       <div class="govuk-form-group">
         <%= f.govuk_check_box :apply_sync_enabled, true, multiple: false, label: { text: "Import application data from Apply?", size: "s" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1117,6 +1117,8 @@ en:
               taken: Enter a unique DTTP ID
             code:
               invalid: Enter a provider code in the correct format, like 12Y
+            ukprn:
+              invalid: Enter a UKPRN in the correct format, like 12345678
         user:
           attributes:
             first_name:

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -97,6 +97,7 @@ namespace :example_data do
       # Create the provider for that persona
       provider = Provider.create_with(dttp_id: SecureRandom.uuid).find_or_create_by!(
         name: persona_attributes[:provider],
+        ukprn: Faker::Number.number(digits: 8),
         code: persona_attributes[:provider_code].presence || Faker::Alphanumeric.alphanumeric(number: 3).upcase,
       )
 

--- a/spec/factories/dttp/providers.rb
+++ b/spec/factories/dttp/providers.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
       "Provider #{n}"
     end
     dttp_id { SecureRandom.uuid }
-    ukprn { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
+    ukprn { Faker::Number.number(digits: 8) }
   end
 end

--- a/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
+++ b/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 feature "Creating a new provider" do
   let(:user) { create(:user, system_admin: true) }
   let(:dttp_id) { SecureRandom.uuid }
+  let(:ukprn) { Faker::Number.number(digits: 8) }
 
   before do
     given_i_am_authenticated(user: user)
@@ -15,6 +16,7 @@ feature "Creating a new provider" do
   scenario "submitting with valid parameters" do
     and_i_fill_in_name
     and_i_fill_in_dttp_id
+    and_i_fill_in_ukprn
     and_i_select_apply_sync_enabled
     and_i_submit_the_form
     then_i_should_see_the_provider_index_page
@@ -43,6 +45,10 @@ private
     new_provider_page.dttp_id.set(dttp_id)
   end
 
+  def and_i_fill_in_ukprn
+    new_provider_page.ukprn.set(ukprn)
+  end
+
   def and_i_select_apply_sync_enabled
     new_provider_page.apply_sync_enabled.set(true)
   end
@@ -63,6 +69,9 @@ private
     )
     expect(new_provider_page).to have_text(
       I18n.t("#{translation_key_prefix}.dttp_id.invalid"),
+    )
+    expect(new_provider_page).to have_text(
+      I18n.t("#{translation_key_prefix}.ukprn.invalid"),
     )
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -7,14 +7,17 @@ describe Provider do
     it "validates presence" do
       expect(subject).to validate_presence_of(:name).with_message("Enter a provider name")
       expect(subject).to validate_presence_of(:dttp_id).with_message("Enter a DTTP ID in the correct format, like b77c821a-c12a-4133-8036-6ef1db146f9e")
+      expect(subject).to validate_presence_of(:ukprn).with_message("Enter a UKPRN in the correct format, like 12345678")
     end
 
     it "validates format" do
       subject.dttp_id = "XXX"
       subject.code = "abcd 1234"
+      subject.ukprn = "3333"
       subject.valid?
       expect(subject.errors[:dttp_id]).to include("Enter a DTTP ID in the correct format, like b77c821a-c12a-4133-8036-6ef1db146f9e")
       expect(subject.errors[:code]).to include("Enter a provider code in the correct format, like 12Y")
+      expect(subject.errors[:ukprn]).to include("Enter a UKPRN in the correct format, like 12345678")
     end
   end
 

--- a/spec/support/page_objects/providers/new.rb
+++ b/spec/support/page_objects/providers/new.rb
@@ -7,6 +7,7 @@ module PageObjects
 
       element :name, "#provider-name-field"
       element :dttp_id, "#provider-dttp-id-field"
+      element :ukprn, "#provider-ukprn-field"
       element :apply_sync_enabled, "#provider-apply-sync-enabled-true-field"
 
       element :submit, 'button.govuk-button[type="submit"]'


### PR DESCRIPTION
### Context

https://trello.com/c/5D3EpkuN/3865-s-add-ukprn-field-to-provider-forms

### Changes proposed in this pull request

* Added `ukprn` field to add provider form
* Added validation for `ukprn`

### Guidance to review

* Login as system admin and go to add new provider

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
