### PR TITLE
[xxx] Fix Trainee#hesa_student

### DIFF
--- a/app/models/hesa/student.rb
+++ b/app/models/hesa/student.rb
@@ -3,5 +3,11 @@
 module Hesa
   class Student < ApplicationRecord
     self.table_name = "hesa_students"
+
+    belongs_to :trainee,
+               foreign_key: :hesa_id,
+               primary_key: :hesa_id,
+               inverse_of: :hesa_student,
+               optional: true
   end
 end


### PR DESCRIPTION
### Context

Trainee `belongs_to` Hesa::Student. The association specified an inverse but the inverse doesn't exist so
it's erroring.

### Changes proposed in this pull request

Add the inverse relationship. Rubocop doesn't like relationships without an inverse specified so this seems the pragmatic approach for now. We don't intend for Hesa::Student to be around for long (famous last words).

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
