### PR TITLE
[4117] Backfill some missing itt_end_dates fro our raw HESA data

### DIFF
--- a/db/data/20220519104858_backfill_itt_end_dates_for_hesa_trainees.rb
+++ b/db/data/20220519104858_backfill_itt_end_dates_for_hesa_trainees.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class BackfillIttEndDatesForHesaTrainees < ActiveRecord::Migration[6.1]
+  def up
+    trainees = Trainee.joins(:hesa_student)
+                      .where(itt_end_date: nil)
+                      .where.not({ hesa_student: { itt_end_date: nil } })
+
+    trainees.find_each do |trainee|
+      trainee.without_auditing do
+        trainee.update(itt_end_date: trainee.hesa_student.itt_end_date)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/NkWnDd3G/4117-investigate-missing-dates-from-hesa-import

### Changes proposed in this pull request

Where a trainee has a hesa_student, and that hesa_student has an itt_end_date, update our trainee to have that same itt_end_date.

This will not fix the vast majority of trainees because itt_end_date is not required in HESA. But because of this, we don't show it anywhere in the UI.

We may add a further improvement to use study length (e.g. 1 year) which we do get from HESA to calculate and save the itt_end_date.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
