### PR TITLE
[4800] Unmapped institutions from def-reference gem causing missing country errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ gem "govuk_markdown"
 gem "mechanize" # interact with HESA
 
 # pinned to a commit as v1 doesn't contain the Doctor of Philosophy disambiguation
-gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", ref: "b17828c75162ffd61e438b9dbd458b9a51163c34"
+gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", ref: "442fe3f"
 
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: b17828c75162ffd61e438b9dbd458b9a51163c34
-  ref: b17828c75162ffd61e438b9dbd458b9a51163c34
+  revision: 442fe3f40a15e05edd52aad5254aed7cafa96824
+  ref: 442fe3f
   specs:
     dfe-reference-data (1.0.0)
       activesupport
@@ -297,7 +297,7 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
-    irb (1.4.1)
+    irb (1.4.2)
       reline (>= 0.3.0)
     json (2.6.2)
     json-jwt (1.13.0)

--- a/app/services/degrees/dfe_reference.rb
+++ b/app/services/degrees/dfe_reference.rb
@@ -6,23 +6,10 @@ module Degrees
 
     COMMON_TYPES = ["Bachelor of Arts", "Bachelor of Science", "Master of Arts", "PhD"].freeze
 
-    INSTITUTIONS = DfE::ReferenceData::TweakedReferenceList.new(
-      DfE::ReferenceData::Degrees::INSTITUTIONS,
-      DfE::ReferenceData::Record.new(
-        {
-          "96e9359f-dbad-4486-8de9-f05f3c7104c2" => {
-            name: OTHER,
-            match_synonyms: [],
-            suggestion_synonyms: [],
-            abbreviation: nil,
-          },
-        },
-      ),
-    )
-
     GRADES = DfE::ReferenceData::Degrees::GRADES
     SUBJECTS = DfE::ReferenceData::Degrees::SINGLE_SUBJECTS
     TYPES = DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS
+    INSTITUTIONS = DfE::ReferenceData::Degrees::INSTITUTIONS_INCLUDING_GENERICS
 
     SUPPORTED_GRADES_BY_HESA_CODES = %w[1 2 3 5 12 13 14].freeze
 

--- a/db/data/20221020131904_fix_unmapped_degree_institutions.rb
+++ b/db/data/20221020131904_fix_unmapped_degree_institutions.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+class FixUnmappedDegreeInstitutions < ActiveRecord::Migration[6.1]
+  def up
+    {
+      "22100008860000214" =>
+       [{ graduation_date: "2021-06-01",
+          degree_type: "051",
+          subject: "100062",
+          institution: "0045",
+          grade: "01",
+          country: nil }],
+      "1810518116453" =>
+       [{ graduation_date: "2021-06-06",
+          degree_type: "051",
+          subject: "100318",
+          institution: "1154",
+          grade: "02",
+          country: nil }],
+      "22100078020000260" =>
+       [{ graduation_date: "1991-07-01",
+          degree_type: "051",
+          subject: "100059",
+          institution: "1172",
+          grade: "02",
+          country: nil }],
+      "22100077765162301" =>
+       [{ graduation_date: "2021-01-01",
+          degree_type: "051",
+          subject: "100051",
+          institution: "0045",
+          grade: "98",
+          country: nil }],
+      "22100038616545845" =>
+       [{ graduation_date: "2022-07-05",
+          degree_type: "083",
+          subject: "100095",
+          institution: "1096",
+          grade: "03",
+          country: nil }],
+      "18100071401194353" =>
+       [{ graduation_date: "2018-07-06",
+          degree_type: "005",
+          subject: "100391",
+          institution: "1169",
+          grade: "99",
+          country: nil }],
+      "22100077130003923" =>
+       [{ graduation_date: "2022-06-28",
+          degree_type: "051",
+          subject: "100459",
+          institution: "1001",
+          grade: "02",
+          country: nil }],
+      "22100077130004528" =>
+       [{ graduation_date: "2022-06-01",
+          degree_type: "051",
+          subject: "100459",
+          institution: "1001",
+          grade: "02",
+          country: nil }],
+      "22100068405091262" =>
+       [{ graduation_date: "2022-07-01",
+          degree_type: "051",
+          subject: "100459",
+          institution: "1050",
+          grade: "02",
+          country: nil }],
+      "22100036780000238" =>
+       [{ graduation_date: "2011-08-23",
+          degree_type: "200",
+          subject: "100513",
+          institution: "0133",
+          grade: "14",
+          country: nil }],
+      "22100057900001348" =>
+       [{ graduation_date: "2022-06-22",
+          degree_type: "051",
+          subject: "100654",
+          institution: "1001",
+          grade: "01",
+          country: nil }],
+      "22100078430003116" =>
+       [{ graduation_date: "2014-09-08",
+          degree_type: "051",
+          subject: "100070",
+          institution: "0182",
+          grade: "02",
+          country: nil }],
+      "22100078430003725" =>
+       [{ graduation_date: "2021-06-01",
+          degree_type: "083",
+          subject: "100497",
+          institution: "1071",
+          grade: "03",
+          country: nil }],
+      "22100078430001994" =>
+       [{ graduation_date: "2021-07-01",
+          degree_type: "051",
+          subject: "100070",
+          institution: "0182",
+          grade: "02",
+          country: nil }],
+      "22100071545032316" =>
+       [{ graduation_date: "2020-01-01",
+          degree_type: "402",
+          subject: "100459",
+          institution: "1153",
+          grade: "14",
+          country: nil }],
+      "22100012820000017" =>
+       [{ graduation_date: "2020-07-01",
+          degree_type: "400",
+          subject: "100433",
+          institution: "1082",
+          grade: "02",
+          country: nil }],
+      "22100078480005894" =>
+       [{ graduation_date: "2022-07-01",
+          degree_type: "051",
+          subject: "100463",
+          institution: "1050",
+          grade: "01",
+          country: nil }],
+      "22100071390001691" =>
+       [{ graduation_date: "2011-07-05",
+          degree_type: "051",
+          subject: "100059",
+          institution: "0186",
+          grade: "02",
+          country: nil }],
+      "22100078020001234" =>
+       [{ graduation_date: "2022-07-01",
+          degree_type: "051",
+          subject: "100457",
+          institution: "1124",
+          grade: "01",
+          country: nil }],
+      "22100008860003031" =>
+       [{ graduation_date: "2002-06-01",
+          degree_type: "051",
+          subject: "100078",
+          institution: "1082",
+          grade: "02",
+          country: nil }],
+      "1910518402973" =>
+       [{ graduation_date: "2022-03-24",
+          degree_type: "401",
+          subject: "100271",
+          institution: "7006",
+          grade: "12",
+          country: nil }],
+      "22100078480004392" =>
+       [{ graduation_date: "2007-07-01",
+          degree_type: "083",
+          subject: "100131",
+          institution: "0186",
+          grade: "03",
+          country: nil }],
+      "22100039560000044" =>
+       [{ graduation_date: "2022-06-22",
+          degree_type: "051",
+          subject: "100457",
+          institution: "1139",
+          grade: "02",
+          country: nil }],
+      "22100008860000616" =>
+       [{ graduation_date: "2005-09-01",
+          degree_type: "401",
+          subject: "100070",
+          institution: "0182",
+          grade: "12",
+          country: nil }],
+      "22100071390003732" =>
+       [{ graduation_date: "2014-07-10",
+          degree_type: "051",
+          subject: "100063",
+          institution: "0186",
+          grade: "05",
+          country: nil }],
+    }.each do |hesa_id, hesa_degrees|
+      trainee = Trainee.find_by(hesa_id: hesa_id)
+
+      next unless trainee
+
+      Degree.without_auditing do
+        trainee.degrees.delete_all
+        Degrees::CreateFromHesa.call(trainee: trainee, hesa_degrees: hesa_degrees)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -83,6 +83,25 @@ module Degrees
           expect(degree.country).to be_nil
           expect(degree.institution_uuid).to eq("bb3e182c-1425-ec11-b6e6-000d3adf095a")
         end
+
+        context "non-awarding institution" do
+          let(:hesa_degrees) do
+            [
+              {
+                graduation_date: "2003-06-01",
+                degree_type: "400",
+                subject: "100485",
+                institution: "0045",
+                grade: "02",
+                country: nil,
+              },
+            ]
+          end
+
+          it "sets the institution to 'other'" do
+            expect(degree.institution).to eq("Other UK institution")
+          end
+        end
       end
 
       context "institution is Institute of Education (0133)" do


### PR DESCRIPTION
### Context
https://trello.com/c/TmgbXgRa/4800-unmapped-institutions-from-def-reference-gem-causing-missing-country-errors

### Changes proposed in this pull request
- Update `Degrees::DfeReference` to use the `DfE::ReferenceData::Degrees::INSTITUTIONS_INCLUDING_GENERICS`
- Update `Degrees::CreateFromHesa` to fallback to "Other UK institution" if the institution HESA code is not in the `dfe-reference` gem
- Data migration to re-create degrees for those trainees that had an insitution HESA code but couldn't be found in the `dfe-reference` gem. This will make those degrees UK based instead of non-UK.

### Guidance to review
 "Other UK institution" has now been added to the degree institution list and can be tested by visiting a new or edit degree page

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
