### PR TITLE
[xxx] Handle HESA XML with null values in various cases

### DIFF
--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -96,7 +96,7 @@ module Hesa
                 convert_all_null_values_to_nil(h)
               end
             else
-              v == "NULL" ? nil : v
+              v.downcase == "null" ? nil : v
             end
           end
         end


### PR DESCRIPTION
### Context
During testing HESA TRNData integration, the XML returned contains "Null" instead of "NULL" (this is likely a manual typo). Instead of getting HESA to fix this, it's quicker to handle both cases within Register and prevent issues around this in the future.

This is preventing `Trainees::MapStateFromHesa` from calculating the correct state which in turn prevents `submitted_for_trn_at` from been set leading to a error running `Dqt::RetrieveTrnJob` which depends on it. 

### Changes proposed in this pull request
- Downcase XML values and compare to "null"

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
