### PR TITLE
[4396] Ensure apply trainee seeds are shown the confirm course page

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -235,6 +235,16 @@ namespace :example_data do
               )
             end
 
+            # Ensure no subjects are set on apply applications - this means that
+            # the user is required to confirm the course.
+            if attrs[:apply_application].present?
+              attrs.merge!(
+                course_subject_one: nil,
+                course_subject_two: nil,
+                course_subject_three: nil,
+              )
+            end
+
             if provider.name.include?(PROVIDER_C) && HESA_TRAINING_ROUTES.include?(route.to_s) && state != :draft
               trainee = FactoryBot.create(:trainee, route, state, :imported_from_hesa, attrs)
               if sample_index < sample_size * 50.0 / 100


### PR DESCRIPTION
### Context

https://trello.com/c/wrpShJxi/4396-apply-drafts-users-not-asked-to-confirm-course

When Apply trainees are imported, we fill in the course uuid not the subjects. When the course is then confirmed, we fill in the subjects. If the subjects are present, we skip the 'confirm course' page.

### Changes proposed in this pull request

Update the seeds to ensure we're not pre-filling Apply trainee subjects and hence the 'confirm course' page is shown

### Guidance to review

- Click into a draft Apply trainee
- Click into review course details
- Check that you're shown the confirm course page, not taken straight to the review page.

<img width="703" alt="Screenshot 2022-07-20 at 16 56 27" src="https://user-images.githubusercontent.com/18436946/180028187-56ca0147-61f4-4a11-9ba3-5311a6fe012f.png">

<img width="671" alt="Screenshot 2022-07-20 at 16 56 04" src="https://user-images.githubusercontent.com/18436946/180028197-70591667-3906-4c2b-9600-68bff757d4e9.png">

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
