### PR TITLE
[4508] Data migration to remove duplicate degrees belonging to HESA trainees

### DIFF
--- a/db/data/20220909131155_remove_duplicate_degrees_from_hesa_trainees.rb
+++ b/db/data/20220909131155_remove_duplicate_degrees_from_hesa_trainees.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class RemoveDuplicateDegreesFromHesaTrainees < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.joins(:hesa_student).find_each do |trainee|
+      if trainee.hesa_student.degrees&.any? && find_duplicates(trainee.degrees).any?
+        Degree.without_auditing do
+          trainee.degrees.delete_all
+          hesa_degrees = trainee.hesa_student.degrees.map(&:with_indifferent_access)
+          Degrees::CreateFromHesa.call(trainee: trainee, hesa_degrees: hesa_degrees)
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def find_duplicates(degrees)
+    ids = []
+    set = Set.new
+    degrees.each do |degree|
+      digest = degree.values_at(:subject, :institution, :graduation_year, :uk_degree).map(&:to_s).map(&:downcase).join
+      if set.include?(digest)
+        ids << degree.id
+      else
+        set.add(digest)
+      end
+    end
+    ids
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/egpS9hjF/4508-duplicate-degrees-on-some-hesa-imported-trainees

Recent code fixes should prevent duplicates from been created in the future.

### Changes proposed in this pull request
- Data migration to remove duplicate degrees

### Note
Takes about 3 minutes to run. Approximately 1400 trainees from last year's academic cycle have their degrees removed and recreated using data from the `hesa_students` table. Trial runs demonstrate that the code works as expected.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
