### PR TITLE
[xxx] Fix data migration for missing trainee

### DIFF
--- a/db/data/20220526104624_add_missing_withdrawn_trainee.rb
+++ b/db/data/20220526104624_add_missing_withdrawn_trainee.rb
@@ -5,7 +5,9 @@ class AddMissingWithdrawnTrainee < ActiveRecord::Migration[6.1]
     # This trainee changed course, thus has 2 placement assignments. The data migration will create
     # a duplicate record for the first placement at the request of the provider.
     ActiveRecord::Base.transaction do
-      dttp_trainee = Dttp::Trainee.find(29820)
+      dttp_trainee = Dttp::Trainee.find_by(id: 29820)
+      next unless dttp_trainee
+
       existing_trainee = dttp_trainee.trainee
       trainee_dttp_id = existing_trainee.dttp_id
 


### PR DESCRIPTION
### Context

Staging is failing to deploy with the following error:

```
2022-05-30T13:35:17.33+0100 [APP/TASK/70c5c4f0/0] ERR rails aborted!
2022-05-30T13:35:17.33+0100 [APP/TASK/70c5c4f0/0] ERR StandardError: An error has occurred, this and all later migrations canceled:
2022-05-30T13:35:17.33+0100 [APP/TASK/70c5c4f0/0] ERR Couldn't find Dttp::Trainee with 'id'=29820
2022-05-30T13:35:17.33+0100 [APP/TASK/70c5c4f0/0] ERR /app/db/data/20220526104624_add_missing_withdrawn_trainee.rb:8:in `block in up'
```

This is the PR https://github.com/DFE-Digital/register-trainee-teachers/pull/2380, we didn't realise that data migrations also ran in the staging env.

### Changes proposed in this pull request

Make `AddMissingWithdrawnTrainee` migration a noop if the trainee is missing in a deployed environment (e.g. staging)

### Guidance to review

- You can run this specific migration on your local environment to check that it no longer raises.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml