### PR TITLE
[4534] Add record_source field to trainee

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -64,7 +64,7 @@ module ApplicationRecordCard
       return unless show_record_source
 
       title = I18n.t("components.application_record_card.record_source.title")
-      record_source_text = I18n.t("components.application_record_card.record_source.#{record.record_source}")
+      record_source_text = I18n.t("components.application_record_card.record_source.#{record.derived_record_source}")
       tag.p("#{title}: #{record_source_text}", class: "govuk-caption-m govuk-!-font-size-16 application-record-card__record_source govuk-!-margin-bottom-0 govuk-!-margin-top-2")
     end
 

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -43,7 +43,7 @@ module RecordDetails
       return unless show_record_source
 
       { field_label: t(".record_source.title"),
-        field_value: t(".record_source.#{trainee.record_source}") }
+        field_value: t(".record_source.#{trainee.derived_record_source}") }
     end
 
     def trainee_id_row

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -116,6 +116,6 @@ private
   end
 
   def trainee_params
-    params.fetch(:trainee, {}).permit(:training_route)
+    params.fetch(:trainee, {}).permit(:training_route, :record_source)
   end
 end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -23,6 +23,7 @@ class TraineesController < BaseTraineeController
     provider_id = current_user.provider? ? current_user.organisation.id : nil
     authorize(@trainee = Trainee.new(trainee_params.merge(provider_id: provider_id)))
     trainee.set_early_years_course_details
+
     if trainee.save
       redirect_to(trainee_review_drafts_path(trainee))
     else

--- a/app/jobs/hesa/retrieve_collection_job.rb
+++ b/app/jobs/hesa/retrieve_collection_job.rb
@@ -18,5 +18,9 @@ module Hesa
     def url
       "#{Settings.hesa.collection_base_url}/#{@collection_reference}/#{CollectionRequest.next_from_date}"
     end
+
+    def record_source
+      RecordSources::HESA_COLLECTION
+    end
   end
 end

--- a/app/jobs/hesa/retrieve_job.rb
+++ b/app/jobs/hesa/retrieve_job.rb
@@ -13,7 +13,7 @@ module Hesa
       Nokogiri::XML::Reader(xml_response).each do |node|
         if node.name == "Student" && node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
           student_node = Nokogiri::XML(node.outer_xml).at("./Student")
-          Trainees::CreateFromHesa.call(student_node: student_node)
+          Trainees::CreateFromHesa.call(student_node: student_node, record_source: record_source)
         end
       rescue Trainees::CreateFromHesa::HesaImportError => e
         Sentry.capture_exception(e)
@@ -28,6 +28,10 @@ module Hesa
     end
 
     def url
+      raise(NotImplementedError)
+    end
+
+    def record_source
       raise(NotImplementedError)
     end
   end

--- a/app/jobs/hesa/retrieve_trn_data_job.rb
+++ b/app/jobs/hesa/retrieve_trn_data_job.rb
@@ -14,5 +14,9 @@ module Hesa
     def url
       "#{Settings.hesa.trn_data_base_url}/#{@collection_reference}/Latest"
     end
+
+    def record_source
+      RecordSources::HESA_TRN_DATA
+    end
   end
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -397,7 +397,7 @@ class Trainee < ApplicationRecord
     hesa_id.present?
   end
 
-  def record_source
+  def derived_record_source
     return "hesa" if hesa_record?
 
     return "apply" if apply_application?

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -294,7 +294,7 @@ module Exports
         "apply" => "Apply",
         "dttp" => "DTTP",
         "hesa" => "HESA",
-      }[trainee.record_source]
+      }[trainee.derived_record_source]
     end
 
     def lead_school_name(trainee)

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -64,6 +64,7 @@ module Trainees
         training_route: course&.route,
         disabilities: disabilities,
         study_mode: study_mode,
+        record_source: RecordSources::APPLY,
       }.merge(address).merge(ethnic_background_attributes)
     end
 

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -103,6 +103,7 @@ module Trainees
         dttp_id: dttp_trainee.dttp_id,
         placement_assignment_dttp_id: placement_assignment.dttp_id,
         hesa_id: dttp_trainee.hesa_id,
+        record_source: RecordSources::DTTP,
       }.merge(personal_details_attributes)
        .merge(contact_attributes)
        .merge(ethnicity_and_disability_attributes)

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -11,9 +11,10 @@ module Trainees
 
     class HesaImportError < StandardError; end
 
-    def initialize(student_node:)
+    def initialize(student_node:, record_source:)
       @hesa_trainee = Hesa::Parsers::IttRecord.to_attributes(student_node: student_node)
       @trainee = Trainee.find_or_initialize_by(hesa_id: hesa_trainee[:hesa_id])
+      @record_source = record_source
     end
 
     def call
@@ -34,7 +35,7 @@ module Trainees
 
   private
 
-    attr_reader :hesa_trainee, :trainee
+    attr_reader :hesa_trainee, :trainee, :record_source
 
     def mapped_attributes
       {
@@ -44,6 +45,7 @@ module Trainees
         state: trainee_state,
         hesa_updated_at: hesa_trainee[:hesa_updated_at],
         course_allocation_subject: course_allocation_subject,
+        record_source: record_source,
       }.merge(created_from_hesa_attribute)
        .merge(personal_details_attributes)
        .merge(provider_attributes)

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -45,7 +45,7 @@ module Trainees
         state: trainee_state,
         hesa_updated_at: hesa_trainee[:hesa_updated_at],
         course_allocation_subject: course_allocation_subject,
-        record_source: record_source,
+        record_source: trainee_record_source,
       }.merge(created_from_hesa_attribute)
        .merge(personal_details_attributes)
        .merge(provider_attributes)
@@ -57,6 +57,18 @@ module Trainees
        .merge(school_attributes)
        .merge(training_initiative_attributes)
        .compact
+    end
+
+    # As soon as the trainee has been submitted over the HESA collection
+    # endpoint, the record_source should remain as "HESA collection". Only
+    # trainees who have ONLY ever been submitted over the TRN data endpoint
+    # should have the record_source "HESA TRN data"
+    def trainee_record_source
+      if record_source == RecordSources::HESA_TRN_DATA && trainee.record_source == RecordSources::HESA_COLLECTION
+        return RecordSources::HESA_COLLECTION
+      end
+
+      record_source
     end
 
     def trn

--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -1,3 +1,5 @@
+<%= f.hidden_field :record_source, value: RecordSources::MANUAL %>
+
 <%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "l", text: t("components.page_titles.trainees.training_routes.edit"), tag: "h1" }) do %>
 
   <% if current_user.provider? && current_user.organisation.hpitt_postgrad? %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -241,6 +241,7 @@ shared:
     - progress
     - provider_id
     - recommended_for_award_at
+    - record_source
     - region
     - reinstate_date
     - slug

--- a/config/initializers/record_sources.rb
+++ b/config/initializers/record_sources.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RecordSources
+  APPLY = "Apply"
+  DTTP = "DTTP"
+  HESA_COLLECTION = "HESA collection"
+  HESA_TRN_DATA = "HESA TRN data"
+  MANUAL = "Manual"
+
+  ALL = [APPLY, DTTP, HESA_COLLECTION, HESA_TRN_DATA, MANUAL].freeze
+end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -46,3 +46,7 @@ RSpec/Capybara/FeatureMethods:
 
 RSpec/MessageChain:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Exclude:
+    - "spec/**/*"

--- a/db/migrate/20220812143158_add_record_source_field_to_trainees.rb
+++ b/db/migrate/20220812143158_add_record_source_field_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRecordSourceFieldToTrainees < ActiveRecord::Migration[6.1]
+  def change
+    add_column :trainees, :record_source, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_09_102256) do
+ActiveRecord::Schema.define(version: 2022_08_12_143158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -678,6 +678,7 @@ ActiveRecord::Schema.define(version: 2022_08_09_102256) do
     t.bigint "course_allocation_subject_id"
     t.bigint "start_academic_cycle_id"
     t.bigint "end_academic_cycle_id"
+    t.string "record_source"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["course_allocation_subject_id"], name: "index_trainees_on_course_allocation_subject_id"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -181,6 +181,7 @@ namespace :example_data do
 
                   attrs.merge!(
                     apply_application: FactoryBot.build(:apply_application, accredited_body_code: provider.code),
+                    record_source: RecordSources::APPLY,
                   )
                 else
                   # Create manual drafts for *current* academic cycle

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -575,6 +575,7 @@ FactoryBot.define do
       end
 
       hesa_id { Faker::Number.number(digits: 13) }
+      record_source { RecordSources::HESA_COLLECTION }
       created_from_hesa { true }
       hesa_updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
       hesa_student { create(:hesa_student, hesa_id: hesa_id) }

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -566,6 +566,7 @@ FactoryBot.define do
 
     trait :created_from_dttp do
       created_from_dttp { true }
+      record_source { RecordSources::DTTP }
     end
 
     trait :imported_from_hesa do

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -35,6 +35,8 @@ FactoryBot.define do
     email { "#{first_names}.#{last_name}@example.com" }
     applying_for_bursary { nil }
 
+    record_source { RecordSources::MANUAL }
+
     factory :trainee do
       date_of_birth { Faker::Date.birthday(min_age: 18, max_age: 65) }
     end

--- a/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
@@ -13,6 +13,7 @@ feature "Create trainee journey" do
     and_i_select_assessment_only_route
     and_i_save_the_form
     then_i_should_see_the_new_trainee_overview
+    and_trainee_record_source_is_set_to_manual
   end
 
   scenario "setting up an initial provider led record", "feature_routes.provider_led_postgrad": true do
@@ -133,5 +134,9 @@ private
   def and_trainee_course_subject_one_set_to_early_years_teaching
     expect(Trainee.last.course_subject_one).to eq(CourseSubjects::EARLY_YEARS_TEACHING)
     expect(Trainee.last.course_age_range).to eq(AgeRange::ZERO_TO_FIVE)
+  end
+
+  def and_trainee_record_source_is_set_to_manual
+    expect(Trainee.last.record_source).to eq(RecordSources::MANUAL)
   end
 end

--- a/spec/jobs/hesa/retrieve_collection_job_spec.rb
+++ b/spec/jobs/hesa/retrieve_collection_job_spec.rb
@@ -42,7 +42,7 @@ module Hesa
       end
 
       it "creates or updates a trainee from a student node element" do
-        expect(Trainees::CreateFromHesa).to(receive(:call).with(student_node: instance_of(Nokogiri::XML::Element)))
+        expect(Trainees::CreateFromHesa).to(receive(:call).with(student_node: instance_of(Nokogiri::XML::Element), record_source: RecordSources::HESA_COLLECTION))
         described_class.new.perform
       end
 

--- a/spec/jobs/hesa/retrieve_trn_data_job_spec.rb
+++ b/spec/jobs/hesa/retrieve_trn_data_job_spec.rb
@@ -41,7 +41,7 @@ module Hesa
       end
 
       it "creates or updates a trainee from a student node element" do
-        expect(Trainees::CreateFromHesa).to(receive(:call).with(student_node: instance_of(Nokogiri::XML::Element)))
+        expect(Trainees::CreateFromHesa).to(receive(:call).with(student_node: instance_of(Nokogiri::XML::Element), record_source: RecordSources::HESA_TRN_DATA))
         described_class.new.perform
       end
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -403,8 +403,8 @@ describe Trainee do
       end
     end
 
-    describe "#record_source" do
-      subject { trainee.record_source }
+    describe "#derived_record_source" do
+      subject { trainee.derived_record_source }
 
       context "manual record source" do
         let(:trainee) { create(:trainee) }

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -45,6 +45,7 @@ module Trainees
         course_min_age: course.min_age,
         course_max_age: course.max_age,
         study_mode: "full_time",
+        record_source: RecordSources::APPLY,
       }
     end
 

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -90,6 +90,7 @@ module Trainees
         expect(trainee.created_at).to eq(api_trainee["createdon"])
         expect(trainee.updated_at).to eq(api_trainee["modifiedon"])
         expect(trainee.dttp_update_sha).to eq(trainee.sha)
+        expect(trainee.record_source).to eq(RecordSources::DTTP)
       end
 
       context "when the trainee has a lead school" do

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -21,6 +21,7 @@ module Trainees
     let!(:first_disability) { create(:disability, name: first_disability_name) }
     let(:second_disability_name) { Diversities::DEVELOPMENT_CONDITION }
     let!(:second_disability) { create(:disability, name: second_disability_name) }
+    let(:record_source) { RecordSources::HESA_COLLECTION }
 
     let!(:course_allocation_subject) do
       create(:subject_specialism, name: CourseSubjects::BIOLOGY).allocation_subject
@@ -35,15 +36,16 @@ module Trainees
       create(:provider, ukprn: student_attributes[:ukprn])
       create(:school, urn: student_attributes[:lead_school_urn])
       create_custom_state
-      described_class.call(student_node: student_node)
+      described_class.call(student_node: student_node, record_source: record_source)
     end
 
     describe "HESA information imported from XML" do
-      it "updates the Trainee ID, HESA ID and TRN" do
+      it "updates the Trainee ID, HESA ID, TRN and record_source" do
         expect(trainee.trainee_id).to eq(student_attributes[:trainee_id])
         expect(trainee.hesa_id).to eq(student_attributes[:hesa_id])
         expect(trainee.trn).to eq(student_attributes[:trn])
         expect(trainee.course_allocation_subject).to eq(course_allocation_subject)
+        expect(trainee.record_source).to eq(record_source)
       end
 
       it "updates the trainee's personal details" do
@@ -113,6 +115,14 @@ module Trainees
         it "enqueues Dqt::RegisterForTrnJob" do
           expect(Dqt::RegisterForTrnJob).to have_received(:perform_later).with(Trainee.last)
         end
+      end
+    end
+
+    context "when called with TRN data record source" do
+      let(:record_source) { RecordSources::HESA_TRN_DATA }
+
+      it "sets record source to HESA_TRN_DATA" do
+        expect(trainee.record_source).to eq(record_source)
       end
     end
 

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -118,11 +118,33 @@ module Trainees
       end
     end
 
-    context "when called with TRN data record source" do
+    context "when the trainee was originally created via the TRN data endpoint" do
+      let(:existing_trn) { Faker::Number.number(digits: 7).to_s }
+      let(:create_custom_state) do
+        create(:trainee, hesa_id: student_attributes[:hesa_id], trn: existing_trn, record_source: RecordSources::HESA_TRN_DATA)
+      end
+
+      it "updates the trainee record source to be HESA collection" do
+        expect(trainee.record_source).to eq(RecordSources::HESA_COLLECTION)
+      end
+    end
+
+    context "when the trainee is submitted via TRN data" do
       let(:record_source) { RecordSources::HESA_TRN_DATA }
 
       it "sets record source to HESA_TRN_DATA" do
-        expect(trainee.record_source).to eq(record_source)
+        expect(trainee.record_source).to eq(RecordSources::HESA_TRN_DATA)
+      end
+
+      context "but was originally created via the collection endpoint" do
+        let(:existing_trn) { Faker::Number.number(digits: 7).to_s }
+        let(:create_custom_state) do
+          create(:trainee, hesa_id: student_attributes[:hesa_id], trn: existing_trn, record_source: RecordSources::HESA_COLLECTION)
+        end
+
+        it "does not update the trainee record source" do
+          expect(trainee.record_source).to eq(RecordSources::HESA_COLLECTION)
+        end
       end
     end
 


### PR DESCRIPTION
### Context

https://trello.com/c/fUMWQZqP/4534-add-record-source-field-to-trainee-to-show-us-when-its-only-been-trn-requested

We need a way of distinguishing between trainees who were created over the HESA TRN data endpoint and have never come to us over the HESA collection endpoint. These need to be excluded from the UI.

We decided to add a record_source field to track this. We can also use this to clean up our code elsewhere where we derive the record source from various things (see renamed `def derived_record_source` which can be removed once we do the backfill). Then we can swap the record source filter and all the various scopes to use this new field.

### Changes proposed in this pull request

- Add record_source field to trainees
- Set manually created trainees record_source to manual
- Save trainees created from Apply record source to Apply 
- For completeness, save trainees created from DTTP record source to DTTP 
- Save HESA record_sources on trainees created from HESA (HESA collection and HESA TRN data) 
- Handle swapping between HESA TRN data and HESA collection sources
  - If a trainee is seen over the TRN data endpoint, but was originally created via the collection
  DO NOT set the record_source to be HESA TRN data.
- Temporarily re-name current record_source method until we backfill

Note: no validation on new field until we do the backfill

### Guidance to review

- Check that the record sources still show on trainees as an admin
- Check that the record source filter still works
- Check that the download still contains the correct record source

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
  
  Not PII
  
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml

Confirmed no PII, added to analytics.yml