### PR TITLE
[4778] Protect Trainees::SetAcademicCyclesJob from deleted trainees

### DIFF
--- a/app/jobs/trainees/set_academic_cycles_job.rb
+++ b/app/jobs/trainees/set_academic_cycles_job.rb
@@ -3,6 +3,8 @@
 module Trainees
   class SetAcademicCyclesJob < ApplicationJob
     def perform(trainee)
+      return unless trainee.persisted? # Trainees can be deleted before this job runs
+
       trainee = Trainees::SetAcademicCycles.call(trainee: trainee)
       trainee.save!
     end


### PR DESCRIPTION
### Context
https://trello.com/c/92cvxDcL/4778-trying-to-set-academic-cycle-on-a-trainee-that-doesnt-exist

### Changes proposed in this pull request
- Update `Trainees::SetAcademicCyclesJob` so that it doesn't proceed unless the trainee exists

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
