### PR TITLE
[xxx] Minor bug fixes from HESA TRNData integration testing

### DIFF
--- a/app/jobs/hesa/upload_trn_file_job.rb
+++ b/app/jobs/hesa/upload_trn_file_job.rb
@@ -5,7 +5,9 @@ module Hesa
     def perform
       return unless FeatureService.enabled?(:hesa_trn_requests)
 
-      trainees = Trainee.imported_from_hesa.where("created_at > ?", TrnSubmission.last_submitted_at)
+      trainees = Trainee.imported_from_hesa_trn_data
+                        .where.not(trn: nil) # some trainees could still be waiting for their TRN from DQT
+                        .where("created_at > ?", TrnSubmission.last_submitted_at)
       payload = UploadTrnFile.call(trainees: trainees)
       TrnSubmission.create(payload: payload, submitted_at: Time.zone.now)
     rescue UploadTrnFile::TrnFileUploadError => e

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -213,6 +213,8 @@ class Trainee < ApplicationRecord
   # Even though some records imported from DTTP will have a HESA ID, their original source is HESA so we chose this implementation
   scope :imported_from_hesa, -> { where.not(hesa_id: nil) }
 
+  scope :imported_from_hesa_trn_data, -> { where(record_source: RecordSources::HESA_TRN_DATA) }
+
   scope :complete_for_filter, -> { where(submission_ready: true).or(where(state: COMPLETE_STATES)).or(where(id: imported_from_hesa)) }
   scope :incomplete_for_filter, -> { where.not(id: complete_for_filter) }
 

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -128,7 +128,8 @@ module Trainees
     end
 
     def submitted_for_trn_attributes
-      return {} unless trainee_state == :submitted_for_trn
+      # Withdrawn trainees are also expected to get a TRN
+      return {} unless trainee_state == :submitted_for_trn || trainee_state == :withdrawn
 
       { submitted_for_trn_at: Time.zone.now }
     end

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -128,8 +128,7 @@ module Trainees
     end
 
     def submitted_for_trn_attributes
-      # Withdrawn trainees are also expected to get a TRN
-      return {} unless trainee_state == :submitted_for_trn || trainee_state == :withdrawn
+      return {} unless request_for_trn?
 
       { submitted_for_trn_at: Time.zone.now }
     end
@@ -224,9 +223,14 @@ module Trainees
     end
 
     def enqueue_background_jobs!
-      if FeatureService.enabled?(:integrate_with_dqt) && trainee.trn.blank?
+      if FeatureService.enabled?(:integrate_with_dqt) && request_for_trn?
         Dqt::RegisterForTrnJob.perform_later(trainee)
       end
+    end
+
+    def request_for_trn?
+      # Withdrawn trainees are also expected to get a TRN
+      trainee.trn.blank? && (trainee_state == :submitted_for_trn || trainee_state == :withdrawn)
     end
 
     def training_initiative

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -30,3 +30,7 @@ import_trn_data_from_hesa:
   cron: "0 */2 * * *"
   class: "Hesa::RetrieveTrnDataJob"
   queue: default
+upload_trn_file_to_hesa:
+  cron: "10 */2 * * *"
+  class: "Hesa::UploadTrnFileJob"
+  queue: default

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -299,10 +299,12 @@ module Trainees
       context "when end date is available" do
         let(:date) { "2020-12-12" }
         let(:hesa_reasons_for_leaving_codes) { Hesa::CodeSets::ReasonsForLeavingCourse::MAPPING.invert }
+        let(:existing_trn) { nil }
 
         context "and the trainee did not complete the course" do
           let(:hesa_stub_attributes) do
             {
+              trn: nil,
               end_date: date,
               reason_for_leaving: hesa_reasons_for_leaving_codes[WithdrawalReasons::DEATH],
             }

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -310,6 +310,7 @@ module Trainees
 
           it "creates a withdrawn trainee with the relevant details" do
             expect(trainee.state).to eq("withdrawn")
+            expect(trainee.submitted_for_trn_at).not_to be_nil
             expect(trainee.withdraw_date).to eq(date)
             expect(trainee.withdraw_reason).to eq(WithdrawalReasons::DEATH)
           end


### PR DESCRIPTION
### Context
Some minor bug fixes that came out of `HESA TRNData<->Register<->DQT` integration testing.

### Changes proposed in this pull request
- Update `Hesa::UploadTrnFileJob` to use a better scope so only HESA trainees from TRNData are selected for file upload.
- Update `Trainees::CreateFromHesa` so it sets `submitted_for_trn_at` for withdrawn trainees because they are expected to have a TRN

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
