### PR TITLE
[4106] Add data migration to correct the academic cycle dates

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -267,7 +267,7 @@ private
       errors.add(:itt_start_date, :future)
     elsif !itt_start_date.is_a?(Date)
       errors.add(:itt_start_date, :invalid)
-    elsif one_month_before_academic_cycle_starts?(itt_start_date)
+    elsif before_academic_cycle_starts?(itt_start_date)
       errors.add(:itt_start_date, :too_old)
     end
   end
@@ -312,10 +312,10 @@ private
     next_year + MAX_END_YEARS
   end
 
-  def one_month_before_academic_cycle_starts?(date)
+  def before_academic_cycle_starts?(date)
     return false unless date && academic_cycle
 
-    date < (academic_cycle.start_date - 1.month)
+    date < academic_cycle.start_date
   end
 
   def course

--- a/db/data/20220517120014_update_academic_cycle_dates.rb
+++ b/db/data/20220517120014_update_academic_cycle_dates.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class UpdateAcademicCycleDates < ActiveRecord::Migration[6.1]
+  def up
+    AcademicCycle.all.each do |academic_cycle|
+      academic_cycle.start_date = Date.new(academic_cycle.start_date.year, 8, 1)
+      academic_cycle.end_date = Date.new(academic_cycle.end_date.year, 7, 31)
+      academic_cycle.save!
+    end
+  end
+
+  def down
+    AcademicCycle.all.each do |academic_cycle|
+      academic_cycle.start_date = Date.new(academic_cycle.start_date.year, 9, 1)
+      academic_cycle.end_date = Date.new(academic_cycle.end_date.year, 8, 31)
+      academic_cycle.save!
+    end
+  end
+end

--- a/spec/factories/academic_cycles.rb
+++ b/spec/factories/academic_cycles.rb
@@ -17,15 +17,15 @@ FactoryBot.define do
     end
 
     start_date do
-      Date.new(cycle_year, 9, 1)
+      Date.new(cycle_year, 8, 1)
     end
 
     end_date do
-      Date.new(cycle_year + 1, 8, 31)
+      Date.new(cycle_year + 1, 7, 31)
     end
 
     trait :current do
-      cycle_year { Time.zone.now.month >= 9 ? Time.zone.now.year : Time.zone.now.year - 1 }
+      cycle_year { Time.zone.now.month >= 8 ? Time.zone.now.year : Time.zone.now.year - 1 }
     end
   end
 end


### PR DESCRIPTION
### Context

The academic cycle should run 1 August to 31 July. However Register has it starting on 1 September.

### Changes proposed in this pull request

- This PR adds a data migration to correct the dates for all instances of `AcademicCycle`.

### Guidance to review

- What are the knock-on effects of this change? I think this change will move a batch of trainees from the 2021 cycle to 2022 because `Trainee#academic_cycle` depends on which `AcademicCycle` the trainee's `commencement_date` or `awarded_at` fall in. (By my calculations there are about 4000 odd trainees have one of these values in August 2021.)

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
