### PR TITLE
[4549] Fix: can't sending HESA trainees to DQT for TRN because of missing itt_end_date

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -99,7 +99,7 @@ module Dqt
         {
           "providerUkprn" => trainee.provider.ukprn,
           "programmeStartDate" => trainee.itt_start_date.iso8601,
-          "programmeEndDate" => trainee.itt_end_date.iso8601,
+          "programmeEndDate" => itt_end_date&.iso8601,
           "programmeType" => PROGRAMME_TYPE[trainee.training_route],
           "subject1" => course_subject_code(trainee.course_subject_one),
           "subject2" => course_subject_code(trainee.course_subject_two),
@@ -146,6 +146,10 @@ module Dqt
       def country_code
         country = degree.uk? ? UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED : degree.country
         Hesa::CodeSets::Countries::MAPPING.find { |_, name| name.start_with?(country) }&.first
+      end
+
+      def itt_end_date
+        trainee.itt_end_date || Trainees::CalculateIttEndDate.call(trainee: trainee, actual: true)
       end
 
       attr_reader :trainee, :degree

--- a/app/services/trainees/calculate_itt_end_date.rb
+++ b/app/services/trainees/calculate_itt_end_date.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Trainees
+  class CalculateIttEndDate
+    include ServicePattern
+
+    DURATIONS = %w[hours months days years].freeze
+
+    delegate :commencement_date,
+             :itt_start_date,
+             :itt_end_date,
+             :hesa_metadatum,
+             :training_route, to: :trainee
+
+    def initialize(trainee:, actual: false)
+      @trainee = trainee
+      @actual = actual
+    end
+
+    def call
+      return unless start_date
+
+      if course_duration > 5.years
+        raise("Trainee id: #{trainee.id}, slug: #{trainee.slug} has a course length greater than five years")
+      end
+
+      start_date + course_duration
+    end
+
+  private
+
+    attr_reader :trainee, :actual
+
+    def start_date
+      commencement_date || itt_start_date
+    end
+
+    def course_duration
+      return actual_course_duration if actual
+
+      course_duration = actual_course_duration || estimated_course_duration
+      # Year long courses end on average 10 months after they start, so the calculation below reflects this reality.
+      course_duration_unit == "years" ? course_duration - 2.months : course_duration
+    end
+
+    def actual_course_duration
+      return unless [course_duration_unit, course_duration_amount].all?(&:present?)
+
+      course_duration_amount.public_send(course_duration_unit)
+    end
+
+    def estimated_course_duration
+      return 3.years if UNDERGRAD_ROUTES.include?(training_route)
+      return 2.years if trainee.part_time?
+
+      1.year
+    end
+
+    def course_duration_amount
+      hesa_metadatum&.study_length
+    end
+
+    def course_duration_unit
+      hesa_metadatum&.study_length_unit if DURATIONS.include?(hesa_metadatum&.study_length_unit)
+    end
+  end
+end

--- a/app/services/trainees/set_academic_cycles.rb
+++ b/app/services/trainees/set_academic_cycles.rb
@@ -4,8 +4,6 @@ module Trainees
   class SetAcademicCycles
     include ServicePattern
 
-    DURATIONS = %w[hours months days years].freeze
-
     def initialize(trainee:)
       @trainee = trainee
     end
@@ -20,9 +18,11 @@ module Trainees
 
     attr_reader :trainee
 
-    delegate :commencement_date, :itt_start_date, :awarded_at,
-             :withdraw_date, :itt_end_date, :hesa_metadatum, :training_route,
-             to: :trainee
+    delegate :commencement_date,
+             :itt_start_date,
+             :awarded_at,
+             :withdraw_date,
+             :itt_end_date, to: :trainee
 
     def start_academic_cycle
       start_date.present? ? AcademicCycle.for_date(start_date) : AcademicCycle.current
@@ -37,44 +37,7 @@ module Trainees
     end
 
     def end_date
-      awarded_at || withdraw_date || itt_end_date || start_date_plus_duration
-    end
-
-    def start_date_plus_duration
-      return unless start_date
-
-      if course_duration > 5.years
-        raise("Trainee id: #{trainee.id}, slug: #{trainee.slug} has a course length greater than five years")
-      end
-
-      start_date + course_duration
-    end
-
-    def course_duration
-      course_duration = actual_course_duration || estimated_course_duration
-      # Year long courses end on average 10 months after they start, so the calculation below reflects this reality.
-      course_duration_unit == "years" ? course_duration - 2.months : course_duration
-    end
-
-    def actual_course_duration
-      return unless [course_duration_unit, course_duration_amount].all?(&:present?)
-
-      course_duration_amount.public_send(course_duration_unit)
-    end
-
-    def course_duration_amount
-      hesa_metadatum&.study_length
-    end
-
-    def course_duration_unit
-      hesa_metadatum&.study_length_unit if DURATIONS.include?(hesa_metadatum&.study_length_unit)
-    end
-
-    def estimated_course_duration
-      return 3.years if UNDERGRAD_ROUTES.include?(training_route)
-      return 2.years if trainee.part_time?
-
-      1.year
+      awarded_at || withdraw_date || itt_end_date || CalculateIttEndDate.call(trainee: trainee)
     end
   end
 end

--- a/spec/services/trainees/calculate_itt_end_date_spec.rb
+++ b/spec/services/trainees/calculate_itt_end_date_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe CalculateIttEndDate do
+    let(:trainee) { build(:trainee, :with_start_date, hesa_metadatum: hesa_metadatum, **trainee_attributes) }
+    let(:hesa_metadatum) { build(:hesa_metadatum, study_length: study_length, study_length_unit: study_length_unit) }
+    let(:trainee_attributes) { {} }
+
+    subject { described_class.call(trainee: trainee) }
+
+    context "study_length '1' and study_length_unit is 'years'" do
+      let(:study_length) { 1 }
+      let(:study_length_unit) { "years" }
+
+      it { is_expected.to eq(trainee.commencement_date + 10.months) }
+    end
+
+    context "study_length and study_length_unit is nil" do
+      let(:study_length) { nil }
+      let(:study_length_unit) { nil }
+
+      it { is_expected.to eq(trainee.commencement_date + 1.year) }
+
+      context "trainee is part-time" do
+        let(:trainee_attributes) { { study_mode: :part_time } }
+
+        it { is_expected.to eq(trainee.commencement_date + 2.years) }
+      end
+
+      context "trainee has undergrade training route" do
+        let(:trainee_attributes) { { training_route: UNDERGRAD_ROUTES.keys.sample } }
+
+        it { is_expected.to eq(trainee.commencement_date + 3.years) }
+      end
+    end
+
+    context "only compute actual end date - no adjustments" do
+      let(:study_length) { 1 }
+      let(:study_length_unit) { "years" }
+
+      subject { described_class.call(trainee: trainee, actual: true) }
+
+      it { is_expected.to eq(trainee.commencement_date + 1.year) }
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/EBevEsH4/4549-cant-sending-hesa-trainees-to-dqt-for-trn-because-of-missing-ittenddate

We're trying to request TRN's from DQT using HESA trainees. `Dqt::Params::TrnRequest` expects an `itt_end_date` but it's missing in most HESA trainees. We can work it out by falling back on the course duration data that's stored in the `hesa_metadata` table.

### Changes proposed in this pull request
- Extract code to calculate end date from `Trainees::SetAcademicCycles` into a new service `Trainees::CalculateIttEndDate`
- Update `Dqt::Params::TrnRequest` to use `Trainees::CalculateIttEndDate` if `trainee.itt_end_date` is missing

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
