### PR TITLE
[4311] Switch on creating 2022 Apply trainees in production

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -98,7 +98,7 @@ apply_applications:
       - 2021
       - 2022
   create:
-    recruitment_cycle_year: 2021
+    recruitment_cycle_year: 2022
 
 jobs:
   poll_delay_hours: 1


### PR DESCRIPTION
### Context

https://trello.com/c/cGpb0uO5/4311-switch-on-apply-create-trainees

### Changes proposed in this pull request

We're currently importing Apply applications from 2022. Now we want to enable creating trainees from them in production.

### Guidance to review

### Important business

We are also running this in the production console:

```
ApplyApplication.where(recruitment_cycle_year: 2022).destroy_all
ApplyApplicationSyncRequest.where(recruitment_cycle_year: 2022).destroy_all
ApplyApi::ImportApplicationsJob.perform_later(from_date: Date.parse("2021-10-12"))
```

This is to ensure we get a fresh set of recruited applications from which we will create our 2022 trainees.

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml