### PR TITLE
[4590] Add Registering trainees through HESA guidance page

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -14,4 +14,8 @@ class GuidanceController < ApplicationController
   def manually_registering_trainees
     render(layout: "guidance_markdown")
   end
+
+  def registering_trainees_through_hesa
+    render(layout: "guidance_markdown")
+  end
 end

--- a/app/views/guidance/_manually_registering_trainees.md
+++ b/app/views/guidance/_manually_registering_trainees.md
@@ -1,4 +1,5 @@
 ---
+page_title: Registering trainees manually in Register
 title: Registering trainees manually in this service
 ---
 
@@ -6,7 +7,7 @@ Training providers can register their trainees manually in the Register service 
 
 Get prepared for adding a trainee record manually by [checking what data you need to provide](/check-data).
 
-## How trainees are grouped on the Register homepage
+<h2 class="govuk-heading-m">How trainees are grouped on the Register homepage</h2>
 
 When you log into Register, on the homepage you’ll see a section called ‘Draft trainees’ and a section called ‘Registered trainees’. Under ‘Registered trainees’ there are ‘training statuses’ where trainees are grouped by:
 
@@ -16,26 +17,26 @@ When you log into Register, on the homepage you’ll see a section called ‘Dra
 * awarded this year (all trainees awarded QTS or EYTS in the current academic year)
 * incomplete records (registered trainees that are missing data)
 
-## Getting a teacher reference number (TRN)
+<h2 class="govuk-heading-m">Getting a teacher reference number (TRN)</h2>
 
 Once a draft is complete, you can request a TRN for each trainee record. This is when the trainee becomes registered with the Department for Education.
 
 Trainees will receive their TRN by email.
 
-## Trainee records imported from the Apply for teacher training (Apply) service
+<h2 class="govuk-heading-m">Trainee records imported from the Apply for teacher training (Apply) service</h2>
 
 When an application reaches the ‘recruited’ status in Apply, it will be imported into Register. If an application has any conditions set, it will only reach recruited status in Apply once all conditions have been met.
 
 Applications from Apply will import into Register every day at 4:00am. This is called the ‘Apply integration’.
 
-An application imported from Apply into Register will become a draft trainee record. You can find these records on the homepage under ‘Draft trainees’ at the link called ‘View draft trainees imported from Apply’. **You should not need to manually duplicate applications from Apply into Register.**
+An application imported from Apply into Register will become a draft trainee record. You can find these records on the homepage under ‘Draft trainees’ at the link called ‘View draft trainees imported from Apply’. You should not need to manually duplicate applications from Apply into Register.
 
 On a trainee record from Apply, you’ll see:
 
 * the course the trainee applied for
 * the trainee’s personal details
 
-### What to do with draft records from Apply
+<h3 class="govuk-heading-s">What to do with draft records from Apply</h3>
 
 To register trainees that come from Apply, you’ll need to check if their data is correct and add any further data about their training. This can include:
 
@@ -45,7 +46,7 @@ To register trainees that come from Apply, you’ll need to check if their data 
 
 Once an application is imported into Register, any changes you make to the application in Apply (after it’s in ‘recruited’ status) will not show in Register. Changes to trainee data in Register will also not reflect in Apply. At the moment, our integration only works to bring applications into Register.
 
-## Checking your trainee data to make sure it’s correct
+<h2 class="govuk-heading-m">Checking your trainee data to make sure it’s correct</h2>
 
 There are 3 ways to do this in Register and you can choose whichever one suits you. These are:
 
@@ -53,9 +54,9 @@ There are 3 ways to do this in Register and you can choose whichever one suits y
 * exporting a CSV of your trainees in the ‘Registered trainees’ section, using the ‘start year’ filter to select the current academic year
 * checking your trainees directly in the service one by one
 
-## Adding specific information to a trainee record
+<h2 class="govuk-heading-m">Adding specific information to a trainee record</h2>
 
-### PE with EBaccalaureate (PE with EBacc)
+<h3 class="govuk-heading-s">PE with EBaccalaureate (PE with EBacc)</h3>
 
 Follow these steps to register a trainee on a PE with EBacc course:
 
@@ -63,7 +64,7 @@ Follow these steps to register a trainee on a PE with EBacc course:
 2. Add a second subject as their EBacc subject.
 3. Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) stating their trainee ID and that they are doing PE with EBacc.
 
-## Recommending a trainee for Qualified Teacher Status (QTS) or Early Years Teacher Status (EYTS)
+<h2 class="govuk-heading-m">Recommending a trainee for Qualified Teacher Status (QTS) or Early Years Teacher Status (EYTS)</h2>
 
 When a trainee has successfully completed their training (or completed their assessment for an ‘assessment only’ route) and met the required standards, you can recommend them for QTS or EYTS in Register.
 

--- a/app/views/guidance/_registering_trainees_through_hesa.md
+++ b/app/views/guidance/_registering_trainees_through_hesa.md
@@ -1,0 +1,52 @@
+---
+page_title: Registering trainees through HESA
+title: Registering trainees through HESA (Higher Education Statistics Agency)
+---
+
+Training providers that use HESA need to submit data through the HESA data collection system to register their trainees. Your trainee data will then be imported into Register where you can check it.
+
+[Find out when you should submit your data for the 2022 to 2023 academic year.](/guidance/dates-and-deadlines)
+
+<h2 class="govuk-heading-m">How trainees are grouped on the Register homepage</h2>
+
+When you log into Register, on the homepage you’ll see a section called ‘Draft trainees’ and a section called ‘Registered trainees’. Under ‘Registered trainees’ there are ‘training statuses’ where trainees are grouped by:
+
+* course not started yet (trainees who are registered but their course has not started)
+* in training (all trainees currently doing training, excluding those on courses that have not started or are deferred)
+* currently deferred
+* awarded this year (all trainees awarded QTS or EYTS in the current academic year)
+* incomplete records (registered trainees that are missing data)
+
+<h2 class="govuk-heading-m">Checking data imported into Register from HESA</h2>
+
+Once your data has been imported into Register, you can check it. There are 3 ways to do this in Register and you can choose whichever one suits you. These are:
+
+* using the new ‘Reports’ section and exporting a CSV of your new trainees for the 2022 to 2023 academic year (available in Register soon)
+* exporting a CSV of your trainees in the ‘Registered trainees’ section, using the ‘start year’ filter to select the current academic year
+* checking your trainees directly in the service one by one
+
+In the CSV export from Register, we’ve also included a column called ‘hesa_updated_at’ which shows you the last time a record was updated through HESA. You can use this column to check all your new trainees have imported into Register.
+
+<h2 class="govuk-heading-m">Adding specific information to a trainee record</h2>
+
+<h3 class="govuk-heading-s">How Register defines ‘withdrawn’ and ‘deferred’ trainees</h3>
+
+A ‘deferred’ trainee in Register is a trainee who is registered on a course but then decides to defer to a later date or academic year. In Register, trainees can be deferred if they have started their ITT course or if they never start their ITT course.
+
+In HESA ‘dormant‘ trainee means the same as ’deferred’ in Register. You can record deferred trainees in HESA by using the [Student.MODE field](https://www.hesa.ac.uk/collection/c22053/e/mode).
+
+A ‘withdrawn‘ trainee in Register is a trainee that is registered on an ITT course, started that course, but then decides to withdraw from the qualified teacher status (QTS) part of the course and will not return.
+
+In HESA, withdrawn trainees are recorded by using the [Student.ENDDATE](https://www.hesa.ac.uk/collection/c22053/e/enddate) field and the [Student.RSNEND](https://www.hesa.ac.uk/collection/c22053/e/rsnend) field.
+
+<h2 class="govuk-heading-m">Expected end date for trainees</h2>
+
+HESA has added a new field in their collection for the 2022 to 2023 academic year called [‘expected end date’ (EXPECTEDENDDATE)](https://www.hesa.ac.uk/collection/c22053/e/expectedenddate). 
+
+The Register service requires this field to issue TRNs and for funding purposes. You must fill out this field in HESA, it will then import into Register as ‘ITT end date’.
+
+You should keep this field up to date throughout the trainee’s training.
+
+<h2 class="govuk-heading-m">Recommending a trainee for Qualified Teacher Status (QTS) or Early Years Teacher Status (EYTS)</h2>
+
+When a trainee has successfully completed their training (or completed their assessment for an ‘assessment only’ route) and met the required standards, you can recommend them for QTS or EYTS in the Teaching Regulation Agency (TRA) portal.

--- a/app/views/guidance/_withdrawing_or_deferring_a_trainee.md
+++ b/app/views/guidance/_withdrawing_or_deferring_a_trainee.md
@@ -1,7 +1,8 @@
 ---
+page_title: Registering trainees manually in Register
 title: Registering trainees manually in this service
 ---
-## Withdraw or deferring a trainee
+<h2 class="govuk-heading-m">Withdraw or deferring a trainee</h2>
 
 Once you’ve registered a trainee and they have started their training, you can withdraw or defer them. You can do this using the links on the trainee record in Register.
 

--- a/app/views/guidance/about_register_trainee_teachers.md
+++ b/app/views/guidance/about_register_trainee_teachers.md
@@ -1,4 +1,5 @@
 ---
+page_title: About Register trainee teachers
 title: About Register trainee teachers
 ---
 
@@ -13,7 +14,7 @@ The DfE uses trainee data in Register to:
 * create the ITT performance profiles publication
 * inform policy development
 
-## Access to Register for accredited providers
+<h2 class="govuk-heading-m">Access to Register for accredited providers</h2>
 
 Accredited providers can perform tasks for their trainees in Register, these include:
 
@@ -23,7 +24,7 @@ Accredited providers can perform tasks for their trainees in Register, these inc
 
 If you have trainees eligible for funding, you can view funding information from the 2021 to 2022 academic year onwards. You can view this from the main navigation bar under ‘Funding’. Accredited providers will see monthly payments paid and predicted to be paid for scholarships and bursaries.
 
-## Access to Register for lead schools
+<h2 class="govuk-heading-m">Access to Register for lead schools</h2>
 
 Lead schools that deliver School Direct initial teacher training (ITT) courses in partnership with an accredited provider, can access Register to:
 
@@ -37,7 +38,7 @@ Access to Register for lead schools is view only. As a lead school you cannot:
 * view draft trainee records
 * view a trainee’s diversity information
 
-## How trainees are grouped on the Register homepage
+<h2 class="govuk-heading-m">How trainees are grouped on the Register homepage</h2>
 
 When you log into Register, on the homepage you’ll see a section called ‘Draft trainees’ and a section called ‘Registered trainees’. Under ‘Registered trainees’ there are ‘training statuses’ where trainees are grouped by:
 
@@ -47,7 +48,7 @@ When you log into Register, on the homepage you’ll see a section called ‘Dra
 * awarded this year (all trainees awarded QTS or EYTS in the current academic year)
 * incomplete records (registered trainees that are missing data)
 
-## How Register relates to the initial teacher training (ITT) census publication
+<h2 class="govuk-heading-m">How Register relates to the initial teacher training (ITT) census publication</h2>
 
 Every academic year, the DfE publishes a census of trainee teachers who are starting their training. This is so we have an idea of who could be entering the teaching workforce and can plan teacher recruitment activities.
 
@@ -55,7 +56,7 @@ The ITT census happens in September and October every year. We‘ll notify you a
 
 Once you register your new trainees, your trainee data gets analysed and filtered for the ITT census publication. Not all your new trainees will be included in the ITT census publication, to understand what data will be used read the [Initial Teacher Training Census methodology.](https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology)
 
-## Registering trainees and signing off new trainee data
+<h2 class="govuk-heading-m">Registering trainees and signing off new trainee data</h2>
 
 At the start of every academic year, during September and October, you’ll need to register your new trainees and sign off your new trainee data before the end of October. We ask you to sign off your data so we know it’s accurate for the ITT census publication.
 
@@ -67,13 +68,13 @@ Training providers who use HESA, should submit their data through HESA. Your dat
 
 [Read more about how to register your trainees through HESA.](/guidance/registering-trainees-through-hesa)
 
-### Who you should register
+<h3 class="govuk-heading-s">Who you should register</h3>
 
 You should register all trainees who start their training, even if they decide to drop out after the first few weeks. If they do drop out, you can withdraw them.
 
 Not registering trainees who drop out early means we do not have any record of them, which could affect funding payments.
 
-### Checking and signing off your organisation’s data
+<h3 class="govuk-heading-s">Checking and signing off your organisation’s data</h3>
 
 Once you’ve registered your trainees, you’ll need to check your data is correct. You can do this in Register by:
 
@@ -82,7 +83,7 @@ Once you’ve registered your trainees, you’ll need to check your data is corr
 
 Once you’re confident your new trainee data is correct, a senior person from your organisation (this should be a different person to who submitted the data) must sign it off at the end of October every academic year.
 
-## How Register relates to ITT performance profiles
+<h2 class="govuk-heading-m">How Register relates to ITT performance profiles</h2>
 
 Every academic year, the DfE publishes data on GOV.UK of how many people have successfully completed their teacher training.
 

--- a/app/views/guidance/registering_trainees_through_hesa.html.erb
+++ b/app/views/guidance/registering_trainees_through_hesa.html.erb
@@ -1,0 +1,8 @@
+<%= render "registering_trainees_through_hesa" %>
+
+<%= govuk_details(summary_text: "How to find a trainee once you’ve recommended them for QTS") do %>
+  <p>
+    Once you’ve recommended a trainee for QTS or EYTS, you’ll find their record by going to the ‘Awarded this year’ training status on the Homepage. 
+    You can also filter by ‘Awarded’ on the records list page.
+  </p>
+<% end %>

--- a/app/views/layouts/guidance_markdown.html.erb
+++ b/app/views/layouts/guidance_markdown.html.erb
@@ -1,5 +1,5 @@
 <%= extends_layout :application do %>
-    <%= render PageTitle::View.new(text: @front_matter["title"])%>
+    <%= render PageTitle::View.new(text: @front_matter["page_title"])%>
 
     <%= content_for(:breadcrumbs) do %>
       <%= render GovukComponent::BackLinkComponent.new(
@@ -9,7 +9,7 @@
     <% end %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
-          <%= tag.h1 @front_matter["title"], class: "govuk-heading-xl" %>
+          <%= tag.h1 @front_matter["title"], class: "govuk-heading-l" %>
           <%= yield %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,7 @@ Rails.application.routes.draw do
     get "/about-register-trainee-teachers", to: "guidance#about_register_trainee_teachers"
     get "/dates-and-deadlines", to: "guidance#dates_and_deadlines"
     get "/manually-registering-trainees", to: "guidance#manually_registering_trainees"
+    get "/registering-trainees-through-hesa", to: "guidance#registering_trainees_through_hesa"
   end
 
   if FeatureService.enabled?("funding")

--- a/spec/controllers/guidance_controller_spec.rb
+++ b/spec/controllers/guidance_controller_spec.rb
@@ -47,4 +47,17 @@ describe GuidanceController, type: :controller do
       expect(response).to render_template("manually_registering_trainees")
     end
   end
+
+  describe "#registering_trainees_through_hesa" do
+    it "returns a 200 status code" do
+      get :registering_trainees_through_hesa
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct template and page" do
+      get :registering_trainees_through_hesa
+      expect(response).to render_template("guidance_markdown")
+      expect(response).to render_template("registering_trainees_through_hesa")
+    end
+  end
 end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/kteEJH3D/4590-create-page-for-registering-trainees-through-hesa

Add guidance page 'Registering trainees through HESA'

Make some changes to some existing guidance pages and guidance layout to set correct heading sizes.

Ideally we will update the Govuk-markdown gem to have correct heading sizes/be configurable, but as a quick fix, adding HTML into the md files.

I've added `page_title` into the front matter on markdown pages, this is because sometimes the page title is different to the page heading.

### Changes proposed in this pull request

* add new route
* add new controller action
* add new md file and erb file
* update existing md files to have correct HTML heading classes
* update guidance_markdown.html.erb to handle page_title and use correct title heading class

### Guidance to review

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
