### PR TITLE
adds non-breaking spaces to status cards

### DIFF
--- a/app/components/status_card/view.html.erb
+++ b/app/components/status_card/view.html.erb
@@ -1,5 +1,5 @@
 <a class="app-status-card app-status-card--<%= status_colour %> app-status-card__link" href="<%= target %>">
-  <span class="app-status-card__count"><%= count %></span>
-  <span class="app-status-card__status"><%= state_name %></span>
+  <span class="app-status-card__count"><%= count %> &nbsp; </span>
+  <span class="app-status-card__status"><%= state_name %> &nbsp; </span>
   <span class="govuk-visually-hidden"> records. View these records.</span>
 </a>


### PR DESCRIPTION
### Context

The recent accessibility audit pointed out that the status boxes "contain multiple pieces of text within separate elements on new lines. Placing text within elements on different lines of code does not break up the text programmatically. This means that words become combined and could be difficult for screen reader users to understand what screen reading software is reading." For example:

```
<span class="app-status-card__count">47</span>
<span class="app-status-card__status">Pending TRN</span>
<span class="govuk-visually-hidden"> records. View these records.</span> 
```

Reads as "47pending TRN records. View these records."

### Changes proposed in this pull request

Add non-breaking spaces so the content is read as separate words.