### PR TITLE
[xxx] No more Doctor Phil

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,8 @@ gem "redcarpet"
 
 gem "mechanize" # interact with HESA
 
-gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v1.0.0"
+# pinned to a commit as v1 doesn't contain the Doctor of Philosophy disambiguation
+gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", ref: "9ed4450"
 
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: 81d45ce435c26fc27bbab4bb82c4e18bb42ea4f9
-  tag: v1.0.0
+  revision: 9ed4450e7eac5dff9a200c32dd8980626e04ca99
+  ref: 9ed4450
   specs:
     dfe-reference-data (1.0.0)
       activesupport

--- a/db/data/20220722130512_rename_doctor_of_philosphy.rb
+++ b/db/data/20220722130512_rename_doctor_of_philosphy.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RenameDoctorOfPhilosphy < ActiveRecord::Migration[6.1]
+  def up
+    dphil_id = "656a5652-c197-e711-80d8-005056ac45bb"
+    Degree.where(uk_degree_uuid: dphil_id).update_all(uk_degree: "Doctor of Philosophy (DPhil)")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

The version of dfe-reference-data we are using has an ambiguous 'Doctor of Philosophy' entry that is causing a duplicate entry in our degree type autocomplete and a frustrating amount of flakiness in CI.

This as been fixed in https://github.com/DFE-Digital/dfe-reference-data/pull/42

### Changes proposed in this pull request

* Update to the fixed version
* Update the existing degree string values to keep things all valid and peachy

### Guidance to review

Would be good to check the autocomplete is still working for adding and updating degrees. It now has the abbreviation twice which is mildly annoying but still an improvement. 

<img width="517" alt="Screenshot 2022-07-22 at 14 10 35" src="https://user-images.githubusercontent.com/5216/180448253-f3525d14-3577-47b3-8651-9e74d3cbed7b.png">


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
