### PR TITLE
[4737] Add autocomplete to search for users in the support interface

### DIFF
--- a/app/controllers/system_admin/users_controller.rb
+++ b/app/controllers/system_admin/users_controller.rb
@@ -6,7 +6,9 @@ module SystemAdmin
     before_action :user, only: %i[show delete destroy]
 
     def index
-      @users = filtered_users(policy_scope(User.kept, policy_scope_class: UserPolicy).order_by_last_name.page(params[:page] || 1))
+      @users = filtered_users(policy_scope(User.kept, policy_scope_class: UserPolicy).includes(:providers, :lead_schools).order_by_last_name.page(params[:page] || 1))
+      @user_search_form = UserSearchForm.new
+      @all_users = @users.limit(nil)
     end
 
     def new
@@ -30,6 +32,16 @@ module SystemAdmin
     def destroy
       @user.discard!
       redirect_to(users_path, flash: { success: "User deleted" })
+    end
+
+    def search
+      search_params = params.require(:user_search_form).permit(:user)
+      @user = search_params[:user]
+      if @user
+        redirect_to(user_path(@user))
+      else
+        redirect_to(users_path)
+      end
     end
 
   private

--- a/app/forms/user_search_form.rb
+++ b/app/forms/user_search_form.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class UserSearchForm
+  include ActiveModel::Model
+  include ApplicationHelper
+  attr_accessor :user, :user_raw, :users
+  def initialize(scope: :all)
+    @users = User.send(scope).includes(:providers, :lead_schools).uniq
+  end
+
+  def search_options
+    to_enhanced_options(search_values) do |search_option|
+      [
+        search_option[:name],
+        search_option[:id],
+        { "data-synonyms" => Array(search_option[:synonyms]).join("|") },
+        { "data-hint" => "<span class='autocomplete__option--hint'> #{search_option_preview(search_option)}</span>" },
+      ]
+    end
+  end
+
+private
+
+  def search_option_preview(search_option)
+    return unless search_option
+
+    search_option[:synonyms].join("<br />")
+  end
+
+  def search_values
+    @search_values ||= users.map do |u|
+      {
+        id: u.id,
+        name: u.name,
+        synonyms: [u.email, *u.provider_names, *u.lead_school_names],
+      }
+    end
+  end
+end

--- a/app/lib/user_with_organisation_context.rb
+++ b/app/lib/user_with_organisation_context.rb
@@ -80,4 +80,8 @@ private
   def user_only_has_lead_school?
     !user.system_admin && user.providers.empty? && user.lead_schools.present?
   end
+
+  def search_string_raw
+    nil
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,22 @@ class User < ApplicationRecord
     User.kept.exists?(email: email)
   end
 
+  def search_values
+    {
+      id: id,
+      name: name,
+      synonyms: [email] + Array(provider_names) + Array(lead_school_names),
+    }
+  end
+
+  def provider_names
+    providers.map(&:name)
+  end
+
+  def lead_school_names
+    lead_schools.map(&:name)
+  end
+
 private
 
   def sanitise_email

--- a/app/views/system_admin/users/index.html.erb
+++ b/app/views/system_admin/users/index.html.erb
@@ -19,14 +19,21 @@
 
     <div class="govuk-grid-row">
       <div class ="govuk-grid-column-full">
-        <%= register_form_with url: users_path, method: :get do |f| %>
-          <%= f.govuk_text_field :search,
-                                 label: { text: "Search for a user"},
-                                 hint: { text: "Search using the person’s email address or surname", size: "s" },
-                                 value: params[:search],
-                                 width: "two-thirds" %>
-          <%= f.govuk_submit "Search", class: "submit-search" %>
-        <% end %>
+        <%= register_form_with model: @user_search_form, url: users_search_path, method: :get, local: true do |f| %>
+        <%= render FormComponents::Autocomplete::View.new(
+          f,
+          attribute_name: :user,
+          form_field: f.govuk_select(:user,
+            options_for_select(@user_search_form.search_options),
+            label: { text: "Search for a user",
+              size: "s",
+            },
+            hint: { text: "Search by name, email or organisation"}
+          ),
+          html_attributes: { id: "search-box" },
+        ) %>
+        <%= f.govuk_submit "Submit" %>
+      <% end %>
       </div>
     </div>
 

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -22,6 +22,7 @@ module SystemAdminRoutes
           end
         end
 
+        get "users/search"
         resources :users do
           resources :providers, controller: "user_providers", only: %i[new create] do
             resource :accessions, controller: "providers/accessions", only: %i[edit destroy]
@@ -30,7 +31,6 @@ module SystemAdminRoutes
           resources :lead_schools, controller: "user_lead_schools", only: %i[index new create], path: "lead-schools" do
             resource :accessions, controller: "lead_schools/accessions", only: %i[edit destroy]
           end
-
           member { get :delete }
         end
 

--- a/spec/features/system_admin/users/search_users_spec.rb
+++ b/spec/features/system_admin/users/search_users_spec.rb
@@ -4,22 +4,28 @@ require "rails_helper"
 
 feature "Search users" do
   context "as a system admin" do
-    let(:user) { create(:user, system_admin: true) }
+    let(:user) { create(:user, :with_multiple_organisations, system_admin: true) }
     let!(:second_user) { create(:user, system_admin: true) }
 
     before do
       given_i_am_authenticated(user: user)
     end
 
-    scenario "search users" do
+    scenario "search users", js: true do
       when_i_visit_the_user_index_page
       then_i_see_the_users
-      then_i_enter_the_first_users_last_name_into_the_search_field
-      then_i_click_search
-      then_i_see_only_the_first_user
+      then_i_enter_the_first_users_name_into_the_search_field
+      then_i_press_enter
+      then_i_am_taken_to_the_user_show_page(user)
+      when_i_visit_the_user_index_page
+      then_i_see_the_users
       then_i_enter_the_second_users_email_address_into_the_search_field
-      then_i_click_search
-      then_i_see_only_the_second_user
+      then_i_press_enter
+      then_i_am_taken_to_the_user_show_page(second_user)
+      when_i_visit_the_user_index_page
+      then_i_enter_the_first_users_provider_into_the_search_field
+      then_i_press_enter
+      then_i_am_taken_to_the_user_show_page(user)
     end
   end
 
@@ -30,6 +36,10 @@ feature "Search users" do
   def then_i_see_the_users
     index_page_has_first_user_details
     index_page_has_second_user_details
+  end
+
+  def then_i_am_taken_to_the_user_show_page(user)
+    expect(page).to have_current_path("/system-admin/users/#{user.id}")
   end
 
   def index_page_has_first_user_details
@@ -44,8 +54,8 @@ feature "Search users" do
     expect(admin_users_index_page).to have_text(second_user.email)
   end
 
-  def then_i_enter_the_first_users_last_name_into_the_search_field
-    admin_users_index_page.search.set(user.last_name)
+  def then_i_enter_the_first_users_name_into_the_search_field
+    admin_users_index_page.search.set(user.name)
   end
 
   def then_i_click_search
@@ -61,8 +71,16 @@ feature "Search users" do
     admin_users_index_page.search.set(second_user.email)
   end
 
+  def then_i_enter_the_first_users_provider_into_the_search_field
+    admin_users_index_page.search.set(user.providers.first.name)
+  end
+
   def then_i_see_only_the_second_user
     index_page_has_second_user_details
     expect(admin_users_index_page).not_to have_text(user.first_name)
+  end
+
+  def then_i_press_enter
+    admin_users_index_page.search.native.send_key(:return)
   end
 end

--- a/spec/support/page_objects/system_admin/users/index.rb
+++ b/spec/support/page_objects/system_admin/users/index.rb
@@ -11,8 +11,8 @@ module PageObjects
         end
 
         element :add_a_user, "a", text: "Add a user"
-        element :search, 'input[name="search"]'
-        element :submit_search, ".submit-search"
+        element :search, "#user-search-form-user-field"
+        element :first_option, "#user-search-form-user-field__option--0"
         sections :users, UserRow, ".user-row"
         element :flash_message, ".govuk-notification-banner__header"
         element :flash_message, ".govuk-notification-banner__header"


### PR DESCRIPTION
### Context
To make it easy to find users in support, we should add an autocomplete that lets admins search for users.

This autocomplete should route to the users show page for the selected user. 

![image](https://user-images.githubusercontent.com/44261976/194920010-51f21cc5-3cee-4015-8926-c13e9b588930.png)


### Changes proposed in this pull request

* An autocomplete is added to the users index.
* Admins can search by various attributes (name, email, provider name)
* On confirm, the admin is redirected to the user (no form submission needed)
* Autocomplete styled like screenshot

### Guidance to review

Login and head to system-admin/users and try out the new autocompete! (you need to press enter once you've selected your user)

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
