### PR TITLE
4120 update csv export to handle missing funding years

### DIFF
--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -4,6 +4,8 @@ module Exports
   class TraineeSearchData
     VULNERABLE_CHARACTERS = %w[= + - @].freeze
 
+    DATA_NOT_AVAILABLE = "data not available"
+
     def initialize(trainees)
       @data_for_export = format_trainees(trainees)
     end
@@ -153,11 +155,11 @@ module Exports
       funding_manager = funding_manager(trainee)
 
       if trainee.applying_for_bursary?
-        funding_manager.bursary_amount
+        funding_manager.bursary_amount || DATA_NOT_AVAILABLE
       elsif trainee.applying_for_scholarship?
-        funding_manager.scholarship_amount
+        funding_manager.scholarship_amount || DATA_NOT_AVAILABLE
       elsif trainee.applying_for_grant?
-        funding_manager.grant_amount
+        funding_manager.grant_amount || DATA_NOT_AVAILABLE
       end
     end
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -469,8 +469,9 @@ FactoryBot.define do
 
       after(:create) do |trainee, _|
         funding_method = create(:funding_method, :bursary, :with_subjects, training_route: :provider_led_postgrad)
-        trainee.course_subject_one = funding_method.allocation_subjects.first.name
+        trainee.course_allocation_subject = funding_method.allocation_subjects.first
         trainee.training_route = funding_method.training_route
+        trainee.commencement_date = funding_method.academic_cycle.start_date
       end
     end
 
@@ -479,8 +480,9 @@ FactoryBot.define do
 
       after(:create) do |trainee, _|
         funding_method = create(:funding_method, :grant, :with_subjects, training_route: :early_years_salaried)
-        trainee.course_subject_one = funding_method.allocation_subjects.first.name
+        trainee.course_allocation_subject = funding_method.allocation_subjects.first
         trainee.training_route = funding_method.training_route
+        trainee.commencement_date = funding_method.academic_cycle.start_date
       end
     end
 
@@ -489,8 +491,9 @@ FactoryBot.define do
 
       after(:create) do |trainee, _|
         funding_method = create(:funding_method, :scholarship, :with_subjects, training_route: :provider_led_postgrad)
-        trainee.course_subject_one = funding_method.allocation_subjects.first.name
+        trainee.course_allocation_subject = funding_method.allocation_subjects.first
         trainee.training_route = funding_method.training_route
+        trainee.commencement_date = funding_method.academic_cycle.start_date
       end
     end
 
@@ -499,8 +502,9 @@ FactoryBot.define do
 
       after(:create) do |trainee, _|
         funding_method = create(:funding_method, :grant, :with_subjects, training_route: :provider_led_postgrad)
-        trainee.course_subject_one = funding_method.allocation_subjects.first.name
+        trainee.course_allocation_subject = funding_method.allocation_subjects.first
         trainee.training_route = funding_method.training_route
+        trainee.commencement_date = funding_method.academic_cycle.start_date
       end
     end
 

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -191,6 +191,25 @@ module Exports
       end
     end
 
+    describe "#funding_value" do
+      context "when we know the funding methods for that cycle" do
+        let(:trainee) { create(:trainee, :with_provider_led_bursary) }
+
+        it "returns the amount" do
+          expect(subject.send(:funding_value, trainee)).to eq(FundingMethod.last.amount)
+        end
+      end
+
+      context "when we don't know the funding methods for that cycle" do
+        let(:trainee) { create(:trainee, applying_for_bursary: true) }
+
+        it "returns 'data not available'" do
+          trainee = Trainee.new(applying_for_bursary: true)
+          expect(subject.send(:funding_value, trainee)).to eq("data not available")
+        end
+      end
+    end
+
     describe "#course_summary" do
       it "returns blank" do
         trainee = Trainee.new(study_mode: "full_time")

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -192,20 +192,30 @@ module Exports
     end
 
     describe "#funding_value" do
-      context "when we know the funding methods for that cycle" do
-        let(:trainee) { create(:trainee, :with_provider_led_bursary) }
+      context "when the trainee is funded" do
+        context "when we know the funding methods for that cycle" do
+          let(:trainee) { create(:trainee, :with_provider_led_bursary) }
 
-        it "returns the amount" do
-          expect(subject.send(:funding_value, trainee)).to eq(FundingMethod.last.amount)
+          it "returns the amount" do
+            expect(subject.send(:funding_value, trainee)).to eq(FundingMethod.last.amount)
+          end
+        end
+
+        context "when we don't know the funding methods for that cycle" do
+          let(:trainee) { create(:trainee, applying_for_bursary: true) }
+
+          it "returns 'data not available'" do
+            trainee = Trainee.new(applying_for_bursary: true)
+            expect(subject.send(:funding_value, trainee)).to eq("data not available")
+          end
         end
       end
 
-      context "when we don't know the funding methods for that cycle" do
-        let(:trainee) { create(:trainee, applying_for_bursary: true) }
+      context "when the trainee is not funded" do
+        let(:trainee) { create(:trainee) }
 
-        it "returns 'data not available'" do
-          trainee = Trainee.new(applying_for_bursary: true)
-          expect(subject.send(:funding_value, trainee)).to eq("data not available")
+        it "returns nil" do
+          expect(subject.send(:funding_value, trainee)).to be_nil
         end
       end
     end


### PR DESCRIPTION
### Context

https://trello.com/c/93ZvM6HY/4120-update-csv-export-to-handle-missing-funding-years

### Changes proposed in this pull request

A provider queried why some of their trainees with a bursary were showing nil funding_value in the CSV export.

This is because they were from 2017/18 and we don't have funding methods for then.

Instead of adding all the old funding methods to Register, our 'fix' is to say "data not available" in the funding column in this situation.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
