### PR TITLE
[xxx] Add default timestamps

### DIFF
--- a/db/migrate/20220413165608_add_default_timestamps_for_dttp_accounts.rb
+++ b/db/migrate/20220413165608_add_default_timestamps_for_dttp_accounts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDefaultTimestampsForDttpAccounts < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :dttp_accounts, :created_at, from: nil, to: -> { "CURRENT_TIMESTAMP" }
+    change_column_default :dttp_accounts, :updated_at, from: nil, to: -> { "CURRENT_TIMESTAMP" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_12_173718) do
+ActiveRecord::Schema.define(version: 2022_04_13_165608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -226,8 +226,8 @@ ActiveRecord::Schema.define(version: 2022_04_12_173718) do
     t.string "ukprn"
     t.string "name"
     t.jsonb "response"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.string "urn"
     t.string "accreditation_id"
     t.index ["accreditation_id"], name: "index_dttp_accounts_on_accreditation_id"


### PR DESCRIPTION
### Context

When we sync DTTP data into our local tables we use `upsert` which doesn't automatically add timestamps. So... we need to default them in the DB.

### Changes proposed in this pull request

* Add default timestamps for dttp_accounts 

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
