### PR TITLE
[4202] Add title_tag attribute to our ServiceUpdate component

### DIFF
--- a/app/components/service_update/view.html.erb
+++ b/app/components/service_update/view.html.erb
@@ -1,5 +1,5 @@
 <section id="<%= service_update.id %>">
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= title %></h2>
+  <%= title_element %>
   <p class="govuk-body govuk-!-margin-bottom-2"><%= date_pretty %></p>
   <div class="govuk-body"><%= content_html %></div>
 </section>

--- a/app/components/service_update/view.rb
+++ b/app/components/service_update/view.rb
@@ -3,15 +3,24 @@
 class ServiceUpdate::View < GovukComponent::Base
   attr_reader :service_update
 
-  delegate :title, :content, :date,
-           to: :service_update
+  delegate :title, :content, :date, to: :service_update
 
-  def initialize(service_update:)
+  TITLE_TAGS = %w[h1 h2 h3 h4 h5 h6].freeze
+  TITLE_CLASS = "govuk-heading-m govuk-!-margin-bottom-2"
+
+  def initialize(service_update:, title_tag: "h2")
     @service_update = service_update
+    @title_tag = title_tag
   end
 
   def render?
     service_update
+  end
+
+  def title_element
+    return tag.public_send(title_tag, title, { class: TITLE_CLASS }) if TITLE_TAGS.include?(title_tag)
+
+    tag.h2(title, { class: TITLE_CLASS })
   end
 
   def date_pretty
@@ -22,4 +31,8 @@ class ServiceUpdate::View < GovukComponent::Base
     custom_render = Redcarpet::Render::HTML.new(link_attributes: { class: "govuk-link" })
     Redcarpet::Markdown.new(custom_render).render(content).html_safe
   end
+
+private
+
+  attr_reader :title_tag
 end

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h2 class="govuk-heading-l"><%= t(".service_updates_title") %></h2>
     <% ServiceUpdate.recent_updates.each do |service_update| %>
-      <%= render ServiceUpdate::View.new(service_update: service_update) %>
+      <%= render ServiceUpdate::View.new(service_update: service_update, title_tag: "h3") %>
     <% end %>
     <%= govuk_link_to(t(".service_updates_link"), service_updates_path, { class: "govuk-body" }) %>
   </div>

--- a/spec/components/service_update/view_spec.rb
+++ b/spec/components/service_update/view_spec.rb
@@ -34,5 +34,33 @@ describe ServiceUpdate::View do
     it "renders pretty date" do
       expect(component.date_pretty.strip).to eql("8 November 2021")
     end
+
+    describe "title_element" do
+      context "by default" do
+        it "returns an h2" do
+          expect(component.title_element).to include("h2")
+        end
+      end
+
+      context "when a title_tag is provided" do
+        let(:component) { described_class.new(service_update: service_update, title_tag: title_tag) }
+
+        context "which is valid" do
+          let(:title_tag) { "h3" }
+
+          it "returns that tag" do
+            expect(component.title_element).to include("h3")
+          end
+        end
+
+        context "which is invalid" do
+          let(:title_tag) { "hi" }
+
+          it "returns an h2" do
+            expect(component.title_element).to include("h2")
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/dTGtDNFx/4202-headings-for-service-updates-are-in-illogical-order-on-the-start-page

### Changes proposed in this pull request

- `ServiceUpdate` can now be initialized with optional `title_tag` string
- `title_tag` defaults to 'h2'
- `title_tag` must be valid <h?> tag i.e. 1-6, otherwise it defaults to h2
- `title_tag` determines what html tag to use for the title only

### Guidance to review

- Check `/service-updates` and see that titles of updates are still all `<h2>`
- Check start page and see that titles of updates are now all `<h3>`

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
