### PR TITLE
[4081] Trainee summary page UI

### DIFF
--- a/app/controllers/funding/trainee_summaries_controller.rb
+++ b/app/controllers/funding/trainee_summaries_controller.rb
@@ -3,8 +3,11 @@
 module Funding
   class TraineeSummariesController < ApplicationController
     def show
-      trainee_summary = current_user.organisation.funding_trainee_summaries.order(:created_at).last
+      trainee_summary = current_user.organisation&.funding_trainee_summaries&.order(:created_at)&.last
       @trainee_summary_view = TraineeSummaryView.new(trainee_summary: trainee_summary)
+      current_academic_cycle = AcademicCycle.current
+      @start_year = current_academic_cycle.start_year
+      @end_year = current_academic_cycle.end_year
     end
   end
 end

--- a/app/view_objects/funding/trainee_summary_view.rb
+++ b/app/view_objects/funding/trainee_summary_view.rb
@@ -17,29 +17,33 @@ module Funding
     end
 
     def summary
-      PaymentTypeSummary.new(
-        title: "Summary",
-        summary_data: summary_data,
-      )
+      PaymentTypeSummary.new(title: "Summary", summary_data: summary_data)
     end
 
     def summary_data
       [
-        PaymentTypeSummaryRow.new(payment_type: "ITT Bursaries", total: payment_type_total(data_for_bursaries)),
-        PaymentTypeSummaryRow.new(payment_type: "ITT Scholarship", total: payment_type_total(data_for_scholarships)),
+        PaymentTypeSummaryRow.new(payment_type: "ITT bursaries", total: payment_type_total(data_for_bursaries)),
+        PaymentTypeSummaryRow.new(payment_type: "ITT scholarship", total: payment_type_total(data_for_scholarships)),
         PaymentTypeSummaryRow.new(payment_type: "Early years ITT bursaries", total: payment_type_total(data_for_tiered_bursaries)),
         PaymentTypeSummaryRow.new(payment_type: "Grants", total: payment_type_total(data_for_grants)),
       ]
     end
 
-    def last_updated_at_string
-      @trainee_summary.created_at.strftime("Last updated: %d %B %Y")
+    def last_updated_at
+      trainee_summary.created_at.strftime("%d %B %Y")
+    end
+
+    def empty?
+      return true if trainee_summary.nil? || trainee_summary.rows.empty?
+
+      trainee_summary.rows.none? { |row| row.amounts.any? }
     end
 
     def bursary_breakdown_rows
-      data_for_bursaries.map do |amount|
+      sort(data_for_bursaries).map do |amount|
         total_amount = amount.number_of_trainees * amount.amount_in_pence
-        { route_and_subject: format_route_and_subject_string(amount),
+        { route: amount.row.route,
+          subject: amount.row.subject,
           lead_school: format_lead_school_string(amount),
           trainees: amount.number_of_trainees,
           amount_per_trainee: format_pounds(amount.amount_in_pence),
@@ -48,9 +52,10 @@ module Funding
     end
 
     def scholarship_breakdown_rows
-      data_for_scholarships.map do |amount|
+      sort(data_for_scholarships).map do |amount|
         total_amount = amount.number_of_trainees * amount.amount_in_pence
-        { route_and_subject: format_route_and_subject_string(amount),
+        { route: amount.row.route,
+          subject: amount.row.subject,
           lead_school: format_lead_school_string(amount),
           trainees: amount.number_of_trainees,
           amount_per_trainee: format_pounds(amount.amount_in_pence),
@@ -59,7 +64,7 @@ module Funding
     end
 
     def tiered_bursary_breakdown_rows
-      data_for_tiered_bursaries.map do |amount|
+      sort(data_for_tiered_bursaries).map do |amount|
         total_amount = amount.number_of_trainees * amount.amount_in_pence
         { tier: amount.tier,
           trainees: amount.number_of_trainees,
@@ -69,35 +74,48 @@ module Funding
     end
 
     def grant_breakdown_rows
-      data_for_grants.map do |amount|
+      sort(data_for_grants).map do |amount|
         total_amount = amount.number_of_trainees * amount.amount_in_pence
-        { subject: amount.row.subject,
+        { route: amount.row.route,
+          subject: amount.row.subject,
           trainees: amount.number_of_trainees,
           amount_per_trainee: format_pounds(amount.amount_in_pence),
           total: format_pounds(total_amount) }
       end
     end
 
+    def format_pounds(amount)
+      return "—" if amount.zero?
+
+      number_to_currency(amount.to_d / 100, unit: "£").gsub(/\.00$/, "")
+    end
+
   private
+
+    attr_reader :trainee_summary
 
     def payment_type_total(data_for_payment_type)
       data_for_payment_type.map { |data| (data.amount_in_pence * data.number_of_trainees) }.sum
     end
 
+    def sort(data)
+      Array(data.sort_by { |amount| [amount.row.route, amount.row.subject] })
+    end
+
     def data_for_scholarships
-      @trainee_summary.rows.filter_map { |row| get_scholarship_amounts(row) }.flatten
+      trainee_summary.rows.filter_map { |row| get_scholarship_amounts(row) }.flatten
     end
 
     def data_for_bursaries
-      @trainee_summary.rows.filter_map { |row| get_bursary_amounts(row) }.flatten
+      trainee_summary.rows.filter_map { |row| get_bursary_amounts(row) }.flatten
     end
 
     def data_for_tiered_bursaries
-      @trainee_summary.rows.filter_map { |row| get_tiered_bursary_amounts(row) }.flatten
+      trainee_summary.rows.filter_map { |row| get_tiered_bursary_amounts(row) }.flatten
     end
 
     def data_for_grants
-      @trainee_summary.rows.filter_map { |row| get_grant_amounts(row) }.flatten
+      trainee_summary.rows.filter_map { |row| get_grant_amounts(row) }.flatten
     end
 
     def get_scholarship_amounts(row)
@@ -116,20 +134,10 @@ module Funding
       row.amounts.select(&:grant?)
     end
 
-    def format_route_and_subject_string(amount)
-      "#{amount.row.route}\n#{amount.row.subject}"
-    end
-
     def format_lead_school_string(amount)
       return "—" if amount.row.lead_school_name.nil?
 
       amount.row.lead_school_name
-    end
-
-    def format_pounds(amount)
-      return "—" if amount.zero?
-
-      number_to_currency(amount.to_d / 100, unit: "£")
     end
   end
 end

--- a/app/views/funding/trainee_summaries/_bursaries.html.erb
+++ b/app/views/funding/trainee_summaries/_bursaries.html.erb
@@ -1,0 +1,40 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m" >
+        <%= t("funding.trainee_summary.table_headings.bursaries.title")%>
+      </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header govuk-!-width-one-third">
+            <%= t("funding.trainee_summary.column_headings.route_and_course")%>
+          </th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-third">
+            <%= t("funding.trainee_summary.column_headings.lead_school")%>
+          </th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.trainees")%>
+          </th>
+          <th nowrap scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.amount_per_trainee")%>
+          </th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.total")%>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <%- @trainee_summary_view.bursary_breakdown_rows.each do |bursary_row| %>
+          <% next if bursary_row[:total] == "—" %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= bursary_row[:route] %><br><%= bursary_row[:subject] %><p></p></td>
+            <td class="govuk-table__cell"><%= bursary_row[:lead_school] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= bursary_row[:trainees] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= bursary_row[:amount_per_trainee] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= bursary_row[:total] %></td>
+          </tr>
+        <%- end -%>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/funding/trainee_summaries/_grants.html.erb
+++ b/app/views/funding/trainee_summaries/_grants.html.erb
@@ -1,0 +1,36 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m" >
+        <%= t("funding.trainee_summary.table_headings.grants.title") %>
+      </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th nowrap scope="col" class="govuk-table__header govuk-!-width-one-quarter">
+            <%= t("funding.trainee_summary.column_headings.route_and_course") %>
+          </th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.trainees") %>
+          </th>
+          <th nowrap scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.amount_per_trainee")%>
+          </th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.total") %>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <%- @trainee_summary_view.grant_breakdown_rows.each do |grant_row| %>
+          <% next if grant_row[:total] == "—" %>
+          <tr class="govuk-table__row">
+            <td nowrap class="govuk-table__cell"><%= grant_row[:route]%> <br> <%= grant_row[:subject] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= grant_row[:trainees] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= grant_row[:amount_per_trainee] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= grant_row[:total] %></td>
+          </tr>
+        <%- end -%>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/funding/trainee_summaries/_scholarships.html.erb
+++ b/app/views/funding/trainee_summaries/_scholarships.html.erb
@@ -1,0 +1,40 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m" >
+        <%= t("funding.trainee_summary.table_headings.scholarships.title")%>
+      </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header govuk-!-width-one-third">
+            <%= t("funding.trainee_summary.column_headings.route_and_course")%> 
+          </th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-third">
+            <%= t("funding.trainee_summary.column_headings.lead_school")%>
+          </th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.trainees")%>
+          </th>
+          <th nowrap scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.amount_per_trainee")%>
+          </th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.total")%>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <%- @trainee_summary_view.scholarship_breakdown_rows.each do |scholarship_row| %>
+          <% next if scholarship_row[:total] == "—" %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= scholarship_row[:route] %><br><%= scholarship_row[:subject] %></td>
+            <td class="govuk-table__cell"><%= scholarship_row[:lead_school] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= scholarship_row[:trainees] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= scholarship_row[:amount_per_trainee] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= scholarship_row[:total] %></td>
+          </tr>
+        <%- end -%>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/funding/trainee_summaries/_summary.html.erb
+++ b/app/views/funding/trainee_summaries/_summary.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half-from-desktop">
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m" > <%= @trainee_summary_view.summary.title %> </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header govuk-!-width-three-quarters">
+            <%= t("funding.trainee_summary.column_headings.payment_type") %>
+          </th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.total") %>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @trainee_summary_view.summary.summary_data.each do |summary_row| %>
+          <% next if summary_row.total.zero? %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= summary_row.payment_type %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @trainee_summary_view.format_pounds(summary_row.total) %></td>
+          </tr>
+        <% end %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-!-font-weight-bold">
+            <%= t("funding.trainee_summary.column_headings.total") %>
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric app-table__column-20 govuk-!-font-weight-bold"><%= @trainee_summary_view.format_pounds(@trainee_summary_view.summary.total) %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/funding/trainee_summaries/_tiered_bursaries.html.erb
+++ b/app/views/funding/trainee_summaries/_tiered_bursaries.html.erb
@@ -1,0 +1,36 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m" >
+        <%= t("funding.trainee_summary.table_headings.tiered_bursaries.title") %>
+      </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header govuk-!-width-one-half">
+            <%= t("funding.trainee_summary.column_headings.tier") %>
+          </th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.trainees") %>
+          </th>
+          <th nowrap scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.amount_per_trainee")%>
+          </th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">
+            <%= t("funding.trainee_summary.column_headings.total") %>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <%- @trainee_summary_view.tiered_bursary_breakdown_rows.each do |tiered_bursary_row| %>
+          <% next if tiered_bursary_row[:total] == "—" %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"> <%= t("funding.trainee_summary.column_headings.tier") %> <%= tiered_bursary_row[:tier] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= tiered_bursary_row[:trainees] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= tiered_bursary_row[:amount_per_trainee] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= tiered_bursary_row[:total] %></td>
+          </tr>
+        <%- end -%>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/funding/trainee_summaries/show.html.erb
+++ b/app/views/funding/trainee_summaries/show.html.erb
@@ -1,0 +1,57 @@
+<%= render PageTitle::View.new(i18n_key: "funding") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
+<% end %>
+
+<% if current_user.organisation %>
+  <span class="govuk-caption-xl"><%= current_user.organisation.name %></span>
+<% end %>
+
+<h1 class="govuk-heading-xl">
+  <%= t("funding.view.title") %>
+</h1>
+
+<%= render TabNavigation::View.new(items: [
+  { name: t("funding.payment_schedule.heading", start_year: @start_year, end_year: @end_year), url: funding_payment_schedule_path },
+  { name: t("funding.trainee_summary.heading", start_year: @start_year, end_year: @end_year), url: funding_trainee_summary_path },
+]) %>
+
+<h2 class="govuk-heading-l">
+  <%= t("funding.trainee_summary.heading", start_year: @start_year, end_year: @end_year)%>
+</h2>
+
+<% if @trainee_summary_view.empty? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop" >
+      <p class="govuk-body">
+        <%= @current_user.provider? ? t("funding.trainee_summary.provider.no_funding") : t("funding.trainee_summary.lead_school.no_funding") %>
+      </p>
+      <p class="govuk-body">
+        <%= t("funding.trainee_summary.email_line_one") %>
+        <%= govuk_mail_to(
+          Settings.support_email,
+          Settings.support_email,
+          subject: t("funding.trainee_summary.email_subject")
+        ) %>
+        <%= t("funding.trainee_summary.email_line_two") %>
+      </p>
+    </div>
+  </div>
+<% else %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <p class="govuk-body"><%= t('funding.trainee_summary.last_updated_at', date: @trainee_summary_view&.last_updated_at) %></p>
+    </div>
+  </div>
+
+  <%= render "summary" %>
+
+  <%= render "bursaries" if @trainee_summary_view.bursary_breakdown_rows.any? %>
+
+  <%= render "scholarships" if @trainee_summary_view.scholarship_breakdown_rows.any? %>
+
+  <%= render "tiered_bursaries" if @trainee_summary_view.tiered_bursary_breakdown_rows.any? %>
+
+  <%= render "grants" if @trainee_summary_view.grant_breakdown_rows.any? %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,8 +53,6 @@ en:
         tier_one: Applied for Tier 1
         tier_two: Applied for Tier 2
         tier_three: Applied for Tier 3
-    trainee_summary:
-      heading: Bursaries and scholarships %{start_year} to %{end_year}
     payment_schedule:
       no_data: There are no scheduled payments right now.
       contact_info: Contact becoming a %{email} if you think there should be scheduled payments.
@@ -62,11 +60,38 @@ en:
       total: Total
       running_total: Running total
       payment_breakdown: Payment breakdown
-      heading: Payment Schedule %{start_year} to %{end_year}
+      heading: Payment schedule %{start_year} to %{end_year}
       payments_table_caption:  Payments to %{month_and_year}
       predicted_payments_table_caption: Predicted Payments
       no_payments: No payments for %{month_and_year}
       last_updated_at: "Last updated: %{date}"
+    trainee_summary:
+      heading: Trainee summary %{start_year} to %{end_year}
+      last_updated_at: "Last updated: %{date}"
+      table_headings:
+        bursaries:
+          title: ITT bursaries breakdown
+        scholarships:
+          title: ITT scholarships breakdown
+        tiered_bursaries:
+          title: Early years ITT bursaries breakdown
+        grants:
+          title: Grants breakdown
+      column_headings:
+        amount_per_trainee: Amount per trainee
+        lead_school: Lead school
+        payment_type: Payment type
+        route_and_course: Route and course
+        tier: Tier
+        total: Total
+        trainees: Trainees
+      provider:
+        no_funding: There are no trainees eligible for bursaries and scholarships right now.
+      lead_school:
+        no_funding: There are no trainees eligible for grants right now.
+      email_line_one: Contact
+      email_subject: Funding
+      email_line_two: if you think there should be trainees who are eligible.
   schools:
     view:
       summary_title: Schools
@@ -250,6 +275,7 @@ en:
     itt_end_date:
       hint: The end date of the Initial Teacher Training part of their course.
     page_titles:
+      funding: Funding
       personas: Personas
       pages:
         accessibility: Accessibility statement for Register trainee teachers

--- a/spec/features/funding/trainee_summary_spec.rb
+++ b/spec/features/funding/trainee_summary_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "viewing the trainee summary", feature_funding: true do
+  let(:user) { create(:user) }
+  let(:test_subject) { "Test subject" }
+
+  background {
+    Rails.application.reload_routes!
+    given_i_am_authenticated(user: user)
+    create(:academic_cycle, :current)
+  }
+
+  context "with a trainee summary" do
+    let(:summary) { create(:trainee_summary, payable: user.providers.first) }
+    let(:row) { create(:trainee_summary_row, trainee_summary: summary, subject: test_subject) }
+
+    context "an organisation with bursary data" do
+      background {
+        create(:trainee_summary_row_amount, :with_bursary, row: row)
+        when_i_visit_the_trainee_summary_page
+      }
+      scenario "displays the bursary breakdown table" do
+        then_i_see_the_bursary_table
+      end
+
+      scenario "displays the summary table" do
+        then_i_see_the_summary_table
+      end
+    end
+
+    context "bursary rows with zero totals" do
+      background {
+        create(:trainee_summary_row_amount, :with_bursary, row: row, number_of_trainees: number_of_trainees, amount_in_pence: amount_in_pence)
+        when_i_visit_the_trainee_summary_page
+      }
+
+      context "a bursary subject amount but no trainees" do
+        let(:amount_in_pence) { 10000 }
+        let(:number_of_trainees) { 0 }
+
+        scenario "doesn't display the row in the table" do
+          then_i_do_not_see_the_row_in_the_table
+        end
+      end
+
+      context "trainees but no bursary amount" do
+        let(:amount_in_pence) { 0 }
+        let(:number_of_trainees) { 5 }
+
+        scenario "doesn't display the row in the table" do
+          then_i_do_not_see_the_row_in_the_table
+        end
+      end
+    end
+
+    context "an organisation with scholarship data" do
+      background {
+        create(:trainee_summary_row_amount, :with_scholarship, row: row)
+        when_i_visit_the_trainee_summary_page
+      }
+      scenario "displays the scholarship breakdown table" do
+        then_i_see_the_scholarship_table
+      end
+    end
+
+    context "scholarship rows with zero totals" do
+      background {
+        create(:trainee_summary_row_amount, :with_scholarship, row: row, number_of_trainees: number_of_trainees, amount_in_pence: amount_in_pence)
+        when_i_visit_the_trainee_summary_page
+      }
+
+      context "a scholarship subject amount but no trainees" do
+        let(:amount_in_pence) { 10000 }
+        let(:number_of_trainees) { 0 }
+
+        scenario "doesn't display the row in the table" do
+          then_i_do_not_see_the_row_in_the_table
+        end
+      end
+
+      context "trainees but no scholarship amount" do
+        let(:amount_in_pence) { 0 }
+        let(:number_of_trainees) { 5 }
+
+        scenario "doesn't display the row in the table" do
+          then_i_do_not_see_the_row_in_the_table
+        end
+      end
+    end
+
+    context "an organisation with tiered bursary data" do
+      background {
+        create(:trainee_summary_row_amount, :with_tiered_bursary, row: row)
+        when_i_visit_the_trainee_summary_page
+      }
+      scenario "displays the tiered bursary breakdown table" do
+        then_i_see_the_tiered_bursary_table
+      end
+    end
+
+    context "tiered bursary rows with zero totals" do
+      let(:tier) { 3 }
+
+      background {
+        create(:trainee_summary_row_amount, :with_tiered_bursary, row: row, tier: tier, number_of_trainees: number_of_trainees, amount_in_pence: amount_in_pence)
+        when_i_visit_the_trainee_summary_page
+      }
+
+      context "a tiered bursary subject amount but no trainees" do
+        let(:amount_in_pence) { 10000 }
+        let(:number_of_trainees) { 0 }
+
+        scenario "doesn't display the row in the table" do
+          then_i_do_not_see_the_tiered_bursary_row_in_the_table
+        end
+      end
+
+      context "trainees but no tiered bursary amount" do
+        let(:amount_in_pence) { 0 }
+        let(:number_of_trainees) { 5 }
+
+        scenario "doesn't display the row in the table" do
+          then_i_do_not_see_the_tiered_bursary_row_in_the_table
+        end
+      end
+    end
+
+    context "an organisation with grant data" do
+      background {
+        create(:trainee_summary_row_amount, :with_grant, row: row)
+        when_i_visit_the_trainee_summary_page
+      }
+      scenario "displays the grant breakdown table" do
+        then_i_see_the_grant_table
+      end
+    end
+
+    context "grant rows with zero totals" do
+      background {
+        create(:trainee_summary_row_amount, :with_grant, row: row, number_of_trainees: number_of_trainees, amount_in_pence: amount_in_pence)
+        when_i_visit_the_trainee_summary_page
+      }
+
+      context "a grant subject amount but no trainees" do
+        let(:amount_in_pence) { 10000 }
+        let(:number_of_trainees) { 0 }
+
+        scenario "doesn't display the row in the table" do
+          then_i_do_not_see_the_row_in_the_table
+        end
+      end
+
+      context "trainees but no grant amount" do
+        let(:amount_in_pence) { 0 }
+        let(:number_of_trainees) { 5 }
+
+        scenario "doesn't display the row in the table" do
+          then_i_do_not_see_the_row_in_the_table
+        end
+      end
+    end
+  end
+
+  context "organisation without a trainee summary" do
+    context "with rows but no amounts" do
+      let(:summary) { create(:trainee_summary, payable: user.providers.first) }
+      let!(:row) { create(:trainee_summary_row, trainee_summary: summary) }
+
+      scenario "displays the empty state" do
+        when_i_visit_the_trainee_summary_page
+        then_i_see_the_empty_state
+      end
+    end
+
+    context "with trainee summary nil" do
+      scenario "displays the empty state" do
+        when_i_visit_the_trainee_summary_page
+        then_i_see_the_empty_state
+      end
+    end
+  end
+
+private
+
+  def when_i_visit_the_trainee_summary_page
+    trainee_summary_page.load
+  end
+
+  def then_i_see_the_bursary_table
+    expect(trainee_summary_page). to have_text("ITT bursaries")
+  end
+
+  def then_i_see_the_summary_table
+    expect(trainee_summary_page). to have_text("Summary")
+  end
+
+  def then_i_see_the_scholarship_table
+    expect(trainee_summary_page). to have_text("ITT scholarships")
+  end
+
+  def then_i_see_the_tiered_bursary_table
+    expect(trainee_summary_page). to have_text("Early years ITT bursaries")
+  end
+
+  def then_i_see_the_grant_table
+    expect(trainee_summary_page). to have_text("Grants")
+  end
+
+  def then_i_see_the_empty_state
+    expect(trainee_summary_page). to have_text("There are no trainees eligible")
+  end
+
+  def then_i_do_not_see_the_row_in_the_table
+    expect(trainee_summary_page). not_to have_text(test_subject)
+  end
+
+  def then_i_do_not_see_the_tiered_bursary_row_in_the_table
+    expect(trainee_summary_page). not_to have_text("Tier #{tier}")
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -366,6 +366,10 @@ module Features
       @payment_schedule_page ||= PageObjects::Funding::PaymentSchedule.new
     end
 
+    def trainee_summary_page
+      @trainee_summary_page ||= PageObjects::Funding::TraineeSummary.new
+    end
+
   private
 
     def progress_with_prefix(status)

--- a/spec/support/page_objects/funding/trainee_summary.rb
+++ b/spec/support/page_objects/funding/trainee_summary.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Funding
+    class TraineeSummary < PageObjects::Base
+      set_url "/funding/trainee-summary"
+    end
+  end
+end

--- a/spec/view_objects/funding/trainee_summary_view_spec.rb
+++ b/spec/view_objects/funding/trainee_summary_view_spec.rb
@@ -47,19 +47,23 @@ module Funding
       end
 
       describe "#summary_data" do
-        let(:expected_summary) {
-          [TraineeSummaryView::PaymentTypeSummaryRow.new(payment_type: "ITT Bursaries", total: 400000),
-           TraineeSummaryView::PaymentTypeSummaryRow.new(payment_type: "ITT Scholarship", total: 2300000),
-           TraineeSummaryView::PaymentTypeSummaryRow.new(payment_type: "Early years ITT bursaries", total: 500000),
-           TraineeSummaryView::PaymentTypeSummaryRow.new(payment_type: "Grants", total: 900000)]
-        }
+        let(:expected_summary) do
+          [
+            TraineeSummaryView::PaymentTypeSummaryRow.new(payment_type: "ITT Bursaries", total: 400000),
+            TraineeSummaryView::PaymentTypeSummaryRow.new(payment_type: "ITT Scholarship", total: 2300000),
+            TraineeSummaryView::PaymentTypeSummaryRow.new(payment_type: "Early years ITT bursaries", total: 500000),
+            TraineeSummaryView::PaymentTypeSummaryRow.new(payment_type: "Grants", total: 900000),
+          ]
+        end
         let(:summary_data_map) { subject.summary.summary_data.map { |d| [d.payment_type, d.total] } }
-        let(:expected_summary_data) {
-          [["ITT Bursaries", 400000],
-           ["ITT Scholarship", 2300000],
-           ["Early years ITT bursaries", 500000],
-           ["Grants", 900000]]
-        }
+        let(:expected_summary_data) do
+          [
+            ["ITT bursaries", 400000],
+            ["ITT scholarship", 2300000],
+            ["Early years ITT bursaries", 500000],
+            ["Grants", 900000],
+          ]
+        end
 
         it "returns the correct payment type and total" do
           expect(summary_data_map).to eql(expected_summary_data)
@@ -69,17 +73,22 @@ module Funding
 
     describe "#last_updated_at_string" do
       it "returns the created_at of the last trainee_summary in the correct format" do
-        expect(subject.last_updated_at_string).to eq(summary.created_at.strftime("Last updated: %d %B %Y"))
+        expect(subject.last_updated_at).to eq(summary.created_at.strftime("%d %B %Y"))
       end
     end
 
     describe "#bursary_breakdown_rows" do
       let(:bursary_array) {
-        [{ route_and_subject: "Provider-led\nMaths",
-           lead_school: "BAT Academy",
-           trainees: maths_bursary_trainees,
-           amount_per_trainee: "£2,000.00",
-           total: "£4,000.00" }]
+        [
+          {
+            route: "Provider-led",
+            subject: "Maths",
+            lead_school: "BAT Academy",
+            trainees: maths_bursary_trainees,
+            amount_per_trainee: "£2,000",
+            total: "£4,000",
+          },
+        ]
       }
 
       context "when there are bursaries" do
@@ -90,18 +99,26 @@ module Funding
     end
 
     describe "#scholarship_breakdown_rows" do
-      let(:scholarship_array) {
-        [{ route_and_subject: "Provider-led\nMaths",
-           lead_school: "BAT Academy",
-           trainees: maths_scholarship_trainees,
-           amount_per_trainee: "£5,000.00",
-           total: "£15,000.00" },
-         { route_and_subject: "Provider-led\nBiology",
-           lead_school: "Regminster College",
-           trainees: biology_scholarship_trainees,
-           amount_per_trainee: "£2,000.00",
-           total: "£8,000.00" }]
-      }
+      let(:scholarship_array) do
+        [
+          {
+            route: "Provider-led",
+            subject: "Biology",
+            lead_school: "Regminster College",
+            trainees: biology_scholarship_trainees,
+            amount_per_trainee: "£2,000",
+            total: "£8,000",
+          },
+          {
+            route: "Provider-led",
+            subject: "Maths",
+            lead_school: "BAT Academy",
+            trainees: maths_scholarship_trainees,
+            amount_per_trainee: "£5,000",
+            total: "£15,000",
+          },
+        ]
+      end
 
       context "when there are scholarships" do
         it "returns a breakdown of the scholarships" do
@@ -111,12 +128,9 @@ module Funding
     end
 
     describe "#tiered_bursary_breakdown_rows" do
-      let(:tiered_bursary_array) {
-        [{ tier: 1,
-           trainees: biology_tiered_bursary_trainees,
-           amount_per_trainee: "£1,000.00",
-           total: "£5,000.00" }]
-      }
+      let(:tiered_bursary_array) do
+        [{ tier: 1, trainees: biology_tiered_bursary_trainees, amount_per_trainee: "£1,000", total: "£5,000" }]
+      end
 
       context "when there are tiered bursaries" do
         it "returns a breakdown of the tiered bursaries" do
@@ -126,12 +140,17 @@ module Funding
     end
 
     describe "#grant_breakdown_rows" do
-      let(:grant_array) {
-        [{ subject: "Maths",
-           trainees: maths_grant_trainees,
-           amount_per_trainee: "£3,000.00",
-           total: "£9,000.00" }]
-      }
+      let(:grant_array) do
+        [
+          {
+            route: "Provider-led",
+            subject: "Maths",
+            trainees: maths_grant_trainees,
+            amount_per_trainee: "£3,000",
+            total: "£9,000",
+          },
+        ]
+      end
 
       context "when there are grants" do
         it "returns a breakdown of the grants" do


### PR DESCRIPTION
### Context

Trello ticket: https://trello.com/c/03SxjJas/4081-m-funding-trainee-summary-page

This ticket adds the UI for the trainee summary page. In this ticket we expose more detailed information about bursaries, scholarships, EYITT bursaries and grants, if there are any for that organisation. This is to help organisations track their funding in Register.

For providers:
intro and summary:
<img width="697" alt="Screenshot 2022-05-17 at 16 48 21" src="https://user-images.githubusercontent.com/43522239/168854048-6aeef950-9585-47c8-a922-16a99a167ac9.png">

burs:
<img width="1024" alt="Screenshot 2022-05-17 at 16 49 14" src="https://user-images.githubusercontent.com/43522239/168854136-38e315b0-6b2f-43e3-ab37-8cd9ee75a40b.png">

schol:
<img width="1026" alt="Screenshot 2022-05-17 at 16 49 38" src="https://user-images.githubusercontent.com/43522239/168854204-78dd1ea1-1493-4137-9aa6-3141951031ac.png">

EYITT:
<img width="667" alt="Screenshot 2022-05-17 at 16 49 59" src="https://user-images.githubusercontent.com/43522239/168854293-ff9d7d22-1d13-4385-b260-499eefa80a34.png">


For lead school:
intro and summary:
<img width="614" alt="Screenshot 2022-05-17 at 16 50 44" src="https://user-images.githubusercontent.com/43522239/168854459-d6f8234d-a25d-46bb-833e-5aa4964f899c.png">

grants:
<img width="686" alt="Screenshot 2022-05-17 at 16 51 17" src="https://user-images.githubusercontent.com/43522239/168854539-92fcea29-04a7-4e81-b38b-36501bbedfac.png">

empty state for prov:
<img width="623" alt="Screenshot 2022-05-17 at 16 52 13" src="https://user-images.githubusercontent.com/43522239/168854731-44457800-5d38-4e3c-abc3-38df3cc004e0.png">

empty state lead school
<img width="632" alt="Screenshot 2022-05-17 at 16 52 58" src="https://user-images.githubusercontent.com/43522239/168854875-51077b50-8329-473c-8238-f033e827c366.png">



### Changes proposed in this pull request

* Add trainee_summary/show.html.erb and 5 partials, for bursaries, scholarships, grants, EYITT bursaries and a summary table
* Add methods `sort` and `empty?` to the TraineeSummaryView view object to order data and render the empty state respectively in the view
* Update `format_pounds` method to remove decimal places if there are two zeros e.g. 30.00 => 30
* Add translation files 
* ~~Update test.yml to `funding: true` so that the funding/trainee-summary route is created when the tests run~~

### Guidance to review

* Open the review app https://register-pr-2345.london.cloudapps.digital/ and log in as Denise Theominis
* Select provider on the org page
* Navigate to https://register-pr-2345.london.cloudapps.digital/funding/trainee-summary
* Check through the content here, you'll see tables for summary, bursary, scholarships and EYITT
* Switch to the lead school view for Denise Theominis
* Observe on the trainee summary you will now see information for grants - check this is as expected.
* Log in as persona Emma Smith and navigate as above to see the empty states for providers and lead schools.

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
