### PR TITLE
[3677] Add cohort filter

### DIFF
--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -127,6 +127,7 @@ private
         state: [],
         record_source: [],
         record_completion: [],
+        cohort: [],
       },
     ]
   end

--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -6,6 +6,7 @@ class BaseTraineeController < ApplicationController
     filter_params
     filters
     available_record_sources
+    available_cohorts
     show_source_filters?
     show_cohort_filter?
     paginated_trainees

--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -141,7 +141,7 @@ private
 
   def available_cohorts
     Trainee.cohorts.keys.select do |cohort|
-      trainees = TraineePolicy::Scope.new(current_user, Trainee.public_send(cohort)).resolve
+      trainees = TraineePolicy::Scope.new(current_user, trainee_search_scope.public_send(cohort)).resolve
       trainees.any?
     end
   end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -83,6 +83,7 @@ private
         record_source: [],
         record_completion: [],
         study_mode: [],
+        cohort: [],
       }
     ]
   end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -34,7 +34,7 @@ class TraineesController < BaseTraineeController
     authorize(trainee)
     trainee.draft? ? trainee.destroy! : trainee.discard!
     flash[:success] = t("views.trainees.delete.#{trainee.draft? ? :draft : :record}")
-    redirect_to(trainees_path)
+    redirect_to(trainee.draft? ? drafts_path(cohort: %w[current]) : trainees_path(cohort: %w[current]))
   end
 
 private
@@ -76,7 +76,8 @@ private
       :subject,
       :text_search,
       :start_year,
-      :sort_by, {
+      :sort_by,
+      {
         level: [],
         training_route: [],
         state: [],
@@ -84,7 +85,7 @@ private
         record_completion: [],
         study_mode: [],
         cohort: [],
-      }
+      },
     ]
   end
 

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -35,6 +35,7 @@ private
       **start_year,
       **trainee_start_years,
       **study_modes,
+      **cohorts
     ).with_indifferent_access
   end
 
@@ -140,6 +141,18 @@ private
   def study_mode_options
     %w[full_time part_time].each_with_object([]) do |option, arr|
       arr << option if params[:study_mode]&.include?(option)
+    end
+  end
+
+  def cohorts
+    return {} unless cohort_options.any?
+
+    { "cohort" => cohort_options }
+  end
+
+  def cohort_options
+    Trainee.cohorts.keys.each_with_object([]) do |option, arr|
+      arr << option if params[:cohort]&.include?(option)
     end
   end
 end

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -35,7 +35,7 @@ private
       **start_year,
       **trainee_start_years,
       **study_modes,
-      **cohorts
+      **cohorts,
     ).with_indifferent_access
   end
 

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -119,6 +119,12 @@ module Trainees
       end
     end
 
+    def cohort(trainees, cohort)
+      return trainees if cohort.blank?
+
+      trainees.where(cohort: cohort)
+    end
+
     def filter_trainees
       filtered_trainees = trainees
 
@@ -131,6 +137,7 @@ module Trainees
       filtered_trainees = provider(filtered_trainees, filters[:provider])
       filtered_trainees = submission_ready(filtered_trainees, filters[:record_completion])
       filtered_trainees = study_mode(filtered_trainees, filters[:study_mode])
+      filtered_trainees = cohort(filtered_trainees, filters[:cohort])
 
       record_source(filtered_trainees, filters[:record_source])
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,8 +52,8 @@
       <%= render NavigationBar::View.new(
         items: [
           { name: "Home", url: root_path },
-          ({ name: "Draft trainees", url: drafts_path, current: active_link_for("drafts", @trainee) } unless lead_school_user?),
-          { name: "Registered trainees", url: trainees_path, current: active_link_for("trainees", @trainee) },
+          ({ name: "Draft trainees", url: drafts_path(cohort: %w[current]), current: active_link_for("drafts", @trainee) } unless lead_school_user?),
+          { name: "Registered trainees", url: trainees_path(cohort: %w[current]), current: active_link_for("trainees", @trainee) },
           ({ name: current_user.organisation.name, url: organisations_path, align_right: true } if show_organisation_link?),
         ],
         current_path: request.path,

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -13,7 +13,7 @@
           <li>
             <%= govuk_link_to(
               t(".draft_trainees_link", count: @home_view.draft_trainees_count),
-              drafts_path(cohort: %w[current]),
+              drafts_path,
               { class: "govuk-link--no-visited-state" }
             )%>
           </li>
@@ -22,7 +22,7 @@
           <li>
             <%= govuk_link_to(
               t(".draft_apply_trainees_link", count: @home_view.draft_apply_trainees_count),
-              drafts_path("record_source[]": :apply, cohort: %w[current]),
+              drafts_path("record_source[]": :apply),
               { class: "govuk-link--no-visited-state" }
             )%>
           </li>
@@ -57,7 +57,7 @@
         <li>
           <%= govuk_link_to(
             t(".registered_trainees_link", count: @home_view.registered_trainees_count),
-            trainees_path(cohort: %w[current]),
+            trainees_path,
             { class: "govuk-link--no-visited-state" }
           )%>
         </li>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -13,7 +13,7 @@
           <li>
             <%= govuk_link_to(
               t(".draft_trainees_link", count: @home_view.draft_trainees_count),
-              drafts_path,
+              drafts_path(cohort: %w[current]),
               { class: "govuk-link--no-visited-state" }
             )%>
           </li>
@@ -22,7 +22,7 @@
           <li>
             <%= govuk_link_to(
               t(".draft_apply_trainees_link", count: @home_view.draft_apply_trainees_count),
-              drafts_path("record_source[]": :apply),
+              drafts_path("record_source[]": :apply, cohort: %w[current]),
               { class: "govuk-link--no-visited-state" }
             )%>
           </li>
@@ -57,7 +57,7 @@
         <li>
           <%= govuk_link_to(
             t(".registered_trainees_link", count: @home_view.registered_trainees_count),
-            trainees_path,
+            trainees_path(cohort: %w[current]),
             { class: "govuk-link--no-visited-state" }
           )%>
         </li>

--- a/app/views/trainees/_cohort_filter.html.erb
+++ b/app/views/trainees/_cohort_filter.html.erb
@@ -1,11 +1,11 @@
-<% unless lead_school_user? %>
+<% if show_cohort_filter? %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
         <%= t("views.trainees.index.filters.cohort") %>
       </legend>
       <div class="govuk-checkboxes govuk-checkboxes--small">
-        <% Trainee.cohorts.keys.map do |cohort| %>
+        <% available_cohorts.map do |cohort| %>
           <div class="govuk-checkboxes__item">
             <%= check_box_tag "cohort[]",
                               cohort,

--- a/app/views/trainees/_cohort_filter.html.erb
+++ b/app/views/trainees/_cohort_filter.html.erb
@@ -1,0 +1,23 @@
+<% unless lead_school_user? %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+        <%= t("views.trainees.index.filters.cohort") %>
+      </legend>
+      <div class="govuk-checkboxes govuk-checkboxes--small">
+        <% Trainee.cohorts.keys.map do |cohort| %>
+          <div class="govuk-checkboxes__item">
+            <%= check_box_tag "cohort[]",
+                              cohort,
+                              checked?(filters, :cohort, cohort),
+                              id: "cohort-#{cohort}",
+                              class: "govuk-checkboxes__input" %>
+            <%= label_tag "cohort-#{cohort}",
+                          label_for("cohort", cohort),
+                          class: "govuk-label govuk-checkboxes__label" %>
+          </div>
+        <% end %>
+      </div>
+    </fieldset>
+  </div>
+<% end %>

--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -22,6 +22,8 @@
     <% end %>
   <% end %>
 
+  <%= render "trainees/cohort_filter", search_path: search_path %>
+
   <%= render "trainees/record_completion_filter", search_path: search_path %>
 
   <% if filter_start_year_options(current_user).count > 2 %>

--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -22,7 +22,7 @@
     <% end %>
   <% end %>
 
-  <%= render "trainees/cohort_filter", search_path: search_path %>
+  <%= render "trainees/cohort_filter" %>
 
   <%= render "trainees/record_completion_filter", search_path: search_path %>
 

--- a/app/views/trainees/apply_applications/trainee_data/edit.html.erb
+++ b/app/views/trainees/apply_applications/trainee_data/edit.html.erb
@@ -42,4 +42,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("return_to_draft_later"), trainees_path, { id: "return-to-draft-later" }) %></p>
+<p class="govuk-body"><%= govuk_link_to(t("return_to_draft_later"), trainees_path(cohort: %[current]), { id: "return-to-draft-later" }) %></p>

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -32,7 +32,7 @@
             <p class="govuk-body">
              This trainee record is not complete and cannot be submitted for TRN.
              If you do not have all the required information now, you can
-             <%= govuk_link_to " return to this draft later", trainees_path %>.
+             <%= govuk_link_to " return to this draft later", drafts_path(cohort: %w[current]) %>.
             </p>
           </div>
         <% end %>
@@ -54,4 +54,4 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to("Return to this draft later", drafts_path, { id: "return-to-draft-later" }) %></p>
+<p class="govuk-body"><%= govuk_link_to("Return to this draft later", drafts_path(cohort: %w[current]), { id: "return-to-draft-later" }) %></p>

--- a/app/views/trainees/outcome_details/recommended.html.erb
+++ b/app/views/trainees/outcome_details/recommended.html.erb
@@ -27,7 +27,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li><%= govuk_link_to("view #{trainee_name(@trainee)}’s record", trainee_path(@trainee)) %></li>
-      <li><%= govuk_link_to("view all your records", trainees_path) %></li>
+      <li><%= govuk_link_to("view all your records", trainees_path(cohort: %w[current])) %></li>
     </ul>
   </div>
 </div>

--- a/app/views/trainees/review_drafts/show.html.erb
+++ b/app/views/trainees/review_drafts/show.html.erb
@@ -11,7 +11,7 @@
 
 <h2 class="govuk-heading-m">Final check</h2>
   <%= render GovukButtonLinkTo::View.new(body: "Check this record", url: trainee_check_details_path(@trainee), id: "check-details") %>
-<p class="govuk-body"><%= govuk_link_to("Return to this draft later", trainees_path) %></p>
+<p class="govuk-body"><%= govuk_link_to("Return to this draft later", drafts_path(cohort: %w[current])) %></p>
 
 <p class="govuk-body govuk-!-margin-top-8">
   <%= govuk_link_to "Delete this draft", trainee_confirm_delete_path(@trainee), class: "app-link--warning" %>

--- a/app/views/trn_submissions/show.html.erb
+++ b/app/views/trn_submissions/show.html.erb
@@ -34,7 +34,7 @@
     <ul class="govuk-list govuk-list--bullet">
       <li><%= govuk_link_to("view #{trainee_name(@trainee)}’s record", trainee_path(@trainee)) %></li>
       <li><%= govuk_link_to("add a new trainee", new_trainee_path) %></li>
-      <li><%= govuk_link_to("view all your records", trainees_path) %></li>
+      <li><%= govuk_link_to("view all your records", trainees_path(cohort: %w[current])) %></li>
     </ul>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,6 +384,7 @@ en:
         search_button: Search again
       service_updates: News and updates
     filter:
+      cohort: Cohort
       level: Education phase
       provider: Provider
       record_source: Record source
@@ -628,17 +629,18 @@ en:
           above_the_fold_title: Draft trainees
           below_the_fold_title: Registered trainees
         filters:
-          record_completion: Record completion
-          trainee_start_year: *trainee_start_year
-          incomplete: Incomplete
+          cohort: Cohort
           complete: Complete
+          incomplete: Incomplete
           level: Education phase
           provider: Provider
+          record_completion: Record completion
           search: Search for a trainee
           status: Status
           study_mode: Full time or part time
           subject: Subject
           start_year: Start year
+          trainee_start_year: *trainee_start_year
           type_of_training: Type of training
       edit:
         delete: delete this record,
@@ -1043,6 +1045,10 @@ en:
   activerecord:
     attributes:
       trainee:
+        cohorts:
+          current: Current
+          past: Past
+          future: Next year's
         record_sources:
           title: Record source
           apply: Imported from Apply

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -173,8 +173,8 @@ namespace :example_data do
                   courses = courses.where(recruitment_cycle_year: Settings.current_default_course_year + 1)
 
                   attrs.merge!(
-                    apply_application: FactoryBot.build(:apply_application,
-                                                        accredited_body_code: provider.code),
+                    apply_application: FactoryBot.build(:apply_application, accredited_body_code: provider.code),
+                    cohort: "future",
                   )
                 else
                   # Create manual drafts for *current* academic cycle

--- a/spec/controllers/trainees_controller_spec.rb
+++ b/spec/controllers/trainees_controller_spec.rb
@@ -103,8 +103,8 @@ describe TraineesController do
     context "with a non-draft trainee" do
       let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.organisation) }
 
-      it "redirects to the trainee index page" do
-        expect(get(:destroy, params: { id: trainee })).to redirect_to(trainees_path)
+      it "redirects to the trainee index page, with the current cohort filter applied" do
+        expect(get(:destroy, params: { id: trainee })).to redirect_to(trainees_path(cohort: %w[current]))
       end
     end
   end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -524,19 +524,21 @@ FactoryBot.define do
       hesa_updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 
-    trait :past_cohort do
+    trait :past do
       cohort { "past" }
       itt_start_date { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year - 1) }
       itt_end_date { Faker::Date.in_date_period(month: 8, year: itt_start_date.year + 1) }
+      awarded
+      awarded_at { itt_end_date }
     end
 
-    trait :current_cohort do
+    trait :current do
       cohort { "current" }
       itt_start_date { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year) }
       itt_end_date { Faker::Date.in_date_period(month: 8, year: itt_start_date.year + 1) }
     end
 
-    trait :future_cohort do
+    trait :future do
       cohort { "future" }
       itt_start_date { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year + 1) }
       itt_end_date { Faker::Date.in_date_period(month: 8, year: itt_start_date.year + 1) }

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -523,5 +523,23 @@ FactoryBot.define do
       created_from_hesa { true }
       hesa_updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
+
+    trait :past_cohort do
+      cohort { "past" }
+      itt_start_date { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year - 1) }
+      itt_end_date { Faker::Date.in_date_period(month: 8, year: itt_start_date.year + 1) }
+    end
+
+    trait :current_cohort do
+      cohort { "current" }
+      itt_start_date { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year) }
+      itt_end_date { Faker::Date.in_date_period(month: 8, year: itt_start_date.year + 1) }
+    end
+
+    trait :future_cohort do
+      cohort { "future" }
+      itt_start_date { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year + 1) }
+      itt_end_date { Faker::Date.in_date_period(month: 8, year: itt_start_date.year + 1) }
+    end
   end
 end

--- a/spec/features/trainee_actions/delete_trainee_spec.rb
+++ b/spec/features/trainee_actions/delete_trainee_spec.rb
@@ -111,7 +111,7 @@ private
   end
 
   def i_am_redirected_to_the_trainee_records_list
-    expect(trainee_index_page).to be_displayed
+    expect(trainee_drafts_page).to be_displayed
   end
 
   def and_i_see_a_flash_message

--- a/spec/features/trainee_actions/filtering_trainees_by_cohort_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_by_cohort_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Filtering trainees by cohort" do
+  before do
+    given_i_am_authenticated
+  end
+
+  context "when only current cohort trainees exists" do
+    before do
+      given_only_current_trainees_exist
+      when_i_visit_the_trainee_index_page
+    end
+
+    scenario "cannot filter by cohort" do
+      then_i_should_not_see_the_cohort_filter
+    end
+  end
+
+  context "when trainees from all cohorts exists" do
+    before do
+      given_trainees_from_all_cohorts_exist
+      when_i_visit_the_trainee_index_page
+    end
+
+    scenario "can filter by cohort" do
+      when_i_filter_by_past_cohort
+      then_only_past_cohort_trainees_are_visible
+    end
+  end
+
+  context "when there are no trainees in future cohort" do
+    before do
+      given_only_past_and_current_trainees_exist
+      when_i_visit_the_trainee_index_page
+    end
+
+    scenario "cannot filter by future cohort" do
+      then_i_should_not_see_the_future_cohort_checkbox
+    end
+  end
+
+private
+
+  def given_only_current_trainees_exist
+    @current_cohort_trainee ||= create(:trainee, :awarded, :current_cohort, provider: current_provider)
+  end
+
+  def given_only_past_and_current_trainees_exist
+    @past_cohort_trainee ||= create(:trainee, :awarded, :past_cohort, provider: current_provider)
+    @current_cohort_trainee ||= create(:trainee, :awarded, :current_cohort, provider: current_provider)
+  end
+
+  def given_trainees_from_all_cohorts_exist
+    @past_cohort_trainee ||= create(:trainee, :awarded, :past_cohort, provider: current_provider)
+    @current_cohort_trainee ||= create(:trainee, :awarded, :current_cohort, provider: current_provider)
+    @future_cohort_trainee ||= create(:trainee, :awarded, :future_cohort, provider: current_provider)
+  end
+
+  def current_provider
+    @current_provider ||= @current_user.organisation
+  end
+
+  def when_i_visit_the_trainee_index_page
+    trainee_index_page.load
+    expect(trainee_index_page).to be_displayed
+  end
+
+  def when_i_filter_by_past_cohort
+    trainee_index_page.past_cohort_checkbox.click
+    trainee_index_page.apply_filters.click
+  end
+
+  def then_only_past_cohort_trainees_are_visible
+    expect(trainee_index_page).not_to have_text(full_name(@current_cohort_trainee))
+    expect(trainee_index_page).not_to have_text(full_name(@future_cohort_trainee))
+    expect(trainee_index_page).to have_text(full_name(@past_cohort_trainee))
+  end
+
+  def then_i_should_not_see_the_cohort_filter
+    expect(trainee_index_page).not_to have_cohort_filter
+  end
+
+  def then_i_should_not_see_the_future_cohort_checkbox
+    expect(trainee_index_page).not_to have_future_cohort_checkbox
+  end
+
+  def full_name(trainee)
+    [trainee.first_names, trainee.last_name].join(" ")
+  end
+end

--- a/spec/features/trainee_actions/filtering_trainees_by_cohort_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_by_cohort_spec.rb
@@ -44,18 +44,18 @@ RSpec.feature "Filtering trainees by cohort" do
 private
 
   def given_only_current_trainees_exist
-    @current_cohort_trainee ||= create(:trainee, :awarded, :current_cohort, provider: current_provider)
+    @current_cohort_trainee ||= create(:trainee, :awarded, :current, provider: current_provider)
   end
 
   def given_only_past_and_current_trainees_exist
-    @past_cohort_trainee ||= create(:trainee, :awarded, :past_cohort, provider: current_provider)
-    @current_cohort_trainee ||= create(:trainee, :awarded, :current_cohort, provider: current_provider)
+    @past_cohort_trainee ||= create(:trainee, :awarded, :past, provider: current_provider)
+    @current_cohort_trainee ||= create(:trainee, :awarded, :current, provider: current_provider)
   end
 
   def given_trainees_from_all_cohorts_exist
-    @past_cohort_trainee ||= create(:trainee, :awarded, :past_cohort, provider: current_provider)
-    @current_cohort_trainee ||= create(:trainee, :awarded, :current_cohort, provider: current_provider)
-    @future_cohort_trainee ||= create(:trainee, :awarded, :future_cohort, provider: current_provider)
+    @past_cohort_trainee ||= create(:trainee, :awarded, :past, provider: current_provider)
+    @current_cohort_trainee ||= create(:trainee, :awarded, :current, provider: current_provider)
+    @future_cohort_trainee ||= create(:trainee, :awarded, :future, provider: current_provider)
   end
 
   def current_provider

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -53,11 +53,6 @@ RSpec.feature "Filtering trainees" do
       then_only_assessment_only_trainee_is_visible
     end
 
-    scenario "can filter by cohort" do
-      when_i_filter_by_cohort
-      then_only_that_cohorts_trainee_is_visible
-    end
-
     scenario "can clear filters" do
       when_i_filter_by_subject("Biology")
       then_only_biology_trainees_are_visible
@@ -181,7 +176,6 @@ private
     @primary_trainee ||= create(:trainee, :submitted_for_trn, course_age_range: AgeRange::THREE_TO_EIGHT)
     @apply_non_draft_trainee ||= create(:trainee, :submitted_for_trn, :with_apply_application)
     @dttp_import_trainee ||= create(:trainee, :submitted_for_trn, :created_from_dttp)
-    @current_cohort_trainee ||= create(:trainee, :submitted_for_trn)
     Trainee.update_all(provider_id: @current_user.organisation.id)
   end
 
@@ -265,11 +259,6 @@ private
 
   def when_i_filter_by_early_years_level
     trainee_index_page.early_years_checkbox.click
-    trainee_index_page.apply_filters.click
-  end
-
-  def when_i_filter_by_cohort
-    trainee_index_page.past_cohort_checkbox.click
     trainee_index_page.apply_filters.click
   end
 
@@ -385,10 +374,6 @@ private
   def then_only_the_trainee_imported_from_dttp_is_visible
     expect(trainee_index_page).to have_text(full_name(@dttp_import_trainee))
     expect(trainee_index_page).not_to have_text(full_name(@apply_non_draft_trainee))
-  end
-
-  def then_only_that_cohorts_trainee_is_visible
-    expect(trainee_index_page).not_to have_text(full_name(@current_cohort_trainee))
   end
 
   def full_name(trainee)

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -53,6 +53,11 @@ RSpec.feature "Filtering trainees" do
       then_only_assessment_only_trainee_is_visible
     end
 
+    scenario "can filter by cohort" do
+      when_i_filter_by_cohort
+      then_only_that_cohorts_trainee_is_visible
+    end
+
     scenario "can clear filters" do
       when_i_filter_by_subject("Biology")
       then_only_biology_trainees_are_visible
@@ -176,6 +181,7 @@ private
     @primary_trainee ||= create(:trainee, :submitted_for_trn, course_age_range: AgeRange::THREE_TO_EIGHT)
     @apply_non_draft_trainee ||= create(:trainee, :submitted_for_trn, :with_apply_application)
     @dttp_import_trainee ||= create(:trainee, :submitted_for_trn, :created_from_dttp)
+    @current_cohort_trainee ||= create(:trainee, :submitted_for_trn)
     Trainee.update_all(provider_id: @current_user.organisation.id)
   end
 
@@ -259,6 +265,11 @@ private
 
   def when_i_filter_by_early_years_level
     trainee_index_page.early_years_checkbox.click
+    trainee_index_page.apply_filters.click
+  end
+
+  def when_i_filter_by_cohort
+    trainee_index_page.past_cohort_checkbox.click
     trainee_index_page.apply_filters.click
   end
 
@@ -374,6 +385,10 @@ private
   def then_only_the_trainee_imported_from_dttp_is_visible
     expect(trainee_index_page).to have_text(full_name(@dttp_import_trainee))
     expect(trainee_index_page).not_to have_text(full_name(@apply_non_draft_trainee))
+  end
+
+  def then_only_that_cohorts_trainee_is_visible
+    expect(trainee_index_page).not_to have_text(full_name(@current_cohort_trainee))
   end
 
   def full_name(trainee)

--- a/spec/features/trainee_actions/recommending_for_qts_spec.rb
+++ b/spec/features/trainee_actions/recommending_for_qts_spec.rb
@@ -36,6 +36,6 @@ feature "Recommending for QTS", type: :feature do
   def and_the_page_has_the_correct_links
     recommended_for_qts_page.load(trainee_id: trainee.slug)
     expect(recommended_for_qts_page).to have_link("view #{trainee_name(@trainee)}", href: trainee_path(@trainee))
-    expect(recommended_for_qts_page).to have_link("view all your records", href: trainees_path)
+    expect(recommended_for_qts_page).to have_link("view all your records", href: trainees_path(cohort: %w[current]))
   end
 end

--- a/spec/features/trainee_actions/submit_for_trn_spec.rb
+++ b/spec/features/trainee_actions/submit_for_trn_spec.rb
@@ -174,6 +174,6 @@ feature "submit for TRN" do
     expect(trn_success_page).to have_text("#{trainee_name(trainee)} is registered")
     expect(trn_success_page).to have_link("view #{trainee_name(trainee)}", href: trainee_path(trainee))
     expect(trn_success_page).to have_link("add a new trainee", href: new_trainee_path)
-    expect(trn_success_page).to have_link("view all your records", href: trainees_path)
+    expect(trn_success_page).to have_link("view all your records", href: trainees_path(cohort: %w[current]))
   end
 end

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -25,6 +25,7 @@ module PageObjects
       element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"
       element :subject, "#subject"
       element :provider_filter, "#provider"
+      element :past_cohort_checkbox, "#cohort-past"
 
       element :export_link, ".app-trainee-export"
 

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -25,7 +25,9 @@ module PageObjects
       element :provider_led_postgrad_checkbox, "#training_route-provider_led_postgrad"
       element :subject, "#subject"
       element :provider_filter, "#provider"
+      element :cohort_filter, "#cohort"
       element :past_cohort_checkbox, "#cohort-past"
+      element :future_cohort_checkbox, "#cohort-future"
 
       element :export_link, ".app-trainee-export"
 


### PR DESCRIPTION
### Context

https://trello.com/c/KwLaruTJ/3909-cohort-filter-front-end-basic-implementation

### Changes proposed in this pull request

- Add basic three checkbox filter on draft and registered trainees
- Only show cohort options that are relevant for that provider's trainees
- Don’t show filter if provider has one cohort
- Auto-select ‘current’ when linking through to drafts/registered trainees.. but clear if you press ‘clear filters’

### Guidance to review

- Pick a provider with no Apply drafts (because these are the future trainees)
- Check that there is no cohort filter
- Pick a provider with Apply drafts (because these are the future trainees)
- Check that there is a cohort filter and that this works
- Click the 'Draft' and 'Registered' tabs
- Check that the default is that 'current' cohort is applied

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
