### PR TITLE
[4866] Remove sync_trainee_states_with_dqt cron

### DIFF
--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -34,7 +34,3 @@ upload_trn_file_to_hesa:
   cron: "10 10 * * *"
   class: "Hesa::UploadTrnFileJob"
   queue: hesa
-sync_trainee_states_with_dqt:
-  cron: "0 11 * * *"
-  class: "Dqt::SyncStatesJob"
-  queue: dqt_sync


### PR DESCRIPTION
### Context

Trainees are getting marked as awarded whether they have EYTS or QTS

### Changes proposed in this pull request

Disabling the scheduled run of `sync_trainee_states_with_dqt`

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
