### PR TITLE
bump dfe-analytics to 1.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,7 @@ gem "mechanize" # interact with HESA
 gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v0.1.0"
 
 # for sending analytics data to the analytics platform
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.0.0"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.2.0"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 3b4e180c87125aee0255c70acf81997e4043c878
-  tag: v1.0.0
+  revision: 1c67c5ff401be97578bc370f7e0b090d9b42dad0
+  tag: v1.2.0
   specs:
-    dfe-analytics (1.0.0)
+    dfe-analytics (1.2.0)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 


### PR DESCRIPTION
### Context

Trainee events are causing an error in dfe-analytics because of the handling of `progress`, which fails to get processed by BigQuery. These errors seem to be invisible on production, or at least they were in qa and I haven't spotted them in production yet. The only way we knew about them is that trainee entity events, and only trainee ones, weren't being streamed.

### Changes proposed in this pull request

This new version of the `dfe-analytics` gem includes a fix for sending the "progress" attribute on trainees which is currently causing no trainees to be sent to BQ.

### Guidance to review


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
