### PR TITLE
[xxx] Fix spec issues re itt_end_date / commencement date / trainees being created in the next academic cycle

### DIFF
--- a/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 feature "provider-led (postgrad) end-to-end journey", type: :feature do
-  let(:itt_start_date) { 1.week.from_now }
+  let(:itt_start_date) { 1.month.from_now }
   let(:itt_end_date) { itt_start_date + 1.year }
 
   background {

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -176,14 +176,14 @@ feature "Withdrawing a trainee", type: :feature do
     and_i_choose_they_have_started
     and_i_continue
     and_i_select_no_they_started_later
-    and_i_fill_in_a_new_start_date(1.hour.ago)
+    and_i_fill_in_a_new_start_date(Time.zone.today)
     and_i_continue
     then_i_should_be_on_the_withdrawal_page
     and_i_choose_today
     and_i_choose_a_specific_reason
     and_i_continue
     then_i_am_redirected_to_withdrawal_confirmation_page
-    and_i_see_my_date(1.hour.ago)
+    and_i_see_my_date(Time.zone.today)
   end
 
   def when_i_am_on_the_withdrawal_page
@@ -300,11 +300,19 @@ feature "Withdrawing a trainee", type: :feature do
   end
 
   def given_a_trainee_exists_to_be_withdrawn
-    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample, commencement_date: 10.days.ago)
+    given_a_trainee_exists(
+      %i[submitted_for_trn trn_received].sample,
+      commencement_date: 10.days.ago,
+      itt_end_date: 1.year.from_now,
+    )
   end
 
   def given_a_trainee_exists_to_be_withdrawn_with_no_start_date
-    given_a_trainee_exists(%i[submitted_for_trn trn_received].sample, commencement_date: nil)
+    given_a_trainee_exists(
+      %i[submitted_for_trn trn_received].sample,
+      commencement_date: nil,
+      itt_end_date: 1.year.from_now,
+    )
   end
 
   def given_a_deferred_trainee_exists

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,5 +50,10 @@ RSpec.configure do |config|
     driven_by(:rack_test)
   end
 
+  config.before(:each, type: :feature) do
+    create(:academic_cycle, :current)
+    create(:academic_cycle, next_cycle: true)
+  end
+
   Faker::Config.locale = "en-GB"
 end


### PR DESCRIPTION
### Context

Now we're getting to the end of an academic cycle, some trainees were being created in the next academic cycle.

Also, itt_end_date occuring in June 'threw up' some issues with tests filling in commencement dates of today (i.e. 1 July)

### Changes proposed in this pull request

Fix the tests.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
