### PR TITLE
[xxx] Fix degree type tests by removing constant stubbing

### DIFF
--- a/spec/lib/dqt/params/trainee_request_spec.rb
+++ b/spec/lib/dqt/params/trainee_request_spec.rb
@@ -9,7 +9,8 @@ module Dqt
       let(:degree) { trainee.degrees.first }
       let(:hesa_code) { "11111" }
       let(:ukprn) { DfE::ReferenceData::Degrees::INSTITUTIONS.one(degree.institution_uuid)[:ukprn] }
-      let(:dqt_degree_type) { "DqtDegreeType" }
+      let(:dqt_degree_type) { "BachelorOfArts" }
+      let(:uk_degree_uuid) { "db695652-c197-e711-80d8-005056ac45bb" }
 
       before do
         stub_const(
@@ -22,9 +23,7 @@ module Dqt
           }),
         )
 
-        stub_const("Dqt::CodeSets::DegreeTypes::MAPPING", {
-          degree.uk_degree_uuid => dqt_degree_type,
-        })
+        degree.uk_degree_uuid = uk_degree_uuid
       end
 
       describe "#params" do


### PR DESCRIPTION
### Context

RSpec does no autoloading.

Sometimes this `stub_const` would run before `Dqt::CodeSets::DegreeTypes` was loaded and the tests would fail with:

https://github.com/DFE-Digital/register-trainee-teachers/runs/7765168857?check_suite_focus=true

`uninitialized constant Dqt::CodeSets::DegreeTypes::FOUNDATIONS`

From [sub_const docs](https://relishapp.com/rspec/rspec-mocks/v/3-11/docs/mutating-constants/stub-undefined-constant):

> When the constant is not already defined, all the necessary intermediary modules will be dynamically created

It was making it's own `Dqt::CodeSets::DegreeTypes` module with just `MAPPING` defined.

### Changes proposed in this pull request

In this PR I've remove the use of stub const completely, which fixes the test issue.

We could also do this:

```
stub_const("#{Dqt::CodeSets::DegreeTypes}::MAPPING", {
  degree.uk_degree_uuid => dqt_degree_type,
})
```

The `#{}` loads our module. I tested this and it also fixes the issue 🤷‍♀️ 

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
