### PR TITLE
[4090] Fix incorrectly mapped degree types

### DIFF
--- a/app/lib/dttp/code_sets/degree_types.rb
+++ b/app/lib/dttp/code_sets/degree_types.rb
@@ -205,7 +205,7 @@ module Dttp
           hint: "Including level 6 qualifications, graduate certificates and diplomas, degree apprenticeships and ordinary degrees",
           hesa_code: "402",
         },
-        "Unknown" => { entity_id: "6f6a5652-c197-e711-80d8-005056ac45bb", abbreviation: nil },
+        "Unknown" => { entity_id: "6f6a5652-c197-e711-80d8-005056ac45bb", abbreviation: nil, hesa_code: "999" },
       }.freeze
 
       INACTIVE_MAPPING = {

--- a/app/services/degrees/create_from_hesa.rb
+++ b/app/services/degrees/create_from_hesa.rb
@@ -34,8 +34,8 @@ module Degrees
 
     def country_specific_attributes(degree, hesa_degree)
       country = Hesa::CodeSets::Countries::MAPPING[hesa_degree[:country]]
-      degree_type = Hesa::CodeSets::DegreeTypes::MAPPING[hesa_degree[:degree_type]]
       institution = Hesa::CodeSets::Institutions::MAPPING[hesa_degree[:institution]]
+      degree_type = find_degree_type(hesa_degree[:degree_type])
 
       # Country code is not always provided, so we have
       # to fallback to institution which is always UK based
@@ -67,6 +67,10 @@ module Degrees
 
     def uk_country?(country)
       Hesa::CodeSets::Countries::UK_COUNTRIES.include?(country)
+    end
+
+    def find_degree_type(hesa_code)
+      Dttp::CodeSets::DegreeTypes::MAPPING.find { |_, v| v[:hesa_code].to_i == hesa_code.to_i }&.first
     end
   end
 end

--- a/db/data/20220505125913_fix_degree_types_form_hesa_data_import.rb
+++ b/db/data/20220505125913_fix_degree_types_form_hesa_data_import.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FixDegreeTypesFormHesaDataImport < ActiveRecord::Migration[6.1]
+  def up
+    Hesa::CodeSets::DegreeTypes::MAPPING.each do |hesa_code, hesa_degree_type|
+      register_degree_type = Dttp::CodeSets::DegreeTypes::MAPPING.find { |_, v| v[:hesa_code].to_i == hesa_code.to_i }&.first
+      if register_degree_type
+        Degree.where(uk_degree: hesa_degree_type).update_all(uk_degree: register_degree_type)
+        Degree.where(non_uk_degree: hesa_degree_type).update_all(non_uk_degree: register_degree_type)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -58,7 +58,7 @@ module Degrees
         it "sets non-UK attributes only" do
           expect(degree.locale_code).to eq("non_uk")
           expect(degree.uk_degree).to be_nil
-          expect(degree.non_uk_degree).to eq("Master of Science (M SC)")
+          expect(degree.non_uk_degree).to eq("Master of Science")
           expect(degree.subject).to eq("Mathematics")
           expect(degree.institution).to be_nil
           expect(degree.graduation_year).to eq(2004)


### PR DESCRIPTION
### Context
https://trello.com/c/VXqjt6lu/4090-fix-incorrectly-mapped-degree-types

### Changes proposed in this pull request
 - Fix `Degrees::CreateFromHesa` so it maps the degree type hesa code to `Dttp::CodeSets::DegreeTypes::MAPPING`, not `Hesa::CodeSets::DegreeTypes::MAPPING`
 - Data migration to fix the existing degree types that were import using `Hesa::CodeSets::DegreeTypes::MAPPING`
