### PR TITLE
[4228] Fix 2022 apply applications not being requested properly data migration

### DIFF
--- a/app/jobs/apply_api/import_applications_job.rb
+++ b/app/jobs/apply_api/import_applications_job.rb
@@ -21,8 +21,10 @@ module ApplyApi
   private
 
     def new_applications(recruitment_cycle_year)
-      RetrieveApplications.call(changed_since: @from_date || last_successful_sync,
-                                recruitment_cycle_year: recruitment_cycle_year)
+      RetrieveApplications.call(
+        changed_since: @from_date || last_successful_sync,
+        recruitment_cycle_year: recruitment_cycle_year,
+      )
     end
 
     def last_successful_sync

--- a/app/jobs/apply_api/import_applications_job.rb
+++ b/app/jobs/apply_api/import_applications_job.rb
@@ -22,13 +22,16 @@ module ApplyApi
 
     def new_applications(recruitment_cycle_year)
       RetrieveApplications.call(
-        changed_since: @from_date || last_successful_sync,
+        changed_since: @from_date || last_successful_sync(recruitment_cycle_year),
         recruitment_cycle_year: recruitment_cycle_year,
       )
     end
 
-    def last_successful_sync
-      ApplyApplicationSyncRequest.successful.maximum(:created_at)
+    def last_successful_sync(recruitment_cycle_year)
+      ApplyApplicationSyncRequest
+        .successful
+        .where(recruitment_cycle_year: recruitment_cycle_year)
+        .maximum(:created_at)
     end
   end
 end

--- a/app/lib/apply_api/client.rb
+++ b/app/lib/apply_api/client.rb
@@ -15,21 +15,26 @@ module ApplyApi
 
     GET_SUCCESS = 200
 
-    def self.get(...)
-      response = Request.get(...)
+    def self.get(params)
+      response = Request.get("/applications?#{query(params)}")
 
-      log_request!(response)
+      log_request!(response, params)
 
       raise(HttpError, "status: #{response.code}, body: #{response.body}, headers: #{response.headers}") if response.code != GET_SUCCESS
 
       response
     end
 
-    def self.log_request!(response)
+    def self.log_request!(response, params)
       ApplyApplicationSyncRequest.create!(
         successful: response.code == GET_SUCCESS,
         response_code: response.code,
+        recruitment_cycle_year: params[:recruitment_cycle_year],
       )
+    end
+
+    def self.query(params)
+      params.compact.to_query
     end
   end
 end

--- a/app/services/apply_api/retrieve_applications.rb
+++ b/app/services/apply_api/retrieve_applications.rb
@@ -22,14 +22,14 @@ module ApplyApi
     end
 
     def response
-      @response ||= Client.get("/applications?#{query}")
+      @response ||= Client.get(params)
     end
 
-    def query
+    def params
       {
         recruitment_cycle_year: recruitment_cycle_year,
         changed_since: changed_since&.utc&.iso8601,
-      }.compact.to_query
+      }
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,7 +93,6 @@ apply_applications:
   import:
     recruitment_cycle_years:
       - 2021
-      - 2022
   create:
     recruitment_cycle_year: 2021
 

--- a/db/data/20220613001509_backfill_apply_application_sync_requests_recruitment_cycle_year.rb
+++ b/db/data/20220613001509_backfill_apply_application_sync_requests_recruitment_cycle_year.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class BackfillApplyApplicationSyncRequestsRecruitmentCycleYear < ActiveRecord::Migration[6.1]
+  def up
+    ApplyApplicationSyncRequest.update_all(recruitment_cycle_year: 2021)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/lib/apply_api/client_spec.rb
+++ b/spec/lib/apply_api/client_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ApplyApi
+  describe Client do
+    let(:recruitment_cycle_year) { Settings.current_recruitment_cycle_year }
+    let(:expected_path) { "/applications?recruitment_cycle_year=#{recruitment_cycle_year}" }
+    let(:http_response) { { status: 200, body: ApiStubs::ApplyApi.applications } }
+    let(:request_url) { "#{Settings.apply_api.base_url}#{expected_path}" }
+
+    subject { described_class.get(changed_since: nil, recruitment_cycle_year: recruitment_cycle_year) }
+
+    before do
+      stub_request(:get, request_url).to_return(http_response)
+    end
+
+    it "calls API with correct URL" do
+      expect(ApplyApi::Client::Request).to receive(:get).with(expected_path).and_call_original
+      subject
+    end
+
+    it "creates an ApplyApplicationSyncRequest record with recruitment_cycle_year" do
+      expect { subject }.to(
+        change { ApplyApplicationSyncRequest.successful.where(recruitment_cycle_year: recruitment_cycle_year).count }.by(1),
+      )
+    end
+  end
+end

--- a/spec/services/apply_api/retrieve_applications_spec.rb
+++ b/spec/services/apply_api/retrieve_applications_spec.rb
@@ -22,10 +22,7 @@ module ApplyApi
 
         context "when no 'changed_since' is provided" do
           it "logs the successful request" do
-            subject
-            request = ApplyApplicationSyncRequest.last
-            expect(request).to be_successful
-            expect(request.response_code).to eq status
+            expect(subject).to change { ApplyApplicationSyncRequest.count }.by(1)
           end
 
           it "returns all the Apply applications" do
@@ -47,7 +44,7 @@ module ApplyApi
           let(:expected_path) { "/applications?#{expected_query}" }
 
           it "includes the changed_at param in the request" do
-            expect(Client).to receive(:get).with(expected_path).and_call_original
+            expect(ApplyApi::Client::Request).to receive(:get).with(expected_path).and_call_original
             subject
           end
         end

--- a/spec/services/apply_api/retrieve_applications_spec.rb
+++ b/spec/services/apply_api/retrieve_applications_spec.rb
@@ -22,7 +22,7 @@ module ApplyApi
 
         context "when no 'changed_since' is provided" do
           it "logs the successful request" do
-            expect(subject).to change { ApplyApplicationSyncRequest.count }.by(1)
+            expect { subject }.to change { ApplyApplicationSyncRequest.count }.by(1)
           end
 
           it "returns all the Apply applications" do


### PR DESCRIPTION
### Context

This PR is dependent on https://github.com/DFE-Digital/register-trainee-teachers/pull/2423

We import applications from the Apply register API into our apply_applications table. There are a couple of problems with this.

1. We are in some cases requesting the wrong applications. The API has an `updated_since` parameter. We keep track of the last time we called the API (using a `ApplyApplicationSyncRequest` record) and use this to fill the `updated_since` next time. The logic here is wrong since we started calling the API multiple times for different recruitment cycles. We need to track the last successful call _per recruitment cycle_.2. 
2. The API itself has been failing, particularly when retrieving 2022 applications. This seems to be because the Apply API is timing out when retrieving large datasets (there are around 2K relevant applications in 2022).3. 

This PR attempts to fix issue 1 by storing a different 'last successful call timestamp' for each recruitment cycle year.

Issue 2 seems to require changes on the Apply side, and perhaps some changes on the Register side.

### Changes proposed in this pull request

- [x] Data migration to create `ApplyApplicationSyncRequest` records for each `recruitment_cycle_year`. (We could delete all other records which will have a nil `recruitment_cycle_year`).
- [x] Refactor to give us access to the `recruitment_cycle_year` in the code that creates `ApplyApplicationSyncRequest` records.
- [x] Use `ApplyApplicationSyncRequest#recruitment_cycle_year` in 

### Guidance to review

- Is there a better strategy for backfilling `ApplyApplicationSyncRequest#recruitment_cycle_year`?
- Does the refactoring make sense?
- Are the tests adequate?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
