### PR TITLE
[4052] Wording change 'Privacy policy' to 'Privacy notice'

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -127,7 +127,7 @@
                 <%= govuk_link_to "Cookies", cookie_preferences_path, class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <%= govuk_link_to "Privacy policy", privacy_policy_path, class: "govuk-footer__link" %>
+                <%= govuk_link_to "Privacy", privacy_policy_path, class: "govuk-footer__link" %>
               </li>
             </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,7 +255,7 @@ en:
         accessibility: Accessibility statement for Register trainee teachers
         cookie_policy: Cookies on Register trainee teachers
         guidance: Data requirements
-        privacy_policy: Register trainee teachers privacy policy
+        privacy_policy: Register trainee teachers privacy notice
         forbidden: &forbidden You do not have permission to perform this action
         home: Home
         request_an_account: Request an account for Register trainee teachers (Register)
@@ -881,7 +881,7 @@ en:
     check_data:
       heading: Check what data you need to provide
     privacy_policy:
-      heading: Register trainee teachers privacy policy
+      heading: Register trainee teachers privacy notice
     no_organisation:
       heading: You have not been linked to an organisation yet
   organisations:

--- a/config/locales/pages/privacy_policy/en.yml
+++ b/config/locales/pages/privacy_policy/en.yml
@@ -8,7 +8,7 @@ en:
 
       <p class='govuk-body'>For the purpose of UK General Data Protection Regulation (UK GDPR), the DfE is the data controller for data held and processed in Register. Initial teacher training (ITT) providers, who use Register, are both data processors for DfE and also independent Data Controllers within the delivery of teacher training.</p>
 
-      <h2 class='govuk-heading-m' id='who-this-privacy-policy-is-for'>Who this privacy policy is for</h2>
+      <h2 class='govuk-heading-m' id='who-this-privacy-policy-is-for'>Who this privacy notice is for</h2>
       <ul class='govuk-list govuk-list--bullet'>
         <li>trainee teachers when you register with the Department for Education’s (DfE) Apply for teacher training service</li>
         <li>trainee teachers when you register directly with a teacher training provider</li>
@@ -136,9 +136,9 @@ en:
 
       <p class='govuk-body'>If we cannot resolve your issue, you have the right to raise it with the <a href='https://ico.org.uk/' class='govuk-link'>Information Commissioner's Office (ICO)</a>.</p>
 
-      <h2 class='govuk-heading-m' id='keep-up-to-date'>Keeping our privacy policy up to date</h2>
+      <h2 class='govuk-heading-m' id='keep-up-to-date'>Keeping our privacy notice up to date</h2>
 
-      <p class='govuk-body'>We’ll update this privacy policy when required. You should regularly review the notice.</p>
+      <p class='govuk-body'>We’ll update this privacy notice when required. You should regularly review the notice.</p>
 
       <p class='govuk-body'>This version was last updated on 31 March 2022.
 </p>

--- a/spec/support/page_objects/start.rb
+++ b/spec/support/page_objects/start.rb
@@ -16,7 +16,7 @@ module PageObjects
     section :footer, "footer" do
       element :accessibility_link, ".govuk-footer__link", text: "Accessibility"
       element :cookies_link, ".govuk-footer__link", text: "Cookies"
-      element :privacy_link, ".govuk-footer__link", text: "Privacy policy"
+      element :privacy_link, ".govuk-footer__link", text: "Privacy"
     end
 
     section :primary_navigation, "nav.moj-primary-navigation" do


### PR DESCRIPTION
### Context

This PR is just a wording change, from 'policy' to 'notice' on the 'Register privacy policy'.

See https://trello.com/c/OlU1TBW2/4052-change-wording-of-policy-to-notice-on-register-privacy-policy

### Changes proposed in this pull request

- Change page title
- Change heading and content on privacy notice page
- Change link in footer to just be 'Privacy'

<img width="610" alt="image" src="https://user-images.githubusercontent.com/450843/170454102-d2767934-06c7-4ec8-a13d-77668ed41c49.png">

<img width="802" alt="image" src="https://user-images.githubusercontent.com/450843/170453739-94d13fe2-b945-4566-b031-eadfc3efa714.png">

<img width="802" alt="image" src="https://user-images.githubusercontent.com/450843/170453821-8175b899-b7ba-469a-8fb2-697cbaace481.png">

### Guidance to review

- Anything missing?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
