### PR TITLE
[4749] Service to retrieve a teacher from DQT without a `requestid`

### DIFF
--- a/app/jobs/dqt/sync_trainee_trn_job.rb
+++ b/app/jobs/dqt/sync_trainee_trn_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Dqt
+  class SyncTraineeTrnJob < ApplicationJob
+    queue_as :default
+    retry_on Client::HttpError
+
+    class Error < StandardError; end
+
+    def perform(trainee)
+      return unless FeatureService.enabled?(:integrate_with_dqt)
+
+      teacher = Dqt::FindTeacher.call(trainee: trainee)
+
+      if teacher["trn"].present?
+        Trainees::Update.call(
+          trainee: trainee,
+          params: { trn: teacher["trn"] },
+          update_dqt: false,
+        )
+      else
+        raise(
+          Error,
+          "No TRN found in DQT for trainee: #{trainee.id}",
+        )
+      end
+    end
+  end
+end

--- a/app/services/dqt/find_teacher.rb
+++ b/app/services/dqt/find_teacher.rb
@@ -13,8 +13,12 @@ module Dqt
     end
 
     def call
+      if teachers.empty?
+        raise(Error, "No teachers found with #{error_details}")
+      end
+
       if teachers.count > 1
-        raise(Error, "Multiple teachers found with firstName: #{first_names}, lastName: #{last_name}, dateOfBirth: #{date_of_birth}")
+        raise(Error, "Multiple teachers found with #{error_details}")
       end
 
       teachers.first
@@ -25,7 +29,7 @@ module Dqt
   private
 
     def teachers
-      Client.get("/v2/teachers/find?#{params.to_query}")["results"]
+      @teachers ||= Client.get("/v2/teachers/find?#{params.to_query}")["results"]
     end
 
     def params
@@ -34,6 +38,10 @@ module Dqt
         lastName: last_name,
         dateOfBirth: date_of_birth.iso8601,
       }
+    end
+
+    def error_details
+      "firstName: #{first_names}, lastName: #{last_name}, dateOfBirth: #{date_of_birth}"
     end
   end
 end

--- a/app/services/dqt/find_teacher.rb
+++ b/app/services/dqt/find_teacher.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Dqt
+  class FindTeacher
+    include ServicePattern
+
+    class Error < StandardError; end
+
+    delegate :first_names, :last_name, :date_of_birth, to: :trainee
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      if teachers.count > 1
+        raise(Error, "Multiple teachers found with firstName: #{first_names}, lastName: #{last_name}, dateOfBirth: #{date_of_birth}")
+      end
+
+      teachers.first
+    end
+
+    attr_reader :trainee
+
+  private
+
+    def teachers
+      Client.get("/v2/teachers/find?#{params.to_query}")["results"]
+    end
+
+    def params
+      {
+        firstName: first_names,
+        lastName: last_name,
+        dateOfBirth: date_of_birth.iso8601,
+      }
+    end
+  end
+end

--- a/spec/jobs/dqt/synv_trainee_trn_job_spec.rb
+++ b/spec/jobs/dqt/synv_trainee_trn_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dqt
+  describe SyncTraineeTrnJob do
+    let(:trainee) { create(:trainee) }
+    let(:dqt_teacher) {
+      {
+        "trn" => trn,
+        "firstName" => trainee.first_names,
+        "lastName" => trainee.last_name,
+        "dateOfBirth" => trainee.date_of_birth,
+      }
+    }
+
+    before do
+      allow(FindTeacher).to receive(:call).with(trainee: trainee).and_return(dqt_teacher)
+    end
+
+    context "when a TRN is returned" do
+      let(:trn) { "0123456" }
+
+      it "updates the trainee's TRN to what is in DQT", feature_integrate_with_dqt: true do
+        expect {
+          described_class.perform_now(trainee)
+        }.to change {
+          trainee.trn
+        }.to(trn)
+      end
+    end
+
+    context "when a TRN is not returned" do
+      let(:trn) { nil }
+
+      it "raises an error", feature_integrate_with_dqt: true do
+        expect {
+          described_class.perform_now(trainee)
+        }.to raise_error(SyncTraineeTrnJob::Error, "No TRN found in DQT for trainee: #{trainee.id}")
+      end
+    end
+  end
+end

--- a/spec/services/dqt/find_teacher_spec.rb
+++ b/spec/services/dqt/find_teacher_spec.rb
@@ -31,7 +31,7 @@ module Dqt
       end
 
       context "when multiple teachers are found" do
-        let(:dqt_response) { { "results" => [dqt_trainee, dqt_trainee] }}
+        let(:dqt_response) { { "results" => [dqt_trainee, dqt_trainee] } }
 
         it "raises an error" do
           expect {

--- a/spec/services/dqt/find_teacher_spec.rb
+++ b/spec/services/dqt/find_teacher_spec.rb
@@ -22,19 +22,6 @@ module Dqt
 
       subject { described_class.call(trainee: trainee) }
 
-      context "when multiple teachers are found" do
-        let(:dqt_response) { { "results" => [dqt_trainee, dqt_trainee] }}
-
-        it "raises an error" do
-          expect{
-            subject
-          }.to raise_error(
-            Dqt::FindTeacher::Error,
-            "Multiple teachers found with firstName: #{trainee.first_names}, lastName: #{trainee.last_name}, dateOfBirth: #{trainee.date_of_birth}",
-          )
-        end
-      end
-
       context "when a teacher is found" do
         let(:dqt_response) { { "results" => [dqt_trainee] } }
 
@@ -43,11 +30,29 @@ module Dqt
         end
       end
 
+      context "when multiple teachers are found" do
+        let(:dqt_response) { { "results" => [dqt_trainee, dqt_trainee] }}
+
+        it "raises an error" do
+          expect {
+            subject
+          }.to raise_error(
+            Dqt::FindTeacher::Error,
+            "Multiple teachers found with firstName: #{trainee.first_names}, lastName: #{trainee.last_name}, dateOfBirth: #{trainee.date_of_birth}",
+          )
+        end
+      end
+
       context "when no teacher is found" do
         let(:dqt_response) { { "results" => [] } }
 
         it "returns nil" do
-          expect(subject).to be_nil
+          expect {
+            subject
+          }.to raise_error(
+            Dqt::FindTeacher::Error,
+            "No teachers found with firstName: #{trainee.first_names}, lastName: #{trainee.last_name}, dateOfBirth: #{trainee.date_of_birth}",
+          )
         end
       end
     end

--- a/spec/services/dqt/find_teacher_spec.rb
+++ b/spec/services/dqt/find_teacher_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dqt
+  describe FindTeacher do
+    let(:trainee) { create(:trainee) }
+    let(:dqt_trainee) {
+      {
+        "trn" => "0123456",
+        "firstName" => trainee.first_names,
+        "lastName" => trainee.last_name,
+        "dateOfBirth" => trainee.date_of_birth,
+      }
+    }
+
+    describe "#call" do
+      before do
+        enable_features(:integrate_with_dqt)
+        allow(Dqt::Client).to receive(:get).and_return(dqt_response)
+      end
+
+      subject { described_class.call(trainee: trainee) }
+
+      context "when multiple teachers are found" do
+        let(:dqt_response) { { "results" => [dqt_trainee, dqt_trainee] }}
+
+        it "raises an error" do
+          expect{
+            subject
+          }.to raise_error(
+            Dqt::FindTeacher::Error,
+            "Multiple teachers found with firstName: #{trainee.first_names}, lastName: #{trainee.last_name}, dateOfBirth: #{trainee.date_of_birth}",
+          )
+        end
+      end
+
+      context "when a teacher is found" do
+        let(:dqt_response) { { "results" => [dqt_trainee] } }
+
+        it "returns the teacher" do
+          expect(subject).to eq(dqt_response["results"].first)
+        end
+      end
+
+      context "when no teacher is found" do
+        let(:dqt_response) { { "results" => [] } }
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/fZe1yFlJ/4749-create-or-update-service-to-retrieve-a-trn-without-a-requestid

### Changes proposed in this pull request

- Create Dqt::FindTeacher that takes a trainee and hits the /teachers/find
  DQT API endpoint, passing the first_names, last_name and date_of_birth
  as params
  - If no teachers or multiple teachers are found, it errors
- Create Dqt::SyncTraineeTrnJob which calls the Dqt::FindTeacher service
  and updates the trainee with the returned TRN
  - If no TRN is returned, it errors

### Guidance to review

To be used like so:

```
trainees = Trainee.where({some_condition})
trainees.find_each do |trainee|
  Dqt::SyncTraineeTrnJob.perform_later(trainee: trainee)
end
```

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
