### PR TITLE
[3854] Hide funding row for years we don't know the funding rules

### DIFF
--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -45,6 +45,8 @@ module Funding
     end
 
     def funding_method_row
+      return if no_funding_methods? && data_model.bursary_tier.blank?
+
       if can_apply_for_grant?
         grant_funding_row
       elsif data_model.applying_for_scholarship
@@ -113,6 +115,10 @@ module Funding
 
     def bursary_funding_hint
       "<br>#{tag.span("#{format_currency(bursary_amount)} estimated bursary", class: 'govuk-hint')}"
+    end
+
+    def no_funding_methods?
+      !trainee.academic_cycle || trainee.academic_cycle.funding_methods.none?
     end
 
     def mappable_field(field_value, field_label, action_url)

--- a/app/lib/funding_manager.rb
+++ b/app/lib/funding_manager.rb
@@ -9,7 +9,7 @@ class FundingManager
 
   def initialize(trainee)
     @trainee = trainee
-    @academic_cycle = find_academic_cycle
+    @academic_cycle = trainee.academic_cycle
   end
 
   def bursary_amount
@@ -81,9 +81,5 @@ private
     allocation_subject.funding_methods.find_by(training_route: training_route,
                                                funding_type: funding_type,
                                                academic_cycle: academic_cycle)&.amount
-  end
-
-  def find_academic_cycle
-    AcademicCycle.for_date(trainee.commencement_date || trainee.itt_start_date)
   end
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -363,6 +363,10 @@ class Trainee < ApplicationRecord
     "manual"
   end
 
+  def academic_cycle
+    AcademicCycle.for_date(commencement_date || itt_start_date)
+  end
+
 private
 
   def value_digest

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -97,6 +97,7 @@ module Funding
 
         describe "has no bursary" do
           before do
+            create(:funding_method)
             render_inline(View.new(data_model: data_model))
           end
 
@@ -246,6 +247,14 @@ module Funding
         it "has correct change link" do
           expect(rendered_component).to have_link(href: "/trainees/#{trainee.slug}/funding/bursary/edit", text: "Enter an answer")
         end
+      end
+    end
+
+    describe "when we don't know the funding rules for the trainee's cycle" do
+      let(:trainee) { create(:trainee, :with_start_date, applying_for_bursary: true) }
+
+      it "doesn't render the funding row" do
+        expect(rendered_component).not_to have_text("Funding method")
       end
     end
   end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -409,6 +409,17 @@ describe Trainee do
         end
       end
     end
+
+    describe "academic_cycle" do
+      let(:academic_cycle) { create(:academic_cycle, cycle_year: 2018) }
+      let(:trainee) { create(:trainee, commencement_date: Date.new(academic_cycle.start_year, 9, 1)) }
+
+      subject { trainee.academic_cycle }
+
+      it "returns the AcademicCycle the trainee started in" do
+        expect(subject).to eq(academic_cycle)
+      end
+    end
   end
 
   describe "#with_name_trainee_id_or_trn_like" do


### PR DESCRIPTION
### Context

https://trello.com/c/wlhtFAyO/3854-m-hide-funding-when-we-dont-have-the-funding-rules-in-register

### Changes proposed in this pull request

- Don't render the funding row in the funding component if the trainee is from an academic year for which we have no funding methods in the database.
- Exception: still render the funding row if the trainee is on a tiered bursary. This type of bursary is not stored in the DB anyway.

### Guidance to review

- Update a trainee to have a start date in the 2018/19 academic year
- Check that there's no funding row on their profile

Example trainee: https://register-pr-2180.london.cloudapps.digital/trainees/dNTT4gbimVbFK9ZTDbuRRbtW

<img width="987" alt="Screenshot 2022-03-25 at 11 41 24" src="https://user-images.githubusercontent.com/18436946/160114609-6a7addd6-5b75-4e77-b594-8ba6ba5ed77e.png">

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~