### PR TITLE
[xxx] Fix setting disability disclosure during HESA import

### DIFF
--- a/app/services/concerns/diversity_attributes.rb
+++ b/app/services/concerns/diversity_attributes.rb
@@ -79,6 +79,6 @@ module DiversityAttributes
   end
 
   def ethnicity_disclosed?
-    ethnic_background.present? && ethnic_background != Diversities::INFORMATION_REFUSED
+    ethnic_background.present? && [Diversities::NOT_PROVIDED, Diversities::INFORMATION_REFUSED].exclude?(ethnic_background)
   end
 end

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -154,7 +154,7 @@ module Trainees
     end
 
     def diversity_disclosure
-      if disabilities.any? || ethnicity_disclosed?
+      if disability_disclosed? || ethnicity_disclosed?
         Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed]
       else
         Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed]
@@ -162,7 +162,7 @@ module Trainees
     end
 
     def disability_attributes
-      if disabilities.empty? || disabilities == [Diversities::NOT_PROVIDED]
+      if !disability_disclosed?
         return {
           disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided],
         }
@@ -194,6 +194,10 @@ module Trainees
         ethnic_group: Diversities::ETHNIC_GROUP_ENUMS[:not_provided],
         ethnic_background: Diversities::NOT_PROVIDED,
       }
+    end
+
+    def disability_disclosed?
+      disabilities.any? && disabilities != [Diversities::NOT_PROVIDED]
     end
 
     def sex

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -205,7 +205,7 @@ module Trainees
 
       context "when ethnicity is explicitly 'not provided'" do
         let(:hesa_stub_attributes) do
-          { ethnic_background: hesa_disability_codes[Diversities::NOT_PROVIDED] }
+          { ethnic_background: hesa_ethnicity_codes[Diversities::NOT_PROVIDED] }
         end
 
         it "sets the ethnic_group and background to 'Not provided'" do
@@ -217,13 +217,28 @@ module Trainees
       context "when neither ethnicity nor disabilities are disclosed" do
         let(:hesa_stub_attributes) do
           {
-            ethnic_background: hesa_disability_codes[Diversities::NOT_PROVIDED],
+            ethnic_background: hesa_ethnicity_codes[Diversities::NOT_PROVIDED],
             disability1: nil,
           }
         end
 
         it "sets the diversity disclosure to 'diversity_not_disclosed'" do
           expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed])
+          expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided])
+        end
+      end
+
+      context "when disability is 'Not provided'" do
+        let(:hesa_stub_attributes) do
+          {
+            ethnic_background: hesa_ethnicity_codes[Diversities::NOT_PROVIDED],
+            disability1: hesa_disability_codes[Diversities::NOT_PROVIDED],
+          }
+        end
+
+        it "sets the disclosures to 'not_disclosed'" do
+          expect(trainee.diversity_disclosure).to eq(Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_not_disclosed])
+          expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided])
         end
       end
 


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

- If a trainee is submitted with explicit disability 'Not provided', then set the `disability_disclosure` as `not_provided`
- Previously, we assumed that only `nil` disability meant Not provided (this is what was provided from HESA in their test records), but I'm also assuming now that they could explicitly send the 'Not provided' option as a disability.

### Guidance to review

🚢 

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml