### PR TITLE
[4381] Use DfE::Reference data for sending degree subjects to DQT

### DIFF
--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -7,7 +7,19 @@ module Dqt
     describe TrnRequest do
       let(:trainee) { create(:trainee, :completed, gender: "female", degrees: [degree]) }
       let(:degree) { build(:degree, :uk_degree_with_details) }
-      let(:degree_subject) { Hesa::CodeSets::DegreeSubjects::MAPPING.invert[degree.subject] }
+      let(:hesa_code) { "11111" }
+
+      before do
+        stub_const(
+          "DfE::ReferenceData::Degrees::SUBJECTS",
+          DfE::ReferenceData::HardcodedReferenceList.new({
+            SecureRandom.uuid => {
+              name: degree.subject,
+              hesa_itt_code: hesa_code,
+            },
+          }),
+        )
+      end
 
       describe "#params" do
         subject { described_class.new(trainee: trainee).params }
@@ -55,7 +67,7 @@ module Dqt
           expect(subject["qualification"]).to eq({
             "providerUkprn" => "12345678",
             "countryCode" => "XK",
-            "subject" => degree_subject,
+            "subject" => hesa_code,
             "class" => described_class::DEGREE_CLASSES[degree.grade],
             "date" => Date.new(degree.graduation_year).iso8601,
           })


### PR DESCRIPTION
### Context

https://trello.com/c/YmlyPtIj/4381-update-dqt-params-to-use-dfereferencedata-for-degrees

### Changes proposed in this pull request

- We updated all degree subjects to use the name from the DfE::ReferenceData set
  which may have been slightly different to our original lists from HESA
- This broke the params we were sending to DQT as we were still reverse-looking up
  the subjects from the original list
- Update our params to look up the HESA code for the degree subjects from the
  DfE::ReferenceData gem

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml