### PR TITLE
[4310] Add lead school user import

### DIFF
--- a/app/services/lead_school_user_import.rb
+++ b/app/services/lead_school_user_import.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class LeadSchoolUserImport
+  include ServicePattern
+
+  attr_reader :attributes
+
+  def initialize(attributes:)
+    @attributes = attributes
+  end
+
+  def call
+    missing_schools = []
+
+    attributes.each do |data|
+      school = School.find_by(urn: data["URN"])
+
+      if school.nil?
+        missing_schools << data["URN"]
+      else
+        create_lead_school_user(school, data)
+      end
+    end
+    missing_schools
+  end
+
+private
+
+  def create_lead_school_user(school, data)
+    school.users.create_with(first_name: data["First name"], last_name: data["Surname"])
+    .find_or_create_by!(email: data["Email"])
+  end
+end

--- a/lib/tasks/lead_school_user_import.rake
+++ b/lib/tasks/lead_school_user_import.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :user_import do
+  desc "import lead school users from CSV and add them to lead school"
+  task :lead_school_users, %i[csv_path] => [:environment] do |_, args|
+    csv = CSV.read(args.csv_path, headers: true)
+    missing_schools = LeadSchoolUserImport.call(attributes: csv)
+    abort("School URNs: #{missing_schools.join(', ')} not found") unless missing_schools.empty?
+  end
+end

--- a/spec/services/lead_school_user_import_spec.rb
+++ b/spec/services/lead_school_user_import_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+describe LeadSchoolUserImport do
+  let(:csv) {
+    CSV.read(csv_file_path, headers: true)
+  }
+  let(:csv_file_path) { Rails.root.join("spec/support/fixtures/#{filename}") }
+  let(:filename) { "lead_school_user_import.csv" }
+  let(:csv_urns) { %w[5940019 3446713 5629417 3892190 7739792] }
+
+  subject { described_class.call(attributes: csv) }
+
+  context "when schools do not exist" do
+    it "returns the missing URNs" do
+      expect(subject).to eq(csv_urns)
+    end
+  end
+
+  context "with valid data" do
+    let(:first_csv_email) { "a@piltonbluecoat.devon.sch.uk" }
+    let(:first_csv_urn) { "5940019" }
+    let(:first_school_user) { School.find_by(urn: first_csv_urn).users.first }
+
+    before do
+      csv_urns.each do |urn|
+        create(:school, :lead, urn: urn)
+      end
+    end
+
+    it "creates users" do
+      expect { subject }.to change { User.count }.from(0).to(5)
+    end
+
+    it "links users to lead schools" do
+      expect { subject }.to change { LeadSchoolUser.count }.from(0).to(5)
+      expect(first_school_user.email).to eq(first_csv_email)
+    end
+  end
+end

--- a/spec/support/fixtures/lead_school_user_import.csv
+++ b/spec/support/fixtures/lead_school_user_import.csv
@@ -1,0 +1,6 @@
+URN,School name,First name,Surname,Email
+5940019,Pilton Bluecoat Church of England Academy,a,Smith,a@piltonbluecoat.devon.sch.uk
+3446713,Ashmount School,b,Bloggs,b@ashmount.leics.sch.uk
+5629417,All Souls Church of England Primary School,c,Walsh,c@allsoulsce.rochdale.sch.uk
+3892190,Churchill Community College,d,Brown,d@churchillcc.org
+7739792,Ashmole Academy,e,Lin,e@ashmoleacademy.org


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/cacnwDy3/4310-lead-school-user-import-task

We need an import task that can consume the CSV of lead school users. This task does that. 

I haven't included much validation because this is a one time import done by us and Claire has already sanity checked the CSV. I've included some validation to highlight if any schools are missing from our DB.

Note I've simplified some of the column heading names compared to what's on the spreadsheet that was sent to schools, so these will need to be amended on the spreadsheet before import.

### Changes proposed in this pull request

* Add rake task to consume lead school user CSV and import the users
* Add CSV test fixture

### Guidance to review

* Please check the CSV test fixture and make sure I've sanitised enough of the data. The names and first part of the email addresses have been changed.
* Check I haven't missed any relevant validation
* To run the rake task:
```
be rake user_import:lead_school_users"[csv_path]"
```
There is a test csv in spec/support/fixtures which you could use to run the task.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
