### PR TITLE
Add concurency to the deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: Deploy
+concurrency: build_and_deploy_${{ github.ref_name }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Context
Deploy workflow can run at the same time as the Build and Deploy workflow potentially creating conflicting deployments.

### Changes proposed in this pull request
Add concurrency to prevent workflows running at the same time.

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
