### PR TITLE
[xxx] Hide cohort filter and disable trainee cohort job

### DIFF
--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -147,7 +147,8 @@ private
   end
 
   def show_cohort_filter?
-    available_cohorts.length > 1
+    # available_cohorts.length > 1
+    false
   end
 
   def available_cohorts

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -42,6 +42,6 @@ import_collection_from_hesa:
   cron: "0 */2 * * *"
   class: "Hesa::RetrieveCollectionJob"
   queue: default
-update_trainee_cohorts:
-  cron: "0 5 * * *"
-  class: "Trainees::QueueCohortUpdatesJob"
+# update_trainee_cohorts:
+#   cron: "0 5 * * *"
+#   class: "Trainees::QueueCohortUpdatesJob"

--- a/spec/features/trainee_actions/filtering_trainees_by_cohort_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_by_cohort_spec.rb
@@ -18,17 +18,17 @@ RSpec.feature "Filtering trainees by cohort" do
     end
   end
 
-  context "when trainees from all cohorts exists" do
-    before do
-      given_trainees_from_all_cohorts_exist
-      when_i_visit_the_trainee_index_page
-    end
+  # context "when trainees from all cohorts exists" do
+  #   before do
+  #     given_trainees_from_all_cohorts_exist
+  #     when_i_visit_the_trainee_index_page
+  #   end
 
-    scenario "can filter by cohort" do
-      when_i_filter_by_past_cohort
-      then_only_past_cohort_trainees_are_visible
-    end
-  end
+  #   scenario "can filter by cohort" do
+  #     when_i_filter_by_past_cohort
+  #     then_only_past_cohort_trainees_are_visible
+  #   end
+  # end
 
   context "when there are no trainees in future cohort" do
     before do


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

- Hide the cohort filter for now since we're not setting cohort correctly for many trainees
- Disable the overnight job because missing data on dttp_trainees means this currently fails for a lot of trainees

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
