### PR TITLE
[xxx] Update the gender codes due to changes in the DQT API

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -10,7 +10,8 @@ module Dqt
         male: "Male",
         female: "Female",
         other: "Other",
-        gender_not_provided: "Other",
+        gender_not_provided: "NotProvided",
+        gender_not_available: "NotAvailable",
       }.freeze
 
       PROGRAMME_TYPE = {

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -63,8 +63,8 @@ module Dqt
         context "when gender is gender_not_provided" do
           let(:trainee) { create(:trainee, :completed, gender: "gender_not_provided") }
 
-          it "maps gender to other" do
-            expect(subject["genderCode"]).to eq("Other")
+          it "maps gender to not provided" do
+            expect(subject["genderCode"]).to eq("NotProvided")
           end
         end
 


### PR DESCRIPTION
### Context

The DQT API can now accept the same gender codes as Register.

### Changes proposed in this pull request

* Update the params.
* Stop mapping gender_not_provided to Other on the TRN request that's made to DQT.
* Introduce gender_not_available as a new code that HESA are introducing soon.

Thanks @benilovj for the original PR 👏

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
