### PR TITLE
[4054] Update feedback survey link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,8 +70,8 @@
               <%= Settings.environment.name.titlecase %>
             </strong>
             <span class="govuk-phase-banner__text">
-                This is a new service - <% if FeatureService.enabled?("enable_feedback_link") %>
-                  <%= support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback", classes: "govuk-link--no-visited-state") %>
+                This is a prototype of a new service - <% if FeatureService.enabled?("enable_feedback_link") %>
+                  your <%= govuk_link_to "feedback", Settings.feedback_link_url, class: "govuk-link--no-visited-state" %> will help us improve it
                 <% else %>
                   <%= support_email(name: "report a problem", subject: "Register trainee teachers support", classes: "govuk-link--no-visited-state") %>
                 <% end %>
@@ -93,17 +93,32 @@
       </div>
     </main>
 
-    <%= tag.footer(class: "govuk-footer", role: "contentinfo") do %>
-      <div class="govuk-width-container">
+    <footer class="govuk-footer govuk-footer--app" role="contentinfo">
+      <div class="govuk-width-container ">
+
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-            <h2 class="govuk-heading-m">Get support</h2>
+            <h2 class="govuk-visually-hidden">Support links</h2>
             <div class="govuk-footer__meta-custom">
-              <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                <li>Email: <%= support_email(subject: "Register trainee teachers support", classes: "govuk-footer__link") %></li>
-                <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
-              </ul>
+              <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-half">
+                  <h2 class="govuk-heading-s">
+                    Get support
+                  </h2>
+                  <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
+                    <li>Email: <%= support_email(subject: "Register trainee teachers support", classes: "govuk-footer__link") %></li>
+                    <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
+                  </ul>
+                </div>
+                <div class="govuk-grid-column-one-half">
+                  <h2 class="govuk-heading-s">
+                    Give feedback
+                  </h2>
+                  <p><%= govuk_link_to "Give feedback to help us improve Register trainee teachers", Settings.feedback_link_url, class: "govuk-footer__link" %></p>
+                </div>
+              </div>
             </div>
+
             <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
               <li class="govuk-footer__inline-list-item">
                 <%= govuk_link_to "Accessibility", accessibility_path, class: "govuk-footer__link" %>
@@ -115,12 +130,13 @@
                 <%= govuk_link_to "Privacy policy", privacy_policy_path, class: "govuk-footer__link" %>
               </li>
             </ul>
+
           </div>
           <div class="govuk-footer__meta-item">
-            <%= govuk_link_to raw(%(&copy Crown copyright)), "https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/", class: "govuk-footer__link govuk-footer__copyright-logo" %>
+            <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
           </div>
         </div>
       </div>
-    <% end %>
+    </footer>
   </body>
 </html>

--- a/app/views/trainees/outcome_details/recommended.html.erb
+++ b/app/views/trainees/outcome_details/recommended.html.erb
@@ -17,12 +17,6 @@
       working days.
     </p>
 
-    <%= render FeedbackLink::View.new(
-      enabled: Settings.features.enable_feedback_link,
-      feedback_link_url: Settings.recommended_for_award_feedback_url,
-      feedback_type_text: "recommending a trainee for #{@trainee.award_type}",
-    ) %>
-
     <h2 class="govuk-heading-m">Next steps</h2>
 
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/trn_submissions/show.html.erb
+++ b/app/views/trn_submissions/show.html.erb
@@ -23,12 +23,6 @@
 
     <p class="govuk-body">DfE will contact trainees to give them their TRN.</p>
 
-    <%= render FeedbackLink::View.new(
-      enabled: Settings.features.enable_feedback_link,
-      feedback_link_url: Settings.trn_submitted_feedback_url,
-      feedback_type_text: "registering the trainee",
-    ) %>
-
     <h2 class="govuk-heading-m">Next steps</h2>
 
     <ul class="govuk-list govuk-list--bullet">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,13 +4,7 @@ port: 5000
 base_url: https://localhost:5000
 
 # The url for the google doc feedback link (non-live version)
-feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSdYg4IA2tMiSfqIjM9CslVgFzsSazznD6VoT41g19sJYCwsLQ/viewform"
-
-# The url for the google doc feedback link for recommended for award (non-live version)
-recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSc5ZEOkwsd8NTh3USbaDIL2OSBUtzVFonm7whuXhzFmQK5DHw/viewform"
-
-# The url for the google doc feedback link for submitting a trainee for trn (non-live version)
-trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSeewi8Fl9b90dXjyEX3tE72De8r9yxcFyl51vgOi7hE_fFp1g/viewform"
+feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSd1p-DrskEt7qnF0k0U4jsMgbAAHbz-wrQpvQCmGIJdzkGXcQ/viewform"
 
 # The email address for support queries
 support_email: becomingateacher@digital.education.gov.uk

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,13 +2,7 @@
 base_url: https://www.register-trainee-teachers.service.gov.uk
 
 # The url for the google doc feedback link (live version)
-feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLScTW00rH5Gm8Ama38fgGNQ6Ek7CQPRyadjBfp3BvhYkwJS1jw/viewform"
-
-# The url for the google doc feedback link for recommended for award (live version)
-recommended_for_award_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLScqCdDNyDHNBuUDG5YGWL7TzFI2WdmL6ib5326tUsphtC7PfQ/viewform"
-
-# The url for the google doc feedback link for submitting a trainee for trn (live version)
-trn_submitted_feedback_url: "https://docs.google.com/forms/d/e/1FAIpQLSd-Jc3ef8yNYmIps3H905TuUkVfLYqpwP5ouQilNbHMSElCkg/viewform"
+feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSd6s98QtFceURRhUAguIXutWsJtZRSYehE2o68LvAbchSldiw/viewform"
 
 dttp:
   scope: https://dttp.crm4.dynamics.com/.default


### PR DESCRIPTION
### Context

Ensure feedback link go to the new feedback survey form. Update banner with new form, remove feedback link from trn and qts successful pages.  Update footer so that feedback can be accessed from any page. 