### PR TITLE
[3950] move workflow into the nocache pipeline

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -80,44 +80,6 @@ jobs:
         SLACK_MESSAGE: ':alert: Build failure on ${{ github.event.inputs.environment }} :sadparrot:'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  audit:
-    name: Audit
-    needs: [build]
-    outputs:
-      image_tag: ${{ needs.build.outputs.image_tag }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Set environment variables
-      run: |
-        echo "IMAGE_TAG=${{ needs.build.outputs.image_tag }}" >> $GITHUB_ENV
-
-    - name: Pull docker images
-      run: docker pull ${{ needs.build.outputs.docker_image }}:$IMAGE_TAG
-
-    - name: Bring images up
-      run: |
-        docker-compose up --no-build -d
-
-    - name: Install git
-      run: docker-compose exec -T web /bin/sh -c 'apk add git'
-
-    - name: Bundle audit
-      run: docker-compose exec -T web /bin/sh -c 'bundle-audit check --update'
-
-    - name: Check for Failure
-      if: ${{ failure() }}
-      uses: rtCamp/action-slack-notify@master
-      env:
-        SLACK_COLOR: '#ef5343'
-        SLACK_ICON_EMOJI: ':lock:'
-        SLACK_USERNAME: Register Trainee Teachers
-        SLACK_TITLE: Audit Failure
-        SLACK_MESSAGE: ':alert: Audit failure on ${{ github.event.inputs.environment }} :sadparrot:'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
   test:
     name: Test
     needs: [build]
@@ -220,7 +182,7 @@ jobs:
 
   deploy_all:
     name: Deployment To All
-    environment: 
+    environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy_app.outputs.deploy-url }}
     if: ${{ success() && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -87,3 +87,41 @@ jobs:
           SLACK_TITLE: Build failure on weekly rebuild cache workflow
           SLACK_MESSAGE: ':alert: Build failure :sadparrot:'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  audit:
+    name: Audit
+    needs: [build]
+    outputs:
+      image_tag: ${{ needs.build.outputs.image_tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set environment variables
+        run: |
+          echo "IMAGE_TAG=${{ needs.build.outputs.image_tag }}" >> $GITHUB_ENV
+
+      - name: Pull docker images
+        run: docker pull ${{ needs.build.outputs.docker_image }}:$IMAGE_TAG
+
+      - name: Bring images up
+        run: |
+          docker-compose up --no-build -d
+
+      - name: Install git
+        run: docker-compose exec -T web /bin/sh -c 'apk add git'
+
+      - name: Bundle audit
+        run: docker-compose exec -T web /bin/sh -c 'bundle-audit check --update'
+
+      - name: Check for Failure
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_COLOR: '#ef5343'
+          SLACK_ICON_EMOJI: ':lock:'
+          SLACK_USERNAME: Register Trainee Teachers
+          SLACK_TITLE: Audit Failure
+          SLACK_MESSAGE: ':alert: Audit failure on ${{ github.event.inputs.environment }} :sadparrot:'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

Move auditing of vulnerable gems out of the PR build pipeline into the nocache weekly pipeline. 

### Changes proposed in this pull request

Remove the 'audit' step of the PR pipeline and move it to a weekly check.
