### PR TITLE
[4023] Remove `abbr` tags for ITT

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,9 +120,9 @@ en:
       status_date_prefix:
         deferred: "Deferral date: "
         withdrawn: "Withdrawal date: "
-      itt_has_not_started: <abbr title="Initial teacher training">ITT</abbr> has not started
+      itt_has_not_started: ITT has not started
       not_provided: Not provided
-      deferred_before_itt_started: Trainee deferred before starting their <abbr title="initial teacher training">ITT</abbr>
+      deferred_before_itt_started: Trainee deferred before starting their ITT
   training_details:
     view:
       title: *trainee_id
@@ -130,13 +130,13 @@ en:
   deferral_details:
     view:
       defer_date_label: Date of deferral
-      deferred_before_itt_started: Trainee deferred before their <abbr title="initial teacher training">ITT</abbr> started
-      itt_started_but_trainee_did_not_start: The trainee deferred before starting their <abbr title="initial teacher training">ITT</abbr>
+      deferred_before_itt_started: Trainee deferred before their ITT started
+      itt_started_but_trainee_did_not_start: The trainee deferred before starting their ITT
       summary_title: Deferral details
       start_date_label: *trainee_start_date
   reinstatement_details:
     view:
-      reinstated_before_starting: Trainee returned before their <abbr title="initial teacher training">ITT</abbr> started
+      reinstated_before_starting: Trainee returned before their ITT started
   components:
     admin_feature:
       title: Admin
@@ -460,8 +460,8 @@ en:
           reinstated: Trainee reinstated
           course_uuid: Course updated
           course_max_age: Course age range updated
-          itt_start_date: &itt_start_date <abbr title="Initial teacher training">ITT</abbr> start date
-          itt_end_date: &itt_end_date <abbr title="Initial teacher training">ITT</abbr> end date
+          itt_start_date: &itt_start_date ITT start date
+          itt_end_date: &itt_end_date ITT end date
           course_subject_one: Course subject updated
           commencement_date: Trainee start date updated
           trainee_id: Trainee ID updated
@@ -791,8 +791,8 @@ en:
             We may also use it if we need to get in touch with you about this trainee.
       start_dates:
         commencement_date:
-          label: When did the trainee start their <abbr title="initial teacher training">ITT</abbr>?
-          hint: Their <abbr title="initial teacher training">ITT</abbr> started on %{itt_start_date}
+          label: When did the trainee start their ITT?
+          hint: Their ITT started on %{itt_start_date}
       publish_course_details:
         route_message: Your %{route} courses in the Publish service
         all_courses_message: Your courses in the Publish service
@@ -970,8 +970,8 @@ en:
       multiple_subjects: Subjects
       level: Level
       age_range: Age range
-      itt_start_date: <abbr title="Initial teacher training">ITT</abbr> start date
-      itt_end_date: <abbr title="Initial teacher training">ITT</abbr> end date
+      itt_start_date: ITT start date
+      itt_end_date: ITT end date
       duration: Duration
       study_mode: Full time or part time
       course_details: Course details
@@ -1077,21 +1077,21 @@ en:
     start_statuses:
       edit:
         itt_not_yet_started: They have not started yet
-        label: Did the trainee start their <abbr title="initial teacher training">ITT</abbr> on time?
+        label: Did the trainee start their ITT on time?
         on_time_html: Yes, they started on time — <span class="no-wrap">%{itt_start_date}</span>
         started_later: No, they started later
         trainee_start_date: *trainee_start_date
         trainee_start_date_hint: For example, 8 11 2021
     start_date_verifications:
       show:
-        legend: Did the trainee start their <abbr title="initial teacher training">ITT</abbr>?
+        legend: Did the trainee start their ITT?
         yes_they_started: Yes, they started
         no_they_did_not_start: No, they did not start
     forbidden_deletes:
       show:
         title: Delete forbidden
         heading: You cannot delete this record
-        reason: You can only delete a trainee record before the trainee starts their <abbr title="initial teacher training">ITT</abbr>. You can defer or withdraw the trainee.
+        reason: You can only delete a trainee record before the trainee starts their ITT. You can defer or withdraw the trainee.
         defer: Defer
         withdraw: Withdraw
         return_to_record: Return to trainee record
@@ -1286,7 +1286,7 @@ en:
             date:
               blank: Enter a deferral date
               invalid: Enter a valid deferral date
-              not_before_itt_start_date: &not_before_itt_start_date The date must not be before the <abbr title="initial teacher training">ITT</abbr> start date
+              not_before_itt_start_date: &not_before_itt_start_date The date must not be before the ITT start date
         degrees_form:
           attributes:
             degree_ids:


### PR DESCRIPTION
### Context
There are accessibility issues with this tag and we expect that most
users should be familiar with this abbreviation. So it makes sense to
remove these tags.

### Changes proposed in this pull request
Just remove the `abbr` tags that wrap _ITT_.

### Guidance to review
- Have I missed any?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
