### PR TITLE
[xxx] Send nil to DQT for heQualificationType when it is nil

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -120,7 +120,7 @@ module Dqt
           "class" => DEGREE_CLASSES[degree.grade],
           "date" => Date.parse("01-01-#{degree.graduation_year}").iso8601,
           "ittQualificationAim" => ITT_AIMS[trainee.hesa_metadatum&.itt_aim],
-          "heQualificationType" => CodeSets::DegreeTypes::MAPPING[degree.uk_degree_uuid].to_s,
+          "heQualificationType" => CodeSets::DegreeTypes::MAPPING[degree.uk_degree_uuid],
         }
       end
 

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -89,8 +89,8 @@ module Dqt
         context "when there is no degree type" do
           let(:degree) { build(:degree, :uk_degree_with_details, uk_degree_uuid: nil) }
 
-          it "sends an empty string as heQualificationType" do
-            expect(subject["qualification"]["heQualificationType"]).to eq("")
+          it "sends nil" do
+            expect(subject["qualification"]["heQualificationType"]).to be_nil
           end
         end
 


### PR DESCRIPTION
### Context

We got an error come through in Sentry where we were sending an empty string to DQT when there was no `heQualificationType` (it this case it was a non uk degree). Instead, we need to send `nil`.

### Changes proposed in this pull request

* Update `dqt/params/trn_request.rb` to not send an empty string when there is no `heQualificationType`

### Guidance to review

* Once this is merged I can re-run the failed DQT job and see that the trainee goes through successfully this time

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
