### PR TITLE
[4185] Include actual payments in predicted payments running total

### DIFF
--- a/app/view_objects/funding/payment_schedule_view.rb
+++ b/app/view_objects/funding/payment_schedule_view.rb
@@ -21,7 +21,11 @@ module Funding
     end
 
     def predicted_payments
-      payment_data_for(predicted_months)
+      initial_total = actual_months.sum do |month_index|
+        month_total(month_index)
+      end
+
+      payment_data_for(predicted_months, initial_total: initial_total)
     end
 
     def payment_breakdown
@@ -116,8 +120,8 @@ module Funding
       row.amounts.find { |amount| amount.month == month_index }
     end
 
-    def payment_data_for(months)
-      running_total = 0
+    def payment_data_for(months, initial_total: 0)
+      running_total = initial_total
 
       months.map do |month_index|
         total = month_total(month_index)

--- a/spec/view_objects/funding/payment_schedule_view_spec.rb
+++ b/spec/view_objects/funding/payment_schedule_view_spec.rb
@@ -56,12 +56,12 @@ module Funding
           {
             month: "December 2021",
             total: "£2.00",
-            running_total: "£2.00",
+            running_total: "£3.00",
           },
           {
             month: "January 2022",
             total: "£6.00",
-            running_total: "£8.00",
+            running_total: "£9.00",
           },
         ])
       end


### PR DESCRIPTION
### Context

Currently the predicted payment running total is starting at 0 instead of carrying on from the actual payment running total.

We need to make sure we are adding the last running total on the actual payments to the predicted payment running total.

### Changes proposed in this pull request

- [x] Update `Funding::PaymentScheduleView` to carry forward the running total from the actuals into the set of predicted payments.

<img width="616" alt="image" src="https://user-images.githubusercontent.com/450843/171225980-c380650d-89b9-450b-b53c-7f69a7202ee3.png">

### Guidance to review

- Is this all that needs to be done? Are there other places that we make this calculation?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
