### PR TITLE
[xxx] Disable welcome email

### DIFF
--- a/config/settings/dttpimport.yml
+++ b/config/settings/dttpimport.yml
@@ -14,7 +14,6 @@ dfe_sign_in:
 features:
   basic_auth: true
   enable_feedback_link: false
-  send_emails: false
   import_courses_from_ttapi: true
   import_applications_from_apply: false
   publish_course_details: true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -18,7 +18,6 @@ dfe_sign_in:
 features:
   basic_auth: false
   enable_feedback_link: true
-  send_emails: true
   import_courses_from_ttapi: true
   import_applications_from_apply: true
   publish_course_details: true

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -14,7 +14,6 @@ dfe_sign_in:
 features:
   basic_auth: false
   enable_feedback_link: false
-  send_emails: false
   import_courses_from_ttapi: true
   publish_course_details: true
   routes:


### PR DESCRIPTION
### Context

We are bulk importing lead school users and have an email to send them to tell them that they have been added to the system.

We don't want to email them again with the welcome email which is currently sent after they first login.

Disable it for now and we'll decide if we get rid of it altogether or send it at a different point.

### Changes proposed in this pull request

* Set send_email feature flag to false in all environments

### Guidance to review

The flag is set to false by default in config/settings.yml

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
