### PR TITLE
[4255] Add start_academic_cycle and end_academic_cycle to trainees

### DIFF
--- a/db/migrate/20220615133237_add_start_and_end_academic_cycle_to_trainees.rb
+++ b/db/migrate/20220615133237_add_start_and_end_academic_cycle_to_trainees.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddStartAndEndAcademicCycleToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :trainees, :start_academic_cycle, foreign_key: { to_table: :academic_cycles }
+    add_reference :trainees, :end_academic_cycle, foreign_key: { to_table: :academic_cycles }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_08_084133) do
+ActiveRecord::Schema.define(version: 2022_06_15_133237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -663,6 +663,8 @@ ActiveRecord::Schema.define(version: 2022_06_08_084133) do
     t.datetime "hesa_updated_at"
     t.integer "cohort", default: 0
     t.bigint "course_allocation_subject_id"
+    t.bigint "start_academic_cycle_id"
+    t.bigint "end_academic_cycle_id"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["cohort"], name: "index_trainees_on_cohort"
     t.index ["course_allocation_subject_id"], name: "index_trainees_on_course_allocation_subject_id"
@@ -672,6 +674,7 @@ ActiveRecord::Schema.define(version: 2022_06_08_084133) do
     t.index ["diversity_disclosure"], name: "index_trainees_on_diversity_disclosure"
     t.index ["dttp_id"], name: "index_trainees_on_dttp_id"
     t.index ["employing_school_id"], name: "index_trainees_on_employing_school_id"
+    t.index ["end_academic_cycle_id"], name: "index_trainees_on_end_academic_cycle_id"
     t.index ["ethnic_group"], name: "index_trainees_on_ethnic_group"
     t.index ["gender"], name: "index_trainees_on_gender"
     t.index ["lead_school_id"], name: "index_trainees_on_lead_school_id"
@@ -679,6 +682,7 @@ ActiveRecord::Schema.define(version: 2022_06_08_084133) do
     t.index ["progress"], name: "index_trainees_on_progress", using: :gin
     t.index ["provider_id"], name: "index_trainees_on_provider_id"
     t.index ["slug"], name: "index_trainees_on_slug", unique: true
+    t.index ["start_academic_cycle_id"], name: "index_trainees_on_start_academic_cycle_id"
     t.index ["state"], name: "index_trainees_on_state"
     t.index ["training_route"], name: "index_trainees_on_training_route"
   end
@@ -726,6 +730,8 @@ ActiveRecord::Schema.define(version: 2022_06_08_084133) do
   add_foreign_key "subject_specialisms", "allocation_subjects"
   add_foreign_key "trainee_disabilities", "disabilities"
   add_foreign_key "trainee_disabilities", "trainees"
+  add_foreign_key "trainees", "academic_cycles", column: "end_academic_cycle_id"
+  add_foreign_key "trainees", "academic_cycles", column: "start_academic_cycle_id"
   add_foreign_key "trainees", "allocation_subjects", column: "course_allocation_subject_id"
   add_foreign_key "trainees", "apply_applications"
   add_foreign_key "trainees", "providers"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@rails/webpacker": "^5.4.3",
     "accessible-autocomplete": "^2.0.3",
     "babel-polyfill": "^6.26.0",
-    "core-js": "^3.22.8",
+    "core-js": "^3.23.1",
     "govuk-country-and-territory-autocomplete": "^1.0.2",
     "govuk-frontend": "^4.0.1",
     "jquery": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3408,10 +3408,10 @@ core-js@^2.4.0, core-js@^2.5.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
-core-js@^3.16.2, core-js@^3.22.8:
-  version "3.22.8"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.8.tgz#23f860b1fe60797cc4f704d76c93fea8a2f60631"
-  integrity sha512-UoGQ/cfzGYIuiq6Z7vWL1HfkE9U9IZ4Ub+0XSiJTCzvbZzgPA69oDF2f+lgJ6dFFLEdjW5O6svvoKzXX23xFkA==
+core-js@^3.16.2, core-js@^3.23.1:
+  version "3.23.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.23.1.tgz#9f9a9255115f62c512db56d567f636da32ca0b78"
+  integrity sha512-wfMYHWi1WQjpgZNC9kAlN4ut04TM9fUTdi7CqIoTVM7yaiOUQTklOzfb+oWH3r9edQcT3F887swuVmxrV+CC8w==
 
 core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
### Context

https://trello.com/c/9jBdTZQD/4255-s-add-start-academic-cycle-and-end-academic-cycle-to-trainees

We will be implementing a start year / end year filter for trainees. This is the start of that piece of work, allowing us to associate the trainee to academic cycles.

### Changes proposed in this pull request

- Creates a migration that adds two foreign keys to the trainees table, both to table 'academic_cycles':
  -  start_academic_cycle
  - end_academic_cycle

### Guidance to review

🚢 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
