### PR TITLE
[4757] - add dependent: :destroy to trainee's trn request

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -44,7 +44,7 @@ class Trainee < ApplicationRecord
   has_many :disabilities, through: :trainee_disabilities
 
   has_one :hesa_metadatum, class_name: "Hesa::Metadatum"
-  has_one :dqt_trn_request, class_name: "Dqt::TrnRequest"
+  has_one :dqt_trn_request, class_name: "Dqt::TrnRequest", dependent: :destroy
 
   attribute :progress, Progress.to_type
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -164,6 +164,7 @@ describe Trainee do
     it { is_expected.to have_many(:nationalities).through(:nationalisations) }
     it { is_expected.to have_many(:trainee_disabilities).dependent(:destroy).inverse_of(:trainee) }
     it { is_expected.to have_many(:disabilities).through(:trainee_disabilities) }
+    it { is_expected.to have_one(:dqt_trn_request).dependent(:destroy) }
     it { is_expected.to belong_to(:lead_school).class_name("School").optional }
     it { is_expected.to belong_to(:employing_school).class_name("School").optional }
 


### PR DESCRIPTION
### Context

Provider is trying to delete draft records but having issues: trainees were moved back into draft, but after they had requests made for TRNs. This is preventing deletes owing to the foreign key in `dqt_trn_requests`

### Changes proposed in this pull request

Add `dependent: :destroy` to allow the trn request record to be deleted as well.

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
