### PR TITLE
load cloudfront-rails in deployed envs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,7 @@ gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/df
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.2.1"
 
-group :production do
+group :qa, :review, :staging, :production do
   # Pull list of CloudFront proxies so request.remote_ip returns the correct IP.
   gem "cloudfront-rails"
 end


### PR DESCRIPTION
This gem is relevant in any deployed env in GPaaS.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
