### PR TITLE
[4510] Fire Sentry message when tests are retried in CI

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -163,6 +163,8 @@ jobs:
         docker-compose exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
         docker-compose exec -T web /bin/sh -c "yarn add jest"
         docker-compose exec -T web /bin/sh -c "RAILS_ENV=test bundle exec rails assets:precompile"
+      env:
+        SENTRY_DSN: ${{ steps.get-secret.outputs.sentry_dsn }}
 
     - name: Install chromedriver
       run: docker-compose exec -T web /bin/sh -c 'apk add chromium chromium-chromedriver'
@@ -184,8 +186,6 @@ jobs:
 
     - name: Run Rspec tests
       run: docker-compose exec --env COVERAGE=true -T web /bin/sh -c 'RAILS_ENV=test bundle exec rake spec'
-      env:
-        SENTRY_DSN: ${{ steps.get-secret.outputs.sentry_dsn }}
 
     - name: Run Javascript tests
       run: docker-compose exec -T web /bin/sh -c 'yarn run test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,5 +52,20 @@ RSpec.configure do |config|
     if ex.metadata[:js]
       Capybara.reset!
     end
+
+    # Allow Sentry to pick up messages triggered in our CI test build (and not locally).
+    # Sends a warning when tests are retried so we can track indeterminate tests.
+    if ENV.key?("SENTRY_DSN") && ex.metadata[:retry_exceptions]
+      # Disable WebMock so we can send events to Sentry
+      # Add sleep to avoid race condition
+      WebMock.disable!
+      sleep(3.seconds)
+      SentryForRSpec.report_retry(ex, config)
+      sleep(3.seconds)
+      WebMock.enable!
+      sleep(3.seconds)
+      WebMock.disable_net_connect!(allow_localhost: true)
+      sleep(3.seconds)
+    end
   end
 end

--- a/spec/support/sentry_for_rspec.rb
+++ b/spec/support/sentry_for_rspec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module SentryForRSpec
+  def self.report_retry(example, config)
+    create_sentry_scope(example, config)
+
+    Sentry.with_scope do |scope|
+      create_tags(scope, example)
+      send_message(example)
+    end
+  end
+
+  def self.create_sentry_scope(example, config)
+    Sentry.configure_scope do |scope|
+      scope.set_context(
+        "RSpec",
+        { test_name: example.metadata[:description],
+          test_description: example.metadata[:full_description],
+          location: example.metadata[:location],
+          failure: example.metadata[:retry_exceptions],
+          retry_attempt: example.metadata[:retry_attempts],
+          seed: config.seed },
+      )
+    end
+  end
+
+  def self.create_tags(scope, example)
+    scope.set_tags(location: example.metadata[:location].to_s)
+  end
+
+  def self.send_message(example)
+    Sentry.capture_message("RSpec test retry at #{example.metadata[:location]}", fingerprint: [example.metadata[:location]])
+  end
+end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/Bcoyw3fw/4510-s-capture-more-information-around-the-flakey-tests-so-we-can-try-and-fix-them

We want to add some functionality to easily detect and report on flakey specs. We want to send a capture_message to Sentry when a test has been retried so we can see which ones are flakey.

I've customised the sentry events so that they are grouped by the test path. This means the counts and grouping should increment successfully in Sentry for each fail, like below:
![Screenshot 2022-09-20 at 11 29 26](https://user-images.githubusercontent.com/43522239/191235224-c35c219e-e18f-44e8-9b28-b9853044ecd8.png)


I've added a custom scope so that we can track the information we need, you can see this in the Sentry UI:
![Screenshot 2022-09-15 at 14 20 09](https://user-images.githubusercontent.com/43522239/190414406-f62a8705-4e4b-4548-9c2e-0948b2d28997.png)

I've also added a custom tag (location) but we might not need this/might want more. That allows us to filter by tag in Sentry. Perhaps an 'rspec' tag would be helpful?
![Screenshot 2022-09-15 at 14 21 56](https://user-images.githubusercontent.com/43522239/190414779-b3ca2bec-2543-4a54-94e9-c99e0ed027f3.png)

~~I've added `spec/lib/random_spec.rb` to this PR with some tests that are intentionally flakey so you can see the output.~~
**Note**: I've now removed this file.

Some fun Sentry docs: 
https://docs.sentry.io/platforms/ruby/guides/sidekiq/enriching-events/scopes/
https://docs.sentry.io/platforms/ruby/guides/sidekiq/enriching-events/context/
https://docs.sentry.io/platforms/ruby/usage/sdk-fingerprinting/

### Changes proposed in this pull request

* Add SENTRY_DSN secret to test env in CI
* Add SentryForRSpec module to send out flakey spec events to Sentry
* Disable and enable WebMock in spec_helper to allow Sentry event firing

### Guidance to review

* The test build should run some retries and fire off events to Sentry under the test env filter - see events [here](https://sentry.io/organizations/dfe-teacher-services/issues/?environment=test&project=5552118&query=is%3Aunresolved&statsPeriod=14d)

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
