### PR TITLE
[xxx] Add other to gender code mapping

### DIFF
--- a/app/lib/apply_api/code_sets/genders.rb
+++ b/app/lib/apply_api/code_sets/genders.rb
@@ -3,10 +3,14 @@
 module ApplyApi
   module CodeSets
     module Genders
+      # intersex is needed until it is no longer possible to received the value from
+      # apply, which should be the next recruitment cycle - 2024.
+
       MAPPING = {
         "male" => Trainee.sexes[:male],
         "female" => Trainee.sexes[:female],
         "intersex" => Trainee.sexes[:other],
+        "other" => Trainee.sexes[:other],
         "Prefer not to say" => Trainee.sexes[:sex_not_provided],
         "" => Trainee.sexes[:sex_not_provided],
       }.freeze

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -254,6 +254,20 @@ module Trainees
           expect(trainee.reload.additional_ethnic_background).to eq("Mixed European")
         end
       end
+
+      context "gender" do
+        %w[intersex other].each do |option|
+          context "when the gender attribute is #{option}" do
+            let(:candidate_attributes) { { gender: option.to_s } }
+
+            before { create_trainee_from_apply }
+
+            it "sets the trainee's sex to other" do
+              expect(trainee.reload.sex).to eq("other")
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
Apply has changed one of their radio button values on the gender/sex question for E&D from intersex to other. This is not currently handled by Register's mapping when creating trainees from Apply. Old values are not being updated so there will be both intersex and other values.

### Changes proposed in this pull request
* Add 'other' key-value pair to mapping

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
