### PR TITLE
Move CF and DB github secrets to Azure keyvault

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -37,12 +37,31 @@ jobs:
     - uses: actions/checkout@v3
       name: Checkout
 
+    - name: Set KV environment variables
+      run: |
+        tf_vars_file=terraform/workspace-variables/production.tfvars.json
+        echo "key_vault_name=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+        echo "key_vault_infra_secret_name=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
+        echo "paas_space_name=$(jq -r '.paas_space_name' ${tf_vars_file})" >> $GITHUB_ENV
+
+    - uses: azure/login@v1
+      if: env.TF_STATE_EXISTS == 'true'
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS_PRODUCTION }}
+
+    - uses: DFE-Digital/keyvault-yaml-secret@v1
+      id: get-secrets
+      with:
+        keyvault: ${{ env.key_vault_name }}
+        secret: ${{ env.key_vault_infra_secret_name }}
+        key: CF_USER,CF_PASSWORD
+
     - name: Setup cf cli
       uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
-        CF_USERNAME:   ${{ secrets.CF_USERNAME_PRODUCTION }}
-        CF_PASSWORD:   ${{ secrets.CF_PASSWORD_PRODUCTION }}
-        CF_SPACE_NAME: ${{ secrets.CF_SPACE_PRODUCTION }}
+        CF_USERNAME:   ${{ steps.get-secrets.outputs.CF_USER }}
+        CF_PASSWORD:   ${{ steps.get-secrets.outputs.CF_PASSWORD }}
+        CF_SPACE_NAME: ${{ env.paas_space_name }}
         INSTALL_CONDUIT: true
 
     - name: Setup postgres client
@@ -56,11 +75,17 @@ jobs:
         cf conduit register-postgres-production -- pg_dump -E utf8 --clean --if-exists --no-owner --verbose --no-password -f ${BACKUP_FILE_NAME}.sql
         tar -cvzf ${BACKUP_FILE_NAME}.tar.gz ${BACKUP_FILE_NAME}.sql
 
+    - name: Set Connection String
+      run: |
+        STORAGE_CONN_STR="$(az keyvault secret show --name REGISTER-BACKUP-STORAGE-CONNECTION-STRING --vault-name ${{ env.key_vault_name }} | jq -r .value)"
+        echo "::add-mask::$STORAGE_CONN_STR"
+        echo "STORAGE_CONN_STR=$STORAGE_CONN_STR" >> $GITHUB_ENV
+
     - name: Upload Backup to Azure Storage
       run: |
         az storage blob upload --container-name prod-db-backup \
         --file ${BACKUP_FILE_NAME}.tar.gz --name ${BACKUP_FILE_NAME}.tar.gz --overwrite \
-        --connection-string '${{ secrets.AZURE_PROD_DB_BACKUP_STORAGE_CONNECTION_STRING }}'
+        --connection-string '${{ env.STORAGE_CONN_STR }}'
 
     - name: Sanitise the Database backup
       run: |


### PR DESCRIPTION
### Context

https://trello.com/c/sNdDNMXW/678-remove-bat-cf-and-db-github-secrets

The database backup workflow references some Github secrets that are also maintained elsewhere
- Cf user and pwd, changed to reference Azure keyvault values
- cf space, changed to reference workspace variables
- Storage account connection key, changed to reference Azure keyvault values  

### Changes proposed in this pull request

Update database-backup workflow

### Guidance to review

Check workflow 

Check test run 
https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/3105525276/jobs/5032139097

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
