### PR TITLE
[xxx] Move start/end year filter

### DIFF
--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -42,8 +42,6 @@
     <% end %>
   <% end %>
 
-  <%= render "trainees/record_completion_filter", search_path: search_path %>
-
   <% [:start_year, :end_year].each do |field| %>
     <div class="govuk-form-group">
       <%= label_tag field, t("views.trainees.index.filters.#{field}"), class: "govuk-label govuk-label--s" %>
@@ -55,6 +53,8 @@
         ), class: "govuk-select" %>
     </div>
   <% end %>
+
+  <%= render "trainees/record_completion_filter", search_path: search_path %>
 
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">


### PR DESCRIPTION
### Context

We have filters. They are in the wrong order.

### Changes proposed in this pull request

Put them in the correct order. Move start/end year filter above the record completion filter.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
