### PR TITLE
Add missing end bracket draft Apply trainees

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -895,7 +895,7 @@ en:
       draft_heading: Draft trainees
       draft_trainees_link: View all draft trainees (%{count})
       draft_apply_trainees_link: View draft trainees imported from Apply (%{count} out of %{total} draft trainees)
-      draft_apply_trainees_link_all_apply: View draft trainees imported from Apply (%{count}
+      draft_apply_trainees_link_all_apply: View draft trainees imported from Apply (%{count})
       new_trainee_link: Create a trainee record
       registered_heading: Registered trainees
       guidance_heading: News, guidance and feedback


### PR DESCRIPTION
### Context
There was a missing end bracket on 'View draft trainees imported from Apply (6'.

### Changes proposed in this pull request
Add the missing end bracket.
https://trello.com/c/eO7zXIkF/464-the-end-bracket-is-missing-on-view-draft-trainees-imported-from-apply-6

### Guidance to review
Check I haven't broken **everything** and that there is no longer a missing end bracket.

Blame @peteryates if it does break everything.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
