### PR TITLE
Update Terraform version to 1.2.8

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -66,9 +66,9 @@ runs:
           ${{ env.key_vault_infra_secret_name }}
 
     - name: Pin Terraform version
-      uses: hashicorp/setup-terraform@v1.2.1
+      uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: 1.2.3
+        terraform_version: 1.2.8
 
     - name: Terraform init, Terraform Plan and Apply
       shell: bash

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Terraform v1.2.3
-        uses: hashicorp/setup-terraform@v2.0.0
+      - name: Setup Terraform v1.2.8
+        uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.2.3
+          terraform_version: 1.2.8
 
       - name: Set Environment variables
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@ nodejs 16.14.0
 ruby 2.7.5
 yarn 1.22.18
 bundler 2.1.4
-terraform 1.2.3
+terraform 1.2.8
 cf 7.4.0
 az 2.36.0
 jq 1.6

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.2.3"
+  required_version = "1.2.8"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
### Context
Dependabot is erroring when trying to check the azurerm provider update against version 1.2.3 of Terraform. Update to 1.2.8 to see if this resolves the issue.

### Changes proposed in this pull request
Bump Terraform to 1.2.8

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
