### PR TITLE
More granular training routes on dqt trn request

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -23,8 +23,8 @@ module Dqt
         TRAINING_ROUTE_ENUMS[:hpitt_postgrad] => "TeachFirstProgramme",
         TRAINING_ROUTE_ENUMS[:opt_in_undergrad] => "UndergraduateOptIn",
         TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => "Apprenticeship",
-        TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => "Core",
-        TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => "Core",
+        TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => "ProviderLedPostgrad",
+        TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => "ProviderLedUndergrad",
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => "SchoolDirectTrainingProgrammeSalaried",
         TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => "SchoolDirectTrainingProgrammeSelfFunded",
       }.freeze


### PR DESCRIPTION
### Context

By @benilovj #2569 

Training route is sent to the DQT API as part of the TRN request.

### Changes proposed in this pull request

Pass more granular training routes upon requesting TRN from DQT. 

The [DQT API has now been updated to accept values for provider-led postgrad and undergrad routes](https://qualified-teachers-api-tech-docs.london.cloudapps.digital/#schema-ittprogrammetype), to ensure that no data granularity is lost.

### Guidance to review

n/a

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
