### PR TITLE
[xxx] Fix flakey lead school test

### DIFF
--- a/spec/features/system_admin/users/add_a_lead_school_to_user_spec.rb
+++ b/spec/features/system_admin/users/add_a_lead_school_to_user_spec.rb
@@ -83,7 +83,9 @@ private
   end
 
   def and_i_click_the_first_item_in_the_list
-    click(add_lead_school_to_user_page.autocomplete_list_item)
+    # this will cause capybara to wait for the list to be filtered before clicking 'first'
+    expect(add_lead_school_to_user_page).to have_autocomplete_list_items(count: 1)
+    click(add_lead_school_to_user_page.autocomplete_list_items.first)
   end
 
   def and_i_continue

--- a/spec/support/page_objects/users/add_lead_school.rb
+++ b/spec/support/page_objects/users/add_lead_school.rb
@@ -7,7 +7,7 @@ module PageObjects
 
       element :lead_school, "#system-admin-user-lead-schools-form-query-field"
       element :no_js_lead_school, "#system-admin-user-lead-schools-form-query-field"
-      element :autocomplete_list_item, "#system-admin-user-lead-schools-form-query-field__listbox li:first-child"
+      elements :autocomplete_list_items, "#system-admin-user-lead-schools-form-query-field__listbox li"
       element :submit, 'button.govuk-button[type="submit"]'
     end
   end


### PR DESCRIPTION
### Context

The test for the autocomplete was clicking the first items in the autocomplete but this was happening during the filtering so there was always an indeterminate number of items in the list at the time we clicked 'first'

### Changes proposed in this pull request

* Add a check that the filtering has finished before clicking.
* Refactor the page object a bit to give access to all of the autocomplete items 

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
