### PR TITLE
[4185] Sanitise CSV output in payment schedule export

### DIFF
--- a/spec/services/exports/funding_schedule_data_spec.rb
+++ b/spec/services/exports/funding_schedule_data_spec.rb
@@ -96,6 +96,35 @@ module Exports
       def format_amount(amount_in_pence)
         amount_in_pence.zero? ? "0" : "\"#{ActionController::Base.helpers.number_to_currency(amount_in_pence.to_d / 100, unit: '£')}\""
       end
+
+      context "with vulnerabilities in the data" do
+        let(:expected_header_line) do
+          "Month,'@Training bursary trainees,'+Course extension provider payments,Month total"
+        end
+        let(:expected_data_line) do
+          "'=January 2022,£12.34,£23.45,£35.79"
+        end
+
+        before do
+          suspect_data = [
+            {
+              MONTH_HEADING => "=January 2022",
+              "@Training bursary trainees" => 1234,
+              "+Course extension provider payments" => 2345,
+              MONTH_TOTAL_HEADING => 3579,
+            },
+          ]
+          allow(exporter).to receive(:data).and_return(suspect_data)
+        end
+
+        it "Sanitizes header line correctly" do
+          expect(exporter.to_csv).to include(expected_header_line)
+        end
+
+        it "Sanitizes data correctly" do
+          expect(exporter.to_csv).to include(expected_data_line)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

This is a follow-up to https://github.com/DFE-Digital/register-trainee-teachers/pull/2401 to sanitise CSV data making it more consistent with other CSV exports.

### Changes proposed in this pull request

Add sanitisation of vulnerable characters in `Exports::FundingScheduleData`.

### Guidance to review

Should we generalise this by extracting the sanitisation logic into a service class of some sort? (in a follow-up PR).

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
