### PR TITLE
[4371] Enable apply trainee creation on dttpimport

### DIFF
--- a/config/settings/dttpimport.yml
+++ b/config/settings/dttpimport.yml
@@ -15,7 +15,7 @@ features:
   basic_auth: true
   enable_feedback_link: false
   import_courses_from_ttapi: true
-  import_applications_from_apply: false
+  import_applications_from_apply: true
   publish_course_details: true
   routes:
     early_years_assessment_only: true
@@ -35,3 +35,11 @@ features:
 
 environment:
   name: dttpimport
+
+apply_applications:
+  import:
+    recruitment_cycle_years:
+      - 2021
+      - 2022
+  create:
+    recruitment_cycle_year: 2022


### PR DESCRIPTION
### Context

We are going to start creating 22/23 trainees from apply but want to test this first.

### Changes proposed in this pull request

Enable in dttpimport

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
