### PR TITLE
[4001] Add accreditation_ID to providers

### DIFF
--- a/app/controllers/system_admin/dttp_providers_controller.rb
+++ b/app/controllers/system_admin/dttp_providers_controller.rb
@@ -33,8 +33,12 @@ module SystemAdmin
       @dttp_provider ||= ::Dttp::Provider.find(params[:dttp_provider_id])
     end
 
+    def dttp_provider_account
+      @dttp_provider_account ||= ::Dttp::Account.find_by(dttp_id: dttp_provider.dttp_id)
+    end
+
     def provider_params
-      dttp_provider.attributes.symbolize_keys.slice(:name, :dttp_id, :ukprn)
+      dttp_provider_account.attributes.symbolize_keys.slice(:name, :dttp_id, :ukprn, :accreditation_id)
     end
   end
 end

--- a/app/controllers/system_admin/providers_controller.rb
+++ b/app/controllers/system_admin/providers_controller.rb
@@ -39,7 +39,7 @@ module SystemAdmin
   private
 
     def provider_params
-      params.require(:provider).permit(:name, :dttp_id, :code, :ukprn, :apply_sync_enabled)
+      params.require(:provider).permit(:name, :dttp_id, :code, :ukprn, :accreditation_id, :apply_sync_enabled)
     end
 
     def set_provider

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -9,7 +9,7 @@ class Provider < ApplicationRecord
   validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
   validates :code, format: { with: /\A[A-Z0-9]+\z/i }, allow_blank: true
   validates :ukprn, format: { with: /\A[0-9]{8}\z/ }
-  validates :accreditation_id, presence: true, uniqueness: true
+  validates :accreditation_id, presence: true
 
   has_many :courses, class_name: "Course", foreign_key: :accredited_body_code, primary_key: :code, inverse_of: :provider
   has_many :apply_applications, ->(provider) { unscope(:where).where(accredited_body_code: provider.code) }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -9,6 +9,7 @@ class Provider < ApplicationRecord
   validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
   validates :code, format: { with: /\A[A-Z0-9]+\z/i }, allow_blank: true
   validates :ukprn, format: { with: /\A[0-9]{8}\z/ }
+  validates :accreditation_id, presence: true, uniqueness: true
 
   has_many :courses, class_name: "Course", foreign_key: :accredited_body_code, primary_key: :code, inverse_of: :provider
   has_many :apply_applications, ->(provider) { unscope(:where).where(accredited_body_code: provider.code) }

--- a/app/views/system_admin/providers/edit.html.erb
+++ b/app/views/system_admin/providers/edit.html.erb
@@ -14,6 +14,7 @@
       <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :ukprn, label: { text: "UKPRN", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :code, label: { text: "Provider code", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :accreditation_id, label: { text: "Provider accreditation ID", size: "s" }, width: 20, autocomplete: :off %>
       <div class="govuk-form-group">
         <%= f.govuk_check_box :apply_sync_enabled, true, multiple: false, label: { text: "Import application data from Apply?", size: "s" } %>
       </div>

--- a/app/views/system_admin/providers/new.html.erb
+++ b/app/views/system_admin/providers/new.html.erb
@@ -14,6 +14,7 @@
       <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :ukprn, label: { text: "UKPRN", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :code, label: { text: "Provider code", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :accreditation_id, label: { text: "Provider accreditation ID", size: "s" }, width: 20, autocomplete: :off %>
       <div class="govuk-form-group">
         <%= f.govuk_check_box :apply_sync_enabled, true, multiple: false, label: { text: "Import application data from Apply?", size: "s" } %>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1130,6 +1130,9 @@ en:
               blank: Select the country where the degree was obtained
         provider:
           attributes:
+            accreditation_id: 
+              blank: Enter an accreditation ID
+              taken: Enter a unique accreditation ID
             name:
               blank: Enter a provider name
             dttp_id:

--- a/db/data/20220422144717_backfill_provider_accreditation_id.rb
+++ b/db/data/20220422144717_backfill_provider_accreditation_id.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class BackfillProviderAccreditationId < ActiveRecord::Migration[6.1]
+  def up
+    Provider.where(accreditation_id: nil).each do |provider|
+      dttp_account = Dttp::Account.find_by(dttp_id: provider.dttp_id)
+      provider.update(accreditation_id: dttp_account.accreditation_id) if dttp_account.present?
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20220420095158_add_accreditation_id_to_provider.rb
+++ b/db/migrate/20220420095158_add_accreditation_id_to_provider.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddAccreditationIdToProvider < ActiveRecord::Migration[6.1]
+  def change
+    add_column :providers, :accreditation_id, :string
+    add_index :providers, :accreditation_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -479,6 +479,8 @@ ActiveRecord::Schema.define(version: 2022_04_25_170224) do
     t.boolean "apply_sync_enabled", default: false
     t.string "code"
     t.string "ukprn"
+    t.string "accreditation_id"
+    t.index ["accreditation_id"], name: "index_providers_on_accreditation_id"
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
 

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -102,6 +102,7 @@ namespace :example_data do
         name: persona_attributes[:provider],
         ukprn: Faker::Number.number(digits: 8),
         code: persona_attributes[:provider_code].presence || Faker::Alphanumeric.alphanumeric(number: 3).upcase,
+        accreditation_id: Faker::Number.number(digits: 4),
       )
 
       ProviderUser.find_or_create_by!(user: persona, provider: provider)

--- a/spec/factories/dttp/account.rb
+++ b/spec/factories/dttp/account.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dttp_account, class: "Dttp::Account" do
+    sequence :name do |n|
+      "Provider #{n}"
+    end
+    dttp_id { SecureRandom.uuid }
+    ukprn { Faker::Number.number(digits: 8) }
+    accreditation_id { Faker::Number.number(digits: 4) }
+  end
+end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     dttp_id { SecureRandom.uuid }
     code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     ukprn { Faker::Number.number(digits: 8) }
+    accreditation_id { Faker::Number.number(digits: 4) }
 
     trait :teach_first do
       code { TEACH_FIRST_PROVIDER_CODE }

--- a/spec/features/system_admin/dttp_providers/list_providers_spec.rb
+++ b/spec/features/system_admin/dttp_providers/list_providers_spec.rb
@@ -8,6 +8,7 @@ feature "List providers" do
 
     before do
       @dttp_provider = create(:dttp_provider, name: "Test 1")
+      @dttp_provider_account = create(:dttp_account, name: @dttp_provider.name, dttp_id: @dttp_provider.dttp_id)
       given_i_am_authenticated(user: user)
     end
 

--- a/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
+++ b/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
@@ -6,6 +6,8 @@ feature "Creating a new provider" do
   let(:user) { create(:user, system_admin: true) }
   let(:dttp_id) { SecureRandom.uuid }
   let(:ukprn) { Faker::Number.number(digits: 8) }
+  let(:accreditation_id) { Faker::Number.number(digits: 4) }
+  let(:existing_provider) { create(:provider) }
 
   before do
     given_i_am_authenticated(user: user)
@@ -17,20 +19,34 @@ feature "Creating a new provider" do
     and_i_fill_in_name
     and_i_fill_in_dttp_id
     and_i_fill_in_ukprn
+    and_i_fill_in_accreditation_id
     and_i_select_apply_sync_enabled
     and_i_submit_the_form
     then_i_should_see_the_provider_index_page
   end
 
-  scenario "submitting with invalid parameters" do
+  scenario "submitting with an empty form" do
     and_i_submit_the_form
     then_i_see_error_messages
+  end
+
+  scenario "submitting with an existing accreditation ID" do
+    when_i_enter_an_existing_accreditation_id
+    and_i_fill_in_name
+    and_i_fill_in_dttp_id
+    and_i_fill_in_ukprn
+    and_i_submit_the_form
+    then_i_see_accreditation_id_uniqueness_error
   end
 
 private
 
   def when_i_visit_the_provider_index_page
     providers_index_page.load
+  end
+
+  def when_i_enter_an_existing_accreditation_id
+    new_provider_page.accreditation_id.set(existing_provider.accreditation_id)
   end
 
   def and_i_click_on_add_provider_button
@@ -47,6 +63,10 @@ private
 
   def and_i_fill_in_ukprn
     new_provider_page.ukprn.set(ukprn)
+  end
+
+  def and_i_fill_in_accreditation_id
+    new_provider_page.accreditation_id.set(accreditation_id)
   end
 
   def and_i_select_apply_sync_enabled
@@ -72,6 +92,17 @@ private
     )
     expect(new_provider_page).to have_text(
       I18n.t("#{translation_key_prefix}.ukprn.invalid"),
+    )
+    expect(new_provider_page).to have_text(
+      I18n.t("#{translation_key_prefix}.accreditation_id.blank"),
+    )
+  end
+
+  def then_i_see_accreditation_id_uniqueness_error
+    translation_key_prefix = "activerecord.errors.models.provider.attributes"
+
+    expect(new_provider_page).to have_text(
+      I18n.t("#{translation_key_prefix}.accreditation_id.taken"),
     )
   end
 end

--- a/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
+++ b/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
@@ -30,14 +30,14 @@ feature "Creating a new provider" do
     then_i_see_error_messages
   end
 
-  scenario "submitting with an existing accreditation ID" do
-    when_i_enter_an_existing_accreditation_id
-    and_i_fill_in_name
-    and_i_fill_in_dttp_id
-    and_i_fill_in_ukprn
-    and_i_submit_the_form
-    then_i_see_accreditation_id_uniqueness_error
-  end
+# scenario "submitting with an existing accreditation ID" do
+#   when_i_enter_an_existing_accreditation_id
+#   and_i_fill_in_name
+#   and_i_fill_in_dttp_id
+#   and_i_fill_in_ukprn
+#   and_i_submit_the_form
+#   then_i_see_accreditation_id_uniqueness_error
+# end
 
 private
 

--- a/spec/features/system_admin/providers/editing_a_provider_spec.rb
+++ b/spec/features/system_admin/providers/editing_a_provider_spec.rb
@@ -27,11 +27,11 @@ feature "Edit providers" do
       then_i_should_see_the_provider_index_page
     end
 
-    scenario "editing with an existing accreditation ID" do
-      when_i_enter_an_existing_accreditation_id
-      and_i_submit_the_form
-      then_i_see_accreditation_id_uniqueness_error
-    end
+    # scenario "editing with an existing accreditation ID" do
+    #   when_i_enter_an_existing_accreditation_id
+    #   and_i_submit_the_form
+    #   then_i_see_accreditation_id_uniqueness_error
+    # end
   end
 
   def when_i_visit_the_provider_index_page

--- a/spec/features/system_admin/providers/editing_a_provider_spec.rb
+++ b/spec/features/system_admin/providers/editing_a_provider_spec.rb
@@ -5,18 +5,32 @@ require "rails_helper"
 feature "Edit providers" do
   context "as a system admin" do
     let(:user) { create(:user, system_admin: true) }
+    let(:existing_provider) { create(:provider) }
+    let(:accreditation_id) { Faker::Number.number(digits: 4) }
 
     before do
       given_i_am_authenticated(user: user)
       when_i_visit_the_provider_index_page
+      when_i_click_on_provider_name
+      and_i_click_edit_this_provider
     end
 
     scenario "i can edit a provider" do
-      when_i_click_on_provider_name
-      and_i_click_edit_this_provider
-      and_change_the_provider_name
+      when_i_change_the_provider_name
       and_i_submit_the_form
       the_updated_provider_name_is_displayed
+    end
+
+    scenario "editing the accreditation ID successfully" do
+      when_i_enter_accreditation_id
+      and_i_submit_the_form
+      then_i_should_see_the_provider_index_page
+    end
+
+    scenario "editing with an existing accreditation ID" do
+      when_i_enter_an_existing_accreditation_id
+      and_i_submit_the_form
+      then_i_see_accreditation_id_uniqueness_error
     end
   end
 
@@ -32,8 +46,16 @@ feature "Edit providers" do
     provider_show_page.edit_this_provider.click
   end
 
-  def and_change_the_provider_name
+  def when_i_change_the_provider_name
     fill_in :name, with: "Foo"
+  end
+
+  def when_i_enter_accreditation_id
+    new_provider_page.accreditation_id.set(accreditation_id)
+  end
+
+  def when_i_enter_an_existing_accreditation_id
+    new_provider_page.accreditation_id.set(existing_provider.accreditation_id)
   end
 
   def and_i_submit_the_form
@@ -42,5 +64,17 @@ feature "Edit providers" do
 
   def the_updated_provider_name_is_displayed
     expect(provider_show_page).to have_text("Foo")
+  end
+
+  def then_i_should_see_the_provider_index_page
+    expect(providers_index_page).to be_displayed
+  end
+
+  def then_i_see_accreditation_id_uniqueness_error
+    translation_key_prefix = "activerecord.errors.models.provider.attributes"
+
+    expect(new_provider_page).to have_text(
+      I18n.t("#{translation_key_prefix}.accreditation_id.taken"),
+    )
   end
 end

--- a/spec/support/page_objects/providers/new.rb
+++ b/spec/support/page_objects/providers/new.rb
@@ -8,6 +8,7 @@ module PageObjects
       element :name, "#provider-name-field"
       element :dttp_id, "#provider-dttp-id-field"
       element :ukprn, "#provider-ukprn-field"
+      element :accreditation_id, "#provider-accreditation-id-field"
       element :apply_sync_enabled, "#provider-apply-sync-enabled-true-field"
 
       element :submit, 'button.govuk-button[type="submit"]'


### PR DESCRIPTION
### Context

Providers have an 'accreditation_id'. We don't currently store this on our provider records. It is available in the DTTP data (`dfe_providerid` on the dfe_accounts entity set)

Funding refer to providers using this ID and we need to be able to look up a provider from the funding CSV uploads using it.

NB: we haven't added nullable: false or uniqueness constraints to the db table yet, this is because we want to run the backfill first before adding restrictions

### Changes proposed in this pull request

* Add `accreditation_id` to providers table
* Migration to backfill existing provider accreditation IDs
* Add `accreditation_id` required field to views system admin > providers > new and system admin > providers > edit
* Add `dttp_provider_account` method to dttp_provider_controller so we can slice the `accreditation_id` when creating a new provider from an existing DTTP one

### Guidance to review

For dev review:
* check out the branch and run both new migrations, check they run as expected
* you may want to add an existing provider from the `providers` table to `dttp_accounts` to test the backfill. I tested by adding the `dttp_id` of an existing provider and a fake `accreditation_id` into `dttp_accounts`, then ran the migration (I also pulled down the sanitised prod back up)

For prod review:
* Log in as admin persona and navigate to system admin > providers
* Click 'Add a provider'
* You will see the below new field for accreditation ID:
<img width="559" alt="Screenshot 2022-04-20 at 16 06 17" src="https://user-images.githubusercontent.com/43522239/164262362-4236f1f8-f45d-4388-8b83-a5d817ff88d6.png">

* Try to submit the form without one. You should receive an error message asking to enter an accred ID
* Add a new provider with an accred ID of 4 numbers - this should be successful
* Select an existing provider from provider list and click 'Edit this provider'
* The form should look the same as the new provider form, with accreditation id field. Repeat the same form submission steps as above. You should get the same result.

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
