### PR TITLE
[3856] Update content for service unavailable pages

### DIFF
--- a/service_unavailable_page/web/public/internal/index.html
+++ b/service_unavailable_page/web/public/internal/index.html
@@ -41,8 +41,8 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">This service is temporarily unavailable</h1>
-            <p class="govuk-body">You cannot access this service right now because there is scheduled maintenance work happening. This work will end at 8am on <span class="no-wrap">Saturday 19 March.</span></p>
-            <p class="govuk-body">You can try accessing the service again after this time. </p>
+            <p class="govuk-body">You cannot access this service right now because there is scheduled maintenance work happening.</p>
+            <p class="govuk-body">You can try accessing the service again after this time.</p>
             <p class="govuk-body">If you have any questions, email us at<br>
             <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
           </div>

--- a/service_unavailable_page/web/public/internal/traineeteacherportal.html
+++ b/service_unavailable_page/web/public/internal/traineeteacherportal.html
@@ -40,11 +40,12 @@
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">The DTTP trainee teacher portal is temporarily unavailable</h1>
-            <p class="govuk-body">You cannot access this service right now because there is scheduled maintenance work happening. This work will end at 8am on <span class="no-wrap">Saturday 19 March.</span></p>
-            <p class="govuk-body">You can try accessing the service again after this time. </p>
+            <h1 class="govuk-heading-l">DTTP and Register trainee teachers and are currently unavailable</h1>
+            <p class="govuk-body">DTTP is being switched off and replaced by Register trainee teachers (Register).
+              From Thursday 31 March, all trainee data from the 2020 to 2021 academic year onwards will be available
+              in Register. </p>
             <p class="govuk-body">If you have any questions, email us at<br>
-            <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+            <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=DTTP to Register transition">becomingateacher@digital.education.gov.uk</a>.</p>
           </div>
         </div>
       </main>
@@ -58,7 +59,7 @@
               <div class=" govuk-grid-column-one-half">
                 <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Email</h2>
                 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                  <li><a class="govuk-footer__link" href=" mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> </li>
+                  <li><a class="govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> </li>
                   <li>You’ll get a response within 5 working days, or one working day for urgent requests.</li>
                 </ul>
               </div>


### PR DESCRIPTION
### Context
https://trello.com/c/EOTyueAG/3856-s-content-for-the-down-page-while-were-doing-the-import

### Standard page
<img width="967" alt="Screenshot 2022-03-25 at 14 54 14" src="https://user-images.githubusercontent.com/28728/160145071-3b057a14-b7ce-425e-9817-86cfd02ace33.png">


### `/traineeteacherportal`
<img width="971" alt="Screenshot 2022-03-25 at 14 48 28" src="https://user-images.githubusercontent.com/28728/160144018-277d97da-ef6f-46b6-9890-9819e25ab120.png">

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
