### PR TITLE
[4221] Add hesa id to trn request

### DIFF
--- a/app/lib/dqt/params/trainee_request.rb
+++ b/app/lib/dqt/params/trainee_request.rb
@@ -8,6 +8,7 @@ module Dqt
       def build_params
         {
           "trn" => trainee.trn,
+          "husid" => trainee.hesa_id,
           "initialTeacherTraining" => initial_teacher_training_params,
           "qualification" => qualification_params,
         }

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -59,6 +59,7 @@ module Dqt
           "birthDate" => trainee.date_of_birth.iso8601,
           "emailAddress" => trainee.email,
           "address" => address_params,
+          "husid" => trainee.hesa_id,
           "genderCode" => GENDER_CODES[trainee.gender.to_sym],
           "initialTeacherTraining" => initial_teacher_training_params,
           "qualification" => qualification_params,

--- a/spec/lib/dqt/params/trainee_request_spec.rb
+++ b/spec/lib/dqt/params/trainee_request_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Dqt
   module Params
     describe TraineeRequest do
-      let(:trainee) { create(:trainee, :completed, gender: "female") }
+      let(:trainee) { create(:trainee, :completed, gender: "female", hesa_id: 1) }
       let(:degree) { trainee.degrees.first }
       let(:degree_subject) { Hesa::CodeSets::DegreeSubjects::MAPPING.invert[degree.subject] }
 
@@ -15,6 +15,7 @@ module Dqt
         it "returns a hash including personal attributes" do
           expect(subject).to include({
             "trn" => trainee.trn,
+            "husid" => trainee.hesa_id,
           })
         end
 


### PR DESCRIPTION
### Context

Add 'husid' field to the trn request and update endpoints. This field is not implemented yet on the DQT side but will be added soon.

### Changes proposed in this pull request

Add 'husid' field to request body of trn request and update actions.
