### PR TITLE
Fixed outputs on build-nocache workflow

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ env.IMAGE_TAG }}
+      docker_image: ${{ env.DOCKER_IMAGE }}
     env:
       DOCKER_IMAGE: ghcr.io/dfe-digital/register-trainee-teachers
 
@@ -91,8 +94,6 @@ jobs:
   audit:
     name: Audit
     needs: [build]
-    outputs:
-      image_tag: ${{ needs.build.outputs.image_tag }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Context
The build-nocache workflow is failing because outputs aren't being passed from the build job to the audit job.

### Changes proposed in this pull request
Moved outputs from audit workflow to build workflow.

### Guidance to review
Review [test run](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/2292801427) and confirm it works as expected (it is erroring on the bundle audit but these appear unrelated to the workflow definition).

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
