### PR TITLE
[4442] building the report for sign off

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class ReportsController < BaseTraineeController
+  include DateOfTheNthWeekdayHelper
+  include UsersHelper
+  include TraineeHelper
+
+  def index
+    authorize(current_user, :reports?)
+  end
+
+  def itt_new_starter_data_sign_off
+    authorize(current_user, :reports?)
+    set_instance_variables
+    respond_to do |format|
+      format.html do
+        @census_date = census_date(@current_academic_cycle_start_year).strftime("%d %B %Y")
+      end
+      format.csv do
+        authorize(:trainee, :export?)
+        send_data(data_for_export.data, filename: filename, disposition: :attachment)
+      end
+    end
+  end
+
+private
+
+  def set_instance_variables
+    @current_academic_cycle_label = AcademicCycle.current.label
+    @current_academic_cycle_start_year = AcademicCycle.current.start_year
+    @sign_off_url = Settings.sign_off_trainee_data_url
+  end
+
+  def data_for_export
+    @data_for_export ||= Exports::TraineeSearchData.new(policy_scope(NewStarterTraineesService.new(census_date(AcademicCycle.current.start_year)).call))
+  end
+
+  def filename
+    current_time = Time.zone.now
+    "#{current_time.strftime('%F_%H_%M_%S')}_New-trainees-#{AcademicCycle.current.start_year}-#{AcademicCycle.current.end_year}-sign-off-Register-trainee-teachers_exported_records.csv"
+  end
+
+  def census_date(year)
+    date_of_nth_weekday(10, year, 3, 2)
+  end
+end

--- a/app/helpers/date_of_the_nth_weekday_helper.rb
+++ b/app/helpers/date_of_the_nth_weekday_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DateOfTheNthWeekdayHelper
+  def date_of_nth_weekday(month, year, weekday, nth)
+    base_date = Date.new(year, month)
+    weekday_of_the_first_of_the_month = base_date.wday
+    ret_date = base_date +
+      (weekday > weekday_of_the_first_of_the_month ? weekday - weekday_of_the_first_of_the_month : 7 - weekday_of_the_first_of_the_month + weekday) +
+      (7 * (nth - 1))
+    ret_date.month == month ? ret_date : nil
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -9,6 +9,10 @@ module UsersHelper
     defined?(current_user).present? && current_user.present? && UserPolicy.new(current_user, nil).drafts?
   end
 
+  def can_view_reports?
+    can_view_drafts?
+  end
+
   def can_view_funding?
     FeatureService.enabled?("funding") && defined?(current_user) && !current_user&.system_admin
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -12,4 +12,8 @@ class UserPolicy < ProviderPolicy
   def drafts?
     user.system_admin? || !user.lead_school?
   end
+
+  def reports?
+    user.system_admin? || !user.lead_school?
+  end
 end

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -101,7 +101,7 @@ module Exports
           "itt_end_date" => itt_end_date(trainee),
           "course_duration_in_years" => trainee.course_duration_in_years,
           "course_summary" => course_summary(trainee, course),
-          "commencement_date" => trainee.commencement_date&.iso8601,
+          "trainee_start_date" => trainee.commencement_date&.iso8601,
           "lead_school_name" => lead_school_name(trainee),
           "lead_school_urn" => trainee.lead_school&.urn,
           "employing_school_name" => employing_school_name(trainee),

--- a/app/services/new_starter_trainees_service.rb
+++ b/app/services/new_starter_trainees_service.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class NewStarterTraineesService
+  def initialize(census_date)
+    @census_date = census_date
+  end
+
+  def call
+    Trainee.where("itt_start_date <= :date or commencement_date <= :date", date: census_date)
+           .or(Trainee.where(commencement_date: nil))
+           .where(start_academic_cycle_id: AcademicCycle.current)
+           .where.not(state: 0)
+  end
+
+  attr_reader :census_date
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,6 +54,7 @@
           { name: "Home", url: root_path },
           ({ name: "Draft trainees", url: drafts_path, current: active_link_for("drafts", @trainee) } if can_view_drafts?),
           { name: "Registered trainees", url: trainees_path, current: active_link_for("trainees", @trainee) },
+          ({ name: "Reports", url: reports_path } if can_view_reports?),
           ({ name: "Funding", url: funding_payment_schedule_path, current: active_link_for("funding") } if can_view_funding?),
           ({ name: current_user.organisation.name, url: organisations_path, align_right: true } if show_organisation_link?),
         ],

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,14 @@
+<%= render PageTitle::View.new(text: "Reports") %>
+
+<h1 class="govuk-heading-l">
+    Reports
+</h1>
+
+<ul class="govuk-list govuk-list--spaced">
+  <li>
+    <p>
+      <%= govuk_link_to "Export new trainee data for the 2022 to 2023 academic year for sign off", itt_new_starter_data_sign_off_reports_path %>
+    </p>
+  </li>
+</ul>
+

--- a/app/views/reports/itt_new_starter_data_sign_off.html.erb
+++ b/app/views/reports/itt_new_starter_data_sign_off.html.erb
@@ -1,0 +1,43 @@
+<%= render PageTitle::View.new(text: "Export new trainee data for sign off for the 2022 to 2023 academic year") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: t("back"),
+    href: root_path,
+    ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+  <h1 class="govuk-heading-l">Export new trainee data for sign off for the <%= @current_academic_cycle_label %> academic year</h1>
+    <p class="govuk-body">This export will show the new trainee data you’ve provided to the DfE for trainees who’ve started their initial teacher training (ITT) in the <%= @current_academic_cycle_label %> academic year, and have a trainee start date on or before the second Wednesday of October <%= @current_academic_cycle_start_year %> (sometimes called the census date).</p>
+    <div class="govuk-inset-text">For the <%= @current_academic_cycle_label %> academic year, the ITT census date is
+      <p class="no-wrap"> Wednesday <%= @census_date %>.</p>
+    </div>
+    <h2 class="govuk-heading-m">What you must do to sign off your new trainee data</h2>
+    <p class="govuk-body">Use this export to check you’ve provided accurate data for all your new trainees. You should check for any errors or missing trainees.</p>
+    <p class="govuk-body">Once you’ve checked your data, a senior person from your organisation (preferably a different person to who submitted the data) should <a href=<%=@sign_off_url %> class="govuk-link" rel="noreferrer noopener" target="_blank">sign it off using this form (opens in a new tab)</a>.</p>
+    <p class="govuk-body">You must sign off your data on or before 31 October <%= @current_academic_cycle_start_year %>. Not submitting and signing off new trainee data by this date will mean that we (the DfE) do not have accurate data on your trainees and they may be excluded from the ITT census publication.</p>
+    <h2 class="govuk-heading-m">How new trainee data relates to the ITT census publication</h2>
+    <p class="govuk-body">After signing off your new trainee data, it gets analysed and filtered for the ITT census publication.</p>
+    <p class="govuk-body">Not all your new trainees in this export will be included in the ITT census publication. To understand what data will be used, read the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology" class="govuk-link" rel="noreferrer noopener" target="_blank">Initial Teacher Training Census methodology (opens in a new tab)</a>.</p>
+    <h2 class="govuk-heading-m">New trainees without a start date</h2>
+    <p class="govuk-body">Any new trainee who has a course start date on or before <%= @census_date %>, but does not have a trainee start date, will be included in this export.</p>
+    <p class="govuk-body">If a new trainee starts their course on or before <%= @census_date %>, you should add their trainee start date as soon as possible (if you're registering trainees manually in the Register service). Not adding this means we will not know if the trainee has started their course, which could affect funding payments (if the trainee is eligible for funding).</p>
+    <h2 class="govuk-heading-m">About this export</h2>
+    <p class="govuk-body">This export includes all trainees:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        with their academic start year in <%= @current_academic_cycle_label %>
+      </li>
+      <li>
+        with an ITT course start date on or before the ITT census date
+      </li>
+      <li>
+        with a trainee start date on or before the ITT census date
+      </li>
+    </ul>
+    <p class="govuk-body">If a trainee does not have a trainee start date, they will also be included in this export.</p>
+    <%= govuk_link_to "Export new trainee data (CSV)", itt_new_starter_data_sign_off_reports_path(:csv), class: "govuk-button" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,10 @@ Rails.application.routes.draw do
 
   resources :drafts, only: :index
 
+  resources :reports, only: :index do
+    get "itt-new-starter-data-sign-off", to: "reports#itt_new_starter_data_sign_off", on: :collection
+  end
+
   resources :trainees, except: :edit do
     scope module: :trainees do
       resource :training_details, concerns: :confirmable, only: %i[edit update], path: "/training-details"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -150,3 +150,5 @@ google:
     dataset: replaceme
     api_json_key: ""
     table_name: events
+
+sign_off_trainee_data_url: https://example.com/trainee-data-sign-off

--- a/spec/helpers/date_of_the_nth_weekday_helper_spec.rb
+++ b/spec/helpers/date_of_the_nth_weekday_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DateOfTheNthWeekdayHelper do
+  include DateOfTheNthWeekdayHelper
+
+  it "calculates the date of the 2nd wednesday of october 2022 correctly" do
+    expect(date_of_nth_weekday(10, 2022, 3, 2)).to eq(Date.new(2022, 10, 12))
+  end
+
+  it "calculates the date of the 4th sunday of march 2023 correctly" do
+    expect(date_of_nth_weekday(3, 2023, 0, 4)).to eq(Date.new(2023, 3, 26))
+  end
+
+  it "calculates the date of the 4th sunday of july 2024 correctly" do
+    expect(date_of_nth_weekday(7, 2024, 0, 4)).to eq(Date.new(2024, 7, 28))
+  end
+end

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -110,7 +110,7 @@ module Exports
           "itt_end_date" => trainee.itt_end_date&.iso8601,
           "course_duration_in_years" => trainee.course_duration_in_years,
           "course_summary" => course&.summary,
-          "commencement_date" => trainee.commencement_date&.iso8601,
+          "trainee_start_date" => trainee.commencement_date&.iso8601,
           "lead_school_name" => trainee.lead_school&.name,
           "lead_school_urn" => trainee.lead_school&.urn,
           "employing_school_name" => trainee.employing_school&.name,

--- a/spec/services/new_starter_trainees_service_spec.rb
+++ b/spec/services/new_starter_trainees_service_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+describe NewStarterTraineesService do
+  subject { described_class.new(DateTime.new(2022, 10, 12)).call }
+
+  before do
+    create(:academic_cycle)
+    create(:academic_cycle, previous_cycle: true, id: 10)
+  end
+
+  around do |example|
+    Timecop.freeze(Time.zone.local(2022, 9, 3)) do
+      example.run
+    end
+  end
+
+  let(:valid_trainee) { create(:trainee, state: 1, itt_start_date: 2.months.ago, start_academic_cycle: AcademicCycle.current) }
+  let(:valid_trainee_with_no_commencement_date) { create(:trainee, state: 1, commencement_date: nil, start_academic_cycle: AcademicCycle.current) }
+  let(:valid_draft_trainee) { create(:trainee, state: 0, itt_start_date: 2.months.ago, start_academic_cycle: AcademicCycle.current) }
+  let(:valid_trainee_from_previous_academic_cycle) { create(:trainee, state: 0, itt_start_date: 2.months.ago, start_academic_cycle_id: 10) }
+
+  it "to contain non draft current academic cycle trainees starting before the census date" do
+    expect(subject).to include(valid_trainee)
+  end
+
+  it "to contain non draft current academic cycle trainees with no commencement date" do
+    expect(subject).to include(valid_trainee_with_no_commencement_date)
+  end
+
+  it "to not contain draft trainees" do
+    expect(subject).not_to include(valid_draft_trainee)
+  end
+
+  it "to not contain valid trainees starting in a previous academic cycle" do
+    expect(subject).not_to include(valid_trainee_from_previous_academic_cycle)
+  end
+end


### PR DESCRIPTION
### Context

Providers need to know what data they're signing off on. It's helpful if they can see all the data (which requires some filtering that we don't currently offer on the Registered trainees page) in a report. This allows them to check their data to confirm it.

A reports section has been added to the navigation bar; with a page leading to some guidance and a download report button. 

### Changes proposed in this pull request

Add reports section nav bar heading
Add a reports page 
Add an itt_signoff reports page with a link to download the report 

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
