### PR TITLE
[xxx] Move `ittQualificationAim` attribute in DQT params

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -106,6 +106,7 @@ module Dqt
           "subject3" => course_subject_code(trainee.course_subject_three),
           "ageRangeFrom" => trainee.course_min_age,
           "ageRangeTo" => trainee.course_max_age,
+          "ittQualificationAim" => ITT_AIMS[trainee.hesa_metadatum&.itt_aim],
         }
       end
 
@@ -119,7 +120,6 @@ module Dqt
           "subject" => subject_code,
           "class" => DEGREE_CLASSES[degree.grade],
           "date" => Date.parse("01-01-#{degree.graduation_year}").iso8601,
-          "ittQualificationAim" => ITT_AIMS[trainee.hesa_metadatum&.itt_aim],
           "heQualificationType" => CodeSets::DegreeTypes::MAPPING[degree.uk_degree_uuid],
         }
       end

--- a/spec/lib/dqt/params/trainee_request_spec.rb
+++ b/spec/lib/dqt/params/trainee_request_spec.rb
@@ -37,6 +37,7 @@ module Dqt
             "subject3" => trainee.course_subject_three,
             "ageRangeFrom" => trainee.course_min_age,
             "ageRangeTo" => trainee.course_max_age,
+            "ittQualificationAim" => nil,
           })
         end
 
@@ -45,7 +46,6 @@ module Dqt
             "providerUkprn" => ukprn,
             "countryCode" => "XK",
             "subject" => hesa_code,
-            "ittQualificationAim" => nil,
             "class" => described_class::DEGREE_CLASSES[degree.grade],
             "date" => Date.new(degree.graduation_year).iso8601,
             "heQualificationType" => dqt_degree_type,

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -48,6 +48,7 @@ module Dqt
             "subject3" => trainee.course_subject_three,
             "ageRangeFrom" => trainee.course_min_age,
             "ageRangeTo" => trainee.course_max_age,
+            "ittQualificationAim" => nil,
           })
         end
 
@@ -102,8 +103,8 @@ module Dqt
                    degrees: [degree])
           end
 
-          it "includes the qualitifcation aim and type" do
-            expect(subject["qualification"]).to include("ittQualificationAim" => dqt_itt_aim)
+          it "includes the itt qualification aim and type" do
+            expect(subject["initialTeacherTraining"]).to include("ittQualificationAim" => dqt_itt_aim)
           end
         end
 


### PR DESCRIPTION
### Context

We're sending the `ittQualificationAim` in the qualification to DQT.

It should be in the `initialTeacherTraining`.

### Changes proposed in this pull request

- Move the attribute into the correct position in the JSON.

### Guidance to review

🚢 

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml