### PR TITLE
[4099] enable service domain redirect in sandbox

### DIFF
--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -1,5 +1,5 @@
 # The url for this app, also used by `dfe_sign_in`
-base_url: https://sandbox.register-trainee-teachers.education.gov.uk
+base_url: https://sandbox.register-trainee-teachers.service.gov.uk
 
 dttp:
   scope: https://dttp-test.crm4.dynamics.com/.default


### PR DESCRIPTION
### Context

After testing the redirect in staging, it's still not enabled for sandbox. Best to sort this out before we do prod.

### Changes proposed in this pull request

Enable `education.gov.uk` -> `service.gov.uk` redirect in sandbox env.

### Guidance to review

DSI service config has been updated to add the `sandbox.register-trainee-teachers.service.gov.uk` domain

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
