### PR TITLE
[4281] Backfill missing institution UUIDs for remaining degrees

### DIFF
--- a/db/data/20220623151318_backfill_missing_institution_uuids.rb
+++ b/db/data/20220623151318_backfill_missing_institution_uuids.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class BackfillMissingInstitutionUuids < ActiveRecord::Migration[6.1]
+  def up
+    institutions = {
+      "The Queen's University of Belfast" => "a7db7129-7042-e811-80ff-3863bb3640b8",
+      "The University of Wales (central functions)" => "6a228041-7042-e811-80ff-3863bb3640b8",
+      "Ravensbourne" => "4ff3791d-7042-e811-80ff-3863bb3640b8",
+      "St George's Hospital Medical School" => "94407223-7042-e811-80ff-3863bb3640b8",
+      "Leeds College of Music" => "733e182c-1425-ec11-b6e6-000d3adf095a",
+    }
+
+    institutions.each do |institution, uuid|
+      Degree.where(institution: institution).update_all(institution_uuid: uuid)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/CZj7B0sf/4281-investigate-backfilling-of-missing-institutionuuids

### Changes proposed in this pull request

- These degrees were still missing institution UUIDs after we ran
  our big backfill based on HESA codes, names and name synonyms
- I've manually pulled the UUIDs from the list in the dfe-reference-data
  gem

### Guidance to review

### Important business

**Only merge after https://github.com/DFE-Digital/register-trainee-teachers/pull/2459 has been run, otherwise the rake task will unset the UUIDs**

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
