### PR TITLE
[4460] Update check for uk_degree? on Apply degree mapping

### DIFF
--- a/app/services/degrees/map_from_apply.rb
+++ b/app/services/degrees/map_from_apply.rb
@@ -5,6 +5,8 @@ module Degrees
     include ServicePattern
     include MappingsHelper
 
+    UK_DEGREE_CODES = %w[UK XK].freeze
+
     def initialize(attributes:)
       @attributes = attributes
     end
@@ -85,7 +87,11 @@ module Degrees
     end
 
     def uk_degree?
-      attributes["non_uk_qualification_type"].nil?
+      if attributes["hesa_degctry"]
+        UK_DEGREE_CODES.include?(attributes["hesa_degctry"])
+      else
+        attributes["comparable_uk_degree"].nil? && attributes["non_uk_qualification_type"].nil?
+      end
     end
 
     def find_dfe_reference_subject

--- a/spec/services/degrees/map_from_apply_spec.rb
+++ b/spec/services/degrees/map_from_apply_spec.rb
@@ -98,6 +98,22 @@ module Degrees
                                      other_grade: unrecognised_grade)
         end
       end
+
+      context "degree country, comparable_uk_degree and non_uk_qualification_type are nil" do
+        let(:uk_degree) { "Bachelor of Arts" }
+
+        let(:application_data) do
+          ApiStubs::ApplyApi.application(degree_attributes: {
+            hesa_degctry: nil,
+            comparable_uk_degree: nil,
+            non_uk_qualification_type: nil,
+          })
+        end
+
+        it "sets degree to uk" do
+          expect(subject).to include(uk_degree: uk_degree)
+        end
+      end
     end
 
     context "with a non-uk degree" do
@@ -114,6 +130,26 @@ module Degrees
       end
 
       it { is_expected.to include(expected_non_uk_degree_attributes) }
+
+      context "degree country is nil but comparable_uk_degree exists" do
+        let(:application_data) do
+          ApiStubs::ApplyApi.non_uk_application(degree_attributes: {
+            hesa_degctry: nil,
+            non_uk_qualification_type: nil,
+          }).to_json
+        end
+
+        let(:expected_non_uk_degree_attributes) do
+          {
+            locale_code: Trainee.locale_codes[:non_uk],
+            non_uk_degree: degree_attributes["comparable_uk_degree"],
+          }
+        end
+
+        it "sets correct locale_code and non_uk_degree" do
+          expect(subject).to include(expected_non_uk_degree_attributes)
+        end
+      end
     end
   end
 end

--- a/spec/support/api_stubs/apply_api.rb
+++ b/spec/support/api_stubs/apply_api.rb
@@ -77,7 +77,7 @@ module ApiStubs
         hesa_degsbj: nil,
         hesa_degclss: "01",
         hesa_degest: nil,
-        hesa_degctry: nil,
+        hesa_degctry: "XK",
         hesa_degstdt: "-01-01",
         hesa_degenddt: "2020-01-01",
       }.merge(degree_attributes)


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/bV4sKRnr/4460-m-determining-the-uk-ness-of-a-degree

When Apply import snagging we found that some degrees were being imported as UK degrees, when they were not. I've updated the `uk_degree?` check to now look at `hesa_degctry` first and then fall back to `comparable_uk_degree` and `non_uk_qualification_type`.

### Changes proposed in this pull request

* Update uk_degree? in `/app/services/degrees/map_from_apply.rb`

### Guidance to review

* I'm not sure if we should be/need to check both `comparable_uk_degree` AND `non_uk_qualification_type` are nil - would be good to get thoughts

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
