### PR TITLE
[4555] Add data migration to fill in record source on trainees

### DIFF
--- a/db/data/20220902100022_backfill_record_source_on_trainees.rb
+++ b/db/data/20220902100022_backfill_record_source_on_trainees.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class BackfillRecordSourceOnTrainees < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.where(created_from_dttp: true, hesa_id: nil)
+           .update_all(record_source: RecordSources::DTTP)
+
+    non_trn_data_sources = RecordSources::ALL - [RecordSources::HESA_TRN_DATA]
+
+    Trainee.where.not(hesa_id: nil)
+           .where(record_source: non_trn_data_sources.push(nil))
+           .update_all(record_source: RecordSources::HESA_COLLECTION)
+
+    Trainee.where.not(apply_application: nil)
+           .update_all(record_source: RecordSources::APPLY)
+
+    Trainee.where(apply_application: nil, created_from_dttp: false, hesa_id: nil)
+           .update_all(record_source: RecordSources::MANUAL)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/8mRrqx6O/4555-backfill-the-record-source-field-on-trainees

### Changes proposed in this pull request

Backfill the `record_source` field on trainees.

### Guidance to review

- No backfill for TRN data trainees, as their record source should be being set correctly (although currently there are non of these)
- Check the scope logic in https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/models/trainee.rb - this is what i've based the data migration on.
- Since we show "HESA" in the UI for trainees who were originally imported from DTTP but have a HESA ID, I've mirrored this in setting record_source. But this means that `Trainee.created_from_dttp` will return more trainees than the new `Trainee.where(record_source: "dttp")`. Something to be aware of.

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml