### PR TITLE
[3856] updated the maintenance pages to match

### DIFF
--- a/service_unavailable_page/web/public/internal/index.html
+++ b/service_unavailable_page/web/public/internal/index.html
@@ -40,11 +40,12 @@
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">This service is temporarily unavailable</h1>
-            <p class="govuk-body">You cannot access this service right now because there is scheduled maintenance work happening.</p>
-            <p class="govuk-body">You can try accessing the service again after this time.</p>
+            <h1 class="govuk-heading-l">DTTP and Register trainee teachers and are currently unavailable</h1>
+            <p class="govuk-body">DTTP is being switched off and replaced by Register trainee teachers (Register).
+              From Thursday 31 March, all trainee data from the 2020 to 2021 academic year onwards will be available
+              in Register. </p>
             <p class="govuk-body">If you have any questions, email us at<br>
-            <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+            <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=DTTP to Register transition">becomingateacher@digital.education.gov.uk</a>.</p>
           </div>
         </div>
       </main>
@@ -58,7 +59,7 @@
               <div class=" govuk-grid-column-one-half">
                 <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Email</h2>
                 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                  <li><a class="govuk-footer__link" href=" mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> </li>
+                  <li><a class="govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> </li>
                   <li>You’ll get a response within 5 working days, or one working day for urgent requests.</li>
                 </ul>
               </div>


### PR DESCRIPTION
### Context

The old page didn't mention anything about the migration, and was probably intended for use after the migration is over.