### PR TITLE
[3923] Hide add degree details button on non-awaiting action records

### DIFF
--- a/app/views/trainees/personal_details/show.html.erb
+++ b/app/views/trainees/personal_details/show.html.erb
@@ -20,6 +20,8 @@
       <%= render Degrees::View.new(data_model: @trainee, show_delete_button: true, editable: trainee_editable?) %>
     </div>
   <% else %>
-    <%= render CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), has_errors: false) %>
+    <% if trainee_editable? %>
+      <%= render CollapsedSection::View.new(title: t("components.incomplete_section.degree_details_not_provided"), link_text: t("components.incomplete_section.add_degree_details"), url: trainee_degrees_new_type_path(@trainee), has_errors: false) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
+++ b/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
@@ -21,6 +21,12 @@ feature "View trainees" do
       and_i_click_the_trainee_name_on_the(trainee_index_page)
       then_i_should_see_the_trainee_details_on_the(record_page)
     end
+
+    scenario "viewing the personal details of an inactive but incomplete trainee" do
+      given_a_trainee_exists(:awarded, :provider_led_postgrad, degrees: [])
+      and_i_visit_the_personal_details
+      then_i_should_not_see_any_add_degree_links_on_the(record_page)
+    end
   end
 
   context "when trainee does not belong to me" do
@@ -78,6 +84,10 @@ private
 
   def then_i_should_not_see_any_change_links_on_the(expected_page)
     expect(expected_page).not_to have_link("Change")
+  end
+
+  def then_i_should_not_see_any_add_degree_links_on_the(expected_page)
+    expect(expected_page).not_to have_link("Add degree details")
   end
 
   def and_i_should_not_see_any_action_links


### PR DESCRIPTION
### Context
Before:
![image](https://user-images.githubusercontent.com/910019/161102606-58643436-7474-4cf8-a86f-232411730a24.png)

After:
![image](https://user-images.githubusercontent.com/910019/161102705-93f49db5-db9a-4e7e-b34f-624dd2ec258e.png)

### Changes proposed in this pull request
As it says on the tin.

### Guidance to review

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
