### PR TITLE
[4659] Fix CourseDetails::View, so it can display a changed route

### DIFF
--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -59,7 +59,11 @@ module CourseDetails
 
     def training_route_row
       unless trainee.draft?
-        { field_value: t("activerecord.attributes.trainee.training_routes.#{trainee.training_route}"), field_label: t("components.course_detail.route"), action_url: nil }
+        {
+          field_value: t("activerecord.attributes.trainee.training_routes.#{training_route}"),
+          field_label: t("components.course_detail.route"),
+          action_url: nil,
+        }
       end
     end
 
@@ -127,11 +131,15 @@ module CourseDetails
     end
 
     def course
-      @course ||= trainee.available_courses.find_by(uuid: data_model.course_uuid)
+      @course ||= trainee.available_courses&.find_by(uuid: data_model.course_uuid)
     end
 
     def default_mappable_field(field_value, field_label)
       { field_value: field_value, field_label: field_label, action_url: edit_trainee_course_details_path(trainee) }
+    end
+
+    def training_route
+      course&.route || trainee.training_route
     end
   end
 end

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -247,8 +247,7 @@ module CourseDetails
 
         it "renders route" do
           expect(rendered_component).to have_text(education_phase)
-          expect(rendered_component)
-            .to have_text("Secondary")
+          expect(rendered_component).to have_text("Secondary")
         end
 
         it "renders course age range" do
@@ -265,8 +264,7 @@ module CourseDetails
 
         it "renders route" do
           expect(rendered_component).to have_text(education_phase)
-          expect(rendered_component)
-            .to have_text("Secondary")
+          expect(rendered_component).to have_text("Secondary")
         end
 
         it "renders course age range" do
@@ -297,6 +295,20 @@ module CourseDetails
 
       it "does not render study_mode" do
         expect(rendered_component).not_to have_selector(".govuk-summary-list__row.full-time-or-part-time")
+      end
+    end
+
+    context "trainee with Apply application changes course" do
+      let(:trainee) { create(:trainee, :recommended_for_award, :with_apply_application, :with_publish_course_details) }
+      let!(:new_course) { create(:course_with_subjects, accredited_body_code: trainee.provider.code) }
+      let(:data_model) { PublishCourseDetailsForm.new(trainee, params: { course_uuid: new_course.uuid }) }
+
+      before do
+        render_inline(View.new(data_model: data_model))
+      end
+
+      it "renders the training route from the course" do
+        expect(rendered_component).to have_text(t("activerecord.attributes.trainee.training_routes.#{new_course.route}"))
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/8KhAFVTW/4659-course-not-showing-as-correct-route-from-apply

### Changes proposed in this pull request
This PR is a postfix for #2743 which updates a trainee's route to the course route on change, but the confirm page was not showing the new root.

### Guidance to review
- Find a trainee e.g school direct (fee funded)
- Change course with a different route
- New training route should be displayed in confirm course page

### Important business
- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
