### PR TITLE
[4218] Send TRNs to HESA

### DIFF
--- a/app/jobs/hesa/upload_trn_file_job.rb
+++ b/app/jobs/hesa/upload_trn_file_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Hesa
+  class UploadTrnFileJob < ApplicationJob
+    def perform
+      return unless FeatureService.enabled?(:hesa_trn_requests)
+
+      trainees = Trainee.imported_from_hesa.where("created_at > ?", TrnSubmission.last_submitted_at)
+      payload = UploadTrnFile.call(trainees: trainees)
+      TrnSubmission.create(payload: payload, submitted_at: Time.zone.now)
+    rescue UploadTrnFile::TrnFileUploadError => e
+      Sentry.capture_exception(e)
+    end
+  end
+end

--- a/app/lib/hesa/client.rb
+++ b/app/lib/hesa/client.rb
@@ -6,10 +6,19 @@ module Hesa
       new.get(...)
     end
 
+    def self.upload_trn_file(...)
+      new.upload_trn_file(...)
+    end
+
     def get(url:)
       login
       page = agent.get(url)
       page.body
+    end
+
+    def upload_trn_file(url:, file:)
+      login
+      agent.post(url, { file: file })
     end
 
   private

--- a/app/models/hesa/trn_submission.rb
+++ b/app/models/hesa/trn_submission.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Hesa
+  class TrnSubmission < ApplicationRecord
+    self.table_name = "hesa_trn_submissions"
+
+    def self.last_submitted_at
+      order(:submitted_at)&.last&.submitted_at
+    end
+  end
+end

--- a/app/services/hesa/upload_trn_file.rb
+++ b/app/services/hesa/upload_trn_file.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Hesa
+  class UploadTrnFile
+    include ServicePattern
+
+    class TrnFileUploadError < StandardError; end
+
+    def initialize(trainees:)
+      @trainees = trainees
+      @url = "#{Settings.hesa.trn_file_base_url}/#{Settings.hesa.current_collection_reference}"
+    end
+
+    def call
+      file = Mechanize::Form::FileUpload.new({ "name" => "file" }, "trn_file.csv")
+      file.file_data = build_csv
+      response = Hesa::Client.upload_trn_file(url: url, file: file)
+      raise(TrnFileUploadError, response.body) if response.code != "200"
+
+      file.file_data
+    end
+
+  private
+
+    attr_reader :trainees, :url
+
+    def build_csv
+      CSV.generate do |csv|
+        csv << %w[UKPRN HUSID TRN]
+        trainees.each do |trainee|
+          csv << [trainee.hesa_student.ukprn, trainee.hesa_id, trainee.trn]
+        end
+      end
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,6 +21,7 @@ hesa:
   auth_url: "https://identity.hesa.ac.uk/Account/RemoteLogOn?ReturnDomain=https://datacollection.hesa.ac.uk&ReturnUrl=%2f"
   collection_base_url: "https://datacollection.hesa.ac.uk/apis/itt/1.1/CensusData"
   trn_data_base_url: "https://datacollection.hesa.ac.uk/apis/itt/1.1/TRNData"
+  trn_file_base_url: "https://datacollection.hesa.ac.uk/apis/itt/1.1/TRNFile"
   current_collection_reference: "C21053"
   current_collection_start_date: "2022-04-01"
   username: <get from secrets>
@@ -67,6 +68,7 @@ features:
   funding: false
   redirect_education_domain: true
   set_trainee_cohorts: false
+  hesa_trn_requests: false
   hesa_import:
     sync_collection: false
     sync_trn_data: false

--- a/db/migrate/20220616093411_create_hesa_trn_submissions.rb
+++ b/db/migrate/20220616093411_create_hesa_trn_submissions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateHesaTrnSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :hesa_trn_submissions do |t|
+      t.text :payload
+      t.datetime :submitted_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_15_133237) do
+ActiveRecord::Schema.define(version: 2022_06_16_093411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -484,6 +484,13 @@ ActiveRecord::Schema.define(version: 2022_06_15_133237) do
     t.string "collection_reference"
     t.integer "state"
     t.text "response_body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "hesa_trn_submissions", force: :cascade do |t|
+    t.text "payload"
+    t.datetime "submitted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/hesa/student.rb
+++ b/spec/factories/hesa/student.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :hesa_student, class: "Hesa::Student" do
+    ukprn { Faker::Number.number(digits: 8) }
+  end
+end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -545,6 +545,7 @@ FactoryBot.define do
       hesa_id { Faker::Number.number(digits: 13) }
       created_from_hesa { true }
       hesa_updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+      hesa_student { create(:hesa_student, hesa_id: hesa_id) }
     end
 
     trait :past do

--- a/spec/jobs/hesa/upload_trn_file_job_spec.rb
+++ b/spec/jobs/hesa/upload_trn_file_job_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Hesa
+  describe UploadTrnFileJob do
+    context "feature flag is off" do
+      before { disable_features(:hesa_trn_requests) }
+
+      it "doesn't create a Hesa::TrnSubmission record" do
+        expect { described_class.new.perform }.not_to change { Hesa::TrnSubmission.count }
+      end
+
+      it "doesn't call the HESA API" do
+        expect(Hesa::Client).not_to receive(:upload_trn_file)
+        described_class.new.perform
+      end
+    end
+
+    context "feature flag is on" do
+      before do
+        enable_features(:hesa_trn_requests)
+        allow(UploadTrnFile).to receive(:call)
+      end
+
+      it "uploads file and saves logs payload" do
+        expect { described_class.new.perform }.to change { TrnSubmission.count }.by(1)
+      end
+
+      context "upload error" do
+        let(:hesa_upload_error) { Hesa::UploadTrnFile::TrnFileUploadError.new }
+
+        before do
+          allow(Hesa::UploadTrnFile).to receive(:call).and_raise(hesa_upload_error)
+        end
+
+        it "sends an error message to Sentry" do
+          expect(Sentry).to receive(:capture_exception).with(hesa_upload_error)
+          described_class.new.perform
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/hesa/client_spec.rb
+++ b/spec/lib/hesa/client_spec.rb
@@ -13,6 +13,8 @@ module Hesa
     before do
       allow(Settings.hesa).to receive(:username).and_return("test@example.com")
       allow(Settings.hesa).to receive(:password).and_return("test12345")
+      allow(subject).to receive(:agent).and_return(mechanize)
+      allow(subject).to receive(:login).and_return(true)
     end
 
     describe ".login" do
@@ -36,13 +38,24 @@ module Hesa
       let(:sample_page) { Struct.new(:body).new("Test") }
 
       before do
-        allow(subject).to receive(:agent).and_return(mechanize)
         allow(mechanize).to receive(:get).with(url).and_return(sample_page)
-        allow(subject).to receive(:login).and_return(true)
       end
 
       it "returns XML from URL" do
         expect(subject.get(url: url)).to eql("Test")
+      end
+    end
+
+    describe ".upload_trn_file" do
+      let(:sample_page) { Struct.new(:body).new("True") }
+      let(:file) { double }
+
+      before do
+        allow(mechanize).to receive(:post).with(url, file: file).and_return(sample_page)
+      end
+
+      it "sends a form post request with file data" do
+        subject.upload_trn_file(url: url, file: file)
       end
     end
   end

--- a/spec/services/hesa/upload_trn_file_spec.rb
+++ b/spec/services/hesa/upload_trn_file_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Hesa
+  describe UploadTrnFile do
+    describe ".call" do
+      let(:trainee) { create(:trainee, :imported_from_hesa) }
+      let(:file) { OpenStruct.new }
+      let(:hesa_response) { double(code: "200", body: "True") }
+      let(:url) { "#{Settings.hesa.trn_file_base_url}/#{Settings.hesa.current_collection_reference}" }
+
+      before do
+        allow(Hesa::TrnSubmission).to receive(:last_submitted_at).and_return(1.minute.ago)
+        allow(Mechanize::Form::FileUpload).to receive(:new).with({ "name" => "file" }, "trn_file.csv").and_return(file)
+      end
+
+      it "builds a CSV of TRN data and uploads it as a file to HESA" do
+        expect(Hesa::Client).to receive(:upload_trn_file).with(url: url, file: file).and_return(hesa_response)
+
+        expect(described_class.call(trainees: [trainee])).to eq(file.file_data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/qMssCMFv/4217-l-trn-requests-from-hesa

### Changes proposed in this pull request
- New service `Hesa::UploadTrnFile` that takes care of the file upload of TRN data to HESA
- New model `Hesa::TrnSubmission` to log the HESA uploads
- New background job to to run all this

### Guidance to review
The code was tested against the real API endpoint and return a 200 with the body containing the text "True". I'm assuming it works, but we'll need to try it out with real data to be 100% sure.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
