### PR TITLE
[4252] Add status filter

### DIFF
--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -14,6 +14,7 @@ class BaseTraineeController < ApplicationController
     search_secondary_result_set
     search_secondary_result_title
     total_trainees_count
+    all_trainees_started?
     training_routes
   ].freeze
 
@@ -85,6 +86,10 @@ private
       .sort_by(&TRAINING_ROUTE_ENUMS.values.method(:index))
   end
 
+  def all_trainees_started?
+    policy_scope(trainee_search_scope).course_not_yet_started.blank?
+  end
+
   def current_page_exceeds_total_pages?
     paginated_trainees.total_pages.nonzero? && paginated_trainees.current_page > paginated_trainees.total_pages
   end
@@ -136,7 +141,7 @@ private
       {
         level: [],
         training_route: [],
-        state: [],
+        status: [],
         record_source: [],
         record_completion: [],
       },

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -81,7 +81,7 @@ private
       {
         level: [],
         training_route: [],
-        state: [],
+        status: [],
         record_source: [],
         record_completion: [],
         study_mode: [],

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -188,6 +188,10 @@ class Trainee < ApplicationRecord
     )
   end)
 
+  scope :course_not_yet_started, -> { where("itt_start_date > ?", Time.zone.now).where.not(state: %i[draft deferred withdrawn]) }
+
+  scope :in_training, -> { where(state: %i[submitted_for_trn trn_received recommended_for_award], itt_start_date: Date.new..Time.zone.now) }
+
   scope :with_award_states, (lambda do |*award_states|
     qts_states = award_states.select { |s| s.start_with?("qts") }.map { |s| genericize_state(s) }
     eyts_states = award_states.select { |s| s.start_with?("eyts") }.map { |s| genericize_state(s) }

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -2,7 +2,7 @@
 
 class TraineeFilter
   AWARD_STATES = %w[qts_recommended qts_awarded eyts_recommended eyts_awarded].freeze
-  STATES = Trainee.states.keys.excluding("recommended_for_award", "awarded") + AWARD_STATES
+  STATUSES = %w[course_not_yet_started in_training deferred awarded withdrawn].freeze
 
   RECORD_SOURCES = %w[apply manual dttp hesa].freeze
 
@@ -26,7 +26,7 @@ private
     @merged_filters ||= text_search.merge(
       **level,
       **training_route,
-      **state,
+      **status,
       **subject,
       **text_search,
       **record_source,
@@ -89,15 +89,15 @@ private
     end
   end
 
-  def state
-    return {} unless state_options.any?
+  def status
+    return {} unless status_options.any?
 
-    { "state" => state_options }
+    { "status" => status_options }
   end
 
-  def state_options
-    STATES.each_with_object([]) do |option, arr|
-      arr << option if params[:state]&.include?(option)
+  def status_options
+    STATUSES.each_with_object([]) do |option, arr|
+      arr << option if params[:status]&.include?(option)
     end
   end
 

--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -7,6 +7,26 @@
     <%= text_field_tag "text_search", (filters[:text_search] if filters), spellcheck: false, class: "govuk-input" %>
   </div>
 
+  <% if trainee_search_path?(search_path) %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          <%= t("views.trainees.index.filters.status") %>
+        </legend>
+        <div class="govuk-checkboxes govuk-checkboxes--small">
+          <% TraineeFilter::STATUSES.each do |status, _| %>
+            <% unless status == "course_not_yet_started" && all_trainees_started? %>
+              <div class="govuk-checkboxes__item">
+                <%= check_box_tag "status[]", status, checked?(filters, :status, status), id: "status-#{status}", class: "govuk-checkboxes__input" %>
+                <%= label_tag "status-#{status}", label_for("status", status), class: "govuk-label govuk-checkboxes__label" %>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+  <% end %>
+
   <% if current_user.system_admin? %>
     <%= render AdminFeature::View.new(classes: "app-status-box--filter-outdent") do %>
       <div class="govuk-form-group">
@@ -97,25 +117,6 @@
             <div class="govuk-checkboxes__item">
               <%= check_box_tag "training_route[]", training_route, checked?(filters, :training_route, training_route), id: "training_route-#{training_route}", class: "govuk-checkboxes__input" %>
               <%= label_tag "training_route-#{training_route}", label_for("training_route", training_route), class: "govuk-label govuk-checkboxes__label" %>
-            </div>
-          <% end %>
-        </div>
-      </fieldset>
-    </div>
-  <% end %>
-
-  <% if trainee_search_path?(search_path) %>
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-          <%= t("views.trainees.index.filters.status") %>
-        </legend>
-        <div class="govuk-checkboxes govuk-checkboxes--small">
-          <% TraineeFilter::STATES.each do |state, _| %>
-            <% next if state == "draft" %>
-            <div class="govuk-checkboxes__item">
-              <%= check_box_tag "state[]", state, checked?(filters, :state, state), id: "state-#{state}", class: "govuk-checkboxes__input" %>
-              <%= label_tag "state-#{state}", label_for("state", state), class: "govuk-label govuk-checkboxes__label" %>
             </div>
           <% end %>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,7 +437,7 @@ en:
       provider: Provider
       record_source: Record source
       selected_title: Selected filters
-      state: Status
+      status: Status
       start_year: Start year
       end_year: End year
       subject: Subject
@@ -684,7 +684,7 @@ en:
           provider: Provider
           record_completion: Record completion
           search: Search for a trainee
-          status: Status
+          status: Training status
           study_mode: Full time or part time
           subject: Subject
           start_year: Start year
@@ -1150,6 +1150,12 @@ en:
           qts_awarded: QTS awarded
           eyts_recommended: EYTS recommended
           eyts_awarded: EYTS awarded
+        statuses:
+          course_not_yet_started: Course not started yet
+          in_training: In training
+          deferred: Deferred
+          withdrawn: Withdrawn
+          awarded: Awarded
         training_initiatives:
           transition_to_teach: Transition to Teach
           troops_to_teachers: Troops to Teachers

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -46,8 +46,14 @@ RSpec.feature "Filtering trainees" do
     end
 
     scenario "can filter by status" do
-      when_i_filter_by_trn_received_status
-      then_only_the_trn_received_trainee_is_visible
+      when_i_filter_by_in_training_status
+      then_only_the_in_training_trainee_is_visible
+    end
+
+    scenario "can filter by multiple statuses" do
+      when_i_filter_by_in_training_status
+      and_i_filter_by_withdrawn_status
+      then_the_in_training_and_withdrawn_trainees_are_visible
     end
 
     scenario "can filter by level" do
@@ -236,8 +242,13 @@ private
     trainee_index_page.apply_filters.click
   end
 
-  def when_i_filter_by_trn_received_status
-    trainee_index_page.trn_received_checkbox.click
+  def when_i_filter_by_in_training_status
+    trainee_index_page.in_training_checkbox.click
+    trainee_index_page.apply_filters.click
+  end
+
+  def and_i_filter_by_withdrawn_status
+    trainee_index_page.withdrawn_checkbox.click
     trainee_index_page.apply_filters.click
   end
 
@@ -365,9 +376,14 @@ private
     expect(trainee_index_page).to have_text(I18n.t("components.filter.record_source"))
   end
 
-  def then_only_the_trn_received_trainee_is_visible
+  def then_only_the_in_training_trainee_is_visible
     expect(trainee_index_page).to have_text(full_name(@trn_received_trainee))
     expect(trainee_index_page).not_to have_text(full_name(@withdrawn_trainee))
+  end
+
+  def then_the_in_training_and_withdrawn_trainees_are_visible
+    expect(trainee_index_page).to have_text(full_name(@trn_received_trainee))
+    expect(trainee_index_page).to have_text(full_name(@withdrawn_trainee))
   end
 
   def then_only_assessment_only_trainee_is_visible

--- a/spec/models/trainee_filter_spec.rb
+++ b/spec/models/trainee_filter_spec.rb
@@ -25,7 +25,7 @@ describe TraineeFilter do
           subject: "Biology",
           text_search: "search terms",
           training_route: [TRAINING_ROUTE_ENUMS[:assessment_only]],
-          state: %w[draft],
+          status: %w[course_not_started],
         }
       end
 
@@ -83,8 +83,8 @@ describe TraineeFilter do
       include_examples returns_nil
     end
 
-    context "with invalid state" do
-      let(:params) { { state: %w[not_a_state] } }
+    context "with invalid status" do
+      let(:params) { { status: %w[not_a_status] } }
 
       include_examples returns_nil
     end
@@ -108,6 +108,16 @@ describe TraineeFilter do
 
       it "returns trainee_start_year in hash" do
         expect(subject.filters).to eq({ "trainee_start_year" => ["2020"] })
+      end
+    end
+
+    context "with trainee status" do
+      let(:params) { { status: ["in_training"] } }
+
+      subject { TraineeFilter.new(params: params) }
+
+      it "returns trainee_start_year in hash" do
+        expect(subject.filters).to eq({ "status" => ["in_training"] })
       end
     end
   end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -140,6 +140,30 @@ describe Trainee do
         expect(described_class.imported_from_hesa).to contain_exactly(hesa_trainee)
       end
     end
+
+    describe ".in_training" do
+      let!(:submitted_trainee) { create(:trainee, :submitted_for_trn, itt_start_date: 2.days.ago) }
+      let!(:trn_received_trainee) { create(:trainee, :trn_received, itt_start_date: 2.days.ago) }
+      let!(:recommended_for_award_trainee) { create(:trainee, :recommended_for_award, itt_start_date: 2.days.ago) }
+      let!(:recommended_for_award_trainee_in_future) { create(:trainee, :recommended_for_award, itt_start_date: Time.zone.today + 1.day) }
+      let!(:deferred_trainee) { create(:trainee, :deferred, itt_start_date: 2.days.ago) }
+
+      it "returns trainees in the submitted, trn_received and recommended for award states with start dates in the past" do
+        expect(described_class.in_training).to include(submitted_trainee, trn_received_trainee, recommended_for_award_trainee)
+        expect(described_class.in_training).not_to include(recommended_for_award_trainee_in_future, deferred_trainee)
+      end
+    end
+
+    describe ".course_not_yet_started" do
+      let!(:draft_trainee) { create(:trainee, :draft) }
+      let!(:recommended_for_award_trainee_in_past) { create(:trainee, :recommended_for_award, itt_start_date: 1.day.ago) }
+      let!(:recommended_for_award_trainee_in_future) { create(:trainee, :recommended_for_award, itt_start_date: Time.zone.today + 1.day) }
+
+      it "returns non draft trainees with start dates in the future" do
+        expect(described_class.course_not_yet_started).to include(recommended_for_award_trainee_in_future)
+        expect(described_class.course_not_yet_started).not_to include(draft_trainee, recommended_for_award_trainee_in_past)
+      end
+    end
   end
 
   context "associations" do

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -64,21 +64,48 @@ module Trainees
       end
     end
 
-    context "with state filter" do
-      let!(:submitted_for_trn_trainee) { create(:trainee, :submitted_for_trn) }
-      let!(:qts_awarded_trainee) { create(:trainee, :qts_awarded) }
-      let!(:eyts_awarded_trainee) { create(:trainee, :eyts_awarded) }
+    context "with status filter" do
+      let!(:submitted_for_trn_trainee) { create(:trainee, :submitted_for_trn, :itt_start_date_in_the_past) }
+      let!(:qts_awarded_trainee) { create(:trainee, :qts_awarded, :itt_start_date_in_the_past) }
+      let!(:eyts_awarded_trainee) { create(:trainee, :eyts_awarded, :itt_start_date_in_the_past) }
+      let!(:not_yet_started_trainee) { create(:trainee, :trn_received, :itt_start_date_in_the_future) }
+      let!(:withdrawn_trainee) { create(:trainee, :withdrawn, :itt_start_date_in_the_past) }
+      let!(:deferred_trainee) { create(:trainee, :deferred, :itt_start_date_in_the_past) }
 
-      context "with trn_submitted, qts_awarded" do
-        let(:filters) { { state: %w[submitted_for_trn qts_awarded] } }
+      context "with in_training" do
+        let(:filters) { { status: %w[in_training] } }
 
-        it { is_expected.to contain_exactly(submitted_for_trn_trainee, qts_awarded_trainee) }
+        it { is_expected.to contain_exactly(submitted_for_trn_trainee) }
       end
 
-      context "with only draft trainees" do
-        let(:filters) { { state: %w[draft] } }
+      context "with awarded" do
+        let(:filters) { { status: %w[awarded] } }
 
-        it { is_expected.to contain_exactly(draft_trainee, apply_draft_trainee) }
+        it { is_expected.to contain_exactly(qts_awarded_trainee, eyts_awarded_trainee) }
+      end
+
+      context "with in_training, awarded" do
+        let(:filters) { { status: %w[in_training awarded] } }
+
+        it { is_expected.to contain_exactly(submitted_for_trn_trainee, qts_awarded_trainee, eyts_awarded_trainee) }
+      end
+
+      context "with withdrawn" do
+        let(:filters) { { status: %w[withdrawn] } }
+
+        it { is_expected.to contain_exactly(withdrawn_trainee) }
+      end
+
+      context "with deferred" do
+        let(:filters) { { status: %w[deferred] } }
+
+        it { is_expected.to contain_exactly(deferred_trainee) }
+      end
+
+      context "with course not yet started" do
+        let(:filters) { { status: %w[course_not_yet_started] } }
+
+        it { is_expected.to contain_exactly(not_yet_started_trainee) }
       end
     end
 

--- a/spec/support/page_objects/trainees/index.rb
+++ b/spec/support/page_objects/trainees/index.rb
@@ -34,7 +34,8 @@ module PageObjects
     class Index < Base
       set_url "/trainees"
 
-      element :trn_received_checkbox, "#state-trn_received"
+      element :in_training_checkbox, "#status-in_training"
+      element :withdrawn_checkbox, "#status-withdrawn"
     end
 
     class Drafts < Base


### PR DESCRIPTION
### Context

To enable us to update the squares on the home page we need a new 'Trainee status' filter on the registered trainees view. Add a filter with the following options:

* Course not started yet - non-draft trainees with ITT_start_date is in the future. This should only be visible if the user has trainees that are yet to start - **new trainee scope added to cover this case**
* In training - Default selected if there are no other filters. submitted_for_trn, trn_received, recommended_for_award and excluding course not started yet - **new trainee scope added to cover this case**
* Deferred - **existing trainee scope exists to cover this case**
* Awarded - **existing trainee scope exists to cover this case**
* Withdrawn - **existing trainee scope exists to cover this case**


### Changes proposed in this pull request

Remove old state filter and replace with status filter

### Guidance to review

Test that filters work independentley and together with other filters. 