### PR TITLE
[xxx] Expose DTTP data for system_admins

### DIFF
--- a/app/controllers/system_admin/dttp_trainees_controller.rb
+++ b/app/controllers/system_admin/dttp_trainees_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class DttpTraineesController < ApplicationController
+    def show
+      trainee = Trainee.from_param(params[:id])
+      render(json: trainee.dttp_trainee&.response)
+    end
+
+    def placement_assignments
+      trainee = Trainee.from_param(params[:id])
+      dttp_trainee = trainee.dttp_trainee
+      render(json: dttp_trainee&.placement_assignments&.map(&:response))
+    end
+  end
+end

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -32,6 +32,12 @@ module SystemAdminRoutes
         resources :lead_schools, path: "lead-schools", only: %i[index show] do
           resources :users, controller: "lead_schools/users", only: %i[new create edit update]
         end
+
+        resources :dttp_trainees, only: [:show], path: "dttp-trainees" do
+          member do
+            get :placement_assignments, path: "placement-assignments"
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

We have an archive of DTTP data saved in the database that we have
created trainees from.

### Changes proposed in this pull request

Expose the json at:

```
/system-admin/dttp-trainees/<slug>
/system-admin/dttp-trainees/<slug>/placement_assignments
```

This will help when troubleshooting the import

### Guidance to review

We don't have the DTTP import responses in non-prod environments. This is a system admin feature so just check that it can't be accessed without being logged in as an admin. The actual functionality will need to be tested locally or we can check when it gets to production.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
