### PR TITLE
ignore cloudfront proxy IPs for request.remote_ip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,11 @@ gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/df
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.2.1"
 
+group :production do
+  # Pull list of CloudFront proxies so request.remote_ip returns the correct IP.
+  gem "cloudfront-rails"
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,8 @@ GEM
     chartkick (4.1.3)
     childprocess (4.1.0)
     cliver (0.3.2)
+    cloudfront-rails (0.4.0)
+      railties (> 4.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     config (4.0.0)
@@ -635,6 +637,7 @@ DEPENDENCIES
   byebug
   canonical-rails
   capybara (~> 3.37)
+  cloudfront-rails
   config (~> 4.0)
   cuprite (~> 0.13)
   data_migrate


### PR DESCRIPTION
Up until now, when retrieving the IP of the client we've been getting the CloudFront proxy IPs. The cloudfront-rails gem retrieves and caches the list of CloudFront IPs, and configures Rails to ignore them when retrieving the client IP via `request.remote_ip`.

This is required by `dfe-analytics` to help us better understand who is using our services (using psuedo-anonymisation).

### Guidance to review

This has been tested locally by taking the `gem` line out of the `production` group, and making a request with `X-Forwarded-For` headers that include an IP from CloudFront. Without this gem installed, the CloudFront IP is returned by `request.remote_ip`.

```
$ curl -k -H "X-Forwarded-For: 123.12.34.123, 3.11.53.10, 10.1.2.3" -I https://localhost:5000
Your IP: 3.11.53.10
```

Without it, this IP is ignored:
```
$ curl -k -H "X-Forwarded-For: 123.12.34.123, 3.11.53.10, 10.1.2.3" -I https://localhost:5000
Your IP: 123.12.34.123
```

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
