### PR TITLE
[3920] Add register equivalent mappings for some hesa degree types

### DIFF
--- a/app/lib/dttp/code_sets/degree_types.rb
+++ b/app/lib/dttp/code_sets/degree_types.rb
@@ -209,13 +209,20 @@ module Dttp
       }.freeze
 
       INACTIVE_MAPPING = {
-        "BA (Hons) /Education" => { entity_id: "cf695652-c197-e711-80d8-005056ac45bb" },
-        "BEd (Hons)" => { entity_id: "c3695652-c197-e711-80d8-005056ac45bb" },
-        "BSc (Hons) /Education" => { entity_id: "c7695652-c197-e711-80d8-005056ac45bb" },
-        "BTech (Hons) /Education" => { entity_id: "cb695652-c197-e711-80d8-005056ac45bb" },
-        "BA (Hons) with intercalated PGCE" => { entity_id: "d9695652-c197-e711-80d8-005056ac45bb" },
-        "BSc (Hons) with intercalated PGCE" => { entity_id: "d7695652-c197-e711-80d8-005056ac45bb" },
-        "BA (Hons) Combined Studies/Education of the Deaf" => { entity_id: "d3695652-c197-e711-80d8-005056ac45bb" },
+        # BA (Hons) /Education
+        "BA/Education" => { entity_id: "cf695652-c197-e711-80d8-005056ac45bb" },
+        # BEd (Hons)
+        "BEd" => { entity_id: "c3695652-c197-e711-80d8-005056ac45bb" },
+        # BSc (Hons) /Education
+        "BSc/Education" => { entity_id: "c7695652-c197-e711-80d8-005056ac45bb" },
+        # BTech (Hons) /Education
+        "BTech/Education" => { entity_id: "cb695652-c197-e711-80d8-005056ac45bb" },
+        # BA (Hons) with intercalated PGCE
+        "BA with intercalated PGCE" => { entity_id: "d9695652-c197-e711-80d8-005056ac45bb" },
+        # BSc (Hons) with intercalated PGCE
+        "Bachelor of Science" => { entity_id: "d7695652-c197-e711-80d8-005056ac45bb" },
+        # BA (Hons) Combined Studies/Education of the Deaf
+        "BA Combined Studies/Education of the Deaf" => { entity_id: "d3695652-c197-e711-80d8-005056ac45bb" },
       }.freeze
     end
   end

--- a/db/data/20220401140852_map_degree_types_from_hesa_to_register.rb
+++ b/db/data/20220401140852_map_degree_types_from_hesa_to_register.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class MapDegreeTypesFromHesaToRegister < ActiveRecord::Migration[6.1]
+  def up
+    {
+      "BA (Hons) /Education" => "BA/Education",
+      "BEd (Hons)" => "BEd",
+      "BSc (Hons) /Education" => "BSc/Education",
+      "BTech (Hons) /Education" => "BTech/Education",
+      "BA (Hons) with intercalated PGCE" => "BA with intercalated PGCE",
+      "BSc (Hons) with intercalated PGCE" => "Bachelor of Science",
+      "BA (Hons) Combined Studies/Education of the Deaf" => "BA Combined Studies/Education of the Deaf",
+    }.each do |hesa_degree_type, register_degree_type|
+      Degree.where(uk_degree: hesa_degree_type).update_all(uk_degree: register_degree_type)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/degrees/map_from_dttp_spec.rb
+++ b/spec/services/degrees/map_from_dttp_spec.rb
@@ -74,12 +74,12 @@ module Degrees
       end
 
       context "with an inactive degree type" do
-        let(:degree_type) { "BA (Hons) /Education" }
+        let(:degree_type) { "BA/Education" }
         let(:api_degree_qualification) do
           create(
             :api_degree_qualification,
             _dfe_awardinginstitutionid_value: Dttp::CodeSets::Institutions::MAPPING[institution][:entity_id],
-            _dfe_degreetypeid_value: Dttp::CodeSets::DegreeTypes::INACTIVE_MAPPING[degree_type][:entity_id],
+            _dfe_degreetypeid_value: "cf695652-c197-e711-80d8-005056ac45bb",
             _dfe_classofdegreeid_value: Dttp::CodeSets::Grades::MAPPING[grade][:entity_id],
           )
         end


### PR DESCRIPTION
### Context
Rename the following HESA mappings to register equivalents:

```
BA (Hons) /Education => BA/Education
BEd (Hons) => BEd
BSc (Hons) /Education => BSc/Education
BTech (Hons) /Education => BTech/Education
BA (Hons) with intercalated PGCE => BA with intercalated PGCE
BSc (Hons) with intercalated PGCE => Bachelor of Science
BA (Hons) Combined Studies/Education of the Deaf => BA Combined Studies/Education of the Deaf
```
This gets rid of the "Degree type is missing" blue banner.

### Changes proposed in this pull request
Map the HONS degree types to their non-hons register equivalents.
Add a data migration to update existing records.

### Important business

* ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
* ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
