### PR TITLE
[4502] Add collection_reference column to hesa_students table

### DIFF
--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -214,6 +214,7 @@
   - placements
   - created_at
   - updated_at
+  - collection_reference
   :hesa_trn_requests:
   - id
   - collection_reference

--- a/db/migrate/20220809102256_add_collection_reference_to_hesa_students.rb
+++ b/db/migrate/20220809102256_add_collection_reference_to_hesa_students.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCollectionReferenceToHesaStudents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :hesa_students, :collection_reference, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_26_160157) do
+ActiveRecord::Schema.define(version: 2022_08_09_102256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -484,6 +484,7 @@ ActiveRecord::Schema.define(version: 2022_07_26_160157) do
     t.json "placements"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "collection_reference"
   end
 
   create_table "hesa_trn_requests", force: :cascade do |t|


### PR DESCRIPTION
### Context
https://trello.com/c/7abU2Eac/4502-s-update-hesastudents-with-the-full-c21053-collection

We're not sure how long the `hesa_students` table will be around for. It has proved to be very useful in backfilling missing data. With the C21053 collection coming to a close, we want to backup the whole collection from the start of the academic year just in case we need it for future reference. Adding a `collection_reference` column will help us know the source of each record, especially if we intend on storing future collections.

### Changes proposed in this pull request
- Database migration to add `collection_reference` to `hesa_students` table

### Note
Re-seeding the `hesa_students` table could be done using a data migration, but the size of the XML (40k+ nodes) has proved to be a problem when loaded into memory. The container running the data migrations tend to crash. A safer bet is to run the script on the producation box itself which we have done numerious times in these situations.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
