### PR TITLE
[4228] Reinstate apply apply synching for 2022

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -94,6 +94,7 @@ apply_applications:
   import:
     recruitment_cycle_years:
       - 2021
+      - 2022
   create:
     recruitment_cycle_year: 2021
 


### PR DESCRIPTION
### Context

We had switched this off while working on fixes. Those fixes are now
deployed so we can re-enable synching for 2022.

There is a backlog of ~2K applications so the first time this runs we
will have to monitor this carefully.

### Changes proposed in this pull request

- Just reinstates 2022 in the list of recruitment cycle years to sync.

### Guidance to review

- Anything missing?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
