### PR TITLE
[xxx] Remove double back link from trainee summary

### DIFF
--- a/app/views/funding/trainee_summaries/show.html.erb
+++ b/app/views/funding/trainee_summaries/show.html.erb
@@ -2,10 +2,6 @@
 
 <%= render "funding/navigation" %>
 
-<%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
-<% end %>
-
 <h2 class="govuk-heading-l">
   <%= t("funding.trainee_summary.heading", start_year: @start_year, end_year: @end_year)%>
 </h2>


### PR DESCRIPTION
### Context

Bad merge or something - the back link was refactored into a funding/navigation partial but remained in the main view too.

### Changes proposed in this pull request

Remove the back link from the main view, keep it in the shared partial.

### Guidance to review

On the trainee summary view:

Before:

<img width="458" alt="Screenshot 2022-06-15 at 15 01 20" src="https://user-images.githubusercontent.com/18436946/173846988-a6cc0d3a-9341-4ffe-9602-5ba63a01b130.png">

After:

<img width="452" alt="Screenshot 2022-06-15 at 15 04 17" src="https://user-images.githubusercontent.com/18436946/173847026-764a7747-6874-4e45-a6ad-b07b48e49c64.png">

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
