### PR TITLE
[4298] Add data migration for unimported degrees from DTTP

### DIFF
--- a/db/data/20220628122356_fix_missing_degrees_from_dttp.rb
+++ b/db/data/20220628122356_fix_missing_degrees_from_dttp.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class FixMissingDegreesFromDttp < ActiveRecord::Migration[6.1]
+  def up
+    trainees_with_missing_degrees =
+      Trainee
+      .joins(dttp_trainee: [:degree_qualifications])
+      .where("dttp_degree_qualifications.state": 0)
+      .where(
+        "NOT EXISTS (:degrees)",
+        degrees: Degree.select(1).where("degrees.trainee_id = trainees.id"),
+      )
+
+    trainees_with_missing_degrees.find_each do |trainee|
+      Degrees::CreateFromDttp.call(trainee: trainee)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

There are a number of trainees in the database with missing degree records. It seems that quite a few of these could have been imported from DTTP because there are `Dttp::DegreeQualification` records that were synced from DTTP.

There are other cases where there are `Dttp::PlacementAssignment` records from which we could fill in more of the gaps.

### Changes proposed in this pull request

This PR adds a data migration that fetches a list of trainees that do not have an associated `Degree` record but do have importable DTTP degrees. It then to run the `Degrees::CreateFromDttp` service on each trainee found.

### Guidance to review

This PR needs a bit more work and some sanity checking to make sure I've interpreted the data correctly. Specifically:

- Are there any reasons why the `Dttp::DegreeQualification` records picked out by the query in the migration _cannot_ be used to import into `Trainee` records?
- I think this probably needs manually testing on a copy of the production database before deployment to verify that bad things don't happen. I have tested the query itself in a production rails console and it returns 407 records, the same query is available in blazer: https://www.register-trainee-teachers.service.gov.uk/system-admin/blazer/queries/131-trainees-with-dttp-degree-qualification-but-no-register-degree
- After harvesting as much data as possible from `Dttp::DegreeQualification` we should then look at `Dttp::PlacementAssignment` paired with the `Degree::CreateFromDttpPlacementAssignment` service.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
