### PR TITLE
[4201] Restrict access to funding link until we have an academic year

### DIFF
--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -29,6 +29,8 @@ module FundingHelper
 private
 
   def cannot_start_funding?(trainee)
+    return true if trainee.early_years_route? && trainee.academic_cycle.nil?
+
     funding_manager = FundingManager.new(trainee)
     funding_manager.funding_available? && trainee.course_subject_one.blank?
   end

--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -6,7 +6,7 @@ module FundingHelper
   end
 
   def funding_options(trainee)
-    cannot_start_funding?(trainee) ? :funding_inactive : :funding_active
+    can_start_funding_section?(trainee) ? :funding_active : :funding_inactive
   end
 
   def format_currency(amount)
@@ -28,10 +28,7 @@ module FundingHelper
 
 private
 
-  def cannot_start_funding?(trainee)
-    return true if trainee.early_years_route? && trainee.academic_cycle.nil?
-
-    funding_manager = FundingManager.new(trainee)
-    funding_manager.funding_available? && trainee.course_subject_one.blank?
+  def can_start_funding_section?(trainee)
+    trainee.progress.course_details && trainee.academic_cycle.present?
   end
 end

--- a/spec/components/sections/view_spec.rb
+++ b/spec/components/sections/view_spec.rb
@@ -10,6 +10,7 @@ module Sections
     end
 
     before do
+      create(:academic_cycle, :current)
       render_inline(trainees_sections_component)
     end
 
@@ -68,7 +69,6 @@ module Sections
       include_examples renders_incomplete_section, :course_details, :incomplete
       include_examples renders_incomplete_section, :training_details, :incomplete
       include_examples renders_incomplete_section, :trainee_data, :incomplete
-      include_examples renders_incomplete_section, :funding, :incomplete
 
       context "requires school" do
         include_examples renders_incomplete_section, :schools, :incomplete
@@ -86,10 +86,21 @@ module Sections
 
         include_examples renders_incomplete_section, :course_details, :incomplete
       end
+
+      context "trainee incomplete funding section" do
+        let(:trainee) { create(:trainee, :with_start_date) }
+
+        before {
+          trainee.progress.course_details = true
+          render_inline(trainees_sections_component)
+        }
+
+        include_examples renders_incomplete_section, :funding, :incomplete
+      end
     end
 
     context "trainee in progress" do
-      let(:trainee) { create(:trainee, :in_progress, applying_for_bursary: false, training_initiative: ROUTE_INITIATIVES_ENUMS[:transition_to_teach]) }
+      let(:trainee) { create(:trainee, :in_progress) }
 
       # Personal details is invalid due to nationalities being missing
       include_examples renders_incomplete_section, :personal_details, :in_progress_invalid
@@ -99,25 +110,25 @@ module Sections
       include_examples renders_incomplete_section, :course_details, :in_progress_valid
       include_examples renders_incomplete_section, :training_details, :in_progress_valid
       include_examples renders_incomplete_section, :trainee_data, :in_progress_valid
-      include_examples renders_incomplete_section, :funding, :in_progress_valid
 
       context "requires school" do
         let(:trainee) { create(:trainee, :with_lead_school, :in_progress) }
 
         include_examples renders_incomplete_section, :schools, :in_progress_valid
       end
+
+      context "trainee in progress funding section" do
+        before do
+          trainee.progress.course_details = true
+          render_inline(trainees_sections_component)
+        end
+
+        include_examples renders_incomplete_section, :funding, :in_progress_valid
+      end
     end
 
     context "trainee completed" do
-      let(:trainee) do
-        create(
-          :trainee,
-          :completed,
-          course_uuid: nil,
-          applying_for_bursary: false,
-          training_initiative: ROUTE_INITIATIVES_ENUMS[:transition_to_teach],
-        )
-      end
+      let(:trainee) { create(:trainee, :completed) }
 
       include_examples renders_confirmation, :personal_details
       include_examples renders_confirmation, :contact_details

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -91,6 +91,7 @@ FactoryBot.define do
       with_secondary_course_details
       with_start_date
       with_degree
+      with_funding
     end
 
     trait :with_degree do

--- a/spec/features/end_to_end/assessment_only_journey_spec.rb
+++ b/spec/features/end_to_end/assessment_only_journey_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 feature "assessment-only end-to-end journey", type: :feature do
-  background { given_i_am_authenticated }
+  background {
+    given_i_am_authenticated
+    and_an_academic_cycle_exists
+  }
 
   scenario "submit for TRN" do
     given_i_have_created_an_assessment_only_trainee

--- a/spec/features/end_to_end/early_years_assessment_only_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_assessment_only_journey_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "early_years_assessment_only end-to-end journey", type: :feature do
   background {
     given_i_am_authenticated
-    create(:academic_cycle, :current)
+    and_an_academic_cycle_exists
   }
 
   scenario "submit for TRN", "feature_routes.early_years_assessment_only": true do

--- a/spec/features/end_to_end/early_years_assessment_only_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_assessment_only_journey_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 feature "early_years_assessment_only end-to-end journey", type: :feature do
-  background { given_i_am_authenticated }
+  background {
+    given_i_am_authenticated
+    create(:academic_cycle, :current)
+  }
 
   scenario "submit for TRN", "feature_routes.early_years_assessment_only": true do
     given_i_have_created_an_early_years_assessment_only_trainee

--- a/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 feature "early_years_postgrad end-to-end journey", type: :feature do
-  background { given_i_am_authenticated }
-  before do
+  background {
+    given_i_am_authenticated
     create(:academic_cycle, :current)
-  end
+  }
 
   scenario "submit for TRN", "feature_routes.early_years_postgrad": true do
     given_i_have_created_an_early_years_postgrad_trainee

--- a/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "early_years_postgrad end-to-end journey", type: :feature do
   background {
     given_i_am_authenticated
-    create(:academic_cycle, :current)
+    and_an_academic_cycle_exists
   }
 
   scenario "submit for TRN", "feature_routes.early_years_postgrad": true do

--- a/spec/features/end_to_end/early_years_salaried_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_salaried_journey_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 feature "early_years_salaried end-to-end journey", type: :feature do
-  background { given_i_am_authenticated }
+  background {
+    given_i_am_authenticated
+    create(:academic_cycle, :current)
+  }
 
   scenario "submit for TRN", "feature_routes.early_years_salaried": true do
     given_i_have_created_an_early_years_salaried_trainee

--- a/spec/features/end_to_end/early_years_salaried_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_salaried_journey_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "early_years_salaried end-to-end journey", type: :feature do
   background {
     given_i_am_authenticated
-    create(:academic_cycle, :current)
+    and_an_academic_cycle_exists
   }
 
   scenario "submit for TRN", "feature_routes.early_years_salaried": true do

--- a/spec/features/end_to_end/opt_in_undergrad_spec.rb
+++ b/spec/features/end_to_end/opt_in_undergrad_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 feature "opt-in-undergrad end-to-end journey", type: :feature do
-  background { given_i_am_authenticated }
+  background {
+    given_i_am_authenticated
+    and_an_academic_cycle_exists
+  }
 
   scenario "submit for TRN", "feature_routes.opt_in_undergrad": true do
     given_i_have_created_an_opt_in_undergrad_trainee

--- a/spec/features/end_to_end/pg_teaching_apprenticeship_journey_spec.rb
+++ b/spec/features/end_to_end/pg_teaching_apprenticeship_journey_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 feature "pg_teaching_apprenticeship end-to-end journey", type: :feature do
-  background { given_i_am_authenticated }
+  background {
+    given_i_am_authenticated
+    and_an_academic_cycle_exists
+  }
 
   scenario "submit for TRN", "feature_routes.pg_teaching_apprenticeship": true do
     given_i_have_created_a_pg_teaching_apprenticeship_trainee

--- a/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
@@ -6,7 +6,10 @@ feature "provider-led (postgrad) end-to-end journey", type: :feature do
   let(:itt_start_date) { 1.week.from_now }
   let(:itt_end_date) { itt_start_date + 1.year }
 
-  background { given_i_am_authenticated }
+  background {
+    given_i_am_authenticated
+    and_an_academic_cycle_exists
+  }
 
   scenario "submit for TRN", "feature_routes.provider_led_postgrad": true, feature_publish_course_details: true do
     given_i_have_created_a_provider_led_trainee

--- a/spec/features/end_to_end/provider_led_undergrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_undergrad_journey_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 feature "provider-led (undergrad) end-to-end journey", type: :feature do
-  background { given_i_am_authenticated }
+  background {
+    given_i_am_authenticated
+    and_an_academic_cycle_exists
+  }
 
   scenario "submit for TRN", "feature_routes.provider_led_undergrad": true do
     given_i_have_created_a_provider_led_undergrad_trainee

--- a/spec/features/end_to_end/school_direct_salaried_journey_spec.rb
+++ b/spec/features/end_to_end/school_direct_salaried_journey_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 feature "school-direct-salaried end-to-end journey", type: :feature do
-  background { given_i_am_authenticated }
+  background {
+    given_i_am_authenticated
+    and_an_academic_cycle_exists
+  }
 
   scenario "submit for TRN", "feature_routes.school_direct_salaried": true do
     given_i_have_created_a_school_direct_salaried_trainee

--- a/spec/features/end_to_end/school_direct_tuition_fee_journey_spec.rb
+++ b/spec/features/end_to_end/school_direct_tuition_fee_journey_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 feature "school-direct-tuition-fee end-to-end journey", type: :feature do
-  background { given_i_am_authenticated }
+  background {
+    given_i_am_authenticated
+    and_an_academic_cycle_exists
+  }
 
   scenario "submit for TRN", "feature_routes.school_direct_tuition_fee": true do
     given_i_have_created_a_school_direct_tuition_fee_trainee

--- a/spec/features/end_to_end/teach_first_journey_spec.rb
+++ b/spec/features/end_to_end/teach_first_journey_spec.rb
@@ -5,7 +5,10 @@ require "rails_helper"
 feature "teach-first end-to-end journey", type: :feature do
   let(:user) { create(:user, providers: [create(:provider, code: TEACH_FIRST_PROVIDER_CODE)]) }
 
-  background { given_i_am_authenticated(user: user) }
+  background {
+    given_i_am_authenticated(user: user)
+    and_an_academic_cycle_exists
+  }
 
   scenario "submit for TRN" do
     given_i_have_created_a_teach_first_trainee

--- a/spec/lib/funding_manager_spec.rb
+++ b/spec/lib/funding_manager_spec.rb
@@ -178,7 +178,7 @@ describe FundingManager do
         create(:funding_method_subject, funding_method: funding_method, allocation_subject: subject_specialism.allocation_subject)
       end
 
-      context "and the route is funded in a another academic year" do
+      context "and the route is funded in another academic year" do
         let(:funding_method) { create(:funding_method, training_route: trainee_without_start_dates.training_route, academic_cycle: previous_academic_cycle) }
 
         it "returns true" do

--- a/spec/lib/funding_manager_spec.rb
+++ b/spec/lib/funding_manager_spec.rb
@@ -7,15 +7,19 @@ describe FundingManager do
   let(:bursary_tier) { nil }
   let(:training_route) { :early_years_postgrad }
   let(:trainee) do
-    build(:trainee,
-          :with_start_date,
-          :with_study_mode_and_course_dates,
-          :with_course_allocation_subject,
-          course_subject_one: course_subject_one,
-          training_route: training_route,
-          bursary_tier: bursary_tier)
+    create(:trainee,
+           :with_start_date,
+           :with_study_mode_and_course_dates,
+           :with_course_allocation_subject,
+           course_subject_one: course_subject_one,
+           training_route: training_route,
+           bursary_tier: bursary_tier)
   end
   let(:funding_manager) { described_class.new(trainee) }
+
+  before do
+    create(:academic_cycle, :current)
+  end
 
   describe "#bursary_amount" do
     subject { funding_manager.bursary_amount }

--- a/spec/support/features/training_route_steps.rb
+++ b/spec/support/features/training_route_steps.rb
@@ -46,6 +46,10 @@ module Features
       choose_training_route_for(TRAINING_ROUTE_ENUMS[:opt_in_undergrad])
     end
 
+    def and_an_academic_cycle_exists
+      create(:academic_cycle, :current)
+    end
+
   private
 
     def choose_training_route_for(route)

--- a/spec/support/shared_examples/rendering_the_funding_section.rb
+++ b/spec/support/shared_examples/rendering_the_funding_section.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "rendering the funding section" do
-  context "when a trainee on a route with a bursary" do
+  context "when a trainee is on a route with a bursary" do
     let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
     let(:trainee) { create(:trainee, :with_start_date, :with_study_mode_and_course_dates, :incomplete_draft, route) }
 
@@ -15,7 +15,7 @@ RSpec.shared_examples "rendering the funding section" do
     end
 
     context "and has entered their course details" do
-      before { trainee.course_subject_one = "subject" }
+      before { trainee.progress.course_details = true }
 
       it "renders the funding section as 'incomplete'" do
         render_inline(described_class.new(trainee: trainee))
@@ -24,14 +24,25 @@ RSpec.shared_examples "rendering the funding section" do
     end
   end
 
-  context "when a trainee on a route with no bursary" do
-    let(:trainee) { create(:trainee, :incomplete_draft, TRAINING_ROUTE_ENUMS[:assessment_only]) }
+  context "when a trainee is on a route with no bursary" do
+    let(:trainee) { create(:trainee, :with_start_date, :incomplete_draft, TRAINING_ROUTE_ENUMS[:assessment_only]) }
 
     before { create(:funding_method, :with_subjects, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad]) }
 
-    it "renders the funding section as 'incomplete'" do
-      render_inline(described_class.new(trainee: trainee))
-      expect(rendered_component).to have_css "#funding-status", text: "incomplete"
+    context "and has not entered their course details" do
+      it "renders the funding section as 'cannot start yet'" do
+        render_inline(described_class.new(trainee: trainee))
+        expect(rendered_component).to have_css "#funding-status", text: "cannot start yet"
+      end
+    end
+
+    context "and has entered their course details" do
+      before { trainee.progress.course_details = true }
+
+      it "renders the funding section as 'incomplete'" do
+        render_inline(described_class.new(trainee: trainee))
+        expect(rendered_component).to have_css "#funding-status", text: "incomplete"
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

This fix is related to these two trello tickets: 
https://trello.com/c/sScbSWdC/4201-funding-early-years-salaried-doesnt-show-grant-funding-question-unless-youve-filled-in-course-details
https://trello.com/c/gYvAknvX/4203-funding-page-crashes-if-you-visit-funding-before-filling-in-course-details

For early years routes, we set the subject to `EARLY_YEARS_TEACHING`, which meant that  the original `cannot_start_funding?`  method returned false as course_subject_one was not blank. Therefore the funding section could be accessed before we had the academic year info.

I think it makes sense to prevent providers from filling out this section until we have an academic year for the trainee i.e. they've filled out the course details. This is what we do currently for other routes.

### Changes proposed in this pull request

We first tried this (first commit):

* Add a guard clause to return true in `cannot_start_funding?` if the trainee is on an early years route and does not have an academic year
* Update early years route tests so that an academic cycle exists, so this can be picked up when course dates are added for the trainee (which unlocks funding link)

But then we simplified it / altered the logic to this (see second commit):

* Change method to `can_start_funding_section?` for better readability
* Update the logic so that this method returns true only if the user has completed the course details section and the trainee has an academic cycle. In all other cases, it returns false.
* **This causes a slight change in functionality. For trainees who are on a route which is not funded at all, users now still need to complete the course details section before entering the funding section. Before, they could start it since it would only ever ask about training initiatives. We have decided that this is ok.**

### Guidance to review

* Create new draft trainees for all early years routes and make sure funding section cannot be started until course details are filled (for course details, pick a mix of subjects, some with funding and some without)
* Double check that other routes i.e. provider led and school direct still work as expected (funding cannot be started until course details are completed)

<img width="771" alt="Screenshot 2022-06-06 at 16 45 50" src="https://user-images.githubusercontent.com/43522239/172196307-2d4de26d-7230-462b-b2c4-96e80fb39bb0.png">

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml