### PR TITLE
[xxx] Update importable states in course sync

### DIFF
--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -6,10 +6,8 @@ module TeacherTrainingApi
 
     # For full list, see https://api.publish-teacher-training-courses.service.gov.uk/api-reference.html#schema-courseattributes
     IMPORTABLE_STATES = %w[
-      empty
       rolled_over
       published
-      published_with_unpublished_changes
       withdrawn
     ].freeze
 

--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -4,7 +4,7 @@ module TeacherTrainingApi
   class ImportCourse
     include ServicePattern
 
-    # For full list, see https://api.publish-teacher-training-courses.service.gov.uk/api-reference.html#schema-courseattributes
+    # For full list, see https://api.publish-teacher-training-courses.service.gov.uk/docs/api-reference.html#schema-courseattributes
     IMPORTABLE_STATES = %w[
       rolled_over
       published


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/publish-teacher-training/pull/2940

We're streamlining the values sent within the Course's `state` property in the Publish API. This PR updates the `ImportCourse` sync to accommodate the changes.

### Changes proposed in this pull request

- In publish, `empty` and `draft` are now synonymous. So have removed this as I think Register just needs `rolled_over`, `published` and `withdrawn`?
- Remove `published_with_unpublished_changes` as these courses will be returned under `published`. I don't think Register distinguishes between the two internally?

### Guidance to review

See the changes, let me know if all ok :)
