### PR TITLE
[3733] Import accredited provider id from DTTP

### DIFF
--- a/app/lib/dttp/parsers/account.rb
+++ b/app/lib/dttp/parsers/account.rb
@@ -10,6 +10,7 @@ module Dttp
               name: provider["name"],
               ukprn: provider["dfe_ukprn"],
               dttp_id: provider["accountid"],
+              response: provider,
             }
           end
         end

--- a/app/services/dttp/retrieve_providers.rb
+++ b/app/services/dttp/retrieve_providers.rb
@@ -14,15 +14,7 @@ module Dttp
       "$filter" => "dfe_provider eq true and (statecode eq #{ACTIVE_STATECODE} and statuscode ne #{CLOSED_STATUSCODE}) and (#{INSTITUTION_TYPES})",
     }.freeze
 
-    SELECT = {
-      "$select" => %w[
-        name
-        dfe_ukprn
-        accountid
-      ].join(","),
-    }.freeze
-
-    QUERY = FILTER.merge(SELECT).to_query
+    QUERY = FILTER.to_query
 
   private
 

--- a/db/migrate/20220325163438_add_response_to_dttp_providers.rb
+++ b/db/migrate/20220325163438_add_response_to_dttp_providers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddResponseToDttpProviders < ActiveRecord::Migration[6.1]
+  def change
+    add_column :dttp_providers, :response, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_24_162356) do
+ActiveRecord::Schema.define(version: 2022_03_25_163438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -270,6 +270,7 @@ ActiveRecord::Schema.define(version: 2022_03_24_162356) do
     t.string "ukprn"
     t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.jsonb "response"
     t.index ["dttp_id"], name: "index_dttp_providers_on_dttp_id", unique: true
   end
 

--- a/spec/services/dttp/retrieve_providers_spec.rb
+++ b/spec/services/dttp/retrieve_providers_spec.rb
@@ -7,7 +7,7 @@ module Dttp
     subject { described_class.call(request_uri: request_uri) }
 
     let(:expected_path) do
-      "/accounts?%24filter=dfe_provider+eq+true+and+%28statecode+eq+0+and+statuscode+ne+300000002%29+and+%28_dfe_institutiontypeid_value+eq+b5ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b7ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b9ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bbec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bdec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bfec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+c1ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+cdec33aa-216d-e711-80d2-005056ac45bb%29&%24select=name%2Cdfe_ukprn%2Caccountid"
+      "/accounts?%24filter=dfe_provider+eq+true+and+%28statecode+eq+0+and+statuscode+ne+300000002%29+and+%28_dfe_institutiontypeid_value+eq+b5ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b7ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+b9ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bbec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bdec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+bfec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+c1ec33aa-216d-e711-80d2-005056ac45bb+or+_dfe_institutiontypeid_value+eq+cdec33aa-216d-e711-80d2-005056ac45bb%29"
     end
 
     let(:request_uri) { nil }


### PR DESCRIPTION
### Context

We sync provider records from DTTP. Previously, we only parsed out a few fields. Now we're about to decommission DTTP we want to store all of the fields returned as there are others we will use.

### Changes proposed in this pull request

* Add a `response` column to `dttp_providers`. This is consistent with the other `dttp_` tables.
* When we sync providers, store the JSON for each provider in this table. 

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
