### PR TITLE
[4092] Data migration to remove duplicate degrees

### DIFF
--- a/db/data/20220510084951_remove_trainee_duplicate_degrees.rb
+++ b/db/data/20220510084951_remove_trainee_duplicate_degrees.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class RemoveTraineeDuplicateDegrees < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.all.each do |trainee|
+      next unless trainee.degrees.count > 1
+
+      duplicate_ids = find_duplicate_ids(trainee.degrees)
+      if duplicate_ids.any?
+        trainee.degrees.where(id: duplicate_ids).delete_all
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def find_duplicate_ids(degrees)
+    ids = []
+    set = Set.new
+    degrees.each do |degree|
+      digest = degree.values_at(:subject, :institution, :graduation_year, :uk_degree, :non_uk_degree).join
+      if set.include?(digest)
+        ids << degree.id
+      else
+        set.add(digest)
+      end
+    end
+    ids
+  end
+end

--- a/db/data/20220510084951_remove_trainee_duplicate_degrees.rb
+++ b/db/data/20220510084951_remove_trainee_duplicate_degrees.rb
@@ -2,7 +2,7 @@
 
 class RemoveTraineeDuplicateDegrees < ActiveRecord::Migration[6.1]
   def up
-    Trainee.all.each do |trainee|
+    Trainee.find_each do |trainee|
       next unless trainee.degrees.count > 1
 
       duplicate_ids = find_duplicate_ids(trainee.degrees)


### PR DESCRIPTION
### Context

trello ticket: https://trello.com/c/51qAPRcB/4092-some-trainees-have-duplicate-degrees

It was identified that some trainees imported from DTTP had duplicate degrees. These need to be removed so providers can check their data easily.

The data migration in this PR takes a couple of minutes to run. We decided to do this as a data migration so that we can keep track of this change to the data.

Note we've managed to remove approx. 6000 duplicates with this migration. We have identified some degrees that are not exact duplicates, but do look very similar (such as the subject name differing slightly), however these would need to be reviewed by the provider on a case by case basis to understand if they are actually duplicates/which one is the correct degree.

List of trainees, where some have potential duplicate degrees (that we cannot easily identify): 
[53974, 53655, 11188, 56344, 56460, 56107, 56446, 56406, 56308, 56427, 56110, 57191, 57130, 56493, 56496, 57180, 57214, 57206, 59206, 59277, 59457, 60242, 59677, 60438, 61558, 61275, 61397, 61720, 61751, 61677, 62092]

### Changes proposed in this pull request

* Data migration to remove duplicate degrees. 

### Guidance to review

* Check out the branch and run the data migration with a prod back-up, check it runs as expected.
* Cross check a few trainees to make sure their degrees look as expected.

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
