### PR TITLE
Use workflow concurrency for build and deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,5 @@
 name: Build and Deploy
+concurrency: build_and_deploy_${{ github.ref_name }}
 
 on:
   push:
@@ -219,7 +220,6 @@ jobs:
 
   deploy_all:
     name: Deployment To All
-    concurrency: deploy_all
     environment: 
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy_app.outputs.deploy-url }}


### PR DESCRIPTION
### Context
Currently the deploy-all matrix job has a concurrency group to prevent concurrent deployments.  Observed behaviour is that each job within the matrix is treated as a separate job rather all the jobs in the matrix being treated as a single element.  This results in prod deployments occurring after earlier environments have been skipped.

### Changes proposed in this pull request
- Switch to workflow concurrency to ensure that only 1 `deploy-all` job can run at any one time but that all jobs in that matrix are executed in order
- Retain job concurrency for deploy and delete of review app to prevent the delete job running at the same time as the review app deployment

### Guidance to review

- The concurrency groups have been tested in a [sandbox repo](https://github.com/NickGraham101/actions-sandbox)

### Link to Trello card

https://trello.com/c/zCmvKchC

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
