### PR TITLE
[4634] Exclude HESA TRNData trainees from new starter report

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -32,7 +32,9 @@ private
   end
 
   def data_for_export
-    @data_for_export ||= Exports::TraineeSearchData.new(policy_scope(NewStarterTraineesService.new(census_date(AcademicCycle.current.start_year)).call))
+    @data_for_export ||= Exports::TraineeSearchData.new(
+      policy_scope(FindNewStarterTrainees.new(census_date(AcademicCycle.current.start_year)).call),
+    )
   end
 
   def filename

--- a/app/services/find_new_starter_trainees.rb
+++ b/app/services/find_new_starter_trainees.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class NewStarterTraineesService
+class FindNewStarterTrainees
+  attr_reader :census_date
+
   def initialize(census_date)
     @census_date = census_date
   end
@@ -13,6 +15,4 @@ class NewStarterTraineesService
 
     Trainees::Filter.call(trainees: trainees, filters: nil)
   end
-
-  attr_reader :census_date
 end

--- a/app/services/new_starter_trainees_service.rb
+++ b/app/services/new_starter_trainees_service.rb
@@ -6,10 +6,12 @@ class NewStarterTraineesService
   end
 
   def call
-    Trainee.where("itt_start_date <= :date or commencement_date <= :date", date: census_date)
-           .or(Trainee.where(commencement_date: nil))
-           .where(start_academic_cycle_id: AcademicCycle.current)
-           .where.not(state: 0)
+    trainees = Trainee.where("itt_start_date <= :date or commencement_date <= :date", date: census_date)
+                      .or(Trainee.where(commencement_date: nil))
+                      .where(start_academic_cycle_id: AcademicCycle.current)
+                      .not_draft
+
+    Trainees::Filter.call(trainees: trainees, filters: nil)
   end
 
   attr_reader :census_date

--- a/spec/services/find_new_starter_trainees_spec.rb
+++ b/spec/services/find_new_starter_trainees_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "csv"
 
-describe NewStarterTraineesService do
+describe FindNewStarterTrainees do
   subject { described_class.new(DateTime.new(2022, 10, 12)).call }
 
   before do

--- a/spec/services/new_starter_trainees_service_spec.rb
+++ b/spec/services/new_starter_trainees_service_spec.rb
@@ -37,4 +37,16 @@ describe NewStarterTraineesService do
   it "to not contain valid trainees starting in a previous academic cycle" do
     expect(subject).not_to include(valid_trainee_from_previous_academic_cycle)
   end
+
+  context "when trainee came from HESA TRN data" do
+    before do
+      create(:trainee,
+             state: 1,
+             itt_start_date: 2.months.ago,
+             start_academic_cycle: AcademicCycle.current,
+             record_source: RecordSources::HESA_TRN_DATA)
+    end
+
+    it { is_expected.to be_empty }
+  end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/TZ8Cx3gJ/4634-trainees-from-the-hesa-trn-data-endpoint-will-end-up-in-the-new-starter-report

### Changes proposed in this pull request
- Add another `where` scope to `NewStarterTraineesService` that excludes trainees sourced from HESA TRNData
- Rename `NewStarterTraineesService` to `FindNewStarterTrainees` (Service objects ideally should have a verb to signify the action that takes place when called. It's also unnecessary to have the world 'Service' at the end of the class name.)

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
