### PR TITLE
[xxx] Fix nil handing error on validator

### DIFF
--- a/app/validators/autocomplete_validator.rb
+++ b/app/validators/autocomplete_validator.rb
@@ -8,6 +8,8 @@ class AutocompleteValidator < ActiveModel::EachValidator
     return if raw_value.nil?
 
     value = record.send(attribute)
+    return if value.nil?
+
     if value.downcase != raw_value.downcase
 
       # If the user hasn't selected something, we need to reset the value so that the autocomplete

--- a/spec/validators/autocomplete_validator_spec.rb
+++ b/spec/validators/autocomplete_validator_spec.rb
@@ -59,4 +59,14 @@ describe AutocompleteValidator do
       expect(subject.errors[:search]).to be_blank
     end
   end
+
+  context "when the search value is blank" do
+    let(:search) { nil }
+    let(:search_raw) { "Does ask jeeves still exist?" }
+
+    it "does not add an error" do
+      expect(subject).to be_valid
+      expect(subject.errors[:search]).to be_blank
+    end
+  end
 end


### PR DESCRIPTION
### Context

We are getting this Sentry error: https://sentry.io/organizations/dfe-teacher-services/issues/3662991514/?project=5552118

NoMethodError, Sidekiq/Dqt::RetrieveTrnJob, undefined method `downcase' for nil:NilClass

Currently this is affecting one trainee. https://register-productiondata.london.cloudapps.digital/trainees/xLV9jsQ5B6iZ7yySrX2Hr3Zs

Strangely I can view their record without a problem on productiondata (link above), but on production we get an error page and the above downcase error.

I'm not sure if this fix is the right thing to do - I've added nil handling but we haven't seen this issue with a trainee before. I'm struggling to see what is wrong with their record. We use the AutocompleteValidator in three places:

course_details_form.rb
degree_form.rb
personal_details_form.rb

I can't see anything untoward in these places.

### Changes proposed in this pull request

* Add nil check in `def validate_each` (implemented in the same way as the raw_value nil check) in AutocompleteValidator

### Guidance to review

* Not sure

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
