### PR TITLE
Remove the hesa-Trn_submission payload field from Update analytics.yml

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -136,7 +136,6 @@ shared:
   hesa_trn_submissions:
     - id
     - created_at
-    - payload
     - submitted_at
     - updated_at
   lead_school_users:

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -222,7 +222,7 @@
   - response_body
   - created_at
   - updated_at
-   hesa_trn_submissions:
+  :hesa_trn_submissions:
     - payload
   :users:
   - first_name

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -222,6 +222,8 @@
   - response_body
   - created_at
   - updated_at
+   hesa_trn_submissions:
+    - payload
   :users:
   - first_name
   - last_name


### PR DESCRIPTION
### Context
Need to remove the payload field from the hesa_trn_subission entity so PII is not sent to BigQuery
### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
