### PR TITLE
[4389] Handle UK degrees with no institution

### DIFF
--- a/app/services/degrees/create_from_hesa.rb
+++ b/app/services/degrees/create_from_hesa.rb
@@ -39,13 +39,19 @@ module Degrees
 
       # Country code is not always provided, so we have
       # to fallback to institution which is always UK based
-      if uk_country?(country) || institution
-        degree.institution = institution[:name]
+      if uk_country?(country)
+        # HESA guidance says to leave institution blank and set
+        # country for UK degrees where the HESA list doesn't
+        # have the institution
+        if institution
+          degree.institution = institution[:name]
+          degree.institution_uuid = institution[:id]
+        end
+
         degree.locale_code = "uk"
         degree.country = nil
         degree.uk_degree = degree_type
         degree.non_uk_degree = nil
-        degree.institution_uuid = institution[:id]
       else
         degree.locale_code = "non_uk"
         degree.country = country

--- a/app/services/degrees/create_from_hesa.rb
+++ b/app/services/degrees/create_from_hesa.rb
@@ -39,10 +39,10 @@ module Degrees
 
       # Country code is not always provided, so we have
       # to fallback to institution which is always UK based
-      if uk_country?(country)
+      if uk_country?(country) || institution
         # HESA guidance says to leave institution blank and set
         # country for UK degrees where the HESA list doesn't
-        # have the institution
+        # have the institution so it may not be present for some UK degrees
         if institution
           degree.institution = institution[:name]
           degree.institution_uuid = institution[:id]

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -29,21 +29,6 @@ module Degrees
         expect(trainee.degrees.count).to eq(student_attributes[:degrees].count)
       end
 
-      context "UK degree" do
-        it "sets UK attributes only" do
-          expect(degree.locale_code).to eq("uk")
-          expect(degree.uk_degree).to eq("Unknown")
-          expect(degree.non_uk_degree).to be_nil
-          expect(degree.subject).to eq(hesa_degree[:subject])
-          expect(degree.institution).to eq("The Open University")
-          expect(degree.graduation_year).to eq(2005)
-          expect(degree.grade).to eq("First-class honours")
-          expect(degree.other_grade).to be_nil
-          expect(degree.country).to be_nil
-          expect(degree.institution_uuid).to eq("5c9e1d2d-3fa2-e811-812b-5065f38ba241")
-        end
-      end
-
       context "UK country code but no institution reference" do
         let(:hesa_degrees) do
           [
@@ -58,7 +43,7 @@ module Degrees
           ]
         end
 
-        it "sets UK attributes with nil institution and institution_uuid" do
+        it "creates a UK degree with nil institution and institution_uuid" do
           expect(degree.locale_code).to eq("uk")
           expect(degree.uk_degree).to eq("First Degree")
           expect(degree.non_uk_degree).to be_nil
@@ -69,6 +54,34 @@ module Degrees
           expect(degree.other_grade).to be_nil
           expect(degree.country).to be_nil
           expect(degree.institution_uuid).to be_nil
+        end
+      end
+
+      context "institution but no UK country code" do
+        let(:hesa_degrees) do
+          [
+            {
+              graduation_date: "2003-06-01",
+              degree_type: "400",
+              subject: "100485",
+              institution: "00429",
+              grade: "02",
+              country: nil,
+            },
+          ]
+        end
+
+        it "creates a UK degree" do
+          expect(degree.locale_code).to eq("uk")
+          expect(degree.uk_degree).to eq("First Degree")
+          expect(degree.non_uk_degree).to be_nil
+          expect(degree.subject).to eq("Law")
+          expect(degree.institution).to eq("Raindance Educational Services")
+          expect(degree.graduation_year).to eq(2003)
+          expect(degree.grade).to eq("Upper second-class honours (2:1)")
+          expect(degree.other_grade).to be_nil
+          expect(degree.country).to be_nil
+          expect(degree.institution_uuid).to eq("bb3e182c-1425-ec11-b6e6-000d3adf095a")
         end
       end
 

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -44,6 +44,34 @@ module Degrees
         end
       end
 
+      context "UK country code but no institution reference" do
+        let(:hesa_degrees) do
+          [
+            {
+              graduation_date: "2003-06-01",
+              degree_type: "400",
+              subject: "100485",
+              institution: nil,
+              grade: "02",
+              country: "XF",
+            },
+          ]
+        end
+
+        it "sets UK attributes with nil institution and institution_uuid" do
+          expect(degree.locale_code).to eq("uk")
+          expect(degree.uk_degree).to eq("First Degree")
+          expect(degree.non_uk_degree).to be_nil
+          expect(degree.subject).to eq("Law")
+          expect(degree.institution).to be_nil
+          expect(degree.graduation_year).to eq(2003)
+          expect(degree.grade).to eq("Upper second-class honours (2:1)")
+          expect(degree.other_grade).to be_nil
+          expect(degree.country).to be_nil
+          expect(degree.institution_uuid).to be_nil
+        end
+      end
+
       context "Non-UK degree" do
         let(:hesa_degrees) do
           [{


### PR DESCRIPTION
### Context

HESA guidance tells users to select the country and leave the institution blank for UK degrees where the institution isn't present in the HESA codeset.

Our import is currently failing as we don't handle that https://sentry.io/organizations/dfe-teacher-services/issues/3422498115

### Changes proposed in this pull request

* Update the `Degrees::CreateFromHesa` service to handle this. Set the degree as UK and leave the institution blank.

### Guidance to review

This is tricky to run locally without using production credentials. I have a failing XML file that I can share. We can run on dttpimport before deploying.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
