### PR TITLE
[3905] Maintain cohort state

### DIFF
--- a/app/jobs/trainees/queue_cohort_updates_job.rb
+++ b/app/jobs/trainees/queue_cohort_updates_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Trainees
+  class QueueCohortUpdatesJob < ApplicationJob
+    def perform
+      Trainee.current.or(Trainee.future).find_each do |trainee|
+        SetCohortJob.perform_later(trainee)
+      end
+    end
+  end
+end

--- a/app/jobs/trainees/set_cohort_job.rb
+++ b/app/jobs/trainees/set_cohort_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Trainees
+  class SetCohortJob < ApplicationJob
+    def perform(trainee)
+      Trainees::SetCohort.call(trainee: trainee)
+    end
+  end
+end

--- a/app/models/academic_cycle.rb
+++ b/app/models/academic_cycle.rb
@@ -18,6 +18,10 @@ class AcademicCycle < ApplicationRecord
     where("end_date >= :date AND start_date <= :date", date: date).first
   end
 
+  def self.current
+    for_date(Time.zone.now)
+  end
+
   def trainees_starting
     query = <<~SQL
       COALESCE(commencement_date, itt_start_date) BETWEEN :start_date AND :end_date
@@ -41,7 +45,7 @@ class AcademicCycle < ApplicationRecord
   end
 
   def current?
-    Time.zone.now >= start_date && Time.zone.now < end_date
+    Time.zone.now >= start_date && Time.zone.now <= end_date
   end
 
 private

--- a/app/services/trainees/set_cohort.rb
+++ b/app/services/trainees/set_cohort.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Trainees
+  class SetCohort
+    include ServicePattern
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      return trainee if trainee_is_current? && trainee.current!
+      return trainee if trainee_is_future? && trainee.future!
+      return trainee if trainee_is_past? && trainee.past!
+
+      trainee
+    end
+
+  private
+
+    attr_reader :trainee
+
+    def trainee_is_current?
+      starts_in_the_current_academic_cycle? ||
+        withdrawn_in_the_current_cycle? ||
+        trainee.deferred?
+    end
+
+    def trainee_is_future?
+      trainee.itt_start_date > current_academic_cycle.end_date
+    end
+
+    def trainee_is_past?
+      trainee.itt_end_date < current_academic_cycle.start_date &&
+        (
+          awarded_before_the_current_cycle? ||
+          withdrawn_before_the_current_cycle?
+        )
+    end
+
+    def current_academic_cycle
+      @current_academic_cycle ||= AcademicCycle.current
+    end
+
+    def awarded_before_the_current_cycle?
+      trainee.awarded? && trainee.awarded_at < current_academic_cycle.start_date
+    end
+
+    def withdrawn_before_the_current_cycle?
+      trainee.withdrawn? && trainee.withdraw_date < current_academic_cycle.start_date
+    end
+
+    def starts_in_the_current_academic_cycle?
+      trainee.itt_start_date >= current_academic_cycle.start_date &&
+        trainee.itt_start_date <= current_academic_cycle.end_date
+    end
+
+    def withdrawn_in_the_current_cycle?
+      trainee.withdrawn? &&
+        trainee.withdraw_date >= current_academic_cycle.start_date
+    end
+  end
+end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -42,3 +42,6 @@ import_collection_from_hesa:
   cron: "0 */2 * * *"
   class: "Hesa::RetrieveCollectionJob"
   queue: default
+update_trainee_cohorts:
+  cron: "0 5 * * *"
+  class: "Trainees::QueueCohortUpdatesJob"

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
 
     sequence :trainee_id do |n|
       year = potential_itt_start_date.strftime("%y").to_i
-
       "#{year}/#{year + 1}-#{n}"
     end
 

--- a/spec/jobs/trainees/queue_cohort_udpates_job_spec.rb
+++ b/spec/jobs/trainees/queue_cohort_udpates_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe QueueCohortUpdatesJob do
+    let(:current_trainee) { create(:trainee, :current) }
+    let(:past_trainee) { create(:trainee, :past) }
+    let(:future_trainee) { create(:trainee, :future) }
+
+    before do
+      current_trainee
+      past_trainee
+      future_trainee
+    end
+
+    it "is expected to call Trainee::SetCohort on current and future trainees" do
+      expect(SetCohortJob).to receive(:perform_later).once.with(current_trainee)
+      expect(SetCohortJob).to receive(:perform_later).once.with(future_trainee)
+      expect(SetCohortJob).not_to receive(:perform_later).with(past_trainee)
+
+      described_class.perform_now
+    end
+  end
+end

--- a/spec/jobs/trainees/set_cohort_job_spec.rb
+++ b/spec/jobs/trainees/set_cohort_job_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe SetCohortJob do
+    let(:trainee) { double }
+
+    it "calls SetCohort with the supplied trainee" do
+      expect(SetCohort).to receive(:call).with(trainee: trainee)
+      described_class.perform_now(trainee)
+    end
+  end
+end

--- a/spec/models/academic_cycle_spec.rb
+++ b/spec/models/academic_cycle_spec.rb
@@ -127,4 +127,26 @@ describe AcademicCycle, type: :model do
       it { is_expected.to be(false) }
     end
   end
+
+  describe ".current" do
+    around do |example|
+      Timecop.freeze(2021, 3, 1) do
+        example.run
+      end
+    end
+
+    let(:past_academic_year) { create(:academic_cycle, cycle_year: 2019) }
+    let(:current_academic_year) { create(:academic_cycle, cycle_year: 2020) }
+    let(:future_academic_year) { create(:academic_cycle, cycle_year: 2021) }
+
+    before do
+      past_academic_year
+      current_academic_year
+      future_academic_year
+    end
+
+    subject { described_class.current }
+
+    it { is_expected.to eq(current_academic_year) }
+  end
 end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -715,4 +715,18 @@ describe Trainee do
       expect(trainee.duplicate?).to be(true)
     end
   end
+
+  describe "set_cohort" do
+    let(:trainee) { create(:trainee) }
+
+    it "queues up a SetCohortJob" do
+      expect(Trainees::SetCohortJob).to receive(:perform_later).with(trainee)
+      trainee.set_cohort
+    end
+
+    it "is called after_commit" do
+      expect(Trainees::SetCohortJob).to receive(:perform_later).with(trainee)
+      trainee.update(first_names: "Dennis")
+    end
+  end
 end

--- a/spec/services/trainees/set_cohort_spec.rb
+++ b/spec/services/trainees/set_cohort_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe SetCohort do
+    let(:current_academic_cycle) { create(:academic_cycle, :current) }
+
+    subject { described_class.call(trainee: trainee).cohort }
+
+    context "when a trainee starts in the current academic cycle" do
+      let(:trainee) do
+        build(
+          :trainee,
+          itt_start_date: current_academic_cycle.start_date + 1.week,
+          itt_end_date: current_academic_cycle.start_date + 1.year,
+        )
+      end
+
+      it { is_expected.to eq("current") }
+    end
+
+    context "when a trainee starts after the start of the next academic cycle" do
+      let(:trainee) do
+        build(
+          :trainee,
+          itt_start_date: current_academic_cycle.end_date + 1.week,
+          itt_end_date: current_academic_cycle.end_date + 1.year,
+        )
+      end
+
+      it { is_expected.to eq("future") }
+    end
+
+    context "when a trainee starts before the current academic cycle" do
+      context "and is awarded before the start of the current cycle" do
+        let(:trainee) do
+          build(
+            :trainee,
+            :awarded,
+            awarded_at: current_academic_cycle.start_date - 1.week,
+            itt_start_date: current_academic_cycle.start_date - 1.year,
+            itt_end_date: current_academic_cycle.start_date - 1.week,
+          )
+        end
+
+        it { is_expected.to eq("past") }
+      end
+
+      context "and is withdrawn before the start of the current cycle" do
+        let(:trainee) do
+          build(
+            :trainee,
+            :withdrawn,
+            withdraw_date: current_academic_cycle.start_date - 1.week,
+            itt_start_date: current_academic_cycle.start_date - 1.year,
+            itt_end_date: current_academic_cycle.start_date - 1.week,
+          )
+        end
+
+        it { is_expected.to eq("past") }
+      end
+
+      context "and is deferred before the start of the current cycle" do
+        let(:trainee) do
+          build(
+            :trainee,
+            :deferred,
+            defer_date: current_academic_cycle.start_date - 1.week,
+            itt_start_date: current_academic_cycle.start_date - 1.year,
+            itt_end_date: current_academic_cycle.start_date - 1.week,
+          )
+        end
+
+        it { is_expected.to eq("current") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Trainees can be considered:

past: they have completed their training (or withdrawn) prior to the current academic cycle
current: they are still training or deferred or have withdrawn or been awarded in the current cycle
future: they start after the end of the current cycle

Changes to the trainee record (e.g. ITT start date or a status change) or a change in the current academic cycle can cause this status to change.

### Changes proposed in this pull request

* Add `Trainees:SetCohort`, a service that sets the `Trainee#cohort` field based on the current cycle and trainee state
* Add a job to call this async
* Add a nightly job to run through current and future trainees and update their cohort to ensure this is correctly set
* Add a callback to set the cohort when the trainee is saved
* Add `AcademicCycle.current` to make it easier to get a reference to the 'current' cycle
* Exclude `cohort` from the dqt_update_sha calculation as we don't need to update DQT when a cohort changes. We can consider this internal.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
