### PR TITLE
[3914] Return complete and incomplete trainees correctly

### DIFF
--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -105,10 +105,14 @@ module Trainees
       trainees.where(provider: provider)
     end
 
-    def submission_ready(trainees, record_completion)
+    def record_completion(trainees, record_completion)
       return trainees if record_completion.blank? || record_completion.size > 1
 
-      trainees.where(submission_ready: record_completion.include?("complete"))
+      if record_completion.include?("complete")
+        trainees.complete_for_filter
+      else
+        trainees.incomplete_for_filter
+      end
     end
 
     def study_mode(trainees, study_mode)
@@ -135,7 +139,7 @@ module Trainees
       filtered_trainees = text_search(filtered_trainees, filters[:text_search])
       filtered_trainees = level(filtered_trainees, filters[:level])
       filtered_trainees = provider(filtered_trainees, filters[:provider])
-      filtered_trainees = submission_ready(filtered_trainees, filters[:record_completion])
+      filtered_trainees = record_completion(filtered_trainees, filters[:record_completion])
       filtered_trainees = study_mode(filtered_trainees, filters[:study_mode])
       filtered_trainees = cohort(filtered_trainees, filters[:cohort])
 


### PR DESCRIPTION
### Context

Trello ticket: https://trello.com/c/Bwwap0XI/3914-trainees-show-up-when-filtering-by-incomplete-that-we-should-not-be-considering-incomplete

We hadn't quite got the right scope for incomplete/complete trainees when using record completion filter. I've now aligned it with the functionality of the incomplete badge, so that we consider withdrawn/recommended for award/awarded trainees or HESA records as complete even if they aren't technically submission ready in the data (`submission_ready: false`).

### Changes proposed in this pull request

* Add new scopes in trainee model `:incomplete_for_filter` and `:complete_for_filter`
* Use these scopes in `submission_ready` method in `filter.rb` which returns the trainees for record completion filter
* `:complete_for_filter` checks if the record is submission ready, or is from HESA, or is withdrawn/recommended/awarded
* Add new constant `COMPLETE_STATES` used in new scopes and `awaiting_action?` instance method

### Guidance to review

* As a system admin, go to registered trainees and find Beau Lemke - note Beau is a HESA trainee and I have set Beau to `submission_ready: false`

![Screenshot 2022-04-04 at 12 32 21](https://user-images.githubusercontent.com/43522239/161535239-ba1d1b14-4c2a-417a-af7e-4c177030ca01.png)

![Screenshot 2022-04-04 at 12 33 47](https://user-images.githubusercontent.com/43522239/161535329-1cf3c669-6d29-4f90-8208-1f06ea9ca49e.png)

* Check that Beau appears with the filter option 'complete' and not with option 'incomplete'
![Screenshot 2022-04-04 at 12 34 14](https://user-images.githubusercontent.com/43522239/161535401-021c87ce-63b1-4656-b61d-22b79b4a30dc.png)

* Click through to Beau's trainee record and observe that there is no ITT start date (so record is technically incomplete)

Note for whoever prod reviews, it might be easier for us to product review this together so I can update records live for other states and we can test together.

### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
