### PR TITLE
[xxx] Fix multiple lead school formatting

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -23,14 +23,14 @@
       <h2 class="govuk-heading-m">Lead schools</h2>
       <p class="govuk-body">As a lead school you can only view records. You cannot change them.</p>
       <ul class="govuk-list govuk-!-margin-bottom-7">
-        <li class="govuk-!-margin-bottom-2">
-          <%- @lead_schools.each do |lead_school| -%>
+        <%- @lead_schools.each do |lead_school| -%>
+          <li class="govuk-!-margin-bottom-2">
             <%= govuk_link_to lead_school.name, 
               organisation_path(id: lead_school.id, type: "School"), 
               class: "lead-school-link govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link govuk-link--no-visited-state" 
             %>
-          <%- end -%>
-        </li>
+          </li>
+        <%- end -%>
       </ul>
       <p class="govuk-body">
         If you need to access a different organisation’s records, contact us at <%= support_email %>


### PR DESCRIPTION
### Context

The organisation picker can have multiple lead schools and accredited bodies. The lead school formatting was broken.

#### Before

<img width="742" alt="Screenshot 2022-06-08 at 15 48 48" src="https://user-images.githubusercontent.com/5216/172647382-23ac2fef-1bb0-491a-8698-db9020e431b9.png">

#### After

<img width="766" alt="Screenshot 2022-06-08 at 15 48 11" src="https://user-images.githubusercontent.com/5216/172647398-4963afc4-77be-4231-a989-b8e4a8a5b4dd.png">

### Changes proposed in this pull request

Move <li> tag into the loop.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
