### PR TITLE
[4659] Course not showing correct route from Apply

### DIFF
--- a/app/forms/apply_applications/confirm_course_form.rb
+++ b/app/forms/apply_applications/confirm_course_form.rb
@@ -109,9 +109,5 @@ module ApplyApplications
 
       course.study_mode == COURSE_STUDY_MODES[:full_time_or_part_time]
     end
-
-    def clear_funding_information?
-      course_subjects_changed? || trainee.training_route_changed?
-    end
   end
 end

--- a/app/forms/apply_applications/confirm_course_form.rb
+++ b/app/forms/apply_applications/confirm_course_form.rb
@@ -25,7 +25,7 @@ module ApplyApplications
     def save
       update_trainee_attributes unless trainee_confirmed?
       trainee.progress.course_details = mark_as_reviewed
-      clear_funding_information if course_subjects_changed?
+      clear_funding_information if clear_funding_information?
 
       Trainees::Update.call(trainee: trainee)
     end
@@ -108,6 +108,10 @@ module ApplyApplications
       return false unless course
 
       course.study_mode == COURSE_STUDY_MODES[:full_time_or_part_time]
+    end
+
+    def clear_funding_information?
+      course_subjects_changed? || trainee.training_route_changed?
     end
   end
 end

--- a/app/forms/concerns/course_form_helpers.rb
+++ b/app/forms/concerns/course_form_helpers.rb
@@ -12,8 +12,8 @@ module CourseFormHelpers
     })
   end
 
-  def course_subjects_changed?
-    trainee.course_subject_one_changed? || trainee.course_subject_two_changed? || trainee.course_subject_three_changed?
+  def clear_funding_information?
+    trainee.course_allocation_subject_id_changed? || trainee.training_route_changed?
   end
 
   def course_allocation_subject

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -83,7 +83,7 @@ class CourseDetailsForm < TraineeForm
   def save!
     if valid?
       update_trainee_attributes
-      clear_funding_information if course_subjects_changed?
+      clear_funding_information if clear_funding_information?
       Trainees::Update.call(trainee: trainee)
       clear_stash
     else

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -147,8 +147,4 @@ private
 
     clear_stash
   end
-
-  def clear_funding_information?
-    course_subjects_changed? || trainee.training_route_changed?
-  end
 end

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -53,7 +53,7 @@ class PublishCourseDetailsForm < TraineeForm
     return false unless valid?
 
     update_trainee_attributes
-    clear_funding_information if course_subjects_changed?
+    clear_funding_information if clear_funding_information?
     Trainees::Update.call(trainee: trainee)
     clear_all_stashes
   end
@@ -146,5 +146,9 @@ private
     end
 
     clear_stash
+  end
+
+  def clear_funding_information?
+    course_subjects_changed? || trainee.training_route_changed?
   end
 end

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -95,7 +95,8 @@ class PublishCourseDetailsForm < TraineeForm
 private
 
   def update_trainee_attributes
-    trainee.assign_attributes(course_uuid: course_uuid,
+    trainee.assign_attributes(training_route: course.route,
+                              course_uuid: course_uuid,
                               course_subject_one: course_subject_one,
                               course_subject_two: course_subject_two,
                               course_subject_three: course_subject_three,

--- a/db/data/20220921084032_fix_apply_draft_training_routes.rb
+++ b/db/data/20220921084032_fix_apply_draft_training_routes.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class FixApplyDraftTrainingRoutes < ActiveRecord::Migration[6.1]
+  def up
+    Trainee.draft.where(record_source: RecordSources::APPLY).where.not(course_uuid: nil).find_each do |trainee|
+      if trainee.published_course && trainee.training_route != trainee.published_course.route
+        trainee.without_auditing do
+          trainee.progress.funding = false
+          trainee.assign_attributes(training_route: trainee.published_course.route,
+                                    applying_for_bursary: nil,
+                                    applying_for_scholarship: nil,
+                                    applying_for_grant: nil,
+                                    bursary_tier: nil)
+
+          if trainee.published_course.route == "provider_led_postgrad"
+            trainee.lead_school_id = nil
+          end
+
+          trainee.save!
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/8KhAFVTW/4659-course-not-showing-as-correct-route-from-apply

### Changes proposed in this pull request
- Update `PublishCourseDetailsForm` to copy course route onto `training_route` and to clear funding information of the training routes changes
- Data migration to fix some Apply draft trainees that have a different training route to the course route

### Guidance to review
- Find a trainee e.g school direct (fee funded)
- Change course with a different route
- New training route should be displayed in the trainee show page

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
