### PR TITLE
Add dr docs database loss

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -2,12 +2,18 @@ name: Backup Database to Azure Storage
 
 on:
   workflow_dispatch:
+    inputs:
+      overwriteThisMorningsBackup:
+        required: true
+        type: boolean
+        default: false
   schedule: # 03:00 UTC
     - cron: '0 3 * * *'
 
 jobs:
   backup:
     name: Backup PaaS Database (production)
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.overwriteThisMorningsBackup == 'true') }}
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -35,7 +41,7 @@ jobs:
       uses: DFE-Digital/github-actions/install-postgres-client@master
 
     - name: Set environment variable
-      run: echo "BACKUP_FILE_NAME=register_prod_$(date +"%F-%H-%M-%S")" >> $GITHUB_ENV
+      run: echo "BACKUP_FILE_NAME=register_prod_$(date +"%F")" >> $GITHUB_ENV
 
     - name: Backup Prod DB
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 /db/*.sqlite3-journal
 /db/data_schema.rb
 
+# Ignore SQL backups
+*.sql
+*.tar.gz
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,3 +3,7 @@ ruby 2.7.5
 yarn 1.22.18
 bundler 2.1.4
 terraform 0.13.5
+cf 7.4.0
+az 2.36.0
+jq 1.6
+make 4.2.1

--- a/Makefile
+++ b/Makefile
@@ -144,15 +144,15 @@ disable-maintenance: read-tf-config ## make qa disable-maintenance / make produc
 	cf delete register-unavailable -r -f
 
 get-image-tag:
-	$(eval export TAG=$(shell cf target -s ${SPACE} 1> /dev/null && cf app register-${DEPLOY_ENV} | grep -Po "docker image:\s+\S+:\K\w+"))
+	$(eval export TAG=$(shell cf target -s ${space} 1> /dev/null && cf app register-${DEPLOY_ENV} | grep -Po "docker image:\s+\S+:\K\w+"))
 	@echo ${TAG}
 
 get-postgres-instance-guid: ## Gets the postgres service instance's guid make qa get-postgres-instance-guid
-	$(eval export DB_INSTANCE_GUID=$(shell cf target -s ${SPACE} 1> /dev/null && cf service register-postgres-${DEPLOY_ENV} --guid))
+	$(eval export DB_INSTANCE_GUID=$(shell cf target -s ${space} 1> /dev/null && cf service register-postgres-${DEPLOY_ENV} --guid))
 	@echo ${DB_INSTANCE_GUID}
 
 rename-postgres-service: ## make qa rename-postgres-service
-	cf target -s ${SPACE} 1> /dev/null
+	cf target -s ${space} 1> /dev/null
 	cf rename-service register-postgres-${DEPLOY_ENV} register-postgres-${DEPLOY_ENV}-old
 
 remove-postgres-tf-state: terraform-init ## make qa remove-postgres-tf-state PASSCODE=xxxx
@@ -160,7 +160,7 @@ remove-postgres-tf-state: terraform-init ## make qa remove-postgres-tf-state PAS
 
 set-restore-variables:
 	$(if $(IMAGE_TAG), , $(error can only run with an IMAGE_TAG))
-	$(if $(DB_INSTANCE_GUID), , $(error can only run with DB_INSTANCE_GUID, get it by running `make ${SPACE} get-postgres-instance-guid`))
+	$(if $(DB_INSTANCE_GUID), , $(error can only run with DB_INSTANCE_GUID, get it by running `make ${space} get-postgres-instance-guid`))
 	$(if $(SNAPSHOT_TIME), , $(error can only run with BEFORE_TIME, eg SNAPSHOT_TIME="2021-09-14 16:00:00"))
 	$(eval export TF_VAR_paas_docker_image=ghcr.io/dfe-digital/register-trainee-teachers:$(IMAGE_TAG))
 	$(eval export TF_VAR_paas_restore_from_db_guid=$(DB_INSTANCE_GUID))
@@ -172,4 +172,4 @@ restore-postgres: set-restore-variables deploy ##  make qa restore-postgres IMAG
 restore-data-from-nightly-backup: read-deployment-config read-tf-config # make production restore-data-from-nightly-backup CONFIRM_PRODUCTION=YES CONFIRM_RESTORE=YES BACKUP_DATE="yyyy-mm-dd"
 	bin/download-nightly-backup REGISTER-BACKUP-STORAGE-CONNECTION-STRING ${key_vault_name} ${BACKUP_CONTAINER_NAME} register_${DEPLOY_ENV}_ ${BACKUP_DATE}
 	$(if $(CONFIRM_RESTORE), , $(error Restore can only run with CONFIRM_RESTORE))
-	bin/restore-nightly-backup ${SPACE} ${POSTGRES_DATABASE_NAME} register_${DEPLOY_ENV}_ ${BACKUP_DATE}
+	bin/restore-nightly-backup ${space} ${POSTGRES_DATABASE_NAME} register_${DEPLOY_ENV}_ ${BACKUP_DATE}

--- a/bin/download-nightly-backup
+++ b/bin/download-nightly-backup
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -eu
+
+BACKUP_STORAGE_SECRET_NAME=$1
+KEY_VAULT_NAME=$2
+AZURE_BACKUP_STORAGE_CONTAINER_NAME=$3
+BACKUP_FILENAME_PREFIX=$4
+BACKUP_DATE=$5 #yyyy-mm-dd
+
+
+if [[ -z "${BACKUP_STORAGE_SECRET_NAME}" ]]; then
+  echo "BACKUP_STORAGE_SECRET_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${KEY_VAULT_NAME}" ]]; then
+  echo "KEY_VAULT_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${AZURE_BACKUP_STORAGE_CONTAINER_NAME}" ]]; then
+  echo "AZURE_BACKUP_STORAGE_CONTAINER_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${BACKUP_FILENAME_PREFIX}" ]]; then
+  echo "BACKUP_FILENAME_PREFIX environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${BACKUP_DATE}" ]]; then
+  echo "BACKUP_DATE environment variable not set"
+  exit 1
+fi
+
+STORAGE_CONN_STR="$(az keyvault secret show --name ${BACKUP_STORAGE_SECRET_NAME} --vault-name ${KEY_VAULT_NAME} | jq -r .value)"
+
+BACKUP_ARCHIVE_FILENAME=$(az storage blob list --connection-string ${STORAGE_CONN_STR} --container-name ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} --prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} --output json --query [-1].name | jq -r)
+if [[ -z ${BACKUP_ARCHIVE_FILENAME} ]]; then
+  echo "There are no files found matching the prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} in container ${AZURE_BACKUP_STORAGE_CONTAINER_NAME}"
+  exit 1
+else
+  echo "Downloading ${BACKUP_ARCHIVE_FILENAME} ..."
+  az storage blob download --connection-string ${STORAGE_CONN_STR} -c ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} -n ${BACKUP_ARCHIVE_FILENAME} -f ${BACKUP_ARCHIVE_FILENAME} --output none
+fi

--- a/bin/restore-nightly-backup
+++ b/bin/restore-nightly-backup
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eu
+
+CF_ORG_NAME='dfe'
+SPACE=$1
+POSTGRES_DATABASE_NAME=$2
+BACKUP_FILENAME_PREFIX=$3
+BACKUP_DATE=$4 #yyyy-mm-dd
+
+if [[ -z "${SPACE}" ]]; then
+  echo "SPACE environment variable not set"
+  exit 1
+fi
+
+BACKUP_ARCHIVE_FILENAME=${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.tar.gz
+echo "File(s) extracted from ${BACKUP_ARCHIVE_FILENAME}:"
+tar -xvzf "${BACKUP_ARCHIVE_FILENAME}"
+
+if [[ ! -f "${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql" ]]; then
+  echo "${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql does not exist."
+  exit 1
+else
+  echo "Restoring ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql to ${POSTGRES_DATABASE_NAME} in ${CF_ORG_NAME}/${SPACE}"
+  cf target -o "${CF_ORG_NAME}" -s "${SPACE}"
+  cf conduit ${POSTGRES_DATABASE_NAME} -- psql < "${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql"
+fi

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -12,7 +12,7 @@ Alert all developers that no one should merge to main branch.
 
 ### Local Dependencies
 
-You will need the [az](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and [cf](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) CLIs installed as well as [make](https://www.gnu.org/software/make/) and either [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) or [tfenv](https://github.com/tfutils/tfenv#installation).
+You will need the [az](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and [cf](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) CLIs installed as well as [jq](https://stedolan.github.io/jq/download/), [make](https://www.gnu.org/software/make/) and either [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) or [tfenv](https://github.com/tfutils/tfenv#installation).
 
 ### Maintenance mode
 
@@ -26,6 +26,56 @@ the #twd_publish Slack channel to keep product owners abreast of developments.
 ### Internet Connection
 
 Ensure whoever is executing the process has a reliable and reasonably fast Internet connection.
+
+## Loss of database instance
+
+In case the database instance is lost, the objectives are:
+
+- Recreate the lost postgres database instance
+- Restore data from nightly backup stored in Azure.  The point-in-time and snapshot backups created by the PaaS Postgres service will not be available if it's been deleted.
+
+### Recreate the lost postgres database instance
+
+Please note, this process should take about 25 mins* to complete. In case the database service is deleted or in an inconsistent state we must recreate it and repopulate it.
+First make sure it is fully gone by running
+
+```
+cf services | grep register-postgres
+# check output for lost or corrupted instance
+cf delete-service <instance-name>
+```
+Then recreate the lost postgres database instance using the following make recipes `deploy-plan` and `deploy`.  To see the proposed changes:
+
+```
+TAG=$(cf app register-<env> | awk -F : '$1 == "docker image" {print $3}')
+make <env> register-plan PASSCODE=<my-passcode> IMAGE_TAG=${TAG} [CONFIRM_PRODUCTION=YES]
+```
+To apply proposed changes i.e. create new database instance:
+```
+TAG=$(cf app register-<env> | awk -F : '$1 == "docker image" {print $3}')
+make <env> deploy PASSCODE=<my-passcode> IMAGE_TAG=${TAG} [CONFIRM_PRODUCTION=YES]
+```
+This will create a new postgres database instance as described in the terraform configuration file.
+
+\* based on ~20 minutes to recreate postgres instance and ~5 min restore time when testing process in QA
+
+### Restore Data From Nightly Backup
+
+You will need to be logged into GovUK PaaS and Azure using the `az` and `cf` CLIs.  You will need to raise a [PIM](https://docs.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-resource-roles-activate-your-roles) request to elevate your credentials for a production restore.  A collegue will need to approve this for you.
+
+Once the lost database instance has been recreated, the last nightly backup will need to be restored. To achieve this, use the following makefile recipe: `restore-data-from-nightly-backup`. The following will need to be set: `CONFIRM_PRODUCTION=YES`,  `CONFIRM_RESTORE=YES` and `BACKUP_DATE="yyyy-mm-dd"`.
+
+The make recipe `restore-data-from-nightly-backup` executes 2 scripts, these should be committed with the execute permission (755) set but these may have been inadvertently altered.  If you get a permissions error executing them run `chmod +x <path/to/script>`.
+
+```
+# space is the name of the environment in GOV.UK PaaS, eg 'bat-prod'
+# env is the target environment in the make file e.g. 'production'
+az login
+cf login -o dfe -s <space> -u my.name@digital.education.gov.uk
+make <env> restore-data-from-nightly-backup BACKUP_DATE="yyyy-mm-dd" CONFIRM_PRODUCTION=YES CONFIRM_RESTORE=YES
+```
+
+This will download the latest daily backup from Azure Storage and then populate the new database with data.
 
 ## Data Loss
 


### PR DESCRIPTION
### Context
A DR process is required to handle the loss of the database instance.

### Changes proposed in this pull request
- Remove the timestamp on the database backup
- Add a DR process to docs and supporting make recipe and scripts to execute it

### Guidance to review
- Ensure the process meets the requirements in [technical guidance](https://technical-guidance.education.gov.uk/infrastructure/disaster-recovery/#loss-of-database-instance)
- The solution was developed on a Windows machine running Ubuntu 20 in WSL. It should tested on MacOS ideally or another distribution. A minimal test would be:
  - execute the deploy-plan command documented in [recreate-the-lost-postgres-database-instance](https://github.com/DFE-Digital/teacher-training-api/blob/dr-doc-refinements/docs/disaster-recovery.md#recreate-the-lost-postgres-database-instance)
  - execute the commands in [restore-data-from-nightly-backup](https://github.com/DFE-Digital/teacher-training-api/blob/dr-doc-refinements/docs/disaster-recovery.md#restore-data-from-nightly-backup). This can be done against QA with agreement from the publish team or against the review app by replacing ${DEPLOY_ENV} on [line 90](https://github.com/DFE-Digital/register-trainee-teachers/blob/e12f5544c504f5cb58161ca624b602ae0edee9ac/Makefile#L90) of the make file with pr-2339

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
