### PR TITLE
[4291] Funding rounding issues

### DIFF
--- a/app/helpers/exports_helper.rb
+++ b/app/helpers/exports_helper.rb
@@ -6,6 +6,6 @@ module ExportsHelper
   def sanitize(value)
     return value unless value.is_a?(String)
 
-    value.to_s.starts_with?(*VULNERABLE_CHARACTERS) ? "'#{value}" : value
+    value.to_s.starts_with?(*VULNERABLE_CHARACTERS) ? value.to_s : value
   end
 end

--- a/app/services/funding/payable_payment_schedules_importer.rb
+++ b/app/services/funding/payable_payment_schedules_importer.rb
@@ -29,7 +29,7 @@ module Funding
               row.amounts.create(
                 month: month_index,
                 year: year_for_month(row_hash["Academic year"], month_index),
-                amount_in_pence: row_hash[month_name].to_d * 100,
+                amount_in_pence: in_pence(row_hash[month_name]),
                 predicted: predicted?(month_index),
               )
             end
@@ -58,6 +58,12 @@ module Funding
       return false if first_predicted_month_index.nil?
 
       MONTH_ORDER.index(month_index) >= MONTH_ORDER.index(first_predicted_month_index.to_i)
+    end
+
+    def in_pence(amount_string)
+      return if amount_string.blank?
+
+      amount_string.gsub(",", "").to_d * 100
     end
   end
 end

--- a/spec/services/exports/funding_schedule_data_spec.rb
+++ b/spec/services/exports/funding_schedule_data_spec.rb
@@ -100,35 +100,6 @@ module Exports
       def format_amount(amount_in_pence)
         amount_in_pence.zero? ? "0" : "\"#{ActionController::Base.helpers.number_to_currency(amount_in_pence.to_d / 100, unit: '£')}\""
       end
-
-      context "with vulnerabilities in the data" do
-        let(:expected_header_line) do
-          "Month,'@Training bursary trainees,'+Course extension provider payments,Month total"
-        end
-        let(:expected_data_line) do
-          "'=January 2022,£12.34,£23.45,£35.79"
-        end
-
-        before do
-          suspect_data = [
-            {
-              MONTH_HEADING => "=January 2022",
-              "@Training bursary trainees" => 1234,
-              "+Course extension provider payments" => 2345,
-              MONTH_TOTAL_HEADING => 3579,
-            },
-          ]
-          allow(exporter).to receive(:data).and_return(suspect_data)
-        end
-
-        it "Sanitizes header line correctly" do
-          expect(exporter.to_csv).to include(expected_header_line)
-        end
-
-        it "Sanitizes data correctly" do
-          expect(exporter.to_csv).to include(expected_data_line)
-        end
-      end
     end
   end
 end

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -129,16 +129,6 @@ module Exports
       it "sets the correct row values" do
         expect(subject.data).to include(expected_output.values.join(","))
       end
-
-      context "when names contain whitespace or vulnerable characters" do
-        before do
-          trainee.update!(first_names: "Christophe", middle_names: "Malcolm", last_name: "=SUM(A1&A2)")
-        end
-
-        it "adds an apostrophe before vulnerable characters" do
-          expect(subject.data).to include("Christophe,Malcolm,'=SUM(A1&A2)")
-        end
-      end
     end
 
     describe "#time" do

--- a/spec/services/funding/lead_school_payment_schedules_importer_spec.rb
+++ b/spec/services/funding/lead_school_payment_schedules_importer_spec.rb
@@ -118,7 +118,7 @@ module Funding
               "August" => nil,
               "September" => nil,
               "October" => "16480.10",
-              "November" => "8285.55",
+              "November" => "8,285.55",
               "December" => "8285.55",
               "January" => "8285.55",
               "February" => "8285.55",
@@ -221,6 +221,12 @@ module Funding
         subject
         october_amount = lead_school_two_first_row.amounts.find_by(month: 10)
         expect(october_amount.amount_in_pence).to eq(1648010)
+      end
+
+      it "sets the amount correctly for amounts containing commas" do
+        subject
+        november_amount = lead_school_two_first_row.amounts.find_by(month: 11)
+        expect(november_amount.amount_in_pence).to eq(828555)
       end
 
       it "sets the year correctly" do

--- a/spec/services/funding/provider_payment_schedules_importer_spec.rb
+++ b/spec/services/funding/provider_payment_schedules_importer_spec.rb
@@ -36,7 +36,7 @@ module Funding
               "August" => nil,
               "September" => "1000",
               "October" => "1000",
-              "November" => "1000",
+              "November" => "1200",
               "December" => "1000",
               "January" => "0",
               "February" => "0",
@@ -115,6 +115,12 @@ module Funding
         subject
         august_amount = provider_two_row.amounts.find_by(month: 8)
         expect(august_amount.amount_in_pence).to eq(325000)
+      end
+
+      it "sets the amount correctly for amounts containing commas" do
+        subject
+        november_amount = provider_two_row.amounts.find_by(month: 11)
+        expect(november_amount.amount_in_pence).to eq(162500)
       end
 
       it "sets the year correctly" do


### PR DESCRIPTION
### Context

A user has reported some issues with funding data.

* some values are being weirdly rounded
* numeric values are being prepended by a 'weird' character and treated as text

### Changes proposed in this pull request

* Strip commas from 'numeric' values to avoid them being truncated by `to_d`
* Remove the vulnerable character prefixing for now. We'll review how we're doing this and fix [trello](https://trello.com/c/vPp4EaD0/3334-rework-vulnerable-character-handling-in-funding-exports)

### Guidance to review

I've just removed the escaping tests as checking that a string had quotes seemed a bit tricky. We'll fix in the attached card.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
