### PR TITLE
[4041] Add funding rules for academic year 22/23

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -177,7 +177,6 @@ private
       itt_start_date: itt_start_date,
       itt_end_date: itt_end_date,
       course_education_phase: course_education_phase,
-      course_allocation_subject: course_allocation_subject,
     }
 
     set_course_subject_from_primary_phase if is_primary_phase?
@@ -188,6 +187,7 @@ private
         course_subject_two: course_subject_two.presence,
         course_subject_three: course_subject_three.presence,
         course_age_range: course_age_range,
+        course_allocation_subject: course_allocation_subject,
       })
     end
 

--- a/app/forms/language_specialisms_form.rb
+++ b/app/forms/language_specialisms_form.rb
@@ -4,6 +4,7 @@ class LanguageSpecialismsForm < TraineeForm
   include ActiveModel::Model
   include ActiveModel::AttributeAssignment
   include ActiveModel::Validations::Callbacks
+  include CourseFormHelpers
 
   FIELDS = %i[
     language_specialisms
@@ -31,6 +32,19 @@ class LanguageSpecialismsForm < TraineeForm
 
   def language_specialisms
     (@language_specialisms || []).compact_blank
+  end
+
+  def save!
+    return false unless valid?
+
+    trainee.assign_attributes(
+      course_subject_one: course_subject_one,
+      course_subject_two: course_subject_two,
+      course_subject_three: course_subject_three,
+      course_allocation_subject: course_allocation_subject,
+    )
+    Trainees::Update.call(trainee: trainee)
+    clear_stash
   end
 
   def stash

--- a/app/forms/subject_specialism_form.rb
+++ b/app/forms/subject_specialism_form.rb
@@ -4,6 +4,7 @@ class SubjectSpecialismForm < TraineeForm
   include ActiveModel::Model
   include ActiveModel::AttributeAssignment
   include ActiveModel::Validations::Callbacks
+  include CourseFormHelpers
 
   FIELDS = %i[
     course_subject_one
@@ -29,6 +30,19 @@ class SubjectSpecialismForm < TraineeForm
       course_subject_two,
       course_subject_three,
     ].compact
+  end
+
+  def save!
+    return false unless valid?
+
+    trainee.assign_attributes(
+      course_subject_one: course_subject_one,
+      course_subject_two: course_subject_two,
+      course_subject_three: course_subject_three,
+      course_allocation_subject: course_allocation_subject,
+    )
+    Trainees::Update.call(trainee: trainee)
+    clear_stash
   end
 
   def stash

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -332,8 +332,10 @@ class Trainee < ApplicationRecord
 
   def set_early_years_course_details
     if early_years_route?
-      self.course_subject_one = CourseSubjects::EARLY_YEARS_TEACHING
+      course_subject = CourseSubjects::EARLY_YEARS_TEACHING
+      self.course_subject_one = course_subject
       self.course_age_range = AgeRange::ZERO_TO_FIVE
+      self.course_allocation_subject = SubjectSpecialism.find_by(name: course_subject)&.allocation_subject
     end
   end
 

--- a/config/initializers/academic_cycles.rb
+++ b/config/initializers/academic_cycles.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-CURRENT_ACADEMIC_CYCLE_ID = 7 # { start_date: "01/9/2021", end_date: "31/8/2022" },
-
 ACADEMIC_CYCLES = [
   { start_date: "01/9/2015", end_date: "31/8/2016" },
   { start_date: "01/9/2016", end_date: "31/8/2017" },

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -348,13 +348,6 @@ GRANTS_2023 = [
     ],
   ),
   OpenStruct.new(
-    training_route: TRAINING_ROUTE_ENUMS[:early_years_postgrad],
-    amount: 7_000,
-    allocation_subjects: [
-      AllocationSubjects::EARLY_YEARS_ITT,
-    ],
-  ),
-  OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
     amount: 24_000,
     allocation_subjects: [

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -399,7 +399,7 @@ GRANTS_2022_TO_2023 = [
   ),
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
-    amount: 6_000,
+    amount: 1_000,
     allocation_subjects: [
       AllocationSubjects::BIOLOGY,
     ],

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -314,6 +314,7 @@ BURSARIES_2022_TO_2023 = [
       AllocationSubjects::PHYSICS,
       AllocationSubjects::COMPUTING,
       AllocationSubjects::MODERN_LANGUAGES,
+      AllocationSubjects::ANCIENT_LANGUAGES,
     ],
   ),
 ].freeze

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -92,7 +92,7 @@ EARLY_YEARS_TRAINING_ROUTES = TRAINING_ROUTES.select { |t| t.starts_with?(EARLY_
 
 # 2021 funding rules (which also applied to 2022)
 
-BURSARIES_2021 = [
+BURSARIES_2020_TO_2021 = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_undergrad],
     amount: 9_000,
@@ -163,7 +163,7 @@ BURSARIES_2021 = [
   ),
 ].freeze
 
-SCHOLARSHIPS_2021 = [
+SCHOLARSHIPS_2020_TO_2021 = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 26_000,
@@ -186,7 +186,7 @@ SCHOLARSHIPS_2021 = [
   ),
 ].freeze
 
-GRANTS_2021 = [
+GRANTS_2020_TO_2021 = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:early_years_salaried],
     amount: 14_000,
@@ -239,9 +239,11 @@ GRANTS_2021 = [
   ),
 ].freeze
 
-# 2023 funding rules
+BURSARIES_2021_TO_2022 = BURSARIES_2020_TO_2021
+SCHOLARSHIPS_2021_TO_2022 = SCHOLARSHIPS_2020_TO_2021
+GRANTS_2021_TO_2022 = GRANTS_2020_TO_2021
 
-BURSARIES_2023 = [
+BURSARIES_2022_TO_2023 = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_undergrad],
     amount: 9_000,
@@ -316,7 +318,7 @@ BURSARIES_2023 = [
   ),
 ].freeze
 
-SCHOLARSHIPS_2023 = [
+SCHOLARSHIPS_2022_TO_2023 = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 26_000,
@@ -339,7 +341,7 @@ SCHOLARSHIPS_2023 = [
   ),
 ].freeze
 
-GRANTS_2023 = [
+GRANTS_2022_TO_2023 = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:early_years_salaried],
     amount: 14_000,

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -90,18 +90,12 @@ EARLY_YEARS_ROUTE_NAME_PREFIX = "early_years"
 
 EARLY_YEARS_TRAINING_ROUTES = TRAINING_ROUTES.select { |t| t.starts_with?(EARLY_YEARS_ROUTE_NAME_PREFIX) }
 
-EARLY_YEARS_GRANT = OpenStruct.new(
-  training_route: TRAINING_ROUTE_ENUMS[:early_years_salaried],
-  amount: 14_000,
-  academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
-  allocation_subjects: [AllocationSubjects::EARLY_YEARS_ITT],
-).freeze
+# 2021 funding rules (which also applied to 2022)
 
-SEED_BURSARIES = [
+BURSARIES_2021 = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_undergrad],
     amount: 9_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MATHEMATICS,
       AllocationSubjects::PHYSICS,
@@ -110,7 +104,6 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 24_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -121,7 +114,6 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 10_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MODERN_LANGUAGES,
       AllocationSubjects::CLASSICS,
@@ -130,7 +122,6 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 7_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::BIOLOGY,
     ],
@@ -138,7 +129,6 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 24_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -149,7 +139,6 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 10_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MODERN_LANGUAGES,
       AllocationSubjects::CLASSICS,
@@ -158,7 +147,6 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 7_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::BIOLOGY,
     ],
@@ -166,7 +154,6 @@ SEED_BURSARIES = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:opt_in_undergrad],
     amount: 9_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MATHEMATICS,
       AllocationSubjects::PHYSICS,
@@ -176,11 +163,10 @@ SEED_BURSARIES = [
   ),
 ].freeze
 
-SEED_SCHOLARSHIPS = [
+SCHOLARSHIPS_2021 = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
     amount: 26_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -191,7 +177,6 @@ SEED_SCHOLARSHIPS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
     amount: 26_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -201,12 +186,17 @@ SEED_SCHOLARSHIPS = [
   ),
 ].freeze
 
-SEED_GRANTS = [
-  EARLY_YEARS_GRANT,
+GRANTS_2021 = [
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:early_years_salaried],
+    amount: 14_000,
+    allocation_subjects: [
+      AllocationSubjects::EARLY_YEARS_ITT,
+    ],
+  ),
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
     amount: 24_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -217,7 +207,6 @@ SEED_GRANTS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
     amount: 10_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MODERN_LANGUAGES,
       AllocationSubjects::CLASSICS,
@@ -226,7 +215,6 @@ SEED_GRANTS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
     amount: 7_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::BIOLOGY,
     ],
@@ -234,7 +222,6 @@ SEED_GRANTS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
     amount: 15_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::CHEMISTRY,
       AllocationSubjects::COMPUTING,
@@ -245,10 +232,180 @@ SEED_GRANTS = [
   OpenStruct.new(
     training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
     amount: 1_000,
-    academic_cycle_id: CURRENT_ACADEMIC_CYCLE_ID,
     allocation_subjects: [
       AllocationSubjects::MODERN_LANGUAGES,
       AllocationSubjects::CLASSICS,
+    ],
+  ),
+].freeze
+
+# 2023 funding rules
+
+BURSARIES_2023 = [
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_undergrad],
+    amount: 9_000,
+    allocation_subjects: [
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 24_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 15_000,
+    allocation_subjects: [
+      AllocationSubjects::DESIGN_AND_TECHNOLOGY,
+      AllocationSubjects::GEOGRAPHY,
+      AllocationSubjects::MODERN_LANGUAGES,
+      AllocationSubjects::ANCIENT_LANGUAGES,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 10_000,
+    allocation_subjects: [
+      AllocationSubjects::BIOLOGY,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 24_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 15_000,
+    allocation_subjects: [
+      AllocationSubjects::DESIGN_AND_TECHNOLOGY,
+      AllocationSubjects::GEOGRAPHY,
+      AllocationSubjects::MODERN_LANGUAGES,
+      AllocationSubjects::ANCIENT_LANGUAGES,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 10_000,
+    allocation_subjects: [
+      AllocationSubjects::BIOLOGY,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:opt_in_undergrad],
+    amount: 9_000,
+    allocation_subjects: [
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MODERN_LANGUAGES,
+    ],
+  ),
+].freeze
+
+SCHOLARSHIPS_2023 = [
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 26_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 26_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+].freeze
+
+GRANTS_2023 = [
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:early_years_salaried],
+    amount: 14_000,
+    allocation_subjects: [
+      AllocationSubjects::EARLY_YEARS_ITT,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:early_years_postgrad],
+    amount: 7_000,
+    allocation_subjects: [
+      AllocationSubjects::EARLY_YEARS_ITT,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
+    amount: 24_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
+    amount: 15_000,
+    allocation_subjects: [
+      AllocationSubjects::DESIGN_AND_TECHNOLOGY,
+      AllocationSubjects::GEOGRAPHY,
+      AllocationSubjects::MODERN_LANGUAGES,
+      AllocationSubjects::ANCIENT_LANGUAGES,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
+    amount: 10_000,
+    allocation_subjects: [
+      AllocationSubjects::BIOLOGY,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
+    amount: 15_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
+    amount: 6_000,
+    allocation_subjects: [
+      AllocationSubjects::DESIGN_AND_TECHNOLOGY,
+      AllocationSubjects::GEOGRAPHY,
+      AllocationSubjects::MODERN_LANGUAGES,
+      AllocationSubjects::ANCIENT_LANGUAGES,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
+    amount: 6_000,
+    allocation_subjects: [
+      AllocationSubjects::BIOLOGY,
     ],
   ),
 ].freeze

--- a/db/data/20220509110941_seed_academic_cycles_for20222023.rb
+++ b/db/data/20220509110941_seed_academic_cycles_for20222023.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class SeedAcademicCyclesFor20222023 < ActiveRecord::Migration[6.1]
+  def up
+    # i.e. the academic cycle 2022/23 for the recruitment year 2022
+    academic_cycle = AcademicCycle.for_year(2022)
+
+    SEED_2023_BURSARIES.each do |b|
+      bursary = FundingMethod.find_or_create_by!(
+        training_route: b.training_route,
+        amount: b.amount,
+        funding_type: FUNDING_TYPE_ENUMS[:bursary],
+        academic_cycle: academic_cycle,
+      )
+      b.allocation_subjects.map do |subject|
+        allocation_subject = AllocationSubject.find_by!(name: subject)
+        bursary.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
+      end
+    end
+
+    SEED_2023_SCHOLARSHIPS.each do |s|
+      funding_method = FundingMethod.find_or_create_by!(
+        training_route: s.training_route,
+        amount: s.amount,
+        funding_type: FUNDING_TYPE_ENUMS[:scholarship],
+        academic_cycle_: academic_cycle,
+      )
+      s.allocation_subjects.map do |subject|
+        allocation_subject = AllocationSubject.find_by!(name: subject)
+        funding_method.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
+      end
+    end
+
+    SEED_2023_GRANTS.each do |s|
+      funding_method = FundingMethod.find_or_create_by!(
+        training_route: s.training_route,
+        amount: s.amount,
+        funding_type: FUNDING_TYPE_ENUMS[:grant],
+        academic_cycle: academic_cycle,
+      )
+      s.allocation_subjects.map do |subject|
+        allocation_subject = AllocationSubject.find_by!(name: subject)
+        funding_method.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20220510141655_add_funding_methods_for20222023.rb
+++ b/db/data/20220510141655_add_funding_methods_for20222023.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class SeedAcademicCyclesFor20222023 < ActiveRecord::Migration[6.1]
+class AddFundingMethodsFor20222023 < ActiveRecord::Migration[6.1]
   def up
     # i.e. the academic cycle 2022/23 for the recruitment year 2022
     academic_cycle = AcademicCycle.for_year(2022)
 
-    SEED_2023_BURSARIES.each do |b|
+    BURSARIES_2023.each do |b|
       bursary = FundingMethod.find_or_create_by!(
         training_route: b.training_route,
         amount: b.amount,
@@ -18,12 +18,12 @@ class SeedAcademicCyclesFor20222023 < ActiveRecord::Migration[6.1]
       end
     end
 
-    SEED_2023_SCHOLARSHIPS.each do |s|
+    SCHOLARSHIPS_2023.each do |s|
       funding_method = FundingMethod.find_or_create_by!(
         training_route: s.training_route,
         amount: s.amount,
         funding_type: FUNDING_TYPE_ENUMS[:scholarship],
-        academic_cycle_: academic_cycle,
+        academic_cycle: academic_cycle,
       )
       s.allocation_subjects.map do |subject|
         allocation_subject = AllocationSubject.find_by!(name: subject)
@@ -31,7 +31,7 @@ class SeedAcademicCyclesFor20222023 < ActiveRecord::Migration[6.1]
       end
     end
 
-    SEED_2023_GRANTS.each do |s|
+    GRANTS_2023.each do |s|
       funding_method = FundingMethod.find_or_create_by!(
         training_route: s.training_route,
         amount: s.amount,

--- a/db/data/20220510141655_add_funding_methods_for20222023.rb
+++ b/db/data/20220510141655_add_funding_methods_for20222023.rb
@@ -5,7 +5,7 @@ class AddFundingMethodsFor20222023 < ActiveRecord::Migration[6.1]
     # i.e. the academic cycle 2022/23 for the recruitment year 2022
     academic_cycle = AcademicCycle.for_year(2022)
 
-    BURSARIES_2023.each do |b|
+    BURSARIES_2022_TO_2023.each do |b|
       bursary = FundingMethod.find_or_create_by!(
         training_route: b.training_route,
         amount: b.amount,
@@ -18,7 +18,7 @@ class AddFundingMethodsFor20222023 < ActiveRecord::Migration[6.1]
       end
     end
 
-    SCHOLARSHIPS_2023.each do |s|
+    SCHOLARSHIPS_2022_TO_2023.each do |s|
       funding_method = FundingMethod.find_or_create_by!(
         training_route: s.training_route,
         amount: s.amount,
@@ -31,7 +31,7 @@ class AddFundingMethodsFor20222023 < ActiveRecord::Migration[6.1]
       end
     end
 
-    GRANTS_2023.each do |s|
+    GRANTS_2022_TO_2023.each do |s|
       funding_method = FundingMethod.find_or_create_by!(
         training_route: s.training_route,
         amount: s.amount,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,22 +58,21 @@ end
 SEED_FUNDING_RULES = [
   {
     academic_cycle: AcademicCycle.for_year(2020),
-    bursaries: BURSARIES_2021,
-    scholarships: SCHOLARSHIPS_2021,
-    grants: GRANTS_2021,
+    bursaries: BURSARIES_2020_TO_2021,
+    scholarships: SCHOLARSHIPS_2020_TO_2021,
+    grants: GRANTS_2020_TO_2021,
   },
-  # 2022 bursaries and scholarships were the same as 2021
   {
     academic_cycle: AcademicCycle.for_year(2021),
-    bursaries: BURSARIES_2021,
-    scholarships: SCHOLARSHIPS_2021,
-    grants: GRANTS_2021,
+    bursaries: BURSARIES_2021_TO_2022,
+    scholarships: SCHOLARSHIPS_2021_TO_2022,
+    grants: GRANTS_2021_TO_2022,
   },
   {
     academic_cycle: AcademicCycle.for_year(2022),
-    bursaries: BURSARIES_2023,
-    scholarships: SCHOLARSHIPS_2023,
-    grants: GRANTS_2023,
+    bursaries: BURSARIES_2022_TO_2023,
+    scholarships: SCHOLARSHIPS_2022_TO_2023,
+    grants: GRANTS_2022_TO_2023,
   },
 ].freeze
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,38 +55,56 @@ ACADEMIC_CYCLES.each do |academic_cycle|
   AcademicCycle.find_or_create_by!(start_date: academic_cycle[:start_date], end_date: academic_cycle[:end_date])
 end
 
-(Settings.current_default_course_year..Time.zone.today.year).each do |year|
-  academic_cycle = AcademicCycle.for_year(year)
+SEED_FUNDING_RULES = [
+  {
+    academic_cycle: AcademicCycle.for_year(2020),
+    bursaries: BURSARIES_2021,
+    scholarships: SCHOLARSHIPS_2021,
+    grants: GRANTS_2021,
+  },
+  # 2022 bursaries and scholarships were the same as 2021
+  {
+    academic_cycle: AcademicCycle.for_year(2021),
+    bursaries: BURSARIES_2021,
+    scholarships: SCHOLARSHIPS_2021,
+    grants: GRANTS_2021,
+  },
+  {
+    academic_cycle: AcademicCycle.for_year(2022),
+    bursaries: BURSARIES_2023,
+    scholarships: SCHOLARSHIPS_2023,
+    grants: GRANTS_2023,
+  },
+].freeze
 
-  SEED_BURSARIES.each do |b|
+SEED_FUNDING_RULES.each do |rule|
+  rule[:bursaries].each do |b|
     bursary = FundingMethod.find_or_create_by!(training_route: b.training_route,
                                                amount: b.amount,
-                                               academic_cycle: academic_cycle)
-    bursary.funding_type = :bursary
-    bursary.save!
-
+                                               funding_type: FUNDING_TYPE_ENUMS[:bursary],
+                                               academic_cycle: rule[:academic_cycle])
     b.allocation_subjects.map do |subject|
       allocation_subject = AllocationSubject.find_by!(name: subject)
       bursary.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
     end
   end
 
-  SEED_SCHOLARSHIPS.each do |s|
+  rule[:scholarships].each do |s|
     funding_method = FundingMethod.find_or_create_by!(training_route: s.training_route,
                                                       amount: s.amount,
                                                       funding_type: FUNDING_TYPE_ENUMS[:scholarship],
-                                                      academic_cycle: academic_cycle)
+                                                      academic_cycle: rule[:academic_cycle])
     s.allocation_subjects.map do |subject|
       allocation_subject = AllocationSubject.find_by!(name: subject)
       funding_method.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)
     end
   end
 
-  SEED_GRANTS.each do |s|
+  rule[:grants].each do |s|
     funding_method = FundingMethod.find_or_create_by!(training_route: s.training_route,
                                                       amount: s.amount,
                                                       funding_type: FUNDING_TYPE_ENUMS[:grant],
-                                                      academic_cycle: academic_cycle)
+                                                      academic_cycle: rule[:academic_cycle])
     s.allocation_subjects.map do |subject|
       allocation_subject = AllocationSubject.find_by!(name: subject)
       funding_method.funding_method_subjects.find_or_create_by!(allocation_subject: allocation_subject)

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -599,6 +599,7 @@ describe Trainee do
       trainee.set_early_years_course_details
       expect(trainee.course_subject_one).to eq(CourseSubjects::EARLY_YEARS_TEACHING)
       expect(trainee.course_age_range).to eq(AgeRange::ZERO_TO_FIVE)
+      expect(trainee.course_allocation_subject).to eq(AllocationSubject.find_by(name: AllocationSubjects::EARLY_YEARS_ITT))
     end
   end
 


### PR DESCRIPTION
### Context

https://trello.com/c/ojucDzfT/4041-add-academic-year-22-23-funding-rules

### Changes proposed in this pull request

- Add 2022/23 rules in the initializer (i'm still not 100% that it should be living there.. but i've kept it as-is for now)
- Add data migration to add those funding methods to deployed envs
- Update the seeds to include three years of funding in the review envs

**Related course_allocation_subject bug fixes**
- Set `course_allocation_subject` on EY trainees as soon as they are created like we do for `course_subject_one` (otherwise their allocation subject is nil when it comes to funding)
- Following on from above, only set `course_allocation_subject` in the form if it's not an Early years trainee - otherwise this would re-set it to nil
- Set `course_allocation_subject` on subject specialism and language specialism choice forms, not just on the course/publish course form. As it stands it is actually wiped if you submit a specialism form, leading to no funding being applicable.

Does not include:
- Early years (postgrad) grant - we're not sure how this works yet
- Troops to teachers bursary - this is new functionality

Both of these are carded separately,

### Guidance to review

- Create trainees in the 22/23 year
- Check that you are asked the correct funding options for that route/course combo

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
