### PR TITLE
[4742] Fix: funding not cleared properly when changing courses multiple times

### DIFF
--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -53,7 +53,6 @@ class PublishCourseDetailsForm < TraineeForm
     return false unless valid?
 
     update_trainee_attributes
-    clear_funding_information if clear_funding_information?
     Trainees::Update.call(trainee: trainee)
     clear_all_used_stashes
   end
@@ -93,12 +92,8 @@ private
   def update_trainee_attributes
     trainee.assign_attributes(training_route: course.route,
                               course_uuid: course_uuid,
-                              course_subject_one: course_subject_one,
-                              course_subject_two: course_subject_two,
-                              course_subject_three: course_subject_three,
                               course_education_phase: course&.level,
-                              course_age_range: course_age_range,
-                              course_allocation_subject: course_allocation_subject)
+                              course_age_range: course_age_range)
   end
 
   def course_subjects

--- a/app/forms/subject_specialism_form.rb
+++ b/app/forms/subject_specialism_form.rb
@@ -41,6 +41,7 @@ class SubjectSpecialismForm < TraineeForm
       course_subject_three: course_subject_three,
       course_allocation_subject: course_allocation_subject,
     )
+    clear_funding_information if clear_funding_information?
     Trainees::Update.call(trainee: trainee)
     clear_stash
   end

--- a/spec/forms/publish_course_details_form_spec.rb
+++ b/spec/forms/publish_course_details_form_spec.rb
@@ -55,13 +55,6 @@ describe PublishCourseDetailsForm, type: :model do
           subject_specialism_form.stash_or_save!
         end
 
-        it "updates the trainee with the publish course details" do
-          expect { subject.save! }
-          .to change { trainee.course_subject_one }.to(subject_name)
-          .and change { trainee.course_education_phase }.to(course_level)
-          .and change { trainee.course_allocation_subject }.to(allocation_subject)
-        end
-
         context "with a pg_teaching_apprenticeship trainee" do
           let(:route) { :pg_teaching_apprenticeship }
           let(:trainee) { build(:trainee, route) }

--- a/spec/forms/subject_specialism_form_spec.rb
+++ b/spec/forms/subject_specialism_form_spec.rb
@@ -41,4 +41,21 @@ describe SubjectSpecialismForm, type: :model do
       subject.stash
     end
   end
+
+  describe "#save!" do
+    context "course allocation subject changed" do
+      let(:trainee) { build(:trainee, :with_funding, :with_course_allocation_subject, id: 123456) }
+      let(:course_subject_one) { Dttp::CodeSets::CourseSubjects::MAPPING.keys.sample }
+      let(:params) { { course_subject_one: course_subject_one } }
+
+      before do
+        create(:subject_specialism, name: course_subject_one)
+        subject.save!
+      end
+
+      it "clears funding information" do
+        expect(trainee.applying_for_bursary).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/oKixSiln/4742-drafts-changing-from-a-course-without-funding-to-one-with-funding-user-is-not-asked-about-funding-again

### Changes proposed in this pull request
- Clear funding in `SubjectSpecialismForm` as that is where subject specialism are computed and assigned
- Remove couse subject updates from `PublishCourseDetailsForm` as it will always happen in `SubjectSpecialismForm`

### Guidance to review
- Find a draft traine with a published course
- Change that course to something else
- The review draft page should show funding as incomplete

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
