### PR TITLE
[4316] Update hesa_updated_at on trainees

### DIFF
--- a/db/data/20220629102150_backfill_hesa_updated_at_on_trainees.rb
+++ b/db/data/20220629102150_backfill_hesa_updated_at_on_trainees.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BackfillHesaUpdatedAtOnTrainees < ActiveRecord::Migration[6.1]
+  def up
+    trainees = Trainee.imported_from_hesa.joins(:hesa_student)
+
+    trainees.find_each do |trainee|
+      trainee.update_columns(hesa_updated_at: trainee.hesa_student.hesa_updated_at)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/UW954uIW/4316-s-backfill-the-hesaupdatedat-field-from-the-hesastudents-table-to-the-trainees-table

Backfill the hesa_updated_at for hesa students on the trainees table. This is so we can show HEIs when the hesa trainees were updated on HESA which makes their data sign off easier.

### Changes proposed in this pull request

* Add backfill for hesa_updated_at on trainees

### Guidance to review

* We've used the scope `imported_from_hesa` to find the right trainees. We're not sure if this is the right/best way to select those trainees
* We deployed this to the dttp import env and it looked to run fine. The deploy job took approx 9 minutes. 40235 trainees were updated 
* We checked in prod, and all hesa_trainees have a hesa_updated_at value

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
