### PR TITLE
[3857] Update content for dttp-replaced page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -30,8 +30,8 @@ class PagesController < ApplicationController
     render(:guidance)
   end
 
-  def start_traineeteacherportal
-    render(:start_traineeteacherportal)
+  def dttp_replaced
+    render(:dttp_replaced)
   end
 
 private

--- a/app/views/pages/dttp_replaced.html.erb
+++ b/app/views/pages/dttp_replaced.html.erb
@@ -1,0 +1,15 @@
+<%= render PageTitle::View.new(i18n_key: "pages.dttp_replaced") %>
+
+<div class="govuk-grid-row govuk-main-wrapper--auto-spacing">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
+    <p class="govuk-body"><%= t(".use_register") %></p>
+
+    <%= govuk_link_to t(".button_text"), root_path, class: "govuk-button" %>
+
+    <p class="govuk-body"><%= t(".support") %>
+      <%= govuk_mail_to(Settings.support_email, Settings.support_email, subject: t("pages.request_an_account.email_subject")) %>
+    </p>
+  </div>
+</div>

--- a/app/views/pages/start_traineeteacherportal.html.erb
+++ b/app/views/pages/start_traineeteacherportal.html.erb
@@ -1,9 +1,0 @@
-<%= render PageTitle::View.new %>
-
-<div class="govuk-grid-row govuk-main-wrapper--auto-spacing">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
-
-    Welcome to Register, Trainee Teacher Portal user!
-
-  </div>
-</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,6 +248,7 @@ en:
         internal_server_error: Sorry, something went wrong
         unprocessable_entity: Sorry, the change you wanted was rejected
         no_organisation: You have not been linked to an organisation yet
+        dttp_replaced: DTTP replaced
       sign_in:
         index: Sign in
       trn_submissions:

--- a/config/locales/pages/dttp_replaced/en.yml
+++ b/config/locales/pages/dttp_replaced/en.yml
@@ -1,0 +1,8 @@
+en:
+  pages:
+    dttp_replaced:
+      button_text: Go to Register
+      email_subject: DTTP no longer available
+      heading: DTTP has been replaced by Register trainee teachers
+      support: If you have any questions, email
+      use_register: You must use Register trainee teachers (Register) for any actions previously performed in DTTP.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,10 @@ Rails.application.routes.draw do
 
   if Settings.dttp.portal_host.present?
     constraints(->(req) { req.host == Settings.dttp.portal_host }) do
-      start_traineeteacherportal_url = "#{CanonicalRails.protocol}#{CanonicalRails.host}/start_traineeteacherportal"
+      dttp_replaced_url = "#{CanonicalRails.protocol}#{CanonicalRails.host}/dttp-replaced"
 
-      root to: redirect(start_traineeteacherportal_url), as: :traineeteacherportal_root
-      get "/*ttp_path", to: redirect(start_traineeteacherportal_url), as: :traineeteacherportal
+      root to: redirect(dttp_replaced_url), as: :traineeteacherportal_root
+      get "/*ttp_path", to: redirect(dttp_replaced_url), as: :traineeteacherportal
     end
   end
 
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
   get "/guidance", to: "pages#guidance"
   get "/check-data", to: "pages#check_data"
-  get "/start_traineeteacherportal", to: "pages#start_traineeteacherportal"
+  get "/dttp-replaced", to: "pages#dttp_replaced"
 
   get "/404", to: "errors#not_found", via: :all, as: :not_found
   get "/422", to: "errors#unprocessable_entity", via: :all

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -47,17 +47,17 @@ describe PagesController, type: :controller do
     end
   end
 
-  describe "GET #start_traineeteacherportal" do
+  describe "GET #dttp_replaced" do
     it "returns a 200 status code" do
-      get :start_traineeteacherportal
+      get :dttp_replaced
 
       expect(response).to have_http_status(:ok)
     end
 
-    it "renders the start_traineeteacherportal page" do
-      get :start_traineeteacherportal
+    it "renders the dttp_replaced page" do
+      get :dttp_replaced
 
-      expect(response).to have_rendered("start_traineeteacherportal")
+      expect(response).to have_rendered("dttp_replaced")
     end
   end
 end

--- a/spec/requests/traineeteacherportal_requests_spec.rb
+++ b/spec/requests/traineeteacherportal_requests_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "requests to traineeteacherportal-test.education.gov.uk" do
   it "redirects / to register" do
     get "/", headers: { host: "traineeteacherportal-test.education.gov.uk" }
 
-    expect(response).to redirect_to("https://www.register-trainee-teachers.education.gov.uk/start_traineeteacherportal")
+    expect(response).to redirect_to("https://www.register-trainee-teachers.education.gov.uk/dttp-replaced")
   end
 
   it "redirects other paths typically used by portal to register" do
@@ -15,6 +15,6 @@ RSpec.describe "requests to traineeteacherportal-test.education.gov.uk" do
     # https://traineeteacherportal.education.gov.uk/default.aspx#!/app/partials/dfeAppHome&id=0C1A66E4-0B9A-4C83-A0CB-4F902E76496E
     get "/default.aspx#!/app/partials/dfeAppHome&id=0C1A66E4-0B9A-4C83-A0CB-4F902E76496E", headers: { host: "traineeteacherportal-test.education.gov.uk" }
 
-    expect(response).to redirect_to("https://www.register-trainee-teachers.education.gov.uk/start_traineeteacherportal")
+    expect(response).to redirect_to("https://www.register-trainee-teachers.education.gov.uk/dttp-replaced")
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/W0YDeJnK/3857-m-add-the-starttraineeteacherportal-page-content

### Changes proposed in this pull request

- Update content for the page portal uses see when they are redirected to Register
- Update the path for that page to be `dttp-replaced` rather than `start_traineeteacherportal`

### Guidance to review

- Check the content on `/dttp-replaced`

<img width="1552" alt="Screenshot 2022-03-25 at 13 15 40" src="https://user-images.githubusercontent.com/18436946/160138365-190177ad-8bd4-4efb-984a-a9f92968d385.png">

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
