### PR TITLE
[4494] Allow course lengths greater than 8 years

### DIFF
--- a/app/services/trainees/calculate_itt_end_date.rb
+++ b/app/services/trainees/calculate_itt_end_date.rb
@@ -20,8 +20,8 @@ module Trainees
     def call
       return unless start_date
 
-      if course_duration > 5.years
-        raise("Trainee id: #{trainee.id}, slug: #{trainee.slug} has a course length greater than five years")
+      if course_duration > 8.years
+        raise("Trainee id: #{trainee.id}, slug: #{trainee.slug} has a course length greater than eight years")
       end
 
       start_date + course_duration

--- a/app/services/trainees/calculate_itt_end_date.rb
+++ b/app/services/trainees/calculate_itt_end_date.rb
@@ -20,6 +20,8 @@ module Trainees
     def call
       return unless start_date
 
+      # The longest courses are eight years - these are part time courses which,
+      # if taken full time, would be four years long.
       if course_duration > 8.years
         raise("Trainee id: #{trainee.id}, slug: #{trainee.slug} has a course length greater than eight years")
       end

--- a/spec/services/trainees/set_academic_cycles_spec.rb
+++ b/spec/services/trainees/set_academic_cycles_spec.rb
@@ -139,13 +139,13 @@ module Trainees
           end
         end
 
-        context "and duration that is longer than 5 years" do
+        context "and duration that is longer than 8 years" do
           let(:hesa_metadatum) do
-            build(:hesa_metadatum, study_length: 20, study_length_unit: "years")
+            build(:hesa_metadatum, study_length: 9, study_length_unit: "years")
           end
 
           it "raises an exception" do
-            msg = "Trainee id: #{trainee.id}, slug: #{trainee.slug} has a course length greater than five years"
+            msg = "Trainee id: #{trainee.id}, slug: #{trainee.slug} has a course length greater than eight years"
             expect { subject }.to raise_error(msg)
           end
         end


### PR DESCRIPTION
### Context

- We were raising an error during setting academic cycles if the
  course length was longer than 5 years
- We are now aware that some courses are 8 years long

### Changes proposed in this pull request

- Update the code to not error when attempting to set the academic
  cycle for these trainees

### Guidance to review

🚢 

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml