### PR TITLE
[4080] Funding payment schedule page

### DIFF
--- a/app/controllers/funding/monthly_payments_controller.rb
+++ b/app/controllers/funding/monthly_payments_controller.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Funding
-  class MonthlyPaymentsController < ApplicationController
-    def show; end
-  end
-end

--- a/app/controllers/funding/payment_schedules_controller.rb
+++ b/app/controllers/funding/payment_schedules_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Funding
+  class PaymentSchedulesController < ApplicationController
+    def show
+      payment_schedule = current_user.organisation&.funding_payment_schedules&.order(:created_at)&.last
+      @payment_schedule_view = PaymentScheduleView.new(payment_schedule: payment_schedule)
+      current_academic_cycle = AcademicCycle.current
+      @start_year = current_academic_cycle.start_year
+      @end_year = current_academic_cycle.end_year
+    end
+  end
+end

--- a/app/models/academic_cycle.rb
+++ b/app/models/academic_cycle.rb
@@ -40,6 +40,10 @@ class AcademicCycle < ApplicationRecord
     start_date.year
   end
 
+  def end_year
+    end_date.year
+  end
+
   def label
     "#{start_year} to #{start_year + 1}"
   end

--- a/app/views/funding/payment_schedules/_month_breakdown.html.erb
+++ b/app/views/funding/payment_schedules/_month_breakdown.html.erb
@@ -1,0 +1,45 @@
+<div class="govuk-accordion__section">
+  <div class="govuk-accordion__section-header">
+    <h2 class="govuk-accordion__section-heading">
+      <button type="button"
+              id="accordion-default-heading-<%= index %>"
+              aria-controls="accordion-default-content-<%= index %>"
+              class="govuk-accordion__section-button">
+        <%= month_breakdown.title %>
+        <span class="govuk-accordion__icon"></span>
+      </button>
+    </h2>
+  </div>
+  <div id="accordion-default-content-<%= index %>"
+       class="govuk-accordion__section-content"
+       aria-labelledby="accordion-default-heading-<%= index %>">
+    <%- if month_breakdown.no_payments? -%>
+      <p class="govuk-body"><%= t('funding.payment_schedule.no_payments', month_and_year: month_breakdown.title) %></p>
+    <%- else -%>
+      <table class="govuk-table app-table__in-accordion govuk-!-margin-bottom-6">
+        <caption class="govuk-table__caption govuk-visually-hidden"><%= month_breakdown.title %> payments</caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header app-table__column-50">Payment type</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric app-table__column-25">Amount</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric app-table__column-25">Running total</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% month_breakdown.rows.each do |row| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= row[:description] %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[:amount] %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[:running_total] %></td>
+            </tr>
+          <% end %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-!-font-weight-bold">Total</td>
+            <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= month_breakdown.total_amount %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= month_breakdown.total_running_total %></td>
+          </tr>
+          </tbody>
+      </table>
+    <%- end -%>
+  </div>
+</div>

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -1,0 +1,91 @@
+<%= render PageTitle::View.new(text: "Funding") %>
+
+
+<% if current_user.organisation %>
+  <span class="govuk-caption-xl"><%= current_user.organisation.name %></span>
+<% end %>
+
+<h1 class="govuk-heading-xl"><%= t('funding.view.title') %></h1>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
+<% end %>
+
+<%= render TabNavigation::View.new(items: [
+  { name: t('funding.payment_schedule.heading', start_year: @start_year, end_year: @end_year), url: funding_payment_schedule_path },
+  { name: t('funding.trainee_summary.heading', start_year: @start_year, end_year: @end_year), url: funding_trainee_summary_path },
+]) %>
+
+<%- if @payment_schedule_view.any? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-bottom-3">
+      <h1 class="govuk-heading-l"><%= t('funding.payment_schedule.heading', start_year: @start_year, end_year: @end_year) %></h1>
+      <p class="govuk-body"><%= t('funding.payment_schedule.last_updated_at', date: @payment_schedule_view.last_updated_at) %></p>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <table id="payments" class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-!-margin-bottom-3">
+          <%= t('funding.payment_schedule.payments_table_caption', month_and_year: Time.zone.now.strftime("%b %Y")) %>
+        </caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header"><%= t('funding.payment_schedule.month') %></th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric"><%= t('funding.payment_schedule.total') %></th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric"><%= t('funding.payment_schedule.running_total') %></th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        <%- @payment_schedule_view.actual_payments.each do |actual_payment| -%>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= actual_payment[:month] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= actual_payment[:total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= actual_payment[:running_total] %></td>
+          </tr>
+        <%- end -%>
+        </tbody>
+      </table>
+      <table id="predicted-payments" class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m govuk-!-margin-bottom-3">
+          <%= t('funding.payment_schedule.predicted_payments_table_caption') %>
+        </caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header"><%= t('funding.payment_schedule.month') %></th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric"><%= t('funding.payment_schedule.total') %></th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric"><%= t('funding.payment_schedule.running_total') %></th>
+        </tr>
+        </thead>
+        <tbody>
+        <%- @payment_schedule_view.predicted_payments.each do |predicted_payment| -%>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= predicted_payment[:month] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= predicted_payment[:total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= predicted_payment[:running_total] %></td>
+          </tr>
+        <%- end -%>
+        </tbody>
+      </table>
+      <h2 class="govuk-heading-m"><%= t('funding.payment_schedule.payment_breakdown') %></h2>
+      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+        <%- @payment_schedule_view.payment_breakdown.each_with_index do |month_breakdown, index| -%>
+          <%= render "month_breakdown", month_breakdown: month_breakdown, index: index + 1 %>
+        <%- end -%>
+      </div>
+    </div>
+  </div>
+<%- else -%>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop" >
+      <p class="govuk-body"><%= t("funding.payment_schedule.no_data") %></p>
+      <p class="govuk-body">
+        <%= t("funding.payment_schedule.contact_info", email: govuk_mail_to(
+          Settings.support_email,
+          Settings.support_email,
+          subject: t("funding.view.title")
+        )).html_safe %>
+      </p>
+    </div>
+  </div>
+<%- end -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
           { name: "Home", url: root_path },
           ({ name: "Draft trainees", url: drafts_path(cohort: %w[current]), current: active_link_for("drafts", @trainee) } if can_view_drafts?),
           { name: "Registered trainees", url: trainees_path(cohort: %w[current]), current: active_link_for("trainees", @trainee) },
-          ({ name: "Funding", url: funding_monthly_payments_path, current: active_link_for("funding") } if FeatureService.enabled?("funding")),
+          ({ name: "Funding", url: funding_payment_schedule_path, current: active_link_for("funding") } if FeatureService.enabled?("funding")),
           ({ name: current_user.organisation.name, url: organisations_path, align_right: true } if show_organisation_link?),
         ],
         current_path: request.path,

--- a/app/webpacker/styles/_govuk_overrides.scss
+++ b/app/webpacker/styles/_govuk_overrides.scss
@@ -14,5 +14,12 @@
 
 .govuk-table {
   overflow-x: auto; // Force internal sideways scrolling when content is wider than view
-  display: block;
+}
+
+.app-table__in-accordion tr:last-child td {
+  border-bottom: none;
+}
+
+.govuk-table__header--numeric {
+  text-align: right;
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,10 +48,25 @@ en:
       no_bursary_applied_for: Not funded
       no_grant_applied_for: Not grant funded
       no_funding_available: Not applicable
+      contact_info: Contact %{email} if you think there should be trainees who are eligible.
       tiered_bursary_applied_for:
         tier_one: Applied for Tier 1
         tier_two: Applied for Tier 2
         tier_three: Applied for Tier 3
+    trainee_summary:
+      heading: Bursaries and scholarships %{start_year} to %{end_year}
+    payment_schedule:
+      no_data: There are no scheduled payments right now.
+      contact_info: Contact becoming a %{email} if you think there should be scheduled payments.
+      month: Month
+      total: Total
+      running_total: Running total
+      payment_breakdown: Payment breakdown
+      heading: Payment Schedule %{start_year} to %{end_year}
+      payments_table_caption:  Payments to %{month_and_year}
+      predicted_payments_table_caption: Predicted Payments
+      no_payments: No payments for %{month_and_year}
+      last_updated_at: "Last updated: %{date}"
   schools:
     view:
       summary_title: Schools
@@ -1151,7 +1166,7 @@ en:
               blank: Select the country where the degree was obtained
         provider:
           attributes:
-            accreditation_id: 
+            accreditation_id:
               blank: Enter an accreditation ID
               taken: Enter a unique accreditation ID
             name:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,7 +156,7 @@ Rails.application.routes.draw do
 
   if FeatureService.enabled?("funding")
     namespace :funding do
-      resource :monthly_payments, only: %i[show], path: "/monthly-payments"
+      resource :payment_schedule, only: %i[show], path: "/payment-schedule"
       resource :trainee_summary, only: %i[show], path: "/trainee-summary"
     end
   end

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -12,6 +12,7 @@ features:
     school_direct_tuition_fee: true
     pg_teaching_apprenticeship: true
   redirect_education_domain: true
+  funding: true
 
 environment:
   name: beta

--- a/spec/features/funding/payment_schedule_spec.rb
+++ b/spec/features/funding/payment_schedule_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "viewing the payment schedule" do
+  background do
+    given_i_am_authenticated
+    and_funding_data_exists
+  end
+
+  scenario "viewing payments, predicted payments and payment breakdowns" do
+    given_i_am_on_the_funding_page
+    then_i_should_see_the_actual_payments
+    and_i_should_see_the_predicted_payments
+    and_i_should_see_the_payment_breakdowns
+  end
+
+private
+
+  def and_funding_data_exists
+    create(:academic_cycle, :current)
+    create(:payment_schedule, rows: [
+      build(:payment_schedule_row, amounts: [
+        build(:payment_schedule_row_amount, month: 1, amount_in_pence: 100),
+        build(:payment_schedule_row_amount, month: 2, amount_in_pence: 200),
+        build(:payment_schedule_row_amount, month: 3, amount_in_pence: 600, predicted: true),
+      ]),
+    ], payable: current_user.providers.first)
+  end
+
+  def given_i_am_on_the_funding_page
+    payment_schedule_page.load
+  end
+
+  def then_i_should_see_the_actual_payments
+    expect(payment_schedule_page.payments_table.rows.size).to eq(3) # 1 row is the header
+  end
+
+  def and_i_should_see_the_predicted_payments
+    expect(payment_schedule_page.predicted_payments_table.rows.size).to eq(2) # 1 row is the header
+  end
+
+  def and_i_should_see_the_payment_breakdowns
+    expect(payment_schedule_page.payment_breakdown_tables.size).to eq(3)
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -362,6 +362,10 @@ module Features
       @user_delete_page ||= PageObjects::Users::Delete.new
     end
 
+    def payment_schedule_page
+      @payment_schedule_page ||= PageObjects::Funding::PaymentSchedule.new
+    end
+
   private
 
     def progress_with_prefix(status)

--- a/spec/support/page_objects/funding/payment_schedule.rb
+++ b/spec/support/page_objects/funding/payment_schedule.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Funding
+    class PaymentSchedule < PageObjects::Base
+      set_url "funding/payment-schedule"
+
+      class PaymentsTable < SitePrism::Section
+        elements :rows, "tr"
+      end
+
+      section :payments_table, PaymentsTable, "#payments"
+      section :predicted_payments_table, PaymentsTable, "#predicted-payments"
+      sections :payment_breakdown_tables, PaymentsTable, ".app-table__in-accordion"
+    end
+  end
+end

--- a/spec/view_objects/funding/payment_schedule_view_spec.rb
+++ b/spec/view_objects/funding/payment_schedule_view_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 module Funding
-  describe MonthlyPaymentsView do
+  describe PaymentScheduleView do
     let(:payment_schedule) { build(:payment_schedule, :for_provider, rows: payment_schedule_rows) }
 
     subject { described_class.new(payment_schedule: payment_schedule) }
@@ -98,6 +98,28 @@ module Funding
             total_running_total: "£17.00",
           },
         ])
+      end
+    end
+
+    describe "#any?" do
+      subject { described_class.new(payment_schedule: payment_schedule).any? }
+
+      context "no payment schedule rows" do
+        let(:payment_schedule_rows) { [] }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "payment schedule rows exist" do
+        let(:payment_schedule_rows) do
+          [
+            build(:payment_schedule_row, amounts: [
+              build(:payment_schedule_row_amount, month: 1, amount_in_pence: 100),
+            ]),
+          ]
+        end
+
+        it { is_expected.to be(true) }
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/bh4kk55Z/4080-l-funding-monthly-payments-page

### Changes proposed in this pull request
* Add HTML and ruby logic to display the various tables starting from payments, predicted payments and finally the payment breakdown which are wrapped in accordian boxes

### Note
- The accordian UI is not exactly the same as the prototype. We're going with the latest `gov-uk` version
- Ralph and Maeve looked at the content for the funding stuff and decided to go with the term "Payment Schedule" in the UI instead of "Monthly Payments"

### Guidance to review
* Open the review app https://register-pr-2355.london.cloudapps.digital/ and log in as Denise Theominis
* Select provider on the org page
* Navigate to https://register-pr-2355.london.cloudapps.digital/funding/payments-schedule page
* Check that the design more or less matches the prototype
* Go back to the [organisations page](https://register-pr-2355.london.cloudapps.digital/organisations) and select the lead school and revist the funding page
* There isn't as much data and some accordians will display a message about no payments

### Screenshot
<img width="767" alt="Screenshot 2022-05-19 at 11 36 12" src="https://user-images.githubusercontent.com/28728/169274410-e0b5c10a-e496-4dd6-9271-34fde6cf442c.png">

### Important business
- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
