### PR TITLE
[4099] enable service domain redirect in prod

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,5 +1,5 @@
 # The url for this app, also used by `dfe_sign_in`
-base_url: https://www.register-trainee-teachers.education.gov.uk
+base_url: https://www.register-trainee-teachers.service.gov.uk
 
 # The url for the google doc feedback link (live version)
 feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLScTW00rH5Gm8Ama38fgGNQ6Ek7CQPRyadjBfp3BvhYkwJS1jw/viewform"
@@ -43,7 +43,6 @@ features:
     send_data_to_big_query: true
   integrate_with_dqt: true
   sync_from_hesa: true
-  redirect_education_domain: false
 
 environment:
   name: beta


### PR DESCRIPTION
### Context

We've added and tested code to redirect `education.gov.uk` to `service.gov.uk`. This works in qa, review apps and staging.

### Changes proposed in this pull request

Enable the redirect in prod.

### Guidance to review

Please consider whether any other configuration needs to be updated for this. I've added `www.register-trainee-teachers.service.gov.uk` to the sign-in and sign-out sections of the DFE Sign-In configuration, please also validate those changes if you can.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
