### PR TITLE
[4239] restore SendEventJob for BigQuery

### DIFF
--- a/app/jobs/big_query/send_event_job.rb
+++ b/app/jobs/big_query/send_event_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module BigQuery
+  class SendEventJob < ApplicationJob
+    queue_as :low_priority
+
+    self.logger = ActiveSupport::TaggedLogging.new(Logger.new(IO::NULL))
+
+    def perform(event_json:, dataset: Settings.google.big_query.dataset, table: Settings.google.big_query.table_name)
+      return unless FeatureService.enabled?("google.send_data_to_big_query")
+
+      bq = Google::Cloud::Bigquery.new
+      dataset = bq.dataset(dataset, skip_lookup: true)
+      bq_table = dataset.table(table, skip_lookup: true)
+      bq_table.insert([event_json])
+    end
+  end
+end

--- a/config/initializers/big_query.rb
+++ b/config/initializers/big_query.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "google/cloud/bigquery"
+require_relative "../../app/services/feature_service"
+
+if FeatureService.enabled?("google.send_data_to_big_query")
+  Google::Cloud::Bigquery.configure do |config|
+    config.project_id  = Settings.google.big_query.project_id
+    config.credentials = JSON.parse(Settings.google.big_query.api_json_key)
+  end
+
+  Google::Cloud::Bigquery.new
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,3 +6,4 @@
   - dttp
   - mailers
   - dfe_analytics
+  - low_priority


### PR DESCRIPTION
This was removed prematurely, we need to clean out the job queues before
we disable this job and queue completely. This change re-introduces them
and once the queue is cleared of jobs, we can remove the queue from
Redis (if needed), and then remove this job.

### Context

Previous PR for this ticket removed `SendEventJob`.

### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
