### PR TITLE
[xxx] Add nil TRN check to TraineeUpdate

### DIFF
--- a/app/services/dqt/trainee_update.rb
+++ b/app/services/dqt/trainee_update.rb
@@ -4,6 +4,8 @@ module Dqt
   class TraineeUpdate
     include ServicePattern
 
+    class TraineeUpdateMissingTrn < StandardError; end
+
     def initialize(trainee:)
       return unless FeatureService.enabled?(:integrate_with_dqt)
 
@@ -13,6 +15,8 @@ module Dqt
 
     def call
       return unless FeatureService.enabled?(:integrate_with_dqt)
+
+      raise(TraineeUpdateMissingTrn, "Cannot update trainee on DQT without a trn") if trainee.trn.blank?
 
       dqt_update("/v2/teachers/update/#{trainee.trn}?birthDate=#{trainee.date_of_birth.iso8601}", payload)
     end

--- a/app/services/dqt/trainee_update.rb
+++ b/app/services/dqt/trainee_update.rb
@@ -16,7 +16,7 @@ module Dqt
     def call
       return unless FeatureService.enabled?(:integrate_with_dqt)
 
-      raise(TraineeUpdateMissingTrn, "Cannot update trainee on DQT without a trn") if trainee.trn.blank?
+      raise(TraineeUpdateMissingTrn, "Cannot update trainee on DQT without a trn (id: #{trainee.id})") if trainee.trn.blank?
 
       dqt_update("/v2/teachers/update/#{trainee.trn}?birthDate=#{trainee.date_of_birth.iso8601}", payload)
     end

--- a/spec/services/dqt/trainee_update_spec.rb
+++ b/spec/services/dqt/trainee_update_spec.rb
@@ -5,10 +5,11 @@ require "rails_helper"
 module Dqt
   describe TraineeUpdate do
     describe "#call" do
-      let(:trainee) { create(:trainee, :completed, :with_secondary_course_details, :with_start_date, :with_degree) }
+      let(:trainee) { create(:trainee, :completed, :with_secondary_course_details, :with_start_date, :with_degree, trn: trn) }
       let(:dqt_path) { "/v2/teachers/update/#{trainee.trn}?birthDate=#{trainee.date_of_birth.iso8601}" }
       let(:dqt_payload) { Params::TraineeRequest.new(trainee: trainee).to_json }
       let(:dqt_response) { { status: 204 } }
+      let(:trn) { "1234567" }
 
       subject { described_class.call(trainee: trainee) }
 
@@ -20,6 +21,16 @@ module Dqt
       it "sends a PATCH request to update trainee" do
         expect(Client).to receive(:patch).with(dqt_path, body: dqt_payload)
         subject
+      end
+
+      context "when the trn is blank" do
+        let(:trn) { nil }
+
+        it "raises an error" do
+          expect {
+            subject
+          }.to raise_error(TraineeUpdate::TraineeUpdateMissingTrn)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Worked with Mark on this - we have decided to raise an error if we call TraineeUpdate on a trainee with no TRN. This was causing 405s on the Dqt::UpdateTraineeJob. We need the TRN to be able to send the update to DQT, so let's not call the job, but instead catch the errors. 

### Changes proposed in this pull request

* raise an error if trainee.trn.blank? when we call TraineeUpdate

### Guidance to review

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
