### PR TITLE
[xxx] Add unique index on dttp_accounts dttp_id

### DIFF
--- a/db/migrate/20220412173718_add_dttp_accounts_dttp_id_index.rb
+++ b/db/migrate/20220412173718_add_dttp_accounts_dttp_id_index.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDttpAccountsDttpIdIndex < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :dttp_accounts, :dttp_id
+    add_index :dttp_accounts, :dttp_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_11_123017) do
+ActiveRecord::Schema.define(version: 2022_04_12_173718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -233,7 +233,7 @@ ActiveRecord::Schema.define(version: 2022_04_11_123017) do
     t.string "urn"
     t.string "accreditation_id"
     t.index ["accreditation_id"], name: "index_dttp_accounts_on_accreditation_id"
-    t.index ["dttp_id"], name: "index_dttp_accounts_on_dttp_id"
+    t.index ["dttp_id"], name: "index_dttp_accounts_on_dttp_id", unique: true
     t.index ["ukprn"], name: "index_dttp_accounts_on_ukprn"
     t.index ["urn"], name: "index_dttp_accounts_on_urn"
   end


### PR DESCRIPTION
### Context

I'm trying to sync the DTTP accounts entity set into Register.

### Changes proposed in this pull request

Add a unique index on dttp_id on the dttp_accounts table. We use this to key an upsert so it has to have a unique index.

### Guidance to review

### Important business

* Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
* Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
