### PR TITLE
[4746] Create a Dqt::TrnRequest when the request fails

### DIFF
--- a/app/jobs/dqt/register_for_trn_job.rb
+++ b/app/jobs/dqt/register_for_trn_job.rb
@@ -10,7 +10,7 @@ module Dqt
       return if trainee.trn.present?
 
       trn_request = RegisterForTrn.call(trainee: trainee)
-      RetrieveTrnJob.perform_later(trn_request)
+      RetrieveTrnJob.perform_later(trn_request) unless trn_request.failed?
     end
   end
 end

--- a/app/models/dqt/trn_request.rb
+++ b/app/models/dqt/trn_request.rb
@@ -9,6 +9,7 @@ module Dqt
     enum state: {
       requested: 0,
       received: 1,
+      failed: 2,
     }
 
     validates :request_id, :response, presence: true

--- a/app/models/dqt/trn_request.rb
+++ b/app/models/dqt/trn_request.rb
@@ -12,6 +12,6 @@ module Dqt
       failed: 2,
     }
 
-    validates :request_id, :response, presence: true
+    validates :request_id, presence: true
   end
 end

--- a/app/services/dqt/register_for_trn.rb
+++ b/app/services/dqt/register_for_trn.rb
@@ -21,7 +21,8 @@ module Dqt
   private
 
     def trn_request
-      @trn_request ||= TrnRequest.new(trainee: trainee, request_id: SecureRandom.uuid)
+      @trn_request ||= TrnRequest.create_with(request_id: SecureRandom.uuid)
+                                 .find_or_create_by!(trainee: trainee)
     end
 
     def submit_trn_request

--- a/spec/jobs/dqt/register_for_trn_job_spec.rb
+++ b/spec/jobs/dqt/register_for_trn_job_spec.rb
@@ -43,6 +43,20 @@ module Dqt
           expect(TrnRequest.count).to eq(0)
         end
       end
+
+      context "when the initial request to register the trainee fails" do
+        let(:trainee) { create(:trainee, :with_secondary_course_details, :with_start_date, :with_degree) }
+        let(:trn_request) { double(failed?: true) }
+
+        before do
+          allow(RegisterForTrn).to receive(:call).with(trainee: trainee).and_return(trn_request)
+        end
+
+        it "does not register a TRN request with DQT" do
+          described_class.perform_now(trainee)
+          expect(RetrieveTrnJob).not_to have_received(:perform_later)
+        end
+      end
     end
   end
 end

--- a/spec/models/dqt/trn_request_spec.rb
+++ b/spec/models/dqt/trn_request_spec.rb
@@ -12,7 +12,6 @@ module Dqt
 
     describe "validations" do
       it { is_expected.to validate_presence_of(:request_id) }
-      it { is_expected.to validate_presence_of(:response) }
     end
   end
 end

--- a/spec/services/dqt/register_for_trn_spec.rb
+++ b/spec/services/dqt/register_for_trn_spec.rb
@@ -7,29 +7,54 @@ module Dqt
     describe "#call" do
       let(:trainee) { create(:trainee, :with_secondary_course_details, :with_start_date, :with_degree) }
       let(:request_id) { "3f96614b-0373-475b-bf94-119e0d8d9258" }
-      let(:dqt_response) {
-        {
-          "requestId" => request_id,
-          "status" => "Completed",
-          "trn" => "1234567",
-        }
-      }
 
       before do
         enable_features(:integrate_with_dqt)
         allow(SecureRandom).to receive(:uuid).and_return(request_id)
-        allow(Dqt::Client).to receive(:put).and_return(dqt_response)
-        described_class.call(trainee: trainee)
       end
 
-      it "registers TRN request with DQT" do
-        trn_request = TrnRequest.last
-        expect(trn_request.trainee).to eql(trainee)
-        expect(trn_request.request_id).to eql(request_id)
-        expect(trn_request.state).to eql("requested")
-        expect(trn_request.response).to eql(dqt_response)
+      context "when the response is a success" do
+        let(:dqt_response) {
+          {
+            "requestId" => request_id,
+            "status" => "Completed",
+            "trn" => "1234567",
+          }
+        }
 
-        expect(trainee.state).to eql("submitted_for_trn")
+        before do
+          allow(Dqt::Client).to receive(:put).and_return(dqt_response)
+          described_class.call(trainee: trainee)
+        end
+
+        it "registers TRN request with DQT" do
+          trn_request = TrnRequest.last
+          expect(trn_request.trainee).to eql(trainee)
+          expect(trn_request.request_id).to eql(request_id)
+          expect(trn_request.state).to eql("requested")
+          expect(trn_request.response).to eql(dqt_response)
+
+          expect(trainee.state).to eql("submitted_for_trn")
+        end
+      end
+
+      context "when the response is an error" do
+        let(:error_message) { "status: 500, body: something went wrong, headers: headers" }
+
+        before do
+          allow(Dqt::Client).to receive(:put).and_raise(Client::HttpError, error_message)
+          described_class.call(trainee: trainee)
+        end
+
+        it "saves a failed TRN request" do
+          trn_request = TrnRequest.last
+          expect(trn_request.trainee).to eql(trainee)
+          expect(trn_request.request_id).to eql(request_id)
+          expect(trn_request.state).to eql("failed")
+          expect(trn_request.response).to eql({ "error" => error_message })
+
+          expect(trainee.state).to eql("submitted_for_trn")
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Sometimes we receive a 500 from DQT even though the TRN request is eventually successful. Because of this, we still want to save the dqt_trn_request to the DB when it fails. This means we can kick off a `RetrieveTrnJob` (which requires the request_id) in the future.

### Changes proposed in this pull request

- Add a new `failed` state enum to the Dqt::TrnRequest model
- Update `RegisterForTrn` service to:
  - save a failed Dqt::TrnRequest on failure
  - find_or_create the `Dqt::TrnRequest` so that we're using the same request_id for subsequent calls to DQT.
- Update `RegiserForTrnJob` to only kick off `RetrieveTrnJob` if the dqt_trn_request is not in a failure state.

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml