### PR TITLE
[4115] Fix trainee ID missing or incorrect in HESA import

### DIFF
--- a/app/models/hesa/student.rb
+++ b/app/models/hesa/student.rb
@@ -3,5 +3,12 @@
 module Hesa
   class Student < ApplicationRecord
     self.table_name = "hesa_students"
+
+    belongs_to :trainee,
+               foreign_key: :hesa_id,
+               primary_key: :hesa_id,
+               inverse_of: :hesa_student,
+               optional: true,
+               class_name: "::Student"
   end
 end

--- a/db/data/20220517132907_fix_trainee_ids_imported_from_dttp.rb
+++ b/db/data/20220517132907_fix_trainee_ids_imported_from_dttp.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FixTraineeIdsImportedFromDttp < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.joins(:hesa_student).where("trainees.trainee_id != hesa_students.trainee_id").find_each do |trainee|
+      trainee.without_auditing do
+        trainee.update(trainee_id: trainee.hesa_student.trainee_id)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20220517105051_change_hesa_id_type_to_string_in_hesa_students.rb
+++ b/db/migrate/20220517105051_change_hesa_id_type_to_string_in_hesa_students.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeHesaIdTypeToStringInHesaStudents < ActiveRecord::Migration[6.1]
+  def up
+    change_column :hesa_students, :hesa_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_16_103021) do
+ActiveRecord::Schema.define(version: 2022_05_17_105051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -437,7 +437,7 @@ ActiveRecord::Schema.define(version: 2022_05_16_103021) do
   end
 
   create_table "hesa_students", force: :cascade do |t|
-    t.bigint "hesa_id"
+    t.string "hesa_id"
     t.string "first_names"
     t.string "last_name"
     t.string "email"


### PR DESCRIPTION
### Context
https://trello.com/c/tGiv1UlF/4115-investigate-trainee-id-missing-or-incorrect-in-hesa-import

### Changes proposed in this pull request
- Data migration to go through all the trainees that have a `Hesa::Student` record and check if the trainee ID's match. If not, we update the trainee record the trainee ID from `Hesa::Student`
- DB migration to change the `hesa_id` column on the `hesa_students` table to `string` , so we can do `Trainee.joins(:hesa_student)` without having to typecast
- Add the inverse relationship to `Trainee#hesa_student`, otherwise rails throws an exception

If you run this against prod database, 2026 trainees get affected. Migration takes about 3-5 minutes.
