### PR TITLE
[3905] Add Trainees#cohort

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -158,6 +158,12 @@ class Trainee < ApplicationRecord
     end
   end
 
+  enum cohort: {
+    current: 0,
+    past: 1,
+    future: 2,
+  }
+
   pg_search_scope :with_name_trainee_id_or_trn_like,
                   against: %i[first_names middle_names last_name trainee_id trn],
                   using: { tsearch: { prefix: true } }

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -198,6 +198,7 @@ shared:
     - updated_at
     - withdraw_date
     - withdraw_reason
+    - cohort
   users:
     - created_at
     - dfe_sign_in_uid

--- a/db/migrate/20220329160910_add_cohort_to_trainees.rb
+++ b/db/migrate/20220329160910_add_cohort_to_trainees.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCohortToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :cohort, :integer, default: 0
+    add_index :trainees, :cohort
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_25_163438) do
+ActiveRecord::Schema.define(version: 2022_03_29_160910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -532,7 +532,9 @@ ActiveRecord::Schema.define(version: 2022_03_25_163438) do
     t.boolean "created_from_hesa", default: false, null: false
     t.string "dqt_update_sha"
     t.datetime "hesa_updated_at"
+    t.integer "cohort", default: 0
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
+    t.index ["cohort"], name: "index_trainees_on_cohort"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["discarded_at"], name: "index_trainees_on_discarded_at"


### PR DESCRIPTION
### Context

We are going to filter on 'cohort' ie past, current and future. This logic is complicated so we're going to set the cohort as a state on trainee.

### Changes proposed in this pull request

* Add `Trainee#cohort`. Default to 'current' for now. Logic for updating and maintaining this state will be added in further PRs. Adding this by itself to allow parallel work on the feature.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
