### PR TITLE
[4153] Display only two latest updates on start page

### DIFF
--- a/app/models/service_update.rb
+++ b/app/models/service_update.rb
@@ -18,6 +18,8 @@ class ServiceUpdate
   end
 
   def self.recent_updates
-    all.select { |service_update| service_update.date > 1.month.ago }
+    recent_updates = all.select { |service_update| service_update.date > 1.month.ago }
+
+    recent_updates[0, 2]
   end
 end


### PR DESCRIPTION
### Context

The original trello card has been archived - but there was some discussion on Slack about only displaying the two most recent updates on the homepage. I've implemented that in this PR.

https://trello.com/c/6zBh71i1/4153-remove-old-news-and-updates-content

### Changes proposed in this pull request

* Update `recent_updates` method so we only display the two most recent updates which have dates greater than 1 month ago

### Guidance to review

* View the sign in page on the review app
* Observe you only see two updates now

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
