### PR TITLE
[4669] Allow users to change routes and courses on registered trainees

### DIFF
--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -83,7 +83,7 @@ module CourseDetails
     def course_details
       return "#{course.name} (#{course.code})" if course
 
-      subject_names&.to_s
+      data_model.course_allocation_subject.name
     end
 
     def subject_names

--- a/app/controllers/concerns/publishable.rb
+++ b/app/controllers/concerns/publishable.rb
@@ -4,7 +4,7 @@ module Publishable
   delegate :course_uuid, to: :publish_course_details_form
 
   def course
-    @course ||= trainee.available_courses.find_by!(uuid: course_uuid)
+    @course ||= trainee.available_courses(training_route).find_by!(uuid: course_uuid)
   end
 
   def publish_course_details_form

--- a/app/controllers/trainees/apply_applications/course_details_controller.rb
+++ b/app/controllers/trainees/apply_applications/course_details_controller.rb
@@ -17,7 +17,7 @@ module Trainees
         if @review_course_form.valid?
           return save_course_and_continue if @review_course_form.registered?
 
-          redirect_to(edit_trainee_publish_course_details_path(trainee))
+          redirect_to(edit_trainee_training_route_path(trainee, context: "edit-course"))
         else
           render(:edit)
         end

--- a/app/controllers/trainees/base_controller.rb
+++ b/app/controllers/trainees/base_controller.rb
@@ -13,5 +13,9 @@ module Trainees
     def authorize_trainee
       authorize(trainee)
     end
+
+    def training_route
+      TrainingRoutesForm.new(trainee).training_route
+    end
   end
 end

--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -8,11 +8,13 @@ module Trainees
 
     before_action :set_course_year
 
+    helper_method :training_route
+
     def edit
       @courses = course_year_available_courses
       @publish_course_details_form = PublishCourseDetailsForm.new(trainee)
 
-      if @courses.empty?
+      if @courses.blank?
         page_tracker.remove_last_page
         if params[:year].present?
           @publish_course_details_form.process_manual_entry!
@@ -68,7 +70,7 @@ module Trainees
     end
 
     def course_year_available_courses
-      trainee.available_courses.where(recruitment_cycle_year: @course_year)
+      trainee.available_courses(training_route)&.where(recruitment_cycle_year: @course_year)
     end
 
     def course_params

--- a/app/controllers/trainees/training_routes_controller.rb
+++ b/app/controllers/trainees/training_routes_controller.rb
@@ -2,27 +2,42 @@
 
 module Trainees
   class TrainingRoutesController < BaseController
-    prepend_before_action :ensure_trainee_is_draft!
+    helper_method :training_route
 
-    def edit; end
+    def edit
+      @training_routes_form = TrainingRoutesForm.new(trainee, params: params.slice(:context).permit!)
+    end
 
     def update
-      trainee.update_training_route!(training_route)
-      redirect_url
+      @training_routes_form = TrainingRoutesForm.new(trainee, params: trainee_params, user: current_user)
+
+      if @training_routes_form.stash_or_save!
+        redirect_to(relevant_redirect_path)
+      else
+        render(:edit)
+      end
     end
 
   private
 
-    def redirect_url
-      redirect_to(page_tracker.last_origin_page_path || trainee_path(trainee))
+    def relevant_redirect_path
+      if @training_routes_form.course_change?
+        if trainee.available_courses(training_route).present?
+          edit_trainee_publish_course_details_path(trainee)
+        elsif EARLY_YEARS_TRAINING_ROUTES.include?(training_route)
+          edit_trainee_course_details_path(trainee)
+        else
+          edit_trainee_course_education_phase_path(trainee)
+        end
+      elsif page_tracker.last_origin_page_path.present?
+        page_tracker.last_origin_page_path
+      else
+        trainee_path(trainee)
+      end
     end
 
     def trainee_params
-      params.require(:trainee).permit(:training_route)
-    end
-
-    def training_route
-      trainee_params["training_route"]
+      params.require(:training_routes_form).permit(:training_route, :context)
     end
   end
 end

--- a/app/forms/apply_applications/confirm_course_form.rb
+++ b/app/forms/apply_applications/confirm_course_form.rb
@@ -77,20 +77,20 @@ module ApplyApplications
 
     def update_trainee_attributes
       trainee.assign_attributes({
-        course_subject_one: course_subject_one,
-        course_subject_two: course_subject_two,
-        course_subject_three: course_subject_three,
-        training_route: training_route,
-        course_uuid: course_uuid,
-        course_age_range: course_age_range,
-        itt_start_date: itt_start_date,
-        itt_end_date: itt_end_date,
-        study_mode: study_mode,
+        course_subject_one:,
+        course_subject_two:,
+        course_subject_three:,
+        training_route:,
+        course_uuid:,
+        course_age_range:,
+        itt_start_date:,
+        itt_end_date:,
+        study_mode:,
       })
     end
 
     def course
-      @course ||= trainee.available_courses(training_route).find_by(uuid: uuid)
+      @course ||= trainee.available_courses(training_route).find_by(uuid:)
     end
 
     def trainee_confirmed?

--- a/app/forms/apply_applications/confirm_course_form.rb
+++ b/app/forms/apply_applications/confirm_course_form.rb
@@ -8,16 +8,19 @@ module ApplyApplications
     FIELDS = %i[
       uuid
       mark_as_reviewed
+      training_route
     ].freeze
 
     attr_accessor(*FIELDS, :trainee, :specialisms, :params)
 
     delegate :id, :persisted?, to: :trainee
+    delegate :training_route, to: :training_routes_form
 
     def initialize(trainee, specialisms, params = {})
       @trainee = trainee
       @specialisms = specialisms
       @itt_dates_form = IttDatesForm.new(trainee)
+      @training_routes_form = TrainingRoutesForm.new(trainee)
 
       assign_attributes({ mark_as_reviewed: trainee.progress.course_details }.merge(params))
     end
@@ -70,14 +73,14 @@ module ApplyApplications
 
   private
 
-    attr_accessor :itt_dates_form
+    attr_accessor :itt_dates_form, :training_routes_form
 
     def update_trainee_attributes
       trainee.assign_attributes({
         course_subject_one: course_subject_one,
         course_subject_two: course_subject_two,
         course_subject_three: course_subject_three,
-        training_route: course&.route,
+        training_route: training_route,
         course_uuid: course_uuid,
         course_age_range: course_age_range,
         itt_start_date: itt_start_date,
@@ -87,7 +90,7 @@ module ApplyApplications
     end
 
     def course
-      @course ||= trainee.available_courses.find_by(uuid:)
+      @course ||= trainee.available_courses(training_route).find_by(uuid: uuid)
     end
 
     def trainee_confirmed?

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -22,6 +22,7 @@ class CourseDetailsForm < TraineeForm
     additional_age_range
     study_mode
     primary_course_subjects
+    training_route
   ].freeze
 
   COURSE_DATES = %i[
@@ -56,12 +57,14 @@ class CourseDetailsForm < TraineeForm
   validate :itt_end_date_valid, if: :end_date_required?
 
   delegate :apply_application?, :requires_study_mode?, to: :trainee
+  delegate :training_route, to: :training_routes_form
 
   MAX_END_YEARS = 4
 
   def initialize(...)
     super(...)
     @primary_course_subjects ||= set_primary_phase_subjects if is_primary_phase?
+    @training_routes_form = TrainingRoutesForm.new(trainee)
   end
 
   def course_age_range
@@ -137,6 +140,8 @@ class CourseDetailsForm < TraineeForm
 
 private
 
+  attr_reader :training_routes_form
+
   def requires_secondary_subjects?
     !is_primary_phase? && require_subject?
   end
@@ -173,10 +178,11 @@ private
 
   def update_trainee_attributes
     attributes = {
-      course_uuid:,
-      itt_start_date:,
-      itt_end_date:,
-      course_education_phase:,
+      course_uuid: course_uuid,
+      itt_start_date: itt_start_date,
+      itt_end_date: itt_end_date,
+      training_route: training_route,
+      course_education_phase: course_education_phase,
     }
 
     set_course_subject_from_primary_phase if is_primary_phase?

--- a/app/forms/itt_dates_form.rb
+++ b/app/forms/itt_dates_form.rb
@@ -26,7 +26,8 @@ class IttDatesForm < TraineeForm
   def initialize(...)
     super(...)
     @course_details_form = CourseDetailsForm.new(trainee)
-    @course = trainee.available_courses&.find_by(uuid: course_uuid)
+    @training_routes_form ||= TrainingRoutesForm.new(trainee)
+    @course = trainee.available_courses(@training_routes_form.training_route)&.find_by(uuid: course_uuid)
   end
 
   def save!

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -58,6 +58,7 @@ class PublishCourseDetailsForm < TraineeForm
     return false unless valid?
 
     update_trainee_attributes
+    clear_funding_information if clear_funding_information?
     Trainees::Update.call(trainee:)
     clear_all_course_related_stashes
   end
@@ -77,11 +78,11 @@ class PublishCourseDetailsForm < TraineeForm
   end
 
   def course_education_phase
-    @course_education_phase ||= course&.level || CourseEducationPhaseForm.new(trainee).course_education_phase
+    @course_education_phase = course&.level || CourseEducationPhaseForm.new(trainee).course_education_phase
   end
 
   def study_mode
-    @study_mode ||= StudyModesForm.new(trainee).study_mode
+    @study_mode = StudyModesForm.new(trainee).study_mode
   end
 
   def itt_start_date
@@ -99,8 +100,15 @@ private
   def update_trainee_attributes
     trainee.assign_attributes(training_route: training_routes_form.training_route,
                               course_uuid: course_uuid,
+                              course_subject_one: course_subject_one,
+                              course_subject_two: course_subject_two,
+                              course_subject_three: course_subject_three,
                               course_education_phase: course_education_phase,
-                              course_age_range: course_age_range)
+                              course_age_range: course_age_range,
+                              course_allocation_subject: course_allocation_subject,
+                              itt_start_date: itt_start_date,
+                              itt_end_date: itt_end_date,
+                              study_mode: study_mode)
   end
 
   def course_subjects

--- a/app/forms/training_routes_form.rb
+++ b/app/forms/training_routes_form.rb
@@ -16,7 +16,7 @@ class TrainingRoutesForm < TraineeForm
 
   def initialize(...)
     super(...)
-    @route_data_manager = RouteDataManager.new(trainee: trainee)
+    @route_data_manager = RouteDataManager.new(trainee:)
   end
 
   def compute_fields
@@ -31,7 +31,7 @@ class TrainingRoutesForm < TraineeForm
     if valid?
       assign_attributes_to_trainee
       update_training_route!(trainee.training_route)
-      Trainees::Update.call(trainee: trainee)
+      Trainees::Update.call(trainee:)
       clear_stash
     else
       false

--- a/app/forms/training_routes_form.rb
+++ b/app/forms/training_routes_form.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class TrainingRoutesForm < TraineeForm
+  COURSE_CHANGE = "edit-course"
+
+  FIELDS = %i[
+    training_route
+    context
+  ].freeze
+
+  attr_accessor(*FIELDS)
+
+  validates :training_route, presence: true
+
+  delegate :update_training_route!, to: :route_data_manager
+
+  def initialize(...)
+    super(...)
+    @route_data_manager = RouteDataManager.new(trainee: trainee)
+  end
+
+  def compute_fields
+    trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+  end
+
+  def course_change?
+    context == COURSE_CHANGE
+  end
+
+  def save!
+    if valid?
+      assign_attributes_to_trainee
+      update_training_route!(trainee.training_route)
+      Trainees::Update.call(trainee: trainee)
+      clear_stash
+    else
+      false
+    end
+  end
+
+  def fields_to_ignore_before_stash
+    [:context]
+  end
+
+  def fields_to_ignore_before_save
+    [:context]
+  end
+
+  attr_reader :route_data_manager
+end

--- a/app/helpers/publish_courses_helper.rb
+++ b/app/helpers/publish_courses_helper.rb
@@ -9,14 +9,7 @@ module PublishCoursesHelper
     t(".summary_with_route", summary: apply_course_summary(course), route: t("activerecord.attributes.trainee.training_routes.#{course.route}"))
   end
 
-  def course_summary_text_for(trainee, course)
-    summary_with_route = t(".summary_with_route", summary: course.summary, route: t("activerecord.attributes.trainee.training_routes.#{course.route}"))
-    trainee.apply_application? ? summary_with_route : course.summary
-  end
-
-  def courses_fieldset_text_for(trainee)
-    return t("views.forms.publish_course_details.all_courses_message") if trainee.apply_application?
-
-    t("views.forms.publish_course_details.route_message", route: route_title(trainee.training_route))
+  def courses_fieldset_text_for(_trainee)
+    t("views.forms.publish_course_details.route_message", route: route_title(training_route))
   end
 end

--- a/app/helpers/publish_courses_helper.rb
+++ b/app/helpers/publish_courses_helper.rb
@@ -9,7 +9,7 @@ module PublishCoursesHelper
     t(".summary_with_route", summary: apply_course_summary(course), route: t("activerecord.attributes.trainee.training_routes.#{course.route}"))
   end
 
-  def courses_fieldset_text_for(_trainee)
+  def courses_fieldset_text
     t("views.forms.publish_course_details.route_message", route: route_title(training_route))
   end
 end

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -38,7 +38,7 @@ module TraineeHelper
   end
 
   def show_publish_courses?(trainee)
-    FeatureService.enabled?(:publish_course_details) && trainee.available_courses.present?
+    FeatureService.enabled?(:publish_course_details) && trainee.available_courses(trainee.training_route).present?
   end
 
   def trainee_draft_title(trainee)

--- a/app/lib/route_data_manager.rb
+++ b/app/lib/route_data_manager.rb
@@ -9,7 +9,6 @@ class RouteDataManager
     trainee.training_route = route
     reset_trainee_details if trainee.training_route_changed?
     trainee.set_early_years_course_details
-    Trainees::Update.call(trainee:)
   end
 
 private

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TrainingRouteManager
+  delegate :training_route, to: :trainee
+
   def initialize(trainee)
     @trainee = trainee
   end
@@ -47,8 +49,6 @@ class TrainingRouteManager
 private
 
   attr_reader :trainee
-
-  delegate :training_route, to: :trainee
 
   def enabled?(training_route_enums_key)
     FeatureService.enabled?("routes.#{training_route_enums_key}") && training_route == TRAINING_ROUTE_ENUMS[training_route_enums_key.to_sym]

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -294,9 +294,7 @@ class Trainee < ApplicationRecord
     @training_route_manager ||= TrainingRouteManager.new(self)
   end
 
-  def available_courses
-    return provider.courses.order(:name) if apply_application?
-
+  def available_courses(training_route = self.training_route)
     provider.courses.where(route: training_route).order(:name) if TRAINING_ROUTES_FOR_COURSE.keys.include?(training_route)
   end
 

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -34,6 +34,7 @@ class FormStore
     study_modes
     course_education_phase
     training_details
+    training_routes
   ].freeze
 
   class << self

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render PageTitle::View.new(
-  text: t(".heading", from_year: @course_year, to_year: (@course_year + 1)),
+  text: t(".heading", route: route_title(training_route), from_year: @course_year, to_year: (@course_year + 1)),
   has_errors: @publish_course_details_form.errors.present?,
 ) %>
 
@@ -18,7 +18,7 @@
 
       <%= render TraineeName::View.new(@trainee) %>
 
-      <h1 class="govuk-heading-l"><%= t(".heading", from_year: @course_year, to_year: (@course_year + 1)) %></h1>
+      <h1 class="govuk-heading-l"><%= t(".heading", route: route_title(training_route), from_year: @course_year, to_year: (@course_year + 1)) %></h1>
       <div class="govuk-inset-text">
         <%= link_to t(".change_year_link_text"), edit_trainee_course_years_path(@trainee, year: @course_year), class: "govuk-link govuk-link--no-visited-state" %>
       </div>
@@ -26,19 +26,19 @@
       <div class="govuk-form-group">
         <%= f.govuk_radio_buttons_fieldset :course_uuid,
           legend: { text: t(".course_code_label"), size: "m" },
-          hint: { text: courses_fieldset_text_for(@trainee) },
+          hint: { text: courses_fieldset_text },
           classes: "published-courses" do %>
           <% @courses.each_with_index do |course, i| %>
             <%= f.govuk_radio_button :course_uuid, course.uuid,
               label: { text: "#{course.name} (#{course.code})" },
-              hint: { text: "#{course.summary}" },
+              hint: { text: course.summary },
               link_errors: i == 0
             %>
           <% end %>
 
           <div class="govuk-radios__divider">or</div>
 
-          <%= f.govuk_radio_button :course_uuid, PublishCourseDetailsForm::NOT_LISTED, label: { text: t(".course_not_listed") } %>
+          <%= f.govuk_radio_button :course_uuid, PublishCourseDetailsForm::NOT_LISTED, label: { text: t(".enter_course_details") } %>
         <% end %>
       </div>
 

--- a/app/views/trainees/publish_course_details/edit.html.erb
+++ b/app/views/trainees/publish_course_details/edit.html.erb
@@ -31,7 +31,7 @@
           <% @courses.each_with_index do |course, i| %>
             <%= f.govuk_radio_button :course_uuid, course.uuid,
               label: { text: "#{course.name} (#{course.code})" },
-              hint: { text: course_summary_text_for(@trainee, course) }, 
+              hint: { text: "#{course.summary}" },
               link_errors: i == 0
             %>
           <% end %>

--- a/app/views/trainees/training_routes/edit.html.erb
+++ b/app/views/trainees/training_routes/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(i18n_key: "trainees.training_routes.edit", has_errors: @trainee.errors.present?) %>
+<%= render PageTitle::View.new(i18n_key: "trainees.training_routes.edit", has_errors: @training_routes_form.errors.present?) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
@@ -6,8 +6,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= register_form_with model: @trainee, url: trainee_training_route_path(@trainee), local: true do |f| %>
+    <%= register_form_with model: @training_routes_form, url: trainee_training_route_path(@trainee, context: @context), local: true do |f| %>
       <%= f.govuk_error_summary %>
+      <%= f.hidden_field :context, value: params[:context] %>
+
       <%= render TraineeName::View.new(@trainee) %>
       <%= render "form_fields", f: f %>
       <%= f.govuk_submit %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -816,7 +816,7 @@ en:
           label: When did the trainee start their ITT?
           hint: Their ITT started on %{itt_start_date}
       publish_course_details:
-        route_message: Your %{route} courses in the Publish service
+        route_message: Courses imported from the Publish service
         all_courses_message: Your courses in the Publish service
         route_titles:
           provider_led_postgrad: provider-led postgrad
@@ -1018,7 +1018,7 @@ en:
         summary_with_route: &summary_with_route "%{summary}, %{route}"
     publish_course_details:
       edit:
-        heading: "Your courses starting in %{from_year} to %{to_year}"
+        heading: "Your %{route} courses starting in %{from_year} to %{to_year}"
         change_year_link_text: Choose from courses starting in a different academic year
         course_code_label: What course are they doing?
         course_not_listed: Another course not listed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,6 +242,7 @@ en:
         trainee_start_date: start date
     course_detail:
       title: Course details
+      course_and_route: Course
       education_phase: Education phase
       subject: Subject
       age_range: Age range
@@ -1524,6 +1525,10 @@ en:
               max_char_exceeded: Your entry must not exceed 100 characters
               uniqueness: The trainee ID has already been used for another trainee
               uniqueness_explanation: The ID ‘<span class="no-wrap">%{trainee_id}</span>’ has already been used for <span class="no-wrap">%{short_name}</span> (created <span class="no-wrap">%{created}</span>). Choose a new one or check if this is a duplicate trainee record.
+        training_routes_form:
+          attributes:
+            training_route:
+              blank: Enter a training route
         schools_form:
           attributes:
             query:

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -21,6 +21,8 @@ manager.update_training_route!("school_direct_salaried")
 
 A bunch of fields will be set to `nil`, see `RouteDataManager` class. Ask support to communicate with the user to update the Trainee record for the missing information.
 
+`update_training_route!` no longer kicks off an update to DQT so that will need to be done manually if needed.
+
 ## Unwithdrawing a withdrawn trainee
 
 Sometimes support will ask a dev to unwithdraw a trainee which has been withdrawn in error. You can find the previous trainee state by running `trainee.audits` and comparing the numbers to the enum in `trainee.rb`.

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -6,7 +6,7 @@ module CourseDetails
   describe View do
     include SummaryHelper
 
-    let(:training_route) { "Training route" }
+    let(:course_and_route) { "Course" }
     let(:education_phase) { "Education phase" }
     let(:age_range) { "Age range" }
 
@@ -25,8 +25,8 @@ module CourseDetails
         render_inline(View.new(data_model: trainee, editable: true))
       end
 
-      it "renders 6 rows" do
-        expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 6)
+      it "renders 7 rows" do
+        expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 7)
       end
 
       it "renders missing hint education phase" do
@@ -180,8 +180,8 @@ module CourseDetails
           render_inline(View.new(data_model: trainee))
         end
 
-        it "renders 5 rows" do
-          expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 5)
+        it "renders 6 rows" do
+          expect(rendered_component).to have_selector(".govuk-summary-list__row", count: 6)
         end
       end
     end
@@ -194,8 +194,8 @@ module CourseDetails
       context "non draft" do
         let(:trainee) { create(:trainee, :early_years_undergrad, :with_early_years_course_details, :submitted_for_trn) }
 
-        it "renders the training route" do
-          expect(rendered_component).to have_text(training_route)
+        it "renders the course and training route" do
+          expect(rendered_component).to have_text(course_and_route)
         end
 
         it "does not render education phase" do
@@ -209,10 +209,6 @@ module CourseDetails
 
       context "draft" do
         let(:trainee) { create(:trainee, :early_years_undergrad, :with_early_years_course_details, :draft) }
-
-        it "does not render the training route" do
-          expect(rendered_component).not_to have_text(training_route)
-        end
 
         it "does not render education phase" do
           expect(rendered_component).not_to have_text(education_phase)
@@ -228,10 +224,6 @@ module CourseDetails
       context "draft" do
         let(:trainee) { create(:trainee, :with_secondary_course_details, :draft) }
 
-        it "does not render the training route" do
-          expect(rendered_component).not_to have_text(training_route)
-        end
-
         it "renders route" do
           expect(rendered_component).to have_text(education_phase)
           expect(rendered_component).to have_text("Secondary")
@@ -245,8 +237,8 @@ module CourseDetails
       context "non draft" do
         let(:trainee) { create(:trainee, :with_secondary_course_details, :submitted_for_trn) }
 
-        it "renders the training route" do
-          expect(rendered_component).to have_text(training_route)
+        it "renders the course and training route" do
+          expect(rendered_component).to have_text(course_and_route)
         end
 
         it "renders route" do
@@ -287,7 +279,7 @@ module CourseDetails
 
     context "trainee with Apply application changes course" do
       let(:trainee) { create(:trainee, :recommended_for_award, :with_apply_application, :with_publish_course_details) }
-      let!(:new_course) { create(:course_with_subjects, accredited_body_code: trainee.provider.code) }
+      let!(:new_course) { create(:course_with_subjects, accredited_body_code: trainee.provider.code, route: trainee.training_route) }
       let(:data_model) { PublishCourseDetailsForm.new(trainee, params: { course_uuid: new_course.uuid }) }
 
       before do

--- a/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_course_details_spec.rb
@@ -101,7 +101,6 @@ private
 
   def then_the_course_details_are_updated
     when_i_visit_the_course_details_page
-    # save_and_open_page
 
     expect(course_details_page.subject.value).to eq(trainee.reload.course_subject_one)
     expect(course_details_page.itt_start_date_day.value).to eq(trainee.itt_start_date.day.to_s)

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -12,6 +12,7 @@ feature "Change course", feature_publish_course_details: true do
     and_trainee_related_courses_exist
     and_i_am_on_the_trainee_record_page
     when_i_click_to_change_course_details
+    and_i_do_not_change_training_route
     and_i_choose_a_different_course
     and_i_click_continue
     and_select_a_specialism_if_necessary
@@ -24,8 +25,10 @@ feature "Change course", feature_publish_course_details: true do
     given_i_am_authenticated
     and_a_trainee_exists
     and_trainee_related_courses_exist
+    and_courses_on_another_route_exist
     and_i_am_on_the_trainee_record_page
     when_i_click_to_change_course_details
+    and_i_choose_a_different_training_route
     then_i_am_redirected_to_the_course_years_page
     and_i_choose_a_different_year
     and_i_am_redirected_to_the_publish_course_details_page
@@ -41,6 +44,13 @@ private
     create(:subject_specialism, name: @different_course.name)
   end
 
+  def and_courses_on_another_route_exist
+    create(:course_with_subjects,
+           :secondary,
+           accredited_body_code: trainee.provider.code,
+           route: "school_direct_tuition_fee")
+  end
+
   def and_a_trainee_exists_with_trn_received
     given_a_trainee_exists(:trn_received, :with_publish_course_details, :school_direct_salaried, :with_secondary_education)
   end
@@ -51,6 +61,17 @@ private
 
   def when_i_click_to_change_course_details
     record_page.change_course_details.click
+  end
+
+  def and_i_do_not_change_training_route
+    trainee_edit_training_route_page.continue_button.click
+  end
+
+  def and_i_choose_a_different_training_route
+    trainee_edit_training_route_page.training_route_options.find { |o|
+      o.input.value.include?("school_direct_tuition_fee")
+    }.choose
+    trainee_edit_training_route_page.continue_button.click
   end
 
   def and_i_choose_a_different_course

--- a/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
+++ b/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
@@ -6,23 +6,72 @@ feature "editing a trainee training route" do
   background do
     given_i_am_authenticated
     given_a_trainee_exists(traits)
-    and_i_visit_the_edit_training_route_page
   end
 
   context "draft-trainee" do
     let(:traits) { :draft }
 
-    scenario "viewing the draft-trainee's current training route" do
-      then_i_see_the_course_details
-      and_current_training_route_should_be_selected
+    context "viewing training route" do
+      scenario "viewing the draft-trainee's current training route on training route page" do
+        when_i_visit_the_edit_training_route_page
+        then_i_see_the_course_details
+        and_current_training_route_should_be_selected
+      end
     end
 
     context "editing a draft trainee's current training route" do
       scenario "selecting a valid training route", "feature_routes.provider_led_postgrad": true do
+        when_i_visit_the_edit_training_route_page
         then_i_select_provider_led_postgrad
         and_i_submit_the_new_route
-        and_i_visit_the_edit_training_route_page
+        when_i_visit_the_edit_training_route_page
         and_provider_led_postgrad_should_be_selected
+      end
+    end
+
+    context "editing training route from the review draft page" do
+      scenario "redirects to the trainee path" do
+        when_i_visit_the_review_draft_page
+        and_i_click_on_the_training_route
+        and_i_select_a_route
+        and_i_submit_the_new_route
+        then_i_am_redirected_to_the_trainee_path
+      end
+    end
+
+    context "editing training route from the course details" do
+      let(:traits) { :completed }
+
+      background do
+        given_a_trainee_exists(traits)
+        given_a_route_has_published_courses
+        given_i_am_viewing_the_course_details
+        and_i_click_change_course
+        then_i_should_see_the_training_routes_page
+      end
+
+      context "and the route has published courses" do
+        scenario "redirects to the publish course path" do
+          and_i_select_school_direct_salaried
+          and_i_submit_the_new_route
+          then_i_am_redirected_to_the_publish_course_details_path
+        end
+      end
+
+      context "and the route is early years" do
+        scenario "redirects to the manual course path", "feature_routes.early_years_postgrad": true do
+          and_i_select_early_years_route
+          and_i_submit_the_new_route
+          then_i_am_redirected_to_the_manual_course_details_path
+        end
+      end
+
+      context "and the route does not have published courses" do
+        scenario "redirects to the course education phase path" do
+          and_i_select_a_route_without_published_courses
+          and_i_submit_the_new_route
+          then_i_am_redirected_to_the_course_education_phase_path
+        end
       end
     end
   end
@@ -30,19 +79,61 @@ feature "editing a trainee training route" do
   context "non-draft trainee" do
     let(:traits) { :submitted_for_trn }
 
-    scenario "redirect when editing a non-draft trainee's training route" do
-      expect(record_page).to be_displayed(id: trainee.slug)
+    context "editing a registered trainee's current training route" do
+      scenario "selecting a valid training route but not confirming course details", "feature_routes.provider_led_postgrad": true do
+        when_i_visit_the_edit_training_route_page
+        then_i_see_the_course_details
+        and_i_submit_the_new_route
+        when_i_visit_the_edit_training_route_page
+        and_provider_led_postgrad_should_not_be_selected
+        and_current_training_route_should_be_selected
+      end
     end
   end
 
 private
 
-  def and_i_visit_the_edit_training_route_page
+  def when_i_visit_the_edit_training_route_page
     trainee_edit_training_route_page.load(id: trainee.slug)
+  end
+
+  def when_i_visit_the_review_draft_page
+    review_draft_page.load(id: trainee.slug)
+  end
+
+  def given_i_am_viewing_the_course_details
+    confirm_course_details_page.load(id: trainee.slug)
+  end
+
+  def given_a_route_has_published_courses
+    @course = create(:course_with_subjects,
+                     accredited_body_code: trainee.provider.code,
+                     route: "school_direct_salaried",
+                     subject_names: ["Philosophy"])
+  end
+
+  def and_i_click_change_course
+    confirm_course_details_page.change_course.click
   end
 
   def then_i_see_the_course_details
     expect(trainee_edit_training_route_page).to be_displayed
+  end
+
+  def then_i_should_see_the_training_routes_page
+    expect(trainee_edit_training_route_page).to be_displayed
+  end
+
+  def and_i_select_school_direct_salaried
+    trainee_edit_training_route_page.school_direct_salaried.click
+  end
+
+  def and_i_select_early_years_route
+    trainee_edit_training_route_page.early_years_postgrad.click
+  end
+
+  def and_i_select_a_route_without_published_courses
+    trainee_edit_training_route_page.pg_teaching_apprenticeship.click
   end
 
   def and_current_training_route_should_be_selected
@@ -59,5 +150,37 @@ private
 
   def and_provider_led_postgrad_should_be_selected
     expect(trainee_edit_training_route_page.provider_led_postgrad).to be_checked
+  end
+
+  def and_provider_led_postgrad_should_not_be_selected
+    expect(trainee_edit_training_route_page.provider_led_postgrad).not_to be_checked
+  end
+
+  def and_i_click_on_the_training_route
+    within("div.govuk-inset-text") do
+      find("a").click
+    end
+  end
+
+  def and_i_select_a_route
+    trainee_edit_training_route_page.training_route_options.reject { |route|
+      route.input.value.include?(trainee.training_route)
+    }.first.choose
+  end
+
+  def then_i_am_redirected_to_the_trainee_path
+    expect(review_draft_page).to be_displayed
+  end
+
+  def then_i_am_redirected_to_the_publish_course_details_path
+    expect(publish_course_details_page).to be_displayed
+  end
+
+  def then_i_am_redirected_to_the_manual_course_details_path
+    expect(course_details_page).to be_displayed
+  end
+
+  def then_i_am_redirected_to_the_course_education_phase_path
+    expect(course_education_phase_page).to be_displayed
   end
 end

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -34,6 +34,16 @@ describe CourseDetailsForm, type: :model do
     end
   end
 
+  context "with early years route" do
+    let(:trainee) { build(:trainee, training_route: "early_years_postgrad") }
+    let!(:ey_allocation_subject) { create(:subject_specialism, name: CourseSubjects::EARLY_YEARS_TEACHING).allocation_subject }
+
+    it "sets the correct course subject and allocation subject" do
+      expect(subject.course_subject_one).to eq(CourseSubjects::EARLY_YEARS_TEACHING)
+      expect(subject.course_allocation_subject).to eq(ey_allocation_subject)
+    end
+  end
+
   describe "before validation" do
     describe "#sanitise_course_dates" do
       let(:params) do

--- a/spec/forms/training_routes_form_spec.rb
+++ b/spec/forms/training_routes_form_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TrainingRoutesForm do
+  let(:params) { { training_route: "provider_led_postgrad" } }
+  let(:trainee) { create(:trainee, :incomplete) }
+  let(:form_store) { class_double(FormStore) }
+
+  subject { described_class.new(trainee, params: params, store: form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    before { subject.validate }
+
+    context "without a training_route" do
+      let(:params) { {} }
+      let(:trainee) { build(:trainee, :incomplete, training_route: nil) }
+      let(:error_attr) { "activemodel.errors.models.training_routes_form.attributes.training_route" }
+
+      it "is invalid" do
+        expect(subject.errors[:training_route]).to include(I18n.t("#{error_attr}.blank"))
+      end
+    end
+  end
+
+  describe "#stash" do
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and training_routes" do
+      expect(form_store).to receive(:set).with(trainee.id, :training_routes, subject.params)
+
+      subject.stash
+    end
+
+    it "does not save to the database" do
+      expect(form_store).to receive(:set).with(trainee.id, :training_routes, subject.params)
+
+      expect { subject.stash }.not_to change(trainee, :training_route)
+    end
+  end
+
+  describe "#save" do
+    before do
+      allow(form_store).to receive(:get).and_return(params)
+      allow(form_store).to receive(:set).with(trainee.id, :training_routes, nil)
+    end
+
+    it "takes any data from the form store and saves it to the database and clears the store data" do
+      expect(form_store).to receive(:set).with(trainee.id, :training_routes, nil)
+      expect { subject.save! }.to change(trainee, :training_route).to("provider_led_postgrad")
+    end
+  end
+end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -187,7 +187,7 @@ describe Trainee do
     let(:trainee) { create(:trainee, training_route: course_route) }
     let(:provider) { trainee.provider }
 
-    subject { trainee.available_courses }
+    subject { trainee.available_courses(course_route) }
 
     it "returns courses available for the route ordered by name" do
       expect(subject).to eq([citizenship_course, physics_course])
@@ -196,8 +196,12 @@ describe Trainee do
     context "with a trainee from apply" do
       let(:trainee) { create(:trainee, :with_apply_application) }
 
-      it "returns all courses available from the provider ordered by name" do
-        expect(subject).to eq([citizenship_course, economics_course, physics_course])
+      it "returns all courses available for the route ordered by name" do
+        expect(subject).to eq([citizenship_course, physics_course])
+      end
+
+      it "does not return courses that are associated with the provider but not the route" do
+        expect(subject).not_to eq([citizenship_course, economics_course, physics_course])
       end
     end
   end

--- a/spec/support/page_objects/trainees/apply_registrations/confirm_course.rb
+++ b/spec/support/page_objects/trainees/apply_registrations/confirm_course.rb
@@ -11,6 +11,8 @@ module PageObjects
       class ConfirmCourse < PageObjects::Base
         set_url "/trainees/{id}/apply-application/confirm-course"
 
+        element :change_course, "a", text: "Change course"
+
         element :confirm, "input[name='apply_applications_confirm_course_form[mark_as_reviewed]']"
         element :submit_button, "button[type='submit']"
 

--- a/spec/support/page_objects/trainees/confirm_course_details.rb
+++ b/spec/support/page_objects/trainees/confirm_course_details.rb
@@ -8,8 +8,9 @@ module PageObjects
     end
 
     class ConfirmCourseDetails < PageObjects::Base
-      set_url "/trainees/{trainee_id}/course-details/confirm"
+      set_url "/trainees/{id}/course-details/confirm"
 
+      element :change_course, "a", text: "Change course"
       element :confirm, "input[name='confirm_detail_form[mark_as_completed]']"
       element :continue_button, "button[type='submit']", text: "Continue"
 

--- a/spec/support/page_objects/trainees/edit_training_route.rb
+++ b/spec/support/page_objects/trainees/edit_training_route.rb
@@ -3,13 +3,27 @@
 module PageObjects
   module Trainees
     class EditTrainingRoute < PageObjects::Base
+      include PageObjects::Helpers
+      class TrainingRouteOptions < SitePrism::Section
+        element :input, "input"
+        element :label, "label"
+      end
+
       set_url "/trainees/{id}/training-routes/edit"
 
       element :page_heading, ".govuk-heading-xl"
 
-      element :assessment_only, "#trainee-training-route-assessment-only-field"
+      element :assessment_only, "#training-routes-form-training-route-assessment-only-field"
 
-      element :provider_led_postgrad, "#trainee-training-route-provider-led-postgrad-field"
+      element :provider_led_postgrad, "#training-routes-form-training-route-provider-led-postgrad-field"
+
+      element :school_direct_salaried, "#training-routes-form-training-route-school-direct-salaried-field"
+
+      element :early_years_postgrad, "#training-routes-form-training-route-early-years-postgrad-field"
+
+      element :pg_teaching_apprenticeship, "#training-routes-form-training-route-pg-teaching-apprenticeship-field"
+
+      sections :training_route_options, TrainingRouteOptions, ".govuk-radios__item"
 
       element :continue_button, 'button.govuk-button[type="submit"]'
     end

--- a/spec/support/page_objects/trainees/record.rb
+++ b/spec/support/page_objects/trainees/record.rb
@@ -27,7 +27,7 @@ module PageObjects
 
       element :change_lead_school, "a", text: "Change lead school", visible: false
       element :change_employing_school, "a", text: "Change employing school", visible: false
-      element :change_course_details, "a", text: "Change course details", visible: false
+      element :change_course_details, "a", text: "Change course", visible: false
     end
   end
 end


### PR DESCRIPTION
### Context

This branch includes the new training routes stuff, plus fixes for the below bugs:
https://trello.com/c/fHrmVh7z/5019-funding-method-not-being-cleared-for-publish-course-changes
https://trello.com/c/GbgVm6Lb/5050-production-changing-from-one-publish-course-to-another-publish-course-does-not-update-the-trainees-course-details

Trello: https://trello.com/c/94rk0ez9/4669-l-allow-users-to-change-routes-and-courses-on-registered-trainees

We are allowing registered trainees to amend their training route via the Change course flow. On the course details (for both draft and registered trainees) the route is now displayed as part of the course section, and if you click change, you will be taken to the training routes form and then onto the relevant course flow.

/trainees/{trainee_id}/course-details/confirm
![Screenshot 2022-10-12 at 10 22 27](https://user-images.githubusercontent.com/43522239/195304385-bb570f0a-417e-4648-83b9-40b128f84318.png)

If you click to change course, you will first be displayed with the training route page which now carries a context:
/trainees/{trainee_id}/training-routes/edit?context=edit-course

![Screenshot 2022-10-12 at 10 30 47](https://user-images.githubusercontent.com/43522239/195306393-52424dd6-97a0-453d-8e3d-6847b7d11828.png)

The original functionality for amending the training route on draft trainees has not changed:
/trainees/{trainee_id}/review-draft
![Screenshot 2022-10-12 at 10 29 25](https://user-images.githubusercontent.com/43522239/195305861-376b6fea-3504-4599-b997-006c1b60226d.png)

When the new training route is confirmed we use the existing RouteDataManager to determine what needs to be deleted.

As part of this PR I have not considered removing data that we no longer need e.g. lead schools when the route changed to from school direct to a different route. I would suggest we do this as a follow up piece for v2.


### Changes proposed in this pull request

* Add new TrainingRouteForm and update TrainingRouteController
* Add def training_route to BaseController
* Update RouteDataManager so that it does not send Trainee::Update (this happens in the controller)
* Update PublishCourseDetailsController and PublishCourseDetailsForm
* Update def available_courses on the Trainee model as we no longer show all courses for Apply apps
* Update TrainingRouteManager to expose training_route
* Update TraineeHelper
* Update CourseDetailsForm
* Update ConfirmCourseDetails, which is for Apply trainees
* Update IttDatesForm with TrainingRoutesForm instance
* Add page objects
* Bug fix where we were not changing publish course details properly/amending the allocation subject/clearing funding properly

### Guidance to review

* For different training routes, check that you are redirected on to the correct course options
* Check the route and course change behaviour for both draft and registered trainees (we only stash on registered trainees and not on drafts)
* Make sure we're clearing funding info in the way that is expected
* Check backlinks because i think some of those might not be quite right
* Check the existing functionality for drafts still works
* Check the content makes sense for the new flow (mainly around Apply applications) as I might have missed this

For review bug fixes:
* Switch from a non-funding to a funded publish course for a registered trainee - observe it updates the course correctly and the funding is cleared
* Try the other way around too (funded to non-funded)

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
