### PR TITLE
[4858] Remove export link for System admin when more than 100 trainees

### DIFF
--- a/app/components/sort_links/style.scss
+++ b/app/components/sort_links/style.scss
@@ -40,3 +40,8 @@
 .app-sort-links__item {
   padding: 0.3125em;
 }
+
+.app-sort-links__item--no_padding {
+  padding-left: 0;
+  padding-right: 0.3125em;
+}

--- a/app/components/sort_links/view.rb
+++ b/app/components/sort_links/view.rb
@@ -13,13 +13,13 @@ module SortLinks
   private
 
     def default_sort_link(name, sort_by)
-      return tag.span(name, class: "app-sort-links__item") if params[:sort_by].blank?
+      return tag.span(name, class: "app-sort-links__item--no_padding") if params[:sort_by].blank?
 
       sort_link(name, sort_by)
     end
 
     def sort_link(name, sort_by)
-      sorted_by?(sort_by) ? tag.span(name, class: "app-sort-links__item") : govuk_link_to(name, sort_path(sort_by), class: "app-sort-links__item govuk-link govuk-link--no-visited-state")
+      sorted_by?(sort_by) ? tag.span(name, class: "app-sort-links__item--no_padding") : govuk_link_to(name, sort_path(sort_by), class: "app-sort-links__item govuk-link govuk-link--no-visited-state")
     end
 
     def sort_path(sort_by)

--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -5,6 +5,7 @@ class BaseTraineeController < ApplicationController
     export_results_path
     filter_params
     filters
+    filtered_trainees
     available_record_sources
     show_source_filters?
     paginated_trainees

--- a/app/helpers/exports_helper.rb
+++ b/app/helpers/exports_helper.rb
@@ -12,4 +12,8 @@ module ExportsHelper
 
     value.to_s.starts_with?(*VULNERABLE_CHARACTERS) ? "'#{value}" : value
   end
+
+  def exceeds_export_limit?(current_user, filtered_trainees_count)
+    current_user.system_admin? && filtered_trainees_count > Settings.trainee_export.record_limit
+  end
 end

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -7,7 +7,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-margin-bottom-3">
       <h1 class="govuk-heading-l"><%= t('funding.payment_schedule.heading', start_year: @start_year, end_year: @end_year) %></h1>
       <p class="govuk-body"><%= t('funding.payment_schedule.last_updated_at', date: @payment_schedule_view.last_updated_at) %></p>
-      <p class="govuk-body app-export--link">
+      <p class="govuk-body app-export-link-container">
         <span class="no-wrap">
           <%= govuk_link_to(
             I18n.t('funding.payment_schedule.export_label', start_year: @start_year, end_year: @end_year),

--- a/app/views/funding/trainee_summaries/show.html.erb
+++ b/app/views/funding/trainee_summaries/show.html.erb
@@ -27,7 +27,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <p class="govuk-body"><%= t('funding.trainee_summary.last_updated_at', date: @trainee_summary_view&.last_updated_at) %></p>
-      <p class="govuk-body app-export--link">
+      <p class="govuk-body app-export-link-container">
         <span class="app-nowrap">
           <%= govuk_link_to(
                 I18n.t('funding.trainee_summary.export_label', start_year: @start_year, end_year: @end_year),

--- a/app/views/trainees/_action_bar.html.erb
+++ b/app/views/trainees/_action_bar.html.erb
@@ -1,12 +1,18 @@
 <% unless paginated_trainees.empty? %>
   <%= render SortLinks::View.new %>
   <% if FeatureService.enabled?(:trainee_export) && policy(:trainee).export? %>
-    <div class="app-export--link">
-      <%= govuk_link_to(
-        I18n.t("views.trainees.index.export"),
-        export_results_path,
-        class: "app-trainee-export",
-      ) %>
-    </div>
+    <% if exceeds_export_limit?(@current_user, filtered_trainees.count) %>
+      <div class="app-export-link-container govuk-body govuk-hint">
+        Admins cannot export more than 100 trainees
+      </div>
+    <% else %>
+      <div class="app-export-link-container">
+        <%= govuk_link_to(
+          I18n.t("views.trainees.index.export"),
+          export_results_path,
+          class: "app-trainee-export",
+        ) %>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/webpacker/styles/trainee_list.scss
+++ b/app/webpacker/styles/trainee_list.scss
@@ -32,7 +32,7 @@
       display: flex;
       justify-content: space-between;
 
-      .app-export--link {
+      .app-export-link-container {
         text-align: right;
         float: none;
         width: 40%;

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -151,3 +151,6 @@ google:
     table_name: events
 
 sign_off_trainee_data_url: https://example.com/trainee-data-sign-off
+
+trainee_export:
+  record_limit: 100

--- a/spec/helpers/exports_helper_spec.rb
+++ b/spec/helpers/exports_helper_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ExportsHelper do
+  include ExportsHelper
+
+  describe "#exceeds_export_limit?" do
+    subject { exceeds_export_limit?(user, trainee_count) }
+
+    context "with 100 trainees" do
+      let(:trainee_count) { 100 }
+
+      context "as a system admin" do
+        let(:user) { build(:user, :system_admin) }
+
+        it "returns false" do
+          expect(subject).to be_falsey
+        end
+      end
+
+      context "as a provider user" do
+        let(:user) { build(:user) }
+
+        it "returns false" do
+          expect(subject).to be_falsey
+        end
+      end
+    end
+
+    context "with more than 100 trainees" do
+      let(:trainee_count) { 101 }
+
+      context "as a system admin" do
+        let(:user) { build(:user, :system_admin) }
+
+        it "returns true" do
+          expect(subject).to be_truthy
+        end
+      end
+
+      context "as a provider user" do
+        let(:user) { build(:user) }
+
+        it "returns false" do
+          expect(subject).to be_falsey
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/4W7x9nWU/4858-add-limit-to-number-of-trainees-that-can-be-exported-in-system-admin

This came out of the incident review. We will prevent system admins from exporting over 100 trainees. This PR is cosmetic and hides the link, but does not alter export permissions.

### Changes proposed in this pull request

* Update application.scss
* Update style.scss
* Update ExportsHelper with `def exceeds_export_limit?`
* Update _action_bar_html.erb
* Update components/sort_links/view.rb to get the padding right on the sorting in the action bar

### Guidance to review

* Are there any other export links I've missed? I haven't done anything to the reports export as part of this ticket. This is scoped to year and is more difficult to extract by accident.

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
