### PR TITLE
[4554] Investigate why HESA degree type 008 is not getting mapped correctly

### DIFF
--- a/app/services/degrees/create_from_hesa.rb
+++ b/app/services/degrees/create_from_hesa.rb
@@ -99,7 +99,7 @@ module Degrees
     end
 
     def importable?(hesa_degree)
-      return true unless hesa_degree[:degree_type].include?(UNKNOWN_DEGREE_TYPE)
+      return true unless hesa_degree[:degree_type]&.include?(UNKNOWN_DEGREE_TYPE)
 
       hesa_degree.compact.size > 1
     end

--- a/app/services/degrees/create_from_hesa.rb
+++ b/app/services/degrees/create_from_hesa.rb
@@ -35,7 +35,7 @@ module Degrees
       hesa_degrees.map do |hesa_degree|
         next unless importable?(hesa_degree)
 
-        dfe_subject = dfe_reference_subject_item(hesa_degree[:subject])
+        dfe_subject = DfeReference.find_subject(hecos_code: hesa_degree[:subject])
         degree = trainee.degrees.find_or_initialize_by(subject: dfe_subject&.name)
 
         degree.subject_uuid = dfe_subject&.id
@@ -52,8 +52,8 @@ module Degrees
 
     def set_country_specific_attributes(degree, hesa_degree)
       country = Hesa::CodeSets::Countries::MAPPING[hesa_degree[:country]]
-      dfe_institution = dfe_reference_institution_item(hesa_degree[:institution])
-      dfe_type = dfe_reference_type_item(degree_type_hesa_code(hesa_degree))
+      dfe_institution = DfeReference.find_institution(hesa_code: hesa_degree[:institution])
+      dfe_type = DfeReference.find_type(hesa_code: degree_type_hesa_code(hesa_degree))
 
       # Country code is not always provided, so we have
       # to fallback to institution which is always UK based
@@ -78,7 +78,7 @@ module Degrees
     end
 
     def set_grade_attributes(degree, hesa_degree)
-      dfe_grade = dfe_reference_grade_item(degree_grade_hesa_code(hesa_degree))
+      dfe_grade = DfeReference.find_grade(hesa_code: degree_grade_hesa_code(hesa_degree))
 
       degree.grade = dfe_grade&.name
       degree.grade_uuid = dfe_grade&.id
@@ -86,22 +86,6 @@ module Degrees
 
     def uk_country?(country)
       Hesa::CodeSets::Countries::UK_COUNTRIES.include?(country)
-    end
-
-    def dfe_reference_subject_item(hecos_code)
-      DfeReference.find_subject(hecos_code: hecos_code)
-    end
-
-    def dfe_reference_type_item(hesa_code)
-      DfeReference.find_type(hesa_code: hesa_code)
-    end
-
-    def dfe_reference_institution_item(hesa_code)
-      DfeReference.find_institution(hesa_code: hesa_code)
-    end
-
-    def dfe_reference_grade_item(hesa_code)
-      DfeReference.find_grade(hesa_code: hesa_code)
     end
 
     def degree_type_hesa_code(hesa_degree)

--- a/db/data/20220906090020_fix_degrees_with_unmapped_types.rb
+++ b/db/data/20220906090020_fix_degrees_with_unmapped_types.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class FixDegreesWithUnmappedTypes < ActiveRecord::Migration[6.1]
+  def up
+    unmappable_hesa_codes = Degrees::CreateFromHesa::HONOURS_TO_NON_HONOURS_HESA_CODE_MAP.keys
+
+    Trainee.imported_from_hesa.find_each do |trainee|
+      if trainee.hesa_student&.degrees&.any? { |degree| unmappable_hesa_codes.include?(degree["degree_type"]) }
+        Degree.without_auditing do
+          trainee.degrees.uk.where(uk_degree: nil).delete_all
+          hesa_degrees = trainee.hesa_student.degrees.map(&:with_indifferent_access)
+          Degrees::CreateFromHesa.call(trainee: trainee, hesa_degrees: hesa_degrees)
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -150,6 +150,26 @@ module Degrees
           end
         end
       end
+
+      context "handling honours degree types" do
+        let(:hesa_degrees) do
+          [
+            {
+              graduation_date: "2003-06-01",
+              degree_type: "008",
+              subject: "100485",
+              institution: "00429",
+              grade: "02",
+              country: nil,
+            },
+          ]
+        end
+
+        it "maps the honours HESA code to a non-honours HESA code" do
+          expect(degree.uk_degree).to eq("Bachelor of Arts in Education")
+          expect(degree.uk_degree_uuid).to eq("007a0999-87f7-4afc-8ccd-ce1e1d92c9ac")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/wxSW1Cet/4554-investigate-why-hesa-degree-type-008-is-not-getting-mapped-correctly

We've had a small number of cases of trainee degrees with missing degree type because the HESA code is 002, 004, 006, 008 and 010 which is not supported by the dfe-reference gem. Some trainees have duplicates, so the data migration will remove all degrees and recreate them using data from `hesa_students` table.

### Changes proposed in this pull request
- Data migration to fix missing degree types
- Minor refactoring of `Degrees::CreateFromHesa`
- Add test example to prove that `Degrees::CreateFromHesa` can map unsupported HESA codes such as 008

### Guidance to review
- The data migration will take about 12 minutes to run
- About 500 degrees have a missing degree type that needs to be fixed

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
