### PR TITLE
[4282] Switch default course year to 2022

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -87,7 +87,7 @@ apply_api:
   auth_token: "auth-token-from-env"
 
 current_recruitment_cycle_year: 2022
-current_default_course_year: 2021
+current_default_course_year: 2022
 
 apply_applications:
   import:

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -65,6 +65,7 @@ FactoryBot.define do
         subjects_count { 1 }
         subject_names { [] }
         study_mode { "full_time" }
+        recruitment_cycle_year { Settings.current_default_course_year }
       end
 
       before(:create) do |course, evaluator|
@@ -77,6 +78,7 @@ FactoryBot.define do
         end
 
         course.uuid = evaluator.uuid
+        course.recruitment_cycle_year = evaluator.recruitment_cycle_year
       end
 
       after(:create) do |course, evaluator|

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -425,6 +425,7 @@ FactoryBot.define do
         courses_count { 5 }
         subject_names { [] }
         study_mode { "full_time" }
+        recruitment_cycle_year { Settings.current_default_course_year }
       end
 
       after(:create) do |trainee, evaluator|
@@ -432,7 +433,8 @@ FactoryBot.define do
                     subject_names: evaluator.subject_names,
                     accredited_body_code: trainee.provider.code,
                     route: trainee.training_route,
-                    study_mode: evaluator.study_mode)
+                    study_mode: evaluator.study_mode,
+                    recruitment_cycle_year: evaluator.recruitment_cycle_year)
 
         trainee.reload
       end


### PR DESCRIPTION
### Context

We have a default course year setting which determines what year of courses we display when a user is setting course details on a trainee.

### Changes proposed in this pull request

Set it to 2022 as most users will be adding trainees for next academic cycle now.

### Guidance to review

* The course list should default to 22/23 courses in the course details section.
* I did some possibly controversial defaulting in the factories to fix a few tests that broke once the year was incremented. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
