### PR TITLE
[4370] Remove academic cycle method from trainee

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -78,8 +78,7 @@ module ApplicationRecordCard
       academic_cycle = AcademicCycle.for_date(record.commencement_date)
       return unless academic_cycle
 
-      year_text = "#{academic_cycle.start_year} to #{academic_cycle.start_year + 1}"
-      tag.p("Start year: #{year_text}", class: "govuk-caption-m govuk-!-font-size-16 application-record-card__start_year govuk-!-margin-top-1 govuk-!-margin-bottom-1")
+      tag.p("Start year: #{academic_cycle.label}", class: "govuk-caption-m govuk-!-font-size-16 application-record-card__start_year govuk-!-margin-top-1 govuk-!-margin-bottom-1")
     end
 
     def show_provider

--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -118,7 +118,7 @@ module Funding
     end
 
     def no_funding_methods?
-      !trainee.academic_cycle || trainee.academic_cycle.funding_methods.none?
+      !trainee.start_academic_cycle || trainee.start_academic_cycle.funding_methods.none?
     end
 
     def mappable_field(field_value, field_label, action_url)

--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -29,6 +29,6 @@ module FundingHelper
 private
 
   def can_start_funding_section?(trainee)
-    trainee.progress.course_details && trainee.academic_cycle.present?
+    trainee.progress.course_details && trainee.start_academic_cycle.present?
   end
 end

--- a/app/lib/funding_manager.rb
+++ b/app/lib/funding_manager.rb
@@ -10,7 +10,7 @@ class FundingManager
   def initialize(trainee)
     @trainee = trainee
     @allocation_subject = trainee.course_allocation_subject
-    @academic_cycle = trainee.academic_cycle
+    @academic_cycle = trainee.start_academic_cycle
   end
 
   def bursary_amount
@@ -63,11 +63,11 @@ class FundingManager
   end
 
   def funding_guidance_url
-    "#{funding_year}-to-#{funding_year + 1}"
+    academic_cycle.label.parameterize
   end
 
   def funding_guidance_link_text
-    "#{funding_year} to #{funding_year + 1} (opens a new tab)"
+    "#{academic_cycle.label} (opens a new tab)"
   end
 
 private
@@ -86,9 +86,5 @@ private
     allocation_subject.funding_methods.find_by(training_route: training_route,
                                                funding_type: funding_type,
                                                academic_cycle: academic_cycle)&.amount
-  end
-
-  def funding_year
-    @funding_year ||= AcademicCycle.for_date(trainee.itt_start_date).start_year
   end
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -412,10 +412,6 @@ class Trainee < ApplicationRecord
     "manual"
   end
 
-  def academic_cycle
-    AcademicCycle.for_date(commencement_date || itt_start_date)
-  end
-
 private
 
   def value_digest

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -46,7 +46,8 @@ module Exports
           "provider_trainee_id" => trainee.trainee_id,
           "trn" => trainee.trn,
           "status" => status(trainee),
-          "start_year" => start_year(trainee),
+          "start_academic_year" => trainee.start_academic_cycle&.label,
+          "end_academic_year" => trainee.end_academic_cycle&.label,
           "record_created_at" => trainee.created_at&.iso8601,
           "updated_at" => trainee.updated_at&.iso8601,
           "hesa_updated_at" => trainee.hesa_updated_at&.iso8601,
@@ -274,13 +275,6 @@ module Exports
       return EARLY_YEARS_ROUTE_NAME_PREFIX.humanize if trainee.early_years_route?
 
       trainee.course_education_phase&.upcase_first
-    end
-
-    def start_year(trainee)
-      academic_cycle = trainee.academic_cycle
-      return unless academic_cycle
-
-      "#{academic_cycle.start_year} to #{academic_cycle.start_year + 1}"
     end
 
     def course_education_phase(course)

--- a/app/view_objects/academic_year_filter_options.rb
+++ b/app/view_objects/academic_year_filter_options.rb
@@ -8,12 +8,10 @@ class AcademicYearFilterOptions
 
   def formatted_years(cycle_context)
     compute_academic_cycles(cycle_context).map do |academic_cycle|
-      start_year = academic_cycle.start_date.year
-      end_year = academic_cycle.end_date.year
-      if current_academic_cycle_year?(start_year)
-        "#{start_year} to #{end_year} (current year)"
+      if academic_cycle.current?
+        "#{academic_cycle.label} (current year)"
       else
-        "#{start_year} to #{end_year}"
+        academic_cycle.label
       end
     end
   end
@@ -21,10 +19,6 @@ class AcademicYearFilterOptions
 private
 
   attr_reader :user, :draft
-
-  def current_academic_cycle_year?(year)
-    AcademicCycle.current&.start_year == year
-  end
 
   def compute_academic_cycles(cycle_context)
     scope = TraineePolicy::Scope.new(user, Trainee.public_send(draft ? :draft : :not_draft)).resolve

--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -52,7 +52,7 @@ private
         trainees.awarded.merge(current_academic_cycle.trainees_ending).count,
         trainees_path(
           status: %w[awarded],
-          end_year: "#{current_academic_cycle.start_year} to #{current_academic_cycle.end_year}",
+          end_year: current_academic_cycle.label,
         ),
       ),
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -448,17 +448,6 @@ describe Trainee do
         end
       end
     end
-
-    describe "academic_cycle" do
-      let(:academic_cycle) { create(:academic_cycle, cycle_year: 2018) }
-      let(:trainee) { create(:trainee, commencement_date: Date.new(academic_cycle.start_year, 9, 1)) }
-
-      subject { trainee.academic_cycle }
-
-      it "returns the AcademicCycle the trainee started in" do
-        expect(subject).to eq(academic_cycle)
-      end
-    end
   end
 
   describe "#with_name_trainee_id_or_trn_like" do

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -36,6 +36,7 @@ module Exports
 
     before do
       create(:academic_cycle, :current)
+      create(:academic_cycle, next_cycle: true)
     end
 
     subject { described_class.new([trainee]) }
@@ -53,7 +54,8 @@ module Exports
           "provider_trainee_id" => trainee.trainee_id,
           "trn" => trainee.trn,
           "status" => "QTS awarded",
-          "start_year" => "2021 to 2022",
+          "start_academic_year" => "2021 to 2022",
+          "end_academic_year" => "2022 to 2023",
           "record_created_at" => trainee.created_at&.iso8601,
           "updated_at" => trainee.updated_at&.iso8601,
           "hesa_updated_at" => trainee.hesa_updated_at&.iso8601,

--- a/spec/view_objects/academic_year_filter_options_spec.rb
+++ b/spec/view_objects/academic_year_filter_options_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe AcademicYearFilterOptions do
   let(:current_year_string) do
-    "#{academic_cycle.start_year} to #{academic_cycle.end_year} (current year)"
+    "#{academic_cycle.label} (current year)"
   end
 
   let(:current_user) do
@@ -75,7 +75,7 @@ describe AcademicYearFilterOptions do
     subject { described_class.new(user: current_user, draft: true).formatted_years(cycle_context) }
 
     it "returns the future cycle" do
-      expect(subject).to match_array(["#{academic_cycle.start_year} to #{academic_cycle.end_year}"])
+      expect(subject).to match_array([academic_cycle.label])
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/9hxg3LkC/4370-s-update-csv-export-for-start-and-end-academic-cycles

### Changes proposed in this pull request

- Add `start_academic_cycle` and `end_academic_cycle` to the trainees export
- Remove `start_year` from the export
- Remove the method `academic_cycle` from trainees and update all code that used to use that

### Guidance to review

- Check the download includes the correct headers and values
- Check the label for start year on the trainees list "2021 to 2022"
- Check the label for years in the filters
- Check the homepage awarded this year tile still links to the correctly filtered view
 
<img width="349" alt="Screenshot 2022-07-12 at 14 33 03" src="https://user-images.githubusercontent.com/18436946/178504636-05239599-cf2d-491f-ba9a-5b0a9e99cb46.png">

<img width="245" alt="Screenshot 2022-07-12 at 14 33 07" src="https://user-images.githubusercontent.com/18436946/178504676-93182286-2651-42a9-ae14-431145a143b9.png">


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
