### PR TITLE
[4830] Clear form stashes as well as other course related stashes

### DIFF
--- a/app/forms/concerns/course_form_helpers.rb
+++ b/app/forms/concerns/course_form_helpers.rb
@@ -20,12 +20,15 @@ module CourseFormHelpers
     SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject
   end
 
-  def clear_all_used_stashes
+  def clear_all_course_related_stashes
     [
       IttDatesForm,
       StudyModesForm,
       SubjectSpecialismForm,
       LanguageSpecialismsForm,
+      CourseEducationPhaseForm,
+      CourseDetailsForm,
+      PublishCourseDetailsForm,
     ].each do |klass|
       klass.new(trainee).clear_stash
     end

--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -85,7 +85,7 @@ class CourseDetailsForm < TraineeForm
       update_trainee_attributes
       clear_funding_information if clear_funding_information?
       Trainees::Update.call(trainee: trainee)
-      clear_all_used_stashes
+      clear_all_course_related_stashes
     else
       false
     end

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -54,11 +54,11 @@ class PublishCourseDetailsForm < TraineeForm
 
     update_trainee_attributes
     Trainees::Update.call(trainee: trainee)
-    clear_all_used_stashes
+    clear_all_course_related_stashes
   end
 
   def stash
-    clear_all_used_stashes
+    clear_all_course_related_stashes
 
     super
   end


### PR DESCRIPTION
### Context

Worked on this with John. We think the [downcase error](https://sentry.io/organizations/dfe-teacher-services/issues/3662991514/?project=5552118) is being caused by some dodgy stashed data on the CourseDetailsForm. We recently changed some code which meant we were no longer clearing that stash in the same way on that form. We've added code to make sure we clear the stash correctly as we do with other course related forms.

### Changes proposed in this pull request

* Update method name `def clear_all_course_related_stashes` and add forms CourseEducationPhaseForm, CourseDetailsForm and PublishCourseDetailsForm

### Guidance to review

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
