### PR TITLE
[xxx] Fix provider associations

### DIFF
--- a/app/models/funding/payment_schedule.rb
+++ b/app/models/funding/payment_schedule.rb
@@ -5,6 +5,10 @@ module Funding
     self.table_name = "funding_payment_schedules"
 
     belongs_to :payable, polymorphic: true
-    has_many :rows, class_name: "Funding::PaymentScheduleRow", dependent: :destroy
+    has_many :rows,
+             class_name: "Funding::PaymentScheduleRow",
+             dependent: :destroy,
+             foreign_key: :funding_payment_schedule_id,
+             inverse_of: :payment_schedule
   end
 end

--- a/app/models/funding/payment_schedule_row.rb
+++ b/app/models/funding/payment_schedule_row.rb
@@ -4,7 +4,15 @@ module Funding
   class PaymentScheduleRow < ApplicationRecord
     self.table_name = "funding_payment_schedule_rows"
 
-    belongs_to :funding_payment_schedule
-    has_many :amounts, class_name: "Funding::PaymentScheduleRowAmount", dependent: :destroy
+    belongs_to :payment_schedule,
+               class_name: "Funding::PaymentSchedule",
+               foreign_key: :funding_payment_schedule_id,
+               inverse_of: :rows
+
+    has_many :amounts,
+             class_name: "Funding::PaymentScheduleRowAmount",
+             foreign_key: :funding_payment_schedule_row_id,
+             dependent: :destroy,
+             inverse_of: :row
   end
 end

--- a/app/models/funding/payment_schedule_row_amount.rb
+++ b/app/models/funding/payment_schedule_row_amount.rb
@@ -4,6 +4,9 @@ module Funding
   class PaymentScheduleRowAmount < ApplicationRecord
     self.table_name = "funding_payment_schedule_row_amounts"
 
-    belongs_to :funding_payment_schedule_row
+    belongs_to :row,
+               class_name: "Funding::PaymentScheduleRow",
+               foreign_key: :funding_payment_schedule_row_id,
+               inverse_of: :amounts
   end
 end

--- a/app/models/funding/trainee_summary.rb
+++ b/app/models/funding/trainee_summary.rb
@@ -5,6 +5,10 @@ module Funding
     self.table_name = "funding_trainee_summaries"
 
     belongs_to :payable, polymorphic: true
-    has_many :rows, class_name: "Funding::TraineePaymentSummaryRow", dependent: :destroy
+    has_many :rows,
+             class_name: "Funding::TraineeSummaryRow",
+             foreign_key: "funding_trainee_summary_id",
+             dependent: :destroy,
+             inverse_of: :trainee_summary
   end
 end

--- a/app/models/funding/trainee_summary_row.rb
+++ b/app/models/funding/trainee_summary_row.rb
@@ -4,7 +4,15 @@ module Funding
   class TraineeSummaryRow < ApplicationRecord
     self.table_name = "funding_trainee_summary_rows"
 
-    belongs_to :trainee_summary
-    has_many :amounts, class_name: "Funding::TraineePaymentSummaryRowAmount", dependent: :destroy
+    belongs_to :trainee_summary,
+               class_name: "Funding::TraineeSummary",
+               foreign_key: :funding_trainee_summary_id,
+               inverse_of: :rows
+
+    has_many :amounts,
+             class_name: "Funding::TraineeSummaryRowAmount",
+             foreign_key: :funding_trainee_summary_row_id,
+             dependent: :destroy,
+             inverse_of: :row
   end
 end

--- a/app/models/funding/trainee_summary_row_amount.rb
+++ b/app/models/funding/trainee_summary_row_amount.rb
@@ -4,6 +4,9 @@ module Funding
   class TraineeSummaryRowAmount < ApplicationRecord
     self.table_name = "funding_trainee_summary_row_amounts"
 
-    belongs_to :trainee_summary_row
+    belongs_to :row,
+               class_name: "Funding::TraineeSummaryRow",
+               foreign_key: :funding_trainee_summary_row_id,
+               inverse_of: :amounts
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -15,8 +15,8 @@ class Provider < ApplicationRecord
   has_many :apply_applications, ->(provider) { unscope(:where).where(accredited_body_code: provider.code) }
   has_many :dttp_trainees, class_name: "Dttp::Trainee", foreign_key: :provider_dttp_id, primary_key: :dttp_id, inverse_of: :provider
 
-  has_many :funding_payment_schedules, as: :payable
-  has_many :funding_trainee_summaries, as: :payable
+  has_many :funding_payment_schedules, class_name: "Funding::PaymentSchedule", as: :payable
+  has_many :funding_trainee_summaries, class_name: "Funding::TraineeSummary", as: :payable
 
   audited
 

--- a/spec/models/funding/payment_schedule_row_amount_spec.rb
+++ b/spec/models/funding/payment_schedule_row_amount_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Funding
+  describe PaymentScheduleRowAmount do
+    describe "associations" do
+      it { is_expected.to belong_to(:row) }
+    end
+  end
+end

--- a/spec/models/funding/payment_schedule_row_spec.rb
+++ b/spec/models/funding/payment_schedule_row_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Funding
+  describe PaymentScheduleRow do
+    describe "associations" do
+      it { is_expected.to have_many(:amounts) }
+      it { is_expected.to belong_to(:payment_schedule) }
+    end
+  end
+end

--- a/spec/models/funding/payment_schedule_spec.rb
+++ b/spec/models/funding/payment_schedule_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Funding
+  describe PaymentSchedule do
+    describe "associations" do
+      it { is_expected.to have_many(:rows) }
+      it { is_expected.to belong_to(:payable) }
+    end
+  end
+end

--- a/spec/models/funding/trainee_summary_row_amount_spec.rb
+++ b/spec/models/funding/trainee_summary_row_amount_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Funding
+  describe TraineeSummaryRowAmount do
+    describe "associations" do
+      it { is_expected.to belong_to(:row) }
+    end
+  end
+end

--- a/spec/models/funding/trainee_summary_row_spec.rb
+++ b/spec/models/funding/trainee_summary_row_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Funding
+  describe TraineeSummaryRow do
+    describe "associations" do
+      it { is_expected.to belong_to(:trainee_summary) }
+      it { is_expected.to have_many(:amounts) }
+    end
+  end
+end

--- a/spec/models/funding/trainee_summary_spec.rb
+++ b/spec/models/funding/trainee_summary_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Funding
+  describe TraineeSummary do
+    describe "associations" do
+      it { is_expected.to have_many(:rows) }
+    end
+  end
+end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -35,6 +35,8 @@ describe Provider do
 
   describe "associations" do
     it { is_expected.to have_many(:users) }
+    it { is_expected.to have_many(:funding_payment_schedules) }
+    it { is_expected.to have_many(:funding_trainee_summaries) }
   end
 
   describe "auditing" do


### PR DESCRIPTION
### Context

We've added associations for the funding classes to `Provider` but they can't resolve the class. 

### Changes proposed in this pull request

* Add the class
* Rename the association, removing the `funding_` prefix. (possibly a bit controversially on the `trainee_summaries` one. Open to convincing to not do that 😁 (UPDATE: it was controversial so I undid that bit)

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
