### PR TITLE
4352 missing data not being recognised after being entered part 2

### DIFF
--- a/app/services/degrees/fix_to_match_reference_data.rb
+++ b/app/services/degrees/fix_to_match_reference_data.rb
@@ -23,7 +23,11 @@ module Degrees
     attr_reader :degree
 
     def existing_degree_values
-      @existing_degree_values ||= {
+      @existing_degree_values ||= degree.uk? ? uk_degree_values : non_uk_degree_values
+    end
+
+    def uk_degree_values
+      {
         institution: degree.institution,
         subject: degree.subject,
         grade: degree.grade,
@@ -31,12 +35,30 @@ module Degrees
       }
     end
 
+    def non_uk_degree_values
+      {
+        subject: degree.subject,
+        grade: degree.grade,
+      }
+    end
+
     def update_params
+      degree.uk? ? uk_update_params : non_uk_update_params
+    end
+
+    def uk_update_params
       {
         institution: correct_institution,
         subject: correct_subject,
         grade: correct_grade,
         uk_degree: correct_type,
+      }.compact
+    end
+
+    def non_uk_update_params
+      {
+        subject: correct_subject,
+        grade: correct_grade,
       }.compact
     end
 

--- a/lib/tasks/fix_invalid_degrees.rake
+++ b/lib/tasks/fix_invalid_degrees.rake
@@ -2,8 +2,14 @@
 
 namespace :invalid_degrees do
   desc "imports a csv of trainees from a provided csv"
-  task fix: :environment do
+  task fix_uk: :environment do
     Degree.uk.find_each do |degree|
+      Degrees::FixToMatchReferenceData.call(degree: degree)
+    end
+  end
+
+  task fix_non_uk: :environment do
+    Degree.non_uk.find_each do |degree|
       Degrees::FixToMatchReferenceData.call(degree: degree)
     end
   end

--- a/spec/services/degrees/fix_to_match_reference_data_spec.rb
+++ b/spec/services/degrees/fix_to_match_reference_data_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 module Degrees
   describe FixToMatchReferenceData do
-    let(:degree) { create(:degree, institution: institution, uk_degree: type, subject: subject_name, grade: grade) }
     let(:institution) { "The Open University" }
     let(:type) { "Foundation of Arts" }
     let(:subject_name) { "English studies" }
@@ -12,105 +11,165 @@ module Degrees
 
     subject { described_class.call(degree: degree) }
 
-    describe "institution" do
-      context "value is correct" do
-        it "is left unchanged" do
-          expect(subject).to eq(degree)
-        end
-      end
+    context "uk degree" do
+      let(:degree) { create(:degree, institution: institution, uk_degree: type, subject: subject_name, grade: grade) }
 
-      context "value is incorrect" do
-        context "match is found in reference data" do
-          let(:institution) { "The University of Chichester" }
-
-          it "is updated" do
-            expect(subject.institution).to eq("University of Chichester")
+      describe "institution" do
+        context "value is correct" do
+          it "is left unchanged" do
+            expect(subject).to eq(degree)
           end
         end
 
-        context "match isn't found in reference data" do
-          let(:institution) { "Chorley Wetherspoons" }
+        context "value is incorrect" do
+          context "match is found in reference data" do
+            let(:institution) { "The University of Chichester" }
 
+            it "is updated" do
+              expect(subject.institution).to eq("University of Chichester")
+            end
+          end
+
+          context "match isn't found in reference data" do
+            let(:institution) { "Chorley Wetherspoons" }
+
+            it "is left unchanged" do
+              expect(subject.institution).to eq(institution)
+            end
+          end
+        end
+      end
+
+      describe "type" do
+        context "value is correct" do
           it "is left unchanged" do
-            expect(subject.institution).to eq(institution)
+            expect(subject).to eq(degree)
+          end
+        end
+
+        context "value is incorrect" do
+          context "match is found in reference data with different casing" do
+            let(:type) { "Foundation of arts" }
+
+            it "is updated" do
+              expect(subject.uk_degree).to eq("Foundation of Arts")
+            end
+          end
+
+          context "match isn't found in reference data" do
+            let(:type) { "Dodgy qualification off of the intewebs" }
+
+            it "is left unchanged" do
+              expect(subject.uk_degree).to eq(type)
+            end
+          end
+        end
+      end
+
+      describe "subject" do
+        context "value is correct" do
+          it "is left unchanged" do
+            expect(subject).to eq(degree)
+          end
+        end
+
+        context "value is incorrect" do
+          context "match is found in reference data with different casing" do
+            let(:subject_name) { "English Studies" }
+
+            it "is updated" do
+              expect(subject.subject).to eq("English studies")
+            end
+          end
+
+          context "match isn't found in reference data" do
+            let(:subject_name) { "Harry Styles studies" }
+
+            it "is left unchanged" do
+              expect(subject.subject).to eq(subject_name)
+            end
+          end
+        end
+      end
+
+      describe "grade" do
+        context "value is correct" do
+          it "is left unchanged" do
+            expect(subject).to eq(degree)
+          end
+        end
+
+        context "value is incorrect" do
+          context "match is found in reference data" do
+            let(:grade) { "First class honours" }
+
+            it "is updated" do
+              expect(subject.grade).to eq("First-class honours")
+            end
+          end
+
+          context "match isn't found in reference data" do
+            let(:grade) { "Epic fail" }
+
+            it "is left unchanged" do
+              expect(subject.grade).to eq(grade)
+            end
           end
         end
       end
     end
 
-    describe "type" do
-      context "value is correct" do
-        it "is left unchanged" do
-          expect(subject).to eq(degree)
-        end
-      end
+    context "non uk degree" do
+      let(:degree) { create(:degree, :non_uk, institution: nil, subject: subject_name, grade: grade) }
 
-      context "value is incorrect" do
-        context "match is found in reference data with different casing" do
-          let(:type) { "Foundation of arts" }
-
-          it "is updated" do
-            expect(subject.uk_degree).to eq("Foundation of Arts")
-          end
-        end
-
-        context "match isn't found in reference data" do
-          let(:type) { "Dodgy qualification off of the intewebs" }
-
+      describe "subject" do
+        context "value is correct" do
           it "is left unchanged" do
-            expect(subject.uk_degree).to eq(type)
-          end
-        end
-      end
-    end
-
-    describe "subject" do
-      context "value is correct" do
-        it "is left unchanged" do
-          expect(subject).to eq(degree)
-        end
-      end
-
-      context "value is incorrect" do
-        context "match is found in reference data with different casing" do
-          let(:subject_name) { "English Studies" }
-
-          it "is updated" do
-            expect(subject.subject).to eq("English studies")
+            expect(subject).to eq(degree)
           end
         end
 
-        context "match isn't found in reference data" do
-          let(:subject_name) { "Harry Styles studies" }
+        context "value is incorrect" do
+          context "match is found in reference data with different casing" do
+            let(:subject_name) { "English Studies" }
 
+            it "is updated" do
+              expect(subject.subject).to eq("English studies")
+            end
+          end
+
+          context "match isn't found in reference data" do
+            let(:subject_name) { "Harry Styles studies" }
+
+            it "is left unchanged" do
+              expect(subject.subject).to eq(subject_name)
+            end
+          end
+        end
+      end
+
+      describe "grade" do
+        context "value is correct" do
           it "is left unchanged" do
-            expect(subject.subject).to eq(subject_name)
-          end
-        end
-      end
-    end
-
-    describe "grade" do
-      context "value is correct" do
-        it "is left unchanged" do
-          expect(subject).to eq(degree)
-        end
-      end
-
-      context "value is incorrect" do
-        context "match is found in reference data" do
-          let(:grade) { "First class honours" }
-
-          it "is updated" do
-            expect(subject.grade).to eq("First-class honours")
+            expect(subject).to eq(degree)
           end
         end
 
-        context "match isn't found in reference data" do
-          let(:grade) { "Epic fail" }
+        context "value is incorrect" do
+          context "match is found in reference data" do
+            let(:grade) { "First class honours" }
 
-          it "is left unchanged" do
-            expect(subject.grade).to eq(grade)
+            it "is updated" do
+              expect(subject.grade).to eq("First-class honours")
+            end
+          end
+
+          context "match isn't found in reference data" do
+            let(:grade) { "Epic fail" }
+
+            it "is left unchanged" do
+              expect(subject.grade).to eq(grade)
+            end
           end
         end
       end


### PR DESCRIPTION
### Context

We fixed the UK degrees so as the string values match the DfE::ReferenceData that we're using for validation. Turns out we need to fix the subject and grade on non-uk too.

### Changes proposed in this pull request

* Support non_uk in the service. (It probably would be ok to just run the uk version but reduce the params for non_uk to be sure)
* Add a non_uk version of the rake task.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
