### PR TITLE
Remove statuscake alerts before provider upgrade

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -14,16 +14,5 @@
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1536,
   "paas_worker_app_instances": 2,
-  "paas_worker_app_memory": 1024,
-  "statuscake_alerts": {
-    "alert": {
-      "website_name": "register-production",
-      "website_url": "https://www.register-trainee-teachers.service.gov.uk/ping",
-      "test_type": "HTTP",
-      "check_rate": 60,
-      "contact_group": [151103],
-      "trigger_rate": 0,
-      "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-    }
-  }
+  "paas_worker_app_memory": 1024
 }

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -14,16 +14,5 @@
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1024,
   "paas_worker_app_instances": 1,
-  "paas_worker_app_memory": 512,
-  "statuscake_alerts": {
-    "alert": {
-      "website_name": "register-qa",
-      "website_url": "https://qa.register-trainee-teachers.service.gov.uk/ping",
-      "test_type": "HTTP",
-      "check_rate": 60,
-      "contact_group": [151103],
-      "trigger_rate": 0,
-      "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-    }
-  }
+  "paas_worker_app_memory": 512
 }

--- a/terraform/workspace-variables/sandbox.tfvars.json
+++ b/terraform/workspace-variables/sandbox.tfvars.json
@@ -13,16 +13,5 @@
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1024,
   "paas_worker_app_instances": 2,
-  "paas_worker_app_memory": 512,
-  "statuscake_alerts": {
-    "alert": {
-      "website_name": "register-sandbox",
-      "website_url": "https://sandbox.register-trainee-teachers.service.gov.uk/ping",
-      "test_type": "HTTP",
-      "check_rate": 60,
-      "contact_group": [151103],
-      "trigger_rate": 0,
-      "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-    }
-  }
+  "paas_worker_app_memory": 512
 }

--- a/terraform/workspace-variables/staging.tfvars.json
+++ b/terraform/workspace-variables/staging.tfvars.json
@@ -14,16 +14,5 @@
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1024,
   "paas_worker_app_instances": 1,
-  "paas_worker_app_memory": 512,
-  "statuscake_alerts": {
-    "alert": {
-      "website_name": "register-staging",
-      "website_url": "https://staging.register-trainee-teachers.service.gov.uk/ping",
-      "test_type": "HTTP",
-      "check_rate": 60,
-      "contact_group": [151103],
-      "trigger_rate": 0,
-      "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-    }
-  }
+  "paas_worker_app_memory": 512
 }


### PR DESCRIPTION
### Context

Remove statuscake alerts before adding back during the terraform provider upgrade

### Changes proposed in this pull request

Remove alert config from workspace variables 

### Guidance to review

deploy-plan

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
