### PR TITLE
[4021] Preserve selection of degree type when navigating back

### DIFF
--- a/app/controllers/trainees/degrees/type_controller.rb
+++ b/app/controllers/trainees/degrees/type_controller.rb
@@ -4,7 +4,7 @@ module Trainees
   module Degrees
     class TypeController < BaseController
       def new
-        @degree = trainee.degrees.build
+        @degree = trainee.degrees.build(locale_code_params)
       end
 
       def create

--- a/app/views/trainees/degrees/new.html.erb
+++ b/app/views/trainees/degrees/new.html.erb
@@ -6,7 +6,7 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: "Back",
-    href: trainee_degrees_new_type_path(@trainee),
+    href: trainee_degrees_new_type_path(@trainee, degree: { locale_code: @degree_form.uk? ? "uk" : "non_uk" }),
   ) %>
 <% end %>
 

--- a/spec/features/form_sections/personal_and_education_details/degrees/adding_degree_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/degrees/adding_degree_spec.rb
@@ -60,6 +60,16 @@ RSpec.feature "Adding a degree" do
       end
     end
 
+    context "the user uses the back link on the details page" do
+      scenario "the user clicks the back button" do
+        given_i_have_selected_the_uk_route
+        and_i_am_on_the_degree_details_page
+        and_i_fill_in_the_form
+        and_i_click_back
+        then_i_see_the_type_page_with_uk_selected
+      end
+    end
+
     context "the user enters valid details, with an 'Other' grade" do
       let(:other_grade) { "A different grade" }
 
@@ -261,5 +271,13 @@ private
       )
       expect(degree_details_page).to have_content(message)
     end
+  end
+
+  def and_i_click_back
+    degree_details_page.back.click
+  end
+
+  def then_i_see_the_type_page_with_uk_selected
+    expect(degree_type_page.uk_degree).to be_checked
   end
 end

--- a/spec/support/page_objects/trainees/new_degree_details.rb
+++ b/spec/support/page_objects/trainees/new_degree_details.rb
@@ -28,6 +28,7 @@ module PageObjects
 
       element :error_summary, ".govuk-error-summary"
       element :continue, "button[type='submit']"
+      element :back, "a.govuk-back-link"
     end
   end
 end


### PR DESCRIPTION
### Context

This PR attempts to fix an issue with the back link in the new degree flow in which the degree type selection is lost when navigating back to it from the degree details page.

### Changes proposed in this pull request

Because the new degree record is not persisted until the user completes the details form we have to pass the original degree type selection (uk or non-uk) explicitly (as a URL param) and read this into the model before rendering the form.

### Guidance to review

- Is there a simpler way to do this?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
