### PR TITLE
[4117] Save deferral date during HESA updates

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -50,6 +50,7 @@ module Trainees
        .merge(ethnicity_and_disability_attributes)
        .merge(course_attributes)
        .merge(withdrawal_attributes)
+       .merge(deferral_attributes)
        .merge(funding_attributes)
        .merge(school_attributes)
        .merge(training_initiative_attributes)
@@ -101,6 +102,12 @@ module Trainees
       return {} unless trainee_state == :withdrawn
 
       { withdraw_date: hesa_trainee[:end_date], withdraw_reason: reason_for_leaving }
+    end
+
+    def deferral_attributes
+      return {} unless trainee_state == :deferred
+
+      { defer_date: hesa_trainee[:end_date] }
     end
 
     def school_attributes

--- a/db/data/20220519090946_backfill_deferral_dates_for_hesa_trainees.rb
+++ b/db/data/20220519090946_backfill_deferral_dates_for_hesa_trainees.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BackfillDeferralDatesForHesaTrainees < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.joins(:hesa_student).where(state: "deferred", defer_date: nil).each do |trainee|
+      trainee.without_auditing do
+        trainee.update(defer_date: trainee.hesa_student.end_date)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20220519090946_backfill_deferral_dates_for_hesa_trainees.rb
+++ b/db/data/20220519090946_backfill_deferral_dates_for_hesa_trainees.rb
@@ -2,7 +2,7 @@
 
 class BackfillDeferralDatesForHesaTrainees < ActiveRecord::Migration[6.1]
   def up
-    Trainee.joins(:hesa_student).where(state: "deferred", defer_date: nil).each do |trainee|
+    Trainee.deferred.joins(:hesa_student).where(defer_date: nil).each do |trainee|
       trainee.without_auditing do
         trainee.update(defer_date: trainee.hesa_student.end_date)
       end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -299,12 +299,14 @@ module Trainees
 
           let(:hesa_stub_attributes) do
             {
+              end_date: date,
               reason_for_leaving: hesa_reasons_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::UNKNOWN_COMPLETION],
               mode: hesa_modes[Hesa::CodeSets::Modes::DORMANT_FULL_TIME],
             }
           end
 
           it "creates a deferred trainee with the relevant details" do
+            expect(trainee.defer_date).to eq(Date.parse(date))
             expect(trainee.state).to eq("deferred")
           end
         end


### PR DESCRIPTION
### Context

https://trello.com/c/NkWnDd3G/4117-investigate-missing-dates-from-hesa-import

### Changes proposed in this pull request

HESA doesn't send us a deferral date, but where available we can use the ENDDATE for deferred trainees.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
