### PR TITLE
[xxx] Handle nil graduation year in DQT params

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -133,7 +133,7 @@ module Dqt
           "countryCode" => country_code,
           "subject" => subject_code,
           "class" => DEGREE_CLASSES[degree.grade],
-          "date" => Date.parse("01-01-#{degree.graduation_year}").iso8601,
+          "date" => graduation_date,
           "heQualificationType" => CodeSets::DegreeTypes::MAPPING[degree.uk_degree_uuid],
         }
       end
@@ -149,6 +149,12 @@ module Dqt
 
       def subject_code
         Degrees::DfeReference.find_subject(name: degree.subject)&.hecos_code
+      end
+
+      def graduation_date
+        return if degree.graduation_year.nil?
+
+        Date.parse("01-01-#{degree.graduation_year}").iso8601
       end
 
       def institution_ukprn

--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -96,7 +96,7 @@ module Hesa
                 convert_all_null_values_to_nil(h)
               end
             else
-              v.downcase == "null" ? nil : v
+              v&.downcase == "null" ? nil : v
             end
           end
         end

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -100,6 +100,14 @@ module Dqt
           end
         end
 
+        context "when there is no degree graduation year" do
+          let(:degree) { build(:degree, graduation_year: nil) }
+
+          it "doesn't send a graduation date" do
+            expect(subject["qualification"]["date"]).to be_nil
+          end
+        end
+
         context "where there is no institution uuid" do
           let(:degree) { build(:degree, :uk_degree_with_details, institution_uuid: nil) }
 


### PR DESCRIPTION
### Context

Graduation year for trainees imported from HESA could potentially nil. We need to handle this when sending them over to DQT.

Currently there's a bug in Register because:


```
Date.parse("01-01-#{nil}").iso8601
=> "2022-08-01"
```

`Date.parse("01-01-#{nil}")` == `Date.parse("01-01-")` == `Date.parse("01")` == First of the current month 

### Changes proposed in this pull request

Send nil as the qualification date if the graduation year on the degree is nil.

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
