### PR TITLE
[3956] Add new ancient languages allocation subject and remap ancient langauge specialisms

### DIFF
--- a/app/lib/funding_manager.rb
+++ b/app/lib/funding_manager.rb
@@ -9,6 +9,7 @@ class FundingManager
 
   def initialize(trainee)
     @trainee = trainee
+    @allocation_subject = trainee.course_allocation_subject
     @academic_cycle = trainee.academic_cycle
   end
 
@@ -71,16 +72,12 @@ class FundingManager
 
 private
 
-  attr_reader :trainee, :academic_cycle
+  attr_reader :trainee, :academic_cycle, :allocation_subject
 
   delegate :training_route, :course_subject_one, :bursary_tier, to: :trainee
 
   def available_bursary_amount
     available_amount(:bursary)
-  end
-
-  def allocation_subject
-    @allocation_subject ||= SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject
   end
 
   def available_amount(funding_type)

--- a/config/initializers/allocation_subjects.rb
+++ b/config/initializers/allocation_subjects.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module AllocationSubjects
+  ANCIENT_LANGUAGES = "Ancient languages"
   ART_AND_DESIGN = "Art and design"
   BIOLOGY = "Biology"
   BUSINESS_STUDIES = "Business studies"

--- a/config/initializers/mappings/allocation_subject_to_specialism_mapping.rb
+++ b/config/initializers/mappings/allocation_subject_to_specialism_mapping.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 ALLOCATION_SUBJECT_SPECIALISM_MAPPING = {
+  AllocationSubjects::ANCIENT_LANGUAGES => [
+    CourseSubjects::ANCIENT_HEBREW,
+    CourseSubjects::CLASSICAL_GREEK_STUDIES,
+    CourseSubjects::LATIN_LANGUAGE,
+  ],
   AllocationSubjects::ART_AND_DESIGN => [
     CourseSubjects::ART_AND_DESIGN,
     CourseSubjects::GRAPHIC_DESIGN,
@@ -22,11 +27,8 @@ ALLOCATION_SUBJECT_SPECIALISM_MAPPING = {
     CourseSubjects::APPLIED_CHEMISTRY,
   ],
   AllocationSubjects::CLASSICS => [
-    CourseSubjects::ANCIENT_HEBREW,
-    CourseSubjects::CLASSICAL_GREEK_STUDIES,
     CourseSubjects::CLASSICAL_STUDIES,
     CourseSubjects::HISTORICAL_LINGUISTICS,
-    CourseSubjects::LATIN_LANGUAGE,
   ],
   AllocationSubjects::COMPUTING => [
     CourseSubjects::APPLIED_COMPUTING,

--- a/config/initializers/mappings/publish_to_allocation_subject_mapping.rb
+++ b/config/initializers/mappings/publish_to_allocation_subject_mapping.rb
@@ -59,6 +59,8 @@ PUBLISH_PRIMARY_SUBJECT_SPECIALISM_MAPPING = {
 
 PUBLISH_SECONDARY_SUBJECT_SPECIALISM_MAPPING = {
   # Subjects with a simple 1-to-1 specialism mapping
+  "Ancient Greek" => [CourseSubjects::CLASSICAL_GREEK_STUDIES],
+  "Ancient Hebrew" => [CourseSubjects::ANCIENT_HEBREW],
   "Citizenship" => [CourseSubjects::CITIZENSHIP],
   "Communication and media studies" => [CourseSubjects::MEDIA_AND_COMMUNICATION_STUDIES],
   "Dance" => [CourseSubjects::DANCE],
@@ -66,6 +68,7 @@ PUBLISH_SECONDARY_SUBJECT_SPECIALISM_MAPPING = {
   "Geography" => [CourseSubjects::GEOGRAPHY],
   "Health and social care" => [CourseSubjects::HEALTH_AND_SOCIAL_CARE],
   "History" => [CourseSubjects::HISTORY],
+  "Latin" => [CourseSubjects::LATIN_LANGUAGE],
   "Music" => [CourseSubjects::MUSIC_EDUCATION_AND_TEACHING],
   "Philosophy" => [CourseSubjects::PHILOSOPHY],
   "Psychology" => [CourseSubjects::PSYCHOLOGY],

--- a/db/data/20220422135555_add_new_allocation_subject_ancient_languages.rb
+++ b/db/data/20220422135555_add_new_allocation_subject_ancient_languages.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddNewAllocationSubjectAncientLanguages < ActiveRecord::Migration[6.1]
+  def up
+    allocation_subject = AllocationSubjects::ANCIENT_LANGUAGES
+    subject_specialisms = ALLOCATION_SUBJECT_SPECIALISM_MAPPING[allocation_subject]
+
+    # Remove old mapping of existing specialisms
+    SubjectSpecialism.where(name: subject_specialisms).delete_all
+
+    # Move subject specialisms under new allocation subject
+    AllocationSubject.create(name: allocation_subject).tap do |as|
+      subject_specialisms.each do |subject_specialism|
+        as.subject_specialisms.create(name: subject_specialism)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20220422135700_add_funding_methods_for_ancient_languages.rb
+++ b/db/data/20220422135700_add_funding_methods_for_ancient_languages.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddFundingMethodsForAncientLanguages < ActiveRecord::Migration[6.1]
+  def up
+    classics_allocation_subject = AllocationSubject.find_by(name: AllocationSubjects::CLASSICS)
+    ancient_languages_allocation_subject = AllocationSubject.find_by(name: AllocationSubjects::ANCIENT_LANGUAGES)
+
+    # Copy all the funding methods from Classics until we enter the 22/23 academic year
+    classics_allocation_subject.funding_methods.where(academic_cycle: AcademicCycle.current).each do |funding_method|
+      ancient_languages_allocation_subject.funding_method_subjects.create(funding_method: funding_method)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -12,6 +12,7 @@ module Funding
       let(:trainee) do
         build(:trainee,
               :early_years_postgrad,
+              :with_course_allocation_subject,
               applying_for_bursary: true,
               bursary_tier: BURSARY_TIERS.keys.first)
       end
@@ -200,6 +201,7 @@ module Funding
                  :with_study_mode_and_course_dates,
                  :school_direct_salaried,
                  :with_grant,
+                 course_allocation_subject: allocation_subject,
                  course_subject_one: "chemistry")
         end
 
@@ -217,6 +219,7 @@ module Funding
                  :school_direct_salaried,
                  :with_grant,
                  course_subject_one: "chemistry",
+                 course_allocation_subject: allocation_subject,
                  applying_for_grant: false)
         end
 
@@ -236,7 +239,9 @@ module Funding
                  :with_study_mode_and_course_dates,
                  :school_direct_salaried,
                  :with_grant,
+                 :with_course_allocation_subject,
                  course_subject_one: "chemistry",
+                 course_allocation_subject: allocation_subject,
                  applying_for_grant: nil)
         end
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -184,6 +184,10 @@ FactoryBot.define do
         end.keys.sample
       end
       with_study_mode_and_course_dates
+      with_course_allocation_subject
+    end
+
+    trait :with_course_allocation_subject do
       course_allocation_subject { SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject }
     end
 

--- a/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
@@ -49,6 +49,7 @@ private
     given_a_trainee_exists(:provider_led_postgrad,
                            :with_start_date,
                            :with_study_mode_and_course_dates,
+                           :with_course_allocation_subject,
                            course_subject_one: course_subject)
   end
 
@@ -78,6 +79,7 @@ private
     funding_method = create(:funding_method, training_route: :provider_led_postgrad, amount: 100_000)
     allocation_subject = create(:allocation_subject, name: "magic", funding_methods: [funding_method])
     create(:subject_specialism, allocation_subject: allocation_subject, name: course_subject)
+    trainee.update(course_allocation_subject: allocation_subject)
   end
 
   def then_i_am_redirected_to_the_funding_confirmation_page

--- a/spec/forms/funding/form_validator_spec.rb
+++ b/spec/forms/funding/form_validator_spec.rb
@@ -74,7 +74,8 @@ module Funding
                  :with_start_date,
                  :with_study_mode_and_course_dates,
                  training_route: funding_method.training_route.to_sym,
-                 course_subject_one: subject_specialism.name)
+                 course_subject_one: subject_specialism.name,
+                 course_allocation_subject: allocation_subject)
         end
 
         let(:training_initiative_form) { instance_double(Funding::TrainingInitiativesForm, fields: nil, training_initiative: nil) }

--- a/spec/lib/funding_manager_spec.rb
+++ b/spec/lib/funding_manager_spec.rb
@@ -10,6 +10,7 @@ describe FundingManager do
     build(:trainee,
           :with_start_date,
           :with_study_mode_and_course_dates,
+          :with_course_allocation_subject,
           course_subject_one: course_subject_one,
           training_route: training_route,
           bursary_tier: bursary_tier)


### PR DESCRIPTION
### Context
https://trello.com/c/hT2VezgT/3956-spike-add-new-ancient-languages-allocation-subject-and-remap-ancient-langauge-specialisms

### Changes proposed in this pull request
- Update the `FundingManager` to use the new `course_allocation_subject` relationship on trainee
- Add `ANCIENT_LANGUAGES` to `AllocationSubjects` and move `Latin` and `Ancient Hebrew` and `classical Greek studies` under it.
- Data migration to add `ANCIENT_LANGUAGES` to the `allocation_subjects` table
- Another data migration to copy all the funding methods in the current academic year for "Classics" to "Ancient languages". This is to ensure if any trainee gets the allocation subject "Ancient languages", their funding remains the same.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
