### PR TITLE
[4044] Data migration to update TRN from HESA

### DIFF
--- a/db/data/20220518155102_fetch_trns_from_hesa_records.rb
+++ b/db/data/20220518155102_fetch_trns_from_hesa_records.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class FetchTrnsFromHesaRecords < ActiveRecord::Migration[6.1]
+  def up
+    trainees = Trainee.joins(:hesa_student).where(trainees: { trn: nil }).where.not(hesa_students: { trn: nil })
+    trainees.each do |t|
+      t.update(trn: t.hesa_student.trn)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

There are 43 trainees in production that have no TRN but do have a TRN
in the HESA data.

### Changes proposed in this pull request

Update the trainee records with TRN from HESA where one is available.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
