### PR TITLE
Extra text on ‘Hide this message’ button

### DIFF
--- a/app/views/layouts/_cookie_banner.html.erb
+++ b/app/views/layouts/_cookie_banner.html.erb
@@ -27,7 +27,7 @@
   <%= cookie_banner.message(text: t("cookies.after_consent.message",
                                     cookie_preferences_link: cookie_preferences_link).html_safe) do |message| %>
     <% message.action do %>
-      <button type="button" class="govuk-button"><%= t("cookies.after_consent.button_text")  %></button>
+      <button type="button" class="govuk-button"><%= t("cookies.after_consent.button_text_html")  %></button>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/pages/cookie_policy/en.yml
+++ b/config/locales/pages/cookie_policy/en.yml
@@ -76,7 +76,7 @@ en:
         You’ve <span class="decision accepted">accepted</span><span class="decision rejected"> rejected</span> analytics cookies.
         You can %{cookie_preferences_link} at any time.
       page_link_text: change your cookie settings
-      button_text: Hide this message
+      button_text: Hide this <span class="govuk-visually-hidden">cookies</span> message
     preference_updated: Your cookie preferences have been updated
     message_html:
       <p class="govuk-body">We use some essential cookies to make this service work.</p>

--- a/config/locales/pages/cookie_policy/en.yml
+++ b/config/locales/pages/cookie_policy/en.yml
@@ -76,7 +76,7 @@ en:
         You’ve <span class="decision accepted">accepted</span><span class="decision rejected"> rejected</span> analytics cookies.
         You can %{cookie_preferences_link} at any time.
       page_link_text: change your cookie settings
-      button_text: Hide this <span class="govuk-visually-hidden">cookies</span> message
+      button_text_html: Hide this <span class="govuk-visually-hidden">cookies</span> message
     preference_updated: Your cookie preferences have been updated
     message_html:
       <p class="govuk-body">We use some essential cookies to make this service work.</p>


### PR DESCRIPTION
Adds visually hidden text to give button more context for screen-reader users

Button now reads "Hide this `cookies` message".