### PR TITLE
Add service.gov.uk routes to PaaS

### DIFF
--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -23,6 +23,10 @@ data cloudfoundry_domain register_education_gov_uk {
   name = "register-trainee-teachers.education.gov.uk"
 }
 
+data cloudfoundry_domain register_service_gov_uk {
+  name = "register-trainee-teachers.service.gov.uk"
+}
+
 data cloudfoundry_domain education_gov_uk {
   name = "education.gov.uk"
 }

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -106,6 +106,12 @@ resource cloudfoundry_route web_app_education_gov_uk_route {
   hostname = var.web_app_hostname
 }
 
+resource cloudfoundry_route web_app_service_gov_uk_route {
+  domain   = data.cloudfoundry_domain.register_service_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = var.web_app_hostname
+}
+
 resource cloudfoundry_route web_app_dttp_gov_uk_route {
   for_each = toset(var.dttp_portal)
   domain   = data.cloudfoundry_domain.education_gov_uk.id

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -100,7 +100,7 @@ resource cloudfoundry_route web_app_route {
   hostname = local.web_app_name
 }
 
-resource cloudfoundry_route web_app_service_gov_uk_route {
+resource cloudfoundry_route web_app_education_gov_uk_route {
   domain   = data.cloudfoundry_domain.register_education_gov_uk.id
   space    = data.cloudfoundry_space.space.id
   hostname = var.web_app_hostname

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -49,7 +49,7 @@ locals {
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "register-worker-${local.app_name_suffix}"
   logging_service_name     = "register-logit-${local.app_name_suffix}"
-  web_app_routes           = flatten([cloudfoundry_route.web_app_education_gov_uk_route, cloudfoundry_route.web_app_route, values(cloudfoundry_route.web_app_dttp_gov_uk_route)])
+  web_app_routes           = flatten([cloudfoundry_route.web_app_education_gov_uk_route, cloudfoundry_route.web_app_route, values(cloudfoundry_route.web_app_dttp_gov_uk_route), cloudfoundry_route.web_app_service_gov_uk_route])
   noeviction_maxmemory_policy = {
     maxmemory_policy = "noeviction"
   }

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -49,7 +49,7 @@ locals {
   worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
   worker_app_name          = "register-worker-${local.app_name_suffix}"
   logging_service_name     = "register-logit-${local.app_name_suffix}"
-  web_app_routes           = flatten([cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_route, values(cloudfoundry_route.web_app_dttp_gov_uk_route)])
+  web_app_routes           = flatten([cloudfoundry_route.web_app_education_gov_uk_route, cloudfoundry_route.web_app_route, values(cloudfoundry_route.web_app_dttp_gov_uk_route)])
   noeviction_maxmemory_policy = {
     maxmemory_policy = "noeviction"
   }


### PR DESCRIPTION
### Context

Add register-trainee-teachers.service.gov.uk routes to PaaS for each environment

### Changes proposed in this pull request

- Define domain and routes in PaaS terraform configuration for service.gov.uk
Add domain register_service_gov_uk, route web_app_services_gov_uk_route

- Fix education.gov.uk tf route name
rename web_app_service_gov_uk_route to web_app_education_gov_uk_route

### Guidance to review

- test via make deploy-plan for each env
- check review app 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
