### PR TITLE
[4109] Fix admins cannot see draft trainees in QA

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,4 +4,8 @@ module UsersHelper
   def lead_school_user?
     defined?(current_user) && current_user&.lead_school?
   end
+
+  def can_view_drafts?
+    defined?(current_user).present? && current_user.present? && UserPolicy.new(current_user, nil).drafts?
+  end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -10,6 +10,6 @@ class UserPolicy < ProviderPolicy
   end
 
   def drafts?
-    !user.lead_school?
+    user.system_admin? || !user.lead_school?
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
       <%= render NavigationBar::View.new(
         items: [
           { name: "Home", url: root_path },
-          ({ name: "Draft trainees", url: drafts_path(cohort: %w[current]), current: active_link_for("drafts", @trainee) } unless lead_school_user?),
+          ({ name: "Draft trainees", url: drafts_path(cohort: %w[current]), current: active_link_for("drafts", @trainee) } if policy(current_user).drafts?),
           { name: "Registered trainees", url: trainees_path(cohort: %w[current]), current: active_link_for("trainees", @trainee) },
           ({ name: "Funding", url: funding_monthly_payments_path, current: active_link_for("funding") } if FeatureService.enabled?("funding")),
           ({ name: current_user.organisation.name, url: organisations_path, align_right: true } if show_organisation_link?),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
       <%= render NavigationBar::View.new(
         items: [
           { name: "Home", url: root_path },
-          ({ name: "Draft trainees", url: drafts_path(cohort: %w[current]), current: active_link_for("drafts", @trainee) } if policy(current_user).drafts?),
+          ({ name: "Draft trainees", url: drafts_path(cohort: %w[current]), current: active_link_for("drafts", @trainee) } if current_user && policy(current_user).drafts?),
           { name: "Registered trainees", url: trainees_path(cohort: %w[current]), current: active_link_for("trainees", @trainee) },
           ({ name: "Funding", url: funding_monthly_payments_path, current: active_link_for("funding") } if FeatureService.enabled?("funding")),
           ({ name: current_user.organisation.name, url: organisations_path, align_right: true } if show_organisation_link?),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
       <%= render NavigationBar::View.new(
         items: [
           { name: "Home", url: root_path },
-          ({ name: "Draft trainees", url: drafts_path(cohort: %w[current]), current: active_link_for("drafts", @trainee) } if current_user && policy(current_user).drafts?),
+          ({ name: "Draft trainees", url: drafts_path(cohort: %w[current]), current: active_link_for("drafts", @trainee) } if can_view_drafts?),
           { name: "Registered trainees", url: trainees_path(cohort: %w[current]), current: active_link_for("trainees", @trainee) },
           ({ name: "Funding", url: funding_monthly_payments_path, current: active_link_for("funding") } if FeatureService.enabled?("funding")),
           ({ name: current_user.organisation.name, url: organisations_path, align_right: true } if show_organisation_link?),

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -22,4 +22,32 @@ describe UsersHelper do
       end
     end
   end
+
+  describe "#can_view_drafts?" do
+    context "with no current_user" do
+      it "returns false" do
+        expect(can_view_drafts?).to be(false)
+      end
+    end
+
+    context "with a current_user who is not authorized" do
+      let(:current_user) { double(UserWithOrganisationContext) }
+      let(:user_policy) { double(UserPolicy, drafts?: false) }
+
+      it "returns false" do
+        allow(UserPolicy).to receive(:new).and_return(user_policy)
+        expect(can_view_drafts?).to be(false)
+      end
+    end
+
+    context "with a current_user who is authorized" do
+      let(:current_user) { double(UserWithOrganisationContext) }
+      let(:user_policy) { double(UserPolicy, drafts?: true) }
+
+      it "returns true" do
+        allow(UserPolicy).to receive(:new).and_return(user_policy)
+        expect(can_view_drafts?).to be(true)
+      end
+    end
+  end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -14,6 +14,9 @@ describe UserPolicy do
   let(:lead_school_user) { create(:user, lead_schools: [lead_school]) }
   let(:lead_school_user_context) { UserWithOrganisationContext.new(user: lead_school_user, session: {}) }
 
+  let(:lead_school_admin_user) { create(:user, system_admin: true, lead_schools: [lead_school]) }
+  let(:lead_school_admin_user_context) { UserWithOrganisationContext.new(user: lead_school_admin_user, session: {}) }
+
   before do
     allow(lead_school_user_context).to receive(:lead_school?).and_return(true)
   end
@@ -21,5 +24,6 @@ describe UserPolicy do
   permissions :drafts? do
     it { is_expected.to permit(provider_user_context) }
     it { is_expected.not_to permit(lead_school_user_context) }
+    it { is_expected.to permit(lead_school_admin_user_context) }
   end
 end


### PR DESCRIPTION
### Context

Previously we were hiding the menu item and denying access to _Drafts_ if a user has a lead school even if they were system admins. This came to light on QA because the admin persona there cannot see Drafts.

### Changes proposed in this pull request

This change permits system admins to always see Drafts by updating the `UserPolicy`. It also changes the menu rendering check to refer directly to the policy rather than via a helper so that the rules and front-end are easier to keep in sync.

### Guidance to review

- Is this the correct way to update the authorisation rules?
- Are the tests sufficient?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
