### PR TITLE
[4879] - fix HESA degrees with no institution and country

### DIFF
--- a/app/services/degrees/create_from_hesa.rb
+++ b/app/services/degrees/create_from_hesa.rb
@@ -82,7 +82,7 @@ module Degrees
     end
 
     def uk_country?(country)
-      Hesa::CodeSets::Countries::UK_COUNTRIES.include?(country)
+      country.nil? || Hesa::CodeSets::Countries::UK_COUNTRIES.include?(country)
     end
 
     def degree_type_hesa_code(hesa_degree)
@@ -111,7 +111,7 @@ module Degrees
       hesa_code = institution_hesa_code(hesa_degree)
       institution = DfeReference.find_institution(hesa_code: hesa_code)
 
-      institution || (hesa_code && DfeReference.find_institution(name: "Other UK institution"))
+      institution || DfeReference.find_institution(name: "Other UK institution")
     end
   end
 end

--- a/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
+++ b/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
@@ -4,8 +4,8 @@ class AddOtherToNoCountryNoInstitutionDegrees < ActiveRecord::Migration[6.1]
   def up
     degrees.update_all(
       locale_code: :uk,
-      institution: institution,
-      institution_uuid: institution_uuid,
+      institution: institution.name,
+      institution_uuid: institution.id,
     )
   end
 
@@ -16,11 +16,7 @@ class AddOtherToNoCountryNoInstitutionDegrees < ActiveRecord::Migration[6.1]
 private
 
   def institution
-    ::Dttp::CodeSets::Institutions::OTHER_UK
-  end
-
-  def institution_uuid
-    ::Dttp::CodeSets::Institutions::MAPPING[institution][:entity_id]
+    DfeReference.find_institution(name: "Other UK institution")
   end
 
   def degrees

--- a/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
+++ b/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
@@ -5,7 +5,7 @@ class AddOtherToNoCountryNoInstitutionDegrees < ActiveRecord::Migration[6.1]
     degrees.update_all(
       locale_code: :uk,
       institution: institution,
-      institution_uuid: institution_uuid
+      institution_uuid: institution_uuid,
     )
   end
 
@@ -13,7 +13,7 @@ class AddOtherToNoCountryNoInstitutionDegrees < ActiveRecord::Migration[6.1]
     raise ActiveRecord::IrreversibleMigration
   end
 
-  private
+private
 
   def institution
     ::Dttp::CodeSets::Institutions::OTHER_UK
@@ -31,7 +31,7 @@ class AddOtherToNoCountryNoInstitutionDegrees < ActiveRecord::Migration[6.1]
         locale_code: "non_uk",
         country: nil,
         institution: nil,
-        created_at: Date.new(2022, 10, 01)..Date.today
+        created_at: Date.new(2022, 10, 0o1)..Date.zone.today,
       )
   end
 end

--- a/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
+++ b/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class AddOtherToNoCountryNoInstitutionDegrees < ActiveRecord::Migration[6.1]
+  def up
+    degrees.update_all(
+      locale_code: :uk,
+      institution: institution,
+      institution_uuid: institution_uuid
+    )
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def institution
+    ::Dttp::CodeSets::Institutions::OTHER_UK
+  end
+
+  def institution_uuid
+    ::Dttp::CodeSets::Institutions::MAPPING[institution][:entity_id]
+  end
+
+  def degrees
+    @degrees ||= Degree
+      .includes(:trainee)
+      .where.not(trainee: { hesa_id: nil })
+      .where(
+        locale_code: "non_uk",
+        country: nil,
+        institution: nil,
+        created_at: Date.new(2022, 10, 01)..Date.today
+      )
+  end
+end

--- a/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
+++ b/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
@@ -31,7 +31,7 @@ private
         locale_code: "non_uk",
         country: nil,
         institution: nil,
-        created_at: Date.new(2022, 10, 0o1)..Date.zone.today,
+        created_at: Date.new(2022, 10, 01)..Time.zone.today.end_of_day,
       )
   end
 end

--- a/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
+++ b/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
@@ -27,7 +27,7 @@ private
         locale_code: "non_uk",
         country: nil,
         institution: nil,
-        created_at: Date.new(2022, 10, 01)..Time.zone.today.end_of_day,
+        created_at: Date.new(2022, 10, 1)..Time.zone.today.end_of_day,
       )
   end
 end

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -43,17 +43,45 @@ module Degrees
           ]
         end
 
-        it "creates a UK degree with nil institution and institution_uuid" do
+        it "creates a UK degree with other institution and institution_uuid" do
           expect(degree.locale_code).to eq("uk")
           expect(degree.uk_degree).to eq("First Degree")
           expect(degree.non_uk_degree).to be_nil
           expect(degree.subject).to eq("Law")
-          expect(degree.institution).to be_nil
+          expect(degree.institution).to eq("Other UK institution")
           expect(degree.graduation_year).to eq(2003)
           expect(degree.grade).to eq("Upper second-class honours (2:1)")
           expect(degree.other_grade).to be_nil
           expect(degree.country).to be_nil
-          expect(degree.institution_uuid).to be_nil
+          expect(degree.institution_uuid).to eq("02132969-f5bc-47ca-be9c-b6f6d5b05e1b")
+        end
+      end
+
+      context "No country and no institution" do
+        let(:hesa_degrees) do
+          [
+            {
+              graduation_date: "2003-06-01",
+              degree_type: "400",
+              subject: "100485",
+              institution: nil,
+              grade: "02",
+              country: nil,
+            },
+          ]
+        end
+
+        it "creates a UK degree with other institution and institution_uuid" do
+          expect(degree.locale_code).to eq("uk")
+          expect(degree.uk_degree).to eq("First Degree")
+          expect(degree.non_uk_degree).to be_nil
+          expect(degree.subject).to eq("Law")
+          expect(degree.institution).to eq("Other UK institution")
+          expect(degree.graduation_year).to eq(2003)
+          expect(degree.grade).to eq("Upper second-class honours (2:1)")
+          expect(degree.other_grade).to be_nil
+          expect(degree.country).to be_nil
+          expect(degree.institution_uuid).to eq("02132969-f5bc-47ca-be9c-b6f6d5b05e1b")
         end
       end
 


### PR DESCRIPTION
### Context

These are degrees that are coming from HESA with no country and no institution resulting in failed TRN requests.

### Changes proposed in this pull request

* Map a HESA degree with no country to UK
* Map a HESA degree with no institution to `Other UK institution`
* Backfill HESA degrees with nil country and nil institution to the above.

### Guidance to review

* Check changes in `app/services/degrees/create_from_hesa.rb`
* Check degree filter in `db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb` is sensible

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
