### PR TITLE
Fix flakey spec for lead school autocomplete

### DIFF
--- a/spec/features/system_admin/users/add_a_lead_school_to_user_spec.rb
+++ b/spec/features/system_admin/users/add_a_lead_school_to_user_spec.rb
@@ -2,6 +2,14 @@
 
 require "rails_helper"
 
+SCHOOL_NAMES = [
+  "Mallowtown High",
+  "Lakeacre High",
+  "Iceborough Secondary College",
+  "Clearcourt Secondary College",
+  "Brookville Secondary College",
+].freeze
+
 feature "creating a new lead school for a user" do
   let(:user) { create(:user, system_admin: true) }
   let!(:user_to_be_updated) { create(:user, first_name: "James", last_name: "Rodney") }
@@ -47,7 +55,9 @@ feature "creating a new lead school for a user" do
 private
 
   def and_a_number_of_lead_schools_exist
-    @lead_schools = create_list(:school, 5, :lead)
+    @lead_schools = SCHOOL_NAMES.map do |name|
+      create(:school, :lead, name: name)
+    end
   end
 
   def when_i_visit_the_user_index_page


### PR DESCRIPTION
### Context

This test is flakey due to random school names generated by Faker.

### Changes proposed in this pull request

Hard code list of school names to avoid two potential sources of bugs:

1. Duplicate names that cause the assertion that the autocomplete contains exactly one match to fail.
2. Names that start with the same characters, e.g. _Lakeacre High_ and _Lakeacre High School_ causing the wrong school to be selected in the autocomplete.

### Guidance to review

I tried using `minimum: 1` rather than `count: 1` in the assertion but this causes other issues. Also using `unique` in the factory causes many other tests to fail.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
