### PR TITLE
3943 Add read only function for provider users

### DIFF
--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -48,11 +48,11 @@ class TraineePolicy
   end
 
   def new?
-    user.provider?
+    user.provider? && !user_is_read_only?
   end
 
   def create?
-    user_in_provider_context?
+    user_in_provider_context? && !user_is_read_only?
   end
 
   def update?
@@ -100,11 +100,17 @@ private
   end
 
   def write?
+    return false if user_is_read_only?
+
     user_is_system_admin? || (!trainee.hesa_record? && user_in_provider_context? && trainee.awaiting_action?)
   end
 
   def user_in_provider_context?
     user&.organisation == trainee.provider
+  end
+
+  def user_is_read_only?
+    user&.read_only
   end
 
   def user_in_lead_school_context?

--- a/db/migrate/20220407145510_add_read_only_to_users.rb
+++ b/db/migrate/20220407145510_add_read_only_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReadOnlyToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :read_only, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,10 +14,8 @@ ActiveRecord::Schema.define(version: 2022_04_12_173718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
-  enable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
-  enable_extension "uuid-ossp"
 
   create_table "academic_cycles", force: :cascade do |t|
     t.date "start_date", null: false
@@ -162,9 +160,9 @@ ActiveRecord::Schema.define(version: 2022_04_12_173718) do
     t.integer "duration_in_years", null: false
     t.string "course_length"
     t.integer "qualification", null: false
-    t.integer "level", null: false
     t.integer "route", null: false
     t.string "summary", null: false
+    t.integer "level", null: false
     t.string "accredited_body_code", null: false
     t.integer "min_age", null: false
     t.integer "max_age", null: false
@@ -416,8 +414,8 @@ ActiveRecord::Schema.define(version: 2022_04_12_173718) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "dttp_id"
-    t.string "code"
     t.boolean "apply_sync_enabled", default: false
+    t.string "code"
     t.string "ukprn"
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
@@ -527,14 +525,14 @@ ActiveRecord::Schema.define(version: 2022_04_12_173718) do
     t.text "course_subject_two"
     t.text "course_subject_three"
     t.datetime "awarded_at"
-    t.integer "training_initiative"
     t.boolean "applying_for_bursary"
+    t.integer "training_initiative"
     t.integer "bursary_tier"
     t.integer "study_mode"
     t.boolean "ebacc", default: false
     t.string "region"
-    t.boolean "applying_for_scholarship"
     t.integer "course_education_phase"
+    t.boolean "applying_for_scholarship"
     t.boolean "applying_for_grant"
     t.uuid "course_uuid"
     t.boolean "lead_school_not_applicable", default: false
@@ -579,6 +577,7 @@ ActiveRecord::Schema.define(version: 2022_04_12_173718) do
     t.boolean "system_admin", default: false
     t.datetime "welcome_email_sent_at"
     t.datetime "discarded_at"
+    t.boolean "read_only", default: false
     t.index ["dfe_sign_in_uid"], name: "index_users_on_dfe_sign_in_uid", unique: true
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["dttp_id"], name: "index_unique_active_dttp_users", unique: true, where: "(discarded_at IS NULL)"

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -7,6 +7,7 @@ describe TraineePolicy do
   let(:provider) { create(:provider) }
   let(:other_provider) { create(:provider) }
   let(:provider_user) { user_with_organisation(create(:user, providers: [provider]), provider) }
+  let(:read_only_provider_user) { user_with_organisation(create(:user, providers: [provider], read_only: true), provider) }
   let(:other_provider_user) { user_with_organisation(create(:user, providers: [other_provider]), other_provider) }
   let(:lead_school) { create(:school, :lead) }
   let(:lead_school_user) { user_with_organisation(create(:user, providers: []), lead_school) }
@@ -26,6 +27,7 @@ describe TraineePolicy do
 
   permissions :show?, :index? do
     it { is_expected.to permit(provider_user, provider_trainee) }
+    it { is_expected.to permit(read_only_provider_user, provider_trainee) }
     it { is_expected.to permit(lead_school_user, lead_school_trainee) }
 
     it { is_expected.to permit(system_admin_user, provider_trainee) }
@@ -38,6 +40,7 @@ describe TraineePolicy do
     it { is_expected.to permit(provider_user, provider_trainee) }
 
     it { is_expected.not_to permit(lead_school_user, lead_school_trainee) }
+    it { is_expected.not_to permit(read_only_provider_user, provider_trainee) }
     it { is_expected.not_to permit(system_admin_user, provider_trainee) }
   end
 
@@ -49,6 +52,7 @@ describe TraineePolicy do
     it { is_expected.to permit(provider_user, provider_trainee) }
     it { is_expected.not_to permit(provider_user, hesa_trainee) }
     it { is_expected.not_to permit(lead_school_user, lead_school_trainee) }
+    it { is_expected.not_to permit(read_only_provider_user, provider_trainee) }
 
     it { is_expected.to permit(system_admin_user, provider_trainee) }
     it { is_expected.to permit(system_admin_user, lead_school_trainee) }
@@ -71,6 +75,7 @@ describe TraineePolicy do
 
       it { is_expected.to permit(provider_user, provider_trainee) }
       it { is_expected.not_to permit(other_provider_user, provider_trainee) }
+      it { is_expected.not_to permit(read_only_provider_user, provider_trainee) }
       it { is_expected.not_to permit(lead_school_user, provider_trainee) }
       it { is_expected.to permit(system_admin_user, provider_trainee) }
     end


### PR DESCRIPTION
### Context

Add a read only boolean to the provider users model and do not allow editing of records where this flag is enabled.

https://trello.com/c/LGmo5QAe/3943-read-only-admin-access

### Changes proposed in this pull request

Migration to add read only boolean to users model; add check in TraineePolicy to check for this boolean and decide if user can edit records.

### Guidance to review

Create a user with read_only set to true and check you cannot edit records. 

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
