### PR TITLE
[xxx] Ensure that accreditation IDs are most likely different

### DIFF
--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     dttp_id { SecureRandom.uuid }
     code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     ukprn { Faker::Number.number(digits: 8) }
-    accreditation_id { Faker::Number.number(digits: 4) }
+    sequence(:accreditation_id, "1111")
 
     trait :teach_first do
       code { TEACH_FIRST_PROVIDER_CODE }


### PR DESCRIPTION
### Context

We've added a uniqueness check to accreditation_id on providers. This has caused a flakey test.

### Changes proposed in this pull request

Ensure that when we create providers, we are creating a new accreditation ID by using a four-digit sequence. Providers will now be created like:

```
FactoryBot.build(:provider)

=> #<Provider accreditation_id: "1111">
=> #<Provider accreditation_id: "1112">
=> #<Provider accreditation_id: "1113">
...
```

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
