### PR TITLE
4436 add dqt trn requests to bq

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -79,6 +79,14 @@ shared:
     - created_at
     - id
     - updated_at
+  :dqt_trn_requests:
+  - id
+  - trainee_id
+  - request_id
+  - response
+  - state
+  - created_at
+  - updated_at
   dttp_providers:
     - created_at
     - dttp_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -49,14 +49,6 @@
   :disabilities:
   - name
   - description
-  :dqt_trn_requests:
-  - id
-  - trainee_id
-  - request_id
-  - response
-  - state
-  - created_at
-  - updated_at
   :dttp_accounts:
   - id
   - dttp_id


### PR DESCRIPTION
### Context

Working on https://trello.com/c/wmnFFOF4/4436-add-dqttrnrequests-to-bq to add the dqt_trn_requests table to BigQuery for analysis.

### Changes proposed in this pull request

Remove the dqt_trn_requests table from the config/blocklist.yml and add to the config/analytics.yml

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
no
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
yes - we do

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
