### PR TITLE
[4399] Run Trainees::Update on to set academic cycles on awarded and withdrawn trainees

### DIFF
--- a/app/forms/withdrawal_form.rb
+++ b/app/forms/withdrawal_form.rb
@@ -14,6 +14,7 @@ class WithdrawalForm < MultiDateForm
   def save!
     if valid?
       assign_attributes_to_trainee
+      Trainees::Update.call(trainee: trainee, update_dqt: false)
       Trainees::Withdraw.call(trainee: trainee)
       clear_stash
     else

--- a/app/jobs/dqt/recommend_for_award_job.rb
+++ b/app/jobs/dqt/recommend_for_award_job.rb
@@ -17,6 +17,7 @@ module Dqt
 
         if award_date
           trainee.award_qts!(award_date)
+          Trainees::Update.call(trainee: trainee, update_dqt: false)
         else
           raise(
             DqtNoAwardDateError,

--- a/app/jobs/dqt/retrieve_award_job.rb
+++ b/app/jobs/dqt/retrieve_award_job.rb
@@ -13,7 +13,7 @@ module Dqt
 
       response = Dqt::RetrieveTeacher.call(trainee: trainee)
       awarded_at = response.dig("qualified_teacher_status", "qts_date")
-      Trainees::Update.call(trainee: trainee, params: { awarded_at: awarded_at }, update_dtq: false) if awarded_at
+      Trainees::Update.call(trainee: trainee, params: { awarded_at: awarded_at }, update_dqt: false) if awarded_at
     end
 
   private

--- a/app/services/trainees/update.rb
+++ b/app/services/trainees/update.rb
@@ -4,22 +4,22 @@ module Trainees
   class Update
     include ServicePattern
 
-    def initialize(trainee:, params: {}, update_dtq: true, set_academic_cycles_now: false)
+    def initialize(trainee:, params: {}, update_dqt: true, set_academic_cycles_now: false)
       @trainee = trainee
       @params = params
-      @update_dtq = update_dtq
+      @update_dqt = update_dqt
       @set_academic_cycles_now = set_academic_cycles_now
     end
 
     def call
       trainee.update!(params)
-      Dqt::UpdateTraineeJob.perform_later(trainee) if update_dtq
+      Dqt::UpdateTraineeJob.perform_later(trainee) if update_dqt
       Trainees::SetAcademicCyclesJob.send(set_academic_cycles_now ? :perform_now : :perform_later, trainee)
       true
     end
 
   private
 
-    attr_reader :trainee, :params, :update_dtq, :set_academic_cycles_now
+    attr_reader :trainee, :params, :update_dqt, :set_academic_cycles_now
   end
 end

--- a/app/services/trainees/withdraw.rb
+++ b/app/services/trainees/withdraw.rb
@@ -9,7 +9,6 @@ module Trainees
     end
 
     def call
-      trainee.save!
       Dqt::WithdrawTraineeJob.perform_later(trainee) unless hesa_trainee?
       true
     end

--- a/lib/tasks/backfill_missing_award_dates.rake
+++ b/lib/tasks/backfill_missing_award_dates.rake
@@ -7,7 +7,7 @@ namespace :dqt do
     Trainee.awarded.where(awarded_at: nil).where.not(trn: nil).each do |trainee|
       response = Dqt::RetrieveTeacher.call(trainee: trainee)
       awarded_at = response.dig("qualified_teacher_status", "qts_date")
-      Trainees::Update.call(trainee: trainee, params: { awarded_at: awarded_at }, update_dtq: false) if awarded_at
+      Trainees::Update.call(trainee: trainee, params: { awarded_at: awarded_at }, update_dqt: false) if awarded_at
     rescue Dqt::Client::HttpError
       failed_trainee_ids << trainee.id
     ensure

--- a/spec/forms/withdrawal_form_spec.rb
+++ b/spec/forms/withdrawal_form_spec.rb
@@ -102,5 +102,12 @@ describe WithdrawalForm, type: :model do
 
       expect { subject.save! }.to change(trainee, :withdraw_reason).to(WithdrawalReasons::FINANCIAL_REASONS)
     end
+
+    it "triggers trainee update job" do
+      expect(form_store).to receive(:set).with(trainee.id, :withdrawal, nil)
+      expect(Trainees::Update).to receive(:call).with(trainee: trainee,
+                                                      update_dqt: false)
+      subject.save!
+    end
   end
 end

--- a/spec/jobs/dqt/recommend_for_award_job_spec.rb
+++ b/spec/jobs/dqt/recommend_for_award_job_spec.rb
@@ -21,6 +21,18 @@ module Dqt
           described_class.perform_now(trainee)
         }.to change(trainee, :awarded_at).to(Time.zone.parse(award_date))
       end
+
+      it "triggers the trainee update job" do
+        expect(Trainees::Update).to receive(:call).with(trainee: trainee,
+                                                        update_dqt: false)
+        described_class.perform_now(trainee)
+      end
+
+      it "updates the trainee state to awarded" do
+        expect {
+          described_class.perform_now(trainee)
+        }.to change(trainee, :state).to("awarded")
+      end
     end
 
     context "we don't receive an award date" do

--- a/spec/jobs/dqt/retrieve_award_job_spec.rb
+++ b/spec/jobs/dqt/retrieve_award_job_spec.rb
@@ -21,7 +21,7 @@ module Dqt
       it "updates the trainee but not DQT" do
         expect(Trainees::Update).to receive(:call).with(trainee: trainee,
                                                         params: { awarded_at: award_date },
-                                                        update_dtq: false)
+                                                        update_dqt: false)
         described_class.perform_now(trainee)
       end
     end

--- a/spec/services/trainees/withdraw_spec.rb
+++ b/spec/services/trainees/withdraw_spec.rb
@@ -8,13 +8,6 @@ module Trainees
 
     describe "#call" do
       context "passed a non-HESA trainee that has had attributes set" do
-        it "persists any changes" do
-          trainee.first_names = "Edmund"
-          described_class.call(trainee: trainee)
-          trainee.reload
-          expect(trainee.first_names).to eq("Edmund")
-        end
-
         it "queues a withdrawal to DQT when `withdrawal` option is set" do
           expect(Dqt::WithdrawTraineeJob).to receive(:perform_later).with(trainee)
           described_class.call(trainee: trainee)
@@ -23,13 +16,6 @@ module Trainees
 
       context "passed a HESA trainee that has had attributes set" do
         let(:trainee) { create(:trainee, hesa_id: "12345678") }
-
-        it "persists any changes" do
-          trainee.first_names = "Edmund"
-          described_class.call(trainee: trainee)
-          trainee.reload
-          expect(trainee.first_names).to eq("Edmund")
-        end
 
         it "queues a withdrawal to DQT when `withdrawal` option is set" do
           expect(Dqt::WithdrawTraineeJob).not_to receive(:perform_later).with(trainee)


### PR DESCRIPTION
### Context

This bug: https://trello.com/c/jybTs1QZ/4399-filter-for-trainees-awarded-next-year-has-trainees-awarded-this-year

We realised that we weren't setting academic cycles again after trainees were awarded and withdrawn. This meant the trainees' cycles weren't updating based on newly added award or withdraw dates.

Trainees::Update is where the cycle setting job happens (Trainees::SetAcademicCyclesJob)

**NOTE** Backfill on affected trainees coming in separate PR

### Changes proposed in this pull request

* Add Trainees::Update into RecommendForAwardJob
* Add Trainees::Update into WithdrawalForm
* Don't send either of these updates to DQT as they aren't needed by them - it's just so we can set cycles correctly on our end

### Guidance to review

* I chose to trigger the update in the WithdrawalForm rather than the withdrawal job - I did this as thought it made the Trainee::Update more visible, and the fact it doesn't send to DQT is more obvious too. It's also consistent with our other forms to have the update there. I thought it also made sense for the Withdrawal stuff to be separate and specifically only contain withdrawal stuff that we send to DQT - be good to get thoughts!

For prod review:
* Find or set up a registered trainee with ITT ending in next year's cycle 
* Withdraw the trainee and add a withdrawal date in this year's cycle
* Check the trainee is now appearing in the correct 'end year' filter (in line with the withdrawal date)
* Find or set up a registered trainee with ITT ending in next year's cycle 
* Award the trainee and set the award date to be in this cycle
* Check the trainee is now appearing in the correct 'end year' filter (in line with the awarded_at date)
* Maybe try this with both a manual/apply and a HESA trainee to see the 'Expected in x cycle' in the ITT end date field change correctly for HESA.

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
