### PR TITLE
[4621] Remove 'English as a second or other language' from modern languages

### DIFF
--- a/config/initializers/mappings/allocation_subject_to_specialism_mapping.rb
+++ b/config/initializers/mappings/allocation_subject_to_specialism_mapping.rb
@@ -59,6 +59,7 @@ ALLOCATION_SUBJECT_SPECIALISM_MAPPING = {
   ],
   AllocationSubjects::ENGLISH => [
     CourseSubjects::ENGLISH_STUDIES,
+    CourseSubjects::ENGLISH_AS_SECOND_LANGUAGE,
   ],
   AllocationSubjects::GEOGRAPHY => [
     CourseSubjects::GEOGRAPHY,
@@ -77,7 +78,6 @@ ALLOCATION_SUBJECT_SPECIALISM_MAPPING = {
     CourseSubjects::MODERN_LANGUAGES,
     CourseSubjects::ARABIC_LANGUAGES,
     CourseSubjects::CHINESE_LANGUAGES,
-    CourseSubjects::ENGLISH_AS_SECOND_LANGUAGE,
     CourseSubjects::FRENCH_LANGUAGE,
     CourseSubjects::GERMAN_LANGUAGE,
     CourseSubjects::ITALIAN_LANGUAGE,

--- a/config/initializers/mappings/publish_to_allocation_subject_mapping.rb
+++ b/config/initializers/mappings/publish_to_allocation_subject_mapping.rb
@@ -34,7 +34,6 @@ PUBLISH_PRIMARY_SUBJECTS = [
 ].freeze
 
 PUBLISH_MODERN_LANGUAGES = [
-  PublishSubjects::ENGLISH_AS_SECOND_LANGUAGE,
   PublishSubjects::FRENCH,
   PublishSubjects::GERMAN,
   PublishSubjects::ITALIAN,

--- a/db/data/20220907110350_move_english_as_second_language_under_english_allocation_subject.rb
+++ b/db/data/20220907110350_move_english_as_second_language_under_english_allocation_subject.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class MoveEnglishAsSecondLanguageUnderEnglishAllocationSubject < ActiveRecord::Migration[6.1]
+  def up
+    AllocationSubject.find_by(name: AllocationSubjects::ENGLISH).tap do |allocation_subject|
+      subject_specialism = SubjectSpecialism.find_by(name: PublishSubjects::ENGLISH_AS_SECOND_LANGUAGE)
+      subject_specialism.update(allocation_subject: allocation_subject)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/4Sb4HT6w/4621-update-english-as-a-second-or-other-language

The specialism `English as a second language` should have the allocation subject of `English`, not 'modern languages' - this was a mistake.

Also worth reading to understand to wider challenge of having this subject specialism: https://ukgovernmentdfe.slack.com/archives/C03EM9URG0N/p1662545107189089

### Changes proposed in this pull request
- Remove `English as a second or other language` from modern languages and move it under the allocation subject `English`

### Guidance to review
- You can choose a modern languages course and check it doesn't appear in the list

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
