### PR TITLE
[3908] Reset dqt_update_sha after TRN and Award receipt

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -236,16 +236,19 @@ class Trainee < ApplicationRecord
   def trn_received!(new_trn = nil)
     raise(StateTransitionError, "Cannot transition to :trn_received without a trn") unless new_trn || trn
 
-    # Skip deferred and withdrawn to avoid state change
-    # but to still register trn
+    # Skip deferred and withdrawn to avoid state change but to still register trn
     receive_trn! unless deferred? || withdrawn?
+
     # A deferred trainee will probably already have a trn - don't overwrite that!
     update!(trn: new_trn) unless trn
+
+    reset_dqt_sha!
   end
 
   def award_qts!(awarded_at)
     self.awarded_at = awarded_at
     award!
+    reset_dqt_sha!
   end
 
   def dttp_id=(value)
@@ -387,6 +390,10 @@ class Trainee < ApplicationRecord
 
   def academic_cycle
     AcademicCycle.for_date(commencement_date || itt_start_date)
+  end
+
+  def reset_dqt_sha!
+    update!(dqt_update_sha: sha)
   end
 
 private

--- a/app/services/dqt/trainee_update.rb
+++ b/app/services/dqt/trainee_update.rb
@@ -16,7 +16,7 @@ module Dqt
 
       dqt_update("/v2/teachers/update/#{trainee.trn}?birthDate=#{trainee.date_of_birth.iso8601}", payload)
 
-      trainee.update!(dqt_update_sha: trainee.sha)
+      trainee.reset_dqt_sha!
     end
 
   private

--- a/spec/jobs/dqt/recommend_for_award_job_spec.rb
+++ b/spec/jobs/dqt/recommend_for_award_job_spec.rb
@@ -19,8 +19,21 @@ module Dqt
       it "updates the trainee awarded_at attribute" do
         expect {
           described_class.perform_now(trainee)
-          trainee.reload
         }.to change(trainee, :awarded_at).to(Time.zone.parse(award_date))
+      end
+
+      context "DTQ sha" do
+        let(:trainee_sha) { "ABC" }
+
+        before do
+          allow(trainee).to receive(:sha).and_return(trainee_sha)
+        end
+
+        it "sets the dqt_update_sha to the trainee sha" do
+          expect {
+            described_class.perform_now(trainee)
+          }.to change(trainee, :dqt_update_sha).to(trainee_sha)
+        end
       end
     end
 

--- a/spec/jobs/dqt/retrieve_trn_job_spec.rb
+++ b/spec/jobs/dqt/retrieve_trn_job_spec.rb
@@ -39,13 +39,26 @@ module Dqt
       it "updates the trainee TRN attribute" do
         expect {
           described_class.perform_now(trn_request, timeout_date)
-          trainee.reload
         }.to change(trainee, :trn).to(trn)
       end
 
       it "doesn't queue another job" do
         described_class.perform_now(trn_request, timeout_date)
         expect(RetrieveTrnJob).not_to have_been_enqueued
+      end
+
+      context "DTQ sha" do
+        let(:trainee_sha) { "ABC" }
+
+        before do
+          allow(trainee).to receive(:sha).and_return(trainee_sha)
+        end
+
+        it "sets the dqt_update_sha to the trainee sha" do
+          expect {
+            described_class.perform_now(trn_request, timeout_date)
+          }.to change(trainee, :dqt_update_sha).to(trainee_sha)
+        end
       end
     end
 


### PR DESCRIPTION
### Context
https://trello.com/c/UckdmbRv/3908-reset-dqtupdatesha-after-trn-and-award-receipt

### Changes proposed in this pull request
- Set `dqt_update_sha` to `Trainee#sha` when TRN is received or Award

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
