### PR TITLE
[xxx] Turn off DQT integration in productiondata env

### DIFF
--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -33,10 +33,10 @@ features:
     school_direct_tuition_fee: true
   google:
     send_data_to_big_query: false
-  integrate_with_dqt: true
+  integrate_with_dqt: false
   hesa_import:
     test_mode: true
-    sync_trn_data: true
+    sync_trn_data: false
 
 environment:
   name: productiondata

--- a/terraform/workspace-variables/productiondata.tfvars.json
+++ b/terraform/workspace-variables/productiondata.tfvars.json
@@ -11,6 +11,6 @@
   "paas_space_name": "bat-prod",
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1536,
-  "paas_worker_app_instances": 2,
+  "paas_worker_app_instances": 0,
   "paas_worker_app_memory": 512
 }


### PR DESCRIPTION
### Context

We've finished testing the HESA / DQT integrations in the productiondata env.

### Changes proposed in this pull request

Switch off the settings in productiondata env that pulls in TRN data and sends trainees to DQT.

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
