### PR TITLE
[4160] 2021-2022 record not imported into register from DTTP

### DIFF
--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -250,6 +250,7 @@ module Trainees
         course_subject_three: course(placement_assignment.response["_dfe_ittsubject3id_value"]),
         course_min_age: age_range && age_range[0],
         course_max_age: age_range && age_range[1],
+        course_allocation_subject: course_allocation_subject,
         study_mode: study_mode,
         commencement_date: commencement_date,
         itt_start_date: placement_assignment.programme_start_date,
@@ -425,6 +426,10 @@ module Trainees
 
     def funding_entity_id
       @funding_entity_id ||= placement_assignment.funding_id
+    end
+
+    def course_allocation_subject
+      SubjectSpecialism.find_by(name: course_subject_one_name)&.allocation_subject
     end
 
     def update_shases!

--- a/db/data/20220526104624_add_missing_withdrawn_trainee.rb
+++ b/db/data/20220526104624_add_missing_withdrawn_trainee.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AddMissingWithdrawnTrainee < ActiveRecord::Migration[6.1]
+  def up
+    # This trainee changed course, thus has 2 placement assignments. The data migration will create
+    # a duplicate record for the first placement at the request of the provider.
+    ActiveRecord::Base.transaction do
+      dttp_trainee = Dttp::Trainee.find(29820)
+      existing_trainee = dttp_trainee.trainee
+      trainee_dttp_id = existing_trainee.dttp_id
+
+      # Prevent existing trainee from creating duplicate
+      existing_trainee.update_columns(dttp_id: nil)
+      dttp_trainee.importable!
+
+      # Re-import trainee using their first placement assignment
+      previous_placement_assignment = dttp_trainee.placement_assignments[-1]
+      duplicate_trainee = Trainees::CreateFromDttp.call(dttp_trainee: dttp_trainee,
+                                                        placement_assignment: previous_placement_assignment)
+
+      # We don't want the HESA importer finding and updating this record, so we'll remove the HESA ID. We also don't
+      # want the Dttp::Trainee record to point back back this trainee (only the existing one).
+      duplicate_trainee.update_columns(hesa_id: nil, dttp_id: nil)
+
+      # The existing trainee is also in the wrong state.
+      existing_trainee.update_columns(state: :trn_received,
+                                      dttp_id: trainee_dttp_id,
+                                      withdraw_date: nil,
+                                      withdraw_reason: nil)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/0PqA4b9l/4160-2021-2022-record-not-imported-into-register-from-dttp-sheffield-hallam-university

### Changes proposed in this pull request
- Update `Trainees::CreateFromDttp` to accept a placement assignment other than the latest
- Fix `Trainees::CreateFromDttp` so it sets the `course_allocation_subject`
- Data migration to create a duplicate record of the trainee so it captures a previous placement assignment

### Guidance to review
- You can download the prod DB and run it against it. I did it already and it works as expected. Worth noting that the `trainee_id` is different for each record because it comes from the placement assignment.

### Important business
- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
