### PR TITLE
[4707] Tidy up HPITT bulk submit task

### DIFF
--- a/lib/tasks/trainees_hpitt_bulk_submit.rake
+++ b/lib/tasks/trainees_hpitt_bulk_submit.rake
@@ -1,24 +1,19 @@
 # frozen_string_literal: true
 
-namespace :hpitt do
-  desc "Task to submit all of the HPITT records for TRN"
-  task bulk_submit: :environment do
-    trainees_to_exclude = %w[0034G00002fqS22QAE]
-    teach_first_provider_id = 209
-    teach_first = Provider.find(teach_first_provider_id)
+namespace :trainees do
+  desc "submits all of the HPITT records for TRN"
+  task hpitt_bulk_submit: :environment do
+    provider = Provider.find_by!(code: "HPITT")
 
     current_interval = 0
     interval_increment = 15
     batch_size = 10
 
-    teach_first.trainees.draft.find_in_batches(batch_size: batch_size) do |trainee_group|
+    provider.trainees.draft.find_in_batches(batch_size: batch_size) do |trainee_group|
       trainee_group.each do |trainee|
-        next if trainees_to_exclude.include?(trainee.trainee_id)
-
         next unless Submissions::TrnValidator.new(trainee: trainee).valid?
 
         trainee.submit_for_trn!
-
         Dqt::RegisterForTrnJob.set(wait: current_interval.seconds).perform_later(trainee)
       end
       current_interval += interval_increment


### PR DESCRIPTION
### Context

https://trello.com/c/G22kJqb7/4707-m-prepare-bulk-submission-of-teachfirst-trainees-for-their-trns

### Changes proposed in this pull request

Update and renames tasks to submit hpitt trainees for TRN.

### Guidance to review

If you change one of your providers locally to have the "HPITT" code, you could run this task and check that their completed drafts are submitted for TRN.

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
