### PR TITLE
[3849] Strip trailing leading whitespace from address fields

### DIFF
--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -31,6 +31,16 @@ class Degree < ApplicationRecord
 
   default_scope { order(graduation_year: :asc) }
 
+  auto_strip_attributes(
+    :subject,
+    :institution,
+    :grade,
+    :country,
+    :other_grade,
+    squish: true,
+    nullify: false,
+  )
+
   def graduation_year_valid
     errors.add(:graduation_year, :future) if graduation_year > next_year
     errors.add(:graduation_year, :invalid) unless graduation_year.between?(next_year - MAX_GRAD_YEARS, next_year)

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -201,7 +201,29 @@ class Trainee < ApplicationRecord
   audited associated_with: :provider
   has_associated_audits
 
-  auto_strip_attributes :first_names, :last_name, :postcode, squish: true
+  auto_strip_attributes(
+    :first_names,
+    :middle_names,
+    :last_name,
+    :address_line_one,
+    :address_line_two,
+    :town_city,
+    :postcode,
+    :email,
+    :international_address,
+    :ethnic_background,
+    :additional_ethnic_background,
+    :trn,
+    :additional_withdraw_reason,
+    :region,
+    :hesa_id,
+    :course_subject_one,
+    :course_subject_two,
+    :course_subject_three,
+    :additional_withdraw_reason,
+    squish: true,
+    nullify: false,
+  )
 
   before_save :clear_employing_school_id, if: :employing_school_not_applicable?
   before_save :clear_lead_school_id, if: :lead_school_not_applicable?

--- a/app/models/trainee_disability.rb
+++ b/app/models/trainee_disability.rb
@@ -5,4 +5,6 @@ class TraineeDisability < ApplicationRecord
   belongs_to :trainee
 
   audited associated_with: :trainee
+
+  auto_strip_attributes :additional_disability
 end


### PR DESCRIPTION
### Context

We strip surrounding spaces from some of the trainee fields when the user enters them.

### Changes proposed in this pull request

* Expand the list to include address fields and other user entered data and strings that we may import from HESA, DTTP etc
* Add the stripping to `Degree` as well while we're at it 
* Fix a flakey spec 

### Guidance to review

* Enter a trainee address with extra spaces. They shouldn't be persisted to the database.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
