### PR TITLE
[4179] Skip providers and lead schools that do not exist and report them at end

### DIFF
--- a/lib/tasks/funding.rake
+++ b/lib/tasks/funding.rake
@@ -4,13 +4,15 @@ namespace :funding do
   desc "imports provider payment schedules from a provided csv"
   task :import_provider_payment_schedules, %i[csv_path first_predicted_month_index] => [:environment] do |_, args|
     attributes = Funding::Parsers::ProviderPaymentSchedules.to_attributes(file_path: args.csv_path)
-    Funding::ProviderPaymentSchedulesImporter.call(attributes: attributes, first_predicted_month_index: args.first_predicted_month_index)
+    missing_ids = Funding::ProviderPaymentSchedulesImporter.call(attributes: attributes, first_predicted_month_index: args.first_predicted_month_index)
+    abort("Provider accreditation ids: #{missing_ids.join(', ')} not found") unless missing_ids.empty?
   end
 
   desc "imports lead school payment schedules from a provided csv"
   task :import_lead_school_payment_schedules, %i[csv_path first_predicted_month_index] => [:environment] do |_, args|
     attributes = Funding::Parsers::LeadSchoolPaymentSchedules.to_attributes(file_path: args.csv_path)
-    Funding::LeadSchoolPaymentSchedulesImporter.call(attributes: attributes, first_predicted_month_index: args.first_predicted_month_index)
+    missing_urns = Funding::LeadSchoolPaymentSchedulesImporter.call(attributes: attributes, first_predicted_month_index: args.first_predicted_month_index)
+    abort("Lead school URNs: #{missing_urns.join(', ')} not found") unless missing_urns.empty?
   end
 
   desc "imports provider trainee summaries from a provided csv"

--- a/spec/services/funding/lead_school_payment_schedules_importer_spec.rb
+++ b/spec/services/funding/lead_school_payment_schedules_importer_spec.rb
@@ -275,8 +275,8 @@ module Funding
 
       subject { described_class.call(attributes: invalid_schedules_attributes, first_predicted_month_index: 12) }
 
-      it "raises" do
-        expect { subject }.to raise_error(PayableNotFoundError, "payable with id: 105491 doesn't exist")
+      it "returns a list of lead school urns not found in database" do
+        expect(subject).to eq(["105491"])
       end
     end
   end

--- a/spec/services/funding/provider_payment_schedules_importer_spec.rb
+++ b/spec/services/funding/provider_payment_schedules_importer_spec.rb
@@ -169,8 +169,8 @@ module Funding
 
       subject { described_class.call(attributes: invalid_schedules_attributes, first_predicted_month_index: 12) }
 
-      it "raises" do
-        expect { subject }.to raise_error(PayableNotFoundError, "payable with id: 5635 doesn't exist")
+      it "returns a list of provider accreditation ids not found in database" do
+        expect(subject).to eq(["5635"])
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/gvr8epcX/4179-payment-schedule-import-skip-providers-and-lead-schools-that-do-not-exist-and-report-them-at-end

### Changes proposed in this pull request
- Change `Funding::PayablePaymentSchedulesImporter` so it doesn't blow if a provider or lead school is missing. It instead tracks the missing organisations and reports them after the import

### Guidance to review
- Download a local copy of the prod DB
- Open the each CSV and pick an ID (files are attached to the Trello card)
- Open the console and find the provider and school for each ID
- Change the ID so the import won't be able to find it
- Run the follow rake tasks

```
rake funding:import_lead_school_payment_schedules["SDS_Profile_Apr.csv",1]
```

and

```
rake funding:import_lead_school_payment_schedules["SDS_Profile_Apr.csv",1]
```

- After the import is finished, it should print out information about the missing organisations

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
