### PR TITLE
[4415] Add other option to dfe institutions

### DIFF
--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -45,7 +45,12 @@ module DegreesHelper
 private
 
   def institution_data
-    DfE::ReferenceData::Degrees::INSTITUTIONS.all
+    DfE::ReferenceData::TweakedReferenceList.new(
+      DfE::ReferenceData::Degrees::INSTITUTIONS,
+      {
+        "96e9359f-dbad-4486-8de9-f05f3c7104c2" => { name: "Other", match_synonyms: [], suggestion_synonyms: [], abbreviation: nil },
+      },
+    ).all
   end
 
   def subject_data

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -3,7 +3,7 @@
 class Degree < ApplicationRecord
   include Sluggable
 
-  INSTITUTIONS = DfE::ReferenceData::Degrees::INSTITUTIONS.all.map(&:name)
+  INSTITUTIONS = DfE::ReferenceData::Degrees::INSTITUTIONS.all.map(&:name) << "Other"
   SUBJECTS = DfE::ReferenceData::Degrees::SINGLE_SUBJECTS.all.map(&:name)
   TYPES = DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS.all.map(&:name)
   COMMON_TYPES = ["Bachelor of Arts", "Bachelor of Science", "Master of Arts", "PhD"].freeze

--- a/spec/helpers/degree_helper_spec.rb
+++ b/spec/helpers/degree_helper_spec.rb
@@ -57,6 +57,7 @@ describe DegreesHelper do
       expect(institutions_options).to match([
         [nil, nil, nil],
         [institution, institution, { "data-synonyms" => synonym }],
+        ["Other", "Other", { "data-synonyms" => "" }],
       ])
     end
   end


### PR DESCRIPTION
### Context

We have a user that is unable to recommend a trainee as they need an 'Other' option for institution which the DfE::ReferenceData doesn't support.

### Changes proposed in this pull request

* Add 'Other' option to dropdown
* Add 'Other' option to constant

### Guidance to review

This fixes an issue a user is currently having in production. Work to refactor this to wrap all access to DfE::ReferenceData has been carded up to do this properly.

I've added a UUID for the 'Other' option but am not sure whether that's really a good idea or not. It probably does run the risk that we'll send it somewhere else and that will break something. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
