### PR TITLE
[4397] Update course years form

### DIFF
--- a/app/forms/course_years_form.rb
+++ b/app/forms/course_years_form.rb
@@ -19,11 +19,10 @@ class CourseYearsForm
 
   def course_years_options
     [
-      default_course_year + 1,
       default_course_year,
       default_course_year - 1,
     ].inject({}) do |sum, y|
-      sum[y] = "#{y} to #{y + 1}#{' (current year)' if y == default_course_year}"
+      sum[y] = "#{y} to #{y + 1}"
       sum
     end
   end

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -90,7 +90,7 @@ private
   end
 
   def and_i_choose_a_different_year
-    course_years_page.choose("#{itt_start_date.year} to #{itt_end_date.year} (current year)")
+    course_years_page.choose("#{itt_start_date.year} to #{itt_end_date.year}")
     course_years_page.continue.click
   end
 

--- a/spec/forms/course_years_form_spec.rb
+++ b/spec/forms/course_years_form_spec.rb
@@ -18,8 +18,7 @@ describe CourseYearsForm, type: :model do
 
     it "returns course years hash" do
       expect(subject.course_years_options).to eql({
-        2011 => "2011 to 2012",
-        2010 => "2010 to 2011 (current year)",
+        2010 => "2010 to 2011",
         2009 => "2009 to 2010",
       })
     end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/0uO9YRcl/4397-get-rid-of-current-year-and-2023-to-2024-on-course-years-page

It was reported that users were accidentally registering their trainees too early, in a future year. We don't have the publish courses yet for 2023 - 2024 so we decided to remove this year option.

We've also removed 'current year' as this was potentially confusing users.

<img width="808" alt="Screenshot 2022-07-27 at 13 38 38" src="https://user-images.githubusercontent.com/43522239/181248600-d9c25041-96bf-465e-94ee-c2112b1bab50.png">

### Changes proposed in this pull request

* Update /app/forms/course_years_form.rb to only include this year and last year as options
* Remove 'current year' text

### Guidance to review

* Navigate to the course year page by creating a new trainee record, clicking on course details and clicking on the year change link
* Check the course year picker page looks and works as expected

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
