### PR TITLE
[4270] Skip funding rows without amounts

### DIFF
--- a/app/services/exports/funding_trainee_summary_data.rb
+++ b/app/services/exports/funding_trainee_summary_data.rb
@@ -33,6 +33,8 @@ module Exports
     def format_rows(trainee_summary)
       trainee_summary.rows.map do |row|
         trainee_summary_row_amount = row.amounts.first
+        next if trainee_summary_row_amount.nil?
+
         {
           "Funding type" => funding_type_prefix(row) + trainee_summary_row_amount.payment_type,
           "Route" => row.route,
@@ -43,7 +45,7 @@ module Exports
           "Amount per trainee" => to_pounds(trainee_summary_row_amount.amount_in_pence),
           "Total" => to_pounds(trainee_summary_row_amount.number_of_trainees * trainee_summary_row_amount.amount_in_pence),
         }
-      end
+      end.compact
     end
 
     def sanitise(value)

--- a/spec/services/exports/funding_trainee_summary_data_spec.rb
+++ b/spec/services/exports/funding_trainee_summary_data_spec.rb
@@ -8,6 +8,7 @@ module Exports
     let!(:trainee_summary) { create(:trainee_summary, :for_school) }
     let!(:trainee_summary_row) { create(:trainee_summary_row, trainee_summary: trainee_summary, lead_school_urn: lead_school.urn) }
     let!(:tiered_bursary_amount) { create(:trainee_summary_row_amount, :with_tiered_bursary, row: trainee_summary_row) }
+    let!(:empty_trainee_summary_row) { create(:trainee_summary_row, trainee_summary: trainee_summary) }
 
     before do
       create(:academic_cycle, :current)
@@ -35,6 +36,11 @@ module Exports
 
       it "sets the correct row values" do
         expect(subject.csv).to include(expected_output.values.join(","))
+      end
+
+      it "skips rows without amounts" do
+        expected_csv_with_headers_row_count = 2
+        expect(CSV.parse(subject.csv).length).to eq(expected_csv_with_headers_row_count)
       end
     end
   end


### PR DESCRIPTION
### Context

We create a CSV from trainee summary data. The rows of that data sometimes have no associated amounts. We need to not error in that situation and also not display them in the export.

### Changes proposed in this pull request

* Skip the amount-less rows

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
