### PR TITLE
[xxx] Remove set_cohort callback

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -236,11 +236,6 @@ class Trainee < ApplicationRecord
   before_save :set_submission_ready, if: :completion_trackable?
 
   after_commit :update_trainee_in_dqt, on: :update
-  after_commit :set_cohort
-
-  def set_cohort
-    Trainees::SetCohortJob.perform_later(self)
-  end
 
   def trn_requested!(dttp_id, placement_assignment_dttp_id)
     update!(dttp_id: dttp_id, placement_assignment_dttp_id: placement_assignment_dttp_id)

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -722,18 +722,4 @@ describe Trainee do
       expect(trainee.duplicate?).to be(true)
     end
   end
-
-  describe "set_cohort" do
-    let(:trainee) { create(:trainee) }
-
-    it "queues up a SetCohortJob" do
-      expect(Trainees::SetCohortJob).to receive(:perform_later).with(trainee)
-      trainee.set_cohort
-    end
-
-    it "is called after_commit" do
-      expect(Trainees::SetCohortJob).to receive(:perform_later).with(trainee)
-      trainee.update(first_names: "Dennis")
-    end
-  end
 end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

Remove the set_cohort callback which is causing lots of jobs to be kicked off.

### Guidance to review

### Important business

~* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`
~* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
