### PR TITLE
[3778] Add some HESA trainees, HEI provider and user to the seed data

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
       DB_HOSTNAME: localhost
-    outputs: 
+    outputs:
       docker_image: ${{ env.DOCKER_IMAGE }}
       image_tag: ${{ env.IMAGE_TAG }}
     runs-on: ubuntu-latest
@@ -82,7 +82,7 @@ jobs:
   test:
     name: Test
     needs: [build]
-    outputs: 
+    outputs:
       image_tag: ${{ needs.build.outputs.image_tag }}
     runs-on: ubuntu-latest
     steps:
@@ -119,7 +119,7 @@ jobs:
       run:  docker-compose exec -T web /bin/sh -c 'bundle exec rake lint:scss'
 
     - name: Run Rspec tests
-      run: docker-compose exec --env COVERAGE=true -T web /bin/sh -c 'bundle exec rake spec'
+      run: docker-compose exec --env COVERAGE=true -T web /bin/sh -c 'RAILS_ENV=test bundle exec rake spec'
 
     - name: Run Javascript tests
       run: docker-compose exec -T web /bin/sh -c 'yarn run test'
@@ -164,7 +164,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
+      matrix:
         environment: [qa,staging,production,sandbox,dttpimport]
       max-parallel: 1
     steps:

--- a/config/initializers/personas.rb
+++ b/config/initializers/personas.rb
@@ -2,17 +2,15 @@
 
 PROVIDER_A = "Provider A"
 PROVIDER_B = "Provider B"
-PROVIDER_C = "Teach First"
-PROVIDER_D = "University A"
+PROVIDER_C = "University A"
 TEACH_FIRST_PROVIDER_CODE = "HPITT"
 
 PERSONAS = [
   { first_name: "Agatha", last_name: "Baker", email: "agatha_baker@example.org", system_admin: true },
   { first_name: "Annie", last_name: "Bell", email: "annie_bell@example.org", provider: PROVIDER_A, system_admin: false },
   { first_name: "Damian", last_name: "Campbell", email: "damian_campbell@example.org", provider: PROVIDER_B, system_admin: false },
-  { first_name: "Emma", last_name: "Smith", email: "emma_smith@example.org", provider: PROVIDER_D, system_admin: false, lead_school: true },
-  { first_name: "Teach", last_name: "First", email: "teach_first@example.org", provider: PROVIDER_C, system_admin: false, provider_code: TEACH_FIRST_PROVIDER_CODE },
   { first_name: "Denise", last_name: "Theominis", email: "denise_theominis@example.org", provider: PROVIDER_B, system_admin: false, lead_school: true },
+  { first_name: "Emma", last_name: "Smith", email: "emma_smith@example.org", provider: PROVIDER_C, system_admin: false, lead_school: true },
 ].freeze
 
 PERSONA_EMAILS = PERSONAS.map { |persona| persona[:email] }

--- a/config/initializers/personas.rb
+++ b/config/initializers/personas.rb
@@ -3,12 +3,14 @@
 PROVIDER_A = "Provider A"
 PROVIDER_B = "Provider B"
 PROVIDER_C = "Teach First"
+PROVIDER_D = "University A"
 TEACH_FIRST_PROVIDER_CODE = "HPITT"
 
 PERSONAS = [
   { first_name: "Agatha", last_name: "Baker", email: "agatha_baker@example.org", system_admin: true },
   { first_name: "Annie", last_name: "Bell", email: "annie_bell@example.org", provider: PROVIDER_A, system_admin: false },
   { first_name: "Damian", last_name: "Campbell", email: "damian_campbell@example.org", provider: PROVIDER_B, system_admin: false },
+  { first_name: "Emma", last_name: "Smith", email: "emma_smith@example.org", provider: PROVIDER_D, system_admin: false, lead_school: true },
   { first_name: "Teach", last_name: "First", email: "teach_first@example.org", provider: PROVIDER_C, system_admin: false, provider_code: TEACH_FIRST_PROVIDER_CODE },
   { first_name: "Denise", last_name: "Theominis", email: "denise_theominis@example.org", provider: PROVIDER_B, system_admin: false, lead_school: true },
 ].freeze

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -519,7 +519,9 @@ FactoryBot.define do
     end
 
     trait :imported_from_hesa do
-      hesa_id { Faker::Number.number(digits: 5) }
+      hesa_id { Faker::Number.number(digits: 13) }
+      created_from_hesa { true }
+      hesa_updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/WOaGU49R/3852-m-add-some-hesa-trainees-and-an-hei-and-user-to-the-seed-data

### Changes proposed in this pull request
- Update `example_data.rake` to create a new persona with some HESA trainees associated with a HEI (University) provider

### Guidance to review
- Open rails console and run `Trainee.where.not(hesa_id: nil).count` - expect 0
- Run `rake db:reset && rake db:seed && rake example_data:generate`
- Open rails console and run `Trainee.where.not(hesa_id: nil).count` - expect 169

### Important business
~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
