### PR TITLE
[3970] Store course allocation subject on the trainee

### DIFF
--- a/app/forms/concerns/course_form_helpers.rb
+++ b/app/forms/concerns/course_form_helpers.rb
@@ -15,4 +15,8 @@ module CourseFormHelpers
   def course_subjects_changed?
     trainee.course_subject_one_changed? || trainee.course_subject_two_changed? || trainee.course_subject_three_changed?
   end
+
+  def course_allocation_subject
+    SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject
+  end
 end

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -177,6 +177,7 @@ private
       itt_start_date: itt_start_date,
       itt_end_date: itt_end_date,
       course_education_phase: course_education_phase,
+      course_allocation_subject: course_allocation_subject,
     }
 
     set_course_subject_from_primary_phase if is_primary_phase?

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -35,6 +35,7 @@ class PublishCourseDetailsForm < TraineeForm
           itt_end_date: nil,
           study_mode: nil,
           course_education_phase: nil,
+          course_allocation_subject: nil,
         },
       )
     else
@@ -97,7 +98,8 @@ private
                               course_subject_two: course_subject_two,
                               course_subject_three: course_subject_three,
                               course_education_phase: course&.level,
-                              course_age_range: course_age_range)
+                              course_age_range: course_age_range,
+                              course_allocation_subject: course_allocation_subject)
   end
 
   def course_subjects

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -17,6 +17,8 @@ class Trainee < ApplicationRecord
 
   belongs_to :lead_school, optional: true, class_name: "School"
   belongs_to :employing_school, optional: true, class_name: "School"
+  belongs_to :course_allocation_subject, optional: true, class_name: "AllocationSubject"
+
   belongs_to :published_course,
              ->(trainee) { where(accredited_body_code: trainee.provider.code) },
              class_name: "Course",

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -43,6 +43,7 @@ module Trainees
         trn: trn,
         state: trainee_state,
         hesa_updated_at: hesa_trainee[:hesa_updated_at],
+        course_allocation_subject: course_allocation_subject,
       }.merge(created_from_hesa_attribute)
        .merge(personal_details_attributes)
        .merge(provider_attributes)
@@ -233,6 +234,10 @@ module Trainees
 
     def trainee_state
       @trainee_state ||= MapStateFromHesa.call(hesa_trainee: hesa_trainee)
+    end
+
+    def course_allocation_subject
+      SubjectSpecialism.find_by(name: course_subject_one_name)&.allocation_subject
     end
   end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -43,6 +43,7 @@ shared:
     - summary
     - updated_at
     - uuid
+    - course_allocation_subject_id
   course_subjects:
     - id
     - course_id

--- a/db/data/20220420131249_backfill_allocation_subject_dttp_ids.rb
+++ b/db/data/20220420131249_backfill_allocation_subject_dttp_ids.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class BackfillAllocationSubjectDttpIds < ActiveRecord::Migration[6.1]
+  def up
+    {
+      AllocationSubjects::ART_AND_DESIGN => "aff10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::BIOLOGY => "b1f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::BUSINESS_STUDIES => "b3f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::CHEMISTRY => "b5f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::CLASSICS => "b9f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::COMPUTING => "bdf10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::DESIGN_AND_TECHNOLOGY => "c1f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::DRAMA => "c3f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::EARLY_YEARS_ITT => "fbf10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::ECONOMICS => "c5f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::ENGLISH => "c9f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::GEOGRAPHY => "cbf10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::HISTORY => "cff10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::MATHEMATICS => "d7f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::MODERN_LANGUAGES => "dbf10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::MUSIC => "ddf10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::OTHER_SUBJECTS => "e1f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::PHYSICAL_EDUCATION => "e3f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::PHYSICS => "e5f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::PRIMARY => "e9f10516-aac2-e611-80be-00155d010316",
+      AllocationSubjects::PRIMARY_WITH_MATHEMATICS => "51d3114a-01b5-e811-812e-5065f38b6471",
+      AllocationSubjects::RELIGIOUS_EDUCATION => "f7f10516-aac2-e611-80be-00155d010316",
+    }.each do |name, dttp_id|
+      AllocationSubject.find_by(name: name).update(dttp_id: dttp_id)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20220420131423_add_deprecated_allocation_subjects.rb
+++ b/db/data/20220420131423_add_deprecated_allocation_subjects.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddDeprecatedAllocationSubjects < ActiveRecord::Migration[6.1]
+  def up
+    {
+      "Psychology" => "f5f10516-aac2-e611-80be-00155d010316",
+      "Primary Mathematics Specialist" => "f1f10516-aac2-e611-80be-00155d010316",
+      "Social Sciences" => "f9f10516-aac2-e611-80be-00155d010316",
+      "Primary - General (Mathematics)" => "fdf10516-aac2-e611-80be-00155d010316",
+      "Travel And Tourism" => "d3f10516-aac2-e611-80be-00155d010316",
+      "Physics with maths" => "e7f10516-aac2-e611-80be-00155d010316",
+      "Citizenship" => "b7f10516-aac2-e611-80be-00155d010316",
+    }.each do |name, dttp_id|
+      AllocationSubject.create(name: name, dttp_id: dttp_id, deprecated_on: Time.zone.today)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20220419083227_add_course_allocation_subject_to_trainees.rb
+++ b/db/migrate/20220419083227_add_course_allocation_subject_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCourseAllocationSubjectToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :trainees, :course_allocation_subject, foreign_key: { to_table: "allocation_subjects" }
+  end
+end

--- a/db/migrate/20220419083257_add_dttp_id_and_deprecated_on_columns_to_allocation_subjects.rb
+++ b/db/migrate/20220419083257_add_dttp_id_and_deprecated_on_columns_to_allocation_subjects.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDttpIdAndDeprecatedOnColumnsToAllocationSubjects < ActiveRecord::Migration[6.1]
+  def change
+    change_table :allocation_subjects, bulk: true do |t|
+      t.string :dttp_id, index: { unique: true }
+      t.date :deprecated_on
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_13_165608) do
+ActiveRecord::Schema.define(version: 2022_04_19_083257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -39,6 +39,9 @@ ActiveRecord::Schema.define(version: 2022_04_13_165608) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "dttp_id"
+    t.date "deprecated_on"
+    t.index ["dttp_id"], name: "index_allocation_subjects_on_dttp_id", unique: true
     t.index ["name"], name: "index_allocation_subjects_on_name", unique: true
   end
 
@@ -546,8 +549,10 @@ ActiveRecord::Schema.define(version: 2022_04_13_165608) do
     t.boolean "created_from_hesa", default: false, null: false
     t.datetime "hesa_updated_at"
     t.integer "cohort", default: 0
+    t.bigint "course_allocation_subject_id"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["cohort"], name: "index_trainees_on_cohort"
+    t.index ["course_allocation_subject_id"], name: "index_trainees_on_course_allocation_subject_id"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"
     t.index ["disability_disclosure"], name: "index_trainees_on_disability_disclosure"
     t.index ["discarded_at"], name: "index_trainees_on_discarded_at"
@@ -608,6 +613,7 @@ ActiveRecord::Schema.define(version: 2022_04_13_165608) do
   add_foreign_key "subject_specialisms", "allocation_subjects"
   add_foreign_key "trainee_disabilities", "disabilities"
   add_foreign_key "trainee_disabilities", "trainees"
+  add_foreign_key "trainees", "allocation_subjects", column: "course_allocation_subject_id"
   add_foreign_key "trainees", "apply_applications"
   add_foreign_key "trainees", "providers"
   add_foreign_key "trainees", "schools", column: "employing_school_id"

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -164,6 +164,7 @@ FactoryBot.define do
         end.keys.sample
       end
       with_study_mode_and_course_dates
+      course_allocation_subject { create(:subject_specialism, name: course_subject_one)&.allocation_subject }
     end
 
     trait :with_secondary_course_details do
@@ -183,6 +184,7 @@ FactoryBot.define do
         end.keys.sample
       end
       with_study_mode_and_course_dates
+      course_allocation_subject { SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject }
     end
 
     trait :with_study_mode_and_course_dates do

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -495,6 +495,8 @@ describe CourseDetailsForm, type: :model do
     let(:trainee) { create(:trainee) }
 
     describe "#save!" do
+      let(:allocation_subject) { create(:subject_specialism, name: params[:course_subject_one]).allocation_subject }
+
       before do
         allow(form_store).to receive(:set).with(trainee.id, :course_details, nil)
       end
@@ -511,6 +513,8 @@ describe CourseDetailsForm, type: :model do
           .from(nil).to(Date.parse(valid_start_date.to_s))
           .and change { trainee.itt_end_date }
           .from(nil).to(Date.parse(valid_end_date.to_s))
+          .and change { trainee.course_allocation_subject }
+          .from(nil).to(allocation_subject)
       end
 
       context "with primary education phase" do

--- a/spec/forms/publish_course_details_form_spec.rb
+++ b/spec/forms/publish_course_details_form_spec.rb
@@ -41,6 +41,9 @@ describe PublishCourseDetailsForm, type: :model do
         let(:subject_specialism_form) do
           SubjectSpecialismForm.new(trainee, params: { course_subject_one: subject_name })
         end
+        let(:allocation_subject) do
+          create(:subject_specialism, name: subject_name).allocation_subject
+        end
 
         before do
           create(:course_with_subjects,
@@ -56,6 +59,7 @@ describe PublishCourseDetailsForm, type: :model do
           expect { subject.save! }
           .to change { trainee.course_subject_one }.to(subject_name)
           .and change { trainee.course_education_phase }.to(course_level)
+          .and change { trainee.course_allocation_subject }.to(allocation_subject)
         end
 
         context "with a pg_teaching_apprenticeship trainee" do

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -13,6 +13,10 @@ module Trainees
     let(:hesa_trn) { Faker::Number.number(digits: 7).to_s }
     let(:trainee_degree) { trainee.degrees.first }
 
+    let!(:course_allocation_subject) do
+      create(:subject_specialism, name: CourseSubjects::BIOLOGY).allocation_subject
+    end
+
     subject(:trainee) { Trainee.first }
 
     before do
@@ -29,6 +33,7 @@ module Trainees
         expect(trainee.trainee_id).to eq(student_attributes[:trainee_id])
         expect(trainee.hesa_id).to eq(student_attributes[:hesa_id])
         expect(trainee.trn).to eq(student_attributes[:trn])
+        expect(trainee.course_allocation_subject).to eq(course_allocation_subject)
       end
 
       it "updates the trainee's personal details" do


### PR DESCRIPTION
### Context
https://trello.com/c/iYGaQtlA/3970-store-allocationsubject-on-the-trainee

### Changes proposed in this pull request
- Add a reference to allocation subject to trainee
- Re-calculates allocation subject when a user changes course subjects
- Add `dttp_id` and `deprecated_on` column to `allocation_subjects` table
- Data migration to backfill the `dttp_id` column in `allocation_subjects` table
- Data migration to add deprecated allocation subjects (about 900 trainees have an allocation subject that's no longer available in the current mapping)
- Manual/console data migration to associate each trainee to an allocation subject (see below)

### Guidance to review
- Reseed the database: `rake db:reset && rake db:seed && rake example_data:generate`
- Choose a trainee from assessment only and salary direct
- Open the rails console and note the current allocation subject e.g. `Trainee.from_param(<slug>).course_allocation_subject`
- Change the course details and check the console to confirm allocation subject has changed

### Final step after deployment
Once the DB and data migrations have been deployed we can running the following data migration in the console as it takes about 50 minutes to complete:

```ruby
Trainee.created_from_dttp.in_batches.each_with_index do |trainees, index|
  trainees.each do |trainee|
    allocation_subject_dttp_id = trainee.dttp_trainee.latest_placement_assignment.response["_dfe_allocationsubjectid_value"]
    allocation_subject = AllocationSubject.find_by(dttp_id: allocation_subject_dttp_id)
    trainee.update_column(:course_allocation_subject_id, allocation_subject.id) if allocation_subject
  end
  puts "DTTP batch #{index+1} complete"
end

Trainee.where(created_from_dttp: false).where.not(course_subject_one: nil).in_batches.each_with_index do |trainees, index|
  trainees.each do |trainee|
    course_allocation_subject = SubjectSpecialism.find_by(name: trainee.course_subject_one)&.allocation_subject
    trainee.update_column(:course_allocation_subject_id, course_allocation_subject.id) if course_allocation_subject
  end
  puts "Non-DTTP batch #{index+1} complete"
end
```

### Important business
* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
