### PR TITLE
[3962] Update CreateFromDttp services to handle not applicable lead/employing schools

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -12,6 +12,8 @@ module Trainees
                     "Wales", "Isle of Man",
                     "United Kingdom, not otherwise specified"].freeze
 
+    NOT_APPLICABLE_SCHOOL_URNS = %w[900010 99999996].freeze
+
     def initialize(dttp_trainee:)
       @dttp_trainee = dttp_trainee
       @trainee = Trainee.new(mapped_attributes)
@@ -291,14 +293,26 @@ module Trainees
       return {} if dttp_trainee.latest_placement_assignment.lead_school_id.blank?
 
       # Should we raise when schools are not found so that we can add them?
-      attrs = {
-        lead_school: School.find_by(urn: lead_school_urn),
-      }
+      if NOT_APPLICABLE_SCHOOL_URNS.include?(lead_school_urn)
+        attrs = {
+          lead_school_not_applicable: true,
+        }
+      else
+        attrs = {
+          lead_school: School.find_by(urn: lead_school_urn),
+        }
+      end
 
       if dttp_trainee.latest_placement_assignment.employing_school_id.present?
-        attrs.merge!({
-          employing_school: School.find_by(urn: employing_school_urn),
-        })
+        if NOT_APPLICABLE_SCHOOL_URNS.include?(employing_school_urn)
+          attrs.merge!({
+            employing_school_not_applicable: true,
+          })
+        else
+          attrs.merge!({
+            employing_school: School.find_by(urn: employing_school_urn),
+          })
+        end
       end
 
       attrs

--- a/db/data/20220414085459_fix_employing_schools_not_applicable.rb
+++ b/db/data/20220414085459_fix_employing_schools_not_applicable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class FixEmployingSchoolsNotApplicable < ActiveRecord::Migration[6.1]
+  def up
+    dttp_trainees = Trainee.created_from_dttp.school_direct_salaried.where(employing_school_id: nil)
+
+    # School Direct salaried that might have an employing school school that is not applicable
+    dttp_trainees.each { |trainee| fix_trainee(trainee) }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def fix_trainee(trainee)
+    employing_school_dttp_id = trainee.dttp_trainee&.latest_placement_assignment&.employing_school_id
+    employing_school_urn = Dttp::School.find_by(dttp_id: employing_school_dttp_id)&.urn
+
+    trainee.update(employing_school_not_applicable: true) if %w[900010 99999996].include?(employing_school_urn)
+
+    # It seems if we remove the 'zzz', the URN is actually valid and school records exist
+    trainee.update(employing_school: School.find_by(urn: employing_school_urn.remove("zzz"))) if employing_school_urn&.include?("zzz")
+  end
+end

--- a/spec/factories/dttp/schools.rb
+++ b/spec/factories/dttp/schools.rb
@@ -19,5 +19,9 @@ FactoryBot.define do
     trait :inactive do
       status_code { Dttp::School::STATUS_CODES[:inactive] }
     end
+
+    trait :not_applicable do
+      urn { %w[900010 99999996].sample }
+    end
   end
 end

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -92,6 +92,57 @@ module Trainees
         expect(trainee.dttp_update_sha).to eq(trainee.sha)
       end
 
+      context "when the trainee has a lead school" do
+        let(:api_placement_assignment) {
+          create(:api_placement_assignment,
+                 _dfe_leadschoolid_value: dttp_school.dttp_id)
+        }
+        let(:dttp_school) { create(:dttp_school) }
+        let!(:school) { create(:school, urn: dttp_school.urn) }
+
+        it "maps the trainee to the lead school" do
+          create_trainee_from_dttp
+          trainee = Trainee.last
+          expect(trainee.lead_school).to eq(school)
+        end
+
+        context "when the lead school is not applicable" do
+          let(:dttp_school) { create(:dttp_school, :not_applicable) }
+
+          it "maps the trainee as lead school not applicable" do
+            create_trainee_from_dttp
+            trainee = Trainee.last
+            expect(trainee.lead_school_not_applicable).to be_truthy
+          end
+        end
+      end
+
+      context "when the trainee has an employing school" do
+        let(:api_placement_assignment) {
+          create(:api_placement_assignment,
+                 _dfe_leadschoolid_value: dttp_school.dttp_id,
+                 _dfe_employingschoolid_value: dttp_school.dttp_id)
+        }
+        let(:dttp_school) { create(:dttp_school) }
+        let!(:school) { create(:school, urn: dttp_school.urn) }
+
+        it "maps the trainee to the employing school" do
+          create_trainee_from_dttp
+          trainee = Trainee.last
+          expect(trainee.employing_school).to eq(school)
+        end
+
+        context "when the employing school is not applicable" do
+          let(:dttp_school) { create(:dttp_school, :not_applicable) }
+
+          it "maps the trainee as employing school not applicable" do
+            create_trainee_from_dttp
+            trainee = Trainee.last
+            expect(trainee.employing_school_not_applicable).to be_truthy
+          end
+        end
+      end
+
       context "when the route is early_years_school_direct" do
         let(:api_placement_assignment) { create(:api_placement_assignment, :with_early_years_school_direct) }
 


### PR DESCRIPTION
### Context
Update CreateFromDttp services to handle not applicable lead/employing schools

### Changes proposed in this pull request

Add code from https://github.com/DFE-Digital/register-trainee-teachers/pull/2207 to the `Trainees::CreateFromDttp` service.
Also add a data migration to do a similar thing for Employing schools.
I've ignored [these lines](https://github.com/DFE-Digital/register-trainee-teachers/blob/c23e53f9fcdac0736ac99cd5f602dc5a39dfdfb3/db/data/20220331152016_fix_lead_schools_not_applicable.rb#L30-L32) since the GIAS update should handle these in production.

### Important business

- ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

~NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml~
