### PR TITLE
[4242] Preserve choice of 'Another course not listed'

### DIFF
--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -45,7 +45,11 @@ class PublishCourseDetailsForm < TraineeForm
   end
 
   def save!
-    return true if manual_entry_chosen?
+    if manual_entry_chosen?
+      store.set(id, form_store_key, { course_uuid: NOT_LISTED })
+      return true
+    end
+
     return false unless valid?
 
     update_trainee_attributes

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -55,8 +55,6 @@ class PublishCourseDetailsForm < TraineeForm
   end
 
   def stash
-    return true if manual_entry_chosen?
-
     clear_all_stashes
 
     super

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -38,8 +38,7 @@
 
           <div class="govuk-radios__divider">or</div>
 
-          <%= f.govuk_radio_button :course_uuid, PublishCourseDetailsForm::NOT_LISTED,
-            label: { text: t(".course_not_listed") } %>
+          <%= f.govuk_radio_button :course_uuid, PublishCourseDetailsForm::NOT_LISTED, label: { text: t(".course_not_listed") } %>
         <% end %>
       </div>
 


### PR DESCRIPTION
### Context

https://trello.com/c/svXYFlXU/4242-pages-where-data-is-not-preserved-if-users-use-back-links-publish-course-details

**Issue**
If you go to the course picker page, then pick manual, then back, then refresh - you'll see the answer isn't saved whereas if you pick a course, then go back, then refresh, the answer is saved.

**Tech context:**
- We stash forms for registered trainees so that the data is not overwritten until users confirm the changes
- We save forms for draft trainees. The data is immediately overwritten.

### Changes proposed in this pull request

- Stash `course_uuid: "not_listed"` in the redis form store when the form is stashed OR saved (i.e for both registered trainees and draft trainees) so that the form can re-hydrate from this value

### Guidance to review

Follow the steps as per the trello card and check that the radio button "Another course not listed" is selected as expected.

<img width="579" alt="Screenshot 2022-07-21 at 14 03 03" src="https://user-images.githubusercontent.com/18436946/180221161-a9911aaf-c099-42ad-a786-474e58a66750.png">

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml