### PR TITLE
[4367] Backfill and import award date from DQT

### DIFF
--- a/app/jobs/dqt/retrieve_award_job.rb
+++ b/app/jobs/dqt/retrieve_award_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Dqt
+  class RetrieveAwardJob < ApplicationJob
+    sidekiq_options retry: 0
+    queue_as :default
+    retry_on Client::HttpError
+
+    class TraineeAttributeError < StandardError; end
+
+    def perform(trainee)
+      return unless FeatureService.enabled?(:integrate_with_dqt)
+
+      response = Dqt::RetrieveTeacher.call(trainee: trainee)
+      awarded_at = response.dig("qualified_teacher_status", "qts_date")
+      Trainees::Update.call(trainee: trainee, params: { awarded_at: awarded_at }, update_dtq: false) if awarded_at
+    end
+
+  private
+
+    attr_reader :trainee
+  end
+end

--- a/app/services/dqt/retrieve_teacher.rb
+++ b/app/services/dqt/retrieve_teacher.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Dqt
+  class RetrieveTeacher
+    include ServicePattern
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      Client.get("/v1/teachers/#{trainee.trn}?birthdate=#{trainee.date_of_birth}")
+    end
+
+    attr_reader :trainee
+  end
+end

--- a/app/services/trainees/update.rb
+++ b/app/services/trainees/update.rb
@@ -4,20 +4,21 @@ module Trainees
   class Update
     include ServicePattern
 
-    def initialize(trainee:, params: {})
+    def initialize(trainee:, params: {}, update_dtq: true)
       @trainee = trainee
       @params = params
+      @update_dtq = update_dtq
     end
 
     def call
       trainee.update!(params)
-      Dqt::UpdateTraineeJob.perform_later(trainee)
+      Dqt::UpdateTraineeJob.perform_later(trainee) if update_dtq
       Trainees::SetAcademicCyclesJob.perform_later(trainee)
       true
     end
 
   private
 
-    attr_reader :trainee, :params
+    attr_reader :trainee, :params, :update_dtq
   end
 end

--- a/lib/tasks/backfill_missing_award_dates.rake
+++ b/lib/tasks/backfill_missing_award_dates.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :dqt do
+  desc "Backfill missing trainee award dates"
+  task backfill_missing_award_dates: :environment do
+    failed_trainee_ids = []
+    Trainee.awarded.where(awarded_at: nil).where.not(trn: nil).each do |trainee|
+      response = Dqt::RetrieveTeacher.call(trainee: trainee)
+      awarded_at = response.dig("qualified_teacher_status", "qts_date")
+      Trainees::Update.call(trainee: trainee, params: { awarded_at: awarded_at }, update_dtq: false) if awarded_at
+    rescue Dqt::Client::HttpError
+      failed_trainee_ids << trainee.id
+    ensure
+      sleep(0.1) # DQT API has a limit of 300/rpm
+    end
+    puts failed_trainee_ids
+  end
+end

--- a/spec/jobs/dqt/retrieve_award_job_spec.rb
+++ b/spec/jobs/dqt/retrieve_award_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dqt
+  describe RetrieveAwardJob do
+    let(:trainee) { create(:trainee, :trn_received) }
+    let(:trn_request) { create(:dqt_trn_request, trainee: trainee) }
+    let(:dqt_response) do
+      { "qualified_teacher_status" => { "qts_date" => award_date } }
+    end
+
+    before do
+      enable_features(:integrate_with_dqt)
+      allow(Dqt::RetrieveTeacher).to receive(:call).with(trainee: trainee).and_return(dqt_response)
+    end
+
+    context "qts_date is present" do
+      let(:award_date) { 5.days.ago.iso8601 }
+
+      it "updates the trainee but not DQT" do
+        expect(Trainees::Update).to receive(:call).with(trainee: trainee,
+                                                        params: { awarded_at: award_date },
+                                                        update_dtq: false)
+        described_class.perform_now(trainee)
+      end
+    end
+
+    context "qts_date is nil" do
+      let(:award_date) { nil }
+
+      it "doesn't update the trainee" do
+        expect(Trainees::Update).not_to receive(:call)
+
+        described_class.perform_now(trainee)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/9hxg3LkC/4370-s-update-csv-export-for-start-and-end-academic-cycles

There's about 25k awarded trainees with no award date (mostly from DTTP). We can use DQT to get the QTS date and backfill these trainees. We'll also need to poll for award data from DQT that has been entered via the ITT portal.

### Changes proposed in this pull request
- New client to fetch data from DQT teachers API
- New job to fetch award date from DQT and update trainee
- Rake task to backfill missing award dates for awarded trainees

### Pst-analysis

Due to the API rate limit, it takes 1-2 hours to run the rake task. We will need to disable PR merges during the task run.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
