### PR TITLE
[4875] Add statement timeout for db queries

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,6 +7,8 @@ default: &default
   host: <%= ENV["DB_HOSTNAME"] %>
   port: <%= ENV["DB_PORT"] %>
   database: <%= ENV["DB_DATABASE"] %>
+  variables:
+    statement_timeout: 120_000
 
 development:
   <<: *default


### PR DESCRIPTION
### Context

A long running query brought down the production db  and entire site last week.

### Changes proposed in this pull request

Set a global 2 minute timeout for postgres queries.

### Guidance to review

In the rails console fake a long running query:
```ruby
ActiveRecord::Base.connection.execute("select pg_sleep(86400);")
```

Wait for the 2 minute timeout to trigger and confirm that the query is aborted:
```ruby
2022-10-24 10:11:44.072215 D [90796:10940 (irb):4] (2m 0s) ActiveRecord -- { :sql => "select pg_sleep(86400);", :allocations => 336, :cached => nil }
Traceback (most recent call last):
/Users/mark/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:49:in `exec': ERROR:  canceling statement due to statement timeout (PG::QueryCanceled)
/Users/mark/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:49:in `exec': PG::QueryCanceled: ERROR:  canceling statement due to statement timeout (ActiveRecord::QueryCanceled)
```

- Is two minutes short enough or too long?
- Will there be some other impacts that we haven't thought of?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
