### PR TITLE
[xxx] Fix minus sign wrapping

### DIFF
--- a/app/views/funding/payment_schedules/_month_breakdown.html.erb
+++ b/app/views/funding/payment_schedules/_month_breakdown.html.erb
@@ -16,14 +16,14 @@
       <% month_breakdown.rows.each do |row| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell"><%= row[:description] %></td>
-          <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[:amount] %></td>
-          <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[:running_total] %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= row[:amount] %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= row[:running_total] %></td>
         </tr>
       <% end %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-font-weight-bold">Total</td>
-        <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= month_breakdown.total_amount %></td>
-        <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= month_breakdown.total_running_total %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold no-wrap"><%= month_breakdown.total_amount %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold no-wrap"><%= month_breakdown.total_running_total %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-l"><%= t('funding.payment_schedule.heading', start_year: @start_year, end_year: @end_year) %></h1>
       <p class="govuk-body"><%= t('funding.payment_schedule.last_updated_at', date: @payment_schedule_view.last_updated_at) %></p>
       <p class="govuk-body app-export--link">
-        <span class="app-nowrap">
+        <span class="no-wrap">
           <%= govuk_link_to(
             I18n.t('funding.payment_schedule.export_label', start_year: @start_year, end_year: @end_year),
             funding_csv_export_path(:payment_schedule, @organisation),
@@ -35,8 +35,8 @@
         <%- @payment_schedule_view.actual_payments.each do |actual_payment| -%>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= actual_payment[:month] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= actual_payment[:total] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= actual_payment[:running_total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= actual_payment[:total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= actual_payment[:running_total] %></td>
           </tr>
         <%- end -%>
         </tbody>
@@ -56,8 +56,8 @@
         <%- @payment_schedule_view.predicted_payments.each do |predicted_payment| -%>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= predicted_payment[:month] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= predicted_payment[:total] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= predicted_payment[:running_total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= predicted_payment[:total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= predicted_payment[:running_total] %></td>
           </tr>
         <%- end -%>
         </tbody>

--- a/app/views/funding/trainee_summaries/_bursaries.html.erb
+++ b/app/views/funding/trainee_summaries/_bursaries.html.erb
@@ -31,7 +31,7 @@
             <td class="govuk-table__cell"><%= bursary_row[:lead_school] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= bursary_row[:trainees] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= bursary_row[:amount_per_trainee] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= bursary_row[:total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= bursary_row[:total] %></td>
           </tr>
         <%- end -%>
       </tbody>

--- a/app/views/funding/trainee_summaries/_grants.html.erb
+++ b/app/views/funding/trainee_summaries/_grants.html.erb
@@ -27,7 +27,7 @@
             <td nowrap class="govuk-table__cell"><%= grant_row[:route]%> <br> <%= grant_row[:subject] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= grant_row[:trainees] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= grant_row[:amount_per_trainee] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= grant_row[:total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= grant_row[:total] %></td>
           </tr>
         <%- end -%>
       </tbody>

--- a/app/views/funding/trainee_summaries/_scholarships.html.erb
+++ b/app/views/funding/trainee_summaries/_scholarships.html.erb
@@ -31,7 +31,7 @@
             <td class="govuk-table__cell"><%= scholarship_row[:lead_school] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= scholarship_row[:trainees] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= scholarship_row[:amount_per_trainee] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= scholarship_row[:total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= scholarship_row[:total] %></td>
           </tr>
         <%- end -%>
       </tbody>

--- a/app/views/funding/trainee_summaries/_summary.html.erb
+++ b/app/views/funding/trainee_summaries/_summary.html.erb
@@ -17,14 +17,14 @@
           <% next if summary_row.total.zero? %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= summary_row.payment_type %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= @trainee_summary_view.format_pounds(summary_row.total) %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= @trainee_summary_view.format_pounds(summary_row.total) %></td>
           </tr>
         <% end %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-font-weight-bold">
             <%= t("funding.trainee_summary.column_headings.total") %>
           </td>
-          <td class="govuk-table__cell govuk-table__cell--numeric app-table__column-20 govuk-!-font-weight-bold"><%= @trainee_summary_view.format_pounds(@trainee_summary_view.summary.total) %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric app-table__column-20 govuk-!-font-weight-bold no-wrap"><%= @trainee_summary_view.format_pounds(@trainee_summary_view.summary.total) %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/funding/trainee_summaries/_tiered_bursaries.html.erb
+++ b/app/views/funding/trainee_summaries/_tiered_bursaries.html.erb
@@ -31,7 +31,7 @@
             <td class="govuk-table__cell"> <%= tiered_bursary_row[:tier] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= tiered_bursary_row[:trainees] %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= tiered_bursary_row[:amount_per_trainee] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= tiered_bursary_row[:total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= tiered_bursary_row[:total] %></td>
           </tr>
         <%- end -%>
       </tbody>


### PR DESCRIPTION
### Context

We display funding figures that sometimes get to be quite large and are also sometimes quite largely negative.

For number cells we don't want negative numbers to wrap or else they don't look quite so negative.

### Changes proposed in this pull request

Add nowrap on the funding number table cells

### Guidance to review

Before: 

<img width="766" alt="Screenshot 2022-06-20 at 15 17 37" src="https://user-images.githubusercontent.com/5216/174625725-53c3f507-82d3-4b99-82fa-f884d7252a76.png">

After:

<img width="758" alt="Screenshot 2022-06-20 at 15 18 01" src="https://user-images.githubusercontent.com/5216/174625695-df82df37-0c46-4a8c-bba9-3dc21a1ec917.png">


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
