### PR TITLE
[xxx] Order provider select alphabetically when adding provider to user in system admin

### DIFF
--- a/app/views/system_admin/user_providers/new.html.erb
+++ b/app/views/system_admin/user_providers/new.html.erb
@@ -13,7 +13,7 @@
           Add a provider for <%= @user.name %>
         </h1>
 
-        <p><%= f.govuk_select(:provider, @providers.map(&:name), label: { text: "Add provider", size: "s" }, width: 20, autocomplete: :enabled, class: 'provider-select') %></p>
+        <p><%= f.govuk_select(:provider, @providers.map(&:name).sort, label: { text: "Add provider", size: "s" }, width: 20, autocomplete: :enabled, class: 'provider-select') %></p>
 
         <%= f.govuk_submit %>
       <% end %>


### PR DESCRIPTION
### Context

trello: https://trello.com/c/Pca1xgkB/3967-please-order-the-provider-list-in-system-admin-to-alph-order

It was raised by support that this list being un-alphabetical was leading to increased human error when adding providers to users.

### Changes proposed in this pull request

* Add .sort to the provider drop down when adding a provider to a user

### Guidance to review

* Log into review app as an admin
* Navigate to system admin > users
* Click through on any user and select 'Add a provider'
* Observe the dropdown list of providers is now alphabetical

### Important business

* ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
* ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
