### PR TITLE
[4330] Pre-select in-training filter

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -71,6 +71,16 @@ private
     redirect_to(not_found_path)
   end
 
+  def filter_params
+    user_params = params.permit(permitted_params + permitted_admin_params)
+
+    if user_params.empty? && !user_params[:clear]
+      { status: %w[in_training] }
+    else
+      user_params
+    end
+  end
+
   def permitted_params
     [
       :subject,
@@ -78,6 +88,7 @@ private
       :start_year,
       :end_year,
       :sort_by,
+      :clear,
       {
         level: [],
         training_route: [],

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -9,6 +9,10 @@ module FilterHelper
     tag.span("Remove ", class: "govuk-visually-hidden") + value.upcase_first + tag.span(" #{filter.humanize.downcase} filter", class: "govuk-visually-hidden")
   end
 
+  def clear_search_link(search_path)
+    trainee_search_path?(search_path) ? trainees_path(clear: true) : drafts_path
+  end
+
   def tags_for_filter(filters, filter, value)
     case value
     when String
@@ -30,11 +34,11 @@ private
   def remove_checkbox_tag_link(filters, filter, value)
     new_filters = filters.deep_dup
     new_filters[filter].reject! { |v| v == value }
-    new_filters.to_query.blank? ? nil : "?#{new_filters.to_query}"
+    new_filters.to_query.blank? ? "?clear=true" : "?#{new_filters.to_query}"
   end
 
   def remove_select_tag_link(filters, filter)
     new_filters = filters.reject { |f| f == filter }
-    new_filters.to_query.blank? ? nil : "?#{new_filters.to_query}"
+    new_filters.to_query.blank? ? "?clear=true" : "?#{new_filters.to_query}"
   end
 end

--- a/app/views/trainees/_selected_filters.html.erb
+++ b/app/views/trainees/_selected_filters.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="moj-filter__heading-action">
         <p class="govuk-body">
-        <%= govuk_link_to 'Clear<span class="govuk-visually-hidden"> all filters</span>'.html_safe, search_path, class: "govuk-link--no-visited-state" %>
+        <%= govuk_link_to 'Clear<span class="govuk-visually-hidden"> all filters</span>'.html_safe, clear_search_link(search_path), class: "govuk-link--no-visited-state" %>
         </p>
       </div>
     </div>

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -10,7 +10,10 @@ RSpec.feature "Filtering trainees" do
       given_a_subject_specialism_is_available_for_selection
       when_i_visit_the_trainee_index_page
       then_i_see_my_provider_name
-      then_all_registered_trainees_are_visible
+    end
+
+    scenario "defaults to in training filter selected" do
+      then_only_the_in_training_trainee_is_visible
     end
 
     context "when filtering trainees by record completion" do
@@ -20,6 +23,7 @@ RSpec.feature "Filtering trainees" do
       end
 
       scenario "can filter by complete records" do
+        when_i_deselect_the_in_training_filter
         when_i_filter_by_complete
         then_only_complete_records_are_visible
       end
@@ -31,6 +35,7 @@ RSpec.feature "Filtering trainees" do
     end
 
     scenario "can filter by subject" do
+      when_i_deselect_the_in_training_filter
       when_i_filter_by_subject("Biology")
       then_only_biology_trainees_are_visible
       then_the_tag_is_visible_for("Biology")
@@ -45,14 +50,8 @@ RSpec.feature "Filtering trainees" do
       then_the_record_source_filter_is_not_visible
     end
 
-    scenario "can filter by status" do
-      when_i_filter_by_in_training_status
-      then_only_the_in_training_trainee_is_visible
-    end
-
     scenario "can filter by multiple statuses" do
-      when_i_filter_by_in_training_status
-      and_i_filter_by_withdrawn_status
+      when_i_filter_by_withdrawn_status
       then_the_in_training_and_withdrawn_trainees_are_visible
     end
 
@@ -116,7 +115,10 @@ RSpec.feature "Filtering trainees" do
     end
 
     context "searching" do
-      before { when_i_search_for(search_term) }
+      before do
+        when_i_deselect_the_in_training_filter
+        when_i_search_for(search_term)
+      end
 
       shared_examples_for "a working search" do
         it "returns the correct trainee" do
@@ -242,12 +244,12 @@ private
     trainee_index_page.apply_filters.click
   end
 
-  def when_i_filter_by_in_training_status
+  def when_i_deselect_the_in_training_filter
     trainee_index_page.in_training_checkbox.click
     trainee_index_page.apply_filters.click
   end
 
-  def and_i_filter_by_withdrawn_status
+  def when_i_filter_by_withdrawn_status
     trainee_index_page.withdrawn_checkbox.click
     trainee_index_page.apply_filters.click
   end
@@ -328,7 +330,7 @@ private
   end
 
   def then_all_registered_trainees_are_visible
-    Trainee.where.not(state: "draft").each { |trainee| expect(trainee_index_page).to have_text(full_name(trainee)) }
+    Trainee.not_draft.each { |trainee| expect(trainee_index_page).to have_text(full_name(trainee)) }
   end
 
   def then_all_draft_trainees_are_visible


### PR DESCRIPTION
### Context

https://trello.com/c/5ua7Fnm6/4330-pre-select-in-training-filter-when-visiting-register-trainees-tab-with-no-filters-applied

When a user visits the registered trainee tab with no filters applied (eg using the header nav), we should pre-select the 'in training' filter. This is to show the most relevant trainees to the user.

### Changes proposed in this pull request

- When navigating to the Registered trainees page with no filters applied, select in-training status by default

### Guidance to review

Check that the filter is applied when you click from the nav bar, from back buttons etc
Check that clearing the filters still works

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml