### PR TITLE
Add page title and use translation file

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,7 +1,9 @@
-<h1 class="govuk-heading-l">Choose organisation</h1>
+<%= render PageTitle::View.new(i18n_key: "organisations") %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+
     <%- if @providers.any? -%>
       <h2 class="govuk-heading-m">Accrediting providers</h2>
       <ul class="govuk-list">
@@ -20,7 +22,7 @@
     <%- if @lead_schools.any? -%>
       <h2 class="govuk-heading-m">Lead schools</h2>
       <p class="govuk-body">As a lead school you can only view records. You cannot change them.</p>
-      <ul class="govuk-list">
+      <ul class="govuk-list govuk-!-margin-bottom-7">
         <li class="govuk-!-margin-bottom-2">
           <%- @lead_schools.each do |lead_school| -%>
             <%= govuk_link_to lead_school.name, 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,6 +383,7 @@ en:
         search_hint: Search for a school by it’s unique reference number (URN), name or postcode
         search_button: Search again
       service_updates: News and updates
+      organisations: Choose organisation
     filter:
       level: Education phase
       provider: Provider
@@ -845,6 +846,9 @@ en:
       heading: Privacy Notice for the Register trainee teachers service (Register)
     no_organisation: 
       heading: You have not been linked to an organisation yet
+  organisations:
+    index:
+      heading: Choose organisation
   sign_in:
     new:
       heading: Ask for an account to register trainee teachers


### PR DESCRIPTION
Fixes an issue identified in our accessibility audit - missing page title.

We've copied the pattern seen in other pages. Let us know if we did it wrong!