### PR TITLE
[4568] Fix multiple timeline entries for 'Record imported from HESA'

### DIFF
--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -24,7 +24,8 @@ module Trainees
         return
       end
 
-      raise(MissingCourseError, "Cannot find course with uuid: #{@raw_course['course_uuid']}") if course.nil? # Courses can be missing in non-prod environments
+      # Courses can be missing in non-prod environments
+      raise(MissingCourseError, "Cannot find course with uuid: #{@raw_course['course_uuid']}") if course.nil?
 
       Trainees::SetAcademicCycles.call(trainee: trainee)
       trainee.save!
@@ -147,9 +148,10 @@ module Trainees
     end
 
     def trainee_already_exists?
-      Trainee.exists?(first_names: raw_trainee["first_name"],
-                      last_name: raw_trainee["last_name"],
-                      date_of_birth: raw_trainee["date_of_birth"])
+      scope = application_record.provider.trainees.not_withdrawn.or(Trainee.not_awarded)
+      scope.exists?(first_names: raw_trainee["first_name"],
+                    last_name: raw_trainee["last_name"],
+                    date_of_birth: raw_trainee["date_of_birth"])
     end
 
     def ethnic_background_attributes

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -73,7 +73,7 @@ module Trainees
           ),
         ]
 
-        if hesa_or_dttp_user?
+        if hesa_or_dttp_user? && auditable_type == "Trainee"
           creation_events <<
             TimelineEvent.new(
               title: import_title,


### PR DESCRIPTION
### Context
https://trello.com/c/Dy9EkYtf/4568-multiple-timeline-entries-for-record-imported-from-hesa

### Changes proposed in this pull request
- Fix `Trainees::CreateTimelineEvents` so that it doesn't show 'Record imported from HESA' more than once. This was happening because code was considering new degrees as a trainee record import.

### Guidance to review
Not possible to test in a PR environment. The following screenshots are taken from real trainee in production that was the example used in the Trello card:

Before           |  After
:-------------------------:|:-------------------------:
<img width="635"  src="https://user-images.githubusercontent.com/28728/192541623-bcab8f06-b13e-4446-a6d5-1d60abac24b9.png">  |  <img width="635" alt="Screenshot 2022-09-27 at 14 39 35" src="https://user-images.githubusercontent.com/28728/192542176-aec72071-f9f0-4867-bd37-5a26e316d7ad.png">

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
