### PR TITLE
Put paragraphs in 2/3 grid column

### DIFF
--- a/app/views/guidance/_database_only.html.erb
+++ b/app/views/guidance/_database_only.html.erb
@@ -1,10 +1,14 @@
-<p class="govuk-body">
-  These HESA fields are used for analysis and map to Register’s database, so you will not see them in the Register service or the CSV export.
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <p class="govuk-body">
+      These HESA fields are used for analysis and map to Register’s database, so you will not see them in the Register service or the CSV export.
+    </p>
 
-<p class="govuk-body">
-  For school placements (HESA field PLMNTSCH), although we collect and use this data, you cannot view it in the service or the CSV yet.
-</p>
+    <p class="govuk-body">
+      For school placements (HESA field PLMNTSCH), although we collect and use this data, you cannot view it in the service or the CSV yet.
+    </p>
+  </div>
+</div>
 
 <table class="govuk-table">
   <caption class="govuk-table__caption govuk-visually-hidden">Database only</caption>

--- a/app/views/guidance/_schools.html.erb
+++ b/app/views/guidance/_schools.html.erb
@@ -1,6 +1,10 @@
-<p class="govuk-body">
-  Register will check the URN (unique reference number) of each school to make sure it’s valid. If it’s not, this data will not import into Register.
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <p class="govuk-body">
+      Register will check the URN (unique reference number) of each school to make sure it’s valid. If it’s not, this data will not import into Register.
+    </p>
+  </div>
+</div>
 
 <table class="govuk-table">
   <caption class="govuk-table__caption govuk-visually-hidden">Schools</caption>


### PR DESCRIPTION
### Context
All lines of content should be in 2/3 columns. These were overlooked when this was delivered.

Before:
<img width="1060" alt="Screenshot 2022-10-26 at 10 35 33" src="https://user-images.githubusercontent.com/2204224/197991773-a313034d-18c2-44de-a8be-bf1773f9d257.png">

After:
<img width="1011" alt="Screenshot 2022-10-26 at 11 13 58" src="https://user-images.githubusercontent.com/2204224/198000634-234f9424-3503-4339-b41a-7e6138ff68ab.png">

