### PR TITLE
[4254] - remove 2021 from recruitment_cycle_years

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -96,7 +96,6 @@ current_default_course_year: 2022
 apply_applications:
   import:
     recruitment_cycle_years:
-      - 2021
       - 2022
   create:
     recruitment_cycle_year: 2022


### PR DESCRIPTION
### Context

Within Register, we have this defining which years we request:

```yaml
apply_applications:
  import:
    recruitment_cycle_years:
      - 2021
      - 2022
 ```
* Over on Apply’s side, upon receiving our request they check that the recruitment_cycle_year being sent is within the range they define as RecruitmentCycle.years_visible_to_providers here
* This references the current_year as defined in the CycleTimetable.
* At the moment this calculates the current year as 2023 meaning they only accept requests for 2023 (current year) and 2022 (previous year)
* We can fix this by losing 2021 in the definition above.

Further discussion [here](https://ukgovernmentdfe.slack.com/archives/CGVNJ2Q2F/p1664975872165529) and [here](https://ukgovernmentdfe.slack.com/archives/CAHBLU6ET/p1664962366889509) 


### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
