### PR TITLE
Use-github-environments

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -20,20 +20,32 @@ inputs:
   slack-webhook:
     required: true
 
+outputs:
+  deploy-url:
+    value: ${{ steps.set_env_var.outputs.deploy_url }}
+
 runs:
   using: composite
   steps:
-    - name: Set Current Deployment Environment variable
+    - name: Set Environment variables
+      id: set_env_var
       shell: bash
       run: |
         if [ -n "${{ inputs.pr-number }}" ]; then
           echo "APP_NAME=${{ inputs.pr-number }}" >> $GITHUB_ENV
-          echo "DEPLOY_URL=https://register-pr-${{ inputs.pr-number }}.london.cloudapps.digital" >> $GITHUB_ENV
+          echo "DEPLOY_URL=https://register-pr-${{ inputs.pr-number }}.london.cloudapps.digital"
+          echo "::set-output name=deploy_url::https://register-pr-${{ inputs.pr-number }}.london.cloudapps.digital"
           DEPLOY_ENV=${{ inputs.environment }}-${{ inputs.pr-number }}
           echo "DEPLOY_REF=${{ github.head_ref }}" >> $GITHUB_ENV
         else
           DEPLOY_ENV=${{ inputs.environment }}
           echo "DEPLOY_REF=${{ github.ref }}" >> $GITHUB_ENV
+
+          if [ ${{ inputs.environment }} == "production" ]; then
+            echo "::set-output name=deploy_url::https://www.register-trainee-teachers.education.gov.uk"
+          else
+            echo "::set-output name=deploy_url::https://${{ inputs.environment }}.register-trainee-teachers.education.gov.uk"
+          fi
         fi
 
         echo "DEPLOY_ENV=${DEPLOY_ENV}" >> $GITHUB_ENV
@@ -43,15 +55,6 @@ runs:
         echo "key_vault_app_secret_name=$(jq -r '.key_vault_app_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
         echo "key_vault_infra_secret_name=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
         echo "paas_space_name=$(jq -r '.paas_space_name' ${tf_vars_file})" >> $GITHUB_ENV
-
-    - name: Start ${{ env.DEPLOY_ENV }} Deployment
-      uses: bobheadxi/deployments@v1
-      id: deployment
-      with:
-        step: start
-        token: ${{ github.token }}
-        env: ${{ env.DEPLOY_ENV }}
-        ref: ${{ env.DEPLOY_REF }}
 
     - uses: azure/login@v1
       with:
@@ -128,20 +131,7 @@ runs:
       if: steps.wait_for_smoke_tests.outputs.conclusion != 'success'
       run: exit 1
 
-    - name: Update ${{ env.DEPLOY_ENV }} status
-      if: always()
-      uses: bobheadxi/deployments@v1
-      with:
-        step: finish
-        token: ${{ github.token }}
-        env: ${{ env.DEPLOY_ENV }}
-        status: ${{ job.status }}
-        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-        env_url: ${{ env.DEPLOY_URL }}
-        ref: ${{ env.DEPLOY_REF }}
-        override: false
-
-    - name: Check for Failure
+    - name: Notify Slack channel on job failure
       if: ${{ failure() && github.ref == 'refs/heads/main' }}
       uses: rtCamp/action-slack-notify@master
       env:
@@ -149,6 +139,6 @@ runs:
         SLACK_COLOR: '#ef5343'
         SLACK_ICON_EMOJI: ':github-logo:'
         SLACK_USERNAME: Register Trainee Teachers
-        SLACK_TITLE: Build Failure
+        SLACK_TITLE: Deploy to ${{ inputs.environment }} failed
         SLACK_MESSAGE: ':alert: Build failure on ${{ inputs.environment }} :sadparrot:'
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -182,13 +182,15 @@ jobs:
   deploy_all:
     name: Deployment To All
     concurrency: deploy_all
+    environment: 
+      name: ${{ matrix.environment }}
+      url: ${{ steps.deploy_app.outputs.deploy-url }}
     if: ${{ success() && github.ref == 'refs/heads/main' }}
     needs: [test]
     runs-on: ubuntu-latest
     strategy:
       matrix: 
         environment: [qa,staging,production,sandbox,dttpimport]
-        url: ${{ steps.deploy_app.outputs.deploy-url }}
       max-parallel: 1
     steps:
     - name: Checkout

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -143,10 +143,20 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
+    - name: Start review-${{ github.event.pull_request.number }} Deployment
+      uses: bobheadxi/deployments@v1
+      id: deployment
+      with:
+        env: review-${{ github.event.pull_request.number }}
+        ref: ${{ github.head_ref }}
+        step:  start
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Checkout
       uses: actions/checkout@v2
 
     - name: Deploy App to Review
+      id: deploy_review
       uses: ./.github/actions/deploy/
       with:
         actions-api-access-token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}
@@ -157,6 +167,18 @@ jobs:
         sha: ${{ needs.build.outputs.image_tag }}
         slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
 
+    - name: Update review-${{ github.event.pull_request.number }} status
+      if: always()
+      uses: bobheadxi/deployments@v1
+      with:
+        step: finish
+        token:  ${{ secrets.GITHUB_TOKEN }}
+        env:  review-${{ github.event.pull_request.number }}
+        status: ${{ job.status }}
+        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+        env_url: ${{ steps.deploy_review.outputs.deploy-url }}
+        ref: ${{ github.head_ref }}
+
   deploy_all:
     name: Deployment To All
     concurrency: deploy_all
@@ -166,12 +188,14 @@ jobs:
     strategy:
       matrix: 
         environment: [qa,staging,production,sandbox,dttpimport]
+        url: ${{ steps.deploy_app.outputs.deploy-url }}
       max-parallel: 1
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
     - name: Deploy App to ${{ matrix.environment }}
+      id: deploy_app
       uses: ./.github/actions/deploy/
       with:
         actions-api-access-token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -76,4 +76,4 @@ jobs:
         with:
           step:   deactivate-env
           token:  ${{ secrets.GITHUB_TOKEN }}
-          env:    ${{ env.PR_NUMBER }}
+          env:    review-${{ env.PR_NUMBER }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,9 @@ on:
 jobs:
   deploy:
     name: ${{ github.event.inputs.environment }} deployment
+    environment:
+      name: ${{ github.event.inputs.environment }}
+      url: ${{ steps.deploy_app.outputs.deploy-url }}    
     concurrency: deploy_all # ensures that the job waits for any deployments triggered by the build workflow to finish
     runs-on: ubuntu-latest
     steps:
@@ -27,6 +30,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Deploy App to ${{ github.event.inputs.environment }}
+        id: deploy_app
         uses: ./.github/actions/deploy/
         with:
           actions-api-access-token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}


### PR DESCRIPTION
### Context
The bobheadxi/deployments GitHub Action is used to update deployment statuses, this is ineffective when deploying to persistent environments such as qa or prod.

### Changes proposed in this pull request
This change removes that action from non-review app deployment workflows and uses the built in functionality instead.
Review apps continue to use the bobheadxi/deployments action.

### Guidance to review
- Check that the [environments page](https://github.com/DFE-Digital/teacher-training-api/deployments) is updated as expected including correct View Deployment link
- Check that delete-review-app workflow functions as expected

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
