### PR TITLE
[xxx] Transition the trainees to trn_received in Dqt::SyncTraineeTrnJob

### DIFF
--- a/app/jobs/dqt/sync_trainee_trn_job.rb
+++ b/app/jobs/dqt/sync_trainee_trn_job.rb
@@ -7,22 +7,16 @@ module Dqt
 
     class Error < StandardError; end
 
-    def perform(trainee)
+    def perform(trainee_id)
       return unless FeatureService.enabled?(:integrate_with_dqt)
 
-      teacher = Dqt::FindTeacher.call(trainee: trainee)
+      trainee = Trainee.find(trainee_id)
+      response = Dqt::FindTeacher.call(trainee: trainee)
 
-      if teacher["trn"].present?
-        Trainees::Update.call(
-          trainee: trainee,
-          params: { trn: teacher["trn"] },
-          update_dqt: false,
-        )
+      if response["trn"].present?
+        trainee.trn_received!(response["trn"])
       else
-        raise(
-          Error,
-          "No TRN found in DQT for trainee: #{trainee.id}",
-        )
+        raise(Error, "No TRN found in DQT for trainee: #{trainee.id}")
       end
     end
   end

--- a/spec/jobs/dqt/synv_trainee_trn_job_spec.rb
+++ b/spec/jobs/dqt/synv_trainee_trn_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Dqt
   describe SyncTraineeTrnJob do
-    let(:trainee) { create(:trainee) }
+    let(:trainee) { create(:trainee, :submitted_for_trn) }
     let(:dqt_teacher) {
       {
         "trn" => trn,
@@ -21,12 +21,15 @@ module Dqt
     context "when a TRN is returned" do
       let(:trn) { "0123456" }
 
-      it "updates the trainee's TRN to what is in DQT", feature_integrate_with_dqt: true do
+      it "updates the trainee's TRN to what is in DQT and transitions them to trn_received", feature_integrate_with_dqt: true do
         expect {
-          described_class.perform_now(trainee)
+          described_class.perform_now(trainee.id)
         }.to change {
-          trainee.trn
+          trainee.reload.trn
         }.to(trn)
+        .and change {
+          trainee.state
+        }.to("trn_received")
       end
     end
 
@@ -35,7 +38,7 @@ module Dqt
 
       it "raises an error", feature_integrate_with_dqt: true do
         expect {
-          described_class.perform_now(trainee)
+          described_class.perform_now(trainee.id)
         }.to raise_error(SyncTraineeTrnJob::Error, "No TRN found in DQT for trainee: #{trainee.id}")
       end
     end


### PR DESCRIPTION
### Context

Another change :)

As well as assigning the trn to the trainee, we need to transition them to `trn_received`. There is logic in the trainee model which ensures that only `submitted_for_trn`, `withdrawn` or `deferred` trainees can be transitioned to `trn_received`

### Changes proposed in this pull request

- Transition the trainees to `trn_received` using our custom `trn_received!(trn)` method which also set the trn
- Stop using the `Trainees::Update` service since we don't need anything it does (setting academic cycles, updating DQT) 
- Also pass around the trainee ID rather than the whole trainee, this is erroring.

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
