### PR TITLE
Update zlib to r3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --update --no-cache --virtual build-dependances \
     apk del build-dependances
 
 # Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest libraries
-RUN apk add --no-cache libretls=3.3.4-r3 ncurses-libs=6.3_p20211120-r1 zlib=1.2.12-r2
+RUN apk add --no-cache libretls=3.3.4-r3 ncurses-libs=6.3_p20211120-r1 zlib=1.2.12-r3
 
 COPY package.json yarn.lock ./
 RUN  yarn install --frozen-lockfile && \


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/publish-teacher-training/pull/2907 was raised to fix https://github.com/advisories/GHSA-cfmr-vrgj-vqwv however the r2 package has been removed and replaced by r3. This caused errors when referencing r2 so we need to ensure the reference is updated to use r3.

### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
