### PR TITLE
[4191] Change /privacy-policy to /privacy-notice

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -22,8 +22,8 @@ class PagesController < ApplicationController
     render(:accessibility)
   end
 
-  def privacy_policy
-    render(:privacy_policy)
+  def privacy_notice
+    render(:privacy_notice)
   end
 
   def guidance

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -127,7 +127,7 @@
                 <%= govuk_link_to "Cookies", cookie_preferences_path, class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <%= govuk_link_to "Privacy", privacy_policy_path, class: "govuk-footer__link" %>
+                <%= govuk_link_to "Privacy", privacy_notice_path, class: "govuk-footer__link" %>
               </li>
             </ul>
 

--- a/app/views/pages/privacy_notice.html.erb
+++ b/app/views/pages/privacy_notice.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "pages.privacy_policy") %>
+<%= render PageTitle::View.new(i18n_key: "pages.privacy_notice") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,7 +287,7 @@ en:
         accessibility: Accessibility statement for Register trainee teachers
         cookie_policy: Cookies on Register trainee teachers
         guidance: Data requirements
-        privacy_policy: Register trainee teachers privacy notice
+        privacy_notice: Register trainee teachers privacy notice
         forbidden: &forbidden You do not have permission to perform this action
         home: Home
         request_an_account: Request an account for Register trainee teachers (Register)
@@ -912,7 +912,7 @@ en:
       heading: Register trainee teachers data sharing agreement
     check_data:
       heading: Check what data you need to provide
-    privacy_policy:
+    privacy_notice:
       heading: Register trainee teachers privacy notice
     no_organisation:
       heading: You have not been linked to an organisation yet

--- a/config/locales/pages/data_sharing_agreement/en.yml
+++ b/config/locales/pages/data_sharing_agreement/en.yml
@@ -145,7 +145,7 @@ en:
           trainees how their data will be used. This privacy notice will
           include the email address they can use to contact the Register
           support team, and can be found at 
-          <a class='govuk-link' href='https://www.register-trainee-teachers.education.gov.uk/privacy-policy'>www.register-trainee-teachers.education.gov.uk/privacy-policy</a>
+          <a class='govuk-link' href='https://www.register-trainee-teachers.education.gov.uk/privacy-notice'>www.register-trainee-teachers.education.gov.uk/privacy-notice</a>
         </p>
         <h3 class='govuk-heading-s'>
           What the provider can use personal data the DfE data shared
@@ -228,7 +228,7 @@ en:
           Privacy notices
         </h2>
         <p class='govuk-body'>
-          Refer to the <a class='govuk-link' href='/privacy-policy'></a>Register
+          Refer to the <a class='govuk-link' href='/privacy-notice'></a>Register
           privacy notice</a> to see how Register handles data entered
           directly into the service.
         </p>

--- a/config/locales/pages/privacy_policy/en.yml
+++ b/config/locales/pages/privacy_policy/en.yml
@@ -1,6 +1,6 @@
 en:
   pages:
-    privacy_policy:
+    privacy_notice:
       body_html: "
       <h2 class='govuk-heading-m' id='who-are-we'>Who we are</h2>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,9 @@ Rails.application.routes.draw do
   get :sha, controller: :heartbeat
 
   get "/accessibility", to: "pages#accessibility", as: :accessibility
-  get "/privacy-policy", to: "pages#privacy_policy", as: :privacy_policy
+  get "/privacy-policy", to: redirect("/privacy-notice")
+  get "/privacy-notice", to: "pages#privacy_notice", as: :privacy_notice
+
   get "/guidance", to: "pages#guidance"
   get "/check-data", to: "pages#check_data"
   get "/data-sharing-agreement", to: "pages#data_sharing_agreement"

--- a/spec/features/static_pages_spec.rb
+++ b/spec/features/static_pages_spec.rb
@@ -18,7 +18,7 @@ feature "static pages" do
   scenario "navigate to privacy policy" do
     given_i_am_on_the_start_page
     and_i_click_on_the_privacy_link_in_the_footer
-    then_i_should_see_the_privacy_policy
+    then_i_should_see_the_privacy_notice
   end
 
   scenario "navigate to sign in" do
@@ -79,9 +79,9 @@ private
     expect(edit_cookie_preferences_page.page_heading).to have_text("Cookies")
   end
 
-  def then_i_should_see_the_privacy_policy
-    expect(privacy_policy_page).to be_displayed
-    expect(privacy_policy_page.page_heading).to have_text(t("components.page_titles.pages.privacy_policy"))
+  def then_i_should_see_the_privacy_notice
+    expect(privacy_notice_page).to be_displayed
+    expect(privacy_notice_page.page_heading).to have_text(t("components.page_titles.pages.privacy_notice"))
   end
 
   def when_i_click_on_request_an_account

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -326,8 +326,8 @@ module Features
       @edit_cookie_preferences_page ||= PageObjects::EditCookiePreferences.new
     end
 
-    def privacy_policy_page
-      @privacy_policy_page ||= PageObjects::PrivacyPolicy.new
+    def privacy_notice_page
+      @privacy_notice_page ||= PageObjects::PrivacyNotice.new
     end
 
     def start_date_verification_page

--- a/spec/support/page_objects/base.rb
+++ b/spec/support/page_objects/base.rb
@@ -23,8 +23,8 @@ module PageObjects
     element :page_heading, ".govuk-heading-l"
   end
 
-  class PrivacyPolicy < PageObjects::Base
-    set_url "/privacy-policy"
+  class PrivacyNotice < PageObjects::Base
+    set_url "/privacy-notice"
 
     element :page_heading, ".govuk-heading-l"
   end


### PR DESCRIPTION
### Context

https://trello.com/c/55UX3DRp/4191-change-the-register-privacy-notice-url-from-policy-to-notice-and-redirect-the-link

### Changes proposed in this pull request

- Update the footer link and data sharing agreement link to go to /privacy-notice
- Rename all methods and files to reference notice rather than policy, for tidyness
- Redirect old /privacy-policy to /privacy-notice

### Guidance to review

- Click the Privacy link in the footer
- Check that it goes to /privacy-notice
- Directly access /privacy-policy via the browser
- Check that this redirects to /privacy-notice

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
