### PR TITLE
[3964] Import dttp_accounts

### DIFF
--- a/app/jobs/dttp/sync_accounts_job.rb
+++ b/app/jobs/dttp/sync_accounts_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Dttp
+  class SyncAccountsJob < ApplicationJob
+    queue_as :dttp
+
+    def perform(request_uri = nil)
+      @account_list = RetrieveAccounts.call(request_uri: request_uri)
+
+      Account.upsert_all(account_attributes, unique_by: :dttp_id)
+
+      Dttp::SyncAccountsJob.perform_later(next_page_url) if next_page?
+    end
+
+  private
+
+    attr_reader :account_list
+
+    def account_attributes
+      Parsers::Account.to_account_attributes(accounts: account_list[:items])
+    end
+
+    def next_page_url
+      account_list[:meta][:next_page_url]
+    end
+
+    def next_page?
+      next_page_url.present?
+    end
+  end
+end

--- a/app/lib/dttp/parsers/account.rb
+++ b/app/lib/dttp/parsers/account.rb
@@ -25,6 +25,17 @@ module Dttp
             }
           end
         end
+
+        def to_account_attributes(accounts:)
+          accounts.map do |account|
+            {
+              name: account["name"],
+              ukprn: account["dfe_ukprn"],
+              dttp_id: account["accountid"],
+              response: account,
+            }
+          end
+        end
       end
     end
   end

--- a/app/models/dttp/account.rb
+++ b/app/models/dttp/account.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Dttp
+  class Account < ApplicationRecord
+    self.table_name = "dttp_accounts"
+  end
+end

--- a/app/services/dttp/retrieve_accounts.rb
+++ b/app/services/dttp/retrieve_accounts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Dttp
+  class RetrieveAccounts
+    include ServicePattern
+    include SyncPattern
+
+  private
+
+    def default_path
+      @default_path ||= "/accounts"
+    end
+  end
+end

--- a/db/migrate/20220406101914_create_dttp_accounts.rb
+++ b/db/migrate/20220406101914_create_dttp_accounts.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateDttpAccounts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :dttp_accounts do |t|
+      t.uuid :dttp_id, nullable: false
+      t.string :ukprn
+      t.string :name
+      t.jsonb :response
+      t.timestamps
+    end
+
+    add_index :dttp_accounts, :dttp_id
+    add_index :dttp_accounts, :ukprn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_29_160910) do
+ActiveRecord::Schema.define(version: 2022_04_06_101914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -221,6 +221,17 @@ ActiveRecord::Schema.define(version: 2022_03_29_160910) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["request_id"], name: "index_dqt_trn_requests_on_request_id", unique: true
     t.index ["trainee_id"], name: "index_dqt_trn_requests_on_trainee_id"
+  end
+
+  create_table "dttp_accounts", force: :cascade do |t|
+    t.uuid "dttp_id"
+    t.string "ukprn"
+    t.string "name"
+    t.jsonb "response"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["dttp_id"], name: "index_dttp_accounts_on_dttp_id"
+    t.index ["ukprn"], name: "index_dttp_accounts_on_ukprn"
   end
 
   create_table "dttp_bursary_details", force: :cascade do |t|

--- a/spec/services/dttp/retrieve_accounts_spec.rb
+++ b/spec/services/dttp/retrieve_accounts_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dttp
+  describe RetrieveAccounts do
+    subject { described_class.call(request_uri: request_uri) }
+
+    let(:expected_path) do
+      "/accounts"
+    end
+
+    let(:request_uri) { nil }
+
+    it_behaves_like "dttp info retriever"
+  end
+end


### PR DESCRIPTION
### Context

We have imported all accounts that belong to providers to dttp_providers but we've realised that there may be important data e.g. degree institution UKPRNs that we might want from other accounts.

So... let's import them all.

Once this is merged we'll run this manually as we have with the other entities.

### Changes proposed in this pull request

* Add Dttp::Account
* Add Dttp::RetreiveAccounts
* Add Dttp::SyncAccountsJob

### Guidance to review

This is mostly copy-pasta 🍝 from the Provider version.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
