### PR TITLE
[3949] Don't send TRN or award requests to DQT for HESA records

### DIFF
--- a/app/jobs/dqt/recommend_for_award_job.rb
+++ b/app/jobs/dqt/recommend_for_award_job.rb
@@ -8,15 +8,21 @@ module Dqt
     def perform(trainee)
       return unless FeatureService.enabled?(:integrate_with_dqt)
 
-      award_date = RecommendForAward.call(trainee: trainee)
-
-      if award_date
-        trainee.award_qts!(award_date)
+      if trainee.hesa_record?
+        message = "Trainee id: #{trainee.id}, slug: #{trainee.slug} has been recommended for award but is a HESA trainee"
+        username = "Register Trainee Teachers: Job Failure"
+        SlackNotifierService.call(message: message, username: username)
       else
-        raise(
-          DqtNoAwardDateError,
-          "failed to retrieve award date from DQT for trainee: #{trainee.id}",
-        )
+        award_date = RecommendForAward.call(trainee: trainee)
+
+        if award_date
+          trainee.award_qts!(award_date)
+        else
+          raise(
+            DqtNoAwardDateError,
+            "failed to retrieve award date from DQT for trainee: #{trainee.id}",
+          )
+        end
       end
     end
   end

--- a/app/jobs/dqt/register_for_trn_job.rb
+++ b/app/jobs/dqt/register_for_trn_job.rb
@@ -8,8 +8,14 @@ module Dqt
     def perform(trainee)
       return unless FeatureService.enabled?(:integrate_with_dqt)
 
-      trn_request = RegisterForTrn.call(trainee: trainee)
-      RetrieveTrnJob.perform_later(trn_request)
+      if trainee.hesa_record?
+        message = "Trainee id: #{trainee.id}, slug: #{trainee.slug} has been registered for TRN but is a HESA trainee"
+        username = "Register Trainee Teachers: Job Failure"
+        SlackNotifierService.call(message: message, username: username)
+      else
+        trn_request = RegisterForTrn.call(trainee: trainee)
+        RetrieveTrnJob.perform_later(trn_request)
+      end
     end
   end
 end

--- a/spec/jobs/dqt/recommend_for_award_job_spec.rb
+++ b/spec/jobs/dqt/recommend_for_award_job_spec.rb
@@ -30,5 +30,21 @@ module Dqt
         }.to raise_error(DqtNoAwardDateError)
       end
     end
+
+    context "with a HESA trainee" do
+      before do
+        allow(trainee).to receive(:hesa_record?).and_return(true)
+      end
+
+      it "reports to Slack" do
+        expect(SlackNotifierService).to receive(:call).with(message: "Trainee id: #{trainee.id}, slug: #{trainee.slug} has been recommended for award but is a HESA trainee", username: "Register Trainee Teachers: Job Failure")
+        described_class.perform_now(trainee)
+      end
+
+      it "doesn't send the trainee to DQT" do
+        expect(RecommendForAward).not_to receive(:call)
+        described_class.perform_now(trainee)
+      end
+    end
   end
 end

--- a/spec/jobs/dqt/register_for_trn_job_spec.rb
+++ b/spec/jobs/dqt/register_for_trn_job_spec.rb
@@ -32,6 +32,23 @@ module Dqt
 
         expect(trainee.state).to eql("submitted_for_trn")
       end
+
+      context "with a HESA trainee" do
+        before do
+          allow(SlackNotifierService).to receive(:call)
+          allow(trainee).to receive(:hesa_record?).and_return(true)
+        end
+
+        it "reports to Slack" do
+          expect(SlackNotifierService).to receive(:call).with(message: "Trainee id: #{trainee.id}, slug: #{trainee.slug} has been registered for TRN but is a HESA trainee", username: "Register Trainee Teachers: Job Failure")
+          described_class.perform_now(trainee)
+        end
+
+        it "doesn't send the trainee to DQT" do
+          expect(RecommendForAward).not_to receive(:call)
+          described_class.perform_now(trainee)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

We send requests for TRN and recommendations for award to DQT. We don't want to do this for HESA records at the moment as it will incorrectly set the source of those records in DQT to register rather than HESA and stop them appearing in the ITT portal.

Until we iron this out we should not send them. There likely won't be any/many but if there are any notify slack so as we can work it out manually with the DQT team.

### Changes proposed in this pull request

* Notify slack and noop for HESA records in the TRN requests and award recommendation.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
