### PR TITLE
Correct casing for 'Trainee Data'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -545,7 +545,7 @@ en:
       view:
         heading_1_name: Draft record for %{name}
         heading_1_no_name: Draft record
-        heading_2: Trainee Data
+        heading_2: Trainee data
     confirm_course:
       view:
         change: Change
@@ -956,7 +956,7 @@ en:
     view:
       heading_1_name: Draft record for %{name}
       heading_1_no_name: Draft record
-      heading_2: Trainee Data
+      heading_2: Trainee data
   invalid_data_summary:
     view:
       invalid_answers_summary: This application contains %{total_invalid_fields} answer that you need to amend. This is because they were entered in a free text format.


### PR DESCRIPTION
Remove uppercase d in 'Trainee Data'.

### Context
'Trainee Data' should be 'Trainee data'.
https://trello.com/c/YyfRQWjd/468-trainee-data-page-has-upper-case-d-it-should-be-a-lower-case-d

### Changes proposed in this pull request
Change the uppercase D to a lowercase d.

### Guidance to review
Check that I haven't broken anything and it's lowercase. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
