### PR TITLE
[4377] Fix 'North Macedonia'

### DIFF
--- a/app/lib/hesa/code_sets/countries.rb
+++ b/app/lib/hesa/code_sets/countries.rb
@@ -161,7 +161,7 @@ module Hesa
         "LT" => "Lithuania",
         "LU" => "Luxembourg",
         "MO" => "Macao (Special Administrative Region of China) [Macao]",
-        "MK" => "Macedonia [Macedonia, The Former Yugoslav Republic of]",
+        "MK" => "North Macedonia",
         "MG" => "Madagascar",
         "MW" => "Malawi",
         "MY" => "Malaysia",


### PR DESCRIPTION
### Context

We look up HESA codes for non-uk degree countries to send to DQT.  We have a 'North Macedonia' degree that is currently stuck as we don't have a value for it.

### Changes proposed in this pull request

Update the HESA codeset with 'North Macedonia' which replaced the previous value as per https://www.hesa.ac.uk/collection/c21054/a/nation

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
