### PR TITLE
[4587] Update homepage with new guidance sections

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -6,7 +6,7 @@ class GuidanceController < ApplicationController
   def show; end
 
   def about_register_trainee_teachers
-    render(template: "guidance/about_register_trainee_teachers.md", layout: "guidance_markdown")
+    render(format: :md, layout: "guidance_markdown")
   end
 
   def dates_and_deadlines; end

--- a/app/views/guidance/_manually_registering_trainees.md
+++ b/app/views/guidance/_manually_registering_trainees.md
@@ -5,7 +5,7 @@ title: Registering trainees manually in this service
 
 Training providers can register their trainees manually in the Register service by creating draft trainee records and adding the required data about your trainees.
 
-Get prepared for adding a trainee record manually by [checking what data you need to provide](/check-data).
+Get prepared for adding a trainee record manually by [checking what data you need to provide](/guidance/check-data).
 
 <h2 class="govuk-heading-m">How trainees are grouped on the Register homepage</h2>
 

--- a/app/views/guidance/_withdrawing_or_deferring_a_trainee.md
+++ b/app/views/guidance/_withdrawing_or_deferring_a_trainee.md
@@ -2,7 +2,7 @@
 page_title: Registering trainees manually in Register
 title: Registering trainees manually in this service
 ---
-<h2 class="govuk-heading-m">Withdraw or deferring a trainee</h2>
+<h2 class="govuk-heading-m">Withdraw or defer a trainee</h2>
 
 Once you’ve registered a trainee and they have started their training, you can withdraw or defer them. You can do this using the links on the trainee record in Register.
 

--- a/app/views/guidance/about_register_trainee_teachers.md
+++ b/app/views/guidance/about_register_trainee_teachers.md
@@ -52,13 +52,15 @@ When you log into Register, on the homepage you’ll see a section called ‘Dra
 
 Every academic year, the DfE publishes a census of trainee teachers who are starting their training. This is so we have an idea of who could be entering the teaching workforce and can plan teacher recruitment activities.
 
-The ITT census happens in September and October every year. We‘ll notify you about the exact dates each year. [Find out what the dates and deadlines are for the 2022 to 2023 academic year.](/guidance/dates-and-deadlines)
+The ITT census happens in September and October every year. We‘ll notify you about the exact dates each year. 
 
 Once you register your new trainees, your trainee data gets analysed and filtered for the ITT census publication. Not all your new trainees will be included in the ITT census publication, to understand what data will be used read the [Initial Teacher Training Census methodology.](https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology)
 
 <h2 class="govuk-heading-m">Registering trainees and signing off new trainee data</h2>
 
 At the start of every academic year, during September and October, you’ll need to register your new trainees and sign off your new trainee data before the end of October. We ask you to sign off your data so we know it’s accurate for the ITT census publication.
+
+[Find out what the dates and deadlines are for the 2022 to 2023 academic year.](/guidance/dates-and-deadlines)
 
 Training providers that do not use the Higher Education Statistics Agency (HESA) data collection system should register their trainees manually in the Register service. 
 
@@ -78,6 +80,7 @@ Not registering trainees who drop out early means we do not have any record of t
 
 Once you’ve registered your trainees, you’ll need to check your data is correct. You can do this in Register by:
 
+* using the new ‘Reports’ section and exporting a CSV of your new trainees for the 2022 to 2023 academic year (available in Register soon)
 * exporting a CSV of your trainees in the ‘Registered trainees’ section, using the ‘start year’ filter to select the current academic year
 * checking your trainees directly in the service one by one
 

--- a/app/views/guidance/show.html.erb
+++ b/app/views/guidance/show.html.erb
@@ -11,25 +11,36 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <h1 class="govuk-heading-l">How to use this service</h1>
         <ul class="govuk-list govuk-list--spaced">
-        <li>
-          <a class="govuk-link" href="/guidance/about-register-trainee-teachers">About Register trainee teachers</a>
-        </li>
-        <li>
-          <a class="govuk-link" href="/guidance/dates-and-deadlines">Dates and deadlines for the 2022 to 2023 academic year</a>
-        </li>
-        <li>
-          <a class="govuk-link" href="/guidance/manually-registering-trainees">Registering trainees manually in this service</a>
-        </li>
-        <li>
-          <a class="govuk-link" href="/guidance/check-data">Check what data you need to provide to register trainees manually</a>
-        </li>
-        <li>
-        <li>
-          <a class="govuk-link" href="/guidance/registering-trainees-through-hesa">Registering trainees through HESA</a>
-        </li>
-        <li>
-          <a class="govuk-link" href="/guidance/hesa-register-data-mapping">Check the data mapping between HESA and Register trainee teachers</a>
-        </li>
-      </ul>
+          <li>
+            <%= govuk_link_to(
+              "About Register trainee teachers",
+              about_register_trainee_teachers_guidance_path,
+            )%>
+          </li>
+          <li>
+            <%= govuk_link_to(
+              "Dates and deadlines for the 2022 to 2023 academic year",
+              dates_and_deadlines_guidance_path,
+            )%>
+          </li>
+          <li>
+            <%= govuk_link_to(
+              "Registering trainees manually in this service",
+              manually_registering_trainees_guidance_path,
+            )%>
+          </li>
+          <li>
+            <%= govuk_link_to(
+              "Check what data you need to provide to register trainees manually",
+              check_data_guidance_path,
+            )%>
+          </li>
+          <li>
+            <%= govuk_link_to(
+              "Registering trainees through HESA",
+              registering_trainees_through_hesa_guidance_path,
+            )%>
+          </li>
+        </ul>
+      </div>
     </div>
-  </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -59,26 +59,45 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h2 class="govuk-heading-l"><%= t(".guidance_heading") %></h2>
+    <h2 class="govuk-heading-l">How to use this service</h2>
     <ul class="govuk-list govuk-list--spaced">
       <li>
         <%= govuk_link_to(
-          t(".service_updates_link"),
-          service_updates_path,
-          { class: "govuk-link--no-visited-state" }
-        )%>
-      </li>
-      <li>
-        <%= govuk_link_to(
-          t(".guidance_about_link"),
+          "View all guidance for Register trainee teachers",
           guidance_path,
           { class: "govuk-link--no-visited-state" }
         )%>
       </li>
       <li>
         <%= govuk_link_to(
-          t(".guidance_data_link"),
-          check_data_path,
+          "Dates and deadlines for the 2022 to 2023 academic year",
+          dates_and_deadlines_guidance_path,
+          { class: "govuk-link--no-visited-state" }
+        )%>
+      </li>
+      <li>
+        <%= govuk_link_to(
+          "Registering trainees manually in this service",
+          manually_registering_trainees_guidance_path,
+          { class: "govuk-link--no-visited-state" }
+        )%>
+      </li>
+      <li>
+        <%= govuk_link_to(
+          "Registering trainees through HESA",
+          registering_trainees_through_hesa_guidance_path,
+          { class: "govuk-link--no-visited-state" }
+        )%>
+      </li>
+    </ul>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <h2 class="govuk-heading-l">News and feedback</h2>
+    <ul class="govuk-list govuk-list--spaced">
+      <li>
+        <%= govuk_link_to("View news and updates",
+          service_updates_path,
           { class: "govuk-link--no-visited-state" }
         )%>
       </li>


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/P0foCnnX/4587-create-how-to-use-the-service-section-on-homepage-for-signed-in-users

Added changes to homepage to include new guidance links. 

Also refactor the guidance show page to use the govuk component `govuk-link-to` instead of lots of HTML.

~~NOTE: The old check-data page is still being used for these links. We'll need to make sure we switch to the new link in the last ticket where we create the new check-data page.~~ Now done.

### Changes proposed in this pull request

* Update home.html.erb to use the new links
* Refactor guidance/show.html.erb
* Add a couple content changes from Maeve

### Guidance to review

* ~~All links should work correctly except for the data check - this is coming in another PR~~ - all links should now work!

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
