### PR TITLE
Swap order of action links so it matches visual order

### DIFF
--- a/app/views/trainees/_action_bar.html.erb
+++ b/app/views/trainees/_action_bar.html.erb
@@ -1,4 +1,5 @@
 <% unless paginated_trainees.empty? %>
+  <%= render SortLinks::View.new %>
   <% if FeatureService.enabled?(:trainee_export) && policy(:trainee).export? %>
     <div class="app-export--link">
       <%= govuk_link_to(
@@ -8,5 +9,4 @@
       ) %>
     </div>
   <% end %>
-  <%= render SortLinks::View.new %>
 <% end %>

--- a/app/webpacker/styles/trainee_list.scss
+++ b/app/webpacker/styles/trainee_list.scss
@@ -3,6 +3,7 @@
 .app-records-actions {
   margin: 0 0 govuk-spacing(3) 0;
   border-bottom: 1px solid govuk-colour("mid-grey");
+  @include govuk-clearfix();
 
   @include govuk-media-query($until: $mobile-big-start) {
     padding-bottom: govuk-spacing(4);
@@ -30,7 +31,6 @@
     .app-records-actions-text-links {
       display: flex;
       justify-content: space-between;
-      flex-direction: row-reverse;
 
       .app-export--link {
         text-align: right;


### PR DESCRIPTION
Swaps the html order of the sort links and export link to match the visual order - as raised by our accessibility audit.

NB: the layout is a bit awkward on mobile - we'll address that in a later PR. 
