### PR TITLE
[4439] HESA import: don't create degrees with degree_type: '999'

### DIFF
--- a/db/data/20220729144112_delete_empty_degrees.rb
+++ b/db/data/20220729144112_delete_empty_degrees.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class DeleteEmptyDegrees < ActiveRecord::Migration[6.1]
+  def up
+    degrees = Degree.where(
+      grade: "Other",
+      other_grade: nil,
+      uk_degree: nil,
+      non_uk_degree: nil,
+      subject: nil,
+      institution: nil,
+      graduation_year: nil,
+    )
+
+    degrees.destroy_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -109,6 +109,47 @@ module Degrees
           expect(degree.country).to eq("India")
         end
       end
+
+      context "degree type 999" do
+        context "and all other values are nil" do
+          let(:hesa_degrees) do
+            [
+              {
+                graduation_date: nil,
+                degree_type: "999",
+                subject: nil,
+                institution: nil,
+                grade: nil,
+                country: nil,
+              },
+            ]
+          end
+
+          it "does not save the degree" do
+            expect(trainee.degrees.count).to eq(0)
+          end
+        end
+
+        context "and at least one other value present" do
+          let(:hesa_degrees) do
+            [
+              {
+                graduation_date: nil,
+                degree_type: "999",
+                subject: nil,
+                institution: nil,
+                grade: "14",
+                country: nil,
+              },
+            ]
+          end
+
+          it "saves the degree" do
+            expect(trainee.degrees.count).to eq(1)
+            expect(degree.grade).to eq("Pass")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/bOpAYUtb/4439-l-investigate-hesa-import-creating-other-grade-degrees-that-arent-visible

We have around 8k degrees (mostly linked to undergrad trainees) that contain grade: "Other" and no other useful information. We realised these are most likely being created when HESA sends us degrees with `degree_type: "999"` (their code for 'unknown'). These degrees contain no other useful information e.g. subject, institution, grade, etc. 

We've changed the code so that we no longer create these degrees. 

This ticket also includes a backfill to delete the incorrectly created degrees.

### Changes proposed in this pull request

* Update `/degrees/create_from_hesa.rb` so that we skip over any degrees with `degree_type: "999"`
* Add a data migration to destroy the approx 8k degrees

### Guidance to review

* Check that how I've scoped the degrees in the data migration makes sense

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
