### PR TITLE
[4216] Remove reference to published course if subject specialism is changed manually

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -181,6 +181,8 @@ private
 
     set_course_subject_from_primary_phase if is_primary_phase?
 
+    attributes.merge!(course_uuid: nil) if course_allocation_subject_changed?
+
     unless trainee.early_years_route?
       attributes.merge!({
         course_subject_one: course_subject_one,
@@ -343,5 +345,9 @@ private
       sanitised_date = public_send(date_attribute).to_s.gsub(/\s+/, "")
       public_send("#{date_attribute}=", sanitised_date)
     end
+  end
+
+  def course_allocation_subject_changed?
+    trainee.course_allocation_subject != course_allocation_subject
   end
 end

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -561,17 +561,30 @@ describe CourseDetailsForm, type: :model do
 
       context "when the course_subject has changed" do
         let(:progress) { Progress.new(course_details: true, funding: true, personal_details: true) }
-        let(:trainee) { create(:trainee, :with_funding, :with_secondary_course_details, applying_for_scholarship: true, course_subject_one: CourseSubjects::BIOLOGY, progress: progress) }
+        let(:trainee) do
+          create(:trainee,
+                 :with_funding,
+                 :with_publish_course_details,
+                 applying_for_scholarship: true,
+                 course_subject_one: CourseSubjects::BIOLOGY,
+                 progress: progress)
+        end
+
         let(:params) do
           {
             course_subject_one: CourseSubjects::HISTORICAL_LINGUISTICS,
           }
         end
 
-        it "nullifies the bursary information and resets funding section progress" do
+        before do
+          create(:subject_specialism, name: CourseSubjects::HISTORICAL_LINGUISTICS)
+        end
+
+        it "nullifies the course_uuid, bursary information and resets funding section progress" do
           expect { subject.save! }
           .to change { trainee.applying_for_bursary }
           .from(trainee.applying_for_bursary).to(nil)
+          .and change { trainee.course_uuid }.to(nil)
           .and change { trainee.applying_for_scholarship }.to(nil)
           .and change { trainee.progress.funding }.from(true).to(false)
         end


### PR DESCRIPTION
### Context
https://trello.com/c/YXc61urj/4216-if-the-allocation-subject-of-a-trainee-changes-away-from-what-the-attached-publish-course-has-we-should-delete-publish-course-re

### Changes proposed in this pull request
- Update `CourseDetailsForm#update_trainee_attributes` to nullify `Trainee#course_uuid` if the course allocation subject is changed via manually changing the subject specialism

### Guidance to review
- Choose a provider-led draft trainee
- Enter the course details section and change the subject
- The course information section of the summary should now display "Course details added manually" instead of the course name and code

### Important business
- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
