### PR TITLE
[4189] Payment schedule accordion behaviour

### DIFF
--- a/app/view_objects/funding/payment_schedule_view.rb
+++ b/app/view_objects/funding/payment_schedule_view.rb
@@ -6,7 +6,7 @@ module Funding
 
     BLANK_CHARACTER = "–"
 
-    MonthBreakdown = Struct.new(:title, :rows, :total_amount, :total_running_total) do
+    MonthBreakdown = Struct.new(:title, :rows, :total_amount, :total_running_total, :last_actual_month?) do
       def no_payments?
         rows.all? { |row| row[:amount] == BLANK_CHARACTER }
       end
@@ -32,6 +32,7 @@ module Funding
           sort(month_breakdown(month_index)),
           format_pounds(total_amount_for(payment_rows, month_index)),
           format_pounds(total_running_total_for(payment_rows, month_index)),
+          last_actual_month?(month_index),
         )
       }
     end
@@ -143,6 +144,10 @@ module Funding
 
     def sort(payment_rows)
       payment_rows.sort { |a, b| a[:description] <=> b[:description] }
+    end
+
+    def last_actual_month?(month_index)
+      actual_months.last == month_index
     end
   end
 end

--- a/app/views/funding/payment_schedules/_month_breakdown.html.erb
+++ b/app/views/funding/payment_schedules/_month_breakdown.html.erb
@@ -1,45 +1,28 @@
-<div class="govuk-accordion__section">
-  <div class="govuk-accordion__section-header">
-    <h2 class="govuk-accordion__section-heading">
-      <button type="button"
-              id="accordion-default-heading-<%= index %>"
-              aria-controls="accordion-default-content-<%= index %>"
-              class="govuk-accordion__section-button">
-        <%= month_breakdown.title %>
-        <span class="govuk-accordion__icon"></span>
-      </button>
-    </h2>
-  </div>
-  <div id="accordion-default-content-<%= index %>"
-       class="govuk-accordion__section-content"
-       aria-labelledby="accordion-default-heading-<%= index %>">
-    <%- if month_breakdown.no_payments? -%>
-      <p class="govuk-body"><%= t('funding.payment_schedule.no_payments', month_and_year: month_breakdown.title) %></p>
-    <%- else -%>
-      <table class="govuk-table app-table__in-accordion govuk-!-margin-bottom-6">
-        <caption class="govuk-table__caption govuk-visually-hidden"><%= month_breakdown.title %> payments</caption>
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header app-table__column-50">Payment type</th>
-            <th scope="col" class="govuk-table__header govuk-table__header--numeric app-table__column-25">Amount</th>
-            <th scope="col" class="govuk-table__header govuk-table__header--numeric app-table__column-25">Running total</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <% month_breakdown.rows.each do |row| %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell"><%= row[:description] %></td>
-              <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[:amount] %></td>
-              <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[:running_total] %></td>
-            </tr>
-          <% end %>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell govuk-!-font-weight-bold">Total</td>
-            <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= month_breakdown.total_amount %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= month_breakdown.total_running_total %></td>
-          </tr>
-          </tbody>
-      </table>
-    <%- end -%>
-  </div>
-</div>
+<%- if month_breakdown.no_payments? -%>
+  <p class="govuk-body"><%= t('funding.payment_schedule.no_payments', month_and_year: month_breakdown.title) %></p>
+<%- else -%>
+  <table class="govuk-table app-table__in-accordion govuk-!-margin-bottom-6">
+    <caption class="govuk-table__caption govuk-visually-hidden"><%= month_breakdown.title %> payments</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header app-table__column-50">Payment type</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric app-table__column-25">Amount</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric app-table__column-25">Running total</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% month_breakdown.rows.each do |row| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= row[:description] %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[:amount] %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[:running_total] %></td>
+        </tr>
+      <% end %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-font-weight-bold">Total</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= month_breakdown.total_amount %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= month_breakdown.total_running_total %></td>
+      </tr>
+    </tbody>
+  </table>
+<%- end -%>

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -27,7 +27,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <table id="payments" class="govuk-table">
         <caption class="govuk-table__caption govuk-table__caption--m govuk-!-margin-bottom-3">
-          <%= t('funding.payment_schedule.payments_table_caption', month_and_year: Time.zone.now.strftime("%b %Y")) %>
+          <%= t('funding.payment_schedule.payments_table_caption', month_and_year: Time.zone.now.strftime("%B %Y")) %>
         </caption>
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -68,11 +68,13 @@
         </tbody>
       </table>
       <h2 class="govuk-heading-m"><%= t('funding.payment_schedule.payment_breakdown') %></h2>
-      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-        <%- @payment_schedule_view.payment_breakdown.each_with_index do |month_breakdown, index| -%>
-          <%= render "month_breakdown", month_breakdown: month_breakdown, index: index + 1 %>
-        <%- end -%>
-      </div>
+      <%= govuk_accordion do |accordion|
+        @payment_schedule_view.payment_breakdown.each do |month_breakdown|
+          accordion.section(heading_text: month_breakdown.title, expanded: month_breakdown.last_actual_month?) do 
+            render partial: "month_breakdown", locals: { month_breakdown: month_breakdown }            
+          end
+        end
+      end %>
     </div>
   </div>
 <%- else -%>

--- a/spec/view_objects/funding/payment_schedule_view_spec.rb
+++ b/spec/view_objects/funding/payment_schedule_view_spec.rb
@@ -71,13 +71,15 @@ module Funding
       let(:payment_schedule_rows) do
         [
           build(:payment_schedule_row, description: "Payment Schedule 1", amounts: [
-            build(:payment_schedule_row_amount, month: 1, year: 2022, amount_in_pence: 200),
-            build(:payment_schedule_row_amount, month: 12, year: 2021, amount_in_pence: 500),
+            build(:payment_schedule_row_amount, month: 1, year: 2022, amount_in_pence: 200, predicted: true),
+            build(:payment_schedule_row_amount, month: 11, year: 2021, amount_in_pence: 100, predicted: false),
+            build(:payment_schedule_row_amount, month: 12, year: 2021, amount_in_pence: 500, predicted: false),
 
           ]),
           build(:payment_schedule_row, description: "Payment Schedule 2", amounts: [
-            build(:payment_schedule_row_amount, month: 1, year: 2022, amount_in_pence: 300),
-            build(:payment_schedule_row_amount, month: 12, year: 2021, amount_in_pence: 700),
+            build(:payment_schedule_row_amount, month: 1, year: 2022, amount_in_pence: 300, predicted: true),
+            build(:payment_schedule_row_amount, month: 11, year: 2021, amount_in_pence: 200, predicted: false),
+            build(:payment_schedule_row_amount, month: 12, year: 2021, amount_in_pence: 700, predicted: false),
           ]),
         ]
       end
@@ -85,22 +87,34 @@ module Funding
       it "returns a list of monthly breakdown objects grouped by month and year" do
         expect(subject.payment_breakdown.map(&:to_h)).to eq([
           {
+            title: "November 2021",
+            rows: [
+              { description: "Payment Schedule 1", amount: "£1.00", running_total: "£1.00" },
+              { description: "Payment Schedule 2", amount: "£2.00", running_total: "£2.00" },
+            ],
+            total_amount: "£3.00",
+            total_running_total: "£3.00",
+            last_actual_month?: false,
+          },
+          {
             title: "December 2021",
             rows: [
-              { description: "Payment Schedule 1", amount: "£5.00", running_total: "£5.00" },
-              { description: "Payment Schedule 2", amount: "£7.00", running_total: "£7.00" },
+              { description: "Payment Schedule 1", amount: "£5.00", running_total: "£6.00" },
+              { description: "Payment Schedule 2", amount: "£7.00", running_total: "£9.00" },
             ],
             total_amount: "£12.00",
-            total_running_total: "£12.00",
+            total_running_total: "£15.00",
+            last_actual_month?: true,
           },
           {
             title: "January 2022",
             rows: [
-              { description: "Payment Schedule 1", amount: "£2.00", running_total: "£7.00" },
-              { description: "Payment Schedule 2", amount: "£3.00", running_total: "£10.00" },
+              { description: "Payment Schedule 1", amount: "£2.00", running_total: "£8.00" },
+              { description: "Payment Schedule 2", amount: "£3.00", running_total: "£12.00" },
             ],
             total_amount: "£5.00",
-            total_running_total: "£17.00",
+            total_running_total: "£20.00",
+            last_actual_month?: false,
           },
         ])
       end


### PR DESCRIPTION
### Context

On the funding payment schedule page we display a list of summary tables by month in an accordion component. We want the last actual month to be open when the user visits the page.

### Changes proposed in this pull request

* Use the govuk_accordion component
* Add `last_actual_month?` boolean to the `MonthBreakdown` struct that we return from the view object
* Expand the last actual month accordion element
* Update the formatting of the subheading to render the full month name. It was rendering an abbreviated version e.g. Jun

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
