### PR TITLE
[xxx] Set default publish course year to 2022

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -87,7 +87,7 @@ apply_api:
   auth_token: "auth-token-from-env"
 
 current_recruitment_cycle_year: 2022
-current_default_course_year: 2021
+current_default_course_year: 2022
 
 apply_applications:
   import:


### PR DESCRIPTION
### Context

We have a default course year setting that defines which year of publish courses we display to users when we have no other start date information on a trainee.

### Changes proposed in this pull request

Start showing the 2022 start courses as default.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
