### PR TITLE
[3899] Initialize dqt_update_sha

### DIFF
--- a/db/data/20220324150013_initialize_dqt_update_sha.rb
+++ b/db/data/20220324150013_initialize_dqt_update_sha.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class InitializeDqtUpdateSha < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.all.find_each do |trainee|
+      trainee.update(dqt_update_sha: trainee.sha)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

We determine if a record needs to be sent as an update by setting a SHA of the record and then checking if it has changed. We need to initialize this before we turn on the DQT integration to avoid sending unnecessary updates.

### Changes proposed in this pull request

* set dqt_update_sha in a data migration.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
