### PR TITLE
[3899] Switch production to DQT

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -71,7 +71,7 @@ features:
     show_start_year_filter: false
   user_can_have_multiple_organisations: true
   sync_from_hesa: false
-  integrate_with_dqt: false
+  integrate_with_dqt: true
 
 dfe_sign_in:
   # Our service name

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -27,7 +27,6 @@ features:
   enable_feedback_link: true
   sync_from_dttp: true
   send_emails: true
-  persist_to_dttp: true
   import_courses_from_ttapi: true
   import_applications_from_apply: true
   publish_course_details: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -6,7 +6,6 @@ features:
   use_dfe_sign_in: false
   enable_feedback_link: true
   publish_course_details: true
-  persist_to_dttp: false
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -22,7 +22,6 @@ features:
   import_courses_from_ttapi: true
   import_applications_from_apply: true
   publish_course_details: true
-  persist_to_dttp: true
   routes:
     early_years_assessment_only: true
     early_years_postgrad: true
@@ -36,7 +35,6 @@ features:
     school_direct_tuition_fee: true
   google:
     send_data_to_big_query: true
-  integrate_with_dqt: true
 
 environment:
   name: staging


### PR DESCRIPTION
### Context

We are switching to using DQT for TRN/QTS directly this evening. We will no longer persist data to DTTP.

### Changes proposed in this pull request

In all environments:

* Disable writing to DTTP
* Enable the DQT integration
 
### Guidance to review

* The sync from DTT flags are still true although we're not really relying on that now. We can fix that in a future PR
* We likely will still have `Retrieve(Trn|Award)` jobs scheduled. We should let them play out so check this flag change won't affect those 

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
