### PR TITLE
[4371] Handle unrecognised grade

### DIFF
--- a/app/services/degrees/map_from_apply.rb
+++ b/app/services/degrees/map_from_apply.rb
@@ -77,10 +77,10 @@ module Degrees
     def grade_params
       grade = find_dfe_reference_grade
 
-      if Degree::GRADES.include?(grade.name)
+      if grade
         { grade: grade.name, grade_uuid: grade.id, other_grade: nil }
       else
-        { grade: Degree::OTHER_GRADE, grade_uuid: grade.id, other_grade: grade.name }
+        { grade: Degree::OTHER_GRADE, grade_uuid: nil, other_grade: attributes["grade"] }
       end
     end
 

--- a/spec/services/degrees/map_from_apply_spec.rb
+++ b/spec/services/degrees/map_from_apply_spec.rb
@@ -82,20 +82,20 @@ module Degrees
         it { is_expected.to include(expected_uk_degree_attributes) }
       end
 
-      context "grade outside the Register scope (Dttp::CodeSets::Grades::MAPPING)" do
-        let(:degree_grade) { "Aegrotat" }
+      context "unrecognised grade" do
+        let(:unrecognised_grade) { "Balloney" }
 
-        before do
+        let(:application_data) do
           ApiStubs::ApplyApi.application(degree_attributes: {
-            grade: dfe_degree_grade_reference_data[:name],
-            grade_uuid: dfe_degree_grade_reference_data[:id],
+            grade: unrecognised_grade,
+            grade_uuid: nil,
+            hesa_degclss: nil,
           })
         end
 
-        it "stores the UUID but saved the name in the other_grade attribute" do
-          expect(subject).to include(grade: Dttp::CodeSets::Grades::OTHER,
-                                     grade_uuid: dfe_degree_grade_reference_data[:id],
-                                     other_grade: dfe_degree_grade_reference_data[:name])
+        it "stores the other grade" do
+          expect(subject).to include(grade: "Other",
+                                     other_grade: unrecognised_grade)
         end
       end
     end


### PR DESCRIPTION
### Context

We've switched to using the reference data for Apply imports. There is a failing import (at least one) that doesn't have a matching value for grade. Handle that by setting the grade to other.

### Changes proposed in this pull request

* Set unrecognised grade to other

### Guidance to review

We should review which values are being set with this and maybe revise the 'solution'. This will hopefully allow the test import to succeed and we can card up any further work.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
