### PR TITLE
Add labels to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,8 +34,16 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  labels:
+  - DevOps
+  - dependencies
+  - github_actions
 - package-ecosystem: terraform
   directory: "/terraform"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  labels:
+  - DevOps
+  - dependencies
+  - terraform


### PR DESCRIPTION
### Context
Ensure the DevOps label is added to pull requests that relate to either Terraform provider versions or GitHub action and workflow task versions. This ensures the team are notified up new pull requests on their Slack channel.

### Changes proposed in this pull request
Add the labeler file and workflow to automatically label new pull requests based on the paths of files being changed.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
