### PR TITLE
[3900] Set dqt_update_sha on import

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -60,7 +60,7 @@ module Trainees
 
       dttp_trainee.imported!
 
-      update_dttp_sha!
+      update_shases!
 
       set_created_at_and_updated_at!
       trainee
@@ -396,8 +396,10 @@ module Trainees
       @funding_entity_id ||= dttp_trainee.latest_placement_assignment.funding_id
     end
 
-    def update_dttp_sha!
-      trainee.dttp_update_sha = trainee.sha
+    def update_shases!
+      sha = trainee.sha
+      trainee.dttp_update_sha = sha
+      trainee.dqt_update_sha = sha
 
       trainee.save!
     end

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -90,6 +90,7 @@ module Trainees
         expect(trainee.created_at).to eq(api_trainee["createdon"])
         expect(trainee.updated_at).to eq(api_trainee["modifiedon"])
         expect(trainee.dttp_update_sha).to eq(trainee.sha)
+        expect(trainee.dqt_update_sha).to eq(trainee.sha)
       end
 
       context "when the country is something other than England and has a non-uk postcode" do


### PR DESCRIPTION
### Context

When we import trainees from DTTP we don't want to then send updates for all of them to DQT.

### Changes proposed in this pull request

* set the dqt_update_sha on Trainee when we create from DTTP.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
