### PR TITLE
[xxx] Fix broken tests

### DIFF
--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -43,9 +43,9 @@ module Trainees
         scope_name = scope_map[source]
 
         if i.zero?
-          scoped_trainees = scoped_trainees.send(scope_name)
+          scoped_trainees = scoped_trainees.public_send(scope_name)
         else
-          scoped_trainees = scoped_trainees.or(trainees.send(scope_name))
+          scoped_trainees = scoped_trainees.or(trainees.public_send(scope_name))
         end
       end
 

--- a/config/initializers/academic_cycles.rb
+++ b/config/initializers/academic_cycles.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+ACADEMIC_CYCLE_START_MONTH = 8
+ACADEMIC_CYCLE_END_MONTH = 7
+
 ACADEMIC_CYCLES = [
   { start_date: "01/8/2015", end_date: "31/7/2016" },
   { start_date: "01/8/2016", end_date: "31/7/2017" },

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require Rails.root.join("spec/support/api_stubs/apply_api")
-require Rails.root.join("spec/support/date_helpers")
 require Rails.root.join("config/environment")
+require Rails.root.join("spec/support/current_academic_cycle")
+require Rails.root.join("spec/support/api_stubs/apply_api")
 
 # Course names are not all that important here because it's for marketing
 # purposes (can be anything). What's important are the subjects associated

--- a/spec/controllers/trainees/start_statuses_controller_spec.rb
+++ b/spec/controllers/trainees/start_statuses_controller_spec.rb
@@ -78,8 +78,10 @@ describe Trainees::StartStatusesController, type: :controller do
         end
       end
 
-      context "withdrawal form has started and contains a withdrawal date before the commencement date" do
-        let(:trainee) { create(:trainee, :submitted_for_trn, withdraw_date: Date.new(2022, 1, 1)) }
+      context "withdrawal form has started and contains a withdrawal date after the commencement date" do
+        let(:commencement_date) { compute_valid_itt_start_date }
+        let(:withdraw_date) { compute_valid_itt_start_date + 1.day }
+        let(:trainee) { create(:trainee, :submitted_for_trn, withdraw_date: withdraw_date) }
         let(:page_context) { :withdraw }
         let(:send_request) do
           post(:update,
@@ -87,15 +89,15 @@ describe Trainees::StartStatusesController, type: :controller do
                  trainee_id: trainee,
                  trainee_start_status_form: {
                    "commencement_status" => "itt_started_on_time",
-                   "commencement_date(3i)" => "2",
-                   "commencement_date(2i)" => "1",
-                   "commencement_date(1i)" => "2022",
+                   "commencement_date(3i)" => commencement_date.day,
+                   "commencement_date(2i)" => commencement_date.month,
+                   "commencement_date(1i)" => commencement_date.year,
                    context: page_context,
                  },
                })
         end
 
-        it "redirects to the withdrawal page" do
+        it "redirects to the withdrawal confirmation page" do
           expect(response).to redirect_to(trainee_confirm_withdrawal_path(trainee))
         end
       end

--- a/spec/controllers/trainees_controller_spec.rb
+++ b/spec/controllers/trainees_controller_spec.rb
@@ -50,10 +50,8 @@ describe TraineesController do
 
     describe "csv export" do
       context "with a provider user" do
-        let(:trainee) { create(:trainee, :submitted_for_trn, provider: user.organisation) }
-
         before do
-          trainee
+          create(:trainee, :submitted_for_trn, provider: user.organisation)
           get(:index, format: "csv")
         end
 

--- a/spec/factories/academic_cycles.rb
+++ b/spec/factories/academic_cycles.rb
@@ -9,12 +9,12 @@ FactoryBot.define do
 
       cycle_year do
         cycles = [
-          -> { current_recruitment_cycle_year - 1 if previous_cycle },
-          -> { current_recruitment_cycle_year + 1 if next_cycle },
-          -> { current_recruitment_cycle_year + 2 if one_after_next_cycle },
+          -> { current_academic_year - 1 if previous_cycle },
+          -> { current_academic_year + 1 if next_cycle },
+          -> { current_academic_year + 2 if one_after_next_cycle },
         ].map(&:call).compact
 
-        cycles.any? ? cycles.first : current_recruitment_cycle_year
+        cycles.any? ? cycles.first : current_academic_year
       end
     end
 
@@ -27,7 +27,7 @@ FactoryBot.define do
     end
 
     trait :current do
-      cycle_year { Time.zone.now.month >= 8 ? Time.zone.now.year : Time.zone.now.year - 1 }
+      cycle_year { current_academic_year }
     end
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     route { TRAINING_ROUTES_FOR_COURSE.keys.sample }
     study_mode { TRAINEE_STUDY_MODE_ENUMS.keys.sample }
     uuid { SecureRandom.uuid }
-    recruitment_cycle_year { current_recruitment_cycle_year }
+    recruitment_cycle_year { current_academic_year }
 
     summary do |builder|
       qualifications = builder.qualification.to_s.gsub("_", " ").upcase.gsub("WITH", "with")
@@ -36,8 +36,8 @@ FactoryBot.define do
     end
 
     trait :with_full_time_dates do
-      full_time_start_date { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year) }
-      full_time_end_date { Faker::Date.in_date_period(month: 8, year: current_recruitment_cycle_year + 1) }
+      full_time_start_date { Faker::Date.in_date_period(month: ACADEMIC_CYCLE_START_MONTH, year: current_academic_year) }
+      full_time_end_date { Faker::Date.in_date_period(month: ACADEMIC_CYCLE_END_MONTH, year: current_academic_year + 1) }
     end
 
     factory :course_with_unmappable_subject do

--- a/spec/factories/dttp/api_placement_assignment.rb
+++ b/spec/factories/dttp/api_placement_assignment.rb
@@ -15,8 +15,8 @@ FactoryBot.define do
     _dfe_ittsubject1id_value { Dttp::CodeSets::CourseSubjects::MAPPING.to_a.sample[1][:entity_id] }
     _dfe_ittsubject2id_value { Dttp::CodeSets::CourseSubjects::MAPPING.to_a.sample[1][:entity_id] }
     _dfe_ittsubject3id_value { Dttp::CodeSets::CourseSubjects::MAPPING.to_a.sample[1][:entity_id] }
-    dfe_programmestartdate { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year).strftime("%Y-%m-%d") }
-    dfe_programmeeenddate { Faker::Date.in_date_period(month: 8, year: current_recruitment_cycle_year + 1).strftime("%Y-%m-%d") }
+    dfe_programmestartdate { Faker::Date.in_date_period(month: ACADEMIC_CYCLE_START_MONTH, year: current_academic_year).strftime("%Y-%m-%d") }
+    dfe_programmeeenddate { Faker::Date.in_date_period(month: ACADEMIC_CYCLE_END_MONTH, year: current_academic_year + 1).strftime("%Y-%m-%d") }
     dfe_commencementdate { Faker::Date.between(from: dfe_programmestartdate, to: dfe_programmeeenddate).strftime("%Y-%m-%d") }
     _dfe_coursephaseid_value { Dttp::CodeSets::AgeRanges::MAPPING.to_a.sample[1][:entity_id] }
     _dfe_studymodeid_value { Dttp::CodeSets::CourseStudyModes::MAPPING.to_a.sample[1][:entity_id] }

--- a/spec/factories/dttp/placement_assignments.rb
+++ b/spec/factories/dttp/placement_assignments.rb
@@ -6,8 +6,10 @@ FactoryBot.define do
     contact_dttp_id { SecureRandom.uuid }
     provider_dttp_id { SecureRandom.uuid }
     academic_year { Dttp::Trainee::ACADEMIC_YEAR_ENTITY_IDS.sample }
-    programme_start_date { Faker::Date.in_date_period(month: 9) }
-    programme_end_date { Faker::Date.in_date_period(month: 8, year: Faker::Date.in_date_period.year + 1) }
+    programme_start_date { Faker::Date.in_date_period(month: ACADEMIC_CYCLE_START_MONTH) }
+    programme_end_date do
+      Faker::Date.in_date_period(month: ACADEMIC_CYCLE_END_MONTH, year: Faker::Date.in_date_period.year + 1)
+    end
     trainee_status { SecureRandom.uuid }
     response {
       create(

--- a/spec/factories/funding/payment_schedule_rows.rb
+++ b/spec/factories/funding/payment_schedule_rows.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
           build(
             :payment_schedule_row_amount,
             month: month,
-            year: (1..7).include?(month) ? academic_cycle.end_date.year : academic_cycle.start_date.year,
+            year: (1..7).include?(month) ? academic_cycle.end_year : academic_cycle.start_year,
             predicted: index > current_month_index,
           )
         end

--- a/spec/factories/funding_methods.rb
+++ b/spec/factories/funding_methods.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     training_route { TRAINING_ROUTES.keys.sample }
     amount { Faker::Number.number(digits: 5) }
     funding_type { FUNDING_TYPE_ENUMS[:bursary] }
-    academic_cycle { AcademicCycle.first || create(:academic_cycle) }
+    academic_cycle { AcademicCycle.current || create(:academic_cycle, :current) }
 
     trait :with_subjects do
       after(:create) do |funding_method, _|

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :abstract_trainee, class: "Trainee" do
     transient do
       randomise_subjects { false }
-      potential_itt_start_date { itt_start_date || Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year) }
+      potential_itt_start_date { itt_start_date || compute_valid_itt_start_date }
     end
 
     sequence :trainee_id do |n|
@@ -197,7 +197,7 @@ FactoryBot.define do
 
     trait :with_study_mode_and_course_dates do
       study_mode { TRAINEE_STUDY_MODE_ENUMS.keys.sample }
-      itt_start_date { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year) }
+      itt_start_date { compute_valid_itt_start_date }
       itt_end_date do
         additional_years = if [2, 9, 10].include?(training_route)
                              3
@@ -206,13 +206,13 @@ FactoryBot.define do
                            else
                              1
                            end
-        Faker::Date.in_date_period(month: 6, year: current_recruitment_cycle_year + additional_years)
+        Faker::Date.in_date_period(month: ACADEMIC_CYCLE_END_MONTH, year: current_academic_year + additional_years)
       end
     end
 
     trait :with_study_mode_and_future_course_dates do
       study_mode { TRAINEE_STUDY_MODE_ENUMS.keys.sample }
-      itt_start_date { Faker::Date.in_date_period(month: 9, year: current_recruitment_cycle_year + 1) }
+      itt_start_date { Faker::Date.in_date_period(month: ACADEMIC_CYCLE_START_MONTH, year: current_academic_year + 1) }
       itt_end_date do
         additional_years = if [2, 9, 10].include?(training_route)
                              3
@@ -221,7 +221,7 @@ FactoryBot.define do
                            else
                              1
                            end
-        Faker::Date.in_date_period(month: 6, year: itt_start_date.year + additional_years)
+        Faker::Date.in_date_period(month: ACADEMIC_CYCLE_END_MONTH, year: itt_start_date.year + additional_years)
       end
     end
 
@@ -236,7 +236,7 @@ FactoryBot.define do
         if itt_start_date.present?
           Faker::Date.between(from: itt_start_date, to: itt_start_date + rand(20).days)
         else
-          Time.zone.today
+          compute_valid_itt_start_date
         end
       end
     end

--- a/spec/features/funding/payment_schedule_spec.rb
+++ b/spec/features/funding/payment_schedule_spec.rb
@@ -55,7 +55,7 @@ private
 
   def then_i_see_my_exported_data_in_csv_format
     expect(csv_data).to include("Month,#{Funding::PaymentScheduleRow.first.description},Month total")
-    expect(csv_data).to include("March 2022,£6.00,£6.00")
+    expect(csv_data).to include("March #{current_academic_year + 1},£6.00,£6.00")
     expect(csv_data).to include("Total,£9.00,£9.00")
   end
 

--- a/spec/features/trainee_actions/recommending_for_qts_spec.rb
+++ b/spec/features/trainee_actions/recommending_for_qts_spec.rb
@@ -19,7 +19,7 @@ feature "Recommending for QTS", type: :feature do
   end
 
   def and_a_trainee_exists_ready_for_qts
-    given_a_trainee_exists(:with_placement_assignment, :trn_received)
+    given_a_trainee_exists(:with_placement_assignment, :trn_received, :itt_start_date_in_the_past)
     stub_dttp_placement_assignment_request(outcome_date: Time.zone.today, status: 204)
   end
 

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -260,9 +260,9 @@ describe CourseDetailsForm, type: :model do
             end
           end
 
-          context "the start date fields are 01/08/2021" do
+          context "the start date fields are 01/08/#{current_academic_year}" do
             let(:start_date_attributes) do
-              { start_day: "01", start_month: "08", start_year: "2021" }
+              { start_day: "01", start_month: "08", start_year: current_academic_year }
             end
 
             let(:academic_cycle) { build(:academic_cycle) }

--- a/spec/forms/withdrawal_form_spec.rb
+++ b/spec/forms/withdrawal_form_spec.rb
@@ -73,7 +73,6 @@ describe WithdrawalForm, type: :model do
       it "hydrates the date values from the deferral date" do
         expect(subject.fields).to match(
           a_hash_including(
-            date_string: "other",
             day: trainee.defer_date.day,
             month: trainee.defer_date.month,
             year: trainee.defer_date.year,

--- a/spec/lib/funding_manager_spec.rb
+++ b/spec/lib/funding_manager_spec.rb
@@ -6,16 +6,15 @@ describe FundingManager do
   let(:course_subject_one) { nil }
   let(:bursary_tier) { nil }
   let(:training_route) { :early_years_postgrad }
+  let(:funding_manager) { described_class.new(trainee) }
   let(:trainee) do
     create(:trainee,
-           :with_start_date,
            :with_study_mode_and_course_dates,
            :with_course_allocation_subject,
            course_subject_one: course_subject_one,
            training_route: training_route,
            bursary_tier: bursary_tier)
   end
-  let(:funding_manager) { described_class.new(trainee) }
 
   before do
     create(:academic_cycle, :current)
@@ -223,18 +222,17 @@ describe FundingManager do
 
         context "with trainee course subject one" do
           let(:course_subject_one) { subject_specialism.name }
-
           let(:subject_specialism) { create(:subject_specialism) }
           let(:amount) { 24_000 }
           let(:funding_method) { create(:funding_method, training_route: training_route, amount: amount) }
 
           before do
-            create(:funding_method_subject, funding_method: funding_method, allocation_subject: subject_specialism.allocation_subject)
+            create(:funding_method_subject,
+                   funding_method: funding_method,
+                   allocation_subject: subject_specialism.allocation_subject)
           end
 
-          it "returns true" do
-            expect(subject).to be_truthy
-          end
+          it { is_expected.to be_truthy }
         end
       end
     end

--- a/spec/services/exports/funding_schedule_data_spec.rb
+++ b/spec/services/exports/funding_schedule_data_spec.rb
@@ -68,7 +68,7 @@ module Exports
       end
 
       it "sets the correct filename" do
-        expect(exporter.filename).to eq("#{payment_schedule.payable.name.downcase.gsub(' ', '-')}-payment_schedule-2021-to-2022.csv")
+        expect(exporter.filename).to eq("#{payment_schedule.payable.name.downcase.gsub(' ', '-')}-payment_schedule-#{academic_cycle.label.parameterize}.csv")
       end
     end
 

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 module Exports
   describe TraineeSearchData do
+    let(:academic_cycle) { AcademicCycle.current }
     let(:trainee) do
       create(
         :trainee,
@@ -27,8 +28,8 @@ module Exports
         applying_for_bursary: true,
         international_address: "Test addr",
         degrees: degrees,
-        itt_start_date: AcademicCycle.current.start_date,
-        itt_end_date: AcademicCycle.current.end_date,
+        itt_start_date: academic_cycle.start_date,
+        itt_end_date: academic_cycle.end_date,
       )
     end
     let(:degrees) { [build(:degree, :uk_degree_with_details, institution: Dttp::CodeSets::Institutions::MAPPING.keys.first)] }
@@ -55,8 +56,8 @@ module Exports
           "provider_trainee_id" => trainee.trainee_id,
           "trn" => trainee.trn,
           "status" => "QTS awarded",
-          "start_academic_year" => "2021 to 2022",
-          "end_academic_year" => "2021 to 2022",
+          "start_academic_year" => academic_cycle.label,
+          "end_academic_year" => academic_cycle.label,
           "record_created_at" => trainee.created_at&.iso8601,
           "updated_at" => trainee.updated_at&.iso8601,
           "hesa_updated_at" => trainee.hesa_updated_at&.iso8601,

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -11,11 +11,6 @@ module Trainees
     let(:filters) { nil }
     let(:trainees) { Trainee.all }
 
-    before do
-      create(:academic_cycle, cycle_year: 2019)
-      create(:academic_cycle, cycle_year: 2020)
-    end
-
     it { is_expected.to match_array(trainees) }
 
     context "empty trainee exists" do
@@ -151,12 +146,12 @@ module Trainees
     end
 
     context "start and end year filters" do
-      let(:current_year) { Time.zone.now.year }
+      let!(:trainee) { create(:trainee, start_academic_cycle: academic_cycle) }
+      let(:year_filter) { "#{current_academic_year} to #{current_academic_year + 1}" }
       let(:academic_cycle) { create(:academic_cycle, :current) }
 
       context "with start_year filter" do
-        let!(:trainee) { create(:trainee, start_academic_cycle: academic_cycle) }
-        let(:filters) { { start_year: "#{current_year - 1} to #{current_year}" } }
+        let(:filters) { { start_year: year_filter } }
 
         context "trainee starting in that year" do
           it "returns the trainee" do
@@ -187,7 +182,7 @@ module Trainees
 
       context "with end_year filter" do
         let!(:trainee) { create(:trainee, end_academic_cycle: academic_cycle) }
-        let(:filters) { { end_year: "#{current_year - 1} to #{current_year}" } }
+        let(:filters) { { end_year: year_filter } }
 
         context "trainee ending in that year" do
           it "returns the trainee" do

--- a/spec/support/current_academic_cycle.rb
+++ b/spec/support/current_academic_cycle.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+def current_academic_year
+  Time.zone.now.month >= ACADEMIC_CYCLE_START_MONTH ? Time.zone.now.year : Time.zone.now.year - 1
+end
+
+def compute_valid_itt_start_date
+  # The itt_start_date always needs to be in the past.
+  if Time.zone.now.month == ACADEMIC_CYCLE_START_MONTH
+    Faker::Date.between(from: Time.zone.now.beginning_of_month, to: Time.zone.now.yesterday)
+  else
+    Faker::Date.in_date_period(month: ACADEMIC_CYCLE_START_MONTH, year: current_academic_year)
+  end
+end

--- a/spec/support/date_helpers.rb
+++ b/spec/support/date_helpers.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-def current_recruitment_cycle_year
-  current_date = Time.zone.now
-  current_year = current_date.year
-  return current_year - 1 if current_date < Date.new(current_year, 10, 1)
-
-  current_year
-end

--- a/spec/view_objects/academic_year_filter_options_spec.rb
+++ b/spec/view_objects/academic_year_filter_options_spec.rb
@@ -3,9 +3,7 @@
 require "rails_helper"
 
 describe AcademicYearFilterOptions do
-  let(:current_year_string) do
-    "#{academic_cycle.label} (current year)"
-  end
+  let(:current_year_string) { "#{academic_cycle.label} (current year)" }
 
   let(:current_user) do
     double(lead_school?: false, provider?: true, organisation: trainee.provider, system_admin?: false)

--- a/spec/view_objects/home_view_spec.rb
+++ b/spec/view_objects/home_view_spec.rb
@@ -7,15 +7,15 @@ describe HomeView do
 
   let(:draft_trainee) { create(:trainee, :draft) }
   let!(:current_academic_cycle) { create(:academic_cycle, :current) }
-  let(:last_current_academic_cycle) { create(:academic_cycle, previous_cycle: true) }
+  let(:previous_academic_cycle) { create(:academic_cycle, previous_cycle: true) }
 
   subject { described_class.new(trainees) }
 
   describe "#badges" do
-    let(:not_started_trainee) { create(:trainee, :trn_received, itt_start_date: current_academic_cycle.end_date + 1.day) }
+    let(:not_started_trainee) { create(:trainee, :trn_received, itt_start_date: current_academic_cycle.end_date + 2.months) }
     let(:in_training_trainees) { create_list(:trainee, 2, :trn_received) }
     let(:awarded_this_year_trainee) { create(:trainee, :awarded, end_academic_cycle: current_academic_cycle) }
-    let(:awarded_last_year_trainee) { create(:trainee, :awarded, end_academic_cycle: last_current_academic_cycle) }
+    let(:awarded_last_year_trainee) { create(:trainee, :awarded, end_academic_cycle: previous_academic_cycle) }
     let(:deferred_trainees) { create_list(:trainee, 2, :deferred) }
     let(:incomplete_trainee) { create(:trainee, :trn_received, :incomplete) }
 
@@ -53,7 +53,7 @@ describe HomeView do
             trainee_count: 1,
             link: trainees_path(
               status: %w[awarded],
-              end_year: "#{current_academic_cycle.start_year} to #{current_academic_cycle.end_year}",
+              end_year: current_academic_cycle.label,
             ),
           },
           {


### PR DESCRIPTION
### Context
The specs were not robust enough to handle the change in academic cycle which occurs automatically on 1 August.

### Changes proposed in this pull request
- Change the way the current academic cycle is computed during spec run
- New helper method `compute_valid_itt_start_date` to ensures we always have a date in the past
- Add new constants `ACADEMIC_CYCLE_START_MONTH` and `ACADEMIC_CYCLE_END_MONTH`

