### PR TITLE
[4182] export for trainee summary

### DIFF
--- a/app/services/exports/funding_trainee_summary_data.rb
+++ b/app/services/exports/funding_trainee_summary_data.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Exports
+  class FundingTraineeSummaryData
+    VULNERABLE_CHARACTERS = %w[= + - @].freeze
+
+    def initialize(trainee_summary, organisation_name)
+      @organisation_name = organisation_name
+      @trainee_summary = trainee_summary
+      @data = format_rows(trainee_summary)
+    end
+
+    def csv
+      header_row ||= data.first&.keys
+
+      CSV.generate(headers: true) do |rows|
+        rows << header_row
+
+        data.map(&:values).each do |value|
+          rows << value.map { |v| sanitise(v) }
+        end
+      end
+    end
+
+    def filename
+      "#{@organisation_name.gsub(' ', '-')}-trainee-summary-#{@trainee_summary.academic_year}-to-#{@trainee_summary.academic_year.to_i + 1}.csv"
+    end
+
+  private
+
+    attr_reader :data
+
+    def format_rows(trainee_summary)
+      trainee_summary.rows.map do |row|
+        trainee_summary_row_amount = row.amounts.first
+        {
+          "Funding type" => funding_type_prefix(row) + trainee_summary_row_amount.payment_type,
+          "Route" => row.route,
+          "Course" => row.subject,
+          "Lead school" => row.lead_school_name,
+          "Tier" => trainee_summary_row_amount.tier.present? ? "Tier #{trainee_summary_row_amount.tier}" : "Not applicable",
+          "Number of trainees" => trainee_summary_row_amount.number_of_trainees,
+          "Amount per trainee" => to_pounds(trainee_summary_row_amount.amount_in_pence),
+          "Total" => to_pounds(trainee_summary_row_amount.number_of_trainees * trainee_summary_row_amount.amount_in_pence),
+        }
+      end
+    end
+
+    def sanitise(value)
+      return value unless value.is_a?(String)
+
+      value.start_with?(*VULNERABLE_CHARACTERS) ? value.prepend("'") : value
+    end
+
+    def to_pounds(value_in_pence)
+      ActionController::Base.helpers.number_to_currency(value_in_pence.to_d / 100, unit: "£")
+    end
+
+    def funding_type_prefix(row)
+      early_years_routes = ["Early years (assessment only)", "Early years (postgrad)", "Early years (salaried)", "Early years (undergrad)"]
+      if early_years_routes.include?(row.route)
+        "EYITT "
+      else
+        "ITT "
+      end
+    end
+  end
+end

--- a/app/view_objects/funding/navigation_view.rb
+++ b/app/view_objects/funding/navigation_view.rb
@@ -24,7 +24,7 @@ module Funding
     end
 
     def path_for_funding_trainee_summary
-      return funding_trainee_summary_path if !system_admin
+      return funding_trainee_summary_path(format: :html) if !system_admin
 
       if organisation.is_a?(Provider)
         provider_funding_trainee_summary_path(organisation)

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -56,7 +56,7 @@
       <h2 class="govuk-heading-m"><%= t('funding.payment_schedule.payment_breakdown') %></h2>
       <%= govuk_accordion do |accordion|
         @payment_schedule_view.payment_breakdown.each do |month_breakdown|
-          accordion.section(heading_text: month_breakdown.title, expanded: month_breakdown.last_actual_month?) do 
+          accordion.section(heading_text: month_breakdown.title, expanded: month_breakdown.last_actual_month?) do
             render partial: "funding/payment_schedules/month_breakdown", locals: { month_breakdown: month_breakdown }
           end
         end

--- a/app/views/funding/trainee_summaries/show.html.erb
+++ b/app/views/funding/trainee_summaries/show.html.erb
@@ -2,6 +2,10 @@
 
 <%= render "funding/navigation" %>
 
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
+<% end %>
+
 <h2 class="govuk-heading-l">
   <%= t("funding.trainee_summary.heading", start_year: @start_year, end_year: @end_year)%>
 </h2>
@@ -27,6 +31,15 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <p class="govuk-body"><%= t('funding.trainee_summary.last_updated_at', date: @trainee_summary_view&.last_updated_at) %></p>
+      <p class="govuk-body app-export--link">
+        <span class="app-nowrap">
+          <%= govuk_link_to(
+                I18n.t('funding.trainee_summary.export_label', start_year: @start_year, end_year: @end_year),
+                funding_trainee_summary_path(format: :csv),
+                class: "app-trainee-export govuk-link--no-visited-state",
+                ) %>
+        </span>
+      </p>
     </div>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
       last_updated_at: "Last updated: %{date}"
     trainee_summary:
       heading: Trainee summary %{start_year} to %{end_year}
+      export_label: Export trainee summary %{start_year} to %{end_year}
       last_updated_at: "Last updated: %{date}"
       table_headings:
         bursaries:
@@ -869,7 +870,7 @@ en:
       step_2_heading: "Step 2: Email us to request a Register account"
       send_email: Once you have a DfE Sign-in account with a named email address, email
       email_subject: Request a Register account
-      
+
       tell_us: "In your email, tell us:"
       bullets3:
         1: the name of the accredited provider or lead school you work for

--- a/spec/factories/funding/trainee_summary_rows.rb
+++ b/spec/factories/funding/trainee_summary_rows.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :trainee_summary_row, class: "Funding::TraineeSummaryRow" do
     association :trainee_summary, factory: :trainee_summary
 
-    subject { ["Biology"] }
+    subject { "Biology" }
     route { "Provider-led" }
     lead_school_name { "The School of Life" }
     lead_school_urn { Faker::Number.number(digits: 7) }

--- a/spec/features/funding/trainee_summary_spec.rb
+++ b/spec/features/funding/trainee_summary_spec.rb
@@ -28,6 +28,11 @@ feature "viewing the trainee summary", feature_funding: true do
       scenario "displays the summary table" do
         then_i_see_the_summary_table
       end
+
+      scenario "downloads trainee summary export csv" do
+        and_i_export_the_results
+        then_i_see_my_exported_data_in_csv_format
+      end
     end
 
     context "bursary rows with zero totals" do
@@ -218,5 +223,29 @@ private
 
   def then_i_do_not_see_the_tiered_bursary_row_in_the_table
     expect(trainee_summary_page). not_to have_text("Tier #{tier}")
+  end
+
+  def and_i_export_the_results
+    trainee_summary_page.export_link.click
+  end
+
+  def then_i_see_my_exported_data_in_csv_format
+    expect(csv_data).to include("Funding type,Route,Course,Lead school,Tier,Number of trainees,Amount per trainee,Total")
+    expect(csv_data).to include("bursary")
+    expect(csv_data).to include(row.route)
+    expect(csv_data).to include(row.subject)
+    expect(csv_data).to include(row.lead_school_name)
+    expect(csv_data).to include("Not applicable")
+    expect(csv_data).to include(row.amounts.first.number_of_trainees.to_s)
+    expect(csv_data).to include(to_pounds(row.amounts.first.amount_in_pence))
+    expect(csv_data).to include(to_pounds(row.amounts.first.number_of_trainees * row.amounts.first.amount_in_pence))
+  end
+
+  def csv_data
+    @csv_data ||= trainee_summary_page.text
+  end
+
+  def to_pounds(value_in_pence)
+    ActionController::Base.helpers.number_to_currency(value_in_pence.to_d / 100, unit: "£")
   end
 end

--- a/spec/services/exports/funding_trainee_summary_data_spec.rb
+++ b/spec/services/exports/funding_trainee_summary_data_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Exports
+  describe FundingTraineeSummaryData do
+    let!(:lead_school) { create(:school, lead_school: true) }
+    let!(:trainee_summary) { create(:trainee_summary, :for_school) }
+    let!(:trainee_summary_row) { create(:trainee_summary_row, trainee_summary: trainee_summary, lead_school_urn: lead_school.urn) }
+    let!(:tiered_bursary_amount) { create(:trainee_summary_row_amount, :with_tiered_bursary, row: trainee_summary_row) }
+
+    before do
+      create(:academic_cycle, :current)
+    end
+
+    subject { described_class.new(trainee_summary, lead_school.name) }
+
+    describe "#csv" do
+      let(:expected_output) do
+        {
+          "Funding type" => "ITT #{tiered_bursary_amount.payment_type}",
+          "Route" => trainee_summary_row.route,
+          "Course" => trainee_summary_row.subject,
+          "Lead school" => trainee_summary_row.lead_school_name,
+          "Tier" => "Tier #{tiered_bursary_amount.tier}",
+          "Number of trainees" => tiered_bursary_amount.number_of_trainees,
+          "Amount per trainee" => "\"#{ActionController::Base.helpers.number_to_currency(tiered_bursary_amount.amount_in_pence.to_d / 100, unit: '£')}\"",
+          "Total" => "\"#{ActionController::Base.helpers.number_to_currency(tiered_bursary_amount.number_of_trainees * tiered_bursary_amount.amount_in_pence.to_d / 100, unit: '£')}\"",
+        }
+      end
+
+      it "sets the correct headers" do
+        expect(subject.csv).to include(expected_output.keys.join(","))
+      end
+
+      it "sets the correct row values" do
+        expect(subject.csv).to include(expected_output.values.join(","))
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/funding/trainee_summary.rb
+++ b/spec/support/page_objects/funding/trainee_summary.rb
@@ -4,6 +4,7 @@ module PageObjects
   module Funding
     class TraineeSummary < PageObjects::Base
       set_url "/funding/trainee-summary"
+      element :export_link, ".app-trainee-export"
     end
   end
 end


### PR DESCRIPTION
### Context

Add csv export function for trainee summary, The rows are the payment details per route and course combinations. 

Adding the button in to actually download the csv still needs to be done, Could use advice on where this needs to go.

### Changes proposed in this pull request

Add a csv exporter class that consumes a trainee_summary and produces a csv

Download csv link: 
<img width="1792" alt="Screenshot 2022-06-09 at 15 23 47" src="https://user-images.githubusercontent.com/44261976/172870561-d42f8d02-dcf7-44a2-9d34-75ff9059458c.png">

Csv Output: 
<img width="1792" alt="Screenshot 2022-06-09 at 15 22 27" src="https://user-images.githubusercontent.com/44261976/172870265-0752b86d-82b6-4dfa-87fa-3e3212bae488.png">
