### PR TITLE
[4860] Clear data about withdrawal or deferred if trainee goes back to `trn_received`

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -57,7 +57,6 @@ module Trainees
        .merge(funding_attributes)
        .merge(school_attributes)
        .merge(training_initiative_attributes)
-       .compact
     end
 
     # As soon as the trainee has been submitted over the HESA collection
@@ -73,6 +72,11 @@ module Trainees
     end
 
     def trn
+      # From the HESA data it appears that a TRN might not always be submitted with
+      # an update, even though a TRN has previously been submitted. This prevents a
+      # blank TRN in the HESA update from overwriting an existing TRN in register.
+      return trainee.trn if hesa_trainee[:trn].nil? && trainee.trn.present?
+
       hesa_trainee[:trn] if TRN_REGEX.match?(hesa_trainee[:trn])
     end
 
@@ -99,13 +103,13 @@ module Trainees
     end
 
     def withdrawal_attributes
-      return {} unless trainee_state == :withdrawn
+      return { withdraw_date: nil, withdraw_reason: nil } unless trainee_state == :withdrawn
 
       { withdraw_date: hesa_trainee[:end_date], withdraw_reason: reason_for_leaving }
     end
 
     def deferral_attributes
-      return {} unless trainee_state == :deferred
+      return { defer_date: nil } unless trainee_state == :deferred
 
       { defer_date: hesa_trainee[:end_date] }
     end

--- a/db/data/20221025091052_fix_trainee_states.rb
+++ b/db/data/20221025091052_fix_trainee_states.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FixTraineeStates < ActiveRecord::Migration[6.1]
+  def up
+    %w[0263134/2/03 1317509/2/03 1505948/2/03 2010427/1/03 2035745/1/03].each do |trainee_id|
+      Trainee.find_by(trainee_id: trainee_id)&.update_columns(state: :trn_received)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/VVsDRyYA/4860-trainee-not-coming-through-on-hesa-correctly

Trainees that have been withdrawn or deferred can return to the course (state goes back to `trn_received`). Therefore we should wipe the data related to withdrawal or deferral. In card we have one such case:

> This trainee (Kylie Nash, link below) withdrew from Wolverhampton in 2021. They have now returned and are reported as being on the course in HESA. It's still saying they are withdrawn on Register with a leave date of October 2021 and a start date of September 2022, which is obviously contradictory.

### Changes proposed in this pull request
- Remove `compact` statement to allow for `nil` values that are intended to clear previously populated data based on the previous state

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
