### PR TITLE
[xxx] Fix Romania mapping for Apply import

### DIFF
--- a/app/lib/apply_api/code_sets/nationalities.rb
+++ b/app/lib/apply_api/code_sets/nationalities.rb
@@ -176,7 +176,7 @@ module ApplyApi
         "prydeinig" => "GB",
         "puerto rican" => "PR",
         "qatari" => "QA",
-        "romanian" => "RP",
+        "romanian" => "RO",
         "russian" => "RU",
         "rwandan" => "RW",
         "salvadorean" => "SV",


### PR DESCRIPTION
### Context

I noticed this when running the Apply import on productiondata - we were getting this [Sentry error](https://sentry.io/organizations/dfe-teacher-services/issues/3460796196/?environment=productiondata&project=5552118&query=is%3Aunresolved).

Apply had corrected the nationality mapping back in Oct 2021 from RP to RO and we still had the incorrect code in Register.

I've updated the code to RO. I checked the data running the below query. There were 92 trainees imported after the date that Apply made the fix. They all have nationalities that look legit so I don't think we need to correct any data. 

```
Trainee.with_apply_application.where("trainees.created_at > ?", date.to_date).where(start_academic_cycle: 7).where.not
(itt_start_date: nil).count

# 92 trainees

Trainee.with_apply_application.where("trainees.created_at > ?", date.to_date).where(start_academic_cycle: 7).where.not
(itt_start_date: nil).left_joins(:nationalities).where(nationalities: {name:nil}).count

# 0 trainees. I did a left join as thought this would capture the trainees where data did not exist in nationalities table

Trainee.with_apply_application.where("trainees.created_at > ?", date.to_date).where(start_academic_cycle: 7).where.not
(itt_start_date: nil).left_joins(:nationalities).pluck(:name).uniq
=> ["british", "lithuanian", "french", "german", "irish", "ghanaian"]
```

### Changes proposed in this pull request

* Update Romania mapping to RO for Apply imports

### Guidance to review

* Sense check my SQL checking

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
