### PR TITLE
[4612] Add the Dqt::SyncStatesJob to the sidekiq scheduler

### DIFF
--- a/app/jobs/dqt/sync_states_job.rb
+++ b/app/jobs/dqt/sync_states_job.rb
@@ -15,6 +15,8 @@ module Dqt
                         .where(dqt_trn_validation_clause)
 
       trainees.find_in_batches(batch_size: batch_size).with_index do |group, batch|
+        # The API rate limit is 300 requests per minute so by default we're
+        # kicking off 100 trainees every 30 seconds to stay within that.
         Dqt::SyncStatesBatchJob.set(wait: interval * batch).perform_later(group.pluck(:id))
       end
     end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -34,8 +34,7 @@ upload_trn_file_to_hesa:
   cron: "10 */2 * * *"
   class: "Hesa::UploadTrnFileJob"
   queue: default
-# sync_trainee_states_from_dqt:
-#   cron: "0 11 * * *"
-#   class: "Dqt::SyncStatesJob"
-#   queue: dqt_sync
-
+sync_trainee_states_with_dqt:
+  cron: "0 11 * * *"
+  class: "Dqt::SyncStatesJob"
+  queue: dqt_sync


### PR DESCRIPTION
### Context

We manually ran the job last week and it took 3 hours with 37k trainees.
After that run, we now only have 13k HESA trainees in `trn_received` so this job will take approx 1 hour.
We also fixed all of the 50 trainees that 404'd during the first run, so we're happy to now run this on a schedule.

### Changes proposed in this pull request

- Run the `Dqt::SyncStatesJob` daily at 11am.
- Add a comment about the DQT API rate limit.

### Guidance to review

- Is 11am a reasonable time to run it? I decided that if we were to get errors we'd rather see them during the day rather than wake up to them?
- Are we happy running this daily, or is it ok being a weekly thing? We could then bump up the frequency during busy 'awarding' periods.

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml