### PR TITLE
[4745] Show itt_end_date for HESA trainees

### DIFF
--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -123,7 +123,6 @@ module CourseDetails
 
     def itt_end_date
       return t("components.confirmation.not_provided_from_hesa_update") if data_model.itt_end_date.blank? && trainee.hesa_record?
-      return t("components.confirmation.expected_hesa_end_date", academic_end_label: trainee.end_academic_cycle.label) if trainee.hesa_record? && trainee.end_academic_cycle.present?
 
       if data_model.itt_end_date.present?
         date_for_summary_view(data_model.itt_end_date)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,7 +166,6 @@ en:
         blank: Draft record
     confirmation:
       not_provided_from_hesa_update: Not provided from HESA update
-      expected_hesa_end_date: Expected in academic year %{academic_end_label}
       missing: missing
       not_provided: Not provided
       heading: Confirm %{section_title}

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -173,19 +173,6 @@ module CourseDetails
         end
       end
 
-      context "with a end_academic_cycle" do
-        let(:end_academic_cycle) { create(:academic_cycle, one_after_next_cycle: true) }
-        let(:trainee) { create(:trainee, :with_primary_education, :with_publish_course_details, hesa_id: "XXX", end_academic_cycle: end_academic_cycle) }
-
-        before do
-          render_inline(View.new(data_model: trainee))
-        end
-
-        it "renders the projected end date" do
-          expect(rendered_component).to have_text("Expected in academic year #{end_academic_cycle.label}")
-        end
-      end
-
       context "without a publish course" do
         let(:trainee) { create(:trainee, hesa_id: "XXX", itt_end_date: Time.zone.today) }
 


### PR DESCRIPTION
### Context

HESA now send us an ITT end date, so we should show this on the record if present

### Changes proposed in this pull request

Before:
<img width="989" alt="Screenshot 2022-10-14 at 13 21 50" src="https://user-images.githubusercontent.com/18436946/195846162-078bc151-e02d-47e8-99b4-946de476e1f9.png">

After:
<img width="986" alt="Screenshot 2022-10-14 at 13 22 04" src="https://user-images.githubusercontent.com/18436946/195846186-decf1553-93df-441c-8f20-59b306bf58f6.png">

### Guidance to review

Find a HESA trainee
See that their itt_end_date is now shown

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
