### PR TITLE
[4305] Set UUID fields when importing from Apply

### DIFF
--- a/app/forms/degree_form.rb
+++ b/app/forms/degree_form.rb
@@ -33,7 +33,7 @@ class DegreeForm
 
   validates :institution, inclusion: { in: Degree::INSTITUTIONS }, allow_nil: true
   validates :subject, inclusion: { in: Degree::SUBJECTS }, allow_nil: true
-  validates :uk_degree, inclusion: { in: Degree::DEGREE_TYPES }, allow_nil: true
+  validates :uk_degree, inclusion: { in: Degree::TYPES }, allow_nil: true
 
   delegate :uk?, :non_uk?, :non_uk_degree_non_enic?, :persisted?, to: :degree
 

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -4,27 +4,27 @@ module DegreesHelper
   include ApplicationHelper
 
   def degree_type_options
-    to_enhanced_options(degree_type_data) do |name, attributes|
-      synonyms = (attributes[:synonyms] || []) << attributes[:abbreviation]
+    to_enhanced_options(degree_type_data) do |ref_data|
+      synonyms = (ref_data[:synonyms] || []) << ref_data[:abbreviation]
       data = {
         "data-synonyms" => synonyms.join("|"),
-        "data-append" => attributes[:abbreviation] && tag.strong("(#{attributes[:abbreviation]})"),
-        "data-boost" => (Dttp::CodeSets::DegreeTypes::COMMON.include?(name) ? 1.5 : 1),
-        "data-hint" => attributes[:hint] && tag.span(attributes[:hint], class: "autocomplete__option--hint"),
+        "data-append" => ref_data[:abbreviation] && tag.strong("(#{ref_data[:abbreviation]})"),
+        "data-boost" => (Degree::COMMON_TYPES.include?(ref_data[:name]) ? 1.5 : 1),
+        "data-hint" => ref_data[:hint] && tag.span(ref_data[:hint], class: "autocomplete__option--hint"),
       }.compact
-      [name, name, data]
+      [ref_data[:name], ref_data[:name], data]
     end
   end
 
   def institutions_options
-    to_enhanced_options(institution_data) do |name, attributes|
-      [name, name, { "data-synonyms" => (attributes[:synonyms] || []).join("|") }]
+    to_enhanced_options(institution_data) do |ref_data|
+      [ref_data[:name], ref_data[:name], { "data-synonyms" => (ref_data[:synonyms] || []).join("|") }]
     end
   end
 
   def subjects_options
-    to_enhanced_options(subject_data) do |name, attributes|
-      [name, name, { "data-synonyms" => (attributes[:synonyms] || []).join("|") }]
+    to_enhanced_options(subject_data) do |ref_data|
+      [ref_data[:name], ref_data[:name], { "data-synonyms" => (ref_data[:synonyms] || []).join("|") }]
     end
   end
 
@@ -33,7 +33,7 @@ module DegreesHelper
   end
 
   def grades
-    Dttp::CodeSets::Grades::MAPPING.keys
+    Degree::GRADES
   end
 
   def path_for_degrees(trainee)
@@ -45,15 +45,15 @@ module DegreesHelper
 private
 
   def institution_data
-    Dttp::CodeSets::Institutions::MAPPING
+    DfE::ReferenceData::Degrees::INSTITUTIONS.all
   end
 
   def subject_data
-    Dttp::CodeSets::DegreeSubjects::MAPPING
+    DfE::ReferenceData::Degrees::SUBJECTS.all
   end
 
   def degree_type_data
-    Dttp::CodeSets::DegreeTypes::MAPPING
+    DfE::ReferenceData::Degrees::TYPES.all
   end
 
   def countries

--- a/app/helpers/mappings_helper.rb
+++ b/app/helpers/mappings_helper.rb
@@ -12,7 +12,9 @@ module MappingsHelper
   end
 
   def almost_identical?(source_string, incoming_string)
-    sanitised_word(incoming_string).start_with?(sanitised_word(source_string))
+    return false if source_string.blank? || incoming_string.blank?
+
+    sanitised_word(source_string.downcase)&.start_with?(sanitised_word(incoming_string.downcase))
   end
 
   def sanitised_word(word)
@@ -26,6 +28,6 @@ module MappingsHelper
 
     # The hesa code can sometimes be padded with some leading zeros
     # So we need to sensibly convert the strings to their integer values for an equal comparison
-    BigDecimal(code).to_i
+    BigDecimal(code).to_i.to_s
   end
 end

--- a/app/lib/dttp/code_sets/degree_types.rb
+++ b/app/lib/dttp/code_sets/degree_types.rb
@@ -5,8 +5,6 @@ module Dttp
     module DegreeTypes
       BACHELOR_OF_ARTS = "Bachelor of Arts"
 
-      COMMON = [BACHELOR_OF_ARTS, "Bachelor of Science", "Master of Arts", "PhD"].freeze
-
       MAPPING = {
         BACHELOR_OF_ARTS => { entity_id: "db695652-c197-e711-80d8-005056ac45bb", abbreviation: "BA", hesa_code: "51" },
         "Bachelor of Arts Economics" => { entity_id: "dd695652-c197-e711-80d8-005056ac45bb", abbreviation: "BAEcon", hesa_code: "52" },

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -3,9 +3,16 @@
 class Degree < ApplicationRecord
   include Sluggable
 
-  INSTITUTIONS = Dttp::CodeSets::Institutions::MAPPING.keys
-  SUBJECTS = Dttp::CodeSets::DegreeSubjects::MAPPING.keys
-  DEGREE_TYPES = Dttp::CodeSets::DegreeTypes::MAPPING.keys
+  INSTITUTIONS = DfE::ReferenceData::Degrees::INSTITUTIONS.all.map(&:name)
+  SUBJECTS = DfE::ReferenceData::Degrees::SUBJECTS.all.map(&:name)
+  TYPES = DfE::ReferenceData::Degrees::TYPES.all.map(&:name)
+  COMMON_TYPES = ["Bachelor of Arts", "Bachelor of Science", "Master of Arts", "PhD"].freeze
+
+  # TODO: switch over to DfE::ReferenceData::GRADES when the time is right. Currently,
+  # it doesn't support 'Other' and it has a lot more options which come from DTTP/HESA.
+  GRADES = Dttp::CodeSets::Grades::MAPPING.keys
+  OTHER_GRADE = "Other"
+
   MAX_GRAD_YEARS = 60
 
   attr_writer :is_apply_import

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -60,6 +60,7 @@ shared:
     - created_at
     - dttp_id
     - grade
+    - grade_uuid
     - graduation_year
     - id
     - institution
@@ -69,8 +70,10 @@ shared:
     - other_grade
     - slug
     - subject
+    - subject_uuid
     - trainee_id
     - uk_degree
+    - uk_degree_uuid
     - updated_at
   disabilities:
     - created_at

--- a/db/migrate/20220630135252_add_uuid_columns_to_degrees.rb
+++ b/db/migrate/20220630135252_add_uuid_columns_to_degrees.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddUuidColumnsToDegrees < ActiveRecord::Migration[6.1]
+  def change
+    change_table :degrees, bulk: true do |t|
+      t.uuid :uk_degree_uuid
+      t.uuid :subject_uuid
+      t.uuid :grade_uuid
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_22_105221) do
+ActiveRecord::Schema.define(version: 2022_06_30_135252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -202,6 +202,9 @@ ActiveRecord::Schema.define(version: 2022_06_22_105221) do
     t.string "slug", null: false
     t.uuid "dttp_id"
     t.uuid "institution_uuid"
+    t.uuid "uk_degree_uuid"
+    t.uuid "subject_uuid"
+    t.uuid "grade_uuid"
     t.index ["dttp_id"], name: "index_degrees_on_dttp_id"
     t.index ["locale_code"], name: "index_degrees_on_locale_code"
     t.index ["slug"], name: "index_degrees_on_slug", unique: true

--- a/spec/components/invalid_data_text/view_spec.rb
+++ b/spec/components/invalid_data_text/view_spec.rb
@@ -17,7 +17,7 @@ module InvalidDataText
 
       it "renders the correct css" do
         expect(rendered_component).to have_css(".app-inset-text__title")
-        expect(rendered_component).to have_text("The trainee entered ‘University of Warwick’, which was not recognised. You need to search for the closest match.")
+        expect(rendered_component).to have_text("The trainee entered ‘Unknown institution’, which was not recognised. You need to search for the closest match.")
       end
     end
 

--- a/spec/factories/apply_applications.rb
+++ b/spec/factories/apply_applications.rb
@@ -3,15 +3,20 @@
 FactoryBot.define do
   factory :apply_application do
     sequence(:apply_id)
-    application { JSON.parse(ApiStubs::ApplyApi.application) }
+    application { JSON.parse(ApiStubs::ApplyApi.application(degree_attributes: degree_attributes)) }
     invalid_data { {} }
     accredited_body_code { create(:provider).code }
     recruitment_cycle_year { Settings.apply_applications.create.recruitment_cycle_year }
 
     transient do
       degree_slug { SecureRandom.base58(Sluggable::SLUG_LENGTH).to_s }
-      invalid_institution { "University of Warwick" }
+      invalid_institution { "Unknown institution" }
       invalid_subject { "History1" }
+      degree_attributes { {} }
+    end
+
+    trait :invalid do
+      degree_attributes { { institution_details: invalid_institution } }
     end
 
     trait :importable do
@@ -23,6 +28,7 @@ FactoryBot.define do
     end
 
     trait :with_invalid_data do
+      invalid
       invalid_data do
         {
           "degrees" => {

--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -12,18 +12,16 @@ FactoryBot.define do
 
     trait :uk_degree_type do
       locale_code { :uk }
-      uk_degree { Dttp::CodeSets::DegreeTypes::MAPPING.keys.sample }
+      uk_degree { Degree::TYPES.sample }
     end
 
     trait :uk_degree_with_details do
       uk_degree_type
-
-      subject { Dttp::CodeSets::DegreeSubjects::MAPPING.keys.sample }
-
-      institution { Dttp::CodeSets::Institutions::MAPPING.keys.sample }
-      grade { Dttp::CodeSets::Grades::MAPPING.keys.sample }
+      subject { Degree::SUBJECTS.sample }
+      grade { Degree::GRADES.sample }
       graduation_year { rand(NEXT_YEAR - Degree::MAX_GRAD_YEARS..NEXT_YEAR) }
       institution_uuid { DfE::ReferenceData::Degrees::INSTITUTIONS.all_as_hash.keys.sample }
+      institution { institution_uuid && DfE::ReferenceData::Degrees::INSTITUTIONS.one(institution_uuid)[:name] }
     end
 
     trait :non_uk_degree_type do
@@ -34,10 +32,8 @@ FactoryBot.define do
 
     trait :non_uk_degree_with_details do
       non_uk_degree_type
-
-      subject { Dttp::CodeSets::DegreeSubjects::MAPPING.keys.sample }
-
-      grade { Dttp::CodeSets::Grades::MAPPING.keys.sample }
+      subject { Degree::SUBJECTS.sample }
+      grade { Degree::GRADES.sample }
       country { Dttp::CodeSets::Countries::MAPPING.keys.sample }
       graduation_year { rand(NEXT_YEAR - Degree::MAX_GRAD_YEARS..NEXT_YEAR) }
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -479,7 +479,7 @@ FactoryBot.define do
     end
 
     trait :with_invalid_apply_application do
-      degrees { [build(:degree, :uk_degree_with_details, institution: "University of Warwick")] }
+      degrees { [build(:degree, :uk_degree_with_details, institution: "Unknown institution")] }
       apply_application { build(:apply_application, :with_invalid_data, degree_slug: degrees.first.slug) }
     end
 

--- a/spec/forms/degree_form_spec.rb
+++ b/spec/forms/degree_form_spec.rb
@@ -111,11 +111,11 @@ describe DegreeForm, type: :model do
     end
 
     context "degree transitions from invalid to valid" do
-      let(:trainee) { build(:trainee, :with_invalid_apply_application) }
+      let(:trainee) { create(:trainee, :with_invalid_apply_application) }
       let(:degree) { trainee.degrees.first }
 
       before do
-        degree.institution = Dttp::CodeSets::Institutions::MAPPING.keys.sample
+        degree.institution = Degree::INSTITUTIONS.sample
       end
 
       it "deletes the invalid degree" do

--- a/spec/helpers/degree_helper_spec.rb
+++ b/spec/helpers/degree_helper_spec.rb
@@ -11,9 +11,15 @@ describe DegreesHelper do
     let(:degree_synonym) { "Bachelors" }
 
     before do
-      stub_const("Dttp::CodeSets::DegreeTypes::MAPPING", {
-        degree_type => { abbreviation: degree_abbreviation, synonyms: [degree_synonym] },
-      })
+      stub_const("DfE::ReferenceData::Degrees::TYPES",
+                 DfE::ReferenceData::HardcodedReferenceList.new({
+                   SecureRandom.uuid => {
+                     name: degree_type,
+                     abbreviation: degree_abbreviation,
+                     synonyms: [degree_synonym],
+                   },
+                 }))
+
       stub_const("Dttp::CodeSets::DegreeTypes::COMMON", [degree_type])
     end
 
@@ -38,9 +44,13 @@ describe DegreesHelper do
     let(:synonym) { "UCL" }
 
     before do
-      stub_const("Dttp::CodeSets::Institutions::MAPPING", {
-        institution => { synonyms: [synonym] },
-      })
+      stub_const("DfE::ReferenceData::Degrees::INSTITUTIONS",
+                 DfE::ReferenceData::HardcodedReferenceList.new({
+                   SecureRandom.uuid => {
+                     name: institution,
+                     synonyms: [synonym],
+                   },
+                 }))
     end
 
     it "iterates over array and prints out correct institutions options" do
@@ -56,9 +66,13 @@ describe DegreesHelper do
     let(:synonym) { "maths" }
 
     before do
-      stub_const("Dttp::CodeSets::DegreeSubjects::MAPPING", {
-        degree_subject => { synonyms: [synonym] },
-      })
+      stub_const("DfE::ReferenceData::Degrees::SUBJECTS",
+                 DfE::ReferenceData::HardcodedReferenceList.new({
+                   SecureRandom.uuid => {
+                     name: degree_subject,
+                     synonyms: [synonym],
+                   },
+                 }))
     end
 
     it "iterates over array and prints out correct subjects values" do

--- a/spec/helpers/mappings_helper_spec.rb
+++ b/spec/helpers/mappings_helper_spec.rb
@@ -37,7 +37,7 @@ describe MappingsHelper do
 
   describe "#sanitised_hesa" do
     it "returns the integer value for a hesa code" do
-      expect(sanitised_hesa("004")).to eq(4)
+      expect(sanitised_hesa("004")).to eq("4")
     end
 
     it "returns nil if no code is given" do

--- a/spec/helpers/trainee_helper_spec.rb
+++ b/spec/helpers/trainee_helper_spec.rb
@@ -55,7 +55,7 @@ describe TraineeHelper do
 
     context "with invalid data" do
       it "return the invalid data message" do
-        expect(invalid_data_message("institution", degree)).to eq("The trainee entered ‘University of Warwick’, which was not recognised. You need to search for the closest match.")
+        expect(invalid_data_message("institution", degree)).to eq("The trainee entered ‘Unknown institution’, which was not recognised. You need to search for the closest match.")
       end
     end
 

--- a/spec/services/degrees/create_from_apply_spec.rb
+++ b/spec/services/degrees/create_from_apply_spec.rb
@@ -14,23 +14,40 @@ module Degrees
       }.to change(trainee.degrees, :count).by(1)
     end
 
-    it "updates invalid entries against the ApplyApplication" do
-      create_from_apply
-      created_degree_slug = trainee.degrees.last.slug
-      expect(trainee.apply_application.degrees_invalid_data).to eq({ created_degree_slug => { "institution" => "University of Warwick" } })
+    context "invalid application" do
+      let(:trainee) { create(:trainee, :with_invalid_apply_application) }
+
+      it "updates invalid entries against the ApplyApplication" do
+        create_from_apply
+        created_degree_slug = trainee.degrees.last.slug
+        expect(trainee.apply_application.degrees_invalid_data).to eq({
+          created_degree_slug => {
+            "institution" => "Unknown institution",
+          },
+        })
+      end
     end
 
     context "with multiple degrees" do
+      let(:trainee) { create(:trainee, :with_apply_application) }
+      let(:invalid_institution) { "Unknown institution" }
+      let(:invalid_apply_degree) do
+        ApiStubs::ApplyApi.uk_degree(institution_details: invalid_institution).transform_keys(&:to_s)
+      end
+
       before do
-        trainee.apply_application.application_attributes["qualifications"]["degrees"] << ApiStubs::ApplyApi.uk_degree.transform_keys(&:to_s)
+        trainee.apply_application.application_attributes["qualifications"]["degrees"] = [
+          invalid_apply_degree,
+          invalid_apply_degree,
+        ]
       end
 
       it "updates invalid entries against the ApplyApplication" do
         create_from_apply
         degree_one_slug, degree_two_slug = trainee.degrees.pluck(:slug)
         expect(trainee.apply_application.degrees_invalid_data).to eq({
-          degree_one_slug => { "institution" => "University of Warwick" },
-          degree_two_slug => { "institution" => "University of Warwick" },
+          degree_one_slug => { "institution" => invalid_institution },
+          degree_two_slug => { "institution" => invalid_institution },
         })
       end
     end

--- a/spec/services/degrees/map_from_apply_spec.rb
+++ b/spec/services/degrees/map_from_apply_spec.rb
@@ -4,15 +4,46 @@ require "rails_helper"
 
 module Degrees
   describe MapFromApply do
-    let(:application_data) { ApiStubs::ApplyApi.application }
-    let(:apply_application) { create(:apply_application, application: application_data) }
+    let(:degree_subject) { "Accountancy" }
+    let(:degree_grade) { "First-class honours" }
+    let(:degree_qualification_type) { "Bachelor of Accountancy" }
+    let(:degree_institution) { "The Open University" }
     let(:degree_attributes) { JSON.parse(application_data).dig("attributes", "qualifications", "degrees").first }
-    let(:expected_subject) { degree_attributes["subject"] }
+
+    let(:application_data) do
+      ApiStubs::ApplyApi.application(degree_attributes: {
+        subject: dfe_degree_subject_reference_data[:name],
+        hesa_degsbj: dfe_degree_subject_reference_data[:hesa_itt_code],
+        grade: dfe_degree_grade_reference_data[:name],
+        hesa_degclss: dfe_degree_grade_reference_data[:hesa_itt_code],
+        qualification_type: dfe_degree_type_reference_data[:abbreviation],
+        hesa_degtype: dfe_degree_type_reference_data[:hesa_itt_code],
+        institution_details: dfe_degree_institution_reference_data[:name],
+        hesa_degest: dfe_degree_institution_reference_data[:hesa_itt_code],
+      })
+    end
+
+    let(:dfe_degree_type_reference_data) do
+      DfE::ReferenceData::Degrees::TYPES.some(name: degree_qualification_type).first
+    end
+
+    let(:dfe_degree_subject_reference_data) do
+      DfE::ReferenceData::Degrees::SUBJECTS.some(name: degree_subject).first
+    end
+
+    let(:dfe_degree_grade_reference_data) do
+      DfE::ReferenceData::Degrees::GRADES.some(name: degree_grade).first
+    end
+
+    let(:dfe_degree_institution_reference_data) do
+      DfE::ReferenceData::Degrees::INSTITUTIONS.some(name: degree_institution).first
+    end
 
     let(:common_attributes) do
       {
         is_apply_import: true,
-        subject: expected_subject,
+        subject: dfe_degree_subject_reference_data[:name],
+        subject_uuid: dfe_degree_subject_reference_data[:id],
         graduation_year: degree_attributes["award_year"],
       }
     end
@@ -23,150 +54,66 @@ module Degrees
     it { is_expected.to include(common_attributes) }
 
     context "with a uk degree" do
-      let(:expected_institution) { degree_attributes["institution_details"] }
-      let(:expected_uk_degree) { Dttp::CodeSets::DegreeTypes::BACHELOR_OF_ARTS }
-      let(:expected_grade) { Dttp::CodeSets::Grades::FIRST_CLASS_HONOURS }
-
       let(:expected_uk_degree_attributes) do
         {
           locale_code: Trainee.locale_codes[:uk],
-          uk_degree: expected_uk_degree,
-          institution: expected_institution,
-          grade: expected_grade,
+          uk_degree: dfe_degree_type_reference_data[:name],
+          uk_degree_uuid: dfe_degree_type_reference_data[:id],
+          institution: dfe_degree_institution_reference_data[:name],
+          institution_uuid: dfe_degree_institution_reference_data[:id],
+          grade: dfe_degree_grade_reference_data[:name],
+          grade_uuid: dfe_degree_grade_reference_data[:id],
         }
-      end
-
-      context "institution" do
-        let(:expected_institution) { "The University of Love" }
-        let(:stub_institution_mapping) { { expected_institution => { entity_id: "1", hesa_code: "1" } } }
-
-        let(:application_data) do
-          ApiStubs::ApplyApi.application(degree_attributes: { hesa_degest: "0001" })
-        end
-
-        before do
-          stub_const("Dttp::CodeSets::Institutions::MAPPING", stub_institution_mapping)
-        end
-
-        it { is_expected.to include(expected_uk_degree_attributes) }
-      end
-
-      context "subject" do
-        let(:expected_subject) { "Art of charm" }
-        let(:stub_subject_mapping) { { expected_subject => { entity_id: "1" } } }
-
-        let(:application_data) do
-          ApiStubs::ApplyApi.application(degree_attributes: { subject: "art Of ChaRm" })
-        end
-
-        before do
-          stub_const("Dttp::CodeSets::DegreeSubjects::MAPPING", stub_subject_mapping)
-        end
-
-        it { is_expected.to include(expected_uk_degree_attributes) }
-      end
-
-      context "degree type" do
-        let(:stub_degree_type_mapping) do
-          {
-            "Bachelor of Charm" => { entity_id: "1", abbreviation: "BAc", hesa_code: "1" },
-            "Doctor of Love" => { entity_id: "2", abbreviation: "BAs", hesa_code: "2" },
-          }
-        end
-
-        before do
-          stub_const("Dttp::CodeSets::DegreeTypes::MAPPING", stub_degree_type_mapping)
-        end
-
-        context "with hesa code" do
-          let(:expected_uk_degree) { "Bachelor of Charm" }
-
-          let(:application_data) do
-            ApiStubs::ApplyApi.application(degree_attributes: { hesa_degtype: "0001" })
-          end
-
-          it { is_expected.to include(expected_uk_degree_attributes) }
-        end
-
-        context "with abbreviation" do
-          let(:expected_uk_degree) { "Doctor of Love" }
-
-          let(:application_data) do
-            ApiStubs::ApplyApi.application(degree_attributes: { qualification_type: "BAs" })
-          end
-
-          it { is_expected.to include(expected_uk_degree_attributes) }
-        end
-      end
-
-      context "grade" do
-        let(:expected_grade) { Dttp::CodeSets::Grades::FIRST_CLASS_HONOURS }
-
-        context "with hesa code" do
-          let(:application_data) do
-            ApiStubs::ApplyApi.application(degree_attributes: { hesa_degclss: "01", grade: "First class honours" })
-          end
-
-          it "sets the value to the actual grade" do
-            expect(subject).to include(
-              expected_uk_degree_attributes.merge(other_grade: nil),
-            )
-          end
-        end
-
-        context "when the grade is predicted" do
-          let(:application_data) do
-            ApiStubs::ApplyApi.application(degree_attributes: { hesa_degclss: nil, grade: grade })
-          end
-
-          context "first-class honours" do
-            let(:grade) { "First class honours (Predicted)" }
-
-            it "sets the value to the actual grade" do
-              expect(subject).to include(expected_uk_degree_attributes.merge(other_grade: nil))
-            end
-          end
-
-          context "second-class honours" do
-            let(:expected_grade) { Dttp::CodeSets::Grades::UPPER_SECOND_CLASS_HONOURS }
-            let(:grade) { "Upper second-class honours (2:1)(2:1(predicted)" }
-
-            it "sets the value to the actual grade" do
-              expect(subject).to include(expected_uk_degree_attributes.merge(other_grade: nil))
-            end
-          end
-        end
-
-        context "when the grade can't be found" do
-          let(:expected_grade) { Dttp::CodeSets::Grades::OTHER }
-
-          let(:application_data) do
-            ApiStubs::ApplyApi.application(degree_attributes: { hesa_degclss: nil, grade: "merit" })
-          end
-
-          it "sets the value to other" do
-            expect(subject).to include(
-              expected_uk_degree_attributes.merge(other_grade: degree_attributes["grade"]),
-            )
-          end
-        end
       end
 
       it { is_expected.to include(expected_uk_degree_attributes) }
+
+      context "HESA codes are not present" do
+        let(:application_data) do
+          ApiStubs::ApplyApi.application(degree_attributes: {
+            uk_degree: dfe_degree_type_reference_data[:name],
+            subject: dfe_degree_subject_reference_data[:name],
+            grade: dfe_degree_grade_reference_data[:name],
+            qualification_type: dfe_degree_type_reference_data[:abbreviation],
+            institution_details: dfe_degree_institution_reference_data[:name],
+          })
+        end
+
+        it { is_expected.to include(expected_uk_degree_attributes) }
+      end
+
+      context "grade outside the Register scope (Dttp::CodeSets::Grades::MAPPING)" do
+        let(:degree_grade) { "Aegrotat" }
+
+        before do
+          ApiStubs::ApplyApi.application(degree_attributes: {
+            grade: dfe_degree_grade_reference_data[:name],
+            grade_uuid: dfe_degree_grade_reference_data[:id],
+          })
+        end
+
+        it "stores the UUID but saved the name in the other_grade attribute" do
+          expect(subject).to include(grade: Dttp::CodeSets::Grades::OTHER,
+                                     grade_uuid: dfe_degree_grade_reference_data[:id],
+                                     other_grade: dfe_degree_grade_reference_data[:name])
+        end
+      end
     end
 
     context "with a non-uk degree" do
-      let(:non_uk_degree_attributes) do
+      let(:application_data) do
+        ApiStubs::ApplyApi.non_uk_application(degree_attributes: { subject: degree_subject }).to_json
+      end
+
+      let(:expected_non_uk_degree_attributes) do
         {
           locale_code: Trainee.locale_codes[:non_uk],
-          non_uk_degree: degree_attributes["comparable_uk_degree"],
           country: "St Kitts and Nevis",
+          non_uk_degree: degree_attributes["comparable_uk_degree"],
         }
       end
 
-      let(:degree_attributes) { ApiStubs::ApplyApi.non_uk_degree.as_json }
-
-      it { is_expected.to include(non_uk_degree_attributes) }
+      it { is_expected.to include(expected_non_uk_degree_attributes) }
     end
   end
 end

--- a/spec/support/api_stubs/apply_api.rb
+++ b/spec/support/api_stubs/apply_api.rb
@@ -42,7 +42,7 @@ module ApiStubs
       }
     end
 
-    def self.non_uk_application
+    def self.non_uk_application(degree_attributes: {})
       {
         id: "3772",
         type: "application",
@@ -55,7 +55,7 @@ module ApiStubs
           candidate: candidate_info,
           contact_details: non_uk_contact_details,
           course: course,
-          qualifications: qualifications,
+          qualifications: non_uk_qualifications(degree_attributes),
           hesa_itt_data: {},
         },
       }
@@ -83,7 +83,7 @@ module ApiStubs
       }.merge(degree_attributes)
     end
 
-    def self.non_uk_degree
+    def self.non_uk_degree(degree_attributes = {})
       {
         id: 123,
         qualification_type: "BA",
@@ -92,17 +92,17 @@ module ApiStubs
         grade: "AA*B",
         start_year: "1989",
         award_year: "1992",
-        institution_details: "University of Huddersfield",
+        institution_details: "",
         equivalency_details: "Enic: 4000123456 - Between GCSE and GCSE AS Level - Equivalent to GCSE C",
         comparable_uk_degree: "masters_degree",
-        hesa_degtype: "085",
-        hesa_degsbj: "100323",
-        hesa_degclss: "12",
-        hesa_degest: "0052",
+        hesa_degtype: "",
+        hesa_degsbj: "",
+        hesa_degclss: "",
+        hesa_degest: "",
         hesa_degctry: "KN",
         hesa_degstdt: "2021-01-01",
         hesa_degenddt: "2020-01-01",
-      }
+      }.merge(degree_attributes)
     end
 
     def self.candidate_info(candidate_attributes = {})
@@ -177,6 +177,14 @@ module ApiStubs
           },
         ],
         degrees: [uk_degree(degree_attributes)],
+        other_qualifications: [],
+        missing_gcses_explanation: nil,
+      }
+    end
+
+    def self.non_uk_qualifications(degree_attributes = {})
+      {
+        degrees: [non_uk_degree(degree_attributes)],
         other_qualifications: [],
         missing_gcses_explanation: nil,
       }


### PR DESCRIPTION
### Context
https://trello.com/c/3ccIySaQ/4305-m-set-uuid-fields-when-importing-from-apply

### Changes proposed in this pull request
- DB migration to add `uk_degree_uuid`, `subject_uuid` and `grade_uuid` to degrees table
- Update `Degrees::MapFromApply` to use `DfE::ReferenceData`
- Fix various specs that broke after using `DfE::ReferenceData`. `DfE::ReferenceData` is slightly different than the DTTP codesets data. For example, names are sentence case, not title case.
- Add new database fields to `analytics.yml`

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
