### PR TITLE
[4183] Trainee summary view bugs

### DIFF
--- a/app/view_objects/funding/trainee_summary_view.rb
+++ b/app/view_objects/funding/trainee_summary_view.rb
@@ -23,7 +23,7 @@ module Funding
     def summary_data
       [
         PaymentTypeSummaryRow.new(payment_type: "ITT bursaries", total: payment_type_total(data_for_bursaries)),
-        PaymentTypeSummaryRow.new(payment_type: "ITT scholarship", total: payment_type_total(data_for_scholarships)),
+        PaymentTypeSummaryRow.new(payment_type: "ITT scholarships", total: payment_type_total(data_for_scholarships)),
         PaymentTypeSummaryRow.new(payment_type: "Early years ITT bursaries", total: payment_type_total(data_for_tiered_bursaries)),
         PaymentTypeSummaryRow.new(payment_type: "Grants", total: payment_type_total(data_for_grants)),
       ]
@@ -40,7 +40,7 @@ module Funding
     end
 
     def bursary_breakdown_rows
-      sort(data_for_bursaries).map do |amount|
+      sort_by_route_then_subject(data_for_bursaries).map do |amount|
         total_amount = amount.number_of_trainees * amount.amount_in_pence
         { route: amount.row.route,
           subject: amount.row.subject,
@@ -52,7 +52,7 @@ module Funding
     end
 
     def scholarship_breakdown_rows
-      sort(data_for_scholarships).map do |amount|
+      sort_by_route_then_subject(data_for_scholarships).map do |amount|
         total_amount = amount.number_of_trainees * amount.amount_in_pence
         { route: amount.row.route,
           subject: amount.row.subject,
@@ -64,9 +64,10 @@ module Funding
     end
 
     def tiered_bursary_breakdown_rows
-      sort(data_for_tiered_bursaries).map do |amount|
+      sort_by_route_then_tier(data_for_tiered_bursaries).map do |amount|
         total_amount = amount.number_of_trainees * amount.amount_in_pence
-        { tier: amount.tier,
+        { route: amount.row.route,
+          tier: "Tier #{amount.tier}",
           trainees: amount.number_of_trainees,
           amount_per_trainee: format_pounds(amount.amount_in_pence),
           total: format_pounds(total_amount) }
@@ -74,7 +75,7 @@ module Funding
     end
 
     def grant_breakdown_rows
-      sort(data_for_grants).map do |amount|
+      sort_by_route_then_subject(data_for_grants).map do |amount|
         total_amount = amount.number_of_trainees * amount.amount_in_pence
         { route: amount.row.route,
           subject: amount.row.subject,
@@ -98,8 +99,12 @@ module Funding
       data_for_payment_type.map { |data| (data.amount_in_pence * data.number_of_trainees) }.sum
     end
 
-    def sort(data)
+    def sort_by_route_then_subject(data)
       Array(data.sort_by { |amount| [amount.row.route, amount.row.subject] })
+    end
+
+    def sort_by_route_then_tier(data)
+      Array(data.sort_by { |amount| [amount.row.route, amount.tier] })
     end
 
     def data_for_scholarships

--- a/app/views/funding/_navigation.html.erb
+++ b/app/views/funding/_navigation.html.erb
@@ -1,0 +1,14 @@
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
+<% end %>
+
+<% if current_user.organisation %>
+  <span class="govuk-caption-xl"><%= current_user.organisation.name %></span>
+<% end %>
+
+<h1 class="govuk-heading-xl"><%= t("funding.view.title") %></h1>
+
+<%= render TabNavigation::View.new(items: [
+  { name: t("funding.payment_schedule.heading", start_year: @start_year, end_year: @end_year), url: funding_payment_schedule_path },
+  { name: t("funding.trainee_summary.heading", start_year: @start_year, end_year: @end_year), url: funding_trainee_summary_path },
+]) %>

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: "Funding") %>
+<%= render PageTitle::View.new(text: t("components.page_titles.funding.payment_schedule", start_year: @start_year, end_year: @end_year)) %>
 
 <%= render "funding/navigation" %>
 

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -1,20 +1,6 @@
 <%= render PageTitle::View.new(text: "Funding") %>
 
-
-<% if current_user.organisation %>
-  <span class="govuk-caption-xl"><%= current_user.organisation.name %></span>
-<% end %>
-
-<h1 class="govuk-heading-xl"><%= t('funding.view.title') %></h1>
-
-<%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
-<% end %>
-
-<%= render TabNavigation::View.new(items: [
-  { name: t('funding.payment_schedule.heading', start_year: @start_year, end_year: @end_year), url: funding_payment_schedule_path },
-  { name: t('funding.trainee_summary.heading', start_year: @start_year, end_year: @end_year), url: funding_trainee_summary_path },
-]) %>
+<%= render "funding/navigation" %>
 
 <%- if @payment_schedule_view.any? %>
   <div class="govuk-grid-row">

--- a/app/views/funding/trainee_summaries/_tiered_bursaries.html.erb
+++ b/app/views/funding/trainee_summaries/_tiered_bursaries.html.erb
@@ -1,11 +1,14 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
+  <div class="govuk-grid-column-full">
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--m" >
         <%= t("funding.trainee_summary.table_headings.tiered_bursaries.title") %>
       </caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header govuk-!-width-one-half">
+            <%= t("funding.trainee_summary.column_headings.route") %>
+          </th>
           <th scope="col" class="govuk-table__header govuk-!-width-one-half">
             <%= t("funding.trainee_summary.column_headings.tier") %>
           </th>
@@ -24,7 +27,8 @@
         <%- @trainee_summary_view.tiered_bursary_breakdown_rows.each do |tiered_bursary_row| %>
           <% next if tiered_bursary_row[:total] == "—" %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"> <%= t("funding.trainee_summary.column_headings.tier") %> <%= tiered_bursary_row[:tier] %></td>
+            <td class="govuk-table__cell"> <%= tiered_bursary_row[:route] %></td>
+            <td class="govuk-table__cell"> <%= tiered_bursary_row[:tier] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= tiered_bursary_row[:trainees] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= tiered_bursary_row[:amount_per_trainee] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= tiered_bursary_row[:total] %></td>

--- a/app/views/funding/trainee_summaries/show.html.erb
+++ b/app/views/funding/trainee_summaries/show.html.erb
@@ -1,21 +1,6 @@
-<%= render PageTitle::View.new(i18n_key: "funding") %>
+<%= render PageTitle::View.new(text: t("components.page_titles.funding", start_year: @start_year, end_year: @end_year)) %>
 
-<%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
-<% end %>
-
-<% if current_user.organisation %>
-  <span class="govuk-caption-xl"><%= current_user.organisation.name %></span>
-<% end %>
-
-<h1 class="govuk-heading-xl">
-  <%= t("funding.view.title") %>
-</h1>
-
-<%= render TabNavigation::View.new(items: [
-  { name: t("funding.payment_schedule.heading", start_year: @start_year, end_year: @end_year), url: funding_payment_schedule_path },
-  { name: t("funding.trainee_summary.heading", start_year: @start_year, end_year: @end_year), url: funding_trainee_summary_path },
-]) %>
+<%= render "funding/navigation" %>
 
 <h2 class="govuk-heading-l">
   <%= t("funding.trainee_summary.heading", start_year: @start_year, end_year: @end_year)%>

--- a/app/views/funding/trainee_summaries/show.html.erb
+++ b/app/views/funding/trainee_summaries/show.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: t("components.page_titles.funding", start_year: @start_year, end_year: @end_year)) %>
+<%= render PageTitle::View.new(text: t("components.page_titles.funding.trainee_summary", start_year: @start_year, end_year: @end_year)) %>
 
 <%= render "funding/navigation" %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
         lead_school: Lead school
         payment_type: Payment type
         route_and_course: Route and course
+        route: Route
         tier: Tier
         total: Total
         trainees: Trainees

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,7 +275,7 @@ en:
     itt_end_date:
       hint: The end date of the Initial Teacher Training part of their course.
     page_titles:
-      funding: Funding
+      funding: Funding - Trainee summary %{start_year} to %{end_year}
       personas: Personas
       pages:
         accessibility: Accessibility statement for Register trainee teachers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,7 +276,9 @@ en:
     itt_end_date:
       hint: The end date of the Initial Teacher Training part of their course.
     page_titles:
-      funding: Funding - Trainee summary %{start_year} to %{end_year}
+      funding:
+        trainee_summary: Funding - Trainee summary %{start_year} to %{end_year}
+        payment_schedule: Funding - Payment schedule %{start_year} to %{end_year}
       personas: Personas
       pages:
         accessibility: Accessibility statement for Register trainee teachers

--- a/spec/view_objects/funding/trainee_summary_view_spec.rb
+++ b/spec/view_objects/funding/trainee_summary_view_spec.rb
@@ -59,7 +59,7 @@ module Funding
         let(:expected_summary_data) do
           [
             ["ITT bursaries", 400000],
-            ["ITT scholarship", 2300000],
+            ["ITT scholarships", 2300000],
             ["Early years ITT bursaries", 500000],
             ["Grants", 900000],
           ]
@@ -129,7 +129,15 @@ module Funding
 
     describe "#tiered_bursary_breakdown_rows" do
       let(:tiered_bursary_array) do
-        [{ tier: 1, trainees: biology_tiered_bursary_trainees, amount_per_trainee: "£1,000", total: "£5,000" }]
+        [
+          {
+            route: "Provider-led",
+            tier: "Tier 1",
+            trainees: biology_tiered_bursary_trainees,
+            amount_per_trainee: "£1,000",
+            total: "£5,000",
+          },
+        ]
       end
 
       context "when there are tiered bursaries" do


### PR DESCRIPTION
### Context

https://trello.com/c/ZKEGWHsN/4183-trainee-summary-view-bugs

### Changes proposed in this pull request

* Update the page title to 'Funding - Trainee summary 2021 to 2022'
* Correct the typo on the Summary table - 'ITT scholarships'

On the EYITT table:

* Make the table full-width (like the bursaries and scholarships tables)
* Add a new first column which displays the route
* Sort table by route and then tier 

<img width="1392" alt="Screenshot 2022-05-31 at 15 19 49" src="https://user-images.githubusercontent.com/18436946/171196176-86ec5a6f-c437-42bb-99ed-2a14db2951b3.png">

### Guidance to review

- View the funding trainee summary for a provider
- Check that the above issues have been addressed

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
