### PR TITLE
Change system admin to 'Support for Register'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
   header:
     items:
       sign_out: Sign out
-      system_admin: System admin
+      system_admin: Support for Register
   contact_details:
     view:
       address: &address Address


### PR DESCRIPTION
### Context
'System admin' isn't terminology used by any other BAT service. We want to use 'Support for Register' as this is what support agents would understand and it's more consistent. We have a later ticket to change URLs and other parts.

### Changes proposed in this pull request
- Change the content for 'system admin' to 'Support for Register'.

### Guidance to review
- Check it didn't break anything.
- 
### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
