### PR TITLE
[xxx] Handle DQT response with no body

### DIFF
--- a/app/lib/dqt/client.rb
+++ b/app/lib/dqt/client.rb
@@ -35,7 +35,7 @@ module Dqt
     end
 
     def self.handle_response(response:, statuses:)
-      return JSON.parse(response.body) if statuses.include?(response.code)
+      return JSON.parse(response.body || "{}") if statuses.include?(response.code)
 
       raise(HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}")
     end


### PR DESCRIPTION
### Context

The DQT update endpoint returns a 204 with an empty body so `response.body` is nil. `JSON.parse(nil)` doesn't work.

### Changes proposed in this pull request

If `response.body` is nil then return an empty hash.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
