### PR TITLE
[4306] Rework vulnerable character handling to render negative amounts correctly

### DIFF
--- a/app/helpers/exports_helper.rb
+++ b/app/helpers/exports_helper.rb
@@ -2,10 +2,14 @@
 
 module ExportsHelper
   VULNERABLE_CHARACTERS = %w[= + - @].freeze
+  NEGATIVE_AMOUNT_PREFIX = %w[-£].freeze
+  SAFE_NEGATIVE_AMOUNT_REGEX = /\A-{1}£{1}\d+\,?\d+\.?\d*\Z/.freeze
 
   def sanitize(value)
     return value unless value.is_a?(String)
 
-    value.to_s.starts_with?(*VULNERABLE_CHARACTERS) ? value.to_s : value
+    return value if value.to_s.starts_with?(*NEGATIVE_AMOUNT_PREFIX) && value.match?(SAFE_NEGATIVE_AMOUNT_REGEX)
+
+    value.to_s.starts_with?(*VULNERABLE_CHARACTERS) ? "'#{value}" : value
   end
 end

--- a/spec/services/exports/funding_schedule_data_spec.rb
+++ b/spec/services/exports/funding_schedule_data_spec.rb
@@ -100,6 +100,57 @@ module Exports
       def format_amount(amount_in_pence)
         amount_in_pence.zero? ? "0" : "\"#{ActionController::Base.helpers.number_to_currency(amount_in_pence.to_d / 100, unit: '£')}\""
       end
+
+      context "with vulnerabilities in the data" do
+        let(:expected_header_line) do
+          "Month,'@Training bursary trainees,'+Course extension provider payments,Month total"
+        end
+        let(:expected_data_line) do
+          "'=January 2022,£12.34,£23.45,£35.79"
+        end
+
+        before do
+          suspect_data = [
+            {
+              MONTH_HEADING => "=January 2022",
+              "@Training bursary trainees" => 1234,
+              "+Course extension provider payments" => 2345,
+              MONTH_TOTAL_HEADING => 3579,
+            },
+          ]
+          allow(exporter).to receive(:data).and_return(suspect_data)
+        end
+
+        it "Sanitizes header line correctly" do
+          expect(exporter.to_csv).to include(expected_header_line)
+        end
+
+        it "Sanitizes data correctly" do
+          expect(exporter.to_csv).to include(expected_data_line)
+        end
+      end
+
+      context "with negative prefixes in the data" do
+        let(:expected_data_line_with_negative_prefixes) do
+          "'-£January 2022,\"-£1,234.00\",\"-£2,345.00\",\"-£3,579.00\""
+        end
+
+        before do
+          suspect_data = [
+            {
+              MONTH_HEADING => "-£January 2022",
+              "@Training bursary trainees" => -123400,
+              "+Course extension provider payments" => -234500,
+              MONTH_TOTAL_HEADING => -357900,
+            },
+          ]
+          allow(exporter).to receive(:data).and_return(suspect_data)
+        end
+
+        it "renders strings and numeric values correctly" do
+          expect(exporter.to_csv).to include(expected_data_line_with_negative_prefixes)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Trello ticket: https://trello.com/c/vPp4EaD0/4306-m-rework-vulnerable-character-handling-in-funding-exports

We had introduced some vulnerable character handling on the CSV exports. This was rendering numeric values starting with a minus sign as strings in Excel, which meant that providers could not easily manipulate their financial data.

In this PR I've reintroduced the vulnerable character handling but have added a regex to exclude numeric values starting with '-£' 

I've been reading the OWASP guidance which also suggests the below:
* Wrap each cell field in double quotes
* Prepend each cell field with a single quote
* Escape every double quote using an additional double quote

I originally implemented this but it looks horrible in some of the fields and made the data harder to use.

### Changes proposed in this pull request

* Add new regex condition into export_helper for string values starting with '-£' and only containing digits
* Reimplement vulnerable character sanitizing

### Guidance to review

* Please test out my regex and make sure it makes sense
* Export the CSVs and sense check them
* Open and check CSVs in Excel and Numbers if possible
* I've tested on DTTP import env with Liverpool Hope and the minus amounts are now coming through correctly and can be summed as numbers

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
