### PR TITLE
[xxx] Save submitted_for_trn on trainee during hesa import

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -53,6 +53,7 @@ module Trainees
        .merge(course_attributes)
        .merge(withdrawal_attributes)
        .merge(deferral_attributes)
+       .merge(submitted_for_trn_attributes)
        .merge(funding_attributes)
        .merge(school_attributes)
        .merge(training_initiative_attributes)
@@ -124,6 +125,12 @@ module Trainees
       return {} unless trainee_state == :deferred
 
       { defer_date: hesa_trainee[:end_date] }
+    end
+
+    def submitted_for_trn_attributes
+      return {} unless trainee_state == :submitted_for_trn
+
+      { submitted_for_trn_at: Time.zone.now }
     end
 
     def school_attributes

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -113,7 +113,17 @@ module Trainees
         let(:hesa_stub_attributes) { {} }
 
         it "enqueues Dqt::RegisterForTrnJob" do
-          expect(Dqt::RegisterForTrnJob).to have_received(:perform_later).with(Trainee.last)
+          expect(Dqt::RegisterForTrnJob).to have_received(:perform_later).with(trainee)
+        end
+      end
+
+      context "when the trainee has no TRN and no reason for leaving", feature_integrate_with_dqt: true do
+        let(:hesa_stub_attributes) { { trn: nil } }
+
+        it "sets the state to submitted_for_trn and the submitted_for_trn_at" do
+          expect(trainee.state).to eq("submitted_for_trn")
+          expect(trainee.submitted_for_trn_at).not_to be_nil
+          expect(Dqt::RegisterForTrnJob).to have_received(:perform_later).with(trainee)
         end
       end
     end


### PR DESCRIPTION
### Context

We're setting some trainees to `submitted_for_trn` during the HESA import (if they're missing a TRN). 

We're also going to kick off the `RegisterForTrnJob` off the the back of this.

Currently `RegisterForTrn` service will fail due to lack of `submitted_for_trn_at`

### Changes proposed in this pull request

- Update `submitted_for_trn_at` when we set the state to be `submitted_for_trn` in the `CreateFromHesa` service.

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml