### PR TITLE
[4541] Hide trainees when they have only been requested for TRN via HESA

### DIFF
--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -6,7 +6,7 @@ module Trainees
     ALL_SCIENCES_FILTER = "Sciences - biology, chemistry, physics"
 
     def initialize(trainees:, filters:)
-      @trainees = remove_empty_trainees(trainees)
+      @trainees = remove_hesa_trn_data_trainees(remove_empty_trainees(trainees))
       @filters = filters
     end
 
@@ -22,6 +22,10 @@ module Trainees
 
     def remove_empty_trainees(trainees)
       trainees.where.not(id: FindEmptyTrainees.call(trainees: trainees, ids_only: true))
+    end
+
+    def remove_hesa_trn_data_trainees(trainees)
+      trainees.where.not(record_source: RecordSources::HESA_TRN_DATA)
     end
 
     def course_education_phase(trainees, course_education_phases)

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -8,18 +8,28 @@ module Trainees
 
     let(:draft_trainee) { create(:trainee, :incomplete_draft, first_names: "Draft") }
     let(:apply_draft_trainee) { create(:trainee, :with_apply_application, first_names: "Apply") }
+    let(:hesa_trn_data_trainee) { create(:trainee, record_source: RecordSources::HESA_TRN_DATA) }
+    let(:hesa_collection_trainee) { create(:trainee, record_source: RecordSources::HESA_COLLECTION) }
     let(:filters) { nil }
     let(:trainees) { Trainee.all }
 
     it { is_expected.to match_array(trainees) }
 
-    context "empty trainee exists" do
+    context "when an empty trainee exists" do
       let!(:empty_trainee) do
         Trainee.create(provider_id: draft_trainee.provider.id,
                        training_route: TRAINING_ROUTE_ENUMS[:assessment_only])
       end
 
       it { is_expected.not_to include(empty_trainee) }
+    end
+
+    context "when a trainee created from the HESA TRN data endpoint exists" do
+      it { is_expected.not_to include(hesa_trn_data_trainee) }
+    end
+
+    context "when a trainee submitted in the HESA collection exists" do
+      it { is_expected.to include(hesa_collection_trainee) }
     end
 
     context "with training_route filter" do


### PR DESCRIPTION
### Context

https://trello.com/c/dkz9DVtT/4541-hide-trainees-when-they-have-only-been-requested-for-trn-via-hesa-in-register-ui-and-user-exports

### Changes proposed in this pull request

Use our new `record_source` field on trainees to hide those with `HESA TRN data` source.

### Guidance to review

- Check that the HESA TRN data trainee with TRN 3638452 is not visible in the Registered trainees list
- Check that they're also not visible in the download

<img width="659" alt="Screenshot 2022-08-16 at 14 07 06" src="https://user-images.githubusercontent.com/18436946/184887058-5d7e8511-978e-4962-a711-9c2104ae42ac.png">

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml