### PR TITLE
[xxx] Fix SetCohort to handle when trainee.itt_start_date is nil

### DIFF
--- a/app/services/trainees/set_cohort.rb
+++ b/app/services/trainees/set_cohort.rb
@@ -9,6 +9,7 @@ module Trainees
     end
 
     def call
+      return trainee if trainee.itt_start_date.nil?
       return trainee if trainee_is_current? && trainee.current!
       return trainee if trainee_is_future? && trainee.future!
       return trainee if trainee_is_past? && trainee.past!

--- a/spec/services/trainees/set_cohort_spec.rb
+++ b/spec/services/trainees/set_cohort_spec.rb
@@ -74,6 +74,18 @@ module Trainees
 
         it { is_expected.to eq("current") }
       end
+
+      context "when a trainee has no ITT start date" do
+        let(:trainee) do
+          build(
+            :trainee,
+            itt_start_date: nil,
+            itt_end_date: nil,
+          )
+        end
+
+        it { is_expected.to eq("current") }
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

sentry error: https://sentry.io/organizations/dfe-teacher-services/issues/3167438207/events/latest/?environment=production&project=5552118

When the trainee's ITT start date is nil, we're getting an error when we try to set the cohort.

### Changes proposed in this pull request

* When trainee.itt_start_date is nil, do nothing in SetCohort
* Trainees are set to current cohort by default
* Trainees with no ITT start date i.e. draft trainees will therefore be current cohort

### Guidance to review

### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
