### PR TITLE
[4118] Fix primary PE subjects

### DIFF
--- a/db/data/20220519162059_fix_primary_pe_subjects.rb
+++ b/db/data/20220519162059_fix_primary_pe_subjects.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class FixPrimaryPeSubjects < ActiveRecord::Migration[6.1]
+  def up
+    trainee_ids = [
+      100790,
+      90738,
+      90740,
+      90747,
+      91105,
+      102185,
+      106488,
+      106494,
+      106564,
+      106573,
+      106584,
+      106539,
+      106590,
+      106595,
+      106572,
+      106568,
+      106658,
+      106650,
+      106676,
+      106695,
+      106697,
+      106714,
+      106735,
+      106778,
+      106781,
+      106774,
+      109263,
+      109265,
+      85174,
+      109624,
+    ]
+
+    primary_allocation_subject_id = AllocationSubject.find_by(name: "Primary").id
+
+    Trainee.where(id: trainee_ids).each do |trainee|
+      trainee.without_auditing do
+        trainee.update(
+          course_subject_one: "primary teaching",
+          course_subject_two: "sport and exercise sciences",
+          course_allocation_subject_id: primary_allocation_subject_id,
+        )
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

These trainees were submitted with PE as the course_subject_one but they are primary with PE. These should be fixed in HESA or they'll get overwritten in the next collection. Will raise that with the ops team.

### Changes proposed in this pull request

Fix the subjects and allocation subjects.

### Guidance to review

The trainees should all belong to provider 227 and have course_subject_one as 'sports and exercise sciences' but an age range of 5 - 11.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
