### PR TITLE
[xxx] Make dev default DQT API URL

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,7 +28,7 @@ hesa:
   password: <get from secrets>
 
 dqt:
-  base_url: "https://teacher-qualifications-api.education.gov.uk/"
+  base_url: https://qualified-teachers-api-dev.london.cloudapps.digital
   api_key: <get from secrets>
 
 # Used to add feature flags in the app to control access to certain features.

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,7 +2,7 @@
 base_url: https://www.register-trainee-teachers.service.gov.uk
 
 # The url for the google doc feedback link (live version)
-feedback_link_url: "https://docs.google.com/forms/d/e/1FAIpQLSd6s98QtFceURRhUAguIXutWsJtZRSYehE2o68LvAbchSldiw/viewform"
+feedback_link_url: https://docs.google.com/forms/d/e/1FAIpQLSd6s98QtFceURRhUAguIXutWsJtZRSYehE2o68LvAbchSldiw/viewform
 
 dttp:
   scope: https://dttp.crm4.dynamics.com/.default
@@ -14,6 +14,9 @@ dfe_sign_in:
   issuer: https://oidc.signin.education.gov.uk
   # URL of the users profile
   profile: https://profile.signin.education.gov.uk
+
+dqt:
+  base_url: https://teacher-qualifications-api.education.gov.uk/
 
 features:
   basic_auth: false


### PR DESCRIPTION
### Context

The DQT API has four environments:

dev: https://qualified-teachers-api-dev.london.cloudapps.digital
test: https://test-teacher-qualifications-api.education.gov.uk/
pre-prod: https://qualified-teachers-api-preprod.london.cloudapps.digital/
production: https://teacher-qualifications-api.education.gov.uk/

The default setting was set to the production URL and then overridden in the environment files. This has a risk of unintentionally configuring an environment against production.

### Changes proposed in this pull request

* Make the dev URL the default and explicitly set the production URL in production
* Default productiondata to dev as we'd generally not want that to talk to DQT unless we're explicitly testing that in which case we can add the configuration.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
