### PR TITLE
[xxx] Turn the HESA collection back on after incident

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -40,7 +40,7 @@ features:
   integrate_with_dqt: true
   hesa_trn_requests: true
   hesa_import:
-    sync_collection: false
+    sync_collection: true
     sync_trn_data: true
 environment:
   name: beta


### PR DESCRIPTION
### Context

We turned off pulling in HESA data to send to DQT because we had an incident whereby dupes were being created on DQT. We (and DQT) have done the work to stop this happening now.

Fix:
https://github.com/DFE-Digital/register-trainee-teachers/pull/2786

### Changes proposed in this pull request

Turn the HESA collection back on.

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
