### PR TITLE
Tweak margin bottom on summary cards so there's less whitespace

### DIFF
--- a/app/components/summary_card/style.scss
+++ b/app/components/summary_card/style.scss
@@ -58,7 +58,7 @@
 
   // Summary list component overrides
   .govuk-summary-list {
-    margin-bottom: 0;
+    margin-bottom: govuk-spacing(-2);
   }
 
   // Remove last item’s bottom border on mobile


### PR DESCRIPTION
The summary card and the GDS summary list both add space to the bottom item - this means the last row of the summary card currently has too much whitespace. The prototype already had a fix for this but it wasn't applied to production.

Before:
<img width="992" alt="Screenshot 2022-05-31 at 11 39 52" src="https://user-images.githubusercontent.com/2204224/171155265-7904f016-e5e3-4571-b8b9-ab83a57a7ef0.png">

After:
<img width="1006" alt="Screenshot 2022-05-31 at 12 23 16" src="https://user-images.githubusercontent.com/2204224/171162342-3a5bccad-563b-44e2-83e7-a114b65c7b06.png">

