### PR TITLE
[4283] Fix DQT country mapping

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -107,7 +107,7 @@ module Dqt
 
         {
           "providerUkprn" => nil,
-          "countryCode" => country_codes[degree.uk? ? UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED : degree.country],
+          "countryCode" => find_country_code(degree.uk? ? UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED : degree.country),
           "subject" => degree_subject,
           "class" => DEGREE_CLASSES[degree.grade],
           "date" => Date.parse("01-01-#{degree.graduation_year}").iso8601,
@@ -126,8 +126,8 @@ module Dqt
         Hesa::CodeSets::DegreeSubjects::MAPPING.invert[degree.subject]
       end
 
-      def country_codes
-        @country_codes ||= Hesa::CodeSets::Countries::MAPPING.invert
+      def find_country_code(country)
+        Hesa::CodeSets::Countries::MAPPING.find { |_, name| name.start_with?(country) }&.first
       end
     end
   end

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -87,6 +87,15 @@ module Dqt
               "countryCode" => "AL",
             })
           end
+
+          context "country has extra information" do
+            let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details, country: "Hong Kong (Special Administrative Region of China)") }
+            let(:trainee) { create(:trainee, :completed, degrees: [non_uk_degree]) }
+
+            it "maps the degree country to HESA countryCode" do
+              expect(subject["qualification"]).to include({ "countryCode" => "HK" })
+            end
+          end
         end
 
         context "when trainee has no degree" do


### PR DESCRIPTION
### Context
https://trello.com/c/ee2KkgeM/4283-fix-dqt-country-mapping

While investigating an issue with updating a trainee's DQT record, it was discovered that the country value was missing from the DQT payload. Further investigation revealed that the degree country data can sometimes have two variations of the same country, e.g. "Hong Kong" and "Hong Kong (Special Administrative Region of China) [Hong Kong]" or "Iran" and "Iran [Iran, Islamic Republic of]". The `Hesa::CodeSets::Countries::MAPPING` only holds one variation.

### Changes proposed in this pull request
- Update `Dqt::Params::TrnRequest` to lookup country code using partial string search instead of the whole string

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
