### PR TITLE
[4541] Hide HESA TRN data trainees

### DIFF
--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -6,7 +6,7 @@ module Trainees
     ALL_SCIENCES_FILTER = "Sciences - biology, chemistry, physics"
 
     def initialize(trainees:, filters:)
-      @trainees = remove_empty_trainees(trainees)
+      @trainees = remove_hesa_trn_data_trainees(remove_empty_trainees(trainees))
       @filters = filters
     end
 
@@ -22,6 +22,11 @@ module Trainees
 
     def remove_empty_trainees(trainees)
       trainees.where.not(id: FindEmptyTrainees.call(trainees: trainees, ids_only: true))
+    end
+
+    def remove_hesa_trn_data_trainees(trainees)
+      visible_sources = RecordSources::ALL - [RecordSources::HESA_TRN_DATA]
+      trainees.where(record_source: visible_sources.push(nil))
     end
 
     def course_education_phase(trainees, course_education_phases)

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -181,7 +181,6 @@ namespace :example_data do
 
                   attrs.merge!(
                     apply_application: FactoryBot.build(:apply_application, accredited_body_code: provider.code),
-                    record_source: RecordSources::APPLY,
                   )
                 else
                   # Create manual drafts for *current* academic cycle

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -35,8 +35,6 @@ FactoryBot.define do
     email { "#{first_names}.#{last_name}@example.com" }
     applying_for_bursary { nil }
 
-    record_source { RecordSources::MANUAL }
-
     factory :trainee do
       date_of_birth { Faker::Date.birthday(min_age: 18, max_age: 65) }
     end
@@ -566,7 +564,6 @@ FactoryBot.define do
 
     trait :created_from_dttp do
       created_from_dttp { true }
-      record_source { RecordSources::DTTP }
     end
 
     trait :imported_from_hesa do
@@ -575,7 +572,6 @@ FactoryBot.define do
       end
 
       hesa_id { Faker::Number.number(digits: 13) }
-      record_source { RecordSources::HESA_COLLECTION }
       created_from_hesa { true }
       hesa_updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
       hesa_student { create(:hesa_student, hesa_id: hesa_id) }

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -22,6 +22,24 @@ module Trainees
       it { is_expected.not_to include(empty_trainee) }
     end
 
+    context "when HESA TRN data trainee exists" do
+      let!(:hesa_trn_data_trainee) { create(:trainee, record_source: RecordSources::HESA_TRN_DATA) }
+
+      it { is_expected.not_to include(hesa_trn_data_trainee) }
+    end
+
+    context "when a HESA collection trainee exists" do
+      let!(:hesa_collection_trainee) { create(:trainee, record_source: RecordSources::HESA_COLLECTION) }
+
+      it { is_expected.to include(hesa_collection_trainee) }
+    end
+
+    context "when a trainee exists with nil record source" do
+      let!(:nil_record_source_trainee) { create(:trainee, record_source: nil) }
+
+      it { is_expected.to include(nil_record_source_trainee) }
+    end
+
     context "with training_route filter" do
       let!(:provider_led_postgrad_trainee) { create(:trainee, :provider_led_postgrad) }
       let(:filters) { { training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad] } }


### PR DESCRIPTION
### Context

https://trello.com/c/dkz9DVtT/4541-hide-trainees-when-they-have-only-been-requested-for-trn-via-hesa-in-register-ui-and-user-exports

### Changes proposed in this pull request

- Hide trainees whose record source is HESA TRN data from the UI
- Ensure that we don't hide trainees with nil record_source before the backfill is run :)

### Guidance to review

- Check that the HESA TRN data trainee (TRN 9922817) is not in the list nor the download

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml