### PR TITLE
[4284] Update end academic cycle estimation

### DIFF
--- a/app/services/trainees/set_academic_cycles.rb
+++ b/app/services/trainees/set_academic_cycles.rb
@@ -51,7 +51,9 @@ module Trainees
     end
 
     def course_duration
-      actual_course_duration || estimated_course_duration
+      course_duration = actual_course_duration || estimated_course_duration
+      # Year long courses end on average 10 months after they start, so the calculation below reflects this reality.
+      course_duration_unit == "years" ? course_duration - 2.months : course_duration
     end
 
     def actual_course_duration

--- a/spec/services/trainees/set_academic_cycles_spec.rb
+++ b/spec/services/trainees/set_academic_cycles_spec.rb
@@ -105,7 +105,7 @@ module Trainees
           end
 
           it "calculates the end academic cycle" do
-            expect(subject).to eq(next_academic_cycle)
+            expect(subject).to eq(current_academic_cycle)
           end
         end
 


### PR DESCRIPTION
### Context

Current end academic cycle estimation code predicts 2 months too long for course end date for course lengths 1 year or greater, update code to calculate the correct value.
