### PR TITLE
[4494] Create academic cycles in the future

### DIFF
--- a/config/initializers/academic_cycles.rb
+++ b/config/initializers/academic_cycles.rb
@@ -13,4 +13,11 @@ ACADEMIC_CYCLES = [
   { start_date: "01/8/2021", end_date: "31/7/2022" },
   { start_date: "01/8/2022", end_date: "31/7/2023" },
   { start_date: "01/8/2023", end_date: "31/7/2024" },
+  { start_date: "01/8/2024", end_date: "31/7/2025" },
+  { start_date: "01/8/2025", end_date: "31/7/2026" },
+  { start_date: "01/8/2026", end_date: "31/7/2027" },
+  { start_date: "01/8/2027", end_date: "31/7/2028" },
+  { start_date: "01/8/2028", end_date: "31/7/2029" },
+  { start_date: "01/8/2029", end_date: "31/7/2030" },
+  { start_date: "01/8/2030", end_date: "31/7/2031" },
 ].freeze

--- a/db/data/20220830134128_add_future_academic_cycles.rb
+++ b/db/data/20220830134128_add_future_academic_cycles.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddFutureAcademicCycles < ActiveRecord::Migration[6.1]
+  def up
+    ACADEMIC_CYCLES.each do |academic_cycle|
+      AcademicCycle.find_or_create_by!(start_date: academic_cycle[:start_date], end_date: academic_cycle[:end_date])
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

- Now we know that courses can be 8 years long, we need at least 8
  future academic cycles in the database
- This is because we associate a trainee with an end_academic_cycle

### Changes proposed in this pull request

- Add a data migration to include academic cycles up until the year 2031

### Guidance to review

- Check that adding these extra cycles hasn't 'broken' any of the UI (year dropdowns?)

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml