### PR TITLE
[xxx] Map non-HESA subjects for DQT

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -115,6 +115,11 @@ module Dqt
       end
 
       def course_subject_code(subject_name)
+        # these three subjects are not coded by HESA so we've agreed these encodings with the DQT team
+        return "999001" if subject_name == ::CourseSubjects::CITIZENSHIP
+        return "999002" if subject_name == ::CourseSubjects::PHYSICAL_EDUCATION
+        return "999003" if subject_name == ::CourseSubjects::DESIGN_AND_TECHNOLOGY
+
         Hesa::CodeSets::CourseSubjects::MAPPING.invert[subject_name]
       end
 

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -115,6 +115,34 @@ module Dqt
             expect(subject["qualification"]).to be_nil
           end
         end
+
+        context "when the trainee course subject one is non-hesa" do
+          let(:trainee) { create(:trainee, :completed, course_subject_one: course_subject) }
+
+          context "citizenship" do
+            let(:course_subject) { ::CourseSubjects::CITIZENSHIP }
+
+            it "sets subject to 999001" do
+              expect(subject["initialTeacherTraining"]["subject1"]).to eq("999001")
+            end
+          end
+
+          context "physical education" do
+            let(:course_subject) { ::CourseSubjects::PHYSICAL_EDUCATION }
+
+            it "sets subject to 999002" do
+              expect(subject["initialTeacherTraining"]["subject1"]).to eq("999002")
+            end
+          end
+
+          context "design and technology" do
+            let(:course_subject) { ::CourseSubjects::DESIGN_AND_TECHNOLOGY }
+
+            it "sets subject to 999003" do
+              expect(subject["initialTeacherTraining"]["subject1"]).to eq("999003")
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

We send course information to DQT. Subjects are encoded using the encodings from HESA. We have added three subjects to the register list that don't currently existing in that codeset.

We've agreed encodings with the DQT team for the non-HESA subjects that we added.

* citizenship - 999001
* physical education - 999002
* design and technology - 999003

### Changes proposed in this pull request

* Add the new encodings to the params we send to DQT.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
