### PR TITLE
[3976] `Trainees::Update` service

### DIFF
--- a/app/controllers/trainees/course_years_controller.rb
+++ b/app/controllers/trainees/course_years_controller.rb
@@ -9,7 +9,7 @@ module Trainees
     def update
       @course_years_form = CourseYearsForm.new(course_years_params)
       if @course_years_form.valid?
-        trainee.update(course_uuid: nil)
+        Trainees::Update.call(trainee: trainee, params: { course_uuid: nil })
         redirect_to(edit_trainee_publish_course_details_path(trainee, year: @course_years_form.course_year))
       else
         render(:edit)

--- a/app/forms/apply_applications/confirm_course_form.rb
+++ b/app/forms/apply_applications/confirm_course_form.rb
@@ -27,7 +27,7 @@ module ApplyApplications
       trainee.progress.course_details = mark_as_reviewed
       clear_funding_information if course_subjects_changed?
 
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
     end
 
     def course_subject_one

--- a/app/forms/apply_applications/trainee_data_form.rb
+++ b/app/forms/apply_applications/trainee_data_form.rb
@@ -36,7 +36,7 @@ module ApplyApplications
       trainee.progress.diversity = true
       trainee.progress.degrees = true
       trainee.progress.trainee_data = true
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
     end
 
     def progress_status(progress_key)

--- a/app/forms/contact_details_form.rb
+++ b/app/forms/contact_details_form.rb
@@ -35,7 +35,7 @@ class ContactDetailsForm < TraineeForm
   def save!
     if valid?
       update_trainee_attributes
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
       store.set(trainee.id, :contact_details, nil)
     else
       false

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -84,7 +84,7 @@ class CourseDetailsForm < TraineeForm
     if valid?
       update_trainee_attributes
       clear_funding_information if course_subjects_changed?
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
       clear_stash
     else
       false

--- a/app/forms/course_education_phase_form.rb
+++ b/app/forms/course_education_phase_form.rb
@@ -13,7 +13,7 @@ class CourseEducationPhaseForm < TraineeForm
     if valid?
       trainee.assign_attributes(fields)
       clear_course_subjects if trainee.course_education_phase_changed?
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
       clear_stash
     else
       false

--- a/app/forms/diversities/disclosure_form.rb
+++ b/app/forms/diversities/disclosure_form.rb
@@ -32,7 +32,7 @@ module Diversities
     def save_trainee!
       trainee.assign_attributes(fields.except(*fields_to_ignore_before_save))
       trainee.disability_disclosure = diversity_not_disclosed? ? Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided] : nil
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
     end
 
     def compute_fields

--- a/app/forms/itt_dates_form.rb
+++ b/app/forms/itt_dates_form.rb
@@ -32,7 +32,7 @@ class IttDatesForm < TraineeForm
   def save!
     if valid?
       update_trainee_itt_dates
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
       copy_dates_to_course if for_all_trainees?
       clear_stash
     else

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -44,7 +44,7 @@ class PersonalDetailsForm < TraineeForm
   def save!
     if valid?
       update_trainee_attributes
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
       clear_stash
     else
       false

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -23,16 +23,19 @@ class PublishCourseDetailsForm < TraineeForm
 
   def process_manual_entry!
     if trainee.draft?
-      trainee.update!(
-        course_uuid: nil,
-        course_subject_one: nil,
-        course_subject_two: nil,
-        course_subject_three: nil,
-        course_age_range: nil,
-        itt_start_date: nil,
-        itt_end_date: nil,
-        study_mode: nil,
-        course_education_phase: nil,
+      Trainees::Update.call(
+        trainee: trainee,
+        params: {
+          course_uuid: nil,
+          course_subject_one: nil,
+          course_subject_two: nil,
+          course_subject_three: nil,
+          course_age_range: nil,
+          itt_start_date: nil,
+          itt_end_date: nil,
+          study_mode: nil,
+          course_education_phase: nil,
+        },
       )
     else
       CourseDetailsForm.new(trainee).nullify_and_stash!
@@ -46,7 +49,7 @@ class PublishCourseDetailsForm < TraineeForm
 
     update_trainee_attributes
     clear_funding_information if course_subjects_changed?
-    trainee.save!
+    Trainees::Update.call(trainee: trainee)
     clear_all_stashes
   end
 

--- a/app/forms/start_date_verification_form.rb
+++ b/app/forms/start_date_verification_form.rb
@@ -17,7 +17,7 @@ class StartDateVerificationForm < TraineeForm
   def save!
     if valid?
       update_trainee_commencement_status
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
       clear_stash
     else
       false

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -31,7 +31,7 @@ class TraineeForm
   def save!
     if valid?
       assign_attributes_to_trainee
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
       clear_stash
     else
       false

--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -15,7 +15,7 @@ class TraineeStartDateForm < TraineeForm
   def save!
     if valid?
       update_trainee_commencement_date
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
       clear_stash
     else
       false

--- a/app/forms/trainee_start_status_form.rb
+++ b/app/forms/trainee_start_status_form.rb
@@ -25,7 +25,7 @@ class TraineeStartStatusForm < TraineeForm
   def save!
     if valid?
       update_trainee_commencement_date
-      trainee.save!
+      Trainees::Update.call(trainee: trainee)
       clear_stash
     else
       false

--- a/app/lib/route_data_manager.rb
+++ b/app/lib/route_data_manager.rb
@@ -9,7 +9,7 @@ class RouteDataManager
     trainee.training_route = route
     reset_trainee_details if trainee.training_route_changed?
     trainee.set_early_years_course_details
-    trainee.save!
+    Trainees::Update.call(trainee: trainee)
   end
 
 private

--- a/app/services/trainees/update.rb
+++ b/app/services/trainees/update.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Trainees
+  class Update
+    include ServicePattern
+
+    def initialize(trainee:, params: {})
+      @trainee = trainee
+      @params = params
+    end
+
+    def call
+      trainee.update!(params)
+      Dqt::UpdateTraineeJob.perform_later(trainee)
+      Trainees::SetCohortJob.perform_later(trainee)
+      true
+    end
+
+  private
+
+    attr_reader :trainee, :params
+  end
+end

--- a/spec/services/trainees/update_spec.rb
+++ b/spec/services/trainees/update_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe Update do
+    let(:trainee) { create(:trainee) }
+
+    describe "#call" do
+      context "valid params" do
+        let(:params) { { first_names: "Dave", last_name: "Hill", address_line_one: "Merry Christmas Street" } }
+
+        before do
+          allow(Dqt::UpdateTraineeJob).to receive(:perform_later)
+          allow(Trainees::SetCohortJob).to receive(:perform_later)
+        end
+
+        it "updates the trainee" do
+          described_class.call(trainee: trainee, params: params)
+          trainee.reload
+          expect(trainee.first_names).to eq("Dave")
+          expect(trainee.last_name).to eq("Hill")
+          expect(trainee.address_line_one).to eq("Merry Christmas Street")
+        end
+
+        it "queues an update to DQT" do
+          expect(Dqt::UpdateTraineeJob).to receive(:perform_later).with(trainee)
+          described_class.call(trainee: trainee, params: params)
+        end
+
+        it "queues a cohort update" do
+          expect(Trainees::SetCohortJob).to receive(:perform_later).with(trainee)
+          described_class.call(trainee: trainee, params: params)
+        end
+
+        it "returns true" do
+          expect(described_class.call(trainee: trainee, params: params)).to be(true)
+        end
+      end
+
+      context "passed a trainee that has had attributes set" do
+        context "with no params" do
+          it "persists any changes" do
+            trainee.first_names = "Baldric"
+            described_class.call(trainee: trainee)
+            trainee.reload
+            expect(trainee.first_names).to eq("Baldric")
+          end
+        end
+
+        context "with params" do
+          it "persists any changes with the params" do
+            trainee.first_names = "Baldric"
+            described_class.call(trainee: trainee, params: { last_name: "Bladder" })
+            trainee.reload
+            expect(trainee.first_names).to eq("Baldric")
+            expect(trainee.last_name).to eq("Bladder")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We had added some callbacks to i) update DQT and ii) set the trainee cohort when a trainee is updated. These have been problematic and we've removed them.

This is an alternative approach with a service responsible for updating the trainee and doing those two things ^. We use this service when we want the full update and associated tasks.

This gives us the option of updating a trainee without doing those things, e.g. in a data migration, console etc and makes it explicit.

On the downside we need to make sure we use it at the right times.

### Changes proposed in this pull request

* Add `Trainee::Update`
* Change the form objects to persist the trainee using the service
* Update some controllers

### Guidance to review

* We need to check that we're using this everywhere we need to
* There are some places e.g. the state transitions in `Trainee` where `Trainee#update` is still called directly. These are triggered by returning values from DQT so we don't want to notify DQT. We also won't change a trainee's cohort as a result of these except where a trainee is awarded or withdrawn and that award falls in the previous cycle (even though the change was made in the current one). We intend to run a periodic process for transitioning cohort anyway so these will be handled by that.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
