### PR TITLE
Move dqt jobs to their own queue

### DIFF
--- a/app/jobs/dqt/recommend_for_award_job.rb
+++ b/app/jobs/dqt/recommend_for_award_job.rb
@@ -2,7 +2,7 @@
 
 module Dqt
   class RecommendForAwardJob < ApplicationJob
-    queue_as :default
+    queue_as :dqt
     retry_on Client::HttpError
 
     def perform(trainee)

--- a/app/jobs/dqt/register_for_trn_job.rb
+++ b/app/jobs/dqt/register_for_trn_job.rb
@@ -9,7 +9,7 @@ module Dqt
     })
 
     sidekiq_options retry: 0
-    queue_as :default
+    queue_as :dqt
 
     def perform(trainee)
       return unless FeatureService.enabled?(:integrate_with_dqt)

--- a/app/jobs/dqt/retrieve_award_job.rb
+++ b/app/jobs/dqt/retrieve_award_job.rb
@@ -3,7 +3,7 @@
 module Dqt
   class RetrieveAwardJob < ApplicationJob
     sidekiq_options retry: 0
-    queue_as :default
+    queue_as :dqt
     retry_on Client::HttpError
 
     class TraineeAttributeError < StandardError; end

--- a/app/jobs/dqt/retrieve_trn_job.rb
+++ b/app/jobs/dqt/retrieve_trn_job.rb
@@ -2,7 +2,7 @@
 
 module Dqt
   class RetrieveTrnJob < ApplicationJob
-    queue_as :default
+    queue_as :dqt
     retry_on Client::HttpError
     include NotifyOnTimeout
 


### PR DESCRIPTION
### Context

DQT background jobs are going into the default queue. There is a dedicated `dqt` queue that is already used by two other related jobs.

### Changes proposed in this pull request

Use the `dqt` queue for DQT related background jobs.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
