### PR TITLE
[4351] Show withdraw date form if a deferred trainee has no defer_date

### DIFF
--- a/app/views/trainees/withdrawals/show.html.erb
+++ b/app/views/trainees/withdrawals/show.html.erb
@@ -25,7 +25,7 @@
         <% end %>
       <% end %>
 
-      <% if @trainee.deferred? %>
+      <% if @trainee.deferred? && @trainee.defer_date.present? %>
         <h3 class="govuk-heading-s"><%= t("views.forms.withdrawal_date.deferral_notice_heading") %></h3>
         <%= render GovukComponent::InsetTextComponent.new(classes: "deferral-notice") do %>
           <p class="govuk-body deferral-notice_text">


### PR DESCRIPTION
### Context

https://trello.com/c/Hg8cqVqL/4351-register-error-unable-to-withdraw-deferred-student

We have some bad-data trainees in the system. They came from DTTP as deferred, but have no defer date.

There's a bug whereby if a user tries to withdraw one of these, they can't, because we default to using the (non-existent) defer date.

### Changes proposed in this pull request

Show the normal withdraw form if the deferred trainee has no defer date.

### Guidance to review

- I've removed the defer date from this deferred trainee:
- Check that you can still withdraw them.

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml