### PR TITLE
remove TF_STATE_EXISTS from db backup workflow

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -45,7 +45,6 @@ jobs:
         echo "paas_space_name=$(jq -r '.paas_space_name' ${tf_vars_file})" >> $GITHUB_ENV
 
     - uses: azure/login@v1
-      if: env.TF_STATE_EXISTS == 'true'
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS_PRODUCTION }}
 


### PR DESCRIPTION
### Context

Remove an if statement that shouldn't be in the db backup workflow
Added incorrectly under PR 2744

### Changes proposed in this pull request

removed
if: env.TF_STATE_EXISTS == 'true'

### Guidance to review

check syntax

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
