### PR TITLE
Removed comma from change hint

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -742,7 +742,7 @@ en:
           label_names:
             register: Yes, register on %{course}
             change: No, change the course
-            change_hint: For trainees, who have changed courses since applying
+            change_hint: For trainees who have changed courses since applying
       common:
         today: Today
         yesterday: Yesterday


### PR DESCRIPTION
https://trello.com/c/Sgs5kQaC/4573-confirm-course-training-details-delete-comma-from-hint-text

### Context
There is a comma in hint text where there shouldn't be.

### Changes proposed in this pull request
Remove the comma.

### Guidance to review
Check the comma is removed.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
