### PR TITLE
[4167] Support no predicted months for funding

### DIFF
--- a/app/services/funding/payable_payment_schedules_importer.rb
+++ b/app/services/funding/payable_payment_schedules_importer.rb
@@ -6,7 +6,7 @@ module Funding
 
     MONTH_ORDER = [8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7].freeze
 
-    def initialize(attributes:, first_predicted_month_index:)
+    def initialize(attributes:, first_predicted_month_index: nil)
       @attributes = attributes
       @first_predicted_month_index = first_predicted_month_index
     end
@@ -30,7 +30,7 @@ module Funding
                 month: month_index,
                 year: year_for_month(row_hash["Academic year"], month_index),
                 amount_in_pence: row_hash[month_name].to_d * 100,
-                predicted: MONTH_ORDER.index(month_index) >= MONTH_ORDER.index(first_predicted_month_index.to_i),
+                predicted: predicted?(month_index),
               )
             end
           end
@@ -52,6 +52,12 @@ module Funding
       years = year_string.split("/")
       year_string = [1, 2, 3, 4, 5, 6, 7].include?(month_index) ? "20#{years[1]}" : years[0]
       year_string.to_i
+    end
+
+    def predicted?(month_index)
+      return false if first_predicted_month_index.nil?
+
+      MONTH_ORDER.index(month_index) >= MONTH_ORDER.index(first_predicted_month_index.to_i)
     end
   end
 end

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -41,27 +41,29 @@
         <%- end -%>
         </tbody>
       </table>
-      <table id="predicted-payments" class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--m govuk-!-margin-bottom-3">
-          <%= t('funding.payment_schedule.predicted_payments_table_caption') %>
-        </caption>
-        <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header"><%= t('funding.payment_schedule.month') %></th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric"><%= t('funding.payment_schedule.total') %></th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric"><%= t('funding.payment_schedule.running_total') %></th>
-        </tr>
-        </thead>
-        <tbody>
-        <%- @payment_schedule_view.predicted_payments.each do |predicted_payment| -%>
+      <%- if @payment_schedule_view.predicted_payments.any? %>
+        <table id="predicted-payments" class="govuk-table">
+          <caption class="govuk-table__caption govuk-table__caption--m govuk-!-margin-bottom-3">
+            <%= t('funding.payment_schedule.predicted_payments_table_caption') %>
+          </caption>
+          <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= predicted_payment[:month] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= predicted_payment[:total] %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= predicted_payment[:running_total] %></td>
+            <th scope="col" class="govuk-table__header"><%= t('funding.payment_schedule.month') %></th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric"><%= t('funding.payment_schedule.total') %></th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric"><%= t('funding.payment_schedule.running_total') %></th>
           </tr>
-        <%- end -%>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+          <%- @payment_schedule_view.predicted_payments.each do |predicted_payment| -%>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= predicted_payment[:month] %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= predicted_payment[:total] %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric no-wrap"><%= predicted_payment[:running_total] %></td>
+            </tr>
+          <%- end -%>
+          </tbody>
+        </table>
+      <%- end -%>
       <h2 class="govuk-heading-m"><%= t('funding.payment_schedule.payment_breakdown') %></h2>
       <%= govuk_accordion do |accordion|
         @payment_schedule_view.payment_breakdown.each do |month_breakdown|

--- a/spec/services/funding/lead_school_payment_schedules_importer_spec.rb
+++ b/spec/services/funding/lead_school_payment_schedules_importer_spec.rb
@@ -239,10 +239,21 @@ module Funding
         end
       end
 
-      it "sets predicted correctly" do
-        subject
-        expect(lead_school_one_first_row.amounts.find_by(month: 11)).not_to be_predicted
-        expect(lead_school_one_first_row.amounts.find_by(month: 12)).to be_predicted
+      context "first predicted month is passed" do
+        it "sets predicted correctly" do
+          subject
+          expect(lead_school_one_first_row.amounts.find_by(month: 11)).not_to be_predicted
+          expect(lead_school_one_first_row.amounts.find_by(month: 12)).to be_predicted
+        end
+      end
+
+      context "first predicted month is nil" do
+        subject { described_class.call(attributes: schedules_attributes, first_predicted_month_index: nil) }
+
+        it "sets all months predicted to false" do
+          subject
+          expect(lead_school_one_first_row.amounts.where(predicted: false).count).to eq(12)
+        end
       end
     end
 

--- a/spec/services/funding/provider_payment_schedules_importer_spec.rb
+++ b/spec/services/funding/provider_payment_schedules_importer_spec.rb
@@ -133,10 +133,21 @@ module Funding
         end
       end
 
-      it "sets predicted correctly" do
-        subject
-        expect(provider_one_first_row.amounts.find_by(month: 11)).not_to be_predicted
-        expect(provider_one_first_row.amounts.find_by(month: 12)).to be_predicted
+      context "predicted month is passed" do
+        it "sets predicted correctly" do
+          subject
+          expect(provider_one_first_row.amounts.find_by(month: 11)).not_to be_predicted
+          expect(provider_one_first_row.amounts.find_by(month: 12)).to be_predicted
+        end
+      end
+
+      context "predicted month is nil" do
+        subject { described_class.call(attributes: schedules_attributes, first_predicted_month_index: nil) }
+
+        it "sets all months as actual" do
+          subject
+          expect(provider_one_first_row.amounts.where(predicted: false).count).to eq(12)
+        end
       end
     end
 


### PR DESCRIPTION
### Context

For July each year the funding data will be all actual months and non-predicted.

### Changes proposed in this pull request

* Update the import services to allow not passing of `first_predicted_month` to signify that there isn't one.
* Update the view to now render the title and header row of the 'predicted' section when there aren't any

Before:
<img width="686" alt="Screenshot 2022-06-21 at 15 46 12" src="https://user-images.githubusercontent.com/5216/174829272-2c8be2be-113c-4621-9754-875a5303a702.png">

After:
<img width="715" alt="Screenshot 2022-06-21 at 15 34 57" src="https://user-images.githubusercontent.com/5216/174829284-2117cb5e-5e8f-4e7a-905a-44bf19f01829.png">

### Guidance to review

To test upload a payment schedule CSV and omit the first_predicted_month argument

e.g. `bundle exec rake "funding:import_provider_payment_schedules[<file-path>]"

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
