### PR TITLE
[4187] Fix payment schedule ordering

### DIFF
--- a/app/view_objects/funding/payment_schedule_view.rb
+++ b/app/view_objects/funding/payment_schedule_view.rb
@@ -86,7 +86,7 @@ module Funding
 
     def actual_months
       payment_schedule.rows.flat_map do |row|
-        row.amounts.filter_map do |amount|
+        row.amounts.order(:year, :month).filter_map do |amount|
           amount.month unless amount.predicted?
         end
       end.uniq
@@ -94,14 +94,14 @@ module Funding
 
     def predicted_months
       payment_schedule.rows.flat_map do |row|
-        row.amounts.filter_map do |amount|
+        row.amounts.order(:year, :month).filter_map do |amount|
           amount.month if amount.predicted?
         end
       end.uniq
     end
 
     def all_months
-      payment_schedule.rows.first.amounts.map(&:month)
+      payment_schedule.rows.first.amounts.order(:year, :month).map(&:month)
     end
 
     def month_name_and_year(month_index)

--- a/spec/view_objects/funding/payment_schedule_view_spec.rb
+++ b/spec/view_objects/funding/payment_schedule_view_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Funding
   describe PaymentScheduleView do
-    let(:payment_schedule) { build(:payment_schedule, :for_provider, rows: payment_schedule_rows) }
+    let(:payment_schedule) { create(:payment_schedule, :for_provider, rows: payment_schedule_rows) }
 
     subject { described_class.new(payment_schedule: payment_schedule) }
 
@@ -12,23 +12,29 @@ module Funding
       let(:payment_schedule_rows) do
         [
           build(:payment_schedule_row, amounts: [
-            build(:payment_schedule_row_amount, month: 1, amount_in_pence: 100),
-            build(:payment_schedule_row_amount, month: 2, amount_in_pence: 200),
+            build(:payment_schedule_row_amount, month: 1, year: 2022, amount_in_pence: 100),
+            build(:payment_schedule_row_amount, month: 2, year: 2022, amount_in_pence: 200),
+            build(:payment_schedule_row_amount, month: 8, year: 2021, amount_in_pence: 50),
           ]),
         ]
       end
 
-      it "returns actual payments" do
+      it "returns actual payments ordered year, month" do
         expect(subject.actual_payments).to eq([
+          {
+            month: "August 2021",
+            total: "£0.50",
+            running_total: "£0.50",
+          },
           {
             month: "January 2022",
             total: "£1.00",
-            running_total: "£1.00",
+            running_total: "£1.50",
           },
           {
             month: "February 2022",
             total: "£2.00",
-            running_total: "£3.00",
+            running_total: "£3.50",
           },
         ])
       end
@@ -38,9 +44,9 @@ module Funding
       let(:payment_schedule_rows) do
         [
           build(:payment_schedule_row, amounts: [
-            build(:payment_schedule_row_amount, month: 1, amount_in_pence: 100),
-            build(:payment_schedule_row_amount, month: 2, amount_in_pence: 200, predicted: true),
-            build(:payment_schedule_row_amount, month: 3, amount_in_pence: 600, predicted: true),
+            build(:payment_schedule_row_amount, month: 1, year: 2022, amount_in_pence: 600, predicted: true),
+            build(:payment_schedule_row_amount, month: 11, year: 2021, amount_in_pence: 100),
+            build(:payment_schedule_row_amount, month: 12, year: 2021, amount_in_pence: 200, predicted: true),
           ]),
         ]
       end
@@ -48,12 +54,12 @@ module Funding
       it "only returns predicted payments" do
         expect(subject.predicted_payments).to eq([
           {
-            month: "February 2022",
+            month: "December 2021",
             total: "£2.00",
             running_total: "£2.00",
           },
           {
-            month: "March 2022",
+            month: "January 2022",
             total: "£6.00",
             running_total: "£8.00",
           },
@@ -62,17 +68,16 @@ module Funding
     end
 
     describe "#payment_breakdown" do
-      let(:current_year) { Time.zone.now.year }
       let(:payment_schedule_rows) do
         [
           build(:payment_schedule_row, description: "Payment Schedule 1", amounts: [
-            build(:payment_schedule_row_amount, month: 1, amount_in_pence: 200),
-            build(:payment_schedule_row_amount, month: 2, amount_in_pence: 500),
+            build(:payment_schedule_row_amount, month: 1, year: 2022, amount_in_pence: 200),
+            build(:payment_schedule_row_amount, month: 12, year: 2021, amount_in_pence: 500),
 
           ]),
           build(:payment_schedule_row, description: "Payment Schedule 2", amounts: [
-            build(:payment_schedule_row_amount, month: 1, amount_in_pence: 300),
-            build(:payment_schedule_row_amount, month: 2, amount_in_pence: 700),
+            build(:payment_schedule_row_amount, month: 1, year: 2022, amount_in_pence: 300),
+            build(:payment_schedule_row_amount, month: 12, year: 2021, amount_in_pence: 700),
           ]),
         ]
       end
@@ -80,21 +85,21 @@ module Funding
       it "returns a list of monthly breakdown objects grouped by month and year" do
         expect(subject.payment_breakdown.map(&:to_h)).to eq([
           {
-            title: "January #{current_year}",
+            title: "December 2021",
             rows: [
-              { description: "Payment Schedule 1", amount: "£2.00", running_total: "£2.00" },
-              { description: "Payment Schedule 2", amount: "£3.00", running_total: "£3.00" },
-            ],
-            total_amount: "£5.00",
-            total_running_total: "£5.00",
-          },
-          {
-            title: "February #{current_year}",
-            rows: [
-              { description: "Payment Schedule 1", amount: "£5.00", running_total: "£7.00" },
-              { description: "Payment Schedule 2", amount: "£7.00", running_total: "£10.00" },
+              { description: "Payment Schedule 1", amount: "£5.00", running_total: "£5.00" },
+              { description: "Payment Schedule 2", amount: "£7.00", running_total: "£7.00" },
             ],
             total_amount: "£12.00",
+            total_running_total: "£12.00",
+          },
+          {
+            title: "January 2022",
+            rows: [
+              { description: "Payment Schedule 1", amount: "£2.00", running_total: "£7.00" },
+              { description: "Payment Schedule 2", amount: "£3.00", running_total: "£10.00" },
+            ],
+            total_amount: "£5.00",
             total_running_total: "£17.00",
           },
         ])


### PR DESCRIPTION
### Context

The funding payment schedule view has an ordering bug. Months should start at August <first year> and run to July <second year>.

### Changes proposed in this pull request

Order rows by year, month

November 2021
December 2021
January 2022
February 2022

This should happen in actual and predicted payments and the summaries.

#### With fix:
<img width="435" alt="Screenshot 2022-05-30 at 18 13 43" src="https://user-images.githubusercontent.com/5216/171037682-7567f473-e6a1-43bb-a385-c5ff8fc0869e.png">

### Guidance to review

We don't have funding example data as yet so needs to be QAd locally for now.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
