### PR TITLE
[xxx] Don't run the DQT update nightly job

### DIFF
--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -2,10 +2,6 @@ update_trainees_to_dttp:
   cron: "0 0 * * *"
   class: "Dttp::QueueTraineeUpdatesJob"
   queue: dttp
-update_trainees_to_dqt:
-  cron: "0 0 * * *"
-  class: "Dqt::QueueTraineeUpdatesJob"
-  queue: dqt
 truncate_activerecord_session_store:
   cron: "0 0 * * *"
   class: "SessionStoreTruncateJob"


### PR DESCRIPTION
### Context

We run a nightly task to loop through the trainees and queue up a job to send any that have been updated to DQT. We seem to be sending an awful lot of them at what should be a relatively quiet time of year. 

### Changes proposed in this pull request

Temporarily disabling the job while we investigate

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
