### PR TITLE
[4589] Add check data page

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -18,4 +18,8 @@ class GuidanceController < ApplicationController
   def registering_trainees_through_hesa
     render(layout: "guidance_markdown")
   end
+
+  def check_data
+    render(format: :md, layout: "guidance_markdown")
+  end
 end

--- a/app/views/guidance/check_data.md
+++ b/app/views/guidance/check_data.md
@@ -1,0 +1,78 @@
+---
+page_title: Check what data you need to provide
+title: Check what data you need to provide
+---
+
+This information is mainly for school centred initial teacher training providers (SCITTs) that use this service to manually register their trainees.
+
+You’ll need the following information about a trainee to complete their record manually in Register.
+
+<h2 class="govuk-heading-m">Personal details</h2>
+
+First names  
+Middle names  
+Last or family name  
+Date of birth  
+Sex  
+Nationality
+***
+<h2 class="govuk-heading-m">Contact details</h2>
+
+Address  
+Email address
+***
+<h2 class="govuk-heading-m">Diversity information (optional)</h2>
+<div class="govuk-inset-text">If the trainee chose not to share this information during the application process, do not ask for it for the purpose of registering them.</div>
+
+Ethnicity  
+Disability
+***
+<h2 class="govuk-heading-m">Degrees</h2>
+<h4 class="govuk-heading-s">If it’s a UK degree Type (for example, BA or BSc)</h4>
+
+Awarding institution  
+Subject  
+Grade  
+Graduation year  
+<h4 class="govuk-heading-s">If it’s not a UK degree</h4>
+
+Country where the degree was obtained  
+Subject  
+UK ENIC comparable degree (if provided)  
+Graduation year
+***
+<h2 class="govuk-heading-m">Course details</h2>  
+
+<h4 class="govuk-heading-s">If it’s a course on Publish teacher training courses</h4>
+Which Publish course  
+Subject specialisms  
+Full or part time  
+ITT start date  
+Expected end date  
+
+<h4 class="govuk-heading-s">If it's not a course on Publish teacher training courses</h4> 
+Primary or secondary  
+Subjects  
+Age range  
+Full or part time (not for assessment only)  
+ITT start date  
+Expected end date  
+
+<h4 class="govuk-heading-s">If it's a course leading to Early Years Teacher Status (EYTS) </h4> 
+Full or part time  
+ITT start date  
+Expected end date  
+Trainee start date  
+Trainee start date
+***
+<h2 class="govuk-heading-m">Schools </h2> 
+This is only required for School direct and Teaching apprenticeship routes.
+***
+<h2 class="govuk-heading-m">Funding details</h2>
+
+Whether the trainee is on a training initiative  
+<h4 class="govuk-heading-s">For courses with bursaries, scholarships or grants available</h4>
+
+Whether you’re applying for a bursary for the trainee  
+Whether you’re applying for a grant for the trainee  
+Whether the trainee is applying for a scholarship  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,7 @@ Rails.application.routes.draw do
     get "/dates-and-deadlines", to: "guidance#dates_and_deadlines"
     get "/manually-registering-trainees", to: "guidance#manually_registering_trainees"
     get "/registering-trainees-through-hesa", to: "guidance#registering_trainees_through_hesa"
+    get "/check-data", to: "guidance#check_data"
   end
 
   if FeatureService.enabled?("funding")

--- a/spec/controllers/guidance_controller_spec.rb
+++ b/spec/controllers/guidance_controller_spec.rb
@@ -60,4 +60,17 @@ describe GuidanceController, type: :controller do
       expect(response).to render_template("registering_trainees_through_hesa")
     end
   end
+
+  describe "#check_data" do
+    it "returns a 200 status code" do
+      get :check_data
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct template and page" do
+      get :check_data
+      expect(response).to render_template("guidance_markdown")
+      expect(response).to render_template("check_data")
+    end
+  end
 end


### PR DESCRIPTION
### Context

Edit content for new page  ‘Check what data you need to provide’.

This is because we are improving and expanding the guidance pages for Register. 

### Changes proposed in this pull request

add new markdown file and html.erb file to render the guidance page on the check-data route 

### Guidance to review

Go to the guidance/check-data route and ensure the markdown has rendered correctly.