### PR TITLE
[3850] Hide HESA non-editable inset for non-editable trainees

### DIFF
--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -10,7 +10,7 @@
 
   <%= render RecordHeader::View.new(trainee: @trainee, hide_progress_tag: policy(@trainee).hide_progress_tag?) %>
 
-  <% if @trainee.hesa_record? %>
+  <% if @trainee.hesa_record? && @trainee.awaiting_action? && current_user.provider? %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <%= render GovukComponent::InsetTextComponent.new(classes: "govuk-!-padding-top-0 govuk-!-padding-bottom-0") do %>


### PR DESCRIPTION
### Context
The HESA non-editable inset text is only being shown against trainees
that are not in awarded, recommended_for_award, or withdrawn states.
This is also hidden for lead school users, since they cannot edit
records anyway.

### Changes proposed in this pull request
Add a check if the user is a provider user, and if the trainee is `awaiting_action?`.

### Guidance to review
I've set up all trainees on provider A as HESA trainees. as well as if you log in as a lead school user (look for these lovely people: Chadwick, Deanna, Johnathan, Jamika)

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
