### PR TITLE
[4053] Make accreditation_id unique on Provider

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -9,7 +9,7 @@ class Provider < ApplicationRecord
   validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
   validates :code, format: { with: /\A[A-Z0-9]+\z/i }, allow_blank: true
   validates :ukprn, format: { with: /\A[0-9]{8}\z/ }
-  validates :accreditation_id, presence: true
+  validates :accreditation_id, presence: true, uniqueness: true
 
   has_many :courses, class_name: "Course", foreign_key: :accredited_body_code, primary_key: :code, inverse_of: :provider
   has_many :apply_applications, ->(provider) { unscope(:where).where(accredited_body_code: provider.code) }

--- a/db/migrate/20220503114908_add_unique_constraint_to_accrediation_id_on_providers.rb
+++ b/db/migrate/20220503114908_add_unique_constraint_to_accrediation_id_on_providers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUniqueConstraintToAccrediationIdOnProviders < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :providers, :accreditation_id
+    add_index :providers, :accreditation_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_25_170224) do
+ActiveRecord::Schema.define(version: 2022_05_03_114908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -480,7 +480,7 @@ ActiveRecord::Schema.define(version: 2022_04_25_170224) do
     t.string "code"
     t.string "ukprn"
     t.string "accreditation_id"
-    t.index ["accreditation_id"], name: "index_providers_on_accreditation_id"
+    t.index ["accreditation_id"], name: "index_providers_on_accreditation_id", unique: true
     t.index ["dttp_id"], name: "index_providers_on_dttp_id", unique: true
   end
 

--- a/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
+++ b/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
@@ -30,14 +30,14 @@ feature "Creating a new provider" do
     then_i_see_error_messages
   end
 
-# scenario "submitting with an existing accreditation ID" do
-#   when_i_enter_an_existing_accreditation_id
-#   and_i_fill_in_name
-#   and_i_fill_in_dttp_id
-#   and_i_fill_in_ukprn
-#   and_i_submit_the_form
-#   then_i_see_accreditation_id_uniqueness_error
-# end
+  scenario "submitting with an existing accreditation ID" do
+    when_i_enter_an_existing_accreditation_id
+    and_i_fill_in_name
+    and_i_fill_in_dttp_id
+    and_i_fill_in_ukprn
+    and_i_submit_the_form
+    then_i_see_accreditation_id_uniqueness_error
+  end
 
 private
 

--- a/spec/features/system_admin/providers/editing_a_provider_spec.rb
+++ b/spec/features/system_admin/providers/editing_a_provider_spec.rb
@@ -27,11 +27,11 @@ feature "Edit providers" do
       then_i_should_see_the_provider_index_page
     end
 
-    # scenario "editing with an existing accreditation ID" do
-    #   when_i_enter_an_existing_accreditation_id
-    #   and_i_submit_the_form
-    #   then_i_see_accreditation_id_uniqueness_error
-    # end
+    scenario "editing with an existing accreditation ID" do
+      when_i_enter_an_existing_accreditation_id
+      and_i_submit_the_form
+      then_i_see_accreditation_id_uniqueness_error
+    end
   end
 
   def when_i_visit_the_provider_index_page


### PR DESCRIPTION
### Context

https://trello.com/c/joHq9QVg/4053-s-make-accreditation-id-unique-and-required-on-the-provider-model-and-at-the-db-level

### Changes proposed in this pull request

- Add a unique constraint on accreditation_id on providers in the DB
- Add a unique validation on accreditation_id the providers model
- Uncomment tests for uniqueness checks

Note: There are a couple of test providers in production and lots in staging that currently have no accreditation_id. We could make up fake (but unique) ones for these providers, but in the interest of getting the uniqueness constraint in, I'm leaving the DB presence out for now.

### Guidance to review

- Sign in as an admin
- In the system admin interface, add an accreditation ID to a provider that already exists on another provider
- Check the error message is correct when you try and save

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
