### PR TITLE
[4550] Adjust find_item to use internal DfeReference

### DIFF
--- a/app/services/degrees/dfe_reference.rb
+++ b/app/services/degrees/dfe_reference.rb
@@ -43,11 +43,11 @@ module Degrees
 
     class << self
       def find_subject(uuid: nil, name: nil, hecos_code: nil)
-        find_item(:single_subjects, id: uuid, hecos_code: hecos_code, name: name)
+        find_item(:subjects, id: uuid, hecos_code: hecos_code, name: name)
       end
 
       def find_type(uuid: nil, name: nil, abbreviation: nil, hesa_code: nil)
-        find_item(:types_including_generics,
+        find_item(:types,
                   id: uuid,
                   name: name,
                   hesa_itt_code: hesa_code,
@@ -63,7 +63,7 @@ module Degrees
       end
 
       def find_item(list_type, filters)
-        ref_dataset = DfE::ReferenceData::Degrees.const_get(list_type.to_s.upcase)
+        ref_dataset = Degrees::DfeReference.const_get(list_type.to_s.upcase)
 
         return ref_dataset.one(filters[:id]) if filters[:id].present?
 

--- a/spec/lib/dqt/params/trainee_request_spec.rb
+++ b/spec/lib/dqt/params/trainee_request_spec.rb
@@ -7,22 +7,12 @@ module Dqt
     describe TraineeRequest do
       let(:trainee) { create(:trainee, :completed, gender: "female", hesa_id: 1) }
       let(:degree) { trainee.degrees.first }
-      let(:hesa_code) { "11111" }
-      let(:ukprn) { DfE::ReferenceData::Degrees::INSTITUTIONS.one(degree.institution_uuid)[:ukprn] }
+      let(:hesa_code) { Degrees::DfeReference::SUBJECTS.all.find { _1.name == degree.subject }&.hecos_code }
+      let(:ukprn) { Degrees::DfeReference::INSTITUTIONS.one(degree.institution_uuid)[:ukprn] }
       let(:dqt_degree_type) { "BachelorOfArts" }
       let(:uk_degree_uuid) { "db695652-c197-e711-80d8-005056ac45bb" }
 
       before do
-        stub_const(
-          "DfE::ReferenceData::Degrees::SINGLE_SUBJECTS",
-          DfE::ReferenceData::HardcodedReferenceList.new({
-            SecureRandom.uuid => {
-              name: degree.subject,
-              hecos_code: hesa_code,
-            },
-          }),
-        )
-
         degree.uk_degree_uuid = uk_degree_uuid
       end
 

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -7,20 +7,8 @@ module Dqt
     describe TrnRequest do
       let(:trainee_attributes) { {} }
       let(:degree) { build(:degree, :uk_degree_with_details) }
-      let(:hesa_code) { "11111" }
+      let(:hesa_code) { Degrees::DfeReference::SUBJECTS.all.find { _1.name == degree.subject }&.hecos_code }
       let(:trainee) { create(:trainee, :completed, gender: "female", degrees: [degree], **trainee_attributes) }
-
-      before do
-        stub_const(
-          "DfE::ReferenceData::Degrees::SINGLE_SUBJECTS",
-          DfE::ReferenceData::HardcodedReferenceList.new({
-            SecureRandom.uuid => {
-              name: degree.subject,
-              hecos_code: hesa_code,
-            },
-          }),
-        )
-      end
 
       describe "#params" do
         subject { described_class.new(trainee: trainee).params }


### PR DESCRIPTION
### Context

The test suite was failing due to a non-deterministic test when the grade selected was `Other`

### Changes proposed in this pull request

Fix the `find_item` method to use the constants defined within the same class rather than directly from the ReferenceData gem.

### Guidance to review

This test should no longer fail on random runs:
```bash
bundle exec rspec ./spec/forms/degree_form_spec.rb:150
```

These tests failed after the actual code changes and have been updated:
```bash
bundle exec rspec ./spec/lib/dqt/params/trainee_request_spec.rb:53
bundle exec rspec ./spec/lib/dqt/params/trn_request_spec.rb:76
```

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
