### PR TITLE
[4636] Do not upload a trn file when no trainees are in scope

### DIFF
--- a/app/services/hesa/upload_trn_file.rb
+++ b/app/services/hesa/upload_trn_file.rb
@@ -12,6 +12,8 @@ module Hesa
     end
 
     def call
+      return if trainees.empty?
+
       file = Mechanize::Form::FileUpload.new({ "name" => "file" }, "trn_file.csv")
       file.file_data = build_csv
       response = Hesa::Client.upload_trn_file(url: url, file: file)

--- a/spec/services/hesa/upload_trn_file_spec.rb
+++ b/spec/services/hesa/upload_trn_file_spec.rb
@@ -20,6 +20,12 @@ module Hesa
 
         expect(described_class.call(trainees: [trainee])).to eq(file.file_data)
       end
+
+      it "does not upload a file if there are no trainees in scope" do
+        expect(Hesa::Client).not_to receive(:upload_trn_file)
+
+        expect(described_class.call(trainees: [])).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

HESA are receiving empty csv files when no trainees are in scope.

### Changes proposed in this pull request

Do not upload a csv file with zero records.

### Guidance to review

From the development console check that:

```ruby
Hesa::UploadTrnFile.call(trainees: []).nil?
=> true
```

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
