### PR TITLE
Reduce the concurrency for register for trn jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "govuk_design_system_formbuilder"
 # Background job processor
 gem "sidekiq", "~> 6.5"
 gem "sidekiq-cron", "~> 1.7"
+gem "sidekiq-throttled"
 
 # UK postcode parsing and validation for Ruby
 gem "uk_postcode"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,6 +457,7 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.5.1)
     redis (4.8.0)
+    redis-prescription (1.0.0)
     regexp_parser (2.5.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -545,6 +546,10 @@ GEM
     sidekiq-cron (1.7.0)
       fugit (~> 1)
       sidekiq (>= 4.2.1)
+    sidekiq-throttled (0.17.0)
+      concurrent-ruby
+      redis-prescription
+      sidekiq (>= 6.4)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -698,6 +703,7 @@ DEPENDENCIES
   shoulda-matchers (~> 5.2)
   sidekiq (~> 6.5)
   sidekiq-cron (~> 1.7)
+  sidekiq-throttled
   simplecov (~> 0.21.2)
   site_prism (~> 3.7)
   skylight

--- a/app/jobs/dqt/register_for_trn_job.rb
+++ b/app/jobs/dqt/register_for_trn_job.rb
@@ -2,6 +2,12 @@
 
 module Dqt
   class RegisterForTrnJob < ApplicationJob
+    include Sidekiq::Throttled::Job
+    sidekiq_throttle({
+      concurrency: { limit: 1 },
+      threshold: { limit: 20, period: 1.minute },
+    })
+
     sidekiq_options retry: 0
     queue_as :default
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sidekiq/throttled"
+
 if ENV.key?("VCAP_SERVICES")
   service_config = JSON.parse(ENV["VCAP_SERVICES"])
   redis_config = service_config["redis"]
@@ -24,3 +26,5 @@ end
 if Settings.sidekiq.schedule_file && Sidekiq.server?
   Sidekiq::Cron::Job.load_from_hash!(YAML.load_file(Settings.sidekiq.schedule_file))
 end
+
+Sidekiq::Throttled.setup!


### PR DESCRIPTION
### Context

DQT is receiving multiple requests almost simultaneously

### Changes proposed in this pull request

We'd like to throttle our trn requests until DQT have increased their confidence in their handling of duplicate requests

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
