### PR TITLE
[4364] Send ITT aim and qualification to DQT

### DIFF
--- a/app/controllers/trainees/start_statuses_controller.rb
+++ b/app/controllers/trainees/start_statuses_controller.rb
@@ -56,11 +56,10 @@ module Trainees
 
     def trainee_commencement_date_before_withdrawal_date?
       withdrawal_date = WithdrawalForm.new(trainee).date
-      if withdrawal_date.present?
-        @trainee_start_status_form.withdrawing? && @trainee_start_status_form.commencement_date < withdrawal_date
-      else
-        false
-      end
+
+      return false unless withdrawal_date
+
+      @trainee_start_status_form.withdrawing? && @trainee_start_status_form.commencement_date < withdrawal_date
     end
   end
 end

--- a/spec/controllers/trainees/start_statuses_controller_spec.rb
+++ b/spec/controllers/trainees/start_statuses_controller_spec.rb
@@ -78,24 +78,9 @@ describe Trainees::StartStatusesController, type: :controller do
         end
       end
 
-      context "withdrawal form has started and contains a withdrawal date after the commencement date" do
-        let(:commencement_date) { compute_valid_itt_start_date }
-        let(:withdraw_date) { compute_valid_itt_start_date + 2.days }
-        let(:trainee) { create(:trainee, :submitted_for_trn, withdraw_date: withdraw_date) }
+      context "withdrawal form has started and the commencement date is before the withdrawal date" do
+        let(:trainee) { create(:trainee, :submitted_for_trn, :with_withdrawal_date) }
         let(:page_context) { :withdraw }
-        let(:send_request) do
-          post(:update,
-               params: {
-                 trainee_id: trainee,
-                 trainee_start_status_form: {
-                   "commencement_status" => "itt_started_on_time",
-                   "commencement_date(3i)" => commencement_date.day,
-                   "commencement_date(2i)" => commencement_date.month,
-                   "commencement_date(1i)" => commencement_date.year,
-                   context: page_context,
-                 },
-               })
-        end
 
         it "redirects to the withdrawal confirmation page" do
           expect(response).to redirect_to(trainee_confirm_withdrawal_path(trainee))

--- a/spec/factories/hesa/metadata.rb
+++ b/spec/factories/hesa/metadata.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  # rubocop:disable Lint/EmptyBlock
-  factory :hesa_metadatum, class: "Hesa::Metadatum" do; end
-  # rubocop:enable Lint/EmptyBlock
+  factory :hesa_metadatum, class: "Hesa::Metadatum" do
+    study_length do
+      {
+        weeks: [53, 68],
+        months: [9, 10, 11, 12, 14, 16, 20, 36],
+        years: (1..4).to_a,
+      }[study_length_unit].sample
+    end
+    study_length_unit { %i[weeks months years].sample }
+    itt_aim { Hesa::CodeSets::IttAims::MAPPING.values.sample }
+    itt_qualification_aim { Hesa::CodeSets::IttQualificationAims::MAPPING.values.sample }
+    fundability { Hesa::CodeSets::FundCodes::MAPPING.values.sample }
+    service_leaver { Hesa::CodeSets::ServiceLeavers::MAPPING.values.sample }
+    year_of_course { (0..5).to_a.sample }
+  end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -567,10 +567,18 @@ FactoryBot.define do
     end
 
     trait :imported_from_hesa do
+      transient do
+        itt_aim { Hesa::CodeSets::IttAims::MAPPING.values.sample }
+      end
+
       hesa_id { Faker::Number.number(digits: 13) }
       created_from_hesa { true }
       hesa_updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
       hesa_student { create(:hesa_student, hesa_id: hesa_id) }
+
+      after(:create) do |trainee, evaluator|
+        create(:hesa_metadatum, trainee: trainee, itt_aim: evaluator.itt_aim)
+      end
     end
   end
 end

--- a/spec/lib/dqt/params/trainee_request_spec.rb
+++ b/spec/lib/dqt/params/trainee_request_spec.rb
@@ -51,6 +51,7 @@ module Dqt
             "providerUkprn" => ukprn,
             "countryCode" => "XK",
             "subject" => hesa_code,
+            "ittQualificationAim" => nil,
             "class" => described_class::DEGREE_CLASSES[degree.grade],
             "date" => Date.new(degree.graduation_year).iso8601,
           })


### PR DESCRIPTION
### Context
https://trello.com/c/zycc6dpI/4364-m-send-fittaim-and-fqlaim-for-hesa-trainees

### Changes proposed in this pull request
- Update `Dqt::Params::TrnRequest` to send `ittQualificationAim`

### Important business
- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
