### PR TITLE
[xxx] Don't display discarded users in system_admin

### DIFF
--- a/app/views/system_admin/lead_schools/show.html.erb
+++ b/app/views/system_admin/lead_schools/show.html.erb
@@ -64,8 +64,8 @@
   { name: "Users", url: lead_school_path(@lead_school) },
 ]) %>
 
-<% if @lead_school.users.any? %>
-  <% @lead_school.users.each do |user| %>
+<% if @lead_school.users.kept.any? %>
+  <% @lead_school.users.kept.each do |user| %>
     <%= render UserCard::View.new(
       user: user,
       edit_path: edit_lead_school_user_path(@lead_school, user),

--- a/app/views/system_admin/providers/show.html.erb
+++ b/app/views/system_admin/providers/show.html.erb
@@ -48,13 +48,15 @@
 
 <h2 class="govuk-heading-m">Users</h2>
 
-<% if @users_view.users.any? %>
-  <% @users_view.users.each do |user| %>
-    <%= render UserCard::View.new(
-      user: user,
-      edit_path: edit_provider_user_path(@provider, user),
-    ) %>
-  <% end %>
+<% if @users_view.users.kept.any? %>
+  <div class="govuk-!-margin-bottom-8 registered-users">
+    <% @users_view.users.kept.each do |user| %>
+      <%= render UserCard::View.new(
+        user: user,
+        edit_path: edit_provider_user_path(@provider, user),
+      ) %>
+    <% end %>
+  </div>
 <% else %>
   <p class="govuk-body">There are no users yet.</p>
 <% end %>


### PR DESCRIPTION
### Context

We have soft delete on the User model. Only show 'kept' users on the lead school and provider pages in system admin.

### Changes proposed in this pull request

* Add the kept scope for these pages

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
