### PR TITLE
[4352] Missing data not being recognised after being entered

### DIFF
--- a/app/services/degrees/fix_to_match_reference_data.rb
+++ b/app/services/degrees/fix_to_match_reference_data.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Degrees
+  class FixToMatchReferenceData
+    include ServicePattern
+
+    def initialize(degree:)
+      @degree = degree
+    end
+
+    def call
+      params_to_update = existing_degree_values.merge(update_params)
+
+      if params_to_update != existing_degree_values
+        degree.update_columns(update_params)
+      end
+
+      degree
+    end
+
+  private
+
+    attr_reader :degree
+
+    def existing_degree_values
+      @existing_degree_values ||= {
+        institution: degree.institution,
+        subject: degree.subject,
+        grade: degree.grade,
+        uk_degree: degree.uk_degree,
+      }
+    end
+
+    def update_params
+      {
+        institution: correct_institution,
+        subject: correct_subject,
+        grade: correct_grade,
+        uk_degree: correct_type,
+      }.compact
+    end
+
+    def correct_subject
+      ref_version = find_in_reference_data(:subjects, degree.subject)
+      return ref_version[:name] if ref_version
+    end
+
+    def correct_institution
+      ref_version = find_in_reference_data(:institutions, degree.institution)
+      return ref_version[:name] if ref_version
+    end
+
+    def correct_grade
+      ref_version = find_in_reference_data(:grades, degree.grade)
+      return ref_version[:name] if ref_version
+    end
+
+    def correct_type
+      ref_version = find_in_reference_data(:types, degree.uk_degree)
+      return ref_version[:name] if ref_version
+    end
+
+    def find_in_reference_data(collection_constant, value)
+      return if value.nil?
+
+      refdataset = DfE::ReferenceData::Degrees.const_get(collection_constant.to_s.upcase)
+      by_key = refdataset.some(name: value).first
+      return by_key if by_key.present?
+
+      synonym_key = collection_constant == :institutions ? :match_synonyms : :synonyms
+
+      refdataset.all.find do |item|
+        item[synonym_key].include?(value) ||
+          item.name.downcase == value.downcase
+      end
+    end
+  end
+end

--- a/lib/tasks/fix_invalid_degrees.rake
+++ b/lib/tasks/fix_invalid_degrees.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :invalid_degrees do
+  desc "imports a csv of trainees from a provided csv"
+  task fix: :environment do
+    Degree.uk.find_each do |degree|
+      Degrees::FixToMatchReferenceData.call(degree: degree)
+    end
+  end
+end

--- a/spec/services/degrees/fix_to_match_reference_data_spec.rb
+++ b/spec/services/degrees/fix_to_match_reference_data_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Degrees
+  describe FixToMatchReferenceData do
+    let(:degree) { create(:degree, institution: institution, uk_degree: type, subject: subject_name, grade: grade) }
+    let(:institution) { "The Open University" }
+    let(:type) { "Foundation of Arts" }
+    let(:subject_name) { "English studies" }
+    let(:grade) { "First-class honours" }
+
+    subject { described_class.call(degree: degree) }
+
+    describe "institution" do
+      context "value is correct" do
+        it "is left unchanged" do
+          expect(subject).to eq(degree)
+        end
+      end
+
+      context "value is incorrect" do
+        context "match is found in reference data" do
+          let(:institution) { "The University of Chichester" }
+
+          it "is updated" do
+            expect(subject.institution).to eq("University of Chichester")
+          end
+        end
+
+        context "match isn't found in reference data" do
+          let(:institution) { "Chorley Wetherspoons" }
+
+          it "is left unchanged" do
+            expect(subject.institution).to eq(institution)
+          end
+        end
+      end
+    end
+
+    describe "type" do
+      context "value is correct" do
+        it "is left unchanged" do
+          expect(subject).to eq(degree)
+        end
+      end
+
+      context "value is incorrect" do
+        context "match is found in reference data with different casing" do
+          let(:type) { "Foundation of arts" }
+
+          it "is updated" do
+            expect(subject.uk_degree).to eq("Foundation of Arts")
+          end
+        end
+
+        context "match isn't found in reference data" do
+          let(:type) { "Dodgy qualification off of the intewebs" }
+
+          it "is left unchanged" do
+            expect(subject.uk_degree).to eq(type)
+          end
+        end
+      end
+    end
+
+    describe "subject" do
+      context "value is correct" do
+        it "is left unchanged" do
+          expect(subject).to eq(degree)
+        end
+      end
+
+      context "value is incorrect" do
+        context "match is found in reference data with different casing" do
+          let(:subject_name) { "English Studies" }
+
+          it "is updated" do
+            expect(subject.subject).to eq("English studies")
+          end
+        end
+
+        context "match isn't found in reference data" do
+          let(:subject_name) { "Harry Styles studies" }
+
+          it "is left unchanged" do
+            expect(subject.subject).to eq(subject_name)
+          end
+        end
+      end
+    end
+
+    describe "grade" do
+      context "value is correct" do
+        it "is left unchanged" do
+          expect(subject).to eq(degree)
+        end
+      end
+
+      context "value is incorrect" do
+        context "match is found in reference data" do
+          let(:grade) { "First class honours" }
+
+          it "is updated" do
+            expect(subject.grade).to eq("First-class honours")
+          end
+        end
+
+        context "match isn't found in reference data" do
+          let(:grade) { "Epic fail" }
+
+          it "is left unchanged" do
+            expect(subject.grade).to eq(grade)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We used to use reference lists pulled from DTTP for the following degree fields:

institution
type (currently called 'uk_degree' in register 🤦)
grade
subject

User's picked from those lists and the string values were stored on the trainee model.

We are moving towards using the DfE::ReferenceData library for these lists and some no longer match so appear invalid, preventing users recommending their trainees.

In most cases the values either match a synonym in the reference data or are slightly differently cased.

We need to update the values we hold with their reference data equivalent.

We will do further work to add the UUIDs but that has not been included in this PR as this is a production issue that needs to be fixed.

### Changes proposed in this pull request

* Add `Degrees::FixToMatchReferenceData` service. This service takes a degree and attempts to find a match in the relevant reference data in this precedence:
  * A direct string match on name
  * A matching the synonyms collection (`match_synonyms` for institution, `synonyms` on the others)
  * A case insensitive match on name
If a match is found it updates the degree record with the correct value. If all values match then the degree is left unchanged. The service calls `update_columns` to avoid adding extra audit messages or touching updated_at.

* Add a rake task that loops through UK degrees and runs them through the service.

### Guidance to review

* Issues in this migration will be tricky to recover from so a thorough review would be good. The task should run on a local anonymised backup restore. 
* Set some degrees to have:
  * a differently cased version of a 'name' attribute that exists in the reference data (https://github.com/DFE-Digital/dfe-reference-data/tree/main/lib/dfe/reference_data/degrees)
  * a value that is a synonym
* Run that through the service and it should be updated to have correct values as per the reference data 'name' attributes

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
