### PR TITLE
[xxx] Enable DQT integration in productiondata environment

### DIFF
--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -33,6 +33,7 @@ features:
     school_direct_tuition_fee: true
   google:
     send_data_to_big_query: false
+  integrate_with_dqt: true
   hesa_import:
     test_mode: true
     sync_trn_data: true


### PR DESCRIPTION
### Context
This feature flag was not turned on in `productiondata` environment. Overlooked in PR #2662.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
