### PR TITLE
Xxx add worker console make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,10 @@ console: read-tf-config
 	cf target -s ${space}
 	cf ssh register-${DEPLOY_ENV} -t -c "cd /app && /usr/local/bin/bundle exec rails c"
 
+worker-console: read-tf-config
+	cf target -s ${space}
+	cf ssh register-worker-${DEPLOY_ENV} -t -c "cd /app && /usr/local/bin/bundle exec rails c"
+
 enable-maintenance: read-tf-config ## make qa enable-maintenance / make production enable-maintenance CONFIRM_PRODUCTION=y
 	$(if $(HOST_NAME), $(eval REAL_HOSTNAME=${HOST_NAME}), $(eval REAL_HOSTNAME=${DEPLOY_ENV}))
 	cf target -s ${space}

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,14 @@ worker-console: read-tf-config
 	cf target -s ${space}
 	cf ssh register-worker-${DEPLOY_ENV} -t -c "cd /app && /usr/local/bin/bundle exec rails c"
 
+ssh: read-tf-config
+	cf target -s ${space}
+	cf ssh register-${DEPLOY_ENV}
+
+worker-ssh: read-tf-config
+	cf target -s ${space}
+	cf ssh register-worker-${DEPLOY_ENV}
+
 enable-maintenance: read-tf-config ## make qa enable-maintenance / make production enable-maintenance CONFIRM_PRODUCTION=y
 	$(if $(HOST_NAME), $(eval REAL_HOSTNAME=${HOST_NAME}), $(eval REAL_HOSTNAME=${DEPLOY_ENV}))
 	cf target -s ${space}


### PR DESCRIPTION
### Context

We have `make` commands for common interactions with parts of our infrastructure.

When running things on a production machine we try to use the worker instances to avoid overloading the applications servers.

### Changes proposed in this pull request

* Add some commands to help:
  * `make <env> worker-console` - Rails console on a worker instance
  * `make <env> worker-ssh` - SSH onto a worker instance
  * `make <env> ssh` - SSH onto an app server

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
