### PR TITLE
[4278] Lookup existing dsi users by UUID at signin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,7 +42,7 @@ private
     return if dfe_sign_in_user.blank?
 
     @current_user ||= begin
-      user = User.kept.find_by("LOWER(email) = ?", dfe_sign_in_user.email)
+      user = User.kept.find_by("LOWER(dfe_sign_in_uid) = ?", dfe_sign_in_user.dfe_sign_in_uid.downcase)
       UserWithOrganisationContext.new(user: user, session: session) if user.present?
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,9 +42,27 @@ private
     return if dfe_sign_in_user.blank?
 
     @current_user ||= begin
-      user = User.kept.find_by("LOWER(dfe_sign_in_uid) = ?", dfe_sign_in_user.dfe_sign_in_uid.downcase)
+      user = lookup_user_by_dfe_sign_in_uid || lookup_user_by_email
       UserWithOrganisationContext.new(user: user, session: session) if user.present?
     end
+  end
+
+  def lookup_user_by_dfe_sign_in_uid
+    return nil if dfe_sign_in_user&.dfe_sign_in_uid.blank?
+
+    User.kept.find_by(
+      "LOWER(dfe_sign_in_uid) = ?",
+      dfe_sign_in_user.dfe_sign_in_uid.downcase,
+    )
+  end
+
+  def lookup_user_by_email
+    return nil if dfe_sign_in_user&.email.blank?
+
+    User.kept.find_by(
+      "LOWER(email) = ?",
+      dfe_sign_in_user.email.downcase,
+    )
   end
 
   def audit_user

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -3,12 +3,19 @@
 require "rails_helper"
 
 describe ApplicationController, type: :controller do
-  let!(:user) { create(:user, email: "Lovely.User@example.com") }
-
+  let!(:user) do
+    create(
+      :user,
+      email: "Lovely.User@example.com",
+      dfe_sign_in_uid: "6dd394f1-df7d-45f1-976e-687190390d62",
+    )
+  end
+  let(:dfe_sign_in_uid) { "6dd394f1-df7d-45f1-976e-687190390d62" }
   let(:dfe_sign_in_user) do
     {
-      "email" => dfe_sign_in_email,
+      "email" => "Lovely.User@example.com",
       "last_active_at" => 1.hour.ago,
+      "dfe_sign_in_uid" => dfe_sign_in_uid,
     }
   end
 
@@ -30,7 +37,7 @@ describe ApplicationController, type: :controller do
     end
 
     context "if the email in session is not a case sensitive match for a user" do
-      let(:dfe_sign_in_email) { "LOVELY.USER@example.com" }
+      let(:dfe_sign_in_uid) { "6dd394f1-DF7D-45f1-976E-687190390d62" }
 
       it "still finds the user via case insensitive search" do
         get :index
@@ -39,7 +46,7 @@ describe ApplicationController, type: :controller do
     end
 
     context "if the email doesn't match at all" do
-      let(:dfe_sign_in_email) { "lovely.youser@example.com" }
+      let(:dfe_sign_in_uid) { "240e28fb-1164-4054-9323-7d058d63f9b2" }
 
       it "returns nil" do
         get :index

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -3,17 +3,19 @@
 require "rails_helper"
 
 describe ApplicationController, type: :controller do
+  let(:user_email) { "bob@example.com" }
+  let(:user_uid) { "6dd394f1-df7d-45f1-976e-687190390d62" }
   let!(:user) do
     create(
       :user,
-      email: "Lovely.User@example.com",
-      dfe_sign_in_uid: "6dd394f1-df7d-45f1-976e-687190390d62",
+      email: user_email,
+      dfe_sign_in_uid: user_uid,
     )
   end
   let(:dfe_sign_in_uid) { "6dd394f1-df7d-45f1-976e-687190390d62" }
   let(:dfe_sign_in_user) do
     {
-      "email" => "Lovely.User@example.com",
+      "email" => "alice@example.com",
       "last_active_at" => 1.hour.ago,
       "dfe_sign_in_uid" => dfe_sign_in_uid,
     }
@@ -36,12 +38,31 @@ describe ApplicationController, type: :controller do
       end
     end
 
-    context "if the email in session is not a case sensitive match for a user" do
+    context "if the uuid in session is exact match for a user" do
+      let(:dfe_sign_in_uid) { "6dd394f1-df7d-45f1-976e-687190390d62" }
+
+      it "finds the user" do
+        get :index
+        expect(response.body).to include "found user: bob@example.com"
+      end
+    end
+
+    context "if the uuid in the session does not match a user but the email does" do
+      let(:user_uid) { "d04df553-eab2-4fbe-a53a-1217c430dd00" }
+      let(:user_email) { "alice@example.com" }
+
+      it "finds the user" do
+        get :index
+        expect(response.body).to include "found user: alice@example.com"
+      end
+    end
+
+    context "if the uuid in session differs only by case for a user" do
       let(:dfe_sign_in_uid) { "6dd394f1-DF7D-45f1-976E-687190390d62" }
 
       it "still finds the user via case insensitive search" do
         get :index
-        expect(response.body).to include "found user: Lovely.User@example.com"
+        expect(response.body).to include "found user: bob@example.com"
       end
     end
 

--- a/spec/controllers/sign_out_controller_spec.rb
+++ b/spec/controllers/sign_out_controller_spec.rb
@@ -10,6 +10,7 @@ describe SignOutController, type: :controller do
   let(:dfe_sign_in_user) do
     {
       "email" => user.email,
+      "dfe_sign_in_uid" => user.dfe_sign_in_uid,
       "last_active_at" => Time.zone.now,
       "id_token" => "id_token",
       "provider" => provider,

--- a/spec/services/dfe_sign_in_users/update_spec.rb
+++ b/spec/services/dfe_sign_in_users/update_spec.rb
@@ -7,13 +7,41 @@ module DfESignInUsers
     describe ".call" do
       let(:service) { described_class.call(user: user, dfe_sign_in_user: dfe_sign_in_user) }
 
-      context "when user are valid" do
+      context "when user details are valid" do
         let(:user) { create(:user) }
 
         let(:dfe_sign_in_user) do
           template = build(:user)
           DfESignInUser.new(email: template.email,
                             dfe_sign_in_uid: template.dfe_sign_in_uid,
+                            first_name: template.first_name,
+                            last_name: template.last_name)
+        end
+
+        before do
+          service.call
+          user.reload
+        end
+
+        it "updates the user's details" do
+          expect(user.email).to eq(dfe_sign_in_user.email)
+          expect(user.dfe_sign_in_uid).to eq(dfe_sign_in_user.dfe_sign_in_uid)
+          expect(user.first_name).to eq(dfe_sign_in_user.first_name)
+          expect(user.last_name).to eq(dfe_sign_in_user.last_name)
+        end
+
+        it "is successful" do
+          expect(service).to be_successful
+        end
+      end
+
+      context "when user details are valid but name and email address don't match" do
+        let(:user) { create(:user) }
+
+        let(:dfe_sign_in_user) do
+          template = build(:user)
+          DfESignInUser.new(email: template.email,
+                            dfe_sign_in_uid: user.dfe_sign_in_uid,
                             first_name: template.first_name,
                             last_name: template.last_name)
         end


### PR DESCRIPTION
### Context

When we authenticate users via DfE Sign-in (DSI) our service gets a callback from DSI immediately after successful authentication that we use to associate the session with a User record.

To match the correct User record we use the `email` address given by DSI to lookup the User record. We then update the `User#dfe_sign_in_uid` which is also provided in the callback by DSI.

We should be looking up the by `dfe_sign_in_uid` in the first instance, falling back to `email` only when no match is found. This will allow us to automatically handle any changes in a users email address (registered with DSI).

Note that we still need to be able to lookup by `email` for the first time that a new user logs in because at that stage we don't have their `dfe_sign_in_uid`.

### Changes proposed in this pull request

- At the start of a user session we first lookup `User` records using `dfe_sign_in_uid`. There is existing logic to update `email`, `first_name` and `last_name` in Register's DB if they are out of step with DSI.
- If we don't find the matching `dfe_sign_in_uid` we should look them up by `email` address instead. If there is a match we should update this user's `User#dfe_sign_in_uid` with that provided by DSI.
- When lookup by `email` and `dfe_sign_in_uid` both fail authentication fails as normal.

### Guidance to review

- Does this open up any security issues?
- Is this consistent with the way that other services, e.g. Publish and Apply work?
- Are the tests adequate.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
