### PR TITLE
Delete GitHub environment along with review app

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [main]
 
+permissions:
+  deployments: write
+
 jobs:
   delete-review-app:
     name: Delete Review App ${{ github.event.pull_request.number }}
@@ -71,9 +74,18 @@ jobs:
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_REVIEW }}
 
       - name: Update ${{ matrix.environment }} status
+        id: deactivate-env
         if:   ${{ always() && env.TF_STATE_EXISTS == 'true' }}
-        uses: bobheadxi/deployments@v0.4.3
+        uses: bobheadxi/deployments@v1
         with:
           step:   deactivate-env
           token:  ${{ secrets.GITHUB_TOKEN }}
+          env:    review-${{ env.PR_NUMBER }}
+
+      - name: Delete review-${{ env.PR_NUMBER }} environment
+        if:   always() && (steps.deactivate-env.outcome == 'success')
+        uses: bobheadxi/deployments@v1
+        with:
+          step:   delete-env
+          token:  ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}
           env:    review-${{ env.PR_NUMBER }}


### PR DESCRIPTION
### Context
A GitHub environment is created for each review app that is deployed, this environment persists after the review app is deleted.

### Changes proposed in this pull request
- Add a step to the delete-review-app workflow to delete the environment

### Guidance to review
- Close PR to test delete process, reopen PR once tested

### Trello card
https://trello.com/c/ybnYhCK3

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
