### PR TITLE
[xxx] Fix lead school user import

### DIFF
--- a/app/services/lead_school_user_import.rb
+++ b/app/services/lead_school_user_import.rb
@@ -27,7 +27,9 @@ class LeadSchoolUserImport
 private
 
   def create_lead_school_user(school, data)
-    school.users.create_with(first_name: data["First name"], last_name: data["Surname"])
-    .find_or_create_by!(email: data["Email"])
+    user = User.create_with(first_name: data["First name"], last_name: data["Surname"])
+      .find_or_create_by!(email: data["Email"])
+
+    user.lead_schools << school unless user.lead_schools.include?(school)
   end
 end

--- a/spec/services/lead_school_user_import_spec.rb
+++ b/spec/services/lead_school_user_import_spec.rb
@@ -39,4 +39,38 @@ describe LeadSchoolUserImport do
       expect(first_school_user.email).to eq(first_csv_email)
     end
   end
+
+  context "same user with multiple schools" do
+    let(:school_one) { create(:school, :lead) }
+    let(:school_two) { create(:school, :lead) }
+
+    let(:data) do
+      [
+        {
+          "URN" => school_one.urn,
+          "First name" => "Dave",
+          "Surname" => "Smith",
+          "Email" => "dave@example.com",
+        },
+        {
+          "URN" => school_two.urn,
+          "First name" => "Dave",
+          "Surname" => "Smith",
+          "Email" => "dave@example.com",
+        },
+      ]
+    end
+
+    subject { described_class.call(attributes: data) }
+
+    it "creates one user" do
+      subject
+      expect(User.count).to eq(1)
+    end
+
+    it "associates the user with both schools" do
+      subject
+      expect(User.find_by(email: "dave@example.com").lead_schools).to match_array([school_one, school_two])
+    end
+  end
 end


### PR DESCRIPTION
### Context

We are bulk creating lead school users from a CSV. The data contains multiple rows for the same user which were causing the existing task to fail due to a bug in the user creation.

### Changes proposed in this pull request

Find or create the user first and add the school to the user.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
