### PR TITLE
[4286] Add rake task for backfilling institution_uuid

### DIFF
--- a/lib/tasks/institution_uuid.rake
+++ b/lib/tasks/institution_uuid.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+namespace :degrees do
+  desc "add institution_uuid to degrees"
+  task add_institution_uuid: :environment do
+    degrees = Degree.uk
+
+    def hesa_code_for_institute(degree)
+      Hesa::CodeSets::Institutions::MAPPING.filter_map do |institute|
+        if institute.include?(degree.institution)
+          institute.first.to_i.to_s
+        end
+      end
+    end
+
+    degrees.find_each do |degree|
+      hesa_code_for_institute = hesa_code_for_institute(degree)
+      next if hesa_code_for_institute.blank?
+
+      institutions = DfE::ReferenceData::Degrees::INSTITUTIONS.some({ hesa_itt_code: hesa_code_for_institute.first })
+      degree.update_columns(institution_uuid: institutions&.first&.id)
+    end
+
+    degrees = degrees.where(institution_uuid: nil)
+
+    degrees.find_each do |degree|
+      institutions = DfE::ReferenceData::Degrees::INSTITUTIONS.all.filter do |record|
+        ([record.name] + record.suggestion_synonyms + record.match_synonyms).include?(degree.institution)
+      end
+
+      degree.update_columns(institution_uuid: institutions&.first&.id)
+    end
+
+    puts "Done! UK degrees updated."
+  end
+end


### PR DESCRIPTION
### Context

Split off the backfilling from [this PR](https://github.com/DFE-Digital/register-trainee-teachers/pull/2452) into its own rake task here. 

This is so we can safely backfill institution_uuid onto the degrees table without running out of container memory if we do it via a migration in the CI pipeline. 

The rake task takes around 25 mins to run.

### Changes proposed in this pull request

* Add /lib/tasks/institution_uuid.rake

### Guidance to review

* Check logic in rake task, maybe run locally against a prod back up. I cross-checked several uuids after running it and they were all correct.

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
