### PR TITLE
[4742] Fix: course dates get lost when changing course.

### DIFF
--- a/app/forms/concerns/course_form_helpers.rb
+++ b/app/forms/concerns/course_form_helpers.rb
@@ -19,4 +19,17 @@ module CourseFormHelpers
   def course_allocation_subject
     SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject
   end
+
+  def clear_all_used_stashes
+    [
+      IttDatesForm,
+      StudyModesForm,
+      SubjectSpecialismForm,
+      LanguageSpecialismsForm,
+    ].each do |klass|
+      klass.new(trainee).clear_stash
+    end
+
+    clear_stash
+  end
 end

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -85,7 +85,7 @@ class CourseDetailsForm < TraineeForm
       update_trainee_attributes
       clear_funding_information if clear_funding_information?
       Trainees::Update.call(trainee: trainee)
-      clear_stash
+      clear_all_used_stashes
     else
       false
     end

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -55,11 +55,11 @@ class PublishCourseDetailsForm < TraineeForm
     update_trainee_attributes
     clear_funding_information if clear_funding_information?
     Trainees::Update.call(trainee: trainee)
-    clear_all_stashes
+    clear_all_used_stashes
   end
 
   def stash
-    clear_all_stashes
+    clear_all_used_stashes
 
     super
   end
@@ -77,19 +77,15 @@ class PublishCourseDetailsForm < TraineeForm
   end
 
   def study_mode
-    @study_mode ||= ::StudyModesForm.new(trainee).study_mode
+    @study_mode ||= StudyModesForm.new(trainee).study_mode
   end
 
   def itt_start_date
-    if trainee.requires_itt_start_date?
-      itt_dates_form.start_date
-    end || course.start_date
+    itt_dates_form.start_date || course.start_date
   end
 
   def itt_end_date
-    if trainee.requires_itt_start_date?
-      itt_dates_form.end_date
-    end || course.end_date
+    itt_dates_form.end_date || course.end_date
   end
 
 private
@@ -132,19 +128,5 @@ private
 
   def compute_fields
     trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
-  end
-
-  def clear_all_stashes
-    [
-      LanguageSpecialismsForm,
-      SubjectSpecialismForm,
-      StudyModesForm,
-      IttDatesForm,
-      CourseDetailsForm,
-    ].each do |klass|
-      klass.new(trainee).clear_stash
-    end
-
-    clear_stash
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/F9QZeh9e/4748-course-dates-get-lost-on-registered-trainees-when-changing-course

`PublishCourseDetailsForm` wasn't showing `itt_start_date` or `itt_end_date` because it was wrapped in a conditional which I don't think is relevant anymore. I think the conditional was added before we created the ITT dates page.

### Changes proposed in this pull request
- Remove conditional from `PublishCourseDetailsForm#itt_start_date` and `PublishCourseDetailsForm#itt_end_date`. The idea here is that if the `IttDatesForm` has stashed dates, we have to assume it was used previously and `PublishCourseDetailsForm` should default to its values first before falling back to the course dates.
- Extract method to clear all stashes used beforehand and put it in `CourseFormHelpers` so it can be use by `CourseDetailsForm` which was clearing all the stashes after it saves its data.

### Guidance to review
- Start with a registered trainee on a publish course
- Select 'change course'
- Pick a new course and following the journey
- The confirmation page should display dates entered earlier if asked

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
