### PR TITLE
Fix for errant space being shown visually in link

### DIFF
--- a/app/components/status_card/view.html.erb
+++ b/app/components/status_card/view.html.erb
@@ -1,5 +1,5 @@
 <a class="app-status-card app-status-card--<%= status_colour %> app-status-card__link" href="<%= target %>">
-  <span class="app-status-card__count"><%= count %> &nbsp; </span>
-  <span class="app-status-card__status"><%= state_name %> &nbsp; </span>
+  <span class="app-status-card__count"><%= count %></span>
+  <span class="app-status-card__status"> <%= state_name %></span>
   <span class="govuk-visually-hidden"> records. View these records.</span>
 </a>


### PR DESCRIPTION
#2240 accidentally introduced a visible trailing space to the links. This uses a different approach of prepending the second item with a space (that doesn't render).

Before:
<img width="491" alt="Screenshot 2022-04-25 at 12 51 06" src="https://user-images.githubusercontent.com/2204224/165083523-cfbf51dc-dd66-42fe-aebb-5cdb70afa454.png">

After:
<img width="503" alt="Screenshot 2022-04-25 at 12 51 18" src="https://user-images.githubusercontent.com/2204224/165083576-34fe9c0b-d715-415c-9038-a6f3ea52cb48.png">

