### PR TITLE
Force tables to overflow-x

### DIFF
--- a/app/webpacker/styles/_govuk_overrides.scss
+++ b/app/webpacker/styles/_govuk_overrides.scss
@@ -11,3 +11,8 @@
     letter-spacing: -0.05px;
   }
 }
+
+.govuk-table {
+  overflow-x: auto; // Force internal sideways scrolling when content is wider than view
+  display: block;
+}


### PR DESCRIPTION
When viewing the service at 400% on a 1280px display, our tables force content to overflow the background. This copies the approach used by the [GOV.UK Cookies page](https://www.gov.uk/help/cookie-details) to instead set the table to overflow.