### PR TITLE
[4510] Add rspec-retry gem to Register

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -170,6 +170,9 @@ group :test do
   gem "site_prism", "~> 3.7"
 
   gem "webmock"
+
+  # DfE Digital forked rspec-retry detects flaky specs and reports them
+  gem "rspec-retry", git: "https://github.com/DFE-Digital/rspec-retry.git", branch: "main"
 end
 
 # Required for example_data so needed in review, qa and pen too

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,14 @@ GIT
     dfe-reference-data (1.0.0)
       activesupport
 
+GIT
+  remote: https://github.com/DFE-Digital/rspec-retry.git
+  revision: f6b9f3fd9ed7f140794adaf5b08d430265b6ebd2
+  branch: main
+  specs:
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -675,6 +683,7 @@ DEPENDENCIES
   redcarpet
   request_store (~> 1.5)
   rspec-rails (~> 5.1.2)
+  rspec-retry!
   rubocop-rails
   rubocop-rspec
   scss_lint-govuk

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rspec/retry"
+
 if ENV.fetch("COVERAGE", false)
   require "simplecov"
 
@@ -37,4 +39,18 @@ RSpec.configure do |config|
   config.order = :random
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.verbose_retry = true
+
+  config.display_try_failure_messages = true
+
+  config.around do |ex|
+    ex.run_with_retry retry: 3
+  end
+
+  config.retry_callback = proc do |ex|
+    if ex.metadata[:js]
+      Capybara.reset!
+    end
+  end
 end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/Bcoyw3fw/4510-s-capture-more-information-around-the-flakey-tests-so-we-can-try-and-fix-them

We have some issues with flakey specs on Register - we are going to add rspec-retry as a first step and then build some form of reporting for the flakey specs.

We are using a [DfE Digital forked version](https://github.com/DFE-Digital/rspec-retry) of rspec-retry because this has some custom functionality. Apply are also using this.

### Changes proposed in this pull request

* Add DfE-Digital forked version of rspec-retry
* Set to retry 3 times across failing tests

### Guidance to review

* Run the test suite locally and take a look at CI, make sure nothing untoward.
* Check if you think retrying 3 times is the right number of tries

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
