### PR TITLE
[4004] Fix missing degrees

### DIFF
--- a/app/jobs/degrees/create_from_dttp_placement_assignment_job.rb
+++ b/app/jobs/degrees/create_from_dttp_placement_assignment_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Degrees
+  class CreateFromDttpPlacementAssignmentJob < ApplicationJob
+    queue_as :dttp
+
+    def perform(trainee)
+      CreateFromDttpPlacementAssignment.call(trainee: trainee)
+    end
+  end
+end

--- a/app/lib/dttp/code_sets/institutions.rb
+++ b/app/lib/dttp/code_sets/institutions.rb
@@ -404,6 +404,22 @@ module Dttp
         "154b9247-7042-e811-80ff-3863bb3640b8" => UNIVERSITY_CAMPUS_SUFFOLK,
         "9823a753-7042-e811-80ff-3863bb3640b8" => UNIVERSITY_OF_THE_ARTS_LONDON,
         "b2d0c9d6-e897-e711-80d8-005056ac45bb" => "The Royal College of Nursing",
+        "c7cfc9d6-e897-e711-80d8-005056ac45bb" => "The Royal Veterinary College",
+        "2a82cdd0-e897-e711-80d8-005056ac45bb" => "Queen Mary and Westfield College",
+        "2279f34a-2887-e711-80d8-005056ac45bb" => "Bradford College",
+        "55cfc9d6-e897-e711-80d8-005056ac45bb" => "Northern School of Contemporary Dance",
+        "8f23a753-7042-e811-80ff-3863bb3640b8" => "University of St Mark and St John",
+        "32582527-3fa2-e811-812b-5065f38ba241" => "University College for the Creative Arts",
+        "4d1ab82c-ee97-e711-80d8-005056ac45bb" => "Harris Academy Tottenham",
+        "3bc46ffa-ee97-e711-80d8-005056ac45bb" => "Harris Academy St John's Wood",
+        "2416761c-e897-e711-80d8-005056ac45bb" => "Colchester Institute",
+        "2d687c16-e897-e711-80d8-005056ac45bb" => "NCG",
+        "5cbfbf8a-eb97-e711-80d8-005056ac45bb" => "Guildhall School of Music and Drama",
+        "6bc46ffa-ee97-e711-80d8-005056ac45bb" => "Harris Garrard Academy",
+        "edde3e30-ec97-e711-80d8-005056ac45bb" => "Harris Academy Purley",
+        "164a42d4-eb97-e711-80d8-005056ac45bb" => "Harris Academy Falconwood",
+        "25538b4e-ed97-e711-80d8-005056ac45bb" => "Harris Academy Beckenham",
+        "6f9e8dac-e897-e711-80d8-005056ac45bb" => "London College of Printing & Distributive Trades",
       }.freeze
     end
   end

--- a/app/services/degrees/create_from_dttp_placement_assignment.rb
+++ b/app/services/degrees/create_from_dttp_placement_assignment.rb
@@ -62,7 +62,8 @@ module Degrees
 
     def institution
       find_by_entity_id(placement_assignment.degree_awarding_institution, Dttp::CodeSets::Institutions::MAPPING) ||
-        Dttp::CodeSets::Institutions::INACTIVE_MAPPING[placement_assignment.degree_awarding_institution]
+        Dttp::CodeSets::Institutions::INACTIVE_MAPPING[placement_assignment.degree_awarding_institution] ||
+        Dttp::Account.find_by(dttp_id: placement_assignment.degree_awarding_institution)&.response&.fetch("name")
     end
 
     def grade


### PR DESCRIPTION
### Context
https://trello.com/c/f9xgRPny/4063-dttp-unmapped-degrees

There are 32095 trainees with no degree. Not all of them need one, but we having a problem of missing degrees. This is because the trainee has no DTTP degree qualifications to import from. The only other place with degree information is their DTTP placement assignment. This creates a new job to create a trainee's degree from their latest placement assignment.

We still have 3 missing instituions that cannot be found.

### Changes proposed in this pull request
- Add missing institutions not available in the `dttp_accounts` table
- New job to create degree from trainee's latest DTTP placement assignment