### PR TITLE
[xxx] Don't request a TRN from DQT if we already have one

### DIFF
--- a/app/jobs/dqt/register_for_trn_job.rb
+++ b/app/jobs/dqt/register_for_trn_job.rb
@@ -7,6 +7,7 @@ module Dqt
 
     def perform(trainee)
       return unless FeatureService.enabled?(:integrate_with_dqt)
+      return if trainee.trn.present?
 
       trn_request = RegisterForTrn.call(trainee: trainee)
       RetrieveTrnJob.perform_later(trn_request)

--- a/spec/jobs/dqt/register_for_trn_job_spec.rb
+++ b/spec/jobs/dqt/register_for_trn_job_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 module Dqt
   describe RegisterForTrnJob do
     describe "#perform_now" do
-      let(:trainee) { create(:trainee, :with_secondary_course_details, :with_start_date, :with_degree) }
       let(:request_id) { "3f96614b-0373-475b-bf94-119e0d8d9258" }
       let(:dqt_response) {
         {
@@ -20,17 +19,29 @@ module Dqt
         allow(SecureRandom).to receive(:uuid).and_return(request_id)
         allow(Dqt::Client).to receive(:put).and_return(dqt_response)
         allow(RetrieveTrnJob).to receive(:perform_later)
-        described_class.perform_now(trainee)
       end
 
-      it "registers TRN request with DQT" do
-        trn_request = TrnRequest.last
-        expect(trn_request.trainee).to eql(trainee)
-        expect(trn_request.request_id).to eql(request_id)
-        expect(trn_request.state).to eql("requested")
-        expect(trn_request.response).to eql(dqt_response)
+      context "when the trainee doesn't have a TRN" do
+        let(:trainee) { create(:trainee, :with_secondary_course_details, :with_start_date, :with_degree) }
 
-        expect(trainee.state).to eql("submitted_for_trn")
+        it "registers TRN request with DQT" do
+          described_class.perform_now(trainee)
+          trn_request = TrnRequest.last
+          expect(trn_request.trainee).to eql(trainee)
+          expect(trn_request.request_id).to eql(request_id)
+          expect(trn_request.state).to eql("requested")
+          expect(trn_request.response).to eql(dqt_response)
+          expect(trainee.state).to eql("submitted_for_trn")
+        end
+      end
+
+      context "when the trainee already has a trn" do
+        let(:trainee) { create(:trainee, :with_secondary_course_details, :with_start_date, :with_degree, trn: "0123456") }
+
+        it "does not register a TRN request with DQT" do
+          described_class.perform_now(trainee)
+          expect(TrnRequest.count).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

During testing we were manually kicking off TRN requests for trainees who already had TRNs, which confused matters. this shouldn't happen in _real life_ , but this is just an extra check.

### Changes proposed in this pull request

- Check that the trainee doesn't already have a TRN before we request a TRN from DQT.

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml