### PR TITLE
[4777] Check for a trn in Register when setting the trainee state from HESA

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -263,7 +263,7 @@ module Trainees
     end
 
     def trainee_state
-      @trainee_state ||= MapStateFromHesa.call(hesa_trainee: hesa_trainee, trainee_persisted: trainee.persisted?) || trainee.state
+      @trainee_state ||= MapStateFromHesa.call(hesa_trainee: hesa_trainee, trainee: trainee) || trainee.state
     end
   end
 end

--- a/app/services/trainees/map_state_from_hesa.rb
+++ b/app/services/trainees/map_state_from_hesa.rb
@@ -4,10 +4,10 @@ module Trainees
   class MapStateFromHesa
     include ServicePattern
 
-    def initialize(hesa_trainee:, trainee_persisted:)
+    def initialize(hesa_trainee:, trainee:)
       @hesa_trainee = hesa_trainee
-      @trainee_persisted = trainee_persisted
-      @trn = hesa_trainee[:trn]
+      @trainee = trainee
+      @trn = hesa_trainee[:trn] || trainee.trn
     end
 
     def call
@@ -15,7 +15,7 @@ module Trainees
       # If the trainee has completed the course, but the result is unknown we
       # do not know enough to transition their state. If it's the first time
       # we're seeing this trainee, they are created as trn_received (line 41)
-      return nil if trainee_persisted && completed_with_unknown_result?
+      return nil if trainee.persisted? && completed_with_unknown_result?
       return :submitted_for_trn if submitted_for_trn?
       return :trn_received if trn_received?
 
@@ -24,7 +24,7 @@ module Trainees
 
   private
 
-    attr_reader :hesa_trainee, :trn, :trainee_persisted
+    attr_reader :hesa_trainee, :trn, :trainee
 
     def trainee_dormant?
       [

--- a/spec/services/trainees/map_state_from_hesa_spec.rb
+++ b/spec/services/trainees/map_state_from_hesa_spec.rb
@@ -12,8 +12,10 @@ module Trainees
     let(:hesa_mode_codes) { Hesa::CodeSets::Modes::MAPPING.invert }
     let(:hesa_trn) { Faker::Number.number(digits: 7) }
     let(:date_today) { Time.zone.today }
+    let(:register_trn) { nil }
+    let(:trainee) { double(persisted?: persisted, trn: register_trn) }
 
-    subject { described_class.call(hesa_trainee: hesa_trainee, trainee_persisted: persisted) }
+    subject { described_class.call(hesa_trainee: hesa_trainee, trainee: trainee) }
 
     context "when the trainee is new" do
       let(:persisted) { false }
@@ -117,6 +119,13 @@ module Trainees
         end
 
         it { is_expected.to be_falsey }
+      end
+
+      context "when there's no TRN received from HESA, but a TRN in Register already" do
+        let(:hesa_stub_attributes) { { reason_for_leaving: nil, trn: nil } }
+        let(:register_trn) { "1234567" }
+
+        it { is_expected.to eq(:trn_received) }
       end
     end
   end


### PR DESCRIPTION
### Context

This is the timeline which is causing the bug (i think):
- We receive a trainee from HESA over the TRN endpoint and request a TRN from DQT
- We get a TRN back and save it on the trainee in Register, transitioning it to trn_received
- We receive the same trainee from HESA over the collection endpoint, with no TRN (in HESA) and re-set the state to submitted_for_trn
- We send the TRN data back to HESA and they save it on the trainee.

https://trello.com/c/RjRU4lY3/4777-hesa-trainee-updates-overwrite-trainee-state-in-register

### Changes proposed in this pull request

- Check that a trainee has a TRN in Register before calculating the state, otherwise if HESA haven't yet set it their end, we'll likely transition the trainee back to submitted_for_trn.

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml