### PR TITLE
[4022] Fix page heading / title mismatches

### DIFF
--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "pages.accessibility") %>
+<%= render PageTitle::View.new(text: t(".heading")) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(

--- a/app/views/pages/check_data.html.erb
+++ b/app/views/pages/check_data.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "pages.check_data") %>
+<%= render PageTitle::View.new(text: t(".heading")) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(

--- a/app/views/pages/guidance.html.erb
+++ b/app/views/pages/guidance.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "pages.guidance") %>
+<%= render PageTitle::View.new(text: t(".heading")) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "pages.home") %>
+<%= render PageTitle::View.new(text: t(".heading")) %>
 
 <% unless lead_school_user? %>
   <div class="govuk-grid-row">

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "sign_in.index") %>
+<%= render PageTitle::View.new(text: t(".heading")) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(

--- a/app/views/system_admin/providers/users/delete.html.erb
+++ b/app/views/system_admin/providers/users/delete.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "users.delete") %>
+<%= render PageTitle::View.new(text: "Are you sure you want to remove this user?") %>
 
 <%= render GovukComponent::BackLinkComponent.new(
       text: "Back",

--- a/app/views/system_admin/providers/users/new.html.erb
+++ b/app/views/system_admin/providers/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "users.new", has_errors: @user.errors.present?) %>
+<%= render PageTitle::View.new(text: "Add a user for #{@provider.name}", has_errors: @user.errors.present?) %>
 
 <%= render GovukComponent::BackLinkComponent.new(
       text: "Back",

--- a/app/views/trainees/confirm_deletes/show.html.erb
+++ b/app/views/trainees/confirm_deletes/show.html.erb
@@ -1,4 +1,6 @@
-<%= render PageTitle::View.new(text: t("views.confirm_delete.heading", record_type: t(:draft))) %>
+<%= render PageTitle::View.new(
+  text: t("views.confirm_delete.heading", record_type: @trainee.draft? ? t(:draft) : t(:record)),
+) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(text: I18n.t("back_to_draft"), href: trainee_path(@trainee)) %>

--- a/app/views/trainees/confirm_deletes/show.html.erb
+++ b/app/views/trainees/confirm_deletes/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.delete") %>
+<%= render PageTitle::View.new(text: t("views.confirm_delete.heading", record_type: t(:draft))) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(text: I18n.t("back_to_draft"), href: trainee_path(@trainee)) %>

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.course_details.edit", has_errors: @course_details_form.errors.present?) %>
+<%= render PageTitle::View.new(text: ".heading", has_errors: @course_details_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/course_years/edit.html.erb
+++ b/app/views/trainees/course_years/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.course_years.edit", has_errors: @course_years_form.errors.present?) %>
+<%= render PageTitle::View.new(text: t(".heading"), has_errors: @course_years_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/degrees/edit.html.erb
+++ b/app/views/trainees/degrees/edit.html.erb
@@ -1,4 +1,7 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.degrees.edit", has_errors: @degree_form.errors.present?) %>
+<%= render PageTitle::View.new(
+  text: (@degree_form.uk? ? "UK degree details" : "Non-UK degree details"),
+  has_errors: @degree_form.errors.present?,
+) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/degrees/new.html.erb
+++ b/app/views/trainees/degrees/new.html.erb
@@ -1,4 +1,7 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.degrees.edit", has_errors: @degree_form.errors.present?) %>
+<%= render PageTitle::View.new(
+  text: (@degree_form.uk? ? "UK degree details" : "Non-UK degree details"),
+  has_errors: @degree_form.errors.present?,
+) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(

--- a/app/views/trainees/forbidden_withdrawals/show.html.erb
+++ b/app/views/trainees/forbidden_withdrawals/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.forbidden_withdrawals.show") %>
+<%= render PageTitle::View.new(text: t(".heading")) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/language_specialisms/edit.html.erb
+++ b/app/views/trainees/language_specialisms/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.language_specialisms.edit", has_errors: @language_specialisms_form.errors.present?) %>
+<%= render PageTitle::View.new(text: t(".heading"), has_errors: @language_specialisms_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/app/views/trainees/outcome_details/confirm.html.erb
+++ b/app/views/trainees/outcome_details/confirm.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.outcome_details.confirm_#{@trainee.award_type.downcase}") %>
+<%= render PageTitle::View.new(text: "Check #{@trainee.award_type} details") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(text: t(:back_to_record), href: trainee_path(@trainee)) %>

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -1,4 +1,7 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.course_details.edit", has_errors: @publish_course_details_form.errors.present?) %>
+<%= render PageTitle::View.new(
+  text: t(".heading", from_year: @course_year, to_year: (@course_year + 1)),
+  has_errors: @publish_course_details_form.errors.present?,
+) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back), last_origin_page: true) %>

--- a/app/views/trainees/subject_specialisms/edit.html.erb
+++ b/app/views/trainees/subject_specialisms/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.subject_specialisms.edit",
+<%= render PageTitle::View.new(text: t(".heading", subject: @subject.downcase),
                                has_errors: @subject_specialism_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>

--- a/app/views/trainees/training_details/edit.html.erb
+++ b/app/views/trainees/training_details/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: t("views.forms.training_details.title"), has_errors: @training_details_form.errors.present?) %>
+<%= render PageTitle::View.new(text: t("views.forms.training_details.trainee_id.label"), has_errors: @training_details_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,7 +296,7 @@ en:
         personal_details:
           edit: Trainee personal details
         trainee_start_date:
-          edit: &commencement_date Trainee’s start date
+          edit: When did the trainee start their ITT?
         trainee_start_status:
           edit: Did the trainee start their ITT on time?
         training_details:
@@ -612,7 +612,7 @@ en:
         employing_school_id: *employing_school
         school_id: *lead_school
         commencement_date: *trainee_start_date
-        commencement_date_radio_option: *commencement_date
+        commencement_date_radio_option: Trainee’s start date
         trainee_id: *trainee_id
         study_mode: *study_mode
         primary_course_subjects: *course_subject

--- a/spec/features/auth/sign_in_page_spec.rb
+++ b/spec/features/auth/sign_in_page_spec.rb
@@ -9,13 +9,13 @@ feature "sign in page" do
 
   scenario "navigate to sign in", feature_use_dfe_sign_in: false do
     expect(sign_in_page.page_heading).to have_text("Sign in")
-    expect(sign_in_page).to have_title("Sign in - Register trainee teachers - GOV.UK")
+    expect(sign_in_page).to have_title("Sign in to Register trainee teachers - Register trainee teachers - GOV.UK")
     expect(sign_in_page.sign_in_button.text).to eq("Sign in using Persona")
   end
 
   scenario "navigate to sign in", feature_use_dfe_sign_in: true do
     expect(sign_in_page.page_heading).to have_text("Sign in")
-    expect(sign_in_page).to have_title("Sign in - Register trainee teachers - GOV.UK")
+    expect(sign_in_page).to have_title("Sign in to Register trainee teachers - Register trainee teachers - GOV.UK")
     expect(sign_in_page.sign_in_button.value).to eq("Sign in using DfE Sign-in")
   end
 end


### PR DESCRIPTION
### Context

On a number of pages the page title does not match the level 1 heading on that page.

From the accessibility report:

"Users navigating the service will find that in some instances the page title does not follow the GOV Design System specifications. The page title in this case does not include the heading level one."

Pages identified on the card with mismatches are:

* Sign-in
* Home
* Training id
* Course details
* Delete this course record

See https://trello.com/c/fohMelgs/4022-page-headings-and-page-titles-dont-match-in-a-few-places

Note that some page titles are deliberately different to the level 1 headings. In particular we do not include any PII in page titles in cases where the headings do do so.

### Changes proposed in this pull request

- Make the page title match the heading in the cases listed above.
- Identify any other pages that have mismatches and fix those ones too.

Other pages 'fixed' are:
- Guidance page
- Accessibility page
- Delete provider user
- New provider user
- Edit course details
- Edit course year
- Edit / New degrees
- Check outcome details
- Publish course details
- Edit training details
- Edit subject specialisms

### Guidance to review

- Are there any mismatches that I've missed?
- Have I inadvertently introduced PII in the page titles?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
