### PR TITLE
4064 upload hesa review extension to news and guidance

### DIFF
--- a/app/models/service_update.rb
+++ b/app/models/service_update.rb
@@ -17,7 +17,7 @@ class ServiceUpdate
     end
   end
 
-  def self.recent_update
-    all.first
+  def self.recent_updates
+    all.select { |service_update| service_update.date > 1.month.ago }
   end
 end

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -9,7 +9,9 @@
 <div class="govuk-grid-row govuk-main-wrapper--auto-spacing">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h2 class="govuk-heading-l"><%= t(".service_updates_title") %></h2>
-    <%= render ServiceUpdate::View.new(service_update: ServiceUpdate.recent_update) %>
+    <% ServiceUpdate.recent_updates.each do |service_update| %>
+      <%= render ServiceUpdate::View.new(service_update: service_update) %>
+    <% end %>
     <%= govuk_link_to(t(".service_updates_link"), service_updates_path, { class: "govuk-body" }) %>
   </div>
 </div>

--- a/db/service_updates.yml
+++ b/db/service_updates.yml
@@ -1,3 +1,10 @@
+- date: '2022-04-29'
+  title: April HESA census update extended to Friday 13 May 2022
+  content: |
+    The import from HESA to Register is ongoing. This means if you’re a Higher Education Institute (HEI) of Initial Teacher Training (ITT), you can update and upload data to HESA, but you cannot see this update on Register yet. We’ve extended the deadline for the April census update from 29 April to Friday 13 May.
+
+    We will update you when your data is visible to check on Register.
+
 - date: '2022-03-16'
   title: DTTP switch off and transition to Register
   content: |

--- a/spec/models/service_update_spec.rb
+++ b/spec/models/service_update_spec.rb
@@ -7,8 +7,13 @@ describe ServiceUpdate do
     allow(YAML).to receive(:load_file).and_return(
       [
         {
-          date: "2021-09-17",
+          date: "2021-09-21",
           title: "Most recent item",
+          content: "Ths is also another **Markdown** content.",
+        },
+        {
+          date: "2021-09-17",
+          title: "Second most recent item",
           content: "Ths is another **Markdown** content.",
         },
         {
@@ -22,25 +27,38 @@ describe ServiceUpdate do
 
   describe "#all" do
     it "returns all items" do
-      expect(ServiceUpdate.all.count).to be(2)
+      expect(ServiceUpdate.all.count).to be(3)
 
       expect(ServiceUpdate.all[0].title).to eql("Most recent item")
-      expect(ServiceUpdate.all[0].content).to eql("Ths is another **Markdown** content.")
-      expect(ServiceUpdate.all[0].date).to eql("2021-09-17")
+      expect(ServiceUpdate.all[0].content).to eql("Ths is also another **Markdown** content.")
+      expect(ServiceUpdate.all[0].date).to eql("2021-09-21")
 
-      expect(ServiceUpdate.all[1].title).to eql("Lead and employing schools")
-      expect(ServiceUpdate.all[1].content).to eql("Ths is **Markdown** content.")
-      expect(ServiceUpdate.all[1].date).to eql("2021-09-01")
+      expect(ServiceUpdate.all[1].title).to eql("Second most recent item")
+      expect(ServiceUpdate.all[1].content).to eql("Ths is another **Markdown** content.")
+      expect(ServiceUpdate.all[1].date).to eql("2021-09-17")
+
+      expect(ServiceUpdate.all[2].title).to eql("Lead and employing schools")
+      expect(ServiceUpdate.all[2].content).to eql("Ths is **Markdown** content.")
+      expect(ServiceUpdate.all[2].date).to eql("2021-09-01")
     end
   end
 
   describe "#recent_update" do
-    it "returns recent item" do
-      su = ServiceUpdate.recent_update
+    around do |example|
+      Timecop.freeze(2021, 10, 4) do
+        example.run
+      end
+    end
 
-      expect(su.title).to eql("Most recent item")
-      expect(su.content).to eql("Ths is another **Markdown** content.")
-      expect(su.date).to eql("2021-09-17")
+    it "returns all item within the last month" do
+      su = ServiceUpdate.recent_updates
+
+      expect(su.first.title).to eql("Most recent item")
+      expect(su.first.content).to eql("Ths is also another **Markdown** content.")
+      expect(su.first.date).to eql("2021-09-21")
+      expect(su.last.title).to eql("Second most recent item")
+      expect(su.last.content).to eql("Ths is another **Markdown** content.")
+      expect(su.last.date).to eql("2021-09-17")
     end
   end
 end


### PR DESCRIPTION
### Context

Add hesa review extension news to the news and guidance section. Additionally ensure that all updates within the last month are displayed on the homepage, not just the most recent update. 

https://trello.com/c/3cAni69E/4064-upload-hesa-review-extension-to-news-and-guidance

### Guidance to review

Check that guidance renders correctly.

