### PR TITLE
[4588] Add guidance link to footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -121,6 +121,9 @@
 
             <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
               <li class="govuk-footer__inline-list-item">
+                <%= govuk_link_to "How to use this service", guidance_path, class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
                 <%= govuk_link_to "Accessibility", accessibility_path, class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">


### PR DESCRIPTION
### Context

We have a new guidance section called 'How to use this service'. We want to link to it in the footer of every page on Register.

### Changes proposed in this pull request

A small link entitled 'How to use this service' should now appear at the bottom of every page/

