### PR TITLE
[3677] Cohort filter homepage changes

### DIFF
--- a/app/components/badges/view.html.erb
+++ b/app/components/badges/view.html.erb
@@ -4,7 +4,7 @@
         <% state_counts.map do |state, count| %>
             <%= render TraineeStatusCard::View.new(state: state,
                                                    count: count,
-                                                   target: trainees_path(state: map_state_to_filter_params(state))) %>
+                                                   target: trainees_path(state: map_state_to_filter_params(state), cohort: %w[current])) %>
         <% end %>
     </div>
   </div>

--- a/app/views/pages/_badges.html.erb
+++ b/app/views/pages/_badges.html.erb
@@ -1,1 +1,1 @@
-<%= render Badges::View.new(@home_view.state_counts) %>
+<%= render Badges::View.new(@home_view.current_state_counts) %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -75,22 +75,20 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h3 class="govuk-heading-m"><%= t(".current_trainees_heading") %></h3>
-    <ul class="govuk-list govuk-list--spaced">
-      <% if @home_view.current_registered_trainees_count > 0 %>
-        <li>
-          <%= govuk_link_to(
-            t(".current_registered_trainees_link", count: @home_view.current_registered_trainees_count),
-            trainees_path(cohort: %w[current]),
-            { class: "govuk-link--no-visited-state" }
-          )%>
-        </li>
-      <% end %>
-    </ul>
+<% if @home_view.current_registered_trainees_count > 0 %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h3 class="govuk-heading-m"><%= t(".current_trainees_heading") %></h3>
+      <p class="govuk-body">
+        <%= govuk_link_to(
+          t(".current_registered_trainees_link", count: @home_view.current_registered_trainees_count),
+          trainees_path(cohort: %w[current]),
+          { class: "govuk-link--no-visited-state" }
+        )%>
+      </p>
+    </div>
   </div>
-</div>
+<% end %>
 
 <%= render "badges" %>
 

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -62,6 +62,32 @@
           )%>
         </li>
       <% end %>
+      <% if @home_view.future_registered_trainees_count > 0 %>
+        <li>
+          <%= govuk_link_to(
+            t(".future_registered_trainees_link", count: @home_view.future_registered_trainees_count),
+            trainees_path(cohort: %w[future]),
+            { class: "govuk-link--no-visited-state" }
+          )%>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h3 class="govuk-heading-m"><%= t(".current_trainees_heading") %></h3>
+    <ul class="govuk-list govuk-list--spaced">
+      <% if @home_view.current_registered_trainees_count > 0 %>
+        <li>
+          <%= govuk_link_to(
+            t(".current_registered_trainees_link", count: @home_view.current_registered_trainees_count),
+            trainees_path(cohort: %w[current]),
+            { class: "govuk-link--no-visited-state" }
+          )%>
+        </li>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -827,6 +827,9 @@ en:
       new_trainee_link: Create a new trainee record
       registered_heading: Registered trainees
       registered_trainees_link: View all registered trainees (%{count})
+      future_registered_trainees_link: View next year’s trainees (%{count})
+      current_registered_trainees_link: View current trainees (%{count})
+      current_trainees_heading: Current trainees
       guidance_heading: News, guidance and feedback
       service_updates_link: View news and updates
       guidance_about_link: Find out about Register trainee teachers

--- a/spec/components/badges/view_spec.rb
+++ b/spec/components/badges/view_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Badges::View do
     render_inline(described_class.new(counts))
   end
 
+  it "renders links to the current cohort" do
+    counts.each_key do |state|
+      link_text = t("activerecord.attributes.trainee.states.#{state}")
+      href = "/trainees?cohort%5B%5D=current&state%5B%5D=#{state}"
+      expect(rendered_component).to have_link(link_text, href: href)
+    end
+  end
+
   context "No trainees have been awarded or are recommended for qualifications" do
     let(:counts) do
       super().merge(

--- a/spec/view_objects/home_view_spec.rb
+++ b/spec/view_objects/home_view_spec.rb
@@ -7,7 +7,7 @@ describe HomeView do
 
   subject { described_class.new(trainees) }
 
-  describe "#state_counts" do
+  describe "#current_state_counts" do
     context "no trainees in award states" do
       let(:trainees) do
         trainee_id = draft_trainee.id
@@ -15,7 +15,7 @@ describe HomeView do
       end
 
       it "labels award counts generically" do
-        expect(subject.state_counts.symbolize_keys).to eq(
+        expect(subject.current_state_counts.symbolize_keys).to eq(
           awarded: 0,
           deferred: 0,
           draft: 1,
@@ -34,7 +34,7 @@ describe HomeView do
       end
 
       it "labels award counts as eyts" do
-        expect(subject.state_counts.symbolize_keys).to eq(
+        expect(subject.current_state_counts.symbolize_keys).to eq(
           deferred: 0,
           draft: 0,
           submitted_for_trn: 0,
@@ -53,7 +53,7 @@ describe HomeView do
       end
 
       it "labels award counts as qts" do
-        expect(subject.state_counts.symbolize_keys).to eq(
+        expect(subject.current_state_counts.symbolize_keys).to eq(
           deferred: 0,
           draft: 0,
           submitted_for_trn: 0,
@@ -75,7 +75,7 @@ describe HomeView do
       end
 
       it "labels award counts generically" do
-        expect(subject.state_counts.symbolize_keys).to eq(
+        expect(subject.current_state_counts.symbolize_keys).to eq(
           deferred: 0,
           draft: 0,
           submitted_for_trn: 0,
@@ -86,79 +86,89 @@ describe HomeView do
         )
       end
     end
-  end
 
-  describe "#registered_state_counts" do
-    let(:trainees) { Trainee.all }
-
-    it "returns just the state_counts relevant for registered trainees" do
-      expect(subject.registered_state_counts.symbolize_keys).to eq(
-        deferred: 0,
-        submitted_for_trn: 0,
-        trn_received: 0,
-        withdrawn: 0,
-        awarded: 0,
-        recommended_for_award: 0,
-      )
-    end
-  end
-
-  describe "#registered_trainees_count" do
-    let(:trainees) do
-      trainee_ids = [
-        draft_trainee.id,
-        create(:trainee, :assessment_only, :awarded).id,
-        create(:trainee, :early_years_undergrad, :awarded).id,
-      ]
-      Trainee.where(id: trainee_ids)
-    end
-
-    it "returns the number of trainees in registered states" do
-      expect(subject.registered_trainees_count).to eq(2)
-    end
-  end
-
-  describe "#draft_trainees_count" do
-    let(:trainees) do
-      trainee_ids = [
-        draft_trainee.id,
-        create(:trainee, :assessment_only, :awarded).id,
-        create(:trainee, :early_years_undergrad, :awarded).id,
-      ]
-      Trainee.where(id: trainee_ids)
-    end
-
-    it "returns the number of trainees in draft states" do
-      expect(subject.draft_trainees_count).to eq(1)
-    end
-
-    context "with empty trainee exists" do
+    context "with trainees in different cohorts" do
       let(:trainees) do
         trainee_ids = [
-          draft_trainee.id,
-          Trainee.create!(provider: draft_trainee.provider, training_route: TRAINING_ROUTE_ENUMS[:assessment_only]).id,
+          create(:trainee, :assessment_only, :awarded).id,
+          create(:trainee, :early_years_undergrad, :awarded, :past).id,
         ]
         Trainee.where(id: trainee_ids)
       end
 
+      it "only returns the count of current trainees" do
+        expect(subject.current_state_counts.symbolize_keys).to eq(
+          deferred: 0,
+          draft: 0,
+          submitted_for_trn: 0,
+          trn_received: 0,
+          withdrawn: 0,
+          awarded: 1,
+          recommended_for_award: 0,
+        )
+      end
+    end
+  end
+
+  context "with trainees across multiple cohorts and states" do
+    let(:trainees) do
+      trainee_ids = [
+        draft_trainee.id,
+        create(:trainee, :assessment_only, :awarded).id,
+        create(:trainee, :early_years_undergrad, :awarded, :future).id,
+      ]
+      Trainee.where(id: trainee_ids)
+    end
+
+    describe "#registered_trainees_count" do
+      it "returns the number of trainees in registered states" do
+        expect(subject.registered_trainees_count).to eq(2)
+      end
+    end
+
+    describe "#future_registered_trainees_count" do
+      it "returns the number of future trainees in registered states" do
+        expect(subject.future_registered_trainees_count).to eq(1)
+      end
+    end
+
+    describe "#draft_trainees_count" do
+      it "returns the number of trainees in draft states" do
+        expect(subject.draft_trainees_count).to eq(1)
+      end
+    end
+  end
+
+  context "with empty trainees" do
+    let(:trainees) do
+      trainee_ids = [
+        draft_trainee.id,
+        Trainee.create!(provider: draft_trainee.provider, training_route: TRAINING_ROUTE_ENUMS[:assessment_only]).id,
+      ]
+      Trainee.where(id: trainee_ids)
+    end
+
+    describe "#draft_trainees_count" do
       it "does not include empty trainees" do
         expect(subject.draft_trainees_count).to eq(1)
       end
     end
   end
 
-  describe "#draft_apply_trainees_count" do
-    let(:trainees) do
-      trainee_ids = [
-        draft_trainee.id,
-        create(:trainee, :draft, :with_apply_application).id,
-        create(:trainee, :awarded, :with_apply_application).id,
-      ]
-      Trainee.where(id: trainee_ids)
-    end
+  context "with apply trainees" do
+    describe "#draft_apply_trainees_count" do
+      let(:trainees) do
+        trainee_ids = [
+          draft_trainee.id,
+          create(:trainee, :draft, :with_apply_application).id,
+          create(:trainee, :awarded, :with_apply_application).id,
+        ]
+        Trainee.where(id: trainee_ids)
+      end
 
-    it "returns the number of trainees in apply draft states" do
-      expect(subject.draft_apply_trainees_count).to eq(1)
+      it "returns the number of trainees in apply draft states" do
+        expect(subject.draft_apply_trainees_count).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/xs84EsrH/3677-cohort-filter-homepage-changes

### Changes proposed in this pull request

- Updates to HomeView to return counts relating to current cohort
- Updates to home.html.erb to add extra links to current and future cohorts
- Updates to Badges component to link to current cohort filtered views

### Guidance to review

- Check that there's "View next year's trainees" link on the homepage that links to the registered trainees page with 'Next year's' filter selected.
- Check that the count is correct on the link
- Check that there's a "View current trainees" link on the homepage that links to the registered trainees page with 'Current' filter selected
- Check that the boxes are only referring to the current trainee counts
- Check that they all link to the registered trainees page with 'current' plus the correct state selected

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
