### PR TITLE
Refactor smoke test workflow as a reusable action

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -105,28 +105,12 @@ runs:
       if: startsWith(env.DEPLOY_ENV,'review')
       run: cf run-task "register-pr-${{ inputs.pr-number }}" --command "cd /app && bundle exec rails db:seed example_data:generate" --wait
 
-    - name: Trigger ${{ inputs.environment }} Smoke Tests
-      uses: benc-uk/workflow-dispatch@v1.1
+    - name: Run Smoke Tests for ${{ inputs.environment }}
+      uses: ./.github/actions/smoke-test/
       with:
-        workflow: Smoke Tests
-        ref: ${{ github.event.pull_request.head.ref }} # this will be an empty string when triggered by something other than a PR, benc-uk/workflow-dispatch will default to github.context.ref
-        token:    ${{ inputs.actions-api-access-token }}
-        inputs:   '{"environment": "${{ inputs.environment }}", "pr": "${{ inputs.pr-number }}"}'
-
-    - name: Wait for smoke tests
-      id: wait_for_smoke_tests
-      uses: fountainhead/action-wait-for-check@v1.0.0
-      with:
-        token: ${{ github.token }}
-        ref:   ${{ env.DEPLOY_REF }}
-        checkName: smoke-tests-${{ inputs.environment }}
-        timeoutSeconds:  300
-        intervalSeconds: 15
-
-    - name: Stop when smoke tests fail
-      shell: bash
-      if: steps.wait_for_smoke_tests.outputs.conclusion != 'success'
-      run: exit 1
+        environment: ${{ inputs.environment }}
+        pr-number: ${{ inputs.pr-number }}
+        slack-webhook: ${{ inputs.slack-webhook }}
 
     - name: Update ${{ env.DEPLOY_ENV }} status
       if: always()

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -1,0 +1,51 @@
+name: smoke-test
+description: runs smoke tests
+
+inputs:
+  environment:
+    description: Environment to run tests in
+    required: true
+  pr-number:
+    description: PR number if testing a review app
+    required: false
+  slack-webhook:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby 2.7.5
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.5
+
+    - name: Set Environment variables
+      shell: bash
+      run: |
+        if [ ! -z "${{ inputs.pr-number }}" ]; then
+          PR_NUMBER=${{ inputs.pr-number }}
+          echo "base_url: https://register-pr-$PR_NUMBER.london.cloudapps.digital" >> config/settings/review.yml
+        fi;
+
+    - name: Bundle smoke test gems
+      shell: bash
+      run: |
+        gem install bundler
+        echo 'gem "rspec"' >> Gemfile
+        bundle
+
+    - name: Smoke Tests ${{ inputs.environment }}
+      shell: bash
+      run: RAILS_ENV=${{ inputs.environment }} ./bin/bundle exec rspec spec/smoke
+
+    - name: 'Nofiy #twd_publish_register_tech on failure'
+      if: ${{ failure() && inputs.environment != 'review' }}
+      uses: rtCamp/action-slack-notify@master
+      env:
+        SLACK_CHANNEL: twd_publish_register_tech
+        SLACK_COLOR: '#ef5343'
+        SLACK_ICON_EMOJI: ':github-logo:'
+        SLACK_USERNAME: Register Trainee Teachers
+        SLACK_TITLE: Smoke tests failure
+        SLACK_MESSAGE: ':alert: Smoke tests failure on ${{ inputs.environment }} :sadparrot:'
+        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -4,7 +4,16 @@ on:
     inputs:
       environment:
         description: 'The environment to run tests against (qa, staging , production, sandbox or review)'
+        default: qa
         required: true
+        type: choice
+        options:
+        - review
+        - qa
+        - staging
+        - production
+        - sandbox
+        - dttpimport
       pr:
         description: 'The PR number if the environment is review'
         required: false
@@ -12,45 +21,15 @@ on:
 jobs:
   smoke_tests:
     name: smoke-tests-${{ github.event.inputs.environment }}
+    concurrency: smoke-tests-${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - uses: actions/checkout@v2
-
-      - name: Set up Ruby 2.7.5
-        uses: ruby/setup-ruby@v1
+      - name: Run Smoke Tests for ${{ github.event.inputs.environment }}
+        uses: ./.github/actions/smoke-test/
         with:
-          ruby-version: 2.7.5
-
-      - name: Set Environment variables
-        run: |
-          if [ ! -z "${{ github.event.inputs.pr }}" ]; then
-            PR_NUMBER=${{ github.event.inputs.pr }}
-            echo "base_url: https://register-pr-$PR_NUMBER.london.cloudapps.digital" >> config/settings/review.yml
-          fi;
-
-      - name: Bundle smoke test gems
-        run: |
-          gem install bundler
-          echo 'gem "rspec"' >> Gemfile
-          bundle
-
-      - uses: softprops/turnstyle@v1
-        name: Wait for other runs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Smoke Tests ${{ github.event.inputs.environment }}
-        run: RAILS_ENV=${{ github.event.inputs.environment }} ./bin/bundle exec rspec spec/smoke
-
-      - name: 'Nofiy #twd_publish_register_tech on failure'
-        if: ${{ failure() && github.event.inputs.environment != 'review' }}
-        uses: rtCamp/action-slack-notify@master
-        env:
-          SLACK_CHANNEL: twd_publish_register_tech
-          SLACK_COLOR: '#ef5343'
-          SLACK_ICON_EMOJI: ':github-logo:'
-          SLACK_USERNAME: Register Trainee Teachers
-          SLACK_TITLE: Smoke tests failure
-          SLACK_MESSAGE: ':alert: Smoke tests failure on ${{ github.event.inputs.environment }} :sadparrot:'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          environment: ${{ github.event.inputs.environment }}
+          pr-number: ${{ github.event.inputs.pr }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context
The smoke tests are mainly ran using workflow dispatch from the build workflow.  This makes the logs harder to follow and rerunning failed checks harder. 

https://trello.com/c/D6tyzjoj

### Changes proposed in this pull request
This change refactors the workflow as a reusable action.

The `softprops/turnstyle` step has been removed, instead we rely on concurrency at the workflow level to prevent multiple tests running against the same environment (though with the current smoke tests only hitting the healthcheck endpoint this shouldn't be a concern at present).

### Guidance to review
- Check that smoke tests run as expected when:
  - running as part of the `deploy_review` job
  - deploying to an environment, eg QA, using the `deploy` workflow
  - running manually using the `smoke-test` workflow against an environment, eg QA, and a review app

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
