### PR TITLE
Remove 'Return to drafts' link on Trainee data

### DIFF
--- a/app/views/trainees/apply_applications/trainee_data/edit.html.erb
+++ b/app/views/trainees/apply_applications/trainee_data/edit.html.erb
@@ -42,4 +42,3 @@
   </div>
 </div>
 
-<p class="govuk-body"><%= govuk_link_to(t("return_to_draft_later"), trainees_path, { id: "return-to-draft-later" }) %></p>


### PR DESCRIPTION
'Return to this draft record later' shouldn't be on this page.

### Context
https://trello.com/c/owESgrCC/4506-get-rid-of-return-to-draft-link-on-trainee-data-page

On the 'trainee data' page, when registering a trainee, there's a 'return to draft link'. This shouldn't be there and it should be removed.

### Changes proposed in this pull request
Delete 'Return to draft record later' text and link.

### Guidance to review
Check I haven't broken anything and the link is removed. I got rid of the paragraph around it. Hoping that doesn't break anything!

P.S. this is non-urgent, so please feel free to ignore till we're less busy.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
