### PR TITLE
[3878] Fix: subject specialism presence validation is broken for updating courses

### DIFF
--- a/app/forms/subject_specialism_form.rb
+++ b/app/forms/subject_specialism_form.rb
@@ -64,17 +64,13 @@ private
   end
 
   def specialism_is_present
-    if @position && send(subject_attribute).blank?
+    if @position && public_send(subject_attribute).blank?
       errors.add(subject_attribute, I18n.t(ERROR_TRANSLATION_KEY))
     end
   end
 
   def course_subjects(params)
-    subjects = params.slice(
-      :course_subject_one,
-      :course_subject_two,
-      :course_subject_three,
-    ).compact_blank
+    subjects = params.slice(:course_subject_one, :course_subject_two, :course_subject_three)
 
     return {} if subjects.blank?
 

--- a/app/views/trainees/subject_specialisms/edit.html.erb
+++ b/app/views/trainees/subject_specialisms/edit.html.erb
@@ -29,6 +29,8 @@
                                    link_errors: index.zero?,
                                    label: { text: specialism.upcase_first },) %>
         <% end %>
+
+        <%= f.hidden_field course_subject_attribute_name, value: "", multiple: true %>
       <% end %>
     </div>
 

--- a/spec/forms/subject_specialism_form_spec.rb
+++ b/spec/forms/subject_specialism_form_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe SubjectSpecialismForm, type: :model do
-  let(:params) { {} }
+  let(:position) { 1 }
   let(:trainee) { build(:trainee, id: 123456) }
   let(:form_store) { class_double(FormStore) }
 
@@ -11,19 +11,29 @@ describe SubjectSpecialismForm, type: :model do
 
   before do
     allow(form_store).to receive(:get).and_return(nil)
+    allow(form_store).to receive(:set).and_return(nil)
   end
 
   describe "validations" do
-    let(:position) { 1 }
+    let(:params) { {} }
+
+    before { subject.stash_or_save! }
 
     it "validates the presence of the course subject matching the position" do
-      expect(subject.valid?).to be false
       expect(subject.errors[:course_subject_one]).to contain_exactly("Select a specialism")
+    end
+
+    context "trainee has existing course subject data" do
+      let(:params) { { course_subject_one: "" } }
+      let(:trainee) { build(:trainee, id: 123456, course_subject_one: CourseSubjects::ART_AND_DESIGN) }
+
+      it "validates the presence of the course subject matching the position" do
+        expect(subject.errors[:course_subject_one]).to contain_exactly("Select a specialism")
+      end
     end
   end
 
   describe "#stash" do
-    let(:position) { 1 }
     let(:params) { { course_subject_one: "special" } }
 
     it "uses FormStore to temporarily save the fields under a key combination of trainee ID and subject_specialism" do


### PR DESCRIPTION
### Context
https://trello.com/c/NQxoCYfm/3878-subject-specialism-presence-validation-is-broken-for-updating-courses

### Changes proposed in this pull request
- Tweak the `SubjectSpecialismForm` and view template

### Guidance to review
- Select non-draft trainee with existing course
- Change course with mulitple subject specialisms (e.g. art and design)
- Submit empty form

### Screenshot
<img width="833" alt="Screenshot 2022-03-29 at 17 22 25" src="https://user-images.githubusercontent.com/28728/160659234-bd86999e-da21-4da6-ab7a-67f1988738d0.png">

### Important business
~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
