### PR TITLE
[4499] Fix academic cycles for awarded and withdrawn trainees

### DIFF
--- a/lib/tasks/set_academic_cycles_on_some_trainees.rake
+++ b/lib/tasks/set_academic_cycles_on_some_trainees.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :trainee do
+  desc "fix the incorrect end academic cycle for recently awarded and withdrawn trainees"
+  task fix_academic_cycles: :environment do
+    # We have excluded HESA trainees because they are not awarded or withdrawn currently in Register
+    awarded_trainees = Trainee.awarded.where(hesa_id: nil).where("updated_at > ?", "01/06/2022".to_date)
+
+    withdrawn_trainees = Trainee.withdrawn.where(hesa_id: nil).where("updated_at > ?", "01/06/2022".to_date)
+
+    (awarded_trainees + withdrawn_trainees).each do |trainee|
+      Trainees::SetAcademicCyclesJob.perform_later(trainee)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Bug: https://trello.com/c/H8KOaaii/4499-backfill-pr-filter-for-trainees-awarded-next-year-has-trainees-awarded-this-year

We have some trainees that have been awarded/withdrawn but haven't had their end academic cycle updated correctly. This data migration updates those trainees by running the `SetAcademicCycleJob` on them.

We created the new job in June so I've scoped it to trainees updated since then.

### Changes proposed in this pull request

* Add data migration to run SetAcademicCycleJob on trainees with award or withdraw states, updated after 01/06/2022

### Guidance to review

* I'll run it on productiondata to see if it works (runs ok locally)
* Check my scope makes sense and I'm targeting the right trainees

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
