### PR TITLE
[4591] Add Registering trainees manually guidance page

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -10,4 +10,8 @@ class GuidanceController < ApplicationController
   end
 
   def dates_and_deadlines; end
+
+  def manually_registering_trainees
+    render(layout: "guidance_markdown")
+  end
 end

--- a/app/views/guidance/_manually_registering_trainees.md
+++ b/app/views/guidance/_manually_registering_trainees.md
@@ -1,0 +1,70 @@
+---
+title: Registering trainees manually in this service
+---
+
+Training providers can register their trainees manually in the Register service by creating draft trainee records and adding the required data about your trainees.
+
+Get prepared for adding a trainee record manually by [checking what data you need to provide](/check-data).
+
+## How trainees are grouped on the Register homepage
+
+When you log into Register, on the homepage you’ll see a section called ‘Draft trainees’ and a section called ‘Registered trainees’. Under ‘Registered trainees’ there are ‘training statuses’ where trainees are grouped by:
+
+* course not started yet (trainees who are registered but their course has not started)
+* in training (all trainees currently doing training, excluding those on courses that have not started or are deferred)
+* currently deferred
+* awarded this year (all trainees awarded QTS or EYTS in the current academic year)
+* incomplete records (registered trainees that are missing data)
+
+## Getting a teacher reference number (TRN)
+
+Once a draft is complete, you can request a TRN for each trainee record. This is when the trainee becomes registered with the Department for Education.
+
+Trainees will receive their TRN by email.
+
+## Trainee records imported from the Apply for teacher training (Apply) service
+
+When an application reaches the ‘recruited’ status in Apply, it will be imported into Register. If an application has any conditions set, it will only reach recruited status in Apply once all conditions have been met.
+
+Applications from Apply will import into Register every day at 4:00am. This is called the ‘Apply integration’.
+
+An application imported from Apply into Register will become a draft trainee record. You can find these records on the homepage under ‘Draft trainees’ at the link called ‘View draft trainees imported from Apply’. **You should not need to manually duplicate applications from Apply into Register.**
+
+On a trainee record from Apply, you’ll see:
+
+* the course the trainee applied for
+* the trainee’s personal details
+
+### What to do with draft records from Apply
+
+To register trainees that come from Apply, you’ll need to check if their data is correct and add any further data about their training. This can include:
+
+* checking their course is correct (if their course has changed, you can update this in Register)
+* fixing any mistakes that you know of
+* providing any further training data like if the trainee will get funding or who their lead or employing school will be
+
+Once an application is imported into Register, any changes you make to the application in Apply (after it’s in ‘recruited’ status) will not show in Register. Changes to trainee data in Register will also not reflect in Apply. At the moment, our integration only works to bring applications into Register.
+
+## Checking your trainee data to make sure it’s correct
+
+There are 3 ways to do this in Register and you can choose whichever one suits you. These are:
+
+* using the new ‘Reports’ section and exporting a CSV of your new trainees for the 2022 to 2023 academic year (available in Register soon)
+* exporting a CSV of your trainees in the ‘Registered trainees’ section, using the ‘start year’ filter to select the current academic year
+* checking your trainees directly in the service one by one
+
+## Adding specific information to a trainee record
+
+### PE with EBaccalaureate (PE with EBacc)
+
+Follow these steps to register a trainee on a PE with EBacc course:
+
+1. Add a first subject as ‘Physical education’, or a physical education based subject.
+2. Add a second subject as their EBacc subject.
+3. Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) stating their trainee ID and that they are doing PE with EBacc.
+
+## Recommending a trainee for Qualified Teacher Status (QTS) or Early Years Teacher Status (EYTS)
+
+When a trainee has successfully completed their training (or completed their assessment for an ‘assessment only’ route) and met the required standards, you can recommend them for QTS or EYTS in Register.
+
+If the trainee’s record is incomplete (there is missing information), the button will not appear, but there will be a prompt to guide you to add the missing information before you can recommend the trainee.

--- a/app/views/guidance/_withdrawing_or_deferring_a_trainee.md
+++ b/app/views/guidance/_withdrawing_or_deferring_a_trainee.md
@@ -1,0 +1,8 @@
+---
+title: Registering trainees manually in this service
+---
+## Withdraw or deferring a trainee
+
+Once you’ve registered a trainee and they have started their training, you can withdraw or defer them. You can do this using the links on the trainee record in Register.
+
+Trainees who are registered, but then do not start their ITT course at all, do not need to be withdrawn – their records can be deleted.

--- a/app/views/guidance/manually_registering_trainees.html.erb
+++ b/app/views/guidance/manually_registering_trainees.html.erb
@@ -1,0 +1,18 @@
+<%= render "manually_registering_trainees" %>
+        
+<%= govuk_details(summary_text: "How to find a trainee once you’ve recommended them for QTS or EYTS",
+    text: "Once you’ve recommended a trainee for QTS or EYTS, you’ll find their record by going to the
+     ‘Awarded this year’ training status on the Homepage. You can also filter by ‘Awarded’ on the records list page.") %>
+
+<%= render "withdrawing_or_deferring_a_trainee" %>
+
+<%= govuk_details(summary_text: "More information on what ‘withdrawn’ and ‘deferred’ means in Register") do %>
+  <p>
+    A ‘deferred’ trainee in Register is a trainee who is registered on a course but then decides to defer to a later date or academic year. 
+    In Register, trainees can be deferred if they have started their ITT course or if they never start their ITT course.
+  </p>
+  <p>
+    A ‘withdrawn‘ trainee in Register is a trainee that is registered on an ITT course, started that course, but then decides to withdraw 
+    from the qualified teacher status (QTS) part of the course and will not return.
+  </p>
+<% end %>

--- a/app/views/layouts/guidance_markdown.html.erb
+++ b/app/views/layouts/guidance_markdown.html.erb
@@ -8,7 +8,9 @@
       ) %>
     <% end %>
     <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
           <%= tag.h1 @front_matter["title"], class: "govuk-heading-xl" %>
           <%= yield %>
+      </div>
     </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,7 @@ Rails.application.routes.draw do
   resource :guidance, only: %i[show], controller: "guidance" do
     get "/about-register-trainee-teachers", to: "guidance#about_register_trainee_teachers"
     get "/dates-and-deadlines", to: "guidance#dates_and_deadlines"
+    get "/manually-registering-trainees", to: "guidance#manually_registering_trainees"
   end
 
   if FeatureService.enabled?("funding")

--- a/spec/controllers/guidance_controller_spec.rb
+++ b/spec/controllers/guidance_controller_spec.rb
@@ -34,4 +34,17 @@ describe GuidanceController, type: :controller do
       expect(response).to render_template("dates_and_deadlines")
     end
   end
+
+  describe "#manually_registering_trainees" do
+    it "returns a 200 status code" do
+      get :manually_registering_trainees
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct template and page" do
+      get :manually_registering_trainees
+      expect(response).to render_template("guidance_markdown")
+      expect(response).to render_template("manually_registering_trainees")
+    end
+  end
 end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/ASwBVJh8/4591-create-page-for-registering-trainees-manually-in-this-service

Add new guidance page 'Registering trainees manually in this service'. I have used markdown partials to render the content chunks. These are rendered in between the govuk-details components in the ERB file.

### Changes proposed in this pull request

* Add two md partials, _manually_registering_trainees.md and _withdrawing_or_deferring_a_trainee.md
* Add manually_registering_trainees.html.erb
* Use govuk_details component
* Set up new route and controller action(set the layout to use guidance_markdown)

### Guidance to review

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
