### PR TITLE
[4178] Trainee summaries import: skip missing providers and lead schools

### DIFF
--- a/lib/tasks/funding.rake
+++ b/lib/tasks/funding.rake
@@ -16,12 +16,14 @@ namespace :funding do
   desc "imports provider trainee summaries from a provided csv"
   task :import_provider_trainee_summaries, %i[csv_path] => [:environment] do |_, args|
     attributes = Funding::Parsers::ProviderTraineeSummaries.to_attributes(file_path: args.csv_path)
-    Funding::ProviderTraineeSummariesImporter.call(attributes: attributes)
+    missing_ids = Funding::ProviderTraineeSummariesImporter.call(attributes: attributes)
+    abort("Provider accreditation ids: #{missing_ids.join(', ')} not found") unless missing_ids.empty?
   end
 
   desc "imports lead school trainee summaries from a provided csv"
   task :import_lead_school_trainee_summaries, %i[csv_path] => [:environment] do |_, args|
     attributes = Funding::Parsers::LeadSchoolTraineeSummaries.to_attributes(file_path: args.csv_path)
-    Funding::LeadSchoolTraineeSummariesImporter.call(attributes: attributes)
+    missing_urns = Funding::LeadSchoolTraineeSummariesImporter.call(attributes: attributes)
+    abort("Lead school URNs: #{missing_urns.join(', ')} not found") unless missing_urns.empty?
   end
 end

--- a/spec/services/funding/lead_school_trainee_summaries_importer_spec.rb
+++ b/spec/services/funding/lead_school_trainee_summaries_importer_spec.rb
@@ -159,8 +159,8 @@ module Funding
 
       subject { described_class.call(attributes: invalid_summaries_attributes) }
 
-      it "raises a PayableNotFoundError exception" do
-        expect { subject }.to raise_error(PayableNotFoundError, "payable with id: 4444 doesn't exist")
+      it "returns a list of missing lead school urns" do
+        expect(subject).to eq(["4444"])
       end
     end
   end

--- a/spec/services/funding/provider_trainee_summaries_importer_spec.rb
+++ b/spec/services/funding/provider_trainee_summaries_importer_spec.rb
@@ -222,8 +222,8 @@ module Funding
 
       subject { described_class.call(attributes: invalid_summaries_attributes) }
 
-      it "raises a PayableNotFoundError exception" do
-        expect { subject }.to raise_error(PayableNotFoundError, "payable with id: 3333 doesn't exist")
+      it "returns a list of missing provider accreditation ids" do
+        expect(subject).to eq(["3333"])
       end
     end
   end


### PR DESCRIPTION
### Context

With the current implementation of the funding rake tasks `import_provider_trainee_summaries` and `import_lead_school_trainee_summaries` if there is an unrecognised provider accreditation ID or lead school URN in the csv (i.e. it doesn't exist in the DB), the rake task will abort at the point that it hits this organisation.

We want to handle such errors, continue the import and report any missing ids at the end of the task.

### Changes proposed in this pull request

- [x] Modify `Funding::PayableNotFoundError.call` to return a list of missing payable ids rather than raising an exception the first time it finds one.
- [x] Use this return value in the `import_provider_trainee_summaries` and `import_lead_school_trainee_summaries` rake tasks to report the error after completing the import.

### Guidance to review

- This PR is very closely related to https://github.com/DFE-Digital/register-trainee-teachers/pull/2384/files . I've tried to use the approach suggested in comments on that PR.
- I'm not too sure about putting extra logic in the rake tasks because it's not covered by any automated tests. I've tested both rake tasks manually.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
