### PR TITLE
Fix docker build cache

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -55,6 +55,9 @@ jobs:
         echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
         echo "KEY_VAULT_INFRA_SECRET_NAME=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2.0.0
       with:
@@ -90,9 +93,16 @@ jobs:
           type=registry,ref=${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
         build-args: COMMIT_SHA=${{ github.sha }}
 
-    - name: Push ${{ env.DOCKER_IMAGE }} images for review
+    - name: Push images for review
       if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
-      run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
+      uses: docker/build-push-action@v3
+      with:
+        tags: |
+          ${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
+          ${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
+        push: true
+        cache-to: type=inline
+        build-args: COMMIT_SHA=${{ github.sha }}
 
     - name: Run Snyk to check Docker image for vulnerabilities
       if: github.actor != 'dependabot[bot]'
@@ -103,9 +113,16 @@ jobs:
         image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
         args: --file=Dockerfile --severity-threshold=high
 
-    - name: Push ${{ env.DOCKER_IMAGE }} images
+    - name: Push images
       if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') }}
-      run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
+      uses: docker/build-push-action@v3
+      with:
+        tags: |
+          ${{env.DOCKER_IMAGE}}:${{env.IMAGE_TAG}}
+          ${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}
+        push: true
+        cache-to: type=inline
+        build-args: COMMIT_SHA=${{ github.sha }}
 
     - name: Check for Failure
       if: ${{ failure() && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
### Context

https://trello.com/c/7UJWUj9z/681-register-docker-build-not-using-cache

Docker build cache is not always being used when it should be.

### Changes proposed in this pull request

1. Added setup-buildx step
- this configured the docker-container driver
- but then it started alternatively using and not using cache on subsequent runs

2. Change the separate 'docker push' to also use build-push-action as per https://github.com/docker/build-push-action/blob/master/docs/advanced/test-before-push.md and using BUILDKIT_INLINE_CACHE=1
- now it is consistently using cache on each run
e.g.
https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/3150868954
https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/3150986570

### Guidance to review

Check build logs

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
