### PR TITLE
[xxx] Don't set HESA students to awarded

### DIFF
--- a/app/services/trainees/map_state_from_hesa.rb
+++ b/app/services/trainees/map_state_from_hesa.rb
@@ -14,8 +14,6 @@ module Trainees
       return :trn_received if trn_received?
       return :withdrawn if withdrawn?
       return :deferred if trainee_dormant?
-
-      :awarded if successful_completion_of_course?
     end
 
   private

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -284,24 +284,6 @@ module Trainees
           end
         end
 
-        context "and the trainee completed the course" do
-          let(:hesa_stub_attributes) do
-            {
-              end_date: date,
-              reason_for_leaving: hesa_reasons_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::SUCCESSFUL_COMPLETION],
-            }
-          end
-
-          it "does not set the withdraw fields" do
-            expect(trainee.withdraw_date).to be_nil
-            expect(trainee.withdraw_reason).to be_nil
-          end
-
-          it "creates a awarded trainee with the relevant details" do
-            expect(trainee.state).to eq("awarded")
-          end
-        end
-
         context "and the reason for completion is 'Completion of course - result unknown'" do
           let(:hesa_modes) { Hesa::CodeSets::Modes::MAPPING.invert }
 

--- a/spec/services/trainees/map_state_from_hesa_spec.rb
+++ b/spec/services/trainees/map_state_from_hesa_spec.rb
@@ -50,16 +50,5 @@ module Trainees
 
       it { is_expected.to eq(:withdrawn) }
     end
-
-    context "awarded" do
-      let(:hesa_stub_attributes) do
-        {
-          end_date: date_today,
-          reason_for_leaving: hesa_reason_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::SUCCESSFUL_COMPLETION],
-        }
-      end
-
-      it { is_expected.to eq(:awarded) }
-    end
   end
 end


### PR DESCRIPTION
### Context

We receive updates from the HESA API. We are incorrectly setting trainees to 'awarded' when we receive a successful course completion but the two things are different.

### Changes proposed in this pull request

* Don't set trainees to awarded because they have successfully completed the course.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
