### PR TITLE
[4070] Enable HESA import for DTTP import environment

### DIFF
--- a/config/settings/dttpimport.yml
+++ b/config/settings/dttpimport.yml
@@ -31,6 +31,7 @@ features:
     school_direct_tuition_fee: true
   google:
     send_data_to_big_query: false
+  sync_from_hesa: true
 
 environment:
   name: dttpimport


### PR DESCRIPTION
### Context
https://trello.com/c/aWhhE7oQ/4070-turn-on-hesa-import-for-dttp-import-environment
