### PR TITLE
[4704] - Remove pre-selected in-training filter for 'registered trainees' in top navigation

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -72,10 +72,6 @@ private
     redirect_to(not_found_path)
   end
 
-  def filter_params
-    params.permit(permitted_params + permitted_admin_params)
-  end
-
   def permitted_params
     [
       :subject,
@@ -83,7 +79,6 @@ private
       :start_year,
       :end_year,
       :sort_by,
-      :clear,
       {
         level: [],
         training_route: [],

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -73,13 +73,7 @@ private
   end
 
   def filter_params
-    user_params = params.permit(permitted_params + permitted_admin_params)
-
-    if user_params.empty? && !user_params[:clear]
-      { status: %w[in_training] }
-    else
-      user_params
-    end
+    params.permit(permitted_params + permitted_admin_params)
   end
 
   def permitted_params

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -9,10 +9,6 @@ module FilterHelper
     tag.span("Remove ", class: "govuk-visually-hidden") + value.upcase_first + tag.span(" #{filter.humanize.downcase} filter", class: "govuk-visually-hidden")
   end
 
-  def clear_search_link(search_path)
-    trainee_search_path?(search_path) ? trainees_path(clear: true) : drafts_path
-  end
-
   def tags_for_filter(filters, filter, value)
     case value
     when String
@@ -34,11 +30,11 @@ private
   def remove_checkbox_tag_link(filters, filter, value)
     new_filters = filters.deep_dup
     new_filters[filter].reject! { |v| v == value }
-    new_filters.to_query.blank? ? "?clear=true" : "?#{new_filters.to_query}"
+    new_filters.to_query.blank? ? nil : "?#{new_filters.to_query}"
   end
 
   def remove_select_tag_link(filters, filter)
     new_filters = filters.reject { |f| f == filter }
-    new_filters.to_query.blank? ? "?clear=true" : "?#{new_filters.to_query}"
+    new_filters.to_query.blank? ? nil : "?#{new_filters.to_query}"
   end
 end

--- a/app/views/trainees/_selected_filters.html.erb
+++ b/app/views/trainees/_selected_filters.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="moj-filter__heading-action">
         <p class="govuk-body">
-        <%= govuk_link_to 'Clear<span class="govuk-visually-hidden"> all filters</span>'.html_safe, clear_search_link(search_path), class: "govuk-link--no-visited-state" %>
+        <%= govuk_link_to 'Clear<span class="govuk-visually-hidden"> all filters</span>'.html_safe, search_path, class: "govuk-link--no-visited-state" %>
         </p>
       </div>
     </div>

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -10,10 +10,7 @@ RSpec.feature "Filtering trainees" do
       given_a_subject_specialism_is_available_for_selection
       when_i_visit_the_trainee_index_page
       then_i_see_my_provider_name
-    end
-
-    scenario "defaults to in training filter selected" do
-      then_only_the_in_training_trainee_is_visible
+      then_all_registered_trainees_are_visible
     end
 
     context "when filtering trainees by record completion" do
@@ -23,7 +20,6 @@ RSpec.feature "Filtering trainees" do
       end
 
       scenario "can filter by complete records" do
-        when_i_deselect_the_in_training_filter
         when_i_filter_by_complete
         then_only_complete_records_are_visible
       end
@@ -35,7 +31,6 @@ RSpec.feature "Filtering trainees" do
     end
 
     scenario "can filter by subject" do
-      when_i_deselect_the_in_training_filter
       when_i_filter_by_subject("Biology")
       then_only_biology_trainees_are_visible
       then_the_tag_is_visible_for("Biology")
@@ -50,8 +45,14 @@ RSpec.feature "Filtering trainees" do
       then_the_record_source_filter_is_not_visible
     end
 
+    scenario "can filter by status" do
+      when_i_filter_by_in_training_status
+      then_only_the_in_training_trainee_is_visible
+    end
+
     scenario "can filter by multiple statuses" do
-      when_i_filter_by_withdrawn_status
+      when_i_filter_by_in_training_status
+      and_i_filter_by_withdrawn_status
       then_the_in_training_and_withdrawn_trainees_are_visible
     end
 
@@ -115,10 +116,7 @@ RSpec.feature "Filtering trainees" do
     end
 
     context "searching" do
-      before do
-        when_i_deselect_the_in_training_filter
-        when_i_search_for(search_term)
-      end
+      before { when_i_search_for(search_term) }
 
       shared_examples_for "a working search" do
         it "returns the correct trainee" do
@@ -244,12 +242,12 @@ private
     trainee_index_page.apply_filters.click
   end
 
-  def when_i_deselect_the_in_training_filter
+  def when_i_filter_by_in_training_status
     trainee_index_page.in_training_checkbox.click
     trainee_index_page.apply_filters.click
   end
 
-  def when_i_filter_by_withdrawn_status
+  def and_i_filter_by_withdrawn_status
     trainee_index_page.withdrawn_checkbox.click
     trainee_index_page.apply_filters.click
   end
@@ -330,7 +328,7 @@ private
   end
 
   def then_all_registered_trainees_are_visible
-    Trainee.not_draft.each { |trainee| expect(trainee_index_page).to have_text(full_name(trainee)) }
+    Trainee.where.not(state: "draft").each { |trainee| expect(trainee_index_page).to have_text(full_name(trainee)) }
   end
 
   def then_all_draft_trainees_are_visible


### PR DESCRIPTION
### Context

From Round 25 of UR and support tickets, we know that users are finding it confusing that the 'registered trainees' page has a filter for 'in training' selected. It needs to be deselected to search for historic trainees.

Remove the pre-selected 'in training' filter on the 'registered trainees' page here: https://www.register-trainee-teachers.service.gov.uk/trainees

### Guidance to review

not a lot!
