### PR TITLE
[3957] Add dynamic funding guidance link

### DIFF
--- a/app/forms/funding/bursary_form.rb
+++ b/app/forms/funding/bursary_form.rb
@@ -24,6 +24,7 @@ module Funding
     delegate :can_apply_for_scholarship?, :can_apply_for_tiered_bursary?,
              :can_apply_for_grant?, :grant_amount, :bursary_amount,
              :scholarship_amount, :allocation_subject_name,
+             :funding_guidance_link_text, :funding_guidance_url,
              to: :funding_manager
 
     def initialize(trainee, params: {}, user: nil, store: FormStore)

--- a/app/lib/funding_manager.rb
+++ b/app/lib/funding_manager.rb
@@ -61,6 +61,14 @@ class FundingManager
     allocation_subject&.name
   end
 
+  def funding_guidance_url
+    "#{funding_year}-to-#{funding_year + 1}"
+  end
+
+  def funding_guidance_link_text
+    "#{funding_year} to #{funding_year + 1} (opens a new tab)"
+  end
+
 private
 
   attr_reader :trainee, :academic_cycle
@@ -81,5 +89,9 @@ private
     allocation_subject.funding_methods.find_by(training_route: training_route,
                                                funding_type: funding_type,
                                                academic_cycle: academic_cycle)&.amount
+  end
+
+  def funding_year
+    @funding_year ||= AcademicCycle.for_date(trainee.itt_start_date).start_year
   end
 end

--- a/app/views/trainees/funding/bursaries/_grant_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_grant_form.html.erb
@@ -14,8 +14,8 @@
 
   <p class="govuk-body">
     <%= govuk_link_to(
-      t("views.forms.funding.bursaries.guidance_link_text"),
-      t("views.forms.funding.bursaries.guidance_url"),
+      t("views.forms.funding.bursaries.guidance_link_text") + @bursary_form.funding_guidance_link_text,
+      t("views.forms.funding.bursaries.guidance_url") + @bursary_form.funding_guidance_url,
       { target: "_blank", rel: "noreferrer noopener" }
     ) %>
   </p>

--- a/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
@@ -14,8 +14,8 @@
 
   <p class="govuk-body">
     <%= govuk_link_to(
-      t("views.forms.funding.bursaries.guidance_link_text"),
-      t("views.forms.funding.bursaries.guidance_url"),
+      t("views.forms.funding.bursaries.guidance_link_text") + @bursary_form.funding_guidance_link_text,
+      t("views.forms.funding.bursaries.guidance_url") + @bursary_form.funding_guidance_url,
       { target: "_blank", rel: "noreferrer noopener" }
     ) %>
   </p>

--- a/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
@@ -7,8 +7,8 @@
 
   <p class="govuk-body">
     <%= govuk_link_to(
-      t("views.forms.funding.bursaries.guidance_link_text"),
-      t("views.forms.funding.bursaries.guidance_url"),
+      t("views.forms.funding.bursaries.guidance_link_text") + @bursary_form.funding_guidance_link_text,
+      t("views.forms.funding.bursaries.guidance_url") + @bursary_form.funding_guidance_url,
       { target: "_blank", rel: "noreferrer noopener" }
     ) %>
   </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -788,8 +788,8 @@ en:
             tier_three:
               label: Yes - Tier 3 (£2,000)
               hint: 2:2 honours degree
-          guidance_link_text: "Funding: initial teacher training (ITT), academic year 2021 to 2022 (opens in new tab)"
-          guidance_url: https://www.gov.uk/government/publications/funding-initial-teacher-training-itt/funding-initial-teacher-training-itt-academic-year-2021-to-2022
+          guidance_link_text: "Funding: initial teacher training (ITT), academic year "
+          guidance_url: https://www.gov.uk/government/publications/funding-initial-teacher-training-itt/funding-initial-teacher-training-itt-academic-year-
         funding_type:
           bursary:
             label: Yes, apply for a bursary

--- a/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
@@ -4,6 +4,9 @@ require "rails_helper"
 
 feature "early_years_postgrad end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
+  before do
+    create(:academic_cycle, :current)
+  end
 
   scenario "submit for TRN", "feature_routes.early_years_postgrad": true do
     given_i_have_created_an_early_years_postgrad_trainee

--- a/spec/features/form_sections/teacher_training_data/edit_bursary_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_bursary_spec.rb
@@ -7,8 +7,12 @@ feature "edit bursary", type: :feature do
 
   let(:course_subject) { CourseSubjects::LAW }
 
+  before do
+    create(:academic_cycle, :current)
+  end
+
   scenario "edit with valid parameters" do
-    given_a_trainee_exists(:provider_led_postgrad, course_subject_one: course_subject)
+    given_a_trainee_exists(:provider_led_postgrad, course_subject_one: course_subject, itt_start_date: 1.day.ago)
     and_a_bursary_exists_for_their_subject
     when_i_visit_the_bursary_page
     and_i_choose_applying_for_bursary
@@ -18,7 +22,7 @@ feature "edit bursary", type: :feature do
   end
 
   scenario "submitting with invalid parameters" do
-    given_a_trainee_exists(:provider_led_postgrad, course_subject_one: course_subject)
+    given_a_trainee_exists(:provider_led_postgrad, course_subject_one: course_subject, itt_start_date: 1.day.ago)
     and_a_bursary_exists_for_their_subject
     when_i_visit_the_bursary_page
     and_i_submit_the_form
@@ -26,7 +30,7 @@ feature "edit bursary", type: :feature do
   end
 
   scenario "edit with valid parameters for tiered bursary" do
-    given_a_trainee_exists(:early_years_postgrad)
+    given_a_trainee_exists(:early_years_postgrad, itt_start_date: 1.day.ago)
     when_i_visit_the_bursary_page
     and_i_choose_the_applicable_bursary_tier
 

--- a/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
@@ -7,6 +7,10 @@ feature "edit training initiative", type: :feature do
 
   let(:course_subject) { CourseSubjects::LAW }
 
+  before do
+    create(:academic_cycle, :current)
+  end
+
   scenario "edit with valid parameters with bursary" do
     given_a_provider_led_postgrad_trainee_exists
     and_a_bursary_exists_for_their_subject
@@ -25,7 +29,7 @@ feature "edit training initiative", type: :feature do
   end
 
   scenario "edit with valid parameters on the early_years_postgrad route" do
-    given_a_trainee_exists(:early_years_postgrad)
+    given_a_trainee_exists(:early_years_postgrad, itt_start_date: 1.day.ago)
     when_i_visit_the_training_initiative_page
     and_i_update_the_training_initiative
     and_i_submit_the_form


### PR DESCRIPTION
Ensure that the link to funding guidance is for the correct year relevant to the trainee

### Context

Prior to this PR the funding guidance link only went to the 2021/22 funding guidance. Now this link will go to the relevant years funding guidance based on the trainees ITT start date.
