### PR TITLE
Anonymise dfe_sign_in_uid

### DIFF
--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,2 +1,3 @@
 ---
-shared: {}
+  users:
+    - dfe_sign_in_uid

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,3 +1,4 @@
 ---
-  users:
+:shared:
+  :users:
     - dfe_sign_in_uid


### PR DESCRIPTION
### Context

All provider facing services (Publish, Manage and Register) each have their own provider users in their services. There is currently no shared identifier across the services for provider users that is accessible for analytics. Therefore there isn't a method through BQ to see which provider users engage with each service.

With ITT reform changing how we onboard providers into TS, it's important for us to have a true reflection of provider users across the service.

Register has a dfe_sign_in_uid in the users table which is not anonymised.
Apply has a dfe_sign_in_uid in the provider_users and support_users tables which is anonymised
Publish has a sign_in_user_id in the user table which I've confirmed with @avinhurry matches the above IDs, but currently isn't streamed at all (it's in their blocklist)

As a... data infrastructure team
We need to... join up services with a way to identify which provider-users appear in each provider facing service.
So that... improve cross-service analysis abilities and calculate the number of provider-users crossing into each service.

### Changes proposed in this pull request
Anonymise dfe_sign_in_uid in data about users streamed to BigQuery

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
