### PR TITLE
[4459] Use match and suggestion synonyms in degree autocomplete

### DIFF
--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -5,7 +5,7 @@ module DegreesHelper
 
   def degree_type_options
     to_enhanced_options(degree_type_data) do |ref_data|
-      synonyms = (ref_data[:synonyms] || []) << ref_data[:abbreviation]
+      synonyms = Array(ref_data[:match_synonyms]) + Array(ref_data[:suggestion_synonyms]) + Array(ref_data[:abbreviation])
       data = {
         "data-synonyms" => synonyms.join("|"),
         "data-append" => ref_data[:abbreviation] && tag.strong("(#{ref_data[:abbreviation]})"),
@@ -18,13 +18,17 @@ module DegreesHelper
 
   def institutions_options
     to_enhanced_options(institution_data) do |ref_data|
-      [ref_data[:name], ref_data[:name], { "data-synonyms" => (ref_data[:synonyms] || []).join("|") }]
+      [ref_data[:name],
+       ref_data[:name],
+       { "data-synonyms" => (Array(ref_data[:match_synonyms]) + Array(ref_data[:suggestion_synonyms])).join("|") }]
     end
   end
 
   def subjects_options
     to_enhanced_options(subject_data) do |ref_data|
-      [ref_data[:name], ref_data[:name], { "data-synonyms" => (ref_data[:synonyms] || []).join("|") }]
+      [ref_data[:name],
+       ref_data[:name],
+       { "data-synonyms" => (Array(ref_data[:match_synonyms]) + Array(ref_data[:suggestion_synonyms])).join("|") }]
     end
   end
 

--- a/spec/helpers/degree_helper_spec.rb
+++ b/spec/helpers/degree_helper_spec.rb
@@ -8,7 +8,8 @@ describe DegreesHelper do
   describe "#degree_type_options" do
     let(:degree_type) { "Bachelor of Arts" }
     let(:degree_abbreviation) { "BA" }
-    let(:degree_synonym) { "Bachelors" }
+    let(:match_synonym) { "Bachelors" }
+    let(:suggestion_synonym) { "Bachelor" }
 
     before do
       stub_const("DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS",
@@ -16,7 +17,8 @@ describe DegreesHelper do
                    SecureRandom.uuid => {
                      name: degree_type,
                      abbreviation: degree_abbreviation,
-                     synonyms: [degree_synonym],
+                     match_synonyms: [match_synonym],
+                     suggestion_synonyms: [suggestion_synonym],
                    },
                  }))
 
@@ -32,7 +34,7 @@ describe DegreesHelper do
           {
             "data-append" => "<strong>(#{degree_abbreviation})</strong>",
             "data-boost" => 1.5,
-            "data-synonyms" => "#{degree_synonym}|#{degree_abbreviation}",
+            "data-synonyms" => "#{match_synonym}|#{suggestion_synonym}|#{degree_abbreviation}",
           },
         ],
       ])
@@ -41,14 +43,16 @@ describe DegreesHelper do
 
   describe "#institutions_options" do
     let(:institution) { "University College London" }
-    let(:synonym) { "UCL" }
+    let(:suggestion_synonym) { "London College University" }
+    let(:match_synonym) { "UCL" }
 
     before do
       stub_const("DfE::ReferenceData::Degrees::INSTITUTIONS",
                  DfE::ReferenceData::HardcodedReferenceList.new({
                    SecureRandom.uuid => {
                      name: institution,
-                     synonyms: [synonym],
+                     suggestion_synonyms: [suggestion_synonym],
+                     match_synonyms: [match_synonym],
                    },
                  }))
     end
@@ -56,7 +60,7 @@ describe DegreesHelper do
     it "iterates over array and prints out correct institutions options" do
       expect(institutions_options).to match([
         [nil, nil, nil],
-        [institution, institution, { "data-synonyms" => synonym }],
+        [institution, institution, { "data-synonyms" => "#{match_synonym}|#{suggestion_synonym}" }],
         ["Other", "Other", { "data-synonyms" => "" }],
       ])
     end
@@ -64,14 +68,16 @@ describe DegreesHelper do
 
   describe "#subjects_options" do
     let(:degree_subject) { "Mathematics" }
-    let(:synonym) { "maths" }
+    let(:suggestion_synonym) { "Stats" }
+    let(:match_synonym) { "Maths" }
 
     before do
       stub_const("DfE::ReferenceData::Degrees::SINGLE_SUBJECTS",
                  DfE::ReferenceData::HardcodedReferenceList.new({
                    SecureRandom.uuid => {
                      name: degree_subject,
-                     synonyms: [synonym],
+                     match_synonyms: [match_synonym],
+                     suggestion_synonyms: [suggestion_synonym],
                    },
                  }))
     end
@@ -79,7 +85,7 @@ describe DegreesHelper do
     it "iterates over array and prints out correct subjects values" do
       expect(subjects_options).to match([
         [nil, nil, nil],
-        [degree_subject, degree_subject, { "data-synonyms" => synonym }],
+        [degree_subject, degree_subject, { "data-synonyms" => "#{match_synonym}|#{suggestion_synonym}" }],
       ])
     end
   end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/pKMNYdwv/4459-s-degree-autocompletes-not-matching-synonyms

Our degree autocompletes were not using the synonyms to help populate the data, which meant we weren't able to match on some values that should have returned a result.

We've now added in `match_synonyms` and `suggestion_synonyms` to institution, degree type and subject mappings so these should now return results in the autocomplete.

<img width="647" alt="Screenshot 2022-07-26 at 16 33 30" src="https://user-images.githubusercontent.com/43522239/181048464-71255c0b-85cb-4d72-8295-47f314fc83bf.png">
<img width="584" alt="Screenshot 2022-07-26 at 16 33 43" src="https://user-images.githubusercontent.com/43522239/181048484-b4069597-1645-4d1e-a2bf-2e11e264a1c4.png">
<img width="561" alt="Screenshot 2022-07-26 at 16 34 07" src="https://user-images.githubusercontent.com/43522239/181048498-e0127a87-a154-47f9-9980-ebcd8a62a00c.png">


### Changes proposed in this pull request

* Add match and suggestion synonym mapping for institution, subject, type

### Guidance to review

* Check I haven't broken anything in the non-uk degree path
* Check I've handled any `nil` values that might throw an error

For prod review:
* Log in as a non-admin user
* Create a trainee record (any route)
* Go to add a degree for the trainee
* In Awarding Institution, type 'central functions' - you will see that University of Wales is suggested
* You can cross reference this with the reference data gem to see that this is a partial match for a match synonym for Uni of Wales https://github.com/DFE-Digital/dfe-reference-data/tree/main/lib/dfe/reference_data/degrees
* In subject, type 'maths', you will see Mathematics plus others are suggested
* In type, type 'ba (hons)', you will see BA is correctly suggested
* Double check the abbreviations still work too
* Submit the degree successfully

* Double check the non-uk route works as expected
* Feel free to spot check a few more weird ones using the reference data gem (I can help with this if needed)


### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
