### PR TITLE
Add SNYK scan to build workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -47,6 +47,14 @@ jobs:
         echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
         echo "IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
+    - name: Set KV environment variables
+      if: github.actor != 'dependabot[bot]'
+      run: |
+        # tag build to the review env for vars and secrets
+        tf_vars_file=terraform/workspace-variables/review.tfvars.json
+        echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+        echo "KEY_VAULT_INFRA_SECRET_NAME=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1.12.0
       with:
@@ -54,19 +62,50 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - uses: azure/login@v1
+      if: github.actor != 'dependabot[bot]'
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
+
+    - uses: DFE-Digital/keyvault-yaml-secret@v1
+      if: github.actor != 'dependabot[bot]'
+      id: get-secret
+      with:
+        keyvault: ${{ env.KEY_VAULT_NAME }}
+        secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
+        key: SNYK_TOKEN
+
     - name: Build Docker Image
       uses: docker/build-push-action@v2
       with:
         tags: |
           ${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
           ${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
-        push: true
+        push: false
+        load: true
         cache-to: type=inline
         cache-from: |
           type=registry,ref=${{env.DOCKER_IMAGE}}:main
           type=registry,ref=${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
           type=registry,ref=${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
         build-args: COMMIT_SHA=${{ github.sha }}
+
+    - name: Push ${{ env.DOCKER_IMAGE }} images for review
+      if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
+      run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
+
+    - name: Run Snyk to check Docker image for vulnerabilities
+      if: github.actor != 'dependabot[bot]'
+      uses: snyk/actions/docker@master
+      env:
+        SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
+      with:
+        image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
+        args: --file=Dockerfile --severity-threshold=high
+
+    - name: Push ${{ env.DOCKER_IMAGE }} images
+      if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') }}
+      run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
 
     - name: Check for Failure
       if: ${{ failure() && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
### Context

Add SNYK security scan of the docker image to the build workflow. 
It will scan on PR (but not for dependabot) and merge to main.

Any High (or above) vulnerability will cause the build workflow to fail,
and will need to be fixed (or excluded) for the build to continue.

https://trello.com/c/aqX2HVlk/338-scan-docker-images

### Changes proposed in this pull request

Additions to the build-and-deploy workflow

### Guidance to review

Check workflow runs as expected

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
