### PR TITLE
[4495] Remove perform_now from trainees update

### DIFF
--- a/app/forms/apply_applications/trainee_data_form.rb
+++ b/app/forms/apply_applications/trainee_data_form.rb
@@ -36,7 +36,7 @@ module ApplyApplications
       trainee.progress.diversity = true
       trainee.progress.degrees = true
       trainee.progress.trainee_data = true
-      Trainees::Update.call(trainee: trainee, set_academic_cycles_now: true)
+      Trainees::Update.call(trainee: trainee)
     end
 
     def progress_status(progress_key)

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -84,7 +84,7 @@ class CourseDetailsForm < TraineeForm
     if valid?
       update_trainee_attributes
       clear_funding_information if course_subjects_changed?
-      Trainees::Update.call(trainee: trainee, set_academic_cycles_now: true)
+      Trainees::Update.call(trainee: trainee)
       clear_stash
     else
       false

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -54,7 +54,7 @@ class PublishCourseDetailsForm < TraineeForm
 
     update_trainee_attributes
     clear_funding_information if course_subjects_changed?
-    Trainees::Update.call(trainee: trainee, set_academic_cycles_now: true)
+    Trainees::Update.call(trainee: trainee)
     clear_all_stashes
   end
 

--- a/app/services/trainees/update.rb
+++ b/app/services/trainees/update.rb
@@ -4,22 +4,21 @@ module Trainees
   class Update
     include ServicePattern
 
-    def initialize(trainee:, params: {}, update_dqt: true, set_academic_cycles_now: false)
+    def initialize(trainee:, params: {}, update_dqt: true)
       @trainee = trainee
       @params = params
       @update_dqt = update_dqt
-      @set_academic_cycles_now = set_academic_cycles_now
     end
 
     def call
       trainee.update!(params)
       Dqt::UpdateTraineeJob.perform_later(trainee) if update_dqt
-      Trainees::SetAcademicCyclesJob.send(set_academic_cycles_now ? :perform_now : :perform_later, trainee)
+      Trainees::SetAcademicCyclesJob.perform_later(trainee)
       true
     end
 
   private
 
-    attr_reader :trainee, :params, :update_dqt, :set_academic_cycles_now
+    attr_reader :trainee, :params, :update_dqt
   end
 end

--- a/spec/features/end_to_end/assessment_only_journey_spec.rb
+++ b/spec/features/end_to_end/assessment_only_journey_spec.rb
@@ -6,6 +6,7 @@ feature "assessment-only end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN" do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_an_assessment_only_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/end_to_end/early_years_assessment_only_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_assessment_only_journey_spec.rb
@@ -6,6 +6,7 @@ feature "early_years_assessment_only end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.early_years_assessment_only": true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_an_early_years_assessment_only_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_postgrad_journey_spec.rb
@@ -6,6 +6,7 @@ feature "early_years_postgrad end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.early_years_postgrad": true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_an_early_years_postgrad_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/end_to_end/early_years_salaried_journey_spec.rb
+++ b/spec/features/end_to_end/early_years_salaried_journey_spec.rb
@@ -6,6 +6,7 @@ feature "early_years_salaried end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.early_years_salaried": true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_an_early_years_salaried_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/end_to_end/opt_in_undergrad_spec.rb
+++ b/spec/features/end_to_end/opt_in_undergrad_spec.rb
@@ -6,6 +6,7 @@ feature "opt-in-undergrad end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.opt_in_undergrad": true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_an_opt_in_undergrad_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/end_to_end/pg_teaching_apprenticeship_journey_spec.rb
+++ b/spec/features/end_to_end/pg_teaching_apprenticeship_journey_spec.rb
@@ -6,6 +6,7 @@ feature "pg_teaching_apprenticeship end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.pg_teaching_apprenticeship": true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_a_pg_teaching_apprenticeship_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
@@ -9,6 +9,7 @@ feature "provider-led (postgrad) end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.provider_led_postgrad": true, feature_publish_course_details: true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_a_provider_led_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/end_to_end/provider_led_undergrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_undergrad_journey_spec.rb
@@ -6,6 +6,7 @@ feature "provider-led (undergrad) end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.provider_led_undergrad": true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_a_provider_led_undergrad_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/end_to_end/school_direct_salaried_journey_spec.rb
+++ b/spec/features/end_to_end/school_direct_salaried_journey_spec.rb
@@ -6,6 +6,7 @@ feature "school-direct-salaried end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.school_direct_salaried": true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_a_school_direct_salaried_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/end_to_end/school_direct_tuition_fee_journey_spec.rb
+++ b/spec/features/end_to_end/school_direct_tuition_fee_journey_spec.rb
@@ -6,6 +6,7 @@ feature "school-direct-tuition-fee end-to-end journey", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "submit for TRN", "feature_routes.school_direct_tuition_fee": true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_a_school_direct_tuition_fee_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/end_to_end/teach_first_journey_spec.rb
+++ b/spec/features/end_to_end/teach_first_journey_spec.rb
@@ -8,6 +8,7 @@ feature "teach-first end-to-end journey", type: :feature do
   background { given_i_am_authenticated(user: user) }
 
   scenario "submit for TRN" do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_i_have_created_a_teach_first_trainee
     and_the_personal_details_is_complete
     and_the_contact_details_is_complete

--- a/spec/features/form_sections/personal_and_education_details/degrees/adding_degree_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/degrees/adding_degree_spec.rb
@@ -107,6 +107,7 @@ RSpec.feature "Adding a degree" do
 
   describe "Non-UK Route" do
     scenario "the user enters valid details on Non-UK degree details page" do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
       given_i_have_selected_the_non_uk_route
       and_i_am_on_the_degree_details_page
       and_i_fill_in_the_form
@@ -124,6 +125,7 @@ RSpec.feature "Adding a degree" do
     end
 
     scenario "the user submits partially entered autocompletes", js: true do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
       given_i_have_selected_the_non_uk_route
       and_i_am_on_the_degree_details_page
       and_i_fill_in_country_without_selecting_a_value(with: "mongoose")

--- a/spec/features/form_sections/personal_and_education_details/degrees/editing_degree_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/degrees/editing_degree_spec.rb
@@ -26,6 +26,7 @@ feature "editing a degree" do
       # the uk form is a superset of the non_uk one, so we just need one
       # test for autocompletes
       scenario "user partially submits autocompletes", js: true do
+        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
         given_a_trainee_with_a_uk_degree
         when_i_visit_the_edit_degree_details_page
         and_i_fill_in_subject_without_selecting_a_value(with: "moose")

--- a/spec/features/form_sections/personal_and_education_details/edit_personal_details_spec.rb
+++ b/spec/features/form_sections/personal_and_education_details/edit_personal_details_spec.rb
@@ -6,6 +6,7 @@ feature "edit personal details", type: :feature do
   background { given_i_am_authenticated }
 
   scenario "updates personal details with valid data" do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_valid_personal_details_are_provided
     then_the_personal_details_are_updated
   end
@@ -41,6 +42,7 @@ feature "edit personal details", type: :feature do
   end
 
   scenario "partially entering nationality", js: true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     given_a_trainee_exists
     and_nationalities_exist_in_the_system
     when_i_visit_the_personal_details_page

--- a/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
@@ -42,6 +42,7 @@ feature "apply registrations", type: :feature do
     let(:subjects) { ["Art and design"] }
 
     scenario "selecting specialisms" do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
       when_i_enter_the_course_details_page
       and_i_confirm_the_course_details
       and_i_select_a_specialism("Graphic design")

--- a/spec/features/form_sections/teacher_training_data/edit_trainee_start_status_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_trainee_start_status_spec.rb
@@ -38,6 +38,7 @@ feature "edit Trainee start status" do
     end
 
     scenario "when the trainee has not yet started" do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
       given_a_trainee_exists(:submitted_for_trn, :itt_start_date_in_the_future)
       when_i_visit_the_edit_trainee_start_status_page
       when_i_choose_the_trainee_has_not_yet_started

--- a/spec/features/form_sections/teacher_training_data/employing_school_search_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/employing_school_search_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "EmployingSchoolSearch", type: :feature do
   end
 
   scenario "choosing a employing school", js: true do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     and_i_fill_in_my_employing_school
     and_i_click_the_first_item_in_the_list
     and_i_continue

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -5,7 +5,14 @@ require "rails_helper"
 feature "Withdrawing a trainee", type: :feature do
   include SummaryHelper
 
-  before { ActiveJob::Base.queue_adapter.enqueued_jobs.clear }
+  before do
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+  end
+
+  after do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+  end
 
   context "validation errors" do
     before do

--- a/spec/jobs/dqt/sync_states_batch_job_spec.rb
+++ b/spec/jobs/dqt/sync_states_batch_job_spec.rb
@@ -6,6 +6,10 @@ module Dqt
   describe SyncStatesBatchJob do
     let!(:trainee) { create(:trainee) }
 
+    before { ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false }
+
+    after { ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true }
+
     it "enqueues a SyncTraineeStateJob per trainee", feature_integrate_with_dqt: true do
       expect {
         described_class.perform_now([trainee.id])

--- a/spec/services/trainees/submit_for_trn_spec.rb
+++ b/spec/services/trainees/submit_for_trn_spec.rb
@@ -8,6 +8,10 @@ module Trainees
 
     subject { described_class.call(trainee: trainee) }
 
+    before { ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false }
+
+    after { ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true }
+
     context "integrate_with_dqt enabled", feature_integrate_with_dqt: true do
       it "queues a background job to register trainee for TRN" do
         expect {


### PR DESCRIPTION
### Context

Due to a misunderstanding with how perform_now and perform_later works I added a check in the update method that would cause the setacademiccycle job to be performed now if updated from the UI. This should be reverted so that the update returns to its previous asynchronous behaviour.  

### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
