### PR TITLE
Removing sentence in news and updates about HESA

### DIFF
--- a/db/service_updates.yml
+++ b/db/service_updates.yml
@@ -3,7 +3,7 @@
   content: |
      SCITTs, and HEIs with trainees that do not go through HESA, can now start creating draft trainee records in Register for the 2022 to 2023 academic year. You can either register your trainees immediately or wait, and register them closer to the start of their course.
     
-     Applications from Apply for teacher training (Apply) with a ‘recruited’ status will also be imported into Register as draft records. This will only happen for applications that will not go through HESA. Applications will import into Register every day at 4:00am. You should not need to manually duplicate applications from Apply into Register.
+     Applications from Apply for teacher training (Apply) with a ‘recruited’ status will also be imported into Register as draft records. Applications will import into Register every day at 4:00am. You should not need to manually duplicate applications from Apply into Register.
 
 - date: '2022-07-12'
   title: Update your initial teacher training (ITT) data through HESA from 18 to 29 July 2022


### PR DESCRIPTION
Removed line about applications going through HESA to make it less confusing for users in that applications don’t go through HESA anyway. 

### Context

Shaun flagged that the second paragraph might be confusing to users.

### Changes proposed in this pull request

Removing a sentence. I thought it better to remove than try and explain what we mean and making this even more confusing. We’ve also already sent out comms about the details so this section doesn’t need it.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
