### PR TITLE
Rename dttpimport env to productiondata

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -79,7 +79,7 @@ runs:
         CONFIRM_PRODUCTION:       yes
 
     - uses: DFE-Digital/keyvault-yaml-secret@v1
-      if: inputs.environment == 'review' || inputs.environment == 'staging' || inputs.environment == 'dttpimport' || inputs.environment == 'production'
+      if: inputs.environment == 'review' || inputs.environment == 'staging' || inputs.environment == 'productiondata' || inputs.environment == 'production'
       id: get-secrets
       with:
         keyvault: ${{ env.key_vault_name }}
@@ -87,7 +87,7 @@ runs:
         key: CF_USER,CF_PASSWORD
 
     - name: Setup cf cli
-      if: inputs.environment == 'review' || inputs.environment == 'staging' || inputs.environment == 'dttpimport' || inputs.environment == 'production'
+      if: inputs.environment == 'review' || inputs.environment == 'staging' || inputs.environment == 'productiondata' || inputs.environment == 'production'
       uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
         CF_USERNAME:   ${{ steps.get-secrets.outputs.CF_USER }}
@@ -96,7 +96,7 @@ runs:
 
     - name: Run data migrations
       shell: bash
-      if: inputs.environment == 'staging' || inputs.environment == 'dttpimport' || inputs.environment == 'production'
+      if: inputs.environment == 'staging' || inputs.environment == 'productiondata' || inputs.environment == 'production'
       run: cf run-task "register-${{ inputs.environment }}" --command "cd /app && bundle exec rails data:migrate" --wait
 
     - name: Generate example data

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -280,7 +280,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [sandbox,dttpimport]
+        environment: [sandbox,productiondata]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ on:
         - staging
         - production
         - sandbox
-        - dttpimport
+        - productiondata
       sha:
         description: Commit sha to be deployed
         required: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -13,7 +13,7 @@ on:
         - staging
         - production
         - sandbox
-        - dttpimport
+        - productiondata
       pr:
         description: 'The PR number if the environment is review'
         required: false

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ production:
 	$(eval paas_env=production)
 	$(eval BACKUP_CONTAINER_NAME=prod-db-backup)
 
-dttpimport:
+productiondata:
 	$(if $(CONFIRM_PRODUCTION), , $(error Can only run with CONFIRM_PRODUCTION))
-	$(eval DEPLOY_ENV=dttpimport)
+	$(eval DEPLOY_ENV=productiondata)
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-production)
 
 sandbox:

--- a/config/settings/dttpimport.yml
+++ b/config/settings/dttpimport.yml
@@ -1,5 +1,5 @@
 # The url for this app, also used by `dfe_sign_in`
-base_url: https://register-dttpimport.london.cloudapps.digital
+base_url: https://register-productiondata.london.cloudapps.digital
 
 dttp:
   scope: https://dttp.crm4.dynamics.com/.default
@@ -34,7 +34,7 @@ features:
     sync_collection: true
 
 environment:
-  name: dttpimport
+  name: productiondata
 
 apply_applications:
   import:

--- a/terraform/workspace-variables/productiondata.tfvars.json
+++ b/terraform/workspace-variables/productiondata.tfvars.json
@@ -1,10 +1,10 @@
 {
-  "env_config": "dttpimport",
+  "env_config": "productiondata",
   "key_vault_app_secret_name": "REGISTER-APP-SECRETS-DTTPIMPORT",
   "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-PRODUCTION",
   "key_vault_name": "s121p01-shared-kv-01",
   "key_vault_resource_group": "s121p01-shared-rg",
-  "paas_app_environment": "dttpimport",
+  "paas_app_environment": "productiondata",
   "paas_app_start_timeout": 180,
   "paas_postgres_service_plan": "small-11",
   "paas_redis_service_plan": "tiny-5_x",

--- a/terraform/workspace-variables/productiondata_backend.tfvars
+++ b/terraform/workspace-variables/productiondata_backend.tfvars
@@ -1,4 +1,4 @@
 resource_group_name  = "s121p01-register"
 storage_account_name = "s121p01registerterraform"
 container_name       = "tfstate"
-key                  = "dttpimport-bat.tfstate"
+key                  = "productiondata-bat.tfstate"


### PR DESCRIPTION
### Context

The environment `register-dttpimport` was renamed to `register-productiondata`.

### Changes proposed in this pull request

Replace relevant occurances of `dttpimport` with `productiondata`.

### Guidance to review

In your local terminal:

```bash
make productiondata CONFIRM_PRODUCTION=y console
```

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
