### PR TITLE
[4711] Data migration to import Apply applications no longer seen as duplicates

### DIFF
--- a/db/data/20221005141340_import_apply_applications_no_longer_seen_as_duplicates.rb
+++ b/db/data/20221005141340_import_apply_applications_no_longer_seen_as_duplicates.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ImportApplyApplicationsNoLongerSeenAsDuplicates < ActiveRecord::Migration[6.1]
+  def up
+    ApplyApplication.non_importable_duplicate.each do |application|
+      next unless application.provider && application.course
+
+      Trainees::CreateFromApply.call(application: application)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/dM4kLSzT/4711-apply-duplicate-record-check-doesnt-scope-by-provider-or-active-trainees

This PR was meant to also contain the logic that checks if the new trainee exists, but that got accidently commited in another [PR](#2761).

### Changes proposed in this pull request
- Data migration that runs through all the Apply applications marked as `non_importable_duplicate` (approx 900) and tries to re-import them using the new logic that checks if the trainee exists.

### Guidance to review
The data migration was tested locally using prod data. 6 news trainees were created. Takes only a few seconds to run.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
