### PR TITLE
[4316] Use placement assignment data to add hesa_updated_at to hesa trainees created from DTTP

### DIFF
--- a/db/data/20220707105550_backfill_hesa_updated_at_for_dttp_trainees_on_trainees.rb
+++ b/db/data/20220707105550_backfill_hesa_updated_at_for_dttp_trainees_on_trainees.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class BackfillHesaUpdatedAtForDttpTraineesOnTrainees < ActiveRecord::Migration[6.1]
+  def up
+    trainees = Trainee.imported_from_hesa.where(start_academic_cycle: AcademicCycle.current, hesa_updated_at: nil)
+
+    trainees.each do |trainee|
+      dttp_trainee = trainee.dttp_trainee
+      trainee.update_columns(hesa_updated_at: find_hesa_placement_update_date_for(dttp_trainee)) if dttp_trainee
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def find_hesa_placement_update_date_for(dttp_trainee)
+    dttp_trainee.latest_placement_assignment.response["dfe_hesamodifiedon"] || dttp_trainee.latest_placement_assignment.response["dfe_hesacreatedon"]
+  end
+end


### PR DESCRIPTION
### Context

We realised there are a few trainees starting in this academic cycle that are HESA trainees, but came from DTTP. I wasn't able to backfill the `hesa_updated_at` from `hesa_students` for these, so I've taken it from the latest placement assignment instead.

I'm using `"dfe_hesamodifiedon"` or `"dfe_hesacreatedon"` in the latest placement assignment response to update the date.
 
### Changes proposed in this pull request

* Backfill to add hesa_updated_at to hesa trainees that came from DTTP

### Guidance to review

* I've run this on DTTP import and it runs fast (3 mins to deployment)
* All 13 trainees have been updated with a `hesa_updated_at`
* There now shouldn't be any trainees starting this academic year without a `hesa_updated_at`

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
