### PR TITLE
[4211] Update the Data Sharing Agreement

### DIFF
--- a/config/locales/pages/data_sharing_agreement/en.yml
+++ b/config/locales/pages/data_sharing_agreement/en.yml
@@ -3,7 +3,7 @@ en:
     data_sharing_agreement:
       body_html: "
         <p class='govuk-body'>
-          This agreement was last updated on 14 June 2022.
+          This agreement was last updated on 22 June 2022.
         </p>
         <h2 class='govuk-heading-m' id='#data-sharing-details'>
           Data sharing details

--- a/config/locales/pages/data_sharing_agreement/en.yml
+++ b/config/locales/pages/data_sharing_agreement/en.yml
@@ -367,7 +367,7 @@ en:
             they will treat data as Official-Sensitive and apply appropriate security measures to its handling
           </li>
         </ul>
-        <h2 class='govuk-heading-m' id='#third-party-disclosure'>
+        <h2 class='govuk-heading-m' id='third-party-disclosure'>
           Third party disclosure
         </h2>
         <p class='govuk-body'>

--- a/config/locales/pages/data_sharing_agreement/en.yml
+++ b/config/locales/pages/data_sharing_agreement/en.yml
@@ -3,16 +3,16 @@ en:
     data_sharing_agreement:
       body_html: "
         <p class='govuk-body'>
-          This agreement was last updated on 5 April 2022.
+          This agreement was last updated on 14 June 2022.
         </p>
         <h2 class='govuk-heading-m' id='#data-sharing-details'>
           Data sharing details
         </h2>
         <p class='govuk-body'>
           This data sharing agreement (DSA) applies to personal data
-          shared between the Department Education (DfE) and (‘the
+          shared between the Department for Education (DfE) and (‘the
           provider’) as part of the <span class='app-nowrap'>Register
-            trainee teachers</span> service (Register).
+          trainee teachers</span> (Register) service. 
         </p>
         <h3 class='govuk-heading-s'>
           The parties to the data sharing agreement
@@ -28,58 +28,57 @@ en:
           The aims and benefits of the data sharing agreement
         </h2>
         <p class='govuk-body'>
-          The parties consider this data sharing agreement necessary as
-          it will enable the parties to understand how effectively data
-          collected and processed as part of Register is managed.
+          The aim of this data sharing agreement is to enable the parties to
+          understand how data is collected, processed and managed in Register.
         </p>
         <p class='govuk-body'>
-          This data sharing agreement sets out your roles,
-          responsibility, and accountability as Data Controller for the
-          different processing of the personal data that is stored and
-          processed in Register.
+          This data sharing agreement sets out your roles, responsibilities,
+          and accountability as Data Controller for the different processing of
+          the personal data that is stored and processed in Register.
         </p>
         <p class='govuk-body'>
-          Register will replace the existing Database of Trainee
-          Teachers and Providers (DTTP). The DTTP service exists to
-          support the exchange of data on trainee teachers in England
-          between accredited Initial Teacher Training (ITT) Providers
-          and the DfE. Trainee teacher data is a critical business
-          requirement with Providers entering data into the DTTP and
-          that data being used by internal downstream users.
+          Register has replaced the existing Database of Trainee Teachers and
+          Providers (DTTP). The DTTP service existed to support the exchange of
+          data on trainee teachers in England between accredited Initial
+          Teacher Training (ITT) Providers and the DfE. Trainee teacher data is
+          a critical business requirement with accredited providers entering
+          data into the DTTP, and that data being used by internal downstream
+          users.
         </p>
         <h2 class='govuk-heading-m' id='#the-agreed-purposes'>
           The agreed purposes
         </h2>
         <p class='govuk-body'>
-          This collection and processing of this data is vital to DfE
-          for a variety of purposes including (but not limited to):
+          This collection and processing of this data is vital to DfE for a
+          variety of purposes including (but not limited to):
         </p>
         <ul class='govuk-list govuk-list--bullet'>
           <li>collection of data for statistics and publications</li>
           <li>assessing the impact of teacher recruitment campaigns</li>
-          <li>calculation and allocation of funding for bursaries and
-            scholarship</li>
+          <li>calculation and allocation of funding for bursaries, scholarships and grants</li>
           <li>auditing of third party teaching suppliers</li>
+          <li>awarding of teacher status at the end of a trainee’s teacher training</li>
+          <li>creating a trainee’s teacher record once they qualify, which is used throughout their teaching career</li>
         </ul>
         <p class='govuk-body'>
-          This data provides the DfE with past, current, and future
-          foresight of new teachers entering the workforce.
+          This data provides the DfE with past, current, and future foresight
+          of new teachers entering the workforce.
         </p>
         <h2 class='govuk-heading-m' id='#the-personal-data-and-special-category-personal-data-being-shared'>
           The personal data and Special Category personal data being
           shared
         </h2>
         <p class='govuk-body'>
-          The following types of personal data will be shared between
-          the parties for the purposes of this agreement:
+          The following types of personal data will be shared between the
+          parties for the purposes of this agreement:
         </p>
         <ul class='govuk-list govuk-list--bullet'>
-          <li>Full name</li>
-          <li>Date of birth</li>
-          <li>Gender (female, male, other or not provided)</li>
-          <li>Nationality</li>
-          <li>Disability</li>
-          <li>Ethnicity</li>
+          <li>full name</li>
+          <li>date of birth</li>
+          <li>gender (female, male, other or not provided)</li>
+          <li>nationalities</li>
+          <li>disabilities</li>
+          <li>ethnicity</li>
         </ul>
         <p class='govuk-body'>
           The following types of Special Category personal data shall be
@@ -87,10 +86,10 @@ en:
           agreement:
         </p>
         <ul class='govuk-list govuk-list--bullet'>
-          <li>Nationality</li>
-          <li>Gender</li>
-          <li>Ethnicity</li>
-          <li>Disability</li>
+          <li>nationalities</li>
+          <li>gender</li>
+          <li>ethnicity</li>
+          <li>disabilities</li>
         </ul>
         <h3 class='govuk-heading-s'>
           Nationality
@@ -105,19 +104,23 @@ en:
           Gender, ethnicity and disability
         </h3>
         <p class='govuk-body'>
-          We collect these as part of the diversity questionnaire.
+          We collect these as part of a section in the service called
+          ‘Personal details’. This information can also be collected
+          from the <a class='govuk-link'
+          href='https://www.gov.uk/apply-for-teacher-training'>
+          Apply for teacher training</a> (Apply) service, and comes
+          into Register through an integration between the 2 services.
           Gender, ethnicity and disability information is included in
           aggregate tables that are included in annual ITT publications
-          reported by TAD. The user can choose whether to complete the
-          questionnaire.
+          reported by TAD. The user can choose to provide this
+          information.
         </p>
         <h3 class='govuk-heading-s'>
           Identifiable data of providers
         </h3>
         <p class='govuk-body'>
-          There are various combinations of identifiable data which may
-          be collected about a provider (depending on route), these extend
-          to:
+          There are various combinations of identifiable data which may be
+          collected about a provider (depending on route), these extend to:
         </p>
         <ul class='govuk-list govuk-list--bullet'>
           <li>lead school ID</li>
@@ -140,73 +143,70 @@ en:
           In situations where a trainee did not use
           <a class='govuk-link'
             href='https://www.gov.uk/apply-for-teacher-training'>Apply
-            for teacher training</a> (Apply), the provider should inform their
+            for teacher training</a> (Apply),
+          the accredited provider should inform their
           trainees of Register’s privacy notice which describes to
           trainees how their data will be used. This privacy notice will
           include the email address they can use to contact the Register
-          support team, and can be found at 
+          support team, and can be found at
           <a class='govuk-link' href='https://www.register-trainee-teachers.education.gov.uk/privacy-notice'>www.register-trainee-teachers.education.gov.uk/privacy-notice</a>
         </p>
         <h3 class='govuk-heading-s'>
-          What the provider can use personal data the DfE data shared
-          with them for
+          What the provider can use personal data for that’s shared with
+          them by the DfE
         </h3>
         <p class='govuk-body'>
-          Part of the data that the DfE collects for each trainee
-          includes sensitive data, as described above. Where trainee
-          data comes in through Apply the provider is responsible for
-          correcting and updating the data in Register on behalf of the
-          trainee.
+          Part of the data that the DfE collects for each trainee includes
+          sensitive data, as described above. Where trainee data comes in
+          through Apply the accredited provider is responsible for correcting
+          and updating the data in Register on behalf of the trainee.
         </p>
         <p class='govuk-body'>
-          When the data comes through direct entry into Register, the
-          provider collects this information from the trainee and enters
-          it into Register manually and keeps it up to date. The
-          providers remain Data Controllers as they need this data for
-          their student records.
+          When data is directly entered into Register, the accredited provider
+          collects this information from the trainee and enters it into
+          Register manually and keeps it up to date. The accredited providers
+          remain Data Controllers as they need this data for their student
+          records.
+        </p>
+        <p class='govuk-body'>
+          When lead schools import Register’s data they have an obligation to
+          ensure the data is used in accordance with the rules stated in the
+          Third party section of this document.
         </p>
         <h3 class='govuk-heading-s'>
           What the DfE can use personal data shared with the DfE for
         </h3>
         <p class='govuk-body'>
           Register receives the data outlined in this section from Apply
-          (internal to the DfE) or the providers. This data is used to
-          allocate a Teacher reference number (TRN) and Qualified
-          teacher status (QTS) or Early years teacher status (EYTS) to
-          the trainee by the DfE, and for the purposes of preventing
-          duplication in the allocation process. Additionally,
-          statistical analysis is done by the DfE to understand
-          demographic trends in and performance of teacher recruitment.
-          Once a TRN is allocated for the trainee and a QTS or EYTS is
-          awarded, these are passed onto the providers for their student
-          records.
+          (internal to the DfE) or the accredited providers. This data is used
+          to allocate a Teacher reference number (TRN) and Qualified teacher
+          status (QTS) or Early years teacher status (EYTS) to the trainee by
+          the DfE, and for the purposes of preventing duplication in the
+          allocation process. 
+        </p>
+        <p class='govuk-body'>
+          Additionally, statistical analysis is done by the DfE to understand
+          demographic trends in and performance of teacher recruitment. Once a
+          TRN is allocated for the trainee and a QTS or EYTS is awarded, these
+          are passed onto the providers for their student records. The data is
+          also included in the trainee’s teacher record throughout their
+          career.
         </p>
         <h2 class='govuk-heading-m' id='#lawful-basis'>
           Lawful basis
         </h2>
         <p class='govuk-body'>
-          The collection and processing of this data is vital to the DfE
-          for a variety of purposes including (but not limited to):
-        </p>
-        <ul class='govuk-list govuk-list--bullet'>
-          <li>the collection of data for statistics and publications</li>
-          <li>assessing the impact of teacher recruitment campaigns</li>
-          <li>calculation and allocation of funding for bursaries and
-            scholarship</li>
-          <li>auditing of third party teacher training providers</li>
-        </ul>
-        <p class='govuk-body'>
-          This data provides the DfE with past, current, and future
-          foresight of new teachers entering the workforce. This data
-          collection and processing operates under the Secretary of
-          State for Education’s ministerial common law powers. The DfE
-          and providers commit to working together to limit the personal
-          data shared and reducing this where possible. The following
-          statutes underpinned the basis for processing this data.
+          The data collected by Register provides the DfE with past, current,
+          and future foresight of new teachers entering the workforce. This
+          data collection and processing operates under the Secretary of State
+          for Education’s ministerial common law powers. The DfE and providers
+          commit to working together to limit the personal data shared and
+          reduce this where possible. The following statutes underpinned the
+          basis for processing this data.
         </p>
         <p class='govuk-body'>
-          The lawful basis for this processing is Public Interest, as
-          outlined in the legislation:
+          The lawful basis for this processing is Public Interest, as outlined
+          in the legislation:
         </p>
         <ul class='govuk-list govuk-list--bullet'>
           <li>Article 6(1)(e) of the UK General Data Protection Regulation (UK GDPR)</li>
@@ -215,117 +215,132 @@ en:
               DPA Legislation</a></li>
         </ul>
         <p class='govuk-body'>
-          The lawful basis for processing Special Category Data is
-          Substantial Public Interest, as outlined in the legislation:
+          The lawful basis for processing Special Category Data is Substantial
+          Public Interest, as outlined in the legislation:
         </p>
         <ul class='govuk-list govuk-list--bullet'>
           <li>Article 9(2)(g) of the UK GDPR</li>
           <li>Data Protection Act 2018 - Schedule 1: Part 2; <a class='govuk-link'
-              href='https://www.legislation.gov.uk/ukpga/2018/12/schedule/1/part/2'>UK
+              href='https://www.legislation.gov.uk/ukpga/2018/12/section/8'>UK
               DPA Legislation</a></li>
+        </ul>
+        <p class='govuk-body'>
+          The collection and processing of this data is vital to the DfE for a
+          variety of purposes including (but not limited to):
+        </p>
+        <ul class='govuk-list govuk-list--bullet'>
+          <li>the collection of data for statistics and publications</li>
+          <li>assessing the impact of teacher recruitment campaigns</li>
+          <li>calculation and allocation of funding for bursaries, scholarships and grants</li>
+          <li>auditing of third party teacher training providers</li>
+          <li>awarding of teacher status at the end of a trainee’s teacher training</li>
+          <li>creating a trainee’s teacher record once they qualify, which is used throughout their teaching career</li>
         </ul>
         <h2 class='govuk-heading-m' id='#privacy-notices'>
           Privacy notices
         </h2>
-        <p class='govuk-body'>
-          Refer to the <a class='govuk-link' href='/privacy-notice'></a>Register
-          privacy notice</a> to see how Register handles data entered
-          directly into the service.
-        </p>
-        <p class='govuk-body'>
-          In a situation where trainees’ records are entered directly
-          into Register for (non Apply trainees), the provider should
-          inform their trainees of Register’s own privacy notice which
-          describes to trainees how their data will be used. This
-          privacy notice will include the email address they can use to
-          contact the Register support team.
-        </p>
-        <p class='govuk-body'>
-          It is the responsibility of providers, as Data Controllers, to
-          ensure that their respective privacy notices are sufficiently
-          detailed to cover the data sharing activity specified in this
-          DSA, including but not limited to the Purpose and the Lawful
-          Basis for the sharing and processing.
-        </p>
-        <p class='govuk-body'>
-          By agreeing to this data sharing agreement, the DfE and the
-          provider confirm that their respective privacy policies
-          explain the data sharing activities outlined in this
-          agreement.
-        </p>
+          <p class='govuk-body'>
+            <a class='govuk-link' href='/privacy-notice'>Refer
+            to the Register privacy notice</a> to see how Register handles
+            data entered directly into the service.
+          </p>
+          <p class='govuk-body'>
+            In a situation where trainee records are entered directly into
+            Register for non Apply trainees, the provider should inform their
+            trainees of Register’s own privacy notice which describes to
+            trainees how their data will be used. This privacy notice will
+            include the email address they can use to contact the Register
+            support team.
+          </p>
+          <p class='govuk-body'>
+            It is the responsibility of providers, as Data Controllers, to
+            ensure that their respective privacy notices are sufficiently
+            detailed to cover the data sharing activity specified in this DSA,
+            including but not limited to the Purpose and the Lawful Basis for
+            the sharing and processing.
+          </p>
+          <p class='govuk-body'>
+            By agreeing to this data sharing agreement, the DfE and the
+            provider confirm that their respective privacy notices explain the
+            data sharing activities outlined in this agreement.
+          </p>
         <h2 class='govuk-heading-m' id='#data-handling'>
           Data handling
         </h2>
-        <p class='govuk-body'>
-          The DfE and the providers are Independent Data Controllers for
-          the data collected through Register. The primary routes which
-          data enters Register are:
-        </p>
-        <ul class='govuk-list govuk-list--bullet'>
-          <li>
-            providers keying new records directly into Register using
-            information from their own systems to populate Register
-          </li>
-          <li>
-            Register using an API to pull data where providers have
-            managed the application process (with trainees submitting
-            their data via the Apply service). Providers may still need
-            to add course details into these pre-populated records
-          </li>
-        </ul>
-        <p class='govuk-body'>
-          The systems-based connection in which Register may share data:
-        </p>
-        <ul class='govuk-list govuk-list--bullet'>
-          <li>
-            Register connects to Apply to retrieve applicant information
-            to populate its own records
-          </li>
-          <li>
-            Register retrieves course information from the Publish
-            Teacher Training Service
-          </li>
-          <li>
-            School administrators connect to Register to add, view or
-            update their trainee data. Users can only access data
-            connected to their organisation
-          </li>
-          <li>
-            Register reads and writes trainee record data to systems
-            within the DfE for the purpose of allocating or retrieving a
-            TRN for trainees, and for registering their QTS or EYTS from
-            DTTP as part of normal operations
-          </li>
-        </ul>
-        <p class='govuk-body'>
-          The DfE uses <a class='govuk-link' href='https://www.zendesk.co.uk/company/privacy-and-data-protection/#faq-general-1'>Zendesk</a>, a customer relationship management
-          system, to handle queries from provider staff.
-        </p>
-        <p class='govuk-body'>
-          For data concerning trainees imparted to the DfE by users
-          through Zendesk, providers continue to be Data Controllers.
-          The DfE will use this data for analytical purposes as well as
-          for supporting providers with their queries and therefore will
-          become Data Controller at this point for this data.
-        </p>
-        <p class='govuk-body'>
-          The DfE and the provider may use some personal data such as
-          names and date of birth for identification purposes through
-          other channels, such as by phone or email for support and
-          administration purposes.
-        </p>
-        <p class='govuk-body'>
-          Refer to the section on <a class='govuk-link' href='#third-party-disclosure'>third
-          party disclosure</a> for more information on how the DfE
-          shares data.
-        </p>
+          <p class='govuk-body'>
+            The DfE and the providers are Independent Data Controllers for the data collected through Register. The primary routes which data enters Register through are:
+          </p>
+          <ul class='govuk-list govuk-list--bullet'>
+            <li>
+              providers entering new records directly into Register using
+              information from their own systems to populate Register
+            </li>
+            <li>
+              Register using an API to pull data where providers have managed
+              the application process (with trainees submitting their data via
+              the Apply service). Accredited providers may still need to add
+              course details into these pre-populated records
+            </li>
+          </ul>
+          <p class='govuk-body'>
+            The systems-based connection in which Register may share data:
+          </p>
+          <ul class='govuk-list govuk-list--bullet'>
+            <li>
+              Register connects to Apply to retrieve applicant information to
+              populate its own records
+            </li>
+            <li>
+              Register retrieves course information from the Publish teacher
+              training (Publish) service
+            </li>
+            <li>
+              organisations connect to Register to add, view or update their
+              trainee data. Users can only access data connected to their
+              organisation
+            </li>
+            <li>
+              Register reads and writes trainee record data to systems within
+              the DfE for the purpose of allocating or retrieving a TRN for
+              trainees and for registering their QTS or EYTS.
+            </li>
+            <li>
+              lead schools connect to Register to view their funding
+              information and trainees’ information
+            </li>
+          </ul>
+          <p class='govuk-body'>
+            The DfE uses <a class='govuk-link'
+            href='https://www.zendesk.co.uk/company/privacy-and-data-protection/#faq-general-1'>
+            Zendesk</a>, a customer relationship management system, to
+            handle queries from provider staff.
+          </p>
+          <p class='govuk-body'>
+            For data concerning trainees provided to the DfE by users through
+            Zendesk, providers continue to be Data Controllers. The DfE will
+            use this data for analytical purposes as well as for supporting
+            providers with their queries and therefore will also become Data
+            Controller at this point for this data.
+          </p>
+          <p class='govuk-body'>
+            The DfE and the provider may use some personal data such as names
+            and date of birth for identification purposes through other
+            channels, such as by phone or email for support and administration
+            purposes.
+          </p>
+          <p class='govuk-body'>
+            Refer to the section on
+            <a class='govuk-link' href='#third-party-disclosure'>
+            third party disclosure</a> for more information on how the DfE
+            shares data.
+          </p>
         <h3 class='govuk-heading-s'>
           Accuracy of the shared data
         </h3>
         <p class='govuk-body'>
-          The DfE undertakes measures to ensure that the data received
-          by Register is accurate and reflects the information given to
-          the DfE, though the format may be different.
+          The DfE undertakes measures to ensure that the data received by
+          Register is accurate and reflects the information given to the DfE,
+          though the format may be different.
         </p>
         <p class='govuk-body'>
           The data shared by providers must be accurate, up-to-date and
@@ -336,118 +351,122 @@ en:
         </h2>
         <p class='govuk-body'>
           The <a class='govuk-link' href='https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter'>DfE’s
-            personal information charter</a> explains the standards
-          expected of the DfE when holding personal information.
+            personal information charter</a> explains the standards expected of the DfE when holding personal information.
         </p>
         <p class='govuk-body'>
           By consenting to this agreement, the provider confirms that:
         </p>
         <ul class='govuk-list govuk-list--bullet'>
-          <li>their organisation is compliant, and will continue to
-            comply, with the requirements of Data Protection Legislation</li>
-          <li>data will be held in secure systems in line with data
-            protection legislation and security requirements</li>
-          <li>they will treat data as Official-Sensitive and apply
-            appropriate security measures to its handling</li>
+          <li>
+            their organisation is compliant, and will continue to comply, with the requirements of data protection legislation
+          </li>
+          <li>
+            data will be held in secure systems in line with data protection legislation and security requirements
+          </li>
+          <li>
+            they will treat data as Official-Sensitive and apply appropriate security measures to its handling
+          </li>
         </ul>
         <h2 class='govuk-heading-m' id='#third-party-disclosure'>
           Third party disclosure
         </h2>
         <p class='govuk-body'>
-          Where we are required to disclose personal data to comply with
-          legal requirements, we will endeavour to notify the individual
-          prior to disclosure as allowed by law.
+          Where we are required to disclose personal data to comply with legal requirements, we will endeavour to notify the individual prior to disclosure as allowed by law.
         </p>
         <p class='govuk-body'>
-          For other data shared, each party will endeavour to inform the
-          other of any requirements to share data with third parties.
-          The DfE uses some third-party data processors, including
-          Google Analytics, Google Workspace, Zendesk.
+          For other data shared, each party will endeavour to inform the other of any requirements to share data with third parties. The DfE uses some third-party data processors, including Google Analytics, Google Workspace, Zendesk.
         </p>
         <p class='govuk-body'>
-          Providers must comply with Article 28 in the GDPR, which sets
-          out the roles and responsibilities of a Data Processor on
-          appointing and using appropriate data processors.
+          Providers must comply with Article 28 in the GDPR, which sets out the roles and responsibilities of a Data Processor on appointing and using appropriate data processors.
         </p>
         <p class='govuk-body'>
           By consenting to this agreement, the provider confirms that:
         </p>
         <ul class='govuk-list govuk-list--bullet'>
-          <li>their data sharing practices comply with data protection
-            legislation</li>
-          <li>their data sharing practices minimise the risk of
-            individuals being identified by unauthorised parties, using
-            appropriate safeguards to look after shared data</li>
-          <li>they will only share data for the purposes outlined in
-            this agreement</li>
-          <li>they hold data in strict confidence and have appropriate
-            safeguards in place to protect data against unlawful or
-            unauthorised processing</li>
+          <li>
+            their data sharing practices comply with data protection
+            legislation
+          </li>
+          <li>
+            their data sharing practices minimise the risk of individuals being
+            identified by unauthorised parties, using appropriate safeguards to
+            look after shared data
+          </li>
+          <li>
+            they will only share data for the purposes outlined in this
+            agreement
+          </li>
+          <li>
+            they hold data in strict confidence and have appropriate safeguards
+            in place to protect data against unlawful or unauthorised
+            processing
+          </li>
         </ul>
         <h2 class='govuk-heading-m' id='#handling-subject-access-requests'>
           Handling subject access requests (SARs)
         </h2>
         <p class='govuk-body'>
-          The DfE will manage SARs regarding any information for which
-          the DfE is a Data Controller.
+          The DfE will manage SARs regarding any information for which the DfE is a Data Controller.
         </p>
         <p class='govuk-body'>
-          The DfE and the provider will contact each other immediately
-          if they get a request for:
+          The DfE and the provider will contact each other immediately if they get a request for:
         </p>
         <ul class='govuk-list govuk-list--bullet'>
-          <li>Rectification of information (Article 16 of GDPR)</li>
-          <li>Erasure of information (Article 17 of GDPR)</li>
-          <li>Restriction to process information (Article 18 of GDPR)</li>
+          <li>
+            rectification of information (Article 16 of GDPR)
+          </li>
+          <li>
+            erasure of information (Article 17 of GDPR)
+          </li>
+          <li>
+            restriction to process information (Article 18 of GDPR)
+          </li>
         </ul>
         <p class='govuk-body'>
-          For other types of SAR, the provider must notify the DFE
-          within 5 working days.
+          For other types of SARs, the provider must notify the DFE within 5 working days.
         </p>
         <p class='govuk-body'>
-          Data subjects wanting to make an SAR can email the DfE at <a class='govuk-link'
-            href='mailto:becomingateacher@digital.education.gov.uk.?subject=Subject%20access%20request'>becomingateacher@digital.education.gov.uk</a>.
+          Data subjects wanting to make an SAR can email the DfE at
+          <a class='govuk-link'
+          href='mailto:becomingateacher@digital.education.gov.uk.?subject=Subject%20access%20request'>becomingateacher@digital.education.gov.uk</a>.
         </p>
         <h2 class='govuk-heading-m' id='#handling-freedom-of-information-act-requests'>
           Handling freedom of information requests
         </h2>
         <p class='govuk-body'>
-          The DfE is responsible for responding to freedom of
-          information act requests regarding Register data processing
-          and sharing practices.
+          The DfE is responsible for responding to freedom of information act
+          requests regarding Register data processing and sharing practices.
         </p>
         <p class='govuk-body'>
-          The DfE will contact the provider if any support is needed to
-          process a request.
+          The DfE will contact the provider if any support is needed to process
+          a request.
         </p>
         <h2 class='govuk-heading-m' id='#data-storage'>
-          Data storage
+          Data access and storage
         </h2>
         <p class='govuk-body'>
-          The provider must store shared data securely using technical
-          and organisational measures.
+          The provider must store shared data securely using technical and organisational measures.
         </p>
         <p class='govuk-body'>
-          Data should be encrypted at rest, using AES256 and in transit
-          using TLS 1.2 and above, as minimum standards.
+          Data should be encrypted at rest, using AES256 and in transit using TLS 1.2 and above, as minimum standards.
         </p>
         <p class='govuk-body'>
-          Access to data must be controlled and, on a need-to-know
-          basis. All access to data must be logged and reviewed
-          periodically.
+          Access to data must be controlled and on a need-to-know basis. All access to data must be logged and reviewed periodically.
         </p>
         <p class='govuk-body'>
-          The data must be retained in a way that is compliant with EU
-          data protection legislation.
+          The data must be retained in a way that is compliant with EU data protection legislation.
         </p>
         <p class='govuk-body'>
-          By consenting to this agreement, the DfE and the provider
-          agree to:
+          By consenting to this agreement, the DfE and the provider agree to:
         </p>
         <ul class='govuk-list govuk-list--bullet'>
-          <li>hold data in strict confidence</li>
-          <li>have appropriate safeguards in place to protect data
-            against unlawful or unauthorised processing</li>
+          <li>
+            hold data in strict confidence
+          </li>
+          <li>
+            have appropriate safeguards in place to protect data against
+            unlawful or unauthorised processing
+          </li>
         </ul>
         <h2 class='govuk-heading-m' id='#data-retention-and-destruction-schedule'>
           Data retention and destruction schedule
@@ -456,82 +475,79 @@ en:
           Data retention
         </h3>
         <p class='govuk-body'>
-          Personal data must be kept only as long as needed to carry out
-          the activities outlined in this document.
+          Personal data must be kept only as long as needed to carry out the
+          activities outlined in this document.
         </p>
         <p class='govuk-body'>
-          The DfE will keep data for no longer than 7 years. The
-          provider must set an appropriate time limit, in line with the
-          General Data Protection Regulation, for retaining data before
-          erasure or review.
+          The DfE will keep data for no longer than 7 years. The provider must
+          set an appropriate time limit, in line with the General Data
+          Protection Regulation (GDPR), for retaining data before erasure or
+          review.
         </p>
         <h3 class='govuk-heading-s'>
           Data destruction
         </h3>
         <p class='govuk-body'>
-          The provider must destroy the data when it is no longer
-          needed, or when the retention schedule has expired.
+          The provider must destroy the data when it is no longer needed, or
+          when the retention schedule has expired.
         </p>
         <p class='govuk-body'>
-          The provider must follow the National cyber security
-          centre’s advice on secure sanitisation.
+          The provider must follow the National Cyber Security Centre’s advice
+          on secure sanitisation.
         </p>
         <h2 class='govuk-heading-m' id='#security-incidents'>
           Security incidents
         </h2>
-        <p class='govuk-body'>
-          The DfE and the providers are responsible for notifying each
-          other in writing in the event of loss or unauthorised
-          disclosure of information within 24 hours of the event being
-          discovered.
-        </p>
-        <p class='govuk-body'>
-          All communication should be sent by email to <a class='govuk-link'
+          <p class='govuk-body'>
+            The DfE and the providers are responsible for notifying each other in writing in the event of loss or unauthorised disclosure of information within 24 hours of the event being discovered.
+          </p>
+          <p class='govuk-body'>
+            All communication should be sent by email to <a class='govuk-link'
             href='mailto:becomingateacher@digital.education.gov.uk.?subject=Security%20incident'>becomingateacher@digital.education.gov.uk</a>.
-        </p>
-        <p class='govuk-body'>
-          The designated points of contact will discuss and agree the
-          next steps relating to the incident, taking specialist advice
-          where appropriate. Such arrangements will include (but will
-          not be limited to):
-        </p>
-        <ul class='govuk-list govuk-list--bullet'>
-          <li>containing the incident and mitigating any ongoing risk</li>
-          <li>recovering information</li>
-          <li>assessing whether the Information commissioner should be
-            notified or whether data protection officers or data
-            subjects need to be notified</li>
-        </ul>
-        <p class='govuk-body'>
-          The arrangements may vary in each case, depending on the
-          sensitivity of the information and the nature of the loss or
-          unauthorised disclosure. Where appropriate and if relevant to
-          the incident, disciplinary misconduct action and criminal
-          proceedings will be considered.
-        </p>
+          </p>
+          <p class='govuk-body'>
+            The designated points of contact will discuss and agree the next steps relating to the incident, taking specialist advice where appropriate. Such arrangements will include (but will not be limited to):
+          </p>
+          <ul class='govuk-list govuk-list--bullet'>
+            <li>
+              containing the incident and mitigating any ongoing risk
+            </li>
+            <li>
+              recovering information
+            </li>
+            <li>
+              assessing whether the Information commissioner should be notified or whether data protection officers or data subjects need to be notified
+            </li>
+          </ul>
+          <p class='govuk-body'>
+            The arrangements may vary in each case, depending on the
+            sensitivity of the information and the nature of the loss or
+            unauthorised disclosure. Where appropriate and if relevant to the
+            incident, disciplinary misconduct action and criminal proceedings
+            will be considered.
+          </p>
         <h3 class='govuk-heading-m'>
           Consequences of security incidents
         </h3>
         <p class='govuk-body'>
-          Any security incident that occurs will not impact the DfE’s
-          ongoing cooperation with the provider.
+          Any security incident that occurs will not impact the DfE’s ongoing
+          cooperation with the provider.
         </p>
         <p class='govuk-body'>
-          In the event of a personal data breach (or where there is a
-          reason to believe that an incident could arise) the DfE and
-          the provider will pause further data sharing until the
-          signatories of this agreement are satisfied that the cause or
-          incident is resolved.
-        </p>
-        <p class='govuk-body'>
-          If the issue cannot be resolved or if it’s very serious,
-          data sharing will not start again until DfE and the provider
+          In the event of a personal data breach (or where there is a reason to
+          believe that an incident could arise) the DfE and the provider will
+          pause further data sharing until the signatories of this agreement
           are satisfied that the cause or incident is resolved.
         </p>
         <p class='govuk-body'>
-          The DfE contact would raise the incident with the DfE
-          departmental security team and complete formal procedures in
-          the event of a personal data breach.
+          If the issue cannot be resolved or if it’s very serious, data sharing
+          will not start again until DfE and the provider are satisfied that
+          the cause or incident is resolved.
+        </p>
+        <p class='govuk-body'>
+          The DfE contact would raise the incident with the DfE departmental
+          security team and complete formal procedures in the event of a
+          personal data breach.
         </p>
         <h2 class='govuk-heading-m' id='#termination-of-the-agreement'>
           Termination of the agreement
@@ -540,32 +556,44 @@ en:
           When to terminate this agreement
         </h3>
         <p class='govuk-body'>
-          Both participants to this DSA reserve the right to terminate
-          this DSA with 3 months’ notice in the following circumstance:
+          Both participants to this DSA reserve the right to terminate this DSA with 3 months’ notice in the following circumstance:
         </p>
         <ul class='govuk-list govuk-list--bullet'>
           <li>
-            finances, resources or other factors beyond the control of
-            the DfE or the provider
+            finances, resources or other factors beyond the control of the DfE
+            or the provider
           </li>
           <li>
-            if any change occurs which, in the opinion of the DfE and
-            the provider, significantly impairs the value of
-            the data sharing arrangement in meeting their objectives
+            if any change occurs which, in the opinion of the DfE and the
+            provider, significantly impairs the value of the data sharing
+            arrangement in meeting their objectives
           </li>
           <li>
-            in the event of a significant security breach or other
-            serious breach of the terms of this DSA by either
-            participant, the DSA will be terminated or suspended
-            immediately without notice
+            in the event of a significant security breach or other serious
+            breach of the terms of this DSA by either participant, the DSA will
+            be terminated or suspended immediately without notice
           </li>
         </ul>
         <h2 class='govuk-heading-m' id='#your-consent'>
           Your consent
         </h2>
         <p class='govuk-body'>
-          To notify the DfE with your consent to the terms of this
-          data sharing agreement, email <a class='govuk-link' href='mailto:becomingateacher@digital.education.gov.uk.?subject=Data%20sharing%20agreement'>becomingateacher@digital.education.gov.uk</a>
-          with confirmation.
+          A relevant person at your organisation who deals with initial teacher
+          training (ITT) should consent to this DSA.
+        </p>
+        <h3 class='govuk-heading-s'>
+          If you’re an accredited provider
+        </h3>
+        <p class='govuk-body'>
+          To notify the DfE with your consent to the terms of this data sharing
+          agreement, email <a class='govuk-link'
+          href='mailto:becomingateacher@digital.education.gov.uk.?subject=Register%20DSA%20consent'>becomingateacher@digital.education.gov.uk</a> with
+          confirmation.
+        </p>
+        <h3 class='govuk-heading-s'>
+          If you’re a lead school
+        </h3>
+        <p class='govuk-body'>
+          You will have received an email from us asking you to fill out a form where a relevant person from your organisation needs to consent to this data sharing agreement.
         </p>
       "


### PR DESCRIPTION
### Context

We want to update the Register DSA so that Lead Schools can sign it in order to access Register and it makes sense to them.

Some parts of the existing DSA may cause Lead Schools to contact their trainees to ask permission to input their data, when the accredited body should have already done this.

### Changes proposed in this pull request

- Just update the content

![image](https://user-images.githubusercontent.com/450843/175011912-9149c9ca-9c20-45d1-864a-b9a52dc8f125.png)

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
