### PR TITLE
[4652] Update dfe-reference gem to bring in new institution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ gem "govuk_markdown"
 gem "mechanize" # interact with HESA
 
 # pinned to a commit as v1 doesn't contain the Doctor of Philosophy disambiguation
-gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", ref: "9ed4450"
+gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", ref: "4a11f49"
 
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: 9ed4450e7eac5dff9a200c32dd8980626e04ca99
-  ref: 9ed4450
+  revision: 4a11f49acfd89fcdc0e433cd8683816862507ac2
+  ref: 4a11f49
   specs:
     dfe-reference-data (1.0.0)
       activesupport


### PR DESCRIPTION
### Context
https://trello.com/c/9qNctNxM/4652-register-trainee-teachers

New institution is Institute of Chartered Accountants of Scotland

### Changes proposed in this pull request
- Update `Gemfile` to reference the latest dfe-reference gem commit

### Guidance to review
- Add/edit a UK degree
- Search for ICAS or type "Institute..."
- Institute of Chartered Accountants of Scotland should appear

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
