### PR TITLE
[4594] Add new guidance pages

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -8,4 +8,6 @@ class GuidanceController < ApplicationController
   def about_register_trainee_teachers
     render(template: "guidance/about_register_trainee_teachers.md", layout: "guidance_markdown")
   end
+
+  def dates_and_deadlines; end
 end

--- a/app/views/guidance/dates_and_deadlines.html.erb
+++ b/app/views/guidance/dates_and_deadlines.html.erb
@@ -1,0 +1,74 @@
+<%= render PageTitle::View.new(text: "Dates and deadlines") %>
+
+  <%= content_for(:breadcrumbs) do %>
+    <%= render GovukComponent::BackLinkComponent.new(
+        text: "How to use this service",
+        href: guidance_path,
+    ) %>
+  <% end %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">Dates and deadlines for the <span class="nowrap">2022 to 2023</span> academic year</h1>
+    <%= govuk_table do |table| %>
+      <% table.caption(size: 'm', text: 'Deadlines for all training providers') %>
+      <% table.head do |head|%>
+        <% head.row do |row| %>
+          <% row.cell(header: true, text: "Date", width: "one-third") %>
+          <% row.cell(header: true, text: "What happens") %>
+        <% end %>
+      <% end %>
+      <% table.body do |body| %>
+        <% body.row do |row| %>
+          <% row.cell(text: "Wednesday 12 October 2022")%>
+          <% row.cell(text: "The second Wednesday of October every academic year is called the ‘census date’. 
+          If a new trainee starts their course after this date, they will not be included in the ITT census publication. 
+          This is why it’s important to add your new trainees as they start their training.")%>
+        <% end %>
+        <% body.row do |row| %>
+          <% row.cell(text: "31 October 2022")%>
+          <% row.cell(text: "A senior person from your organisation must sign off your new trainee data on or before this date 
+          (this should be a different person to who submitted the data).")%>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_table do |table| %>
+      <% table.caption(size: 'm', text: "Deadlines for higher education institutions (HEIs) that use HESA") %>
+      <% table.head do |head|%>
+        <% head.row do |row| %>
+          <% row.cell(header: true, text: "Date", width: "one-third") %>
+          <% row.cell(header: true, text: "What happens") %>
+        <% end %>
+      <% end %>
+      <% table.body do |body| %>
+        <% body.row do |row| %>
+          <% row.cell(text: "1 September 2022")%>
+          <% row.cell(text: "	HESA data collection system opens. 
+          Training providers can start submitting their ITT trainee data to the DfE through HESA.")%>
+        <% end %>
+        <% body.row do |row| %>
+          <% row.cell(text: "14 October 2022")%>
+          <% row.cell(text: "First data submission required to HESA. 
+          Training providers should have started submitting data by this date.")%>
+        <% end %>
+        <% body.row do |row| %>
+          <% row.cell(text: "31 October 2022	")%>
+          <% row.cell(text: "HESA data collection system closes. 
+          ITT trainee data must be submitted and signed off on or before the data collection system closes. 
+          Not doing this, will mean the DfE has inaccurate data which could affect the ITT census publication.")%>
+        <% end %>
+        <% body.row do |row| %>
+          <% row.cell do %>
+            <div>16 to 31 January 2023</div>
+            <div>17 to 28 April 2023</div>
+            <div>17 to 31 July 2023</div>
+          <% end %>
+          <% row.cell(text: "ITT data collection update periods where you can update your trainee data through HESA 
+          if anything has changed. Data will be imported into Register. 
+          You do not need to sign off your data during these update periods.")%>
+        <% end %>
+      <% end %>
+    <% end %>
+    </div>
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Rails.application.routes.draw do
 
   resource :guidance, only: %i[show], controller: "guidance" do
     get "/about-register-trainee-teachers", to: "guidance#about_register_trainee_teachers"
+    get "/dates-and-deadlines", to: "guidance#dates_and_deadlines"
   end
 
   if FeatureService.enabled?("funding")

--- a/spec/controllers/guidance_controller_spec.rb
+++ b/spec/controllers/guidance_controller_spec.rb
@@ -19,7 +19,19 @@ describe GuidanceController, type: :controller do
     it "renders the correct template and page" do
       get :about_register_trainee_teachers
       expect(response).to render_template("guidance_markdown")
-      expect(response).to render_template("guidance/about_register_trainee_teachers.md")
+      expect(response).to render_template("about_register_trainee_teachers.md")
+    end
+  end
+
+  describe "#dates_and_deadlines" do
+    it "returns a 200 status code" do
+      get :dates_and_deadlines
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct page" do
+      get :dates_and_deadlines
+      expect(response).to render_template("dates_and_deadlines")
     end
   end
 end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/SHnCG4gJ/4594-create-page-for-dates-and-deadlines-for-the-2022-to-2023-academic-year

This is the new guidance page 'Dates and deadlines'. I have used an ERB template because the page is predominantly a table. This is probably better suited to HTML.

I have not put the content in translations files but can do so if necessary.

### Changes proposed in this pull request

* new route 'guidance/dates-and-deadlines'
* new controller method def dates_and_deadlines
* new ERB file 'guidance/dates_and_deadlines.html.erb'

### Guidance to review

* ERB file instead of markdown because the page is a table and not longform content
* No translation files added - can change if we think we need them

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
