### PR TITLE
4632 rename commencement_date to trainee_start_date in the database and in register

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -75,7 +75,7 @@ module ApplicationRecordCard
     end
 
     def start_year
-      academic_cycle = AcademicCycle.for_date(record.commencement_date)
+      academic_cycle = AcademicCycle.for_date(record.trainee_start_date)
       return unless academic_cycle
 
       tag.p("Start year: #{academic_cycle.label}", class: "govuk-caption-m govuk-!-font-size-16 application-record-card__start_year govuk-!-margin-top-1 govuk-!-margin-bottom-1")

--- a/app/components/record_actions/view.rb
+++ b/app/components/record_actions/view.rb
@@ -111,11 +111,11 @@ module RecordActions
     end
 
     def course_started_but_no_specified_start_date?
-      !course_starting_in_the_future? && trainee.commencement_date.blank?
+      !course_starting_in_the_future? && trainee.trainee_start_date.blank?
     end
 
     def relevant_redirect_path
-      if trainee.commencement_date.present?
+      if trainee.trainee_start_date.present?
         trainee_withdrawal_path(trainee)
       else
         trainee_start_date_verification_path(trainee, context: :withdraw)

--- a/app/components/record_details/trainee_start_date.rb
+++ b/app/components/record_details/trainee_start_date.rb
@@ -12,14 +12,14 @@ module RecordDetails
     def text
       return I18n.t("record_details.view.itt_has_not_started").html_safe if trainee.starts_course_in_the_future?
       return I18n.t("record_details.view.deferred_before_itt_started").html_safe if deferred_with_no_start_date?
-      return date_for_summary_view(trainee.commencement_date) if commencement_date_present?
+      return date_for_summary_view(trainee.trainee_start_date) if trainee_start_date_present?
 
       I18n.t("record_details.view.not_provided")
     end
 
     def link
       return if trainee.starts_course_in_the_future?
-      return edit_trainee_start_date_path(trainee) if deferred_with_no_start_date? || commencement_date_present?
+      return edit_trainee_start_date_path(trainee) if deferred_with_no_start_date? || trainee_start_date_present?
 
       edit_trainee_start_status_path(trainee)
     end
@@ -32,12 +32,12 @@ module RecordDetails
 
     attr_reader :trainee
 
-    def commencement_date_present?
-      trainee.commencement_date.present?
+    def trainee_start_date_present?
+      trainee.trainee_start_date.present?
     end
 
     def deferred_with_no_start_date?
-      trainee.deferred? && trainee.commencement_date.blank?
+      trainee.deferred? && trainee.trainee_start_date.blank?
     end
   end
 end

--- a/app/components/trainee_start_date/view.rb
+++ b/app/components/trainee_start_date/view.rb
@@ -12,7 +12,7 @@ module TraineeStartDate
     end
 
     def start_date
-      data_model.commencement_date.strftime("%d %B %Y")
+      data_model.trainee_start_date.strftime("%d %B %Y")
     end
 
   private

--- a/app/components/trainee_start_status/view.rb
+++ b/app/components/trainee_start_status/view.rb
@@ -14,7 +14,7 @@ module TraineeStartStatus
     def start_status_or_date
       return t("components.confirmation.start_status.itt_not_yet_started") if data_model.itt_not_yet_started?
 
-      data_model.commencement_date.strftime("%d %B %Y")
+      data_model.trainee_start_date.strftime("%d %B %Y")
     end
 
   private

--- a/app/components/withdrawal_details/view.rb
+++ b/app/components/withdrawal_details/view.rb
@@ -12,8 +12,8 @@ module WithdrawalDetails
       @deferred = data_model.trainee.deferred?
     end
 
-    def trainee_commencement_date
-      date_for_summary_view(data_model.commencement_date)
+    def trainee_start_date
+      date_for_summary_view(data_model.trainee_start_date)
     end
 
     def withdraw_date
@@ -43,7 +43,7 @@ module WithdrawalDetails
     def start_date_row
       {
         key: t("components.confirmation.withdrawal_details.trainee_start_date_label"),
-        value: trainee_commencement_date,
+        value: trainee_start_date,
         action_href: deferred ? nil : trainee_start_date_verification_path(data_model.trainee, context: :withdraw),
         action_text: deferred ? nil : t(:change),
       }

--- a/app/controllers/trainees/start_dates_controller.rb
+++ b/app/controllers/trainees/start_dates_controller.rb
@@ -3,13 +3,13 @@
 module Trainees
   class StartDatesController < BaseController
     PARAM_CONVERSION = {
-      "commencement_date(3i)" => "day",
-      "commencement_date(2i)" => "month",
-      "commencement_date(1i)" => "year",
+      "trainee_start_date(3i)" => "day",
+      "trainee_start_date(2i)" => "month",
+      "trainee_start_date(1i)" => "year",
     }.freeze
 
     def edit
-      redirect_to(edit_trainee_start_status_path(trainee)) if @trainee.commencement_date.blank?
+      redirect_to(edit_trainee_start_status_path(trainee)) if @trainee.trainee_start_date.blank?
       @trainee_start_date_form = TraineeStartDateForm.new(trainee, params: params.slice(:context).permit!)
     end
 
@@ -26,7 +26,7 @@ module Trainees
   private
 
     def trainee_params
-      params.require(:trainee_start_date_form).permit(:commencement_date, :context, *PARAM_CONVERSION.keys)
+      params.require(:trainee_start_date_form).permit(:trainee_start_date, :context, *PARAM_CONVERSION.keys)
             .transform_keys do |key|
         PARAM_CONVERSION.keys.include?(key) ? PARAM_CONVERSION[key] : key
       end

--- a/app/controllers/trainees/start_statuses_controller.rb
+++ b/app/controllers/trainees/start_statuses_controller.rb
@@ -3,9 +3,9 @@
 module Trainees
   class StartStatusesController < BaseController
     PARAM_CONVERSION = {
-      "commencement_date(3i)" => "day",
-      "commencement_date(2i)" => "month",
-      "commencement_date(1i)" => "year",
+      "trainee_start_date(3i)" => "day",
+      "trainee_start_date(2i)" => "month",
+      "trainee_start_date(1i)" => "year",
     }.freeze
 
     def edit
@@ -41,7 +41,7 @@ module Trainees
     def relevant_redirect_path
       return trainee_forbidden_deletes_path(trainee) if @trainee_start_status_form.deleting?
 
-      return trainee_confirm_withdrawal_path(trainee) if trainee_commencement_date_before_withdrawal_date?
+      return trainee_confirm_withdrawal_path(trainee) if trainee_start_date_before_withdrawal_date?
 
       return trainee_withdrawal_path(trainee) if @trainee_start_status_form.withdrawing?
 
@@ -54,12 +54,12 @@ module Trainees
       trainee_start_status_confirm_path(trainee)
     end
 
-    def trainee_commencement_date_before_withdrawal_date?
+    def trainee_start_date_before_withdrawal_date?
       withdrawal_date = WithdrawalForm.new(trainee).date
 
       return false unless withdrawal_date
 
-      @trainee_start_status_form.withdrawing? && @trainee_start_status_form.commencement_date < withdrawal_date
+      @trainee_start_status_form.withdrawing? && @trainee_start_status_form.trainee_start_date < withdrawal_date
     end
   end
 end

--- a/app/forms/concerns/commencement_date_helpers.rb
+++ b/app/forms/concerns/commencement_date_helpers.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 module CommencementDateHelpers
-  def commencement_date_valid
+  def trainee_start_date_valid
     if [day, month, year].all?(&:blank?)
-      errors.add(:commencement_date, :blank)
-    elsif !commencement_date.is_a?(Date)
-      errors.add(:commencement_date, :invalid)
-    elsif commencement_date < 10.years.ago
-      errors.add(:commencement_date, :too_old)
-    elsif commencement_date.future?
-      errors.add(:commencement_date, :future)
-    elsif trainee.itt_end_date.present? && commencement_date > trainee.itt_end_date
+      errors.add(:trainee_start_date, :blank)
+    elsif !trainee_start_date.is_a?(Date)
+      errors.add(:trainee_start_date, :invalid)
+    elsif trainee_start_date < 10.years.ago
+      errors.add(:trainee_start_date, :too_old)
+    elsif trainee_start_date.future?
+      errors.add(:trainee_start_date, :future)
+    elsif trainee.itt_end_date.present? && trainee_start_date > trainee.itt_end_date
       errors.add(
-        :commencement_date,
+        :trainee_start_date,
         I18n.t(
-          "activemodel.errors.models.trainee_start_status_form.attributes.commencement_date.not_after_itt_end_date_html",
+          "activemodel.errors.models.trainee_start_status_form.attributes.trainee_start_date.not_after_itt_end_date_html",
           itt_end_date: trainee.itt_end_date.strftime("%-d %B %Y"),
         ).html_safe,
       )

--- a/app/forms/deferral_form.rb
+++ b/app/forms/deferral_form.rb
@@ -6,7 +6,7 @@ class DeferralForm < MultiDateForm
   def itt_start_date
     return if itt_not_yet_started?
 
-    @itt_start_date ||= ::TraineeStartStatusForm.new(trainee).commencement_date
+    @itt_start_date ||= ::TraineeStartStatusForm.new(trainee).trainee_start_date
   end
 
   delegate :itt_not_yet_started?, to: :trainee
@@ -14,7 +14,7 @@ class DeferralForm < MultiDateForm
 private
 
   def assign_attributes_to_trainee
-    trainee.commencement_date = itt_start_date if itt_start_date.is_a?(Date)
+    trainee.trainee_start_date = itt_start_date if itt_start_date.is_a?(Date)
     trainee[date_field] = date
   end
 

--- a/app/forms/reinstatement_form.rb
+++ b/app/forms/reinstatement_form.rb
@@ -7,7 +7,7 @@ private
 
   def assign_attributes_to_trainee
     trainee[date_field] = date
-    trainee.commencement_date = date if trainee.deferred? && trainee.commencement_date.nil?
+    trainee.trainee_start_date = date if trainee.deferred? && trainee.trainee_start_date.nil?
   end
 
   def date_field

--- a/app/forms/start_date_verification_form.rb
+++ b/app/forms/start_date_verification_form.rb
@@ -41,7 +41,7 @@ private
   def update_trainee_commencement_status
     attributes = { commencement_status: commencement_status }
 
-    attributes.merge!(commencement_date: nil) if not_yet_started?
+    attributes.merge!(trainee_start_date: nil) if not_yet_started?
 
     trainee.assign_attributes(attributes)
   end

--- a/app/forms/trainee_start_date_form.rb
+++ b/app/forms/trainee_start_date_form.rb
@@ -10,11 +10,11 @@ class TraineeStartDateForm < TraineeForm
   DEFER = "defer"
   DELETE = "delete"
 
-  validate :commencement_date_valid
+  validate :trainee_start_date_valid
 
   def save!
     if valid?
-      update_trainee_commencement_date
+      update_trainee_start_date
       Trainees::Update.call(trainee: trainee)
       clear_stash
     else
@@ -22,7 +22,7 @@ class TraineeStartDateForm < TraineeForm
     end
   end
 
-  def commencement_date
+  def trainee_start_date
     date_hash = { year: year, month: month, day: day }
     date_args = date_hash.values.map(&:to_i)
 
@@ -34,7 +34,7 @@ class TraineeStartDateForm < TraineeForm
   end
 
   def itt_start_date_is_after_deferral_date?
-    deferral_date.is_a?(Date) && commencement_date.after?(deferral_date)
+    deferral_date.is_a?(Date) && trainee_start_date.after?(deferral_date)
   end
 
 private
@@ -45,18 +45,18 @@ private
 
   def compute_fields
     {
-      day: trainee.commencement_date&.day,
-      month: trainee.commencement_date&.month,
-      year: trainee.commencement_date&.year,
+      day: trainee.trainee_start_date&.day,
+      month: trainee.trainee_start_date&.month,
+      year: trainee.trainee_start_date&.year,
     }.merge(new_attributes.slice(:day, :month, :year, :context))
   end
 
-  def update_trainee_commencement_date
-    trainee.assign_attributes(commencement_date: commencement_date, commencement_status: commencement_status)
+  def update_trainee_start_date
+    trainee.assign_attributes(trainee_start_date: trainee_start_date, commencement_status: commencement_status)
   end
 
   def commencement_status
-    if commencement_date.after?(trainee.itt_start_date)
+    if trainee_start_date.after?(trainee.itt_start_date)
       COMMENCEMENT_STATUS_ENUMS[:itt_started_later]
     else
       COMMENCEMENT_STATUS_ENUMS[:itt_started_on_time]

--- a/app/forms/trainee_start_status_form.rb
+++ b/app/forms/trainee_start_status_form.rb
@@ -10,7 +10,7 @@ class TraineeStartStatusForm < TraineeForm
 
   FIELDS = %i[
     commencement_status
-    commencement_date
+    trainee_start_date
     context
     day
     month
@@ -20,11 +20,11 @@ class TraineeStartStatusForm < TraineeForm
   attr_accessor(*FIELDS)
 
   validates :commencement_status, presence: true
-  validate :commencement_date_valid, if: :itt_started_later?
+  validate :trainee_start_date_valid, if: :itt_started_later?
 
   def save!
     if valid?
-      update_trainee_commencement_date
+      update_trainee_start_date
       Trainees::Update.call(trainee: trainee)
       clear_stash
     else
@@ -32,8 +32,8 @@ class TraineeStartStatusForm < TraineeForm
     end
   end
 
-  def commencement_date
-    @commencement_date ||= begin
+  def trainee_start_date
+    @trainee_start_date ||= begin
       set_on_time_itt_start_date if itt_started_on_time?
       unset_itt_start_date if itt_not_yet_started?
 
@@ -79,7 +79,7 @@ class TraineeStartStatusForm < TraineeForm
 private
 
   def itt_start_date_is_after_deferral_date?
-    deferral_date.is_a?(Date) && commencement_date.after?(deferral_date)
+    deferral_date.is_a?(Date) && trainee_start_date.after?(deferral_date)
   end
 
   def deferral_date
@@ -101,23 +101,23 @@ private
   def compute_fields
     {
       commencement_status: trainee.commencement_status,
-      day: trainee.commencement_date&.day,
-      month: trainee.commencement_date&.month,
-      year: trainee.commencement_date&.year,
+      day: trainee.trainee_start_date&.day,
+      month: trainee.trainee_start_date&.month,
+      year: trainee.trainee_start_date&.year,
     }.merge(new_attributes.slice(:day, :month, :year, :commencement_status, :context))
   end
 
-  def update_trainee_commencement_date
+  def update_trainee_start_date
     return unless errors.empty?
 
-    trainee.assign_attributes(commencement_date: formatted_commencement_date, commencement_status: commencement_status)
+    trainee.assign_attributes(trainee_start_date: formatted_trainee_start_date, commencement_status: commencement_status)
   end
 
   def fields_from_store
     store.get(trainee.id, :trainee_start_status).presence || {}
   end
 
-  def formatted_commencement_date
-    commencement_date.is_a?(Date) ? commencement_date : nil
+  def formatted_trainee_start_date
+    trainee_start_date.is_a?(Date) ? trainee_start_date : nil
   end
 end

--- a/app/forms/withdrawal_form.rb
+++ b/app/forms/withdrawal_form.rb
@@ -7,8 +7,8 @@ class WithdrawalForm < MultiDateForm
   validate :withdraw_reason_valid
   validate :additional_withdraw_reason_valid
 
-  def commencement_date
-    @commencement_date ||= ::TraineeStartStatusForm.new(trainee).commencement_date
+  def trainee_start_date
+    @trainee_start_date ||= ::TraineeStartStatusForm.new(trainee).trainee_start_date
   end
 
   def save!

--- a/app/helpers/dates_helper.rb
+++ b/app/helpers/dates_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module DatesHelper
-  def date_before_itt_start_date?(commencement_date, itt_start_date)
+  def date_before_itt_start_date?(trainee_start_date, itt_start_date)
     return false if itt_start_date.blank?
 
-    commencement_date < itt_start_date
+    trainee_start_date < itt_start_date
   end
 
   def valid_date?(date_args)

--- a/app/lib/bulk_import.rb
+++ b/app/lib/bulk_import.rb
@@ -130,7 +130,7 @@ module BulkImport
         "Street" => assign_field[:address_line_two],
         "Study mode" => method(:to_study_mode) >> assign_field[:study_mode],
         "Town or city" => assign_field[:town_city],
-        "Trainee start date" => assign_field[:commencement_date],
+        "Trainee start date" => assign_field[:trainee_start_date],
         "Training initiative" => method(:to_training_initiative) >> assign_field[:training_initiative],
       }
       column_mapper.default = proc {}

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -173,7 +173,7 @@ module Dqt
       end
 
       def start_date
-        trainee.commencement_date || trainee.itt_start_date
+        trainee.trainee_start_date || trainee.itt_start_date
       end
 
       def estimated_course_duration

--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -21,7 +21,7 @@ module Hesa
         lead_school_urn: "F_SDLEAD",
         mode: "F_MODE",
         course_age_range: "F_ITTPHSC",
-        commencement_date: "F_ITTCOMDATE",
+        trainee_start_date: "F_ITTCOMDATE",
         training_initiative: "F_INITIATIVES1",
         hesa_id: "F_HUSID",
         end_date: "F_ENDDATE",

--- a/app/lib/hpitt.rb
+++ b/app/lib/hpitt.rb
@@ -82,7 +82,7 @@ module HPITT
         "Street" => assign_field[:address_line_two],
         "Study mode" => method(:to_study_mode) >> assign_field[:study_mode],
         "Town or city" => assign_field[:town_city],
-        "Trainee start date" => assign_field[:commencement_date],
+        "Trainee start date" => assign_field[:trainee_start_date],
         "TRN" => assign_field[:trn],
       }
       column_mapper.default = proc {}

--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -101,7 +101,7 @@ module Exports
           "itt_end_date" => itt_end_date(trainee),
           "course_duration_in_years" => trainee.course_duration_in_years,
           "course_summary" => course_summary(trainee, course),
-          "trainee_start_date" => trainee.commencement_date&.iso8601,
+          "trainee_start_date" => trainee.trainee_start_date&.iso8601,
           "lead_school_name" => lead_school_name(trainee),
           "lead_school_urn" => trainee.lead_school&.urn,
           "employing_school_name" => employing_school_name(trainee),

--- a/app/services/find_empty_trainees.rb
+++ b/app/services/find_empty_trainees.rb
@@ -33,7 +33,7 @@ class FindEmptyTrainees
     trainees.additional_withdraw_reason
     trainees.defer_date
     trainees.recommended_for_award_at
-    trainees.commencement_date
+    trainees.trainee_start_date
     trainees.reinstate_date
     trainees.lead_school_id
     trainees.employing_school_id

--- a/app/services/find_new_starter_trainees.rb
+++ b/app/services/find_new_starter_trainees.rb
@@ -8,8 +8,8 @@ class FindNewStarterTrainees
   end
 
   def call
-    trainees = Trainee.where("itt_start_date <= :date or commencement_date <= :date", date: census_date)
-                      .or(Trainee.where(commencement_date: nil))
+    trainees = Trainee.where("itt_start_date <= :date or trainee_start_date <= :date", date: census_date)
+                      .or(Trainee.where(trainee_start_date: nil))
                       .where(start_academic_cycle_id: AcademicCycle.current)
                       .not_draft
 

--- a/app/services/trainees/calculate_itt_end_date.rb
+++ b/app/services/trainees/calculate_itt_end_date.rb
@@ -6,7 +6,7 @@ module Trainees
 
     DURATIONS = %w[hours months days years].freeze
 
-    delegate :commencement_date,
+    delegate :trainee_start_date,
              :itt_start_date,
              :itt_end_date,
              :hesa_metadatum,
@@ -34,7 +34,7 @@ module Trainees
     attr_reader :trainee, :actual
 
     def start_date
-      commencement_date || itt_start_date
+      trainee_start_date || itt_start_date
     end
 
     def course_duration

--- a/app/services/trainees/create_from_dttp.rb
+++ b/app/services/trainees/create_from_dttp.rb
@@ -253,7 +253,7 @@ module Trainees
         course_max_age: age_range && age_range[1],
         course_allocation_subject: course_allocation_subject,
         study_mode: study_mode,
-        commencement_date: commencement_date,
+        trainee_start_date: trainee_start_date,
         itt_start_date: placement_assignment.programme_start_date,
         itt_end_date: placement_assignment.programme_end_date,
       }
@@ -265,7 +265,7 @@ module Trainees
       course(placement_assignment.response["_dfe_ittsubject1id_value"])
     end
 
-    def commencement_date
+    def trainee_start_date
       placement_assignment.response["dfe_commencementdate"] || placement_assignment.programme_start_date
     end
 

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -109,7 +109,7 @@ module Trainees
         study_mode: study_mode,
         itt_start_date: hesa_trainee[:itt_start_date],
         itt_end_date: hesa_trainee[:itt_end_date],
-        commencement_date: hesa_trainee[:commencement_date] || hesa_trainee[:itt_start_date],
+        trainee_start_date: hesa_trainee[:trainee_start_date] || hesa_trainee[:itt_start_date],
       }
 
       primary_education_phase? ? fix_invalid_primary_course_subjects(attributes) : attributes

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -30,7 +30,7 @@ module Trainees
       course_subject_one
       itt_start_date
       itt_end_date
-      commencement_date
+      trainee_start_date
       course_max_age
       course_uuid
       course_subject_two

--- a/app/services/trainees/set_academic_cycles.rb
+++ b/app/services/trainees/set_academic_cycles.rb
@@ -18,7 +18,7 @@ module Trainees
 
     attr_reader :trainee
 
-    delegate :commencement_date,
+    delegate :trainee_start_date,
              :itt_start_date,
              :awarded_at,
              :withdraw_date,
@@ -33,7 +33,7 @@ module Trainees
     end
 
     def start_date
-      commencement_date || itt_start_date
+      trainee_start_date || itt_start_date
     end
 
     def end_date

--- a/app/views/trainees/start_dates/edit.html.erb
+++ b/app/views/trainees/start_dates/edit.html.erb
@@ -11,10 +11,10 @@
       <%= f.hidden_field :context, value: params[:context] %>
 
       <%= render TraineeName::View.new(@trainee) %>
-      <%= f.govuk_date_field :commencement_date, legend: {
-        text: t("views.forms.start_dates.commencement_date.label").html_safe, size: "l", tag: "h1"
+      <%= f.govuk_date_field :trainee_start_date, legend: {
+        text: t("views.forms.start_dates.trainee_start_date.label").html_safe, size: "l", tag: "h1"
       }, hint: {
-        text: t("views.forms.start_dates.commencement_date.hint",
+        text: t("views.forms.start_dates.trainee_start_date.hint",
                 itt_start_date: @trainee.itt_start_date.strftime("%d %m %Y")).html_safe } %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/trainees/start_statuses/edit.html.erb
+++ b/app/views/trainees/start_statuses/edit.html.erb
@@ -29,7 +29,7 @@
 
           <%= f.govuk_radio_button(:commencement_status, :itt_started_later,
                                    label: { text: t('.started_later') }) do %>
-            <%= f.govuk_date_field :commencement_date, legend: {
+            <%= f.govuk_date_field :trainee_start_date, legend: {
               text: t(".trainee_start_date"),
               size: "s",
               class: "govuk-fieldset__legend govuk-fieldset__legend--s govuk-!-font-weight-regular"

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -202,7 +202,7 @@ shared:
     - applying_for_scholarship
     - awarded_at
     - bursary_tier
-    - commencement_date
+    - trainee_start_date
     - commencement_status
     - course_allocation_subject_id
     - course_education_phase

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -191,7 +191,7 @@
   - lead_school_urn
   - mode
   - course_age_range
-  - commencement_date
+  - trainee_start_date
   - training_initiative
   - disability
   - end_date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -469,7 +469,7 @@ en:
           itt_start_date: &itt_start_date ITT start date
           itt_end_date: &itt_end_date ITT end date
           course_subject_one: Course subject updated
-          commencement_date: Trainee start date updated
+          trainee_start_date: Trainee start date updated
           trainee_id: Trainee ID updated
           disability_disclosure: Disability disclosures updated
           diversity_disclosure: Diversity disclosures updated
@@ -616,8 +616,8 @@ en:
         lead_school_id: &lead_school_path edit_trainee_lead_schools_path
         employing_school_id: edit_trainee_employing_schools_path
         school_id: *lead_school_path
-        commencement_date: &commencement_date_path edit_trainee_start_date_path
-        commencement_date_radio_option: *commencement_date_path
+        trainee_start_date: &trainee_start_date_path edit_trainee_start_date_path
+        trainee_start_date_radio_option: *trainee_start_date_path
         trainee_id: edit_trainee_training_details_path
         study_mode: *course_path
         primary_course_subjects: *course_path
@@ -664,8 +664,8 @@ en:
         lead_school_id: *lead_school
         employing_school_id: *employing_school
         school_id: *lead_school
-        commencement_date: *trainee_start_date
-        commencement_date_radio_option: Trainee’s start date
+        trainee_start_date: *trainee_start_date
+        trainee_start_date_radio_option: Trainee’s start date
         trainee_id: *trainee_id
         study_mode: *study_mode
         primary_course_subjects: *course_subject
@@ -802,7 +802,7 @@ en:
             This will help you to identify them and search for them in your trainee records.
             We may also use it if we need to get in touch with you about this trainee.
       start_dates:
-        commencement_date:
+        trainee_start_date:
           label: When did the trainee start their ITT?
           hint: Their ITT started on %{itt_start_date}
       publish_course_details:
@@ -1483,7 +1483,7 @@ en:
               invalid: Select a withdrawal reason
         trainee_start_date_form:
           attributes:
-            commencement_date:
+            trainee_start_date:
               blank: Enter a start date
               invalid: Enter a valid start date
               not_after_itt_end_date_html: Trainee start date must not be after the ITT has finished <span class="no-wrap">(%{itt_end_date})</span>
@@ -1491,7 +1491,7 @@ en:
               too_old: Trainee start date cannot be more than 10 years in the past
         trainee_start_status_form:
           attributes:
-            commencement_date:
+            trainee_start_date:
               blank: Enter a start date
               invalid: Enter a valid start date
               not_after_itt_end_date_html: Trainee start date must not be after the ITT has finished <span class="no-wrap">(%{itt_end_date})</span>

--- a/db/migrate/20220906140208_rename_commencement_date_to_trainee_start_date.rb
+++ b/db/migrate/20220906140208_rename_commencement_date_to_trainee_start_date.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RenameCommencementDateToTraineeStartDate < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :trainees, :commencement_date, :trainee_start_date
+    rename_column :hesa_students, :commencement_date, :trainee_start_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_12_143158) do
+ActiveRecord::Schema.define(version: 2022_09_06_140208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -461,7 +461,7 @@ ActiveRecord::Schema.define(version: 2022_08_12_143158) do
     t.string "lead_school_urn"
     t.string "mode"
     t.string "course_age_range"
-    t.string "commencement_date"
+    t.string "trainee_start_date"
     t.string "training_initiative"
     t.string "disability"
     t.string "end_date"
@@ -644,7 +644,7 @@ ActiveRecord::Schema.define(version: 2022_08_12_143158) do
     t.string "slug", null: false
     t.datetime "recommended_for_award_at"
     t.string "dttp_update_sha"
-    t.date "commencement_date"
+    t.date "trainee_start_date"
     t.date "reinstate_date"
     t.uuid "dormancy_dttp_id"
     t.bigint "lead_school_id"

--- a/docs/adr/0007-store-academic-cycles-on-trainees.md
+++ b/docs/adr/0007-store-academic-cycles-on-trainees.md
@@ -48,8 +48,8 @@ trainees.
 
 Rules for determining start academic cycle:
 
-1. Use the trainee's commencement date.
-2. If commencement date is missing, use their ITT start date.
+1. Use the trainee's start date.
+2. If trainee start date is missing, use their ITT start date.
 3. If the ITT start date is missing, default to the current cycle.
 
 Rules for determining end academic cycle:

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -209,9 +209,9 @@ namespace :example_data do
 
             end
 
-            # Make *roughly* 25% of submitted_for_trn trainees not have a commencement date
+            # Make *roughly* 25% of submitted_for_trn trainees not have a trainee start date
             if state == :submitted_for_trn && sample_index < sample_size * 25.0 / 100
-              attrs.merge!(commencement_date: nil)
+              attrs.merge!(trainee_start_date: nil)
             end
 
             # Make 75% of drafts (both apply and manual) incomplete

--- a/spec/components/application_record_card/view_spec.rb
+++ b/spec/components/application_record_card/view_spec.rb
@@ -124,7 +124,7 @@ module ApplicationRecordCard
           training_route: TRAINING_ROUTE_ENUMS[:assessment_only],
           trainee_id: "132456",
           trn: "789456",
-          commencement_date: DateTime.new(2020, 1, 2),
+          trainee_start_date: DateTime.new(2020, 1, 2),
           provider: provider,
           state: state,
         )

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -119,7 +119,7 @@ module Pages
                       ),
                       diversity_disclosure: 1,
                       degrees: [Degree.new(id: 1, locale_code: 1, subject: "subject")],
-                      commencement_date: Time.zone.now,
+                      trainee_start_date: Time.zone.now,
                       training_initiative: ROUTE_INITIATIVES_ENUMS[:transition_to_teach],
                       applying_for_bursary: true,
                       provider: Provider.new)

--- a/spec/components/record_actions/view_spec.rb
+++ b/spec/components/record_actions/view_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe RecordActions::View do
   end
 
   context "when the trainee has missing fields" do
-    let(:trainee) { build(:trainee, :submitted_for_trn, :itt_start_date_in_the_past, commencement_date: nil) }
+    let(:trainee) { build(:trainee, :submitted_for_trn, :itt_start_date_in_the_past, trainee_start_date: nil) }
 
     subject { render_inline(described_class.new(trainee, has_missing_fields: true)).text }
 

--- a/spec/components/record_details/view_preview.rb
+++ b/spec/components/record_details/view_preview.rb
@@ -70,7 +70,7 @@ module RecordDetails
         defer_date: state == :deferred ? Time.zone.today : nil,
         withdraw_date: state == :withdrawn ? Time.zone.today : nil,
         recommended_for_award_at: state == :recommended_for_award ? Time.zone.now : nil,
-        commencement_date: Time.zone.now,
+        trainee_start_date: Time.zone.now,
         commencement_status: commencement_status,
         awarded_at: state == :awarded ? Time.zone.now : nil,
         provider: mock_provider,

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -195,16 +195,16 @@ module RecordDetails
           trainee.itt_start_date = 5.days.ago.to_date
         end
 
-        context "commencement_date is set" do
-          let(:commencement_date) { 5.days.from_now.to_date }
+        context "trainee_start_date is set" do
+          let(:trainee_start_date) { 5.days.from_now.to_date }
 
           before do
-            trainee.commencement_date = commencement_date
+            trainee.trainee_start_date = trainee_start_date
             render_inline(View.new(trainee: trainee, last_updated_event: timeline_event, editable: true))
           end
 
-          it "renders commencement_date" do
-            expect(rendered_component).to have_text(date_for_summary_view(commencement_date))
+          it "renders trainee_start_date" do
+            expect(rendered_component).to have_text(date_for_summary_view(trainee_start_date))
           end
 
           it "renders link to trainee start date form" do
@@ -213,9 +213,9 @@ module RecordDetails
           end
         end
 
-        context "commencement_date is not set" do
+        context "trainee_start_date is not set" do
           before do
-            trainee.commencement_date = nil
+            trainee.trainee_start_date = nil
             render_inline(View.new(trainee: trainee, last_updated_event: timeline_event, editable: true))
           end
 

--- a/spec/components/trainee_start_date/view_preview.rb
+++ b/spec/components/trainee_start_date/view_preview.rb
@@ -11,7 +11,7 @@ module TraineeStartDate
   private
 
     def mock_trainee
-      @mock_trainee ||= Trainee.new(commencement_date: Time.zone.today)
+      @mock_trainee ||= Trainee.new(trainee_start_date: Time.zone.today)
     end
   end
 end

--- a/spec/components/trainee_start_date/view_spec.rb
+++ b/spec/components/trainee_start_date/view_spec.rb
@@ -6,17 +6,17 @@ module TraineeStartDate
   describe View do
     include SummaryHelper
 
-    let(:commencement_date) { Time.zone.today }
+    let(:trainee_start_date) { Time.zone.today }
 
     context "when data has been provided" do
-      let(:trainee) { create(:trainee, commencement_date: commencement_date) }
+      let(:trainee) { create(:trainee, trainee_start_date: trainee_start_date) }
 
       before do
         render_inline(View.new(data_model: trainee))
       end
 
       it "renders the trainee start date" do
-        expect(rendered_component).to have_text(date_for_summary_view(commencement_date))
+        expect(rendered_component).to have_text(date_for_summary_view(trainee_start_date))
       end
     end
   end

--- a/spec/components/trainee_start_status/view_preview.rb
+++ b/spec/components/trainee_start_status/view_preview.rb
@@ -15,7 +15,7 @@ module TraineeStartStatus
   private
 
     def mock_trainee
-      @mock_trainee ||= Trainee.new(commencement_date: Time.zone.today)
+      @mock_trainee ||= Trainee.new(trainee_start_date: Time.zone.today)
     end
   end
 end

--- a/spec/components/trainee_start_status/view_spec.rb
+++ b/spec/components/trainee_start_status/view_spec.rb
@@ -6,8 +6,8 @@ module TraineeStartStatus
   describe View do
     include SummaryHelper
 
-    let(:commencement_date) { Time.zone.today }
-    let(:trainee) { create(:trainee, commencement_date: commencement_date) }
+    let(:trainee_start_date) { Time.zone.today }
+    let(:trainee) { create(:trainee, trainee_start_date: trainee_start_date) }
 
     before do
       render_inline(View.new(data_model: trainee))
@@ -15,7 +15,7 @@ module TraineeStartStatus
 
     context "when data has been provided" do
       it "renders the trainee start date" do
-        expect(rendered_component).to have_text(date_for_summary_view(commencement_date))
+        expect(rendered_component).to have_text(date_for_summary_view(trainee_start_date))
       end
     end
 

--- a/spec/components/withdrawal_details/view_spec.rb
+++ b/spec/components/withdrawal_details/view_spec.rb
@@ -5,13 +5,13 @@ require "rails_helper"
 describe WithdrawalDetails::View do
   include SummaryHelper
 
-  let(:trainee) { build(:trainee, withdraw_date: 2.days.ago, commencement_date: 3.days.ago, id: 1) }
+  let(:trainee) { build(:trainee, withdraw_date: 2.days.ago, trainee_start_date: 3.days.ago, id: 1) }
   let(:withdraw_date) { trainee.withdraw_date }
   let(:withdraw_reason) { nil }
   let(:additional_withdraw_reason) { nil }
 
   let(:data_model) do
-    OpenStruct.new(trainee: trainee, commencement_date: trainee.commencement_date, date: withdraw_date, withdraw_reason: withdraw_reason, additional_withdraw_reason: additional_withdraw_reason)
+    OpenStruct.new(trainee: trainee, trainee_start_date: trainee.trainee_start_date, date: withdraw_date, withdraw_reason: withdraw_reason, additional_withdraw_reason: additional_withdraw_reason)
   end
 
   before do
@@ -19,8 +19,8 @@ describe WithdrawalDetails::View do
   end
 
   context "withdrawn on another day" do
-    it "renders commencement date" do
-      expect(rendered_component).to have_text(date_for_summary_view(trainee.commencement_date))
+    it "renders trainee start date" do
+      expect(rendered_component).to have_text(date_for_summary_view(trainee.trainee_start_date))
     end
 
     it "renders the date of withdrawal" do

--- a/spec/controllers/trainees/start_statuses_controller_spec.rb
+++ b/spec/controllers/trainees/start_statuses_controller_spec.rb
@@ -15,9 +15,9 @@ describe Trainees::StartStatusesController, type: :controller do
              trainee_id: trainee,
              trainee_start_status_form: {
                "commencement_status" => "itt_started_on_time",
-               "commencement_date(3i)" => "",
-               "commencement_date(2i)" => "",
-               "commencement_date(1i)" => "",
+               "trainee_start_date(3i)" => "",
+               "trainee_start_date(2i)" => "",
+               "trainee_start_date(1i)" => "",
                context: page_context,
              },
            })
@@ -78,7 +78,7 @@ describe Trainees::StartStatusesController, type: :controller do
         end
       end
 
-      context "withdrawal form has started and the commencement date is before the withdrawal date" do
+      context "withdrawal form has started and the trainee start date is before the withdrawal date" do
         let(:trainee) { create(:trainee, :submitted_for_trn, :with_withdrawal_date) }
         let(:page_context) { :withdraw }
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -87,7 +87,7 @@ FactoryBot.define do
       international_address { nil }
       locale_code { nil }
       email { nil }
-      commencement_date { nil }
+      trainee_start_date { nil }
     end
 
     trait :in_progress do
@@ -232,7 +232,7 @@ FactoryBot.define do
     end
 
     trait :with_start_date do
-      commencement_date do
+      trainee_start_date do
         if itt_start_date.present?
           Faker::Date.between(from: itt_start_date, to: itt_start_date + rand(20).days)
         else
@@ -503,7 +503,7 @@ FactoryBot.define do
 
         trainee.course_allocation_subject = funding_method.allocation_subjects.first
         trainee.training_route = funding_method.training_route
-        trainee.commencement_date = funding_method.academic_cycle.start_date
+        trainee.trainee_start_date = funding_method.academic_cycle.start_date
       end
     end
 
@@ -514,7 +514,7 @@ FactoryBot.define do
         funding_method = create(:funding_method, :grant, :with_subjects, training_route: :early_years_salaried)
         trainee.course_allocation_subject = funding_method.allocation_subjects.first
         trainee.training_route = funding_method.training_route
-        trainee.commencement_date = funding_method.academic_cycle.start_date
+        trainee.trainee_start_date = funding_method.academic_cycle.start_date
       end
     end
 
@@ -525,7 +525,7 @@ FactoryBot.define do
         funding_method = create(:funding_method, :scholarship, :with_subjects, training_route: :provider_led_postgrad)
         trainee.course_allocation_subject = funding_method.allocation_subjects.first
         trainee.training_route = funding_method.training_route
-        trainee.commencement_date = funding_method.academic_cycle.start_date
+        trainee.trainee_start_date = funding_method.academic_cycle.start_date
       end
     end
 
@@ -543,7 +543,7 @@ FactoryBot.define do
 
         trainee.course_allocation_subject = funding_method.allocation_subjects.first
         trainee.training_route = funding_method.training_route
-        trainee.commencement_date = funding_method.academic_cycle.start_date
+        trainee.trainee_start_date = funding_method.academic_cycle.start_date
       end
     end
 

--- a/spec/features/form_sections/teacher_training_data/edit_trainee_start_date_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_trainee_start_date_spec.rb
@@ -23,7 +23,7 @@ feature "edit Trainee start date" do
   end
 
   scenario "start date is not set" do
-    given_a_trainee_exists(:submitted_for_trn, commencement_date: nil)
+    given_a_trainee_exists(:submitted_for_trn, trainee_start_date: nil)
     when_i_visit_the_edit_trainee_start_date_page
     then_i_am_redirected_to_the_edit_trainee_start_status_page
   end
@@ -33,7 +33,7 @@ feature "edit Trainee start date" do
   end
 
   def when_i_change_the_start_date
-    trainee_start_date_edit_page.set_date_fields(:commencement_date, new_start_date.strftime("%d/%m/%Y"))
+    trainee_start_date_edit_page.set_date_fields(:trainee_start_date, new_start_date.strftime("%d/%m/%Y"))
   end
 
   def when_i_click_continue

--- a/spec/features/form_sections/teacher_training_data/edit_trainee_start_status_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_trainee_start_status_spec.rb
@@ -80,7 +80,7 @@ feature "edit Trainee start status" do
   end
 
   def when_i_change_the_start_date
-    trainee_start_status_edit_page.set_date_fields(:commencement_date, new_start_date.strftime("%d/%m/%Y"))
+    trainee_start_status_edit_page.set_date_fields(:trainee_start_date, new_start_date.strftime("%d/%m/%Y"))
   end
 
   def when_i_click_continue

--- a/spec/features/trainee_actions/defer_trainee_spec.rb
+++ b/spec/features/trainee_actions/defer_trainee_spec.rb
@@ -248,7 +248,7 @@ feature "Deferring a trainee", type: :feature do
 
   def and_i_enter_a_start_date_after_the_deferral_date
     new_start_date = trainee.defer_date + 1.day
-    trainee_start_status_edit_page.set_date_fields(:commencement_date, new_start_date.strftime("%d/%m/%Y"))
+    trainee_start_status_edit_page.set_date_fields(:trainee_start_date, new_start_date.strftime("%d/%m/%Y"))
   end
 
   def given_a_trainee_exists_to_be_deferred
@@ -257,7 +257,7 @@ feature "Deferring a trainee", type: :feature do
 
   def given_a_trainee_exists_with_a_deferral_date
     given_a_trainee_exists(%i[submitted_for_trn trn_received].sample,
-                           commencement_date: 1.month.ago,
+                           trainee_start_date: 1.month.ago,
                            itt_start_date: 1.year.ago,
                            itt_end_date: 1.year.from_now,
                            defer_date: 1.week.ago)
@@ -265,13 +265,13 @@ feature "Deferring a trainee", type: :feature do
 
   def given_a_trainee_with_course_starting_in_the_future_exists
     given_a_trainee_exists(%i[submitted_for_trn trn_received].sample,
-                           commencement_date: nil,
+                           trainee_start_date: nil,
                            itt_start_date: Time.zone.today + 1.day)
   end
 
   def given_a_trainee_with_course_started_in_the_past_exists
     given_a_trainee_exists(%i[submitted_for_trn trn_received].sample,
-                           commencement_date: nil,
+                           trainee_start_date: nil,
                            itt_start_date: Time.zone.today - 1.day)
   end
 

--- a/spec/features/trainee_actions/delete_trainee_spec.rb
+++ b/spec/features/trainee_actions/delete_trainee_spec.rb
@@ -56,7 +56,7 @@ private
     given_a_trainee_exists(:trn_received,
                            :with_publish_course_details,
                            itt_start_date: 10.days.ago,
-                           commencement_date: nil)
+                           trainee_start_date: nil)
   end
 
   def given_a_trainee_thats_deleted

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -202,13 +202,13 @@ private
 
   def given_an_incomplete_hesa_trainee_exists
     @incomplete_hesa_trainee ||= create(:trainee, :imported_from_hesa, :submitted_for_trn)
-    @incomplete_hesa_trainee.update(commencement_date: nil)
+    @incomplete_hesa_trainee.update(trainee_start_date: nil)
     Trainee.update_all(provider_id: @current_user.organisation.id)
   end
 
   def given_an_incomplete_withdrawn_trainee_exists
     @incomplete_withdrawn_trainee ||= create(:trainee, :submitted_for_trn, :withdrawn)
-    @incomplete_withdrawn_trainee.update(commencement_date: nil)
+    @incomplete_withdrawn_trainee.update(trainee_start_date: nil)
     Trainee.update_all(provider_id: @current_user.organisation.id)
   end
 
@@ -284,7 +284,7 @@ private
   end
 
   def when_i_filter_by_incomplete
-    @incomplete_trainee.update(commencement_date: nil)
+    @incomplete_trainee.update(trainee_start_date: nil)
     trainee_index_page.incomplete_checkbox.check
     trainee_index_page.apply_filters.click
   end

--- a/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
+++ b/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
@@ -41,7 +41,7 @@ feature "View trainees" do
   end
 
   context "when i am a lead school user", feature_user_can_have_multiple_organisations: true do
-    let(:trainee) { create(:trainee, :submitted_for_trn, commencement_date: nil, lead_school: @current_user.lead_schools.first) }
+    let(:trainee) { create(:trainee, :submitted_for_trn, trainee_start_date: nil, lead_school: @current_user.lead_schools.first) }
 
     background { given_i_am_authenticated_as_a_lead_school_user }
 

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -302,7 +302,7 @@ feature "Withdrawing a trainee", type: :feature do
   def given_a_trainee_exists_to_be_withdrawn
     given_a_trainee_exists(
       %i[submitted_for_trn trn_received].sample,
-      commencement_date: 10.days.ago,
+      trainee_start_date: 10.days.ago,
       itt_end_date: 1.year.from_now,
     )
   end
@@ -310,7 +310,7 @@ feature "Withdrawing a trainee", type: :feature do
   def given_a_trainee_exists_to_be_withdrawn_with_no_start_date
     given_a_trainee_exists(
       %i[submitted_for_trn trn_received].sample,
-      commencement_date: nil,
+      trainee_start_date: nil,
       itt_end_date: 1.year.from_now,
     )
   end
@@ -392,7 +392,7 @@ feature "Withdrawing a trainee", type: :feature do
   end
 
   def and_i_fill_in_a_new_start_date(date)
-    trainee_start_status_edit_page.set_date_fields("commencement_date", date.strftime("%d/%m/%Y"))
+    trainee_start_status_edit_page.set_date_fields("trainee_start_date", date.strftime("%d/%m/%Y"))
   end
 
   def and_integrate_with_dqt_feature_is_active

--- a/spec/forms/deferral_form_spec.rb
+++ b/spec/forms/deferral_form_spec.rb
@@ -125,7 +125,7 @@ describe DeferralForm, type: :model do
     end
 
     context "when start date is changed" do
-      let(:trainee) { create(:trainee, :deferred, commencement_date: nil) }
+      let(:trainee) { create(:trainee, :deferred, trainee_start_date: nil) }
 
       before do
         allow(FormStore).to receive(:get).with(trainee.id, :trainee_start_status).and_return({
@@ -140,7 +140,7 @@ describe DeferralForm, type: :model do
         expect(FormStore).to receive(:set).with(trainee.id, :trainee_start_status, nil)
         expect(FormStore).to receive(:set).with(trainee.id, :start_date_verification, nil)
 
-        expect { subject.save! }.to change(trainee, :commencement_date).to(Date.parse("21-9-2021"))
+        expect { subject.save! }.to change(trainee, :trainee_start_date).to(Date.parse("21-9-2021"))
       end
     end
   end

--- a/spec/forms/reinstatement_form_spec.rb
+++ b/spec/forms/reinstatement_form_spec.rb
@@ -82,15 +82,15 @@ describe ReinstatementForm, type: :model do
 
     context "itt start date is in the future" do
       let(:trainee) do
-        create(:trainee, :deferred, commencement_date: nil, itt_start_date: Time.zone.today + 1.day)
+        create(:trainee, :deferred, trainee_start_date: nil, itt_start_date: Time.zone.today + 1.day)
       end
 
       before do
         allow(form_store).to receive(:set).with(trainee.id, :reinstatement, nil)
       end
 
-      it "saves the reinstatement date as the commencement date" do
-        expect { subject.save! }.to change(trainee, :commencement_date).to(Date.new(*expected_date_params))
+      it "saves the reinstatement date as the trainee start date" do
+        expect { subject.save! }.to change(trainee, :trainee_start_date).to(Date.new(*expected_date_params))
       end
     end
   end

--- a/spec/forms/start_date_verification_form_spec.rb
+++ b/spec/forms/start_date_verification_form_spec.rb
@@ -39,7 +39,7 @@ describe StartDateVerificationForm, type: :model do
       expect {
         subject.save!
       }.to change(trainee, :commencement_status).to("itt_not_yet_started")
-      .and change(trainee, :commencement_date).to(nil)
+      .and change(trainee, :trainee_start_date).to(nil)
     end
   end
 end

--- a/spec/forms/submissions/missing_data_validator_spec.rb
+++ b/spec/forms/submissions/missing_data_validator_spec.rb
@@ -48,7 +48,7 @@ module Submissions
 
       context "when trainee start date is missing" do
         context "and the course has not started" do
-          let(:trainee) { build(:trainee, :submitted_for_trn, :itt_start_date_in_the_future, commencement_date: nil) }
+          let(:trainee) { build(:trainee, :submitted_for_trn, :itt_start_date_in_the_future, trainee_start_date: nil) }
 
           it "returns an empty array" do
             expect(subject.missing_fields).to be_empty
@@ -56,10 +56,10 @@ module Submissions
         end
 
         context "and the course has already started" do
-          let(:trainee) { build(:trainee, :submitted_for_trn, :itt_start_date_in_the_past, commencement_date: nil) }
+          let(:trainee) { build(:trainee, :submitted_for_trn, :itt_start_date_in_the_past, trainee_start_date: nil) }
 
           it "returns the correct attributes from the invalid form" do
-            expect(subject.missing_fields).to contain_exactly(:commencement_date)
+            expect(subject.missing_fields).to contain_exactly(:trainee_start_date)
           end
         end
       end

--- a/spec/forms/trainee_start_date_form_spec.rb
+++ b/spec/forms/trainee_start_date_form_spec.rb
@@ -6,7 +6,7 @@ describe TraineeStartDateForm, type: :model do
   let(:params) { { year: "2020", month: "12", day: "20" } }
   let(:trainee) { build(:trainee, :incomplete) }
   let(:form_store) { class_double(FormStore) }
-  let(:error_attr) { "activemodel.errors.models.trainee_start_date_form.attributes.commencement_date" }
+  let(:error_attr) { "activemodel.errors.models.trainee_start_date_form.attributes.trainee_start_date" }
 
   subject { described_class.new(trainee, params: params, store: form_store) }
 
@@ -21,7 +21,7 @@ describe TraineeStartDateForm, type: :model do
       let(:params) { { day: 20, month: 20, year: 2020 } }
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.invalid"))
+        expect(subject.errors[:trainee_start_date]).to include(I18n.t("#{error_attr}.invalid"))
       end
     end
 
@@ -29,7 +29,7 @@ describe TraineeStartDateForm, type: :model do
       let(:params) { { day: "", month: "", year: "" } }
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.blank"))
+        expect(subject.errors[:trainee_start_date]).to include(I18n.t("#{error_attr}.blank"))
       end
     end
 
@@ -39,7 +39,7 @@ describe TraineeStartDateForm, type: :model do
       end
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include(
+        expect(subject.errors[:trainee_start_date]).to include(
           I18n.t(
             "#{error_attr}.not_after_itt_end_date_html",
             itt_end_date: trainee.itt_end_date.strftime("%-d %B %Y"),
@@ -54,7 +54,7 @@ describe TraineeStartDateForm, type: :model do
       let(:params) { { year: "2009", month: "12", day: "20" } }
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.too_old"))
+        expect(subject.errors[:trainee_start_date]).to include(I18n.t("#{error_attr}.too_old"))
       end
     end
   end
@@ -78,7 +78,7 @@ describe TraineeStartDateForm, type: :model do
 
     it "takes any data from the form store and saves it to the database" do
       date_params = params.values.map(&:to_i)
-      expect { subject.save! }.to change(trainee, :commencement_date).to(Date.new(*date_params))
+      expect { subject.save! }.to change(trainee, :trainee_start_date).to(Date.new(*date_params))
     end
   end
 end

--- a/spec/forms/trainee_start_status_form_spec.rb
+++ b/spec/forms/trainee_start_status_form_spec.rb
@@ -6,7 +6,7 @@ describe TraineeStartStatusForm, type: :model do
   let(:params) { { year: "2020", month: "12", day: "20", commencement_status: "itt_started_later" } }
   let(:trainee) { build(:trainee, :incomplete) }
   let(:form_store) { class_double(FormStore) }
-  let(:error_attr) { "activemodel.errors.models.trainee_start_status_form.attributes.commencement_date" }
+  let(:error_attr) { "activemodel.errors.models.trainee_start_status_form.attributes.trainee_start_date" }
 
   subject { described_class.new(trainee, params: params, store: form_store) }
 
@@ -30,7 +30,7 @@ describe TraineeStartStatusForm, type: :model do
       let(:params) { { day: 20, month: 20, year: 2020, commencement_status: "itt_started_later" } }
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.invalid"))
+        expect(subject.errors[:trainee_start_date]).to include(I18n.t("#{error_attr}.invalid"))
       end
     end
 
@@ -38,7 +38,7 @@ describe TraineeStartStatusForm, type: :model do
       let(:params) { { day: "", month: "", year: "", commencement_status: "itt_started_later" } }
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.blank"))
+        expect(subject.errors[:trainee_start_date]).to include(I18n.t("#{error_attr}.blank"))
       end
 
       context "when trainee started on time" do
@@ -47,7 +47,7 @@ describe TraineeStartStatusForm, type: :model do
         let(:trainee) { build(:trainee, itt_start_date: Time.zone.today) }
 
         it "uses the trainee's itt_start_date" do
-          expect(subject.commencement_date).to eq(trainee.itt_start_date)
+          expect(subject.trainee_start_date).to eq(trainee.itt_start_date)
         end
 
         it "is valid" do
@@ -58,8 +58,8 @@ describe TraineeStartStatusForm, type: :model do
       context "when trainee did not start yet" do
         let(:params) { { day: "20", month: "12", year: "2020", commencement_status: "itt_not_yet_started" } }
 
-        it "unsets the trainee's commencement_date" do
-          expect(subject.commencement_date).to have_attributes(year: nil, month: nil, day: nil)
+        it "unsets the trainee's trainee_start_date" do
+          expect(subject.trainee_start_date).to have_attributes(year: nil, month: nil, day: nil)
         end
 
         it "is valid" do
@@ -74,7 +74,7 @@ describe TraineeStartStatusForm, type: :model do
       end
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include(
+        expect(subject.errors[:trainee_start_date]).to include(
           I18n.t(
             "#{error_attr}.not_after_itt_end_date_html",
             itt_end_date: trainee.itt_end_date.strftime("%-d %B %Y"),
@@ -89,7 +89,7 @@ describe TraineeStartStatusForm, type: :model do
       let(:params) { { year: "2009", month: "12", day: "20", commencement_status: "itt_started_later" } }
 
       it "is invalid" do
-        expect(subject.errors[:commencement_date]).to include(I18n.t("#{error_attr}.too_old"))
+        expect(subject.errors[:trainee_start_date]).to include(I18n.t("#{error_attr}.too_old"))
       end
     end
   end
@@ -115,7 +115,7 @@ describe TraineeStartStatusForm, type: :model do
       date_params = params.values.map(&:to_i)
       expect {
         subject.save!
-      }.to change(trainee, :commencement_date).to(Date.new(*date_params))
+      }.to change(trainee, :trainee_start_date).to(Date.new(*date_params))
       .and change(trainee, :commencement_status).to("itt_started_later")
     end
   end

--- a/spec/forms/training_details_form_spec.rb
+++ b/spec/forms/training_details_form_spec.rb
@@ -30,7 +30,7 @@ describe TrainingDetailsForm, type: :model do
       end
 
       context "over 100 characters" do
-        let(:trainee) { build(:trainee, commencement_date: Time.zone.today, trainee_id: SecureRandom.alphanumeric(101)) }
+        let(:trainee) { build(:trainee, trainee_start_date: Time.zone.today, trainee_id: SecureRandom.alphanumeric(101)) }
 
         it "returns a max character exceeded message" do
           expect(subject).not_to be_valid
@@ -41,7 +41,7 @@ describe TrainingDetailsForm, type: :model do
       end
 
       context "under 100 characters" do
-        let(:trainee) { build(:trainee, commencement_date: Time.zone.today, trainee_id: SecureRandom.alphanumeric(99)) }
+        let(:trainee) { build(:trainee, trainee_start_date: Time.zone.today, trainee_id: SecureRandom.alphanumeric(99)) }
 
         it "is valid" do
           expect(subject).to be_valid

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -72,7 +72,7 @@ module Dqt
               let(:training_route) { "provider_led_undergrad" }
 
               it "calculates the end date using the course duration data" do
-                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 70.months).iso8601)
+                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.trainee_start_date + 70.months).iso8601)
               end
             end
 
@@ -80,7 +80,7 @@ module Dqt
               let(:training_route) { "school_direct_tuition_fee" }
 
               it "calculates the end date using the course duration data" do
-                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 22.months).iso8601)
+                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.trainee_start_date + 22.months).iso8601)
               end
             end
           end
@@ -92,7 +92,7 @@ module Dqt
               let(:training_route) { "provider_led_undergrad" }
 
               it "calculates the end date using the course duration data" do
-                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 34.months).iso8601)
+                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.trainee_start_date + 34.months).iso8601)
               end
             end
 
@@ -100,7 +100,7 @@ module Dqt
               let(:training_route) { "school_direct_tuition_fee" }
 
               it "calculates the end date using the course duration data" do
-                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 10.months).iso8601)
+                expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.trainee_start_date + 10.months).iso8601)
               end
             end
           end
@@ -110,7 +110,7 @@ module Dqt
             let(:training_route) { "opt_in_undergrad" }
 
             it "calculates the end date using the course duration data" do
-              expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.commencement_date + 22.months).iso8601)
+              expect(subject["initialTeacherTraining"]).to include("programmeEndDate" => (trainee.trainee_start_date + 22.months).iso8601)
             end
           end
         end

--- a/spec/lib/hesa/parsers/itt_record_spec.rb
+++ b/spec/lib/hesa/parsers/itt_record_spec.rb
@@ -30,7 +30,7 @@ module Hesa
             itt_end_date: "2017-10-01",
             mode: "01",
             course_age_range: "13909",
-            commencement_date: nil,
+            trainee_start_date: nil,
             training_initiative: "009",
             hesa_id: "0310261553101",
             reason_for_leaving: nil,

--- a/spec/lib/tasks/bulk_import_spec.rb
+++ b/spec/lib/tasks/bulk_import_spec.rb
@@ -83,7 +83,7 @@ describe "bulk_import:import" do
     expect(trainee.training_route).to eq "school_direct_salaried"
     expect(trainee.training_initiative).to eq "no_initiative"
     expect(trainee.trainee_id).to eq "L0V3LYiD"
-    expect(trainee.commencement_date).to eq Date.parse("01/09/2021")
+    expect(trainee.trainee_start_date).to eq Date.parse("01/09/2021")
 
     expect(trainee.degrees.count).to eq 1
     degree = trainee.degrees.first

--- a/spec/lib/tasks/hpitt_import_spec.rb
+++ b/spec/lib/tasks/hpitt_import_spec.rb
@@ -92,7 +92,7 @@ describe "hpitt:import" do
     expect(trainee.training_initiative).to eq "no_initiative"
     expect(trainee.trn).to eq "1234"
     expect(trainee.trainee_id).to eq "L0V3LYiD"
-    expect(trainee.commencement_date).to eq Date.parse("13/04/2021")
+    expect(trainee.trainee_start_date).to eq Date.parse("13/04/2021")
 
     expect(trainee.progress.attributes.values).to all be(true)
 

--- a/spec/models/academic_cycle_spec.rb
+++ b/spec/models/academic_cycle_spec.rb
@@ -31,31 +31,31 @@ describe AcademicCycle, type: :model do
 
     subject { academic_cycle.trainees_starting }
 
-    context "a trainee with commencement_date in the cycle" do
-      let(:trainee) { create(:trainee, commencement_date: academic_cycle.start_date, itt_start_date: nil) }
+    context "a trainee with trainee_start_date in the cycle" do
+      let(:trainee) { create(:trainee, trainee_start_date: academic_cycle.start_date, itt_start_date: nil) }
 
       it { is_expected.to match_array([trainee]) }
     end
 
     context "a trainee with itt_start_date in the cycle" do
-      let(:trainee) { create(:trainee, itt_start_date: academic_cycle.start_date, commencement_date: nil) }
+      let(:trainee) { create(:trainee, itt_start_date: academic_cycle.start_date, trainee_start_date: nil) }
 
       it { is_expected.to match_array([trainee]) }
     end
 
-    context "a trainee with commencement_date in the cycle and itt_start_date outside the cycle" do
+    context "a trainee with trainee_start_date in the cycle and itt_start_date outside the cycle" do
       let(:trainee) do
-        create(:trainee, itt_start_date: academic_cycle.start_date - 1.day, commencement_date: academic_cycle.start_date)
+        create(:trainee, itt_start_date: academic_cycle.start_date - 1.day, trainee_start_date: academic_cycle.start_date)
       end
 
-      it "returns the trainee having preferred commencement date" do
+      it "returns the trainee having preferred trainee start date" do
         expect(subject).to match_array([trainee])
       end
     end
 
     context "a trainee with commencment_date outside the cycle and itt_start_date inside the cycle" do
       let(:trainee) do
-        create(:trainee, itt_start_date: academic_cycle.start_date, commencement_date: academic_cycle.start_date - 1.day)
+        create(:trainee, itt_start_date: academic_cycle.start_date, trainee_start_date: academic_cycle.start_date - 1.day)
       end
 
       it "does not return the trainee" do
@@ -64,13 +64,13 @@ describe AcademicCycle, type: :model do
     end
 
     context "a trainee that didn't start in the cycle" do
-      let(:trainee) { create(:trainee, commencement_date: academic_cycle.start_date - 1.day, itt_start_date: nil) }
+      let(:trainee) { create(:trainee, trainee_start_date: academic_cycle.start_date - 1.day, itt_start_date: nil) }
 
       it { is_expected.to be_empty }
     end
 
     context "a trainee with no start dates" do
-      let(:trainee) { create(:trainee, :draft, itt_start_date: nil, commencement_date: nil) }
+      let(:trainee) { create(:trainee, :draft, itt_start_date: nil, trainee_start_date: nil) }
 
       context "the current cycle" do
         let(:academic_cycle) { build(:academic_cycle, :current) }

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -110,7 +110,7 @@ module Exports
           "itt_end_date" => trainee.itt_end_date&.iso8601,
           "course_duration_in_years" => trainee.course_duration_in_years,
           "course_summary" => course&.summary,
-          "trainee_start_date" => trainee.commencement_date&.iso8601,
+          "trainee_start_date" => trainee.trainee_start_date&.iso8601,
           "lead_school_name" => trainee.lead_school&.name,
           "lead_school_urn" => trainee.lead_school&.urn,
           "employing_school_name" => trainee.employing_school&.name,

--- a/spec/services/find_new_starter_trainees_spec.rb
+++ b/spec/services/find_new_starter_trainees_spec.rb
@@ -18,7 +18,7 @@ describe FindNewStarterTrainees do
   end
 
   let(:valid_trainee) { create(:trainee, state: 1, itt_start_date: 2.months.ago, start_academic_cycle: AcademicCycle.current) }
-  let(:valid_trainee_with_no_commencement_date) { create(:trainee, state: 1, commencement_date: nil, start_academic_cycle: AcademicCycle.current) }
+  let(:valid_trainee_with_no_trainee_start_date) { create(:trainee, state: 1, trainee_start_date: nil, start_academic_cycle: AcademicCycle.current) }
   let(:valid_draft_trainee) { create(:trainee, state: 0, itt_start_date: 2.months.ago, start_academic_cycle: AcademicCycle.current) }
   let(:valid_trainee_from_previous_academic_cycle) { create(:trainee, state: 0, itt_start_date: 2.months.ago, start_academic_cycle_id: 10) }
 
@@ -26,8 +26,8 @@ describe FindNewStarterTrainees do
     expect(subject).to include(valid_trainee)
   end
 
-  it "to contain non draft current academic cycle trainees with no commencement date" do
-    expect(subject).to include(valid_trainee_with_no_commencement_date)
+  it "to contain non draft current academic cycle trainees with no trainee start date" do
+    expect(subject).to include(valid_trainee_with_no_trainee_start_date)
   end
 
   it "to not contain draft trainees" do

--- a/spec/services/trainees/calculate_itt_end_date_spec.rb
+++ b/spec/services/trainees/calculate_itt_end_date_spec.rb
@@ -14,25 +14,25 @@ module Trainees
       let(:study_length) { 1 }
       let(:study_length_unit) { "years" }
 
-      it { is_expected.to eq(trainee.commencement_date + 10.months) }
+      it { is_expected.to eq(trainee.trainee_start_date + 10.months) }
     end
 
     context "study_length and study_length_unit is nil" do
       let(:study_length) { nil }
       let(:study_length_unit) { nil }
 
-      it { is_expected.to eq(trainee.commencement_date + 1.year) }
+      it { is_expected.to eq(trainee.trainee_start_date + 1.year) }
 
       context "trainee is part-time" do
         let(:trainee_attributes) { { study_mode: :part_time } }
 
-        it { is_expected.to eq(trainee.commencement_date + 2.years) }
+        it { is_expected.to eq(trainee.trainee_start_date + 2.years) }
       end
 
       context "trainee has undergrade training route" do
         let(:trainee_attributes) { { training_route: UNDERGRAD_ROUTES.keys.sample } }
 
-        it { is_expected.to eq(trainee.commencement_date + 3.years) }
+        it { is_expected.to eq(trainee.trainee_start_date + 3.years) }
       end
     end
 
@@ -42,7 +42,7 @@ module Trainees
 
       subject { described_class.call(trainee: trainee, actual: true) }
 
-      it { is_expected.to eq(trainee.commencement_date + 1.year) }
+      it { is_expected.to eq(trainee.trainee_start_date + 1.year) }
     end
   end
 end

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -163,12 +163,12 @@ module Trainees
         end
       end
 
-      context "when the commencement_date is missing" do
+      context "when the trainee_start_date is missing" do
         let(:api_placement_assignment) { create(:api_placement_assignment, dfe_commencementdate: nil) }
 
         it "uses the programme start date" do
           create_trainee_from_dttp
-          expect(Trainee.last.commencement_date).to eq(placement_assignment.programme_start_date)
+          expect(Trainee.last.trainee_start_date).to eq(placement_assignment.programme_start_date)
         end
       end
 
@@ -333,7 +333,7 @@ module Trainees
           create_trainee_from_dttp
           trainee = Trainee.last
           expect(trainee.course_subject_one).to eq(CourseSubjects::MODERN_LANGUAGES)
-          expect(trainee.commencement_date).to eq(placement_assignment_two.response["dfe_commencementdate"].to_date)
+          expect(trainee.trainee_start_date).to eq(placement_assignment_two.response["dfe_commencementdate"].to_date)
         end
 
         it "sets the trainee submitted_for_trn_at date from the first placement assignment" do

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -72,7 +72,7 @@ module Trainees
         expect(trainee.itt_end_date).to eq(Date.parse(student_attributes[:itt_end_date]))
         expect(trainee.start_academic_cycle).to eq(start_academic_cycle)
         expect(trainee.end_academic_cycle).to eq(end_academic_cycle)
-        expect(trainee.commencement_date).to eq(Date.parse(student_attributes[:itt_start_date]))
+        expect(trainee.trainee_start_date).to eq(Date.parse(student_attributes[:itt_start_date]))
       end
 
       it "updates the trainee's school and training details" do
@@ -303,11 +303,11 @@ module Trainees
         end
       end
 
-      context "when commencement_date is not null" do
-        let(:hesa_stub_attributes) { { commencement_date: "2020-09-27" } }
+      context "when trainee_start_date is not null" do
+        let(:hesa_stub_attributes) { { trainee_start_date: "2020-09-27" } }
 
-        it "uses the commencement_date" do
-          expect(trainee.commencement_date).to eq(Date.parse("2020-09-27"))
+        it "uses the trainee_start_date" do
+          expect(trainee.trainee_start_date).to eq(Date.parse("2020-09-27"))
         end
       end
 

--- a/spec/services/trainees/set_academic_cycles_spec.rb
+++ b/spec/services/trainees/set_academic_cycles_spec.rb
@@ -12,25 +12,25 @@ module Trainees
     describe "start_academic_cycle" do
       subject { described_class.call(trainee: trainee).start_academic_cycle }
 
-      context "when a trainee has a commencement_date" do
+      context "when a trainee has a trainee_start_date" do
         let(:trainee) do
           build(
             :trainee,
-            commencement_date: current_academic_cycle.start_date,
+            trainee_start_date: current_academic_cycle.start_date,
             itt_start_date: next_academic_cycle.start_date,
           )
         end
 
-        it "favours commencement_date" do
+        it "favours trainee_start_date" do
           expect(subject).to eq(current_academic_cycle)
         end
       end
 
-      context "when a trainee has no commencement_date, but has an itt_start_date" do
+      context "when a trainee has no trainee_start_date, but has an itt_start_date" do
         let(:trainee) do
           build(
             :trainee,
-            commencement_date: nil,
+            trainee_start_date: nil,
             itt_start_date: next_academic_cycle.start_date,
           )
         end
@@ -40,7 +40,7 @@ module Trainees
         end
       end
 
-      context "when a trainee has no commencement_date/itt_start_date" do
+      context "when a trainee has no trainee_start_date/itt_start_date" do
         let(:trainee) { build(:trainee) }
 
         it "favours current academic cycle" do

--- a/spec/support/page_objects/trainees/edit_trainee_start_date.rb
+++ b/spec/support/page_objects/trainees/edit_trainee_start_date.rb
@@ -7,9 +7,9 @@ module PageObjects
 
       set_url "/trainees/{trainee_id}/trainee-start-date/edit"
 
-      element :commencement_date_day, "#trainee_start_date_form_commencement_date_3i"
-      element :commencement_date_month, "#trainee_start_date_form_commencement_date_2i"
-      element :commencement_date_year, "#trainee_start_date_form_commencement_date_1i"
+      element :trainee_start_date_day, "#trainee_start_date_form_trainee_start_date_3i"
+      element :trainee_start_date_month, "#trainee_start_date_form_trainee_start_date_2i"
+      element :trainee_start_date_year, "#trainee_start_date_form_trainee_start_date_1i"
 
       element :continue, "button[type='submit']"
     end

--- a/spec/support/page_objects/trainees/edit_trainee_start_status.rb
+++ b/spec/support/page_objects/trainees/edit_trainee_start_status.rb
@@ -10,9 +10,9 @@ module PageObjects
       element :commencement_status_started_on_time, "#trainee-start-status-form-commencement-status-itt-started-on-time-field"
       element :commencement_status_started_later, "#trainee-start-status-form-commencement-status-itt-started-later-field"
       element :commencement_status_not_yet_started, "#trainee-start-status-form-commencement-status-itt-not-yet-started-field"
-      element :commencement_date_day, "#trainee_start_status_form_commencement_date_3i"
-      element :commencement_date_month, "#trainee_start_status_form_commencement_date_2i"
-      element :commencement_date_year, "#trainee_start_status_form_commencement_date_1i"
+      element :trainee_start_date_day, "#trainee_start_status_form_trainee_start_date_3i"
+      element :trainee_start_date_month, "#trainee_start_status_form_trainee_start_date_2i"
+      element :trainee_start_date_year, "#trainee_start_status_form_trainee_start_date_1i"
 
       element :continue, "button[type='submit']"
     end

--- a/spec/support/shared_examples/start_date_validations.rb
+++ b/spec/support/shared_examples/start_date_validations.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples "start date validations" do
     let(:params) { { day: future_date.day, month: future_date.month, year: future_date.year, commencement_status: "itt_started_later" } }
 
     it "is invalid" do
-      expect(subject.errors[:commencement_date]).to include("Trainee start date must be in the past")
+      expect(subject.errors[:trainee_start_date]).to include("Trainee start date must be in the past")
     end
   end
 end

--- a/spec/view_objects/missing_data_banner_view_spec.rb
+++ b/spec/view_objects/missing_data_banner_view_spec.rb
@@ -43,8 +43,8 @@ describe MissingDataBannerView do
         end
       end
 
-      context "commencement_date" do
-        let(:field) { :commencement_date }
+      context "trainee_start_date" do
+        let(:field) { :trainee_start_date }
         let(:expected_path) { edit_trainee_start_date_path(trainee) }
 
         it "returns the link to the form containing the missing data" do


### PR DESCRIPTION
### Context

We've changed the name of 'commencement_date' to 'trainee_start_date' in the exports and reports from Register. We need to rename it in the database and code as well, so it's less confusing for us. Its a looooot of changes.

### Changes proposed in this pull request

### Guidance to review

I did a global find and replace of 'commencement_date with trainee_start_date. 

Check the site still runs, the test suite still passes so i think its all good.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
