### PR TITLE
[4897] Increase production app instances to 4

### DIFF
--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -14,7 +14,7 @@
   "paas_space_name": "bat-prod",
   "paas_web_app_hostname": ["www"],
   "paas_dttp_portal": ["traineeteacherportal"],
-  "paas_web_app_instances": 2,
+  "paas_web_app_instances": 4,
   "paas_web_app_memory": 1536,
   "paas_worker_app_instances": 2,
   "paas_worker_app_memory": 1024,


### PR DESCRIPTION
### Context
https://trello.com/c/TE5yaN2z/4897-investigate-register-performance-under-high-load

Production has been going down due to excessive load on expensive pages such as `/trainees`. After load testing the site, it was determined that 2 app instances is not enough especially during busy periods such as Oct-Nov. 4 app instances proved to be much more performant and was able to handle heavy load. Autoscaling is probably the long term approach, but for now, adding more resources gives the users a better experience and reduces downtime.

### Changes proposed in this pull request
- Update Terraform config to increase production app instances from 2 to 4

### Important business
- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
