### PR TITLE
[4368] Enable HESA TRN requests (productiondata env)

### DIFF
--- a/app/jobs/dqt/register_for_trn_job.rb
+++ b/app/jobs/dqt/register_for_trn_job.rb
@@ -8,14 +8,8 @@ module Dqt
     def perform(trainee)
       return unless FeatureService.enabled?(:integrate_with_dqt)
 
-      if trainee.hesa_record?
-        message = "Trainee id: #{trainee.id}, slug: #{trainee.slug} has been registered for TRN but is a HESA trainee"
-        username = "Register Trainee Teachers: Job Failure"
-        SlackNotifierService.call(message: message, username: username)
-      else
-        trn_request = RegisterForTrn.call(trainee: trainee)
-        RetrieveTrnJob.perform_later(trn_request)
-      end
+      trn_request = RegisterForTrn.call(trainee: trainee)
+      RetrieveTrnJob.perform_later(trn_request)
     end
   end
 end

--- a/app/jobs/hesa/retrieve_trn_data_job.rb
+++ b/app/jobs/hesa/retrieve_trn_data_job.rb
@@ -12,7 +12,10 @@ module Hesa
     end
 
     def url
-      "#{Settings.hesa.trn_data_base_url}/#{@collection_reference}/Latest"
+      endpoint = "#{Settings.hesa.trn_data_base_url}/#{@collection_reference}/Latest"
+      return "#{endpoint}/Test" if FeatureService.enabled?("hesa_import.test_mode")
+
+      endpoint
     end
 
     def record_source

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -149,7 +149,18 @@ module Dqt
       end
 
       def itt_end_date
-        trainee.itt_end_date || Trainees::CalculateIttEndDate.call(trainee: trainee, actual: true)
+        trainee.itt_end_date || (start_date + estimated_course_duration)
+      end
+
+      def start_date
+        trainee.commencement_date || trainee.itt_start_date
+      end
+
+      def estimated_course_duration
+        return 3.years if UNDERGRAD_ROUTES.include?(trainee.training_route)
+        return 2.years if trainee.part_time?
+
+        1.year
       end
 
       attr_reader :trainee, :degree

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -10,7 +10,7 @@ module Dqt
         male: "Male",
         female: "Female",
         other: "Other",
-        gender_not_provided: "NotProvided",
+        prefer_not_to_say: "NotProvided",
         gender_not_available: "NotAvailable",
       }.freeze
 

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -38,10 +38,23 @@ module Dqt
         Dttp::CodeSets::Grades::PASS => "Pass",
       }.freeze
 
-      # HESA/Register considers the following mapping as ITT_AIMS, but DQT calls it ittQualificationAim
-      ITT_AIMS = {
+      ITT_QUALIFICATION_AIMS = {
         "Professional status only" => "ProfessionalStatusOnly",
         "Both professional status and academic award" => "ProfessionalStatusAndAcademicAward",
+      }.freeze
+
+      ITT_QUALIFICATION_TYPES = {
+        "BA" => "BA",
+        "BA (Hons)" => "BAHons",
+        "BEd" => "BEd",
+        "BEd (Hons)" => "BEdHons",
+        "BSc" => "BSc",
+        "BSc (Hons)" => "BScHons",
+        "Postgraduate Certificate in Education" => "PostgraduateCertificateInEducation",
+        "Postgraduate Diploma in Education" => "PostgraduateDiplomaInEducation",
+        "Undergraduate Master of Teaching" => "UndergraduateMasterOfTeaching",
+        "Professional Graduate Certificate in Education" => "ProfessionalGraduateCertificateInEducation",
+        "Masters, not by research" => "MastersNotByResearch",
       }.freeze
 
       attr_reader :params
@@ -106,7 +119,8 @@ module Dqt
           "subject3" => course_subject_code(trainee.course_subject_three),
           "ageRangeFrom" => trainee.course_min_age,
           "ageRangeTo" => trainee.course_max_age,
-          "ittQualificationAim" => ITT_AIMS[trainee.hesa_metadatum&.itt_aim],
+          "ittQualificationAim" => ITT_QUALIFICATION_AIMS[trainee.hesa_metadatum&.itt_aim],
+          "ittQualificationType" => ITT_QUALIFICATION_TYPES[trainee.hesa_metadatum&.itt_qualification_aim],
         }
       end
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -44,6 +44,7 @@ class Trainee < ApplicationRecord
   has_many :disabilities, through: :trainee_disabilities
 
   has_one :hesa_metadatum, class_name: "Hesa::Metadatum"
+  has_one :dqt_trn_request, class_name: "Dqt::TrnRequest"
 
   attribute :progress, Progress.to_type
 

--- a/app/services/hesa/upload_trn_file.rb
+++ b/app/services/hesa/upload_trn_file.rb
@@ -28,7 +28,7 @@ module Hesa
       CSV.generate do |csv|
         csv << %w[UKPRN HUSID TRN]
         trainees.each do |trainee|
-          csv << [trainee.hesa_student.ukprn, trainee.hesa_id, trainee.trn]
+          csv << [trainee.provider.ukprn, trainee.hesa_id, trainee.trn]
         end
       end
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -69,6 +69,7 @@ features:
   redirect_education_domain: true
   hesa_trn_requests: false
   hesa_import:
+    test_mode: false
     sync_collection: false
     sync_trn_data: false
   # For the 3 months prior to an academic cycle, we're not sure

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,7 +23,7 @@ hesa:
   trn_data_base_url: "https://datacollection.hesa.ac.uk/apis/itt/1.1/TRNData"
   trn_file_base_url: "https://datacollection.hesa.ac.uk/apis/itt/1.1/TRNFile"
   current_collection_reference: "C22053"
-  current_collection_start_date: "2022-04-01"
+  current_collection_start_date: "2022-08-01"
   username: <get from secrets>
   password: <get from secrets>
 

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -34,7 +34,8 @@ features:
   google:
     send_data_to_big_query: false
   hesa_import:
-    sync_collection: true
+    test_mode: true
+    sync_trn_data: true
 
 environment:
   name: productiondata

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -5,6 +5,9 @@ dttp:
   scope: https://dttp.crm4.dynamics.com/.default
   api_base_url: https://dttp.crm4.dynamics.com/api/data/v9.1
 
+dqt:
+  base_url: https://preprod-teacher-qualifications-api.education.gov.uk
+
 dfe_sign_in:
   # URL that the users are redirected to for signing in
   issuer: https://oidc.signin.education.gov.uk

--- a/spec/jobs/dqt/register_for_trn_job_spec.rb
+++ b/spec/jobs/dqt/register_for_trn_job_spec.rb
@@ -32,23 +32,6 @@ module Dqt
 
         expect(trainee.state).to eql("submitted_for_trn")
       end
-
-      context "with a HESA trainee" do
-        before do
-          allow(SlackNotifierService).to receive(:call)
-          allow(trainee).to receive(:hesa_record?).and_return(true)
-        end
-
-        it "reports to Slack" do
-          expect(SlackNotifierService).to receive(:call).with(message: "Trainee id: #{trainee.id}, slug: #{trainee.slug} has been registered for TRN but is a HESA trainee", username: "Register Trainee Teachers: Job Failure")
-          described_class.perform_now(trainee)
-        end
-
-        it "doesn't send the trainee to DQT" do
-          expect(RecommendForAward).not_to receive(:call)
-          described_class.perform_now(trainee)
-        end
-      end
     end
   end
 end

--- a/spec/lib/dqt/params/trainee_request_spec.rb
+++ b/spec/lib/dqt/params/trainee_request_spec.rb
@@ -38,6 +38,7 @@ module Dqt
             "ageRangeFrom" => trainee.course_min_age,
             "ageRangeTo" => trainee.course_max_age,
             "ittQualificationAim" => nil,
+            "ittQualificationType" => nil,
           })
         end
 

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -121,7 +121,7 @@ module Dqt
         end
 
         context "when gender is gender_not_provided" do
-          let(:trainee) { create(:trainee, :completed, gender: "gender_not_provided") }
+          let(:trainee) { create(:trainee, :completed, gender: "prefer_not_to_say") }
 
           it "maps gender to not provided" do
             expect(subject["genderCode"]).to eq("NotProvided")


### PR DESCRIPTION
### Context
https://trello.com/c/II1neZuc/4368-enable-hesa-trn-requests

This PR is the outcome of testing HESA<->Register<->DQT integration, especially around TRN requests from HESA.

### Changes proposed in this pull request
- Add feature flag to use HESA's test URLs in non-prod environment
- Turn on HESA TRN data import in productiondata environment
- Add ittQualificationType to Dqt::Params::TrnRequest
- Remove HESA guard clause
- Replace Trainees::CalculateIttEndDate with internal method
- Fix GENDER_CODES mapping to reflect changes in HESA schema
- Allow Trainee to access it's DQT TRN request record
- Use provider instead of hesa_student to get UKPRN
- Add preprod DQT API URL to productiondata environment
- Update HESA collection start date for 2022-23 academic year

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
