### PR TITLE
[4475] Fix publish courses with primary level and max age greater than 11

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -5,8 +5,6 @@ class Course < ApplicationRecord
   validates :name, presence: true
   validates :published_start_date, presence: true
   validates :level, presence: true
-  validates :min_age, presence: true
-  validates :max_age, presence: true
   validates :duration_in_years, presence: true
   validates :qualification, presence: true
   validates :route, presence: true

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -6,7 +6,6 @@ module Trainees
     include DiversityAttributes
 
     USERNAME = "HESA"
-    UPPER_BOUND_PRIMARY_AGE = 11
 
     TRN_REGEX = /^(\d{6,7})$/.freeze
 
@@ -201,7 +200,7 @@ module Trainees
     end
 
     def primary_education_phase?
-      course_max_age && course_max_age <= UPPER_BOUND_PRIMARY_AGE
+      course_max_age && course_max_age <= AgeRange::UPPER_BOUND_PRIMARY_AGE
     end
 
     def course_education_phase

--- a/config/initializers/age_ranges.rb
+++ b/config/initializers/age_ranges.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module AgeRange
+  UPPER_BOUND_PRIMARY_AGE = 11
+
   THREE_TO_ELEVEN = [3, 11].freeze
   FIVE_TO_ELEVEN = [5, 11].freeze
   ELEVEN_TO_SIXTEEN = [11, 16].freeze

--- a/db/data/20220727102458_remove_age_range_from_incompatible_courses.rb
+++ b/db/data/20220727102458_remove_age_range_from_incompatible_courses.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RemoveAgeRangeFromIncompatibleCourses < ActiveRecord::Migration[6.1]
+  def up
+    # These primary education courses have age ranges that are incompatible with Register.
+    # The provider will have to enter a compatible age range after selecting the course.
+    # Note: Publish doesn't currently validate age ranges.
+    Course.where(level: :primary)
+          .where("max_age > ?", AgeRange::UPPER_BOUND_PRIMARY_AGE)
+          .update_all(min_age: nil, max_age: nil)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20220726160157_remove_presence_validation_for_course_age_range.rb
+++ b/db/migrate/20220726160157_remove_presence_validation_for_course_age_range.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemovePresenceValidationForCourseAgeRange < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :courses, :min_age, true
+    change_column_null :courses, :max_age, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_30_135252) do
+ActiveRecord::Schema.define(version: 2022_07_26_160157) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -169,8 +169,8 @@ ActiveRecord::Schema.define(version: 2022_06_30_135252) do
     t.string "summary", null: false
     t.integer "level", null: false
     t.string "accredited_body_code", null: false
-    t.integer "min_age", null: false
-    t.integer "max_age", null: false
+    t.integer "min_age"
+    t.integer "max_age"
     t.integer "study_mode"
     t.uuid "uuid"
     t.integer "recruitment_cycle_year"

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -40,8 +40,6 @@ describe Course do
       expect(subject).to validate_presence_of(:name)
       expect(subject).to validate_presence_of(:published_start_date)
       expect(subject).to validate_presence_of(:level)
-      expect(subject).to validate_presence_of(:min_age)
-      expect(subject).to validate_presence_of(:max_age)
       expect(subject).to validate_presence_of(:duration_in_years)
       expect(subject).to validate_presence_of(:qualification)
       expect(subject).to validate_presence_of(:route)

--- a/spec/services/degrees/dfe_reference_spec.rb
+++ b/spec/services/degrees/dfe_reference_spec.rb
@@ -21,13 +21,17 @@ module Degrees
     end
 
     describe ".find_type" do
-      let(:degree_type) { DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS.all.sample }
+      let(:degree_type) do
+        DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS.all.find do |item|
+          item[:hesa_itt_code].present? && item[:abbreviation].present?
+        end
+      end
 
       it "can find the type by UUID" do
         expect(described_class.find_type(uuid: degree_type.id)).to eq(degree_type)
       end
 
-      it "can find the type by name" do
+      it "can find the type by abbreviation" do
         expect(described_class.find_type(abbreviation: degree_type.abbreviation)).to eq(degree_type)
       end
 

--- a/spec/services/teacher_training_api/import_course_spec.rb
+++ b/spec/services/teacher_training_api/import_course_spec.rb
@@ -65,16 +65,16 @@ module TeacherTrainingApi
           end
         end
 
-        context "course has a further_education level" do
-          let(:course_attributes) { { level: "further_education" } }
+        context "course level is primary but max age is greater than 11" do
+          let(:course_attributes) { { level: "primary", max_age: 16 } }
 
-          it "doesn't get imported" do
-            expect { subject }.not_to(change { Course.count })
+          it "doesn't set the age range (provider will have to do it manually to ensure correct values)" do
+            expect(subject).to have_attributes(min_age: nil, max_age: nil)
           end
         end
 
-        context "course has an invalid age range" do
-          let(:course_attributes) { { age_minimum: nil } }
+        context "course has a further_education level" do
+          let(:course_attributes) { { level: "further_education" } }
 
           it "doesn't get imported" do
             expect { subject }.not_to(change { Course.count })


### PR DESCRIPTION
### Context
https://trello.com/c/z5jOlXF2/4475-m-fix-publish-courses-with-primary-level-and-max-age-greater-than-11

### Changes proposed in this pull request
- Removed age range validation on `Course` model
- Update `TeacherTrainingApi::ImportCourse` to set `min_age` and `max_age` conditionally
- Data migration to remove the `min_age` and `max_age` from those courses that are primary level but the `max_age` is beyond 11

### Guidance to review
Mainly backend changeds.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
