### PR TITLE
[xxx] Fix data migration so it works in staging environment

### DIFF
--- a/db/data/20221010142433_backfill_unmapped_hesa_degree_grades.rb
+++ b/db/data/20221010142433_backfill_unmapped_hesa_degree_grades.rb
@@ -7,6 +7,8 @@ class BackfillUnmappedHesaDegreeGrades < ActiveRecord::Migration[6.1]
     url = "#{Settings.hesa.collection_base_url}/#{collection_reference}/#{from_date}"
     xml_response = Hesa::Client.get(url: url)
 
+    return unless xml_response.include?("ITTRecord")
+
     Nokogiri::XML::Reader(xml_response).each do |node|
       next unless node.name == "Student" && node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
 


### PR DESCRIPTION
### Context
The data migration from #2819 is breaking main deployment because the staging environment doesn't have the credentials for HESA login. This quick fix makes sure the XML is valid before continuing any further.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
