### PR TITLE
[4180] Update example_data.rake to include funding information

### DIFF
--- a/config/initializers/personas.rb
+++ b/config/initializers/personas.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-PROVIDER_A = "Provider A"
-PROVIDER_B = "Provider B"
-PROVIDER_C = "University A"
+PROVIDER_A = "Londinium Teacher Training"
+PROVIDER_B = "North County SCITT"
+PROVIDER_C = "University of BAT"
 TEACH_FIRST_PROVIDER_CODE = "HPITT"
 
 PERSONAS = [

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -104,13 +104,16 @@ namespace :example_data do
         code: persona_attributes[:provider_code].presence || Faker::Alphanumeric.alphanumeric(number: 3).upcase,
         accreditation_id: Faker::Number.number(digits: 4),
       )
-
       ProviderUser.find_or_create_by!(user: persona, provider: provider)
-      lead_school = LeadSchoolUser.create!(user: persona, lead_school: School.lead_only.sample) if persona_attributes[:lead_school]
-
-      # Create funding schedules
       FactoryBot.create(:payment_schedule, :for_full_year, payable: provider)
-      FactoryBot.create(:payment_schedule, :for_full_year, payable: lead_school) if lead_school
+      FactoryBot.create(:trainee_summary, :with_bursary_and_scholarship_rows, payable: provider)
+
+      if persona_attributes[:lead_school]
+        lead_school = School.lead_only.sample
+        LeadSchoolUser.create!(user: persona, lead_school: lead_school)
+        FactoryBot.create(:payment_schedule, :for_full_year, payable: lead_school)
+        FactoryBot.create(:trainee_summary, :with_grant_rows, payable: lead_school)
+      end
 
       # For each of the course routes enabled...
       enabled_course_routes.each do |route|

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -106,8 +106,11 @@ namespace :example_data do
       )
 
       ProviderUser.find_or_create_by!(user: persona, provider: provider)
+      lead_school = LeadSchoolUser.create!(user: persona, lead_school: School.lead_only.sample) if persona_attributes[:lead_school]
 
-      LeadSchoolUser.create!(user: persona, lead_school: School.lead_only.sample) if persona_attributes[:lead_school]
+      # Create funding schedules
+      FactoryBot.create(:payment_schedule, :for_full_year, payable: provider)
+      FactoryBot.create(:payment_schedule, :for_full_year, payable: lead_school) if lead_school
 
       # For each of the course routes enabled...
       enabled_course_routes.each do |route|

--- a/spec/factories/funding/payment_schedule_rows.rb
+++ b/spec/factories/funding/payment_schedule_rows.rb
@@ -10,9 +10,15 @@ FactoryBot.define do
       amounts do
         month_order = Funding::PayablePaymentSchedulesImporter::MONTH_ORDER
         current_month_index = month_order.index(Time.zone.today.month)
+        academic_cycle = AcademicCycle.current
 
         month_order.map.with_index do |month, index|
-          build(:payment_schedule_row_amount, month: month, predicted: index > current_month_index)
+          build(
+            :payment_schedule_row_amount,
+            month: month,
+            year: (1..7).include?(month) ? academic_cycle.end_date.year : academic_cycle.start_date.year,
+            predicted: index > current_month_index,
+          )
         end
       end
     end

--- a/spec/factories/funding/payment_schedule_rows.rb
+++ b/spec/factories/funding/payment_schedule_rows.rb
@@ -5,5 +5,16 @@ FactoryBot.define do
     sequence(:description) { |number| "Payment Schedule #{number}" }
 
     amounts { [build(:payment_schedule_row_amount)] }
+
+    trait :for_full_year do
+      amounts do
+        month_order = Funding::PayablePaymentSchedulesImporter::MONTH_ORDER
+        current_month_index = month_order.index(Time.zone.today.month)
+
+        month_order.map.with_index do |month, index|
+          build(:payment_schedule_row_amount, month: month, predicted: index > current_month_index)
+        end
+      end
+    end
   end
 end

--- a/spec/factories/funding/payment_schedules.rb
+++ b/spec/factories/funding/payment_schedules.rb
@@ -11,5 +11,13 @@ FactoryBot.define do
     end
 
     rows { [build(:payment_schedule_row)] }
+
+    trait :for_full_year do
+      rows do
+        ["Training bursary trainees", "Course extension provider payments"].map do |description|
+          build(:payment_schedule_row, :for_full_year, description: description)
+        end
+      end
+    end
   end
 end

--- a/spec/factories/funding/trainee_summaries.rb
+++ b/spec/factories/funding/trainee_summaries.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
           build(:trainee_summary_row, :with_bursary_amount, subject: subject, lead_school_name: nil, lead_school_urn: nil)
         end
         scholarships = [build(:trainee_summary_row, :with_scholarship_amount, subject: AllocationSubjects::CHEMISTRY, route: "School Direct tuition fee")]
-        tiered_bursaries = [build(:trainee_summary_row, :with_tiered_bursary_amount, subject: AllocationSubjects::CLASSICS, route: "School Direct tuition fee")]
+        tiered_bursaries = [build(:trainee_summary_row, :with_tiered_bursary_amount, subject: AllocationSubjects::CLASSICS)]
 
         bursaries + scholarships + tiered_bursaries
       end

--- a/spec/factories/funding/trainee_summaries.rb
+++ b/spec/factories/funding/trainee_summaries.rb
@@ -11,5 +11,25 @@ FactoryBot.define do
     trait :for_school do
       payable { |p| p.association(:school) }
     end
+
+    trait :with_grant_rows do
+      rows do
+        [AllocationSubjects::CHEMISTRY, AllocationSubjects::BIOLOGY].map do |subject|
+          build(:trainee_summary_row, :with_grant_amount, subject: subject)
+        end
+      end
+    end
+
+    trait :with_bursary_and_scholarship_rows do
+      rows do
+        bursaries = [AllocationSubjects::MATHEMATICS, AllocationSubjects::PHYSICS].map do |subject|
+          build(:trainee_summary_row, :with_bursary_amount, subject: subject, lead_school_name: nil, lead_school_urn: nil)
+        end
+        scholarships = [build(:trainee_summary_row, :with_scholarship_amount, subject: AllocationSubjects::CHEMISTRY, route: "School Direct tuition fee")]
+        tiered_bursaries = [build(:trainee_summary_row, :with_tiered_bursary_amount, subject: AllocationSubjects::CLASSICS, route: "School Direct tuition fee")]
+
+        bursaries + scholarships + tiered_bursaries
+      end
+    end
   end
 end

--- a/spec/factories/funding/trainee_summary_rows.rb
+++ b/spec/factories/funding/trainee_summary_rows.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     end
 
     trait :with_grant_amount do
-      route { "School Direct salaried" }
+      route { "School direct (salaried)" }
       amounts do
         [build(:trainee_summary_row_amount, :with_grant)]
       end
@@ -40,6 +40,7 @@ FactoryBot.define do
     end
 
     trait :with_tiered_bursary_amount do
+      route { "Early years (salaried)" }
       amounts do
         [build(:trainee_summary_row_amount, :with_tiered_bursary)]
       end

--- a/spec/factories/funding/trainee_summary_rows.rb
+++ b/spec/factories/funding/trainee_summary_rows.rb
@@ -4,10 +4,45 @@ FactoryBot.define do
   factory :trainee_summary_row, class: "Funding::TraineeSummaryRow" do
     association :trainee_summary, factory: :trainee_summary
 
-    subject { "Biology" }
+    subject { ["Biology"] }
     route { "Provider-led" }
     lead_school_name { "The School of Life" }
     lead_school_urn { Faker::Number.number(digits: 7) }
     cohort_level { "PG" }
+
+    trait :with_lead_school do
+      lead_school_name { "The School of Life" }
+      lead_school_urn { Faker::Number.number(digits: 7) }
+    end
+
+    trait :without_lead_school do
+      lead_school_name { nil }
+      lead_school_urn { nil }
+    end
+
+    trait :with_grant_amount do
+      route { "School Direct salaried" }
+      amounts do
+        [build(:trainee_summary_row_amount, :with_grant)]
+      end
+    end
+
+    trait :with_bursary_amount do
+      amounts do
+        [build(:trainee_summary_row_amount, :with_bursary)]
+      end
+    end
+
+    trait :with_scholarship_amount do
+      amounts do
+        [build(:trainee_summary_row_amount, :with_scholarship)]
+      end
+    end
+
+    trait :with_tiered_bursary_amount do
+      amounts do
+        [build(:trainee_summary_row_amount, :with_tiered_bursary)]
+      end
+    end
   end
 end

--- a/spec/factories/funding/trainee_summary_rows.rb
+++ b/spec/factories/funding/trainee_summary_rows.rb
@@ -10,16 +10,6 @@ FactoryBot.define do
     lead_school_urn { Faker::Number.number(digits: 7) }
     cohort_level { "PG" }
 
-    trait :with_lead_school do
-      lead_school_name { "The School of Life" }
-      lead_school_urn { Faker::Number.number(digits: 7) }
-    end
-
-    trait :without_lead_school do
-      lead_school_name { nil }
-      lead_school_urn { nil }
-    end
-
     trait :with_grant_amount do
       route { "School direct (salaried)" }
       amounts do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :school do
     urn { Faker::Number.unique.number(digits: 7) }
-    name { Faker::University.name }
+    name { Faker::Educator.secondary_school }
     town { Faker::Address.city }
     postcode { Faker::Address.postcode }
     lead_school { false }


### PR DESCRIPTION
### Context

https://trello.com/c/vKKZ5ktF/4180-update-exampledata-rake-to-include-funding-information

### Changes proposed in this pull request

- Update factory for `payment_schedules` to create a full year's worth of payments, taking everything after the current month as predicted
- Update factory for `trainee_summaries` to create different types of rows (bursaries/scholarhips/tiers/grants)
- Use new factories in example_data.rake to create one trainee summary and one payment schedule for each provider / lead school associated with our personas.
- Update provider names to be more realistic

Payment schedule created today:

<img width="661" alt="Screenshot 2022-05-30 at 16 33 53" src="https://user-images.githubusercontent.com/18436946/171024594-7a353628-e440-48b0-889e-e35551a11a18.png">

Payment schedule that would be created in September this year:

<img width="694" alt="Screenshot 2022-05-30 at 16 33 20" src="https://user-images.githubusercontent.com/18436946/171024658-79c9d14c-68c7-41be-9488-98bf89dd1d47.png">

### Guidance to review

- Sign in with different personas and check the funding pages for each provider / lead school

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
