### PR TITLE
Remove unneeded API_TOKEN_FOR_GITHUB_ACTION refs

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -2,8 +2,6 @@ name: deploy
 description: deploys application
 
 inputs:
-  actions-api-access-token:
-    required: true
   arm-access-key:
     required: true
   azure-credentials:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -160,7 +160,6 @@ jobs:
       id: deploy_review
       uses: ./.github/actions/deploy/
       with:
-        actions-api-access-token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}
         arm-access-key: ${{ secrets.ARM_ACCESS_KEY_REVIEW }}
         azure-credentials: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
         environment: review
@@ -200,7 +199,6 @@ jobs:
       id: deploy_app
       uses: ./.github/actions/deploy/
       with:
-        actions-api-access-token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}
         arm-access-key: ${{ secrets[format('ARM_ACCESS_KEY_{0}', matrix.environment)] }}
         azure-credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
         environment: ${{ matrix.environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
     name: ${{ github.event.inputs.environment }} deployment
     environment:
       name: ${{ github.event.inputs.environment }}
-      url: ${{ steps.deploy_app.outputs.deploy-url }}    
+      url: ${{ steps.deploy_app.outputs.deploy-url }}
     concurrency: deploy_all # ensures that the job waits for any deployments triggered by the build workflow to finish
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +34,6 @@ jobs:
         id: deploy_app
         uses: ./.github/actions/deploy/
         with:
-          actions-api-access-token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}
           arm-access-key: ${{ secrets[format('ARM_ACCESS_KEY_{0}', github.event.inputs.environment)] }}
           azure-credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', github.event.inputs.environment)] }}
           environment: ${{ github.event.inputs.environment }}


### PR DESCRIPTION
### Context
The `API_TOKEN_FOR_GITHUB_ACTION` secret isn't needed for most workflows so it has been removed.  It is still required to delete review environments.

### Changes proposed in this pull request
- Remove `actions-api-access-token` input from deploy workflow

### Guidance to review
- Check build & deploy workflow works as expected

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
