### PR TITLE
4331 set academic cycles on create

### DIFF
--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -26,11 +26,11 @@ module Trainees
 
       raise(MissingCourseError, "Cannot find course with uuid: #{@raw_course['course_uuid']}") if course.nil? # Courses can be missing in non-prod environments
 
+      Trainees::SetAcademicCycles.call(trainee: trainee)
       trainee.save!
       save_personal_details!
       create_degrees!
       application_record.imported!
-
       trainee
     end
 

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -20,6 +20,7 @@ module Trainees
     def call
       Audited.audit_class.as_user(USERNAME) do
         trainee.assign_attributes(mapped_attributes)
+        Trainees::SetAcademicCycles.call(trainee: trainee)
 
         if trainee.save!
           create_degrees!

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -14,6 +14,9 @@ module Trainees
     let(:trainee) { create_trainee_from_apply }
     let(:subject_names) { [] }
     let(:course_uuid) { course_info["course_uuid"] }
+    let!(:current_academic_cycle) { create(:academic_cycle) }
+    let!(:next_academic_cycle) { create(:academic_cycle, next_cycle: true) }
+    let!(:after_next_academic_cycle) { create(:academic_cycle, one_after_next_cycle: true) }
 
     let!(:course) do
       create(

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -14,6 +14,9 @@ module Trainees
     let(:trainee_degree) { trainee.degrees.first }
     let(:hesa_course_subject_codes) { Hesa::CodeSets::CourseSubjects::MAPPING.invert }
     let(:hesa_age_range_codes) { Hesa::CodeSets::AgeRanges::MAPPING.invert }
+    let!(:start_academic_cycle) { create(:academic_cycle, cycle_year: 2016) }
+    let!(:end_academic_cycle) { create(:academic_cycle, cycle_year: 2018) }
+    let!(:after_next_academic_cycle) { create(:academic_cycle, one_after_next_cycle: true) }
 
     let!(:course_allocation_subject) do
       create(:subject_specialism, name: CourseSubjects::BIOLOGY).allocation_subject
@@ -61,6 +64,8 @@ module Trainees
         expect(trainee.study_mode).to eq("full_time")
         expect(trainee.itt_start_date).to eq(Date.parse(student_attributes[:itt_start_date]))
         expect(trainee.itt_end_date).to be_nil
+        expect(trainee.start_academic_cycle).to eq(start_academic_cycle)
+        expect(trainee.end_academic_cycle).to be_nil
         expect(trainee.commencement_date).to eq(Date.parse(student_attributes[:itt_start_date]))
       end
 


### PR DESCRIPTION
### Context

We need to set the academic cycles when trainees are created if we know the course details. This can happen from the create from hesa service or the create from apply service. Start and end academic cycles should be set from these services now. 

### Changes proposed in this pull request

Add parameter to the two services to assign start and end academic cycles for which there is a course. 
