### PR TITLE
[4316] Add backfill for hesa_updated_at on trainees which handles leading zeros on hesa_id

### DIFF
--- a/db/data/20220705100148_backfill_hesa_updated_at_for_leading_zero_hesa_ids_on_trainees.rb
+++ b/db/data/20220705100148_backfill_hesa_updated_at_for_leading_zero_hesa_ids_on_trainees.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class BackfillHesaUpdatedAtForLeadingZeroHesaIdsOnTrainees < ActiveRecord::Migration[6.1]
+  def up
+    trainees = Trainee.imported_from_hesa.where(hesa_updated_at: nil)
+
+    trainees.find_each do |trainee|
+      hesa_trainee = Hesa::Student.find_by(hesa_id: strip_leading_zero(trainee.hesa_id))
+      trainee.update_columns(hesa_updated_at: hesa_trainee.hesa_updated_at) if hesa_trainee
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def strip_leading_zero(hesa_id)
+    hesa_id.to_i.to_s
+  end
+end


### PR DESCRIPTION
### Context

Trello ticket: https://trello.com/c/UW954uIW/4316-s-backfill-the-hesaupdatedat-field-from-the-hesastudents-table-to-the-trainees-table

The original backfill that we merged for this piece of work failed to backfill some of the `hesa_updated_at` for some trainees. This is because some trainee hesa_ids have leading zeros in the trainees table, but not in the hesa_students table.

In this ticket we format the `trainee.hesa_id` to remove leading zeros and then match to the `hesa_students` table.

The scoped trainees is about 31568. I'll run on DTTP import to see how many we manage to update and some of these are not present in the hesa_students table.

In the long term we should probably fix the data on `hesa_students` /fix however we added this data to `hesa_students` for next collection. I've done this as a short term fix for now.

### Changes proposed in this pull request

* Add backfill to target trainees with leading zeros in the hesa id

### Guidance to review

* I've run the backfill on dttp import to see how it performs. It took just over 3 mins to run. It updates around 355 trainees.
* Check nil handling is covered

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
