### PR TITLE
[4304] Backfill degree UUIDS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,7 @@ gem "redcarpet"
 
 gem "mechanize" # interact with HESA
 
-gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v0.1.0"
+gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", ref: "96e1b7d"
 
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: bff087e5208c75811619cb65f80633272e792d7f
-  tag: v0.1.0
+  revision: 96e1b7d843d55b96f8dc15218f003e95209f03ce
+  ref: 96e1b7d
   specs:
-    dfe-reference-data (0.1.0)
+    dfe-reference-data (0.2.0)
       activesupport
 
 GEM
@@ -281,7 +281,7 @@ GEM
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
     irb (1.4.1)

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -49,7 +49,7 @@ private
   end
 
   def subject_data
-    DfE::ReferenceData::Degrees::SUBJECTS.all
+    DfE::ReferenceData::Degrees::SINGLE_SUBJECTS.all
   end
 
   def degree_type_data

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -125,7 +125,7 @@ module Dqt
       end
 
       def subject_code
-        DfE::ReferenceData::Degrees::SUBJECTS.some({ name: degree.subject }).first&.hecos_code
+        DfE::ReferenceData::Degrees::SINGLE_SUBJECTS.some({ name: degree.subject }).first&.hecos_code
       end
 
       def institution_ukprn

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -125,7 +125,7 @@ module Dqt
       end
 
       def subject_code
-        DfE::ReferenceData::Degrees::SUBJECTS.some({ name: degree.subject }).first&.hesa_itt_code
+        DfE::ReferenceData::Degrees::SUBJECTS.some({ name: degree.subject }).first&.hecos_code
       end
 
       def institution_ukprn

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -4,7 +4,7 @@ class Degree < ApplicationRecord
   include Sluggable
 
   INSTITUTIONS = DfE::ReferenceData::Degrees::INSTITUTIONS.all.map(&:name)
-  SUBJECTS = DfE::ReferenceData::Degrees::SUBJECTS.all.map(&:name)
+  SUBJECTS = DfE::ReferenceData::Degrees::SINGLE_SUBJECTS.all.map(&:name)
   TYPES = DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS.all.map(&:name)
   COMMON_TYPES = ["Bachelor of Arts", "Bachelor of Science", "Master of Arts", "PhD"].freeze
 

--- a/app/services/degrees/map_from_apply.rb
+++ b/app/services/degrees/map_from_apply.rb
@@ -91,12 +91,12 @@ module Degrees
     def find_dfe_reference_subject
       find_dfe_reference_item(:subjects,
                               uuid: attributes["subject_uuid"],
-                              hesa_itt_code: sanitised_hesa(attributes["hesa_degsbj"]),
+                              hecos_code: sanitised_hesa(attributes["hesa_degsbj"]),
                               name: attributes["subject"])
     end
 
     def find_dfe_reference_type
-      find_dfe_reference_item(:types,
+      find_dfe_reference_item(:types_including_generics,
                               uuid: attributes["degree_type_uuid"],
                               hesa_itt_code: sanitised_hesa(attributes["hesa_degtype"]),
                               abbreviation: attributes["qualification_type"])

--- a/lib/tasks/fix_invalid_degrees.rake
+++ b/lib/tasks/fix_invalid_degrees.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 namespace :invalid_degrees do
-  desc "imports a csv of trainees from a provided csv"
   task fix_uk: :environment do
     Degree.uk.find_each do |degree|
       Degrees::FixToMatchReferenceData.call(degree: degree)

--- a/spec/helpers/degree_helper_spec.rb
+++ b/spec/helpers/degree_helper_spec.rb
@@ -66,7 +66,7 @@ describe DegreesHelper do
     let(:synonym) { "maths" }
 
     before do
-      stub_const("DfE::ReferenceData::Degrees::SUBJECTS",
+      stub_const("DfE::ReferenceData::Degrees::SINGLE_SUBJECTS",
                  DfE::ReferenceData::HardcodedReferenceList.new({
                    SecureRandom.uuid => {
                      name: degree_subject,

--- a/spec/lib/dqt/params/trainee_request_spec.rb
+++ b/spec/lib/dqt/params/trainee_request_spec.rb
@@ -16,7 +16,7 @@ module Dqt
           DfE::ReferenceData::HardcodedReferenceList.new({
             SecureRandom.uuid => {
               name: degree.subject,
-              hesa_itt_code: hesa_code,
+              hecos_code: hesa_code,
             },
           }),
         )

--- a/spec/lib/dqt/params/trainee_request_spec.rb
+++ b/spec/lib/dqt/params/trainee_request_spec.rb
@@ -12,7 +12,7 @@ module Dqt
 
       before do
         stub_const(
-          "DfE::ReferenceData::Degrees::SUBJECTS",
+          "DfE::ReferenceData::Degrees::SINGLE_SUBJECTS",
           DfE::ReferenceData::HardcodedReferenceList.new({
             SecureRandom.uuid => {
               name: degree.subject,

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -11,7 +11,7 @@ module Dqt
 
       before do
         stub_const(
-          "DfE::ReferenceData::Degrees::SUBJECTS",
+          "DfE::ReferenceData::Degrees::SINGLE_SUBJECTS",
           DfE::ReferenceData::HardcodedReferenceList.new({
             SecureRandom.uuid => {
               name: degree.subject,

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -15,7 +15,7 @@ module Dqt
           DfE::ReferenceData::HardcodedReferenceList.new({
             SecureRandom.uuid => {
               name: degree.subject,
-              hesa_itt_code: hesa_code,
+              hecos_code: hesa_code,
             },
           }),
         )

--- a/spec/services/degrees/fix_to_match_reference_data_spec.rb
+++ b/spec/services/degrees/fix_to_match_reference_data_spec.rb
@@ -25,8 +25,12 @@ module Degrees
           context "match is found in reference data" do
             let(:institution) { "The University of Chichester" }
 
-            it "is updated" do
+            it "updates the value" do
               expect(subject.institution).to eq("University of Chichester")
+            end
+
+            it "updates the UUID" do
+              expect(subject.institution_uuid).to eq("0a71f34a-2887-e711-80d8-005056ac45bb")
             end
           end
 
@@ -51,8 +55,36 @@ module Degrees
           context "match is found in reference data with different casing" do
             let(:type) { "Foundation of arts" }
 
-            it "is updated" do
+            it "updates the value" do
               expect(subject.uk_degree).to eq("Foundation of Arts")
+            end
+
+            it "sets the UUID" do
+              expect(subject.uk_degree_uuid).to eq("7022c4c2-ec9a-4eec-98dc-315bfeb1ef3a")
+            end
+          end
+
+          context "match is found in reference data by abbreviation" do
+            let(:type) { "MChem" }
+
+            it "updates the value" do
+              expect(subject.uk_degree).to eq("Master of Chemistry")
+            end
+
+            it "sets the UUID" do
+              expect(subject.uk_degree_uuid).to eq("576a5652-c197-e711-80d8-005056ac45bb")
+            end
+          end
+
+          context "match is present in the generic types" do
+            let(:type) { "Degree equivalent" }
+
+            it "updates the value" do
+              expect(subject.uk_degree).to eq("Degree equivalent")
+            end
+
+            it "sets the UUID" do
+              expect(subject.uk_degree_uuid).to eq("03c4fa67-345e-4d09-8e9b-68c36a450947")
             end
           end
 
@@ -77,8 +109,12 @@ module Degrees
           context "match is found in reference data with different casing" do
             let(:subject_name) { "English Studies" }
 
-            it "is updated" do
+            it "is updates the value" do
               expect(subject.subject).to eq("English studies")
+            end
+
+            it "updates the UUID" do
+              expect(subject.subject_uuid).to eq("e18070f0-5dce-e911-a985-000d3ab79618")
             end
           end
 
@@ -103,8 +139,12 @@ module Degrees
           context "match is found in reference data" do
             let(:grade) { "First class honours" }
 
-            it "is updated" do
+            it "is updates the value" do
               expect(subject.grade).to eq("First-class honours")
+            end
+
+            it "updates the UUID" do
+              expect(subject.grade_uuid).to eq("8741765a-13d8-4550-a413-c5a860a59d25")
             end
           end
 
@@ -133,8 +173,12 @@ module Degrees
           context "match is found in reference data with different casing" do
             let(:subject_name) { "English Studies" }
 
-            it "is updated" do
+            it "is updates the value" do
               expect(subject.subject).to eq("English studies")
+            end
+
+            it "updates the UUID" do
+              expect(subject.subject_uuid).to eq("e18070f0-5dce-e911-a985-000d3ab79618")
             end
           end
 
@@ -159,8 +203,12 @@ module Degrees
           context "match is found in reference data" do
             let(:grade) { "First class honours" }
 
-            it "is updated" do
+            it "updates the value" do
               expect(subject.grade).to eq("First-class honours")
+            end
+
+            it "updates the UUID" do
+              expect(subject.grade_uuid).to eq("8741765a-13d8-4550-a413-c5a860a59d25")
             end
           end
 

--- a/spec/services/degrees/map_from_apply_spec.rb
+++ b/spec/services/degrees/map_from_apply_spec.rb
@@ -13,7 +13,7 @@ module Degrees
     let(:application_data) do
       ApiStubs::ApplyApi.application(degree_attributes: {
         subject: dfe_degree_subject_reference_data[:name],
-        hesa_degsbj: dfe_degree_subject_reference_data[:hesa_itt_code],
+        hesa_degsbj: dfe_degree_subject_reference_data[:hecos_code],
         grade: dfe_degree_grade_reference_data[:name],
         hesa_degclss: dfe_degree_grade_reference_data[:hesa_itt_code],
         qualification_type: dfe_degree_type_reference_data[:abbreviation],
@@ -24,7 +24,7 @@ module Degrees
     end
 
     let(:dfe_degree_type_reference_data) do
-      DfE::ReferenceData::Degrees::TYPES.some(name: degree_qualification_type).first
+      DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS.some(name: degree_qualification_type).first
     end
 
     let(:dfe_degree_subject_reference_data) do

--- a/spec/services/degrees/map_from_apply_spec.rb
+++ b/spec/services/degrees/map_from_apply_spec.rb
@@ -28,7 +28,7 @@ module Degrees
     end
 
     let(:dfe_degree_subject_reference_data) do
-      DfE::ReferenceData::Degrees::SUBJECTS.some(name: degree_subject).first
+      DfE::ReferenceData::Degrees::SINGLE_SUBJECTS.some(name: degree_subject).first
     end
 
     let(:dfe_degree_grade_reference_data) do


### PR DESCRIPTION
### Context

We now have the DfE::ReferenceData library to reference for degree fields. We have backfilled the institution name with varying degrees of success.

This PR expands that to backfill correct values and their associated UUIDs for:

* type (annoyingly referred to as uk_degree and uk_degree_uuid currently)
* institution
* subject
* grade

### Changes proposed in this pull request

* Upgrade the DfE::ReferenceData to commit 96e1b7d which is a release candidate with some breaking changes. This includes the synonyms, abbreviations and extra values that we need
* Expand the backfill to include the extra fields and UUIDs
* Improve the matching to include name, match_synonyms and abbreviation and strip and downcase both sides of the match
* Update references to `hesa_itt_code` for subjects which is now called `hecos_code`
* Fix some missed `TYPES` references to `TYPES_INCLUDING_GENERICS`

### Guidance to review

* This will be run over all uk and non_uk degrees using the `invalid_degrees:fix_uk|non_uk` rake task
* It should run locally on the anonymised backup without error
* It likely will leave some degrees unmapped. We can identify these by them having missing UUID values and address those separately

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
