### PR TITLE
[4108] Fix missing education phase

### DIFF
--- a/db/data/20220520150324_backfill_missing_education_phases.rb
+++ b/db/data/20220520150324_backfill_missing_education_phases.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BackfillMissingEducationPhases < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.where.not(training_route: EARLY_YEARS_TRAINING_ROUTES.keys).where(course_education_phase: nil).find_each do |trainee|
+      trainee.without_auditing do
+        trainee.update(course_education_phase: Dttp::CodeSets::AgeRanges::MAPPING.dig(trainee.course_age_range, :levels)&.first)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/F69RQGhy/4108-dttp-missing-education-phase

### Changes proposed in this pull request
- Data migration that fixes missing `course_education_phase` for Trainees that are not early years related and have an age range

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
