### PR TITLE
[xxx] Fix nil error on new starter data sign off export

### DIFF
--- a/app/services/exports/trainee_search_data.rb
+++ b/app/services/exports/trainee_search_data.rb
@@ -8,12 +8,15 @@ module Exports
     DATA_NOT_AVAILABLE = "data not available"
     END_DATE_NOT_REQUIRED_BY_HESA = "End date not required by HESA so no data available in Register"
     NOT_REQUIRED_BY_HESA = "Not required by HESA so no data available in Register"
+    NO_TRAINEE_DATA = "No trainee data to export"
 
     def initialize(trainees)
       @data_for_export = format_trainees(trainees)
     end
 
     def data
+      return NO_TRAINEE_DATA if data_for_export.blank?
+
       header_row ||= data_for_export.first&.keys
 
       CSV.generate(headers: true) do |rows|

--- a/spec/services/exports/trainee_search_data_spec.rb
+++ b/spec/services/exports/trainee_search_data_spec.rb
@@ -136,6 +136,15 @@ module Exports
       it "sets the correct row values" do
         expect(subject.data).to include(expected_output.values.join(","))
       end
+
+      context "when there is no trainee data" do
+        let(:no_trainees_message) { "No trainee data to export" }
+
+        it "sets the 'no trainee data' message" do
+          trainee.destroy!
+          expect(subject.data).to include(no_trainees_message)
+        end
+      end
     end
 
     describe "#time" do


### PR DESCRIPTION
### Context

Fixes the nil handling error we've seen repeatedly on the ReportsController#itt_new_starter_data_sign_off

https://sentry.io/organizations/dfe-teacher-services/issues/3554532428/?environment=production&project=5552118&query=is%3Aunresolved

There might be a better way to handle this but stops the erroring for now.

### Changes proposed in this pull request

* Add nil handling in trainee_search_data.rb
* We let them export the CSV but I've added a string to say there is no data

### Guidance to review

* Delete trainees for a user and log in as them (I used Damian Campbell persona locally)
* Navigate to reports
* Export the CSV
* See that the CSV successfully exports and contains the message "No trainee data to export"

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
