### PR TITLE
Changes for register service domain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,18 +128,22 @@ enable-maintenance: read-tf-config ## make qa enable-maintenance / make producti
 	cf target -s ${space}
 	cd service_unavailable_page && cf push
 	cf map-route register-unavailable register-trainee-teachers.education.gov.uk --hostname ${REAL_HOSTNAME}
+	cf map-route register-unavailable register-trainee-teachers.service.gov.uk --hostname ${REAL_HOSTNAME}
 	cf map-route register-unavailable education.gov.uk --hostname ${DTTP_HOSTNAME}
 	echo Waiting 5s for route to be registered... && sleep 5
 	cf unmap-route register-${DEPLOY_ENV} register-trainee-teachers.education.gov.uk --hostname ${REAL_HOSTNAME}
+	cf unmap-route register-${DEPLOY_ENV} register-trainee-teachers.service.gov.uk --hostname ${REAL_HOSTNAME}
 	cf unmap-route register-${DEPLOY_ENV} education.gov.uk --hostname ${DTTP_HOSTNAME}
 
 disable-maintenance: read-tf-config ## make qa disable-maintenance / make production disable-maintenance CONFIRM_PRODUCTION=y
 	$(if $(HOST_NAME), $(eval REAL_HOSTNAME=${HOST_NAME}), $(eval REAL_HOSTNAME=${DEPLOY_ENV}))
 	cf target -s ${space}
 	cf map-route register-${DEPLOY_ENV} register-trainee-teachers.education.gov.uk --hostname ${REAL_HOSTNAME}
+	cf map-route register-${DEPLOY_ENV} register-trainee-teachers.service.gov.uk --hostname ${REAL_HOSTNAME}
 	cf map-route register-${DEPLOY_ENV} education.gov.uk --hostname ${DTTP_HOSTNAME}
 	echo Waiting 5s for route to be registered... && sleep 5
 	cf unmap-route register-unavailable register-trainee-teachers.education.gov.uk --hostname ${REAL_HOSTNAME}
+	cf unmap-route register-unavailable register-trainee-teachers.service.gov.uk --hostname ${REAL_HOSTNAME}
 	cf unmap-route register-unavailable education.gov.uk --hostname ${DTTP_HOSTNAME}
 	cf delete register-unavailable -r -f
 

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -18,7 +18,7 @@
   "statuscake_alerts": {
     "alert": {
       "website_name": "register-production",
-      "website_url": "https://www.register-trainee-teachers.education.gov.uk/ping",
+      "website_url": "https://www.register-trainee-teachers.service.gov.uk/ping",
       "test_type": "HTTP",
       "check_rate": 60,
       "contact_group": [151103],

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -18,7 +18,7 @@
   "statuscake_alerts": {
     "alert": {
       "website_name": "register-qa",
-      "website_url": "https://qa.register-trainee-teachers.education.gov.uk/ping",
+      "website_url": "https://qa.register-trainee-teachers.service.gov.uk/ping",
       "test_type": "HTTP",
       "check_rate": 60,
       "contact_group": [151103],

--- a/terraform/workspace-variables/sandbox.tfvars.json
+++ b/terraform/workspace-variables/sandbox.tfvars.json
@@ -17,7 +17,7 @@
   "statuscake_alerts": {
     "alert": {
       "website_name": "register-sandbox",
-      "website_url": "https://sandbox.register-trainee-teachers.education.gov.uk/ping",
+      "website_url": "https://sandbox.register-trainee-teachers.service.gov.uk/ping",
       "test_type": "HTTP",
       "check_rate": 60,
       "contact_group": [151103],

--- a/terraform/workspace-variables/staging.tfvars.json
+++ b/terraform/workspace-variables/staging.tfvars.json
@@ -18,7 +18,7 @@
   "statuscake_alerts": {
     "alert": {
       "website_name": "register-staging",
-      "website_url": "https://staging.register-trainee-teachers.education.gov.uk/ping",
+      "website_url": "https://staging.register-trainee-teachers.service.gov.uk/ping",
       "test_type": "HTTP",
       "check_rate": 60,
       "contact_group": [151103],


### PR DESCRIPTION
### Context

Changes required as part of the move from education.gov.uk to service.gov.uk

### Changes proposed in this pull request

- statuscake website_url updated to the service domain
- Add the service domain to the maintenance page

### Guidance to review

deploy-plan

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
