### PR TITLE
[4384] Remove academic cycle method from trainee

### DIFF
--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -118,7 +118,7 @@ module Funding
     end
 
     def no_funding_methods?
-      !trainee.academic_cycle || trainee.academic_cycle.funding_methods.none?
+      !trainee.start_academic_cycle || trainee.start_academic_cycle.funding_methods.none?
     end
 
     def mappable_field(field_value, field_label, action_url)

--- a/app/forms/apply_applications/trainee_data_form.rb
+++ b/app/forms/apply_applications/trainee_data_form.rb
@@ -36,7 +36,7 @@ module ApplyApplications
       trainee.progress.diversity = true
       trainee.progress.degrees = true
       trainee.progress.trainee_data = true
-      Trainees::Update.call(trainee: trainee)
+      Trainees::Update.call(trainee: trainee, set_academic_cycles_now: true)
     end
 
     def progress_status(progress_key)

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -84,7 +84,7 @@ class CourseDetailsForm < TraineeForm
     if valid?
       update_trainee_attributes
       clear_funding_information if course_subjects_changed?
-      Trainees::Update.call(trainee: trainee)
+      Trainees::Update.call(trainee: trainee, set_academic_cycles_now: true)
       clear_stash
     else
       false

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -50,7 +50,7 @@ class PublishCourseDetailsForm < TraineeForm
 
     update_trainee_attributes
     clear_funding_information if course_subjects_changed?
-    Trainees::Update.call(trainee: trainee)
+    Trainees::Update.call(trainee: trainee, set_academic_cycles_now: true)
     clear_all_stashes
   end
 

--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -29,6 +29,6 @@ module FundingHelper
 private
 
   def can_start_funding_section?(trainee)
-    trainee.progress.course_details && trainee.academic_cycle.present?
+    trainee.progress.course_details && trainee.start_academic_cycle.present?
   end
 end

--- a/app/lib/funding_manager.rb
+++ b/app/lib/funding_manager.rb
@@ -10,7 +10,7 @@ class FundingManager
   def initialize(trainee)
     @trainee = trainee
     @allocation_subject = trainee.course_allocation_subject
-    @academic_cycle = trainee.academic_cycle
+    @academic_cycle = trainee.start_academic_cycle
   end
 
   def bursary_amount

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -406,10 +406,6 @@ class Trainee < ApplicationRecord
     "manual"
   end
 
-  def academic_cycle
-    AcademicCycle.for_date(commencement_date || itt_start_date)
-  end
-
 private
 
   def value_digest

--- a/app/services/trainees/update.rb
+++ b/app/services/trainees/update.rb
@@ -4,21 +4,22 @@ module Trainees
   class Update
     include ServicePattern
 
-    def initialize(trainee:, params: {}, update_dtq: true)
+    def initialize(trainee:, params: {}, update_dtq: true, set_academic_cycles_now: false)
       @trainee = trainee
       @params = params
       @update_dtq = update_dtq
+      @set_academic_cycles_now = set_academic_cycles_now
     end
 
     def call
       trainee.update!(params)
       Dqt::UpdateTraineeJob.perform_later(trainee) if update_dtq
-      Trainees::SetAcademicCyclesJob.perform_later(trainee)
+      Trainees::SetAcademicCyclesJob.send(set_academic_cycles_now ? :perform_now : :perform_later, trainee)
       true
     end
 
   private
 
-    attr_reader :trainee, :params, :update_dtq
+    attr_reader :trainee, :params, :update_dtq, :set_academic_cycles_now
   end
 end

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 module Funding
   describe View do
     let(:data_model) { Funding::FormValidator.new(trainee) }
+    let(:start_academic_cycle) { create(:academic_cycle) }
 
     before { render_inline(View.new(data_model: trainee, editable: true)) }
 
@@ -13,6 +14,8 @@ module Funding
         build(:trainee,
               :early_years_postgrad,
               :with_course_allocation_subject,
+              :with_start_date,
+              start_academic_cycle: start_academic_cycle,
               applying_for_bursary: true,
               bursary_tier: BURSARY_TIERS.keys.first)
       end
@@ -34,6 +37,7 @@ module Funding
               :with_study_mode_and_course_dates,
               training_initiative: training_initiative,
               training_route: route,
+              start_academic_cycle: start_academic_cycle,
               applying_for_bursary: true,
               course_subject_one: subject_specialism.name)
       end
@@ -78,6 +82,7 @@ module Funding
               :with_study_mode_and_course_dates,
               training_initiative: training_initiative,
               training_route: route,
+              start_academic_cycle: start_academic_cycle,
               applying_for_bursary: applying_for_bursary,
               course_subject_one: course_subject_one)
       end
@@ -120,7 +125,9 @@ module Funding
         end
 
         describe "has bursary" do
-          let(:trainee) { create(:trainee, :with_provider_led_bursary, funding_amount: 24000, applying_for_bursary: applying_for_bursary) }
+          let(:trainee) {
+            create(:trainee, :with_provider_led_bursary, funding_amount: 24000, applying_for_bursary: applying_for_bursary, start_academic_cycle: start_academic_cycle)
+          }
 
           before do
             render_inline(View.new(data_model: trainee, editable: true))
@@ -168,7 +175,7 @@ module Funding
     end
 
     context "with grant" do
-      let(:trainee) { create(:trainee, :with_grant, funding_amount: 25000, applying_for_grant: applying_for_grant) }
+      let(:trainee) { create(:trainee, :with_grant, funding_amount: 25000, applying_for_grant: applying_for_grant, start_academic_cycle: start_academic_cycle) }
 
       before do
         render_inline(View.new(data_model: trainee, editable: true))
@@ -209,7 +216,7 @@ module Funding
     end
 
     describe "when we don't know the funding rules for the trainee's cycle" do
-      let(:trainee) { create(:trainee, :with_start_date, applying_for_bursary: true) }
+      let(:trainee) { create(:trainee, :with_start_date, applying_for_bursary: true, start_academic_cycle: start_academic_cycle) }
 
       it "doesn't render the funding row" do
         expect(rendered_component).not_to have_text("Funding method")

--- a/spec/components/sections/view_spec.rb
+++ b/spec/components/sections/view_spec.rb
@@ -17,7 +17,7 @@ module Sections
     context "apply draft trainee in review" do
       let(:section) { :course_details }
       let(:status) { :review }
-      let(:trainee) { create(:trainee, :in_progress, :with_apply_application) }
+      let(:trainee) { create(:trainee, :in_progress, :with_apply_application, start_academic_cycle: AcademicCycle.first) }
 
       it "renders section text for apply draft course details" do
         expect(rendered_component).to have_css(".app-inset-text__title", text: expected_title(section, status))
@@ -60,7 +60,7 @@ module Sections
     end
 
     context "trainee incomplete" do
-      let(:trainee) { create(:trainee, :incomplete) }
+      let(:trainee) { create(:trainee, :incomplete, start_academic_cycle: AcademicCycle.first) }
 
       include_examples renders_incomplete_section, :personal_details, :incomplete
       include_examples renders_incomplete_section, :contact_details, :incomplete
@@ -82,13 +82,13 @@ module Sections
       end
 
       context "trainee on early years route" do
-        let(:trainee) { create(:trainee, :incomplete, training_route: "early_years_undergrad") }
+        let(:trainee) { create(:trainee, :incomplete, training_route: "early_years_undergrad", start_academic_cycle: AcademicCycle.first) }
 
         include_examples renders_incomplete_section, :course_details, :incomplete
       end
 
       context "trainee incomplete funding section" do
-        let(:trainee) { create(:trainee, :with_start_date) }
+        let(:trainee) { create(:trainee, :with_start_date, start_academic_cycle: AcademicCycle.first) }
 
         before {
           trainee.progress.course_details = true

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -438,17 +438,6 @@ describe Trainee do
         end
       end
     end
-
-    describe "academic_cycle" do
-      let(:academic_cycle) { create(:academic_cycle, cycle_year: 2018) }
-      let(:trainee) { create(:trainee, commencement_date: Date.new(academic_cycle.start_year, 9, 1)) }
-
-      subject { trainee.academic_cycle }
-
-      it "returns the AcademicCycle the trainee started in" do
-        expect(subject).to eq(academic_cycle)
-      end
-    end
   end
 
   describe "#with_name_trainee_id_or_trn_like" do

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -190,7 +190,7 @@ module Exports
     describe "#funding_value" do
       context "when the trainee is funded" do
         context "when we know the funding methods for that cycle" do
-          let(:trainee) { create(:trainee, :with_provider_led_bursary) }
+          let(:trainee) { create(:trainee, :with_provider_led_bursary, start_academic_cycle: AcademicCycle.first) }
 
           it "returns the amount" do
             expect(subject.send(:funding_value, trainee)).to eq(FundingMethod.last.amount)

--- a/spec/support/shared_examples/rendering_the_funding_section.rb
+++ b/spec/support/shared_examples/rendering_the_funding_section.rb
@@ -3,7 +3,8 @@
 RSpec.shared_examples "rendering the funding section" do
   context "when a trainee is on a route with a bursary" do
     let(:route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
-    let(:trainee) { create(:trainee, :with_start_date, :with_study_mode_and_course_dates, :incomplete_draft, route) }
+    let(:trainee) { create(:trainee, :with_start_date, :with_study_mode_and_course_dates, :incomplete_draft, route, start_academic_cycle: current_academic_cycle) }
+    let!(:current_academic_cycle) { create(:academic_cycle, :current) }
 
     before { create(:funding_method, :with_subjects, training_route: route) }
 
@@ -25,7 +26,8 @@ RSpec.shared_examples "rendering the funding section" do
   end
 
   context "when a trainee is on a route with no bursary" do
-    let(:trainee) { create(:trainee, :with_start_date, :incomplete_draft, TRAINING_ROUTE_ENUMS[:assessment_only]) }
+    let!(:current_academic_cycle) { create(:academic_cycle, :current) }
+    let(:trainee) { create(:trainee, :with_start_date, :incomplete_draft, TRAINING_ROUTE_ENUMS[:assessment_only], start_academic_cycle: current_academic_cycle) }
 
     before { create(:funding_method, :with_subjects, training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad]) }
 


### PR DESCRIPTION
### Context

The new start_academic_cycle field on trainee should replace the old 'academic_cycle' trainee method. This requires some test fiddling to ensure all trainees in the specs have a start_academic_cycle. The set academic cycle method has also to be called after the course details are added for the feature specs to work. 