### PR TITLE
[4755] Split first names hitting DQT /find API

### DIFF
--- a/app/services/dqt/find_teacher.rb
+++ b/app/services/dqt/find_teacher.rb
@@ -34,7 +34,7 @@ module Dqt
     # `firstName` and `lastName` count as one data item.
     def params
       {
-        firstName: trainee.first_names,
+        firstName: trainee.first_names.split.first,
         lastName: trainee.last_name,
         dateOfBirth: trainee.date_of_birth.iso8601,
         emailAddress: trainee.email,

--- a/spec/services/dqt/find_teacher_spec.rb
+++ b/spec/services/dqt/find_teacher_spec.rb
@@ -37,7 +37,7 @@ module Dqt
           expect {
             subject
           }.to raise_error(
-            Dqt::FindTeacher::Error,
+            FindTeacher::Error,
             "Multiple teachers found in DQT for trainee #{trainee.id}",
           )
         end
@@ -50,9 +50,26 @@ module Dqt
           expect {
             subject
           }.to raise_error(
-            Dqt::FindTeacher::Error,
+            FindTeacher::Error,
             "No teachers found in DQT for trainee #{trainee.id}",
           )
+        end
+      end
+
+      context "when the trainee has multiple first names" do
+        let(:trainee) { create(:trainee, first_names: "Bobby Joe") }
+
+        let(:dqt_response) { { "results" => [dqt_trainee] } }
+
+        it "calls the DQT API with just the _first_ first name" do
+          described_class.call(trainee: trainee)
+          expected_params = {
+            firstName: "Bobby",
+            lastName: trainee.last_name,
+            dateOfBirth: trainee.date_of_birth.iso8601,
+            emailAddress: trainee.email,
+          }
+          expect(Client).to have_received(:get).with("/v2/teachers/find?#{expected_params.to_query}")
         end
       end
     end


### PR DESCRIPTION
### Context

DQT split first names when saving the teacher. So in order for their API to return the trainee, we need to do the same thing when querying.

### Changes proposed in this pull request

Split on the first name when querying for the trainee over the /find endpoint.

### Guidance to review

I've already tested this with some failed trainees and this change returns a trainee.

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml