### PR TITLE
[xxx] Mini refactor `format_trainees`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,6 +155,8 @@ group :development do
   gem "spring"
   gem "spring-commands-rspec", "~> 1.0"
   gem "spring-watcher-listen", "~> 2.0.0"
+
+  gem "benchmark-memory"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
       activerecord (>= 5.0, < 7.1)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
+    benchmark-memory (0.2.0)
+      memory_profiler (~> 1)
     better_html (1.0.16)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -338,6 +340,7 @@ GEM
       webrick (~> 1.7)
       webrobots (~> 0.1.2)
     memoist (0.16.2)
+    memory_profiler (1.0.0)
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
@@ -641,6 +644,7 @@ DEPENDENCIES
   amazing_print (~> 1.4)
   audited (~> 5.0)
   auto_strip_attributes
+  benchmark-memory
   blazer
   bootsnap (>= 1.1.0)
   bundle-audit

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -34,10 +34,11 @@ module Exports
     attr_reader :data_for_export
 
     def format_trainees(trainees)
-      trainees.map do |trainee|
+      formatted_trainees = []
+      Trainee.where(id: trainees.pluck(:id)).includes(:apply_application, :degrees, :end_academic_cycle, :nationalities, :provider, :start_academic_cycle).find_each do |trainee|
         degree = trainee.degrees.first
         course = Course.where(uuid: trainee.course_uuid).first
-        {
+        formatted_trainees << {
           "register_id" => trainee.slug,
           "trainee_url" => "#{Settings.base_url}/trainees/#{trainee.slug}",
           "record_source" => record_source(trainee),
@@ -118,6 +119,7 @@ module Exports
           "additional_withdraw_reason" => trainee.additional_withdraw_reason,
         }
       end
+      formatted_trainees
     end
 
     def course_level(trainee)


### PR DESCRIPTION
### Context

The `format_trainees` method caused `production` instances to crash due to a lack of memory.

### Changes proposed in this pull request

Built a new query to fetch as much info as possible in one go using `:includes` for eager loading and `find_each` for batching (defaults to [1000](https://apidock.com/rails/ActiveRecord/Batches/ClassMethods/find_each))

We can't easily eager load `:published_course` until we [upgrade](https://github.com/rails/rails/pull/42553) rails. Therefore, I have left `course = Course.where(uuid: trainee.course_uuid).first` in there and it will still be called once per trainee and cause a db call each time :-( 

### Guidance to review

Make sure nothing has been broken

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
