### PR TITLE
[xxx] Undo code that hides too many trainees

### DIFF
--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -6,7 +6,7 @@ module Trainees
     ALL_SCIENCES_FILTER = "Sciences - biology, chemistry, physics"
 
     def initialize(trainees:, filters:)
-      @trainees = remove_hesa_trn_data_trainees(remove_empty_trainees(trainees))
+      @trainees = remove_empty_trainees(trainees)
       @filters = filters
     end
 
@@ -22,10 +22,6 @@ module Trainees
 
     def remove_empty_trainees(trainees)
       trainees.where.not(id: FindEmptyTrainees.call(trainees: trainees, ids_only: true))
-    end
-
-    def remove_hesa_trn_data_trainees(trainees)
-      trainees.where.not(record_source: RecordSources::HESA_TRN_DATA)
     end
 
     def course_education_phase(trainees, course_education_phases)

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -8,8 +8,6 @@ module Trainees
 
     let(:draft_trainee) { create(:trainee, :incomplete_draft, first_names: "Draft") }
     let(:apply_draft_trainee) { create(:trainee, :with_apply_application, first_names: "Apply") }
-    let(:hesa_trn_data_trainee) { create(:trainee, record_source: RecordSources::HESA_TRN_DATA) }
-    let(:hesa_collection_trainee) { create(:trainee, record_source: RecordSources::HESA_COLLECTION) }
     let(:filters) { nil }
     let(:trainees) { Trainee.all }
 
@@ -22,14 +20,6 @@ module Trainees
       end
 
       it { is_expected.not_to include(empty_trainee) }
-    end
-
-    context "when a trainee created from the HESA TRN data endpoint exists" do
-      it { is_expected.not_to include(hesa_trn_data_trainee) }
-    end
-
-    context "when a trainee submitted in the HESA collection exists" do
-      it { is_expected.to include(hesa_collection_trainee) }
     end
 
     context "with training_route filter" do


### PR DESCRIPTION
### Context

Too many trainees hidden! draft trainees with null record_source are hidden.

### Changes proposed in this pull request

Revert changes in  https://github.com/DFE-Digital/register-trainee-teachers/pull/2640

### Guidance to review

🚢 

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
