### PR TITLE
[3954] HESA records in Register - Add record source to CSV for record export

### DIFF
--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -35,6 +35,7 @@ module Exports
         {
           "register_id" => trainee.slug,
           "trainee_url" => "#{Settings.base_url}/trainees/#{trainee.slug}",
+          "record_source" => record_source(trainee),
           "apply_id" => trainee.apply_application&.apply_id,
           "provider_trainee_id" => trainee.trainee_id,
           "trn" => trainee.trn,
@@ -277,6 +278,15 @@ module Exports
         "full_time" => "Full time",
         "part_time" => "Part time",
       }[trainee.study_mode]
+    end
+
+    def record_source(trainee)
+      {
+        "manual" => "Manual",
+        "apply" => "Apply",
+        "dttp" => "DTTP",
+        "hesa" => "HESA",
+      }[trainee.record_source]
     end
 
     def sanitise(value)

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -42,6 +42,7 @@ module Exports
         {
           "register_id" => trainee.slug,
           "trainee_url" => "#{Settings.base_url}/trainees/#{trainee.slug}",
+          "record_source" => "Manual",
           "apply_id" => trainee.apply_application&.apply_id,
           "provider_trainee_id" => trainee.trainee_id,
           "trn" => trainee.trn,


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/4lMWy4um/3954-s-hesa-records-in-register-add-record-source-to-csv-for-record-export

We've added record source to the csv export so providers can now see the source of their records.

### Changes proposed in this pull request

* Use record_source on trainee model to find trainee record source
* Add record_source to trainee_search_data csv with correct formatting

### Guidance to review

* Log into review app as Annie Bell, provider A
* Navigate to registered trainees
* I have set three trainees to have record sources of DTTP, HESA and Apply (Porfirio Bayer, Sunshine Medhurst, Linwood Williamson respectively)
* Click on 'Export these records'
* Check the record source column in the export and make sure the above trainees have the correct record source against them
* Check formatting looks ok

### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
