### PR TITLE
Upgrade cloudfoundry and statuscake providers.

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -2,23 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
-  version     = "0.13.0"
-  constraints = "~> 0.12, 0.13.0"
+  version     = "0.15.3"
+  constraints = "0.15.3"
   hashes = [
-    "h1:OJjPngcAb2g8UBunlU0L7qNed+y9TLXoF4VzlUvL9Qk=",
-    "zh:146277a9fb306f5c10cb385dce356f16174762f6e799456638e5981b8fc9fcde",
-    "zh:254fe911a61acae7352f7f91d2e706db975481124cbb2fa8fce8b367b8becebe",
-    "zh:4b71ab53089b869d9689f44e5c869c83446d6754ccfa9587ae297c62a2070aa5",
-    "zh:51cbc92b6ed5640464633bc37323835a1f3a0888bf98b747ff5736360aa15b7f",
-    "zh:61f40fe915c2b2fe545c0e7d7373ccd49e7af8c4557c8657e1b76b6cd67cb640",
-    "zh:66186073b2086097a2b9ebd902530d8417c5cc17c6d8262991172b2a1309eae4",
-    "zh:a759ec60b39f34e200e7d0da043f8f72a9a39dc091828e9290f683e4129619f4",
-    "zh:acecf99eb8a4a9ccfe1e9ce630b56e9d9117d665aecb3dc81050d438630d0c01",
-    "zh:ae1c826b5f84eb87f2fa23505a7c536a782d41eb5080f22e86cb7302fee1d8b4",
-    "zh:b3b7daed0065cc66d88c53692f6539fb77e6ddf30fd154765a6f8e9b3c1df384",
-    "zh:c53c7848eca19f3e7b9bb30d808d3484f371c1c47a03bcc2e736fba3454f8327",
-    "zh:e7cf68083d5d655794613b30cc52e8995c8672b424c6b5c4e9cf915fe2b539d7",
-    "zh:ece9ae93c194866d3365057e731c3571bde825b8558c5e8c4d9e12c1f624cd86",
+    "h1:ebaDoq5SH3X1IP/tMjdu1YbBXvFSZ+T7VOeaLEPrUK4=",
+    "zh:0580532e0968aabecb80157cd66b6b2d2d6f309483eacb611e8416f13a72a7ef",
+    "zh:0caea11d07d568ff8d58a853d37328d09ebe78523615f3707dd5234d6b968fdc",
+    "zh:10d5d76b07c2ba5b596c9a161199e0f210ce257e7d5fd50c44e139098e9b4705",
+    "zh:329e31067f66c72c1f10f9f250fd337681e57220503ba5af6b84e3b276f7aa2f",
+    "zh:41a01de3604cf6d8d4f55ffa2c737d3e4e3ccc322558e570239d7656fc928c06",
+    "zh:45e0aea33a9c7e9e50f4e503afe7cb8ccb2da2cfaf32fec69bdb3ed704f48174",
+    "zh:4e696fac48ba9a14c28eaabbd33be43c963f86ed8687c37aa83568424f3f9812",
+    "zh:5109af4a86556a511c3694ba5ee8752f5b56dd1283b6feb153173aedd300bc40",
+    "zh:616fb3ea24ac70b7b2b2558e5b1f68aa9fbda32067516ddc1d217512ca7eb33d",
+    "zh:779bc7a303891e5f12c6b2b158bde62c16d9b6b378ed060cd64fd6b8775984ac",
+    "zh:7d80dcefed41657722b48b245ec483b35b8760fbef861a552cbdf0e46ec5af1f",
+    "zh:bfacd288f81e07e2faab1055bdcf7f0cb8cf556f53b4f88602ddf9fc4b6b82f1",
+    "zh:ccf49978a916314cf41ce3b052fcee0d115d2d25ec6e9f2e1bbeaa5fe3368949",
+    "zh:d43e291e8c26f65ea008f7d405df52c198e142fc37e9963c0c4cb590e3686bbd",
+    "zh:e4ef54d5010a172cf332da1552079e087591af1fdb4e4bb77d6baefece90d864",
   ]
 }
 
@@ -27,6 +29,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.12.0"
   hashes = [
     "h1:KF6bIhK7POPuO1HYK1G8b5Fae+0n8c/gM+9EBVJJQ2Q=",
+    "h1:fbcdew9/5ihZuiRNxVPIg+nRYqFBeuj2qzUe3PhAdvo=",
     "zh:0bbc93276a38da205d2b8ce34a2f813e96687a2f6fc7addd9bb05b85dab2a662",
     "zh:3af12159e0b5217a7b35f081fba1e34ac8fb995acc7e6d2ec86592a559eb85c8",
     "zh:7d1bdc9b4d9b1990409d52cb915e5acbe17bd81b29d28f7fcdaaf96003dca77c",
@@ -43,20 +46,24 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 }
 
 provider "registry.terraform.io/statuscakedev/statuscake" {
-  version     = "1.0.1"
-  constraints = "1.0.1"
+  version     = "2.0.2-pre"
+  constraints = "2.0.2-pre"
   hashes = [
-    "h1:YOpR2SMftsGw5IeWphloDytm/2h5CH1YonsBpsjRfyc=",
-    "zh:202f23eb15bd2900ab8f93be8a04bdf04321202ed1a969d9590f993faefd342a",
-    "zh:27a8c66ebe0c5436416259371e9eaf00282d45d9966e0c989e9a5fe92d97ac8c",
-    "zh:4632f7d7862fe6e475e96c9cded12221e3c6849c2421e7ea60a80dd189144008",
-    "zh:4ef7e1839fa71de967cfccfdd3e33a7f5a36f67f048322861210089c8ec03c2f",
-    "zh:51670fc6a1861fb3e80f00999e78420c8aec830e8141d58109db0cecece87e85",
-    "zh:6d760d682550ab34c2f1bb3af7b3a9afcaaf9ef589a84587fb85f37b0e4916db",
-    "zh:737605db52be4e79ce78bc448ea691080746ab89f119c73324040da04691a1d9",
-    "zh:b135bda364bad5b1ff5c6e652a832a93b4dac579dd6983fdb3bb0bc9f315f622",
-    "zh:bead0801de80e9736b5ac1604d7e2ca18759b7266df60dfa29921e56df613966",
-    "zh:c8ac03fc938cd438addba11dd8674b153eb16e5450bf2edb8c669f0cfc3c7c24",
-    "zh:e48c0536b185d8ebac7a3861f7cbbd28e1312fb4201586f4946cd0e6ffdb58ab",
+    "h1:8abFfgwho9TIHoOtXIux+ygNi025c7TaUOMds3c63yY=",
+    "zh:08c7a949926cd9eecfc81fde752d55c89e992768a0e9b394114bfec03d12bb56",
+    "zh:188323e94e8527aa898e03d806449e2eef813838b87c459b2f330721e85a575f",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:5af5d441460aa5854ace56b360a5b22c1a24793d51c8c4af6478eb7f6d1da2e7",
+    "zh:6b686f49d59607ff2390ccf5137f9e7654a514c81d81b3ca23b3acdb804f0ce9",
+    "zh:6f2a2082b4b9103e60625e7378500c24e4c5c8a478843f4a3c6f942599680bf3",
+    "zh:736c8bb04612d8b46cf5e1995cac6991e2d9c8c9df57c6cdcd1158330540883e",
+    "zh:7491ba354bf1dd76a01c3e4a8f663b4d7ef421ecfdc944cc9da2d190b1c8fef5",
+    "zh:7d1696eb318ffff4f4d23f1470ce149737cf6441d0563b6a8c9ab555779bb326",
+    "zh:7de09323faeeae9607f982efdcf3aa0ef8e7dbeb7078a98757565948ca9fbeed",
+    "zh:ac9e879763dbadf90553d962dea87d1161a3ac82db3f1a41022d69649539bbbf",
+    "zh:af020751c4b17bcbc49846686fa18bd58e0b9eab5238659e0abf6b106278f500",
+    "zh:c3fb32b1b6adc50b9c8a75cca6d88803db259f18ddd6f3f03f790c9d0fa6e0fb",
+    "zh:c48cc7eaf1935bd1d01b3d124f48aa257bbae27f66337bc252cd062573bc0981",
+    "zh:f7bd42a94d5599bfc8aa08bb2cefcb5de68163cc62f066e0dc0e74db458a1b7a",
   ]
 }

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.13.0"
+      version = "0.15.3"
     }
   }
 }

--- a/terraform/modules/statuscake/main.tf
+++ b/terraform/modules/statuscake/main.tf
@@ -1,11 +1,60 @@
-resource statuscake_test alert {
+resource statuscake_uptime_check alert {
   for_each       = var.alerts
-  website_name   = each.value.website_name
-  website_url    = each.value.website_url
-  test_type      = each.value.test_type
-  check_rate     = each.value.check_rate
-  contact_group  = each.value.contact_group
-  trigger_rate   = each.value.trigger_rate
-  confirmations  = 1
-  node_locations = each.value.node_locations
+
+  name           = each.value.website_name
+  check_interval = each.value.check_rate
+  confirmation   = 2
+  trigger_rate   = 0
+  regions        = [ "london", "dublin" ]
+  contact_groups = each.value.contact_group
+
+  http_check {
+    follow_redirects = true
+    timeout          = 40
+    request_method   = "HTTP"
+    status_codes     = [
+      "204",
+      "205",
+      "206",
+      "303",
+      "400",
+      "401",
+      "403",
+      "404",
+      "405",
+      "406",
+      "408",
+      "410",
+      "413",
+      "444",
+      "429",
+      "494",
+      "495",
+      "496",
+      "499",
+      "500",
+      "501",
+      "502",
+      "503",
+      "504",
+      "505",
+      "506",
+      "507",
+      "508",
+      "509",
+      "510",
+      "511",
+      "521",
+      "522",
+      "523",
+      "524",
+      "520",
+      "598",
+      "599"
+    ]
+  }
+
+  monitored_resource {
+    address = each.value.website_url
+  }
 }

--- a/terraform/modules/statuscake/provider.tf
+++ b/terraform/modules/statuscake/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     statuscake = {
       source  = "StatusCakeDev/statuscake"
-      version = "1.0.1"
+      version = "2.0.2-pre"
     }
   }
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -7,12 +7,12 @@ terraform {
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.13.0"
+      version = "0.15.3"
     }
 
     statuscake = {
       source  = "StatusCakeDev/statuscake"
-      version = "1.0.1"
+      version = "2.0.2-pre"
     }
   }
   backend "azurerm" {
@@ -67,8 +67,7 @@ module "paas" {
 
 #authenticate into provider
 provider "statuscake" {
-  username = local.infra_secrets.STATUSCAKE_USERNAME
-  apikey   = local.infra_secrets.STATUSCAKE_PASSWORD
+  api_token = local.infra_secrets.STATUSCAKE_PASSWORD
 }
 # interface into statusCake module
 module "statuscake" {

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -14,5 +14,13 @@
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1536,
   "paas_worker_app_instances": 2,
-  "paas_worker_app_memory": 1024
+  "paas_worker_app_memory": 1024,
+  "statuscake_alerts": {
+    "alert": {
+      "website_name": "register-production",
+      "website_url": "https://www.register-trainee-teachers.service.gov.uk/ping",
+      "check_rate": 60,
+      "contact_group": [151103]
+    }
+  }
 }

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -14,5 +14,13 @@
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1024,
   "paas_worker_app_instances": 1,
-  "paas_worker_app_memory": 512
+  "paas_worker_app_memory": 512,
+  "statuscake_alerts": {
+    "alert": {
+      "website_name": "register-qa",
+      "website_url": "https://qa.register-trainee-teachers.service.gov.uk/ping",
+      "check_rate": 60,
+      "contact_group": [151103]
+    }
+  }
 }

--- a/terraform/workspace-variables/sandbox.tfvars.json
+++ b/terraform/workspace-variables/sandbox.tfvars.json
@@ -13,5 +13,13 @@
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1024,
   "paas_worker_app_instances": 2,
-  "paas_worker_app_memory": 512
+  "paas_worker_app_memory": 512,
+  "statuscake_alerts": {
+    "alert": {
+      "website_name": "register-sandbox",
+      "website_url": "https://sandbox.register-trainee-teachers.service.gov.uk/ping",
+      "check_rate": 60,
+      "contact_group": [151103]
+    }
+  }
 }

--- a/terraform/workspace-variables/staging.tfvars.json
+++ b/terraform/workspace-variables/staging.tfvars.json
@@ -14,5 +14,13 @@
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1024,
   "paas_worker_app_instances": 1,
-  "paas_worker_app_memory": 512
+  "paas_worker_app_memory": 512,
+  "statuscake_alerts": {
+    "alert": {
+      "website_name": "register-staging",
+      "website_url": "https://staging.register-trainee-teachers.service.gov.uk/ping",
+      "check_rate": 60,
+      "contact_group": [151103]
+    }
+  }
 }


### PR DESCRIPTION
### Context

Currently it is not possible to run our Terraform scripts in an Apple ARM environment because we need newer versions of the CloudFoundry and StatusCake modules.

### Changes proposed in this pull request

Update cloudfoundry module to 0.15.3
Update statuscake to module 2.0.2-pre

Resource changes for statuscake in main.cf
Also hardcoded some of the statuscake settings in the main.cf,
so we no longer need to set them multiple times in the workspace files for each env.

- trigger_rate
- regions (changed to 2 and in the new required format)
- confirmation
- request_method
- status_codes (required by the tf provider)
- timeout (default has changed to 15, so reset to 40)
- enabled follow_redirects

### Guidance to review

deployed to review app
deploy-plan all envs

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
