### PR TITLE
[xxx] Remove DQT update callback on trainee

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -235,8 +235,6 @@ class Trainee < ApplicationRecord
   before_save :clear_lead_school_id, if: :lead_school_not_applicable?
   before_save :set_submission_ready, if: :completion_trackable?
 
-  after_commit :update_trainee_in_dqt, on: :update
-
   def trn_requested!(dttp_id, placement_assignment_dttp_id)
     update!(dttp_id: dttp_id, placement_assignment_dttp_id: placement_assignment_dttp_id)
   end
@@ -439,9 +437,5 @@ private
 
     submission_klass = validate_trn ? Submissions::TrnValidator : Submissions::MissingDataValidator
     self.submission_ready = submission_klass.new(trainee: self).valid?
-  end
-
-  def update_trainee_in_dqt
-    Dqt::UpdateTraineeJob.perform_later(self)
   end
 end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -260,21 +260,6 @@ describe Trainee do
         end
       end
     end
-
-    describe "#update_trainee_in_dqt" do
-      before do
-        allow(Dqt::UpdateTraineeJob).to receive(:perform_later).with(trainee)
-      end
-
-      context "when a trainee is updated" do
-        let(:trainee) { create(:trainee, :draft) }
-
-        it "queues a UpdateTraineeJob job" do
-          trainee.submit_for_trn!
-          expect(Dqt::UpdateTraineeJob).to have_received(:perform_later).with(trainee)
-        end
-      end
-    end
   end
 
   context "class methods" do


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

- Remove `update_trainee_in_dqt` callback which was causing many Dqt::UpdateTraineeJobs to be fired off.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
