### PR TITLE
[4420] Set course_education_phase during Apply import

### DIFF
--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -58,6 +58,7 @@ module Trainees
         disability_disclosure: disability_disclosure,
         email: raw_contact_details["email"],
         course_uuid: course&.uuid,
+        course_education_phase: course&.level,
         course_min_age: course&.min_age,
         course_max_age: course&.max_age,
         training_route: course&.route,

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -39,6 +39,7 @@ module Trainees
         ethnic_background: candidate_info["ethnic_background"],
         diversity_disclosure: Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed],
         email: contact_details["email"],
+        course_education_phase: course.level,
         training_route: course.route,
         course_uuid: course.uuid,
         course_min_age: course.min_age,
@@ -123,6 +124,10 @@ module Trainees
     it "does not capture to sentry" do
       expect(Sentry).not_to receive(:capture_message)
       create_trainee_from_apply
+    end
+
+    context "course education phase" do
+      it { is_expected.to have_attributes(course_education_phase: COURSE_EDUCATION_PHASE_ENUMS[:primary]) }
     end
 
     context "disabilities" do


### PR DESCRIPTION
### Context
https://trello.com/c/2ZJCtdWY/4420-investigate-why-trainees-when-imported-from-apply-are-no-longer-being-set-for-their-phase

### Changes proposed in this pull request
- Update `Trainees::CreateFromApply` set `Trainee#course_education_phase`

### Important business
- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
