### PR TITLE
Fix flakey spec

### DIFF
--- a/spec/jobs/hesa/retrieve_collection_job_spec.rb
+++ b/spec/jobs/hesa/retrieve_collection_job_spec.rb
@@ -46,6 +46,12 @@ module Hesa
       end
 
       describe "HesaCollectionRequest" do
+        around do |example|
+          Timecop.freeze do
+            example.run
+          end
+        end
+
         before { described_class.new.perform }
 
         it "marks the import as successful" do
@@ -61,10 +67,8 @@ module Hesa
         end
 
         it "stores the requested_at" do
-          Timecop.freeze do
-            expected_time = Time.zone.now
-            expect(last_hesa_collection_request.requested_at.tv_sec).to eq(expected_time.tv_sec)
-          end
+          expected_time = Time.zone.now
+          expect(last_hesa_collection_request.requested_at.tv_sec).to eq(expected_time.tv_sec)
         end
       end
 


### PR DESCRIPTION
### Context

I got an off by one second error here because the code under test runs
before we use Timecop to freeze time so if you are very unlucky the
clock will tick a second between the code running and the freeze.

### Changes proposed in this pull request

Solution here is to just move the freeze to an `around` block that
should run before the `before` block.

### Guidance to review

A side-effect here is that we are freezing time for all examples in the given context rather than just the one that actually needs it. Is there a tidier way?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
