### PR TITLE
[4593] Derive itt_end_date to send to DQT

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -177,10 +177,13 @@ module Dqt
       end
 
       def estimated_course_duration
-        return 3.years if UNDERGRAD_ROUTES.include?(trainee.training_route)
-        return 2.years if trainee.part_time?
+        return 70.months if trainee.provider_led_undergrad? && trainee.part_time?
 
-        1.year
+        return 34.months if trainee.provider_led_undergrad? && trainee.full_time?
+
+        return 22.months if trainee.opt_in_undergrad? || trainee.part_time?
+
+        10.months
       end
 
       attr_reader :trainee, :degree

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -62,12 +62,56 @@ module Dqt
         end
 
         context "itt_end_date is missing" do
-          let(:training_route) { TRAINING_ROUTES_FOR_COURSE.keys.sample }
-          let(:hesa_metadatum) { build(:hesa_metadatum, study_length: 1, study_length_unit: "years") }
-          let(:trainee_attributes) { { itt_end_date: nil, hesa_metadatum: hesa_metadatum, training_route: training_route } }
+          let(:hesa_metadatum) { build(:hesa_metadatum) }
+          let(:trainee_attributes) { { itt_end_date: nil, hesa_metadatum: hesa_metadatum, training_route: training_route, study_mode: study_mode } }
 
-          it "calculates the end date using the course duration data" do
-            expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 1.year).iso8601)
+          context "and the trainee is part time" do
+            let(:study_mode) { "part_time" }
+
+            context "provider led undergrad" do
+              let(:training_route) { "provider_led_undergrad" }
+
+              it "calculates the end date using the course duration data" do
+                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 70.months).iso8601)
+              end
+            end
+
+            context "and the trainee is school direct tuition fee" do
+              let(:training_route) { "school_direct_tuition_fee" }
+
+              it "calculates the end date using the course duration data" do
+                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 22.months).iso8601)
+              end
+            end
+          end
+
+          context "and the trainee is full time" do
+            let(:study_mode) { "full_time" }
+
+            context "provider led undergrad" do
+              let(:training_route) { "provider_led_undergrad" }
+
+              it "calculates the end date using the course duration data" do
+                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 34.months).iso8601)
+              end
+            end
+
+            context "and the trainee is school direct tuition fee" do
+              let(:training_route) { "school_direct_tuition_fee" }
+
+              it "calculates the end date using the course duration data" do
+                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 10.months).iso8601)
+              end
+            end
+          end
+
+          context "and the training route is opt in undergrad" do
+            let(:trainee_attributes) { { itt_end_date: nil, hesa_metadatum: hesa_metadatum, training_route: training_route } }
+            let(:training_route) { "opt_in_undergrad" }
+
+            it "calculates the end date using the course duration data" do
+              expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 22.months).iso8601)
+            end
           end
         end
 


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/p3WjA8NW/4593-m-derive-ittenddate-where-a-trainee-has-no-hesa-expectedenddate

ITT end date is optional in HESA. This means some HESA trainees may not have an exact end date. 

DQT needs an ITT end date for trainees. When there is no itt_end_date, derive this from the start date plus course duration and send this to DQT.

Matrix for the course durations: https://docs.google.com/spreadsheets/d/1whYdDcMqOtWDoy12Pk3sIIRnEEN4m4LvtR1ojd37xdk/edit?pli=1#gid=0

### Changes proposed in this pull request

* Update `def estimated_course_duration`

### Guidance to review

* Check the matrix - have I got the durations right?
* Sense check I haven't missed anything in the logic

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
