### PR TITLE
[3907] Map trainees on EYITT - School Direct (Early Years) to EYITT postgrad

### DIFF
--- a/app/lib/dttp/code_sets/routes.rb
+++ b/app/lib/dttp/code_sets/routes.rb
@@ -19,6 +19,11 @@ module Dttp
         TRAINING_ROUTE_ENUMS[:opt_in_undergrad] => { entity_id: "51a5f96f-e122-e811-80ec-005056ac45bb" },
         TRAINING_ROUTE_ENUMS[:hpitt_postgrad] => { entity_id: "7b89922e-acc2-e611-80be-00155d010316" },
       }.freeze
+
+      INACTIVE_MAPPING = {
+        # EYITT - School Direct (Early Years)
+        TRAINING_ROUTE_ENUMS[:early_years_postgrad] => { entity_id: "6d89922e-acc2-e611-80be-00155d010316" },
+      }.freeze
     end
   end
 end

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -123,6 +123,9 @@ module Trainees
       @dttp_route ||= find_by_entity_id(
         dttp_trainee.latest_placement_assignment.route_dttp_id,
         Dttp::CodeSets::Routes::MAPPING,
+      ) || find_by_entity_id(
+        dttp_trainee.latest_placement_assignment.route_dttp_id,
+        Dttp::CodeSets::Routes::INACTIVE_MAPPING,
       )
     end
 

--- a/spec/factories/dttp/api_placement_assignment.rb
+++ b/spec/factories/dttp/api_placement_assignment.rb
@@ -35,6 +35,10 @@ FactoryBot.define do
       _dfe_bursarydetailsid_value { Dttp::CodeSets::BursaryDetails::POSTGRADUATE_BURSARY }
     end
 
+    trait :with_early_years_school_direct do
+      _dfe_routeid_value { "6d89922e-acc2-e611-80be-00155d010316" }
+    end
+
     trait :with_early_years_salaried_bursary do
       enabled_training_routes { ["early_years_salaried"] }
       _dfe_ittsubject1id_value { Dttp::CodeSets::CourseSubjects::EARLY_YEARS_DTTP_ID }

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -93,6 +93,16 @@ module Trainees
         expect(trainee.dqt_update_sha).to eq(trainee.sha)
       end
 
+      context "when the route is early_years_school_direct" do
+        let(:api_placement_assignment) { create(:api_placement_assignment, :with_early_years_school_direct) }
+
+        it "maps the trainee to early_years_postgrad" do
+          create_trainee_from_dttp
+          trainee = Trainee.last
+          expect(trainee.training_route).to eq("early_years_postgrad")
+        end
+      end
+
       context "when the country is something other than England and has a non-uk postcode" do
         let(:api_trainee) { create(:api_trainee, address1_postalcode: nil, address1_country: "France") }
 
@@ -118,7 +128,7 @@ module Trainees
           create_trainee_from_dttp
         end
 
-        it "does not set the local to UK" do
+        it "does not set the locale to UK" do
           expect(Trainee.last.locale_code).to be_nil
         end
 
@@ -127,7 +137,7 @@ module Trainees
             create(:api_trainee, address1_line1: nil, address1_postalcode: nil, address1_country: "England")
           end
 
-          it "sets the local to UK" do
+          it "sets the locale to UK" do
             expect(Trainee.last.locale_code).to eq("uk")
           end
         end


### PR DESCRIPTION
### Context
This change will resolve a missing trainee on the EYITT - School Direct (Early Years) route
from https://github.com/DFE-Digital/register-trainee-teachers/pull/2191

### Changes proposed in this pull request
Add the EYITT - School Direct (Early Years) route as an `INACTIVE_MAPPING`, and map it to early_years_postgrad (EYITT PostGraduate)

### Guidance to review

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
