### PR TITLE
[xxx] Disable DTTP sync in sandbox

### DIFF
--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -14,7 +14,6 @@ dfe_sign_in:
 features:
   basic_auth: false
   enable_feedback_link: false
-  sync_from_dttp: true
   send_emails: false
   persist_to_dttp: false
   import_courses_from_ttapi: true


### PR DESCRIPTION
### Context

DTTP sync is no longer required is erroring.

### Changes proposed in this pull request

Disable it.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
