### PR TITLE
[SPIKE] send alert when no hesa mapping

### DIFF
--- a/app/services/hesa/validate_mapping.rb
+++ b/app/services/hesa/validate_mapping.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Hesa
+  class ValidateMapping
+    include ServicePattern
+
+    HESA_FIELDS_TO_CODESETS_MAP = {
+      bursary_level: Hesa::CodeSets::BursaryLevels,
+      course_age_range: Hesa::CodeSets::AgeRanges,
+      course_subject_one: Hesa::CodeSets::CourseSubjects,
+      course_subject_three: Hesa::CodeSets::CourseSubjects,
+      course_subject_two: Hesa::CodeSets::CourseSubjects,
+      ethnic_background: Hesa::CodeSets::Ethnicities,
+      fund_code: Hesa::CodeSets::FundCodes,
+      itt_aim: Hesa::CodeSets::IttAims,
+      itt_qualification_aim: Hesa::CodeSets::IttQualificationAims,
+      mode: Hesa::CodeSets::StudyModes,
+      reason_for_leaving: Hesa::CodeSets::ReasonsForLeavingCourse,
+      sex: Hesa::CodeSets::Sexes,
+      training_initiative: Hesa::CodeSets::TrainingInitiatives,
+      training_route: Hesa::CodeSets::TrainingRoutes,
+    }.freeze
+
+    HESA_DISABILITIES_TO_CODESETS_MAP = {
+      disability1: Hesa::CodeSets::Disabilities,
+      disability2: Hesa::CodeSets::Disabilities,
+      disability3: Hesa::CodeSets::Disabilities,
+      disability4: Hesa::CodeSets::Disabilities,
+      disability5: Hesa::CodeSets::Disabilities,
+      disability6: Hesa::CodeSets::Disabilities,
+      disability7: Hesa::CodeSets::Disabilities,
+      disability8: Hesa::CodeSets::Disabilities,
+      disability9: Hesa::CodeSets::Disabilities,
+    }.freeze
+
+    def initialize(hesa_trainee:, record_source:)
+      @hesa_trainee = hesa_trainee
+      @record_source = record_source
+    end
+
+    def call
+      unmapped_fields = []
+
+      HESA_FIELDS_TO_CODESETS_MAP.each do |hesa_field, code_set|
+        if hesa_trainee[hesa_field].present? && code_set::MAPPING[hesa_trainee[hesa_field]].blank?
+          unmapped_fields << hesa_field
+        end
+      end
+
+      HESA_DISABILITIES_TO_CODESETS_MAP.each do |hesa_field, code_set|
+        if hesa_trainee[hesa_field].present? && code_set::MAPPING[hesa_trainee[hesa_field]].blank?
+          unmapped_fields << hesa_field
+        end
+      end
+
+      Sentry.capture_message(broken_mapping_message(unmapped_fields)) if unmapped_fields.any?
+    end
+
+  private
+
+    attr_reader :hesa_trainee, :record_source
+
+    def broken_mapping_message(unmapped_fields)
+      "Unmapped fields #{unmapped_fields} on trainee - id: #{hesa_trainee[:trainee_id]} - record source: #{record_source}"
+    end
+  end
+end

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -30,6 +30,7 @@ module Trainees
           store_hesa_metadata!
           enqueue_background_jobs!
           check_for_trn_disparity!
+          check_for_missing_hesa_mappings!
         end
       end
     rescue ActiveRecord::RecordInvalid
@@ -286,6 +287,10 @@ module Trainees
 
     def trainee_state
       @trainee_state ||= MapStateFromHesa.call(hesa_trainee:, trainee:) || trainee.state
+    end
+
+    def check_for_missing_hesa_mappings!
+      Hesa::ValidateMapping.call(hesa_trainee:, record_source:)
     end
   end
 end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -328,6 +328,30 @@ module Trainees
         end
       end
 
+      context "when hesa disability code is invalid" do
+        let(:hesa_stub_attributes) do
+          {
+            course_subject_one: "invalid course subject one codeset",
+          }
+        end
+
+        it "raises an error" do
+          expect(Sentry).to have_received(:capture_message).with("Unmapped fields [:course_subject_one] on trainee - id: #{trainee.trainee_id} - record source: #{trainee.record_source}")
+        end
+      end
+
+      context "when hesa code is invalid" do
+        let(:hesa_stub_attributes) do
+          {
+            disability1: "disability not in codeset",
+          }
+        end
+
+        it "raises an error" do
+          expect(Sentry).to have_received(:capture_message).with("Unmapped fields [:disability1] on trainee - id: #{trainee.trainee_id} - record source: #{trainee.record_source}")
+        end
+      end
+
       context "when just ethnicity is disclosed" do
         let(:hesa_stub_attributes) do
           {


### PR DESCRIPTION
### Context

When we create from hesa or use send a trn request we check the hesa codesets to ensure there is a valid mapping. There is a new service added to ensure this.

This spike: 

* applies to all fields where we take HESA data and that have mapping codes
* make sure alert is fired where we don't map to something.

This should be useful for cases where:

* HESA has added new values but we haven't
* We've intentionally not mapped something because we don't think it's relevant - but we get the value from HESA anyway.

### Changes proposed in this pull request

New ValidateHesaMappings service which checks that the codesets work and there are no unmapped values
### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
