### PR TITLE
[4631] Add hesa data mapping page

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -18,4 +18,16 @@ class GuidanceController < ApplicationController
   def registering_trainees_through_hesa; end
 
   def check_data; end
+
+  def hesa_register_data_mapping
+    tab_param = params[:tab].underscore
+    @tab = valid_tabs.include?(tab_param) ? tab_param : "trainee_progress"
+    render(layout: "application")
+  end
+
+private
+
+  def valid_tabs
+    %w[course_details database_only funding schools trainee_progress personal_details]
+  end
 end

--- a/app/views/guidance/_course_details.html.erb
+++ b/app/views/guidance/_course_details.html.erb
@@ -1,0 +1,60 @@
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-visually-hidden">Course details</caption>
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header">Register CSV column</th>
+    <th class="govuk-table__header">Register field in the service</th>
+    <th class="govuk-table__header">HESA field</th>
+    <th class="govuk-table__header">More information</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body"><tr class="govuk-table__row">
+    <td class="govuk-table__cell">course_route</td>
+    <td class="govuk-table__cell">Training route</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/entryrte">ENTRYRTE</a> (entry route)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">course_allocation_subject<br>course_itt_subject_1<br>course_itt_subject_2<br>course_itt_subject_3</td>
+    <td class="govuk-table__cell">Subject (within course details)</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/sbjca">SBJCA</a> (subject of ITT course)</td>
+    <td class="govuk-table__cell">The course allocation subject is like an overall category that ITT subjects are grouped by.<br><br>We get the ‘course_allocation_subject’ in the CSV from the ‘course_itt_subject_1’. For example, if the trainees’ course subject 1 is French, the allocation subject is Modern languages.</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">course_min_age<br>course_max_age<br>course_education_phase</td>
+    <td class="govuk-table__cell">Age range<br><br>Education phase</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/ittphsc">ITTPHSC</a> (ITT phase or scope)</td>
+    <td class="govuk-table__cell">HESA codes 99803 and 99801 are not used in Register.<br><br>We decide the ‘Education phase’ (primary or secondary) from the ‘Age range’. If the maximum age is 11 or under, we set the ‘Education phase’ to ‘primary’. Anything else will be set to ‘secondary’.</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">course_study_mode</td>
+    <td class="govuk-table__cell">Full time or part time</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/mode">MODE</a> (mode)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">itt_start_date<br>start_academic_year</td>
+    <td class="govuk-table__cell">ITT start date</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/comdate">COMDATE</a> (start date of instance)</td>
+    <td class="govuk-table__cell">‘ITT start date’ (COMDATE) will also be used to set the ‘trainee start date’ (ITTCOMDATE) if ‘ITTCOMDATE’ is not available.</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">itt_end_date<br>end_academic_year</td>
+    <td class="govuk-table__cell">ITT end date</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/expectedenddate">EXPECTEDENDDATE</a> (expected end date)</td>
+    <td class="govuk-table__cell">You must submit this data even though it’s optional in HESA. If you do not add it, we’ll use the trainee’s ITT start date (COMDATE), training route (ENTRYRTE) and if they’re full or part time (MODE) to work out the ITT end date.</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">commencement_date<br>itt_start_date</td>
+    <td class="govuk-table__cell">Trainee start date</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/ittcomdate">ITTCOMDATE</a> (start date of ITT course)</td>
+    <td class="govuk-table__cell">If this is available, it will set the ‘ITT start date’ (COMDATE) and ‘trainee start date’ (ITTCOMDATE)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">withdraw_date</td>
+    <td class="govuk-table__cell">Withdrawal date (in Trainee status field)</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/enddate">ENDDATE</a> (end date of instance)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/guidance/_database_only.html.erb
+++ b/app/views/guidance/_database_only.html.erb
@@ -1,0 +1,62 @@
+<p class="govuk-body">
+  Use the table to check how data maps between HESA and Register trainee teachers (Register).
+</p>
+
+<p class="govuk-body">
+  Where possible, these tables follow the same order as the CSV export and a trainee’s record in Register.
+</p>
+
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-visually-hidden">Database only</caption>
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header">HESA field</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body"><tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/allplace">ALLPLACE</a> (allocated place)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/courseid">COURSEID</a> (course identifier)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/ctitle">CTITLE</a> (course title)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/fundcode">FUNDCODE</a> (fundability code)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/ittaim">ITTAIM</a> (ITT qualification aim)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/nin">NIN</a> (national insurance number)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/numhus">NUMHUS</a> (student instance identifier)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/pgappstdt">PGAPPSTDT</a> (postgraduate teaching apprenticeship start date)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/plmntdys">PLMNTDYS</a> (number of days spent in a placement school)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/plmntsch">PLMNTSCH</a> (placement school)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/psurname">PSURNAME</a> (immediately prior surname)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/qlaim">QLAIM</a> (qualification aim)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/sname16">SNAME16</a> (family name on 16 birthday)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/ttcid">TTCID</a> (teacher training course)</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/yearprg">YEARPRG</a> (year of course)</td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/guidance/_database_only.html.erb
+++ b/app/views/guidance/_database_only.html.erb
@@ -1,9 +1,9 @@
 <p class="govuk-body">
-  Use the table to check how data maps between HESA and Register trainee teachers (Register).
+  These HESA fields are used for analysis and map to Register’s database, so you will not see them in the Register service or the CSV export.
 </p>
 
 <p class="govuk-body">
-  Where possible, these tables follow the same order as the CSV export and a trainee’s record in Register.
+  For school placements (HESA field PLMNTSCH), although we collect and use this data, you cannot view it in the service or the CSV yet.
 </p>
 
 <table class="govuk-table">

--- a/app/views/guidance/_funding.html.erb
+++ b/app/views/guidance/_funding.html.erb
@@ -1,0 +1,24 @@
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-visually-hidden">Funding</caption>
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header">Register CSV column</th>
+    <th class="govuk-table__header">Register field in the service</th>
+    <th class="govuk-table__header">HESA field</th>
+    <th class="govuk-table__header">More information</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body"><tr class="govuk-table__row">
+    <td class="govuk-table__cell">funding_method</td>
+    <td class="govuk-table__cell">Funding method</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/burslev">BURSLEV</a> (bursary level award)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">training_initiative</td>
+    <td class="govuk-table__cell">Training initiative</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/initiatives">INITIATIVES</a> (initiatives)</td>
+    <td class="govuk-table__cell">HESA allows you to add 2 initiatives, but Register will only import the first one.<br><br>The following HESA codes are not mapped to Register:<br>001 Abridged ITT course<br>011 Primary with mathematics specialist<br>019 Additional ITT place for PE with a priority subject</td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/guidance/_personal_details.html.erb
+++ b/app/views/guidance/_personal_details.html.erb
@@ -27,8 +27,8 @@
     <td class="govuk-table__cell">–</td>
   </tr>
   <tr class="govuk-table__row">
-    <td class="govuk-table__cell">gender</td>
-    <td class="govuk-table__cell">Gender</td>
+    <td class="govuk-table__cell">sex</td>
+    <td class="govuk-table__cell">Sex</td>
     <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/sexid">SEXID</a> (sex identifier)</td>
     <td class="govuk-table__cell">HESA code 96 ‘Information refused’ imports into Register as ‘Prefer not to say’<br><br>HESA code 99 ‘Not available’ imports into Register as ‘Gender not provided’</td>
   </tr>

--- a/app/views/guidance/_personal_details.html.erb
+++ b/app/views/guidance/_personal_details.html.erb
@@ -1,0 +1,96 @@
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-visually-hidden">Personal details</caption>
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header">Register CSV column</th>
+    <th class="govuk-table__header">Register field in the service</th>
+    <th class="govuk-table__header">HESA field</th>
+    <th class="govuk-table__header">More information</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body"><tr class="govuk-table__row">
+    <td class="govuk-table__cell">first_names</td>
+    <td class="govuk-table__cell">Full name</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/fnames">FNAMES</a> (forenames)</td>
+    <td class="govuk-table__cell">A trainee’s first name and middle name (if they have one) will go into the Register CSV column called ‘first_names’. The column ‘middle_names’ will be empty.</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">last_names</td>
+    <td class="govuk-table__cell">Full name</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/surname">SURNAME</a> (family name)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">date_of_birth</td>
+    <td class="govuk-table__cell">Date of birth</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/birthdte">BIRTHDTE</a> (date of birth)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">gender</td>
+    <td class="govuk-table__cell">Gender</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/sexid">SEXID</a> (sex identifier)</td>
+    <td class="govuk-table__cell">HESA code 96 ‘Information refused’ imports into Register as ‘Prefer not to say’<br><br>HESA code 99 ‘Not available’ imports into Register as ‘Gender not provided’</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">nationalities</td>
+    <td class="govuk-table__cell">Nationality</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/nation">NATION</a> (nationality)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">email_address</td>
+    <td class="govuk-table__cell">Email address</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/nqtemail">NQTEMAIL</a> (email addresses)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">diversity_disclosure<br>ehnic_group<br>ethnic_background<br>ethnic_background_additional</td>
+    <td class="govuk-table__cell">Ethnicity</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/ethnic">ETHNIC</a> (ethnicity)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">diversity_disclosure<br>disability_disclosure<br>disabilities</td>
+    <td class="govuk-table__cell">Disability</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/disable">DISABLE</a> (disability)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">number_of_degrees degree_1_subject</td>
+    <td class="govuk-table__cell">Subject (within personal details and education)</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/degsbj">DEGSBJ</a> (previous degree subject)</td>
+    <td class="govuk-table__cell">Register only supports 1 degree subject at the moment. If you add multiple subjects for a trainee’s degree, Register will take the first one.</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">degree_1_non_uk_type degree_1_type_of_degree (for UK degrees only)</td>
+    <td class="govuk-table__cell">Degree type</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/degtype">DEGTYPE</a> (previous degree type)</td>
+    <td class="govuk-table__cell">The CSV export from Register does not display degree types with ‘Honours’. For example, in HESA a BEd is code 001 and a BEd (Hons) is code 002. Both these codes will show as ‘Bachelor of Education’ in the CSV.</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">degree_1_awarding_institution</td>
+    <td class="govuk-table__cell">Awarding institution</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/degest">DEGEST</a> (previous degree establishment)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">degree_1_uk_or_non_uk<br>degree_1_country</td>
+    <td class="govuk-table__cell">Country</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/degctry">DEGCTRY</a> (previous degree country)</td>
+    <td class="govuk-table__cell">The ‘degree_1_uk_or_non_uk’ column in the Register CSV will show as ‘UK’ when the following HESA codes are used:<br>XF England<br>XG Northern Ireland<br>XH Scotland<br>XI Wales<br>XK United Kingdom, not otherwise specified<br><br>The ‘degree_1_country’ column in the Register CSV will only populate with countries outside the UK.<br></td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">degree_1_grade</td>
+    <td class="govuk-table__cell">Grade</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/degclss">DEGCLSS</a> (previous degree class)</td>
+    <td class="govuk-table__cell">This information will only show in the Register service and CSV for UK degrees.</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">degree_1_graduation_year</td>
+    <td class="govuk-table__cell">Graduation year</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/degenddt">DEGENDDT</a> (previous degree end date)</td>
+    <td class="govuk-table__cell">Register will show the year the trainee graduated from their degree. For example, 2010.</td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/guidance/_schools.html.erb
+++ b/app/views/guidance/_schools.html.erb
@@ -1,0 +1,28 @@
+<p class="govuk-body">
+  Register will check the URN (unique reference number) of each school to make sure it’s valid. If it’s not, this data will not import into Register.
+</p>
+
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-visually-hidden">Schools</caption>
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header">Register CSV column</th>
+    <th class="govuk-table__header">Register field in the service</th>
+    <th class="govuk-table__header">HESA field</th>
+    <th class="govuk-table__header">More information</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body"><tr class="govuk-table__row">
+    <td class="govuk-table__cell">employing_school_urn</td>
+    <td class="govuk-table__cell">Employing school</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/sdemploy">SDEMPLOY</a> (School Direct employing school)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">lead_school_urn</td>
+    <td class="govuk-table__cell">Lead school</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/sdlead">SDLEAD</a> (School Direct lead school)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/guidance/_trainee_progress.html.erb
+++ b/app/views/guidance/_trainee_progress.html.erb
@@ -1,0 +1,42 @@
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-visually-hidden">Trainee progress</caption>
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header">Register CSV column</th>
+    <th class="govuk-table__header">Register field in the service</th>
+    <th class="govuk-table__header">HESA field</th>
+    <th class="govuk-table__header">More information</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body"><tr class="govuk-table__row">
+    <td class="govuk-table__cell">hesa_id</td>
+    <td class="govuk-table__cell">not displayed</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/husid">HUSID</a> (HESA unique student identifier)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">provider_trainee_id</td>
+    <td class="govuk-table__cell">Trainee ID</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/ownstu">OWNSTU</a> (provider’s own identifier for student)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">trn</td>
+    <td class="govuk-table__cell">TRN</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/trn">TRN</a> (teacher reference number)</td>
+    <td class="govuk-table__cell">–</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">status</td>
+    <td class="govuk-table__cell">Trainee status</td>
+    <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c22053/e/rsnend">RSNEND</a> (reason for ending instance)</td>
+    <td class="govuk-table__cell">If HESA codes 03, 05 or 11 are used we mark the trainee status as ‘withdrawn’ in Register. We’ll also add a ‘withdraw_date’ and ‘withdraw_reason’ in the Register CSV.<br><br>HESA field ‘MODE’ will also impact ‘Trainee status’. If codes 63 or 64 (dormant trainees) are used, the trainee’s status will change to ‘Deferred’ in Register.<br><br>‘Dormant’ in HESA means ‘Deferred’ in Register.</td>
+  </tr>
+  <tr class="govuk-table__row">
+    <td class="govuk-table__cell">hesa_updated_at</td>
+    <td class="govuk-table__cell">not displayed</td>
+    <td class="govuk-table__cell">STATUS_TIMESTAMP</td>
+    <td class="govuk-table__cell">The date the trainee record was last updated in HESA or the TRA portal.<br><br>This is not the date the record was uploaded to HESA. For example, if you update and then upload a record in September, ‘hesa_updated_at’ will show a date for September. If you then upload the same record in January and April without any updates, ‘hesa_updated_at’ will still show with a date in September.</td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/guidance/hesa_register_data_mapping.html.erb
+++ b/app/views/guidance/hesa_register_data_mapping.html.erb
@@ -1,0 +1,49 @@
+<%= render PageTitle::View.new(text: "Hesa register data mapping") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "How to use this service",
+    href: guidance_path,
+    ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">Check the data mapping between HESA and Register trainee teachers</h1>
+    <p class="govuk-body">
+      Use the table to check how data maps between HESA and Register trainee teachers (Register).
+    </p>
+    <p class="govuk-body">
+      Where possible, these tables follow the same order as the CSV export and a trainee’s record in Register.
+    </p>
+  </div>
+    <div class="govuk-grid-column-full">
+    <%= render TabNavigation::View.new(items: [
+      {
+        name: "Trainee progress",
+        url: hesa_register_data_mapping_guidance_url(:trainee_progress)
+      },
+      {
+        name: "Personal details",
+        url: hesa_register_data_mapping_guidance_url(:personal_details)
+      },
+      {
+        name: "Course details",
+        url: hesa_register_data_mapping_guidance_url(:course_details)
+      },
+      {
+        name: "Schools",
+        url: hesa_register_data_mapping_guidance_url(:schools)
+      },
+      {
+        name: "Funding",
+        url: hesa_register_data_mapping_guidance_url(:funding)
+      },
+      {
+        name: "Database only",
+        url: hesa_register_data_mapping_guidance_url(:database_only)
+      },
+    ]) %>
+      <%= render "guidance/#{@tab}" %>
+    </div>
+</div>

--- a/app/views/guidance/hesa_register_data_mapping.html.erb
+++ b/app/views/guidance/hesa_register_data_mapping.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: "Hesa register data mapping") %>
+<%= render PageTitle::View.new(text: "Check the data mapping between HESA and Register trainee teachers - #{@tab.humanize}") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-9">Check the data mapping between HESA and Register trainee teachers</h1>
+    <h1 class="govuk-heading-l">Check the data mapping between HESA and Register trainee teachers</h1>
     <p class="govuk-body">
       Use the table to check how data maps between HESA and Register trainee teachers (Register).
     </p>
@@ -21,27 +21,27 @@
     <%= render TabNavigation::View.new(items: [
       {
         name: "Trainee progress",
-        url: hesa_register_data_mapping_guidance_url(:trainee_progress)
+        url: hesa_register_data_mapping_guidance_url("trainee-progress")
       },
       {
         name: "Personal details",
-        url: hesa_register_data_mapping_guidance_url(:personal_details)
+        url: hesa_register_data_mapping_guidance_url("personal-details")
       },
       {
         name: "Course details",
-        url: hesa_register_data_mapping_guidance_url(:course_details)
+        url: hesa_register_data_mapping_guidance_url("course-details")
       },
       {
         name: "Schools",
-        url: hesa_register_data_mapping_guidance_url(:schools)
+        url: hesa_register_data_mapping_guidance_url("schools")
       },
       {
         name: "Funding",
-        url: hesa_register_data_mapping_guidance_url(:funding)
+        url: hesa_register_data_mapping_guidance_url("funding")
       },
       {
         name: "Database only",
-        url: hesa_register_data_mapping_guidance_url(:database_only)
+        url: hesa_register_data_mapping_guidance_url("database-only")
       },
     ]) %>
       <%= render "guidance/#{@tab}" %>

--- a/app/views/guidance/show.html.erb
+++ b/app/views/guidance/show.html.erb
@@ -41,6 +41,12 @@
               registering_trainees_through_hesa_guidance_path,
             )%>
           </li>
+          <li>
+            <%= govuk_link_to(
+              "Check the data mapping between HESA and Register trainee teachers",
+              hesa_register_data_mapping_url(:trainee_progress),
+              )%>
+          </li>
         </ul>
       </div>
     </div>

--- a/app/views/guidance/show.html.erb
+++ b/app/views/guidance/show.html.erb
@@ -44,7 +44,7 @@
           <li>
             <%= govuk_link_to(
               "Check the data mapping between HESA and Register trainee teachers",
-              hesa_register_data_mapping_url(:trainee_progress),
+              hesa_register_data_mapping_guidance_url("trainee-progress"),
               )%>
           </li>
         </ul>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -89,6 +89,13 @@
           { class: "govuk-link--no-visited-state" }
         )%>
       </li>
+      <li>
+        <%= govuk_link_to(
+          "Check the data mapping between HESA and Register trainee teachers",
+          hesa_register_data_mapping_guidance_url("trainee-progress"),
+          { class: "govuk-link--no-visited-state" }
+          )%>
+      </li>
     </ul>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,6 +165,7 @@ Rails.application.routes.draw do
     get "/manually-registering-trainees", to: "guidance#manually_registering_trainees"
     get "/registering-trainees-through-hesa", to: "guidance#registering_trainees_through_hesa"
     get "/check-data", to: "guidance#check_data"
+    get "/hesa-register-data-mapping/:tab", to: "guidance#hesa_register_data_mapping", as: "hesa_register_data_mapping"
   end
 
   if FeatureService.enabled?("funding")

--- a/spec/controllers/guidance_controller_spec.rb
+++ b/spec/controllers/guidance_controller_spec.rb
@@ -79,4 +79,16 @@ describe GuidanceController, type: :controller do
       expect(response).to render_template("check_data")
     end
   end
+
+  describe "#hesa_register_data_mapping" do
+    it "returns a 200 status code" do
+      get :hesa_register_data_mapping, params: { tab: "trainee_progress" }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct template and page" do
+      get :hesa_register_data_mapping, params: { tab: "trainee_progress" }
+      expect(response).to render_template("hesa_register_data_mapping")
+    end
+  end
 end


### PR DESCRIPTION
### Context

Create new page of content 'Check the data mapping between HESA and Register trainee teachers'

This is because we are improving and expanding the guidance pages for Register. 

### Success
- The Guidance index page has a link to the new page. The link should be called 'Check the data mapping between HESA and Register trainee teachers' - Guidance index page in the prototype: https://register-prototype.herokuapp.com/guidance
- The Homepage has a link to the new page. The link should be called 'Check the data mapping between HESA and Register trainee teachers' - Homepage in the prototype: https://register-prototype.herokuapp.com/home
- New page is created with URL: register-trainee-teachers.service.gov.uk/guidance/hesa-register-data-mapping
- It has the content from the prototype: https://register-prototype.herokuapp.com/guidance/hesa-register-data-mapping/trainee-progress
- It has a backlink to take them back to 'How to use this service': register-trainee-teachers.service.gov.uk/guidance

### Changes proposed in this pull request

### Guidance to review

Compare new pages (guidance/hesa-register-data-mapping/trainee-progress)  to prototype:https://register-prototype.herokuapp.com/guidance/hesa-register-data-mapping/trainee-progress

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
