### PR TITLE
[4656] Rename HPITT service and rake task

### DIFF
--- a/app/services/degrees/create_from_csv_row.rb
+++ b/app/services/degrees/create_from_csv_row.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Degrees
-  class CreateFromHpittCsv
+  class CreateFromCsvRow
     include ServicePattern
 
     class Error < StandardError; end

--- a/app/services/trainees/create_from_csv_row.rb
+++ b/app/services/trainees/create_from_csv_row.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Trainees
-  class CreateFromHpittCsv
+  class CreateFromCsvRow
     include ServicePattern
     include HasDiversityAttributes
     include HasCourseAttributes
@@ -46,7 +46,7 @@ module Trainees
       sanitise_funding
 
       if trainee.save!
-        ::Degrees::CreateFromHpittCsv.call(
+        ::Degrees::CreateFromCsvRow.call(
           trainee: trainee,
           csv_row: csv_row.to_hash.compact.select { |column_name, _| column_name.start_with?("Degree:") },
         )

--- a/lib/tasks/trainees_bulk_submit_hpitt.rake
+++ b/lib/tasks/trainees_bulk_submit_hpitt.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-namespace :hpitt do
+namespace :trainees do
   desc "Task to submit all of the HPITT records for TRN"
-  task bulk_submit: :environment do
+  task bulk_submitt_hpitt: :environment do
     trainees_to_exclude = %w[0034G00002fqS22QAE]
     teach_first_provider_id = 209
     teach_first = Provider.find(teach_first_provider_id)

--- a/lib/tasks/trainees_create_from_csv.rake
+++ b/lib/tasks/trainees_create_from_csv.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-namespace :hpitt do
-  desc "imports a csv of trainees from HPITT"
-  task :import, %i[provider_code csv_path] => [:environment] do |_, args|
+namespace :trainees do
+  desc "creates trainees from a CSV"
+  task :create_from_csv, %i[provider_code csv_path] => [:environment] do |_, args|
     csv = CSV.read(
       args.csv_path,
       headers: true,
@@ -13,7 +13,7 @@ namespace :hpitt do
     provider = Provider.find_by!(code: args.provider_code)
 
     csv.each_with_index do |row, i|
-      Trainees::CreateFromHpittCsv.call(provider: provider, csv_row: row)
+      Trainees::CreateFromCsvRow.call(provider: provider, csv_row: row)
     rescue StandardError => e
       Rails.logger.error("error on row #{i + 1}: #{e.message}")
       Sentry.capture_exception(e)

--- a/spec/lib/tasks/trainees_create_from_csv_spec.rb
+++ b/spec/lib/tasks/trainees_create_from_csv_spec.rb
@@ -2,12 +2,12 @@
 
 require "rails_helper"
 
-describe "hpitt:import" do
+describe "trainees:create_from_csv" do
   include SeedHelper
 
   subject do
     args = Rake::TaskArguments.new(%i[provider_code csv_path], [provider.code, csv_path])
-    Rake::Task["hpitt:import"].execute(args)
+    Rake::Task["trainees:create_from_csv"].execute(args)
   end
 
   before do

--- a/spec/services/trainees/create_from_csv_row_spec.rb
+++ b/spec/services/trainees/create_from_csv_row_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 module Trainees
-  describe CreateFromHpittCsv do
+  describe CreateFromCsvRow do
     include SeedHelper
     let!(:academic_cycle) { create(:academic_cycle, :current) }
     let(:employing_school_urn) { "0123456" }


### PR DESCRIPTION
### Context

Follow on work from https://github.com/DFE-Digital/register-trainee-teachers/pull/2741

I didn't want to rename the files in the same PR so that the diff was preserved for ease of review.

### Changes proposed in this pull request

Rename the HPITT rake task and service now that they can be used for any SCITT.

### Guidance to review

Decide whether you like the names, then 👍 or 👎 . 

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml