### PR TITLE
4644 guidance page snagging fixups

### DIFF
--- a/app/views/guidance/_manually_registering_trainees.md
+++ b/app/views/guidance/_manually_registering_trainees.md
@@ -62,7 +62,7 @@ Follow these steps to register a trainee on a PE with EBacc course:
 
 1. Add a first subject as ‘Physical education’, or a physical education based subject.
 2. Add a second subject as their EBacc subject.
-3. Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) stating their trainee ID and that they are doing PE with EBacc.
+3. Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=Registering%20trainees%20on%20a%20PE%20with%20EBacc%20course) stating their trainee ID and that they are doing PE with EBacc.
 
 <h2 class="govuk-heading-m">Recommending a trainee for Qualified Teacher Status (QTS) or Early Years Teacher Status (EYTS)</h2>
 

--- a/app/views/guidance/about_register_trainee_teachers.md
+++ b/app/views/guidance/about_register_trainee_teachers.md
@@ -60,15 +60,15 @@ Once you register your new trainees, your trainee data gets analysed and filtere
 
 At the start of every academic year, during September and October, you’ll need to register your new trainees and sign off your new trainee data before the end of October. We ask you to sign off your data so we know it’s accurate for the ITT census publication.
 
-[Find out what the dates and deadlines are for the 2022 to 2023 academic year.](/guidance/dates-and-deadlines)
+Find out what the [dates and deadlines are for the 2022 to 2023 academic year](/guidance/dates-and-deadlines).
 
 Training providers that do not use the Higher Education Statistics Agency (HESA) data collection system should register their trainees manually in the Register service. 
 
-[Read about how to register your trainees manually.](/guidance/manually-registering-trainees)
+Read about how to [register your trainees manually](/guidance/manually-registering-trainees).
 
 Training providers who use HESA, should submit their data through HESA. Your data will then be imported into Register where you can check it. 
 
-[Read more about how to register your trainees through HESA.](/guidance/registering-trainees-through-hesa)
+Read more about how to [register your trainees through HESA](/guidance/registering-trainees-through-hesa).
 
 <h3 class="govuk-heading-s">Who you should register</h3>
 

--- a/app/views/guidance/check_data.md
+++ b/app/views/guidance/check_data.md
@@ -9,70 +9,105 @@ You’ll need the following information about a trainee to complete their record
 
 <h2 class="govuk-heading-m">Personal details</h2>
 
-First names  
-Middle names  
-Last or family name  
-Date of birth  
-Sex  
-Nationality
-***
+<ul class="govuk-list"> 
+<li> First names </li>  
+<li> Middle names  </li> 
+<li> Last or family name  </li> 
+<li> Date of birth  </li> 
+<li> Sex </li>
+<li>Nationality</li>
+</ul>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
 <h2 class="govuk-heading-m">Contact details</h2>
 
-Address  
-Email address
-***
+<ul class="govuk-list">
+<li> Address  </li>
+<li> Email address</li>
+</ul>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 <h2 class="govuk-heading-m">Diversity information (optional)</h2>
 <div class="govuk-inset-text">If the trainee chose not to share this information during the application process, do not ask for it for the purpose of registering them.</div>
 
-Ethnicity  
-Disability
-***
-<h2 class="govuk-heading-m">Degrees</h2>
-<h4 class="govuk-heading-s">If it’s a UK degree Type (for example, BA or BSc)</h4>
+<ul class="govuk-list">
+<li> Ethnicity </li>
+<li> Disability </li>
+</ul>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-Awarding institution  
-Subject  
-Grade  
-Graduation year  
+<h2 class="govuk-heading-m">Degrees</h2>
+
+<h4 class="govuk-heading-s">If it’s a UK degree</h4>
+
+<ul class="govuk-list">
+<li> Type (for example, BA or BSc) </li>
+<li> Awarding institution  </li>
+<li> Subject  </li>
+<li> Grade  </li>
+<li> Graduation year </li>  
+</ul>
+
 <h4 class="govuk-heading-s">If it’s not a UK degree</h4>
 
-Country where the degree was obtained  
-Subject  
-UK ENIC comparable degree (if provided)  
-Graduation year
-***
+<ul class="govuk-list">
+<li> Country where the degree was obtained </li>  
+<li> Subject </li> 
+<li> UK ENIC comparable degree (if provided) </li>  
+<li> Graduation year </li> 
+</ul>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
 <h2 class="govuk-heading-m">Course details</h2>  
 
 <h4 class="govuk-heading-s">If it’s a course on Publish teacher training courses</h4>
-Which Publish course  
-Subject specialisms  
-Full or part time  
-ITT start date  
+<ul class="govuk-list">
+<li> Which Publish course  </li>
+<li> Subject specialisms  </li>
+<li> Full or part time  </li>
+<li> ITT start date  </li>
 Expected end date  
+</ul>
 
 <h4 class="govuk-heading-s">If it's not a course on Publish teacher training courses</h4> 
-Primary or secondary  
-Subjects  
-Age range  
-Full or part time (not for assessment only)  
-ITT start date  
-Expected end date  
+
+<ul class="govuk-list">
+<li> Primary or secondary </li>
+<li> Subjects </li>
+<li> Age range </li>
+<li> Full or part time (not for assessment only) </li>
+<li> ITT start date </li>
+<li> Expected end date </li> 
+</ul>
 
 <h4 class="govuk-heading-s">If it's a course leading to Early Years Teacher Status (EYTS) </h4> 
-Full or part time  
-ITT start date  
-Expected end date  
-Trainee start date  
+
+<ul class="govuk-list">
+<li> Full or part time </li>
+<li> ITT start date </li>
+<li> Expected end date  </li>
+</ul>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<h2 class="govuk-heading-m">Trainee start date </h2>
+
 Trainee start date
-***
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
 <h2 class="govuk-heading-m">Schools </h2> 
+
 This is only required for School direct and Teaching apprenticeship routes.
-***
-<h2 class="govuk-heading-m">Funding details</h2>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"><h2 class="govuk-heading-m">Funding details</h2>
 
 Whether the trainee is on a training initiative  
 <h4 class="govuk-heading-s">For courses with bursaries, scholarships or grants available</h4>
 
-Whether you’re applying for a bursary for the trainee  
-Whether you’re applying for a grant for the trainee  
-Whether the trainee is applying for a scholarship  
+<ul class="govuk-list">
+<li> Whether you’re applying for a bursary for the trainee  </li>
+<li> Whether you’re applying for a grant for the trainee  </li>
+<li> Whether the trainee is applying for a scholarship  </li>
+</ul>

--- a/app/views/guidance/dates_and_deadlines.html.erb
+++ b/app/views/guidance/dates_and_deadlines.html.erb
@@ -20,14 +20,18 @@
       <% end %>
       <% table.body do |body| %>
         <% body.row do |row| %>
-          <% row.cell(text: "Wednesday 12 October 2022")%>
-          <% row.cell(text: "The second Wednesday of October every academic year is called the ‘census date’. 
-          If a new trainee starts their course after this date, they will not be included in the ITT census publication. 
+          <% row.cell do %>
+              <span class="no-wrap">Wednesday 12 October 2022</span>
+          <% end %>
+          <% row.cell(text: "The second Wednesday of October every academic year is called the ‘census date’.
+          If a new trainee starts their course after this date, they will not be included in the ITT census publication.
           This is why it’s important to add your new trainees as they start their training.")%>
         <% end %>
         <% body.row do |row| %>
-          <% row.cell(text: "31 October 2022")%>
-          <% row.cell(text: "A senior person from your organisation must sign off your new trainee data on or before this date 
+            <% row.cell do %>
+              <span class="no-wrap">31 October 2022</span>
+            <% end %>
+          <% row.cell(text: "A senior person from your organisation must sign off your new trainee data on or before this date
           (this should be a different person to who submitted the data).")%>
         <% end %>
       <% end %>
@@ -43,29 +47,35 @@
       <% end %>
       <% table.body do |body| %>
         <% body.row do |row| %>
-          <% row.cell(text: "1 September 2022")%>
-          <% row.cell(text: "	HESA data collection system opens. 
+            <% row.cell do %>
+              <span class="no-wrap">1 September 2022</span>
+            <% end %>
+          <% row.cell(text: "	HESA data collection system opens.
           Training providers can start submitting their ITT trainee data to the DfE through HESA.")%>
         <% end %>
         <% body.row do |row| %>
-          <% row.cell(text: "14 October 2022")%>
-          <% row.cell(text: "First data submission required to HESA. 
+            <% row.cell do %>
+              <span class="no-wrap">14 October 2022</span>
+            <% end %>
+          <% row.cell(text: "First data submission required to HESA.
           Training providers should have started submitting data by this date.")%>
         <% end %>
         <% body.row do |row| %>
-          <% row.cell(text: "31 October 2022	")%>
-          <% row.cell(text: "HESA data collection system closes. 
-          ITT trainee data must be submitted and signed off on or before the data collection system closes. 
+            <% row.cell do %>
+              <span class="no-wrap">31 October 2022</span>
+            <% end %>
+          <% row.cell(text: "HESA data collection system closes.
+          ITT trainee data must be submitted and signed off on or before the data collection system closes.
           Not doing this, will mean the DfE has inaccurate data which could affect the ITT census publication.")%>
         <% end %>
         <% body.row do |row| %>
           <% row.cell do %>
-            <div>16 to 31 January 2023</div>
-            <div>17 to 28 April 2023</div>
-            <div>17 to 31 July 2023</div>
+            <div class="no-wrap">16 to 31 January 2023</div>
+            <div class="no-wrap">17 to 28 April 2023</div>
+            <div class="no-wrap">17 to 31 July 2023</div>
           <% end %>
-          <% row.cell(text: "ITT data collection update periods where you can update your trainee data through HESA 
-          if anything has changed. Data will be imported into Register. 
+          <% row.cell(text: "ITT data collection update periods where you can update your trainee data through HESA
+          if anything has changed. Data will be imported into Register.
           You do not need to sign off your data during these update periods.")%>
         <% end %>
       <% end %>


### PR DESCRIPTION
### Context

Fixups from the snagging session for guidance pages:

## Things to fix:

### About Register trainee teachers page (https://register-pr-2710.london.cloudapps.digital/guidance/about-register-trainee-teachers):
1. Remove full-stops from the end of link text (they should be outside of the link). Change these links to not be the whole sentence, so only link where the square brackets are below:

* Find out what the [dates and deadlines are for the 2022 to 2023 academic year].

* Read about how to [register your trainees manually].

* Read more about how to [register your trainees through HESA].

### Dates and deadlines page (https://register-pr-2710.london.cloudapps.digital/guidance/dates-and-deadlines):
1. Add a ‘no wrap’ class to all the dates so they do not split over multiple lines

### Registering trainee manually page (https://register-pr-2710.london.cloudapps.digital/guidance/manually-registering-trainees):
1. Under the section PE with EBacc, make the mailto link have a subject line of ‘Registering trainees on a PE with EBacc course’

### Check data page (https://register-pr-2710.london.cloudapps.digital/guidance/check-data):
1. Change all the lists to use html unordered list instead of paragraph tags

2. Change spacing of the horizontal line to: <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

3. Under ‘Degree’ section move ‘Type (for example, BA or BSc)’ to be on the next line [see prototype]

4. Under Course details section, make the double entry of ‘Trainee start date’ its own section [see prototype]
 for a review if new fields are being added to analytics.yml
