### PR TITLE
[4760] Dont limit the TRN upload to just trn_data hesa trainees

### DIFF
--- a/app/jobs/hesa/upload_trn_file_job.rb
+++ b/app/jobs/hesa/upload_trn_file_job.rb
@@ -5,7 +5,7 @@ module Hesa
     def perform
       return unless FeatureService.enabled?(:hesa_trn_requests)
 
-      trainees = Trainee.imported_from_hesa_trn_data
+      trainees = Trainee.imported_from_hesa
                         .where.not(trn: nil) # some trainees could still be waiting for their TRN from DQT
                         .where("created_at > ?", TrnSubmission.last_submitted_at)
       payload = UploadTrnFile.call(trainees: trainees)


### PR DESCRIPTION
### Context

- Trainees can be submitted for TRN and for census at the same time from HESA.
- If this happens, when the `UploadTrnFileJob` runs, they have a record source of `hesa_collection` and won't be included in the CSV.
- We still want to send the TRNs back in this case!
- We've checked with HESA and they've confirmed that they're happy for TRNs to be returned for trainees regardless of whether they were submitted as part of the collection or over the TRN data endpoint.

https://trello.com/c/r3tCZxpE/4760-not-returning-trns-to-hesa-for-trainees-submitted-via-the-trn-data-endpoint-and-then-very-quickly-over-the-collection-endpoint

### Changes proposed in this pull request

- Widen the scope so that we send back TRNs for trainees with record source `hesa_collection` too.
- This is what we originally had!

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?`
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml