### PR TITLE
[4368] Enable HESA collection / TRN requests in prod

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -35,8 +35,10 @@ features:
   google:
     send_data_to_big_query: true
   integrate_with_dqt: true
+  hesa_trn_requests: true
   hesa_import:
-    sync_collection: false
+    sync_collection: true
+    sync_trn_data: true
 environment:
   name: beta
 


### PR DESCRIPTION
### Context

HESA have now switched the endpoint for C22053 from test data to real data.
We can now turn on our integration to start pulling these trainees into Register (from both the collection and TRN endpoint)

### Changes proposed in this pull request

- Enable retrieving collection from HESA (hesa.sync_collection)
- Enable retrieving TRN data from HESA (hesa.sync_trn_data)
- Enable sending TRNs back to HESA (hesa_trn_requests)

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
