### PR TITLE
[4116] Distinguish between PL UG and PL PG in HESA import

### DIFF
--- a/app/lib/hesa/code_sets/itt_qualification_aims.rb
+++ b/app/lib/hesa/code_sets/itt_qualification_aims.rb
@@ -3,15 +3,24 @@
 module Hesa
   module CodeSets
     module IttQualificationAims
+      BA = "BA"
+      BA_HONS = "BA (Hons)"
+      BED = "BEd"
+      BED_HONS = "BEd (Hons)"
+      BSC = "BSc"
+      BSC_HONS = "BSc (Hons)"
+
+      UNDERGRAD_AIMS = [BA, BA_HONS, BED, BED_HONS, BSC, BSC_HONS].freeze
+
       # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
       # https://www.hesa.ac.uk/collection/c21053/e/qlaim
       MAPPING = {
-        "007" => "BA",
-        "008" => "BA (Hons)",
-        "001" => "BEd",
-        "002" => "BEd (Hons)",
-        "003" => "BSc",
-        "004" => "BSc (Hons)",
+        "007" => BA,
+        "008" => BA_HONS,
+        "001" => BED,
+        "002" => BED_HONS,
+        "003" => BSC,
+        "004" => BSC_HONS,
         "020" => "Postgraduate Certificate in Education",
         "021" => "Postgraduate Diploma in Education",
         "028" => "Undergraduate Master of Teaching",

--- a/app/lib/hesa/code_sets/itt_qualification_aims.rb
+++ b/app/lib/hesa/code_sets/itt_qualification_aims.rb
@@ -9,8 +9,9 @@ module Hesa
       BED_HONS = "BEd (Hons)"
       BSC = "BSc"
       BSC_HONS = "BSc (Hons)"
+      UNDERGRAD_MASTER_OF_TEACHING = "Undergraduate Master of Teaching"
 
-      UNDERGRAD_AIMS = [BA, BA_HONS, BED, BED_HONS, BSC, BSC_HONS].freeze
+      UNDERGRAD_AIMS = [BA, BA_HONS, BED, BED_HONS, BSC, BSC_HONS, UNDERGRAD_MASTER_OF_TEACHING].freeze
 
       # https://www.hesa.ac.uk/collection/c21053/xml/c21053/c21053codelists.xsd
       # https://www.hesa.ac.uk/collection/c21053/e/qlaim
@@ -23,7 +24,7 @@ module Hesa
         "004" => BSC_HONS,
         "020" => "Postgraduate Certificate in Education",
         "021" => "Postgraduate Diploma in Education",
-        "028" => "Undergraduate Master of Teaching",
+        "028" => UNDERGRAD_MASTER_OF_TEACHING,
         "031" => "Professional Graduate Certificate in Education",
         "032" => "Masters, not by research",
       }.freeze

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -136,6 +136,18 @@ module Trainees
     end
 
     def training_route
+      provider_led_undergrad? ? TRAINING_ROUTE_ENUMS[:provider_led_undergrad] : hesa_route
+    end
+
+    def provider_led_undergrad?
+      hesa_route == TRAINING_ROUTE_ENUMS[:provider_led_postgrad] && undergrad_level?
+    end
+
+    def undergrad_level?
+      Hesa::CodeSets::IttQualificationAims::UNDERGRAD_AIMS.include?(itt_qualification_aim)
+    end
+
+    def hesa_route
       Hesa::CodeSets::TrainingRoutes::MAPPING[hesa_trainee[:training_route]]
     end
 

--- a/db/data/20220512110703_fix_postgrad_to_undergrad_trainees.rb
+++ b/db/data/20220512110703_fix_postgrad_to_undergrad_trainees.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class FixPostgradToUndergradTrainees < ActiveRecord::Migration[6.1]
+  def up
+    trainees = Trainee.where(training_route: "provider_led_postgrad").where.not(hesa_updated_at: nil)
+    trainees.each do |trainee|
+      next unless Hesa::CodeSets::IttQualificationAims::UNDERGRAD_AIMS.include?(trainee.hesa_metadatum.itt_qualification_aim)
+
+      trainee.without_auditing do
+        trainee.update(training_route: "provider_led_undergrad")
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -105,6 +105,26 @@ module Trainees
           expect(Dqt::RegisterForTrnJob).to have_received(:perform_later).with(Trainee.last)
         end
       end
+
+      context "when the HESA training route is Provider-led" do
+        let(:hesa_stub_attributes) { { training_route: "01", itt_qualification_aim: itt_qualification_aim } }
+
+        context "when the qualification aim is undergrad level" do
+          let(:itt_qualification_aim) { "001" }
+
+          it "creates a Provider-led (undergrad) trainee" do
+            expect(trainee.training_route).to eq("provider_led_undergrad")
+          end
+        end
+
+        context "when the qualification aim is not undergrad level" do
+          let(:itt_qualification_aim) { "020" }
+
+          it "creates a Provider-led (postgrad) trainee" do
+            expect(trainee.training_route).to eq("provider_led_postgrad")
+          end
+        end
+      end
     end
 
     context "trainee doesn't exist" do

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -124,6 +124,14 @@ module Trainees
             expect(trainee.training_route).to eq("provider_led_postgrad")
           end
         end
+
+        context "when the qualification aim is nil" do
+          let(:itt_qualification_aim) { nil }
+
+          it "creates a Provider-led (undergrad) trainee" do
+            expect(trainee.training_route).to eq("provider_led_postgrad")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### Context

https://trello.com/c/6jWIRQcH/4116-investigate-ug-vs-pg-incorrect-in-hesa-import

### Changes proposed in this pull request

HESA do not distinguish between Provider-led UG and Provider-led PG, and we were assuming all Provider-led trainees are PG.

This PR:
- Updates CreateFromHesa service to look at the itt_qualification_aim to decide whether a provider_led trainee is
  undergrad or postgrad
- Adds a data migration to fix affected trainees (TO COME)

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
