### PR TITLE
[xxx] Fix HESA importer with regards to disabilities

### DIFF
--- a/app/services/concerns/has_diversity_attributes.rb
+++ b/app/services/concerns/has_diversity_attributes.rb
@@ -37,7 +37,7 @@ module HasDiversityAttributes
 
     {
       disability_disclosure: Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled],
-      disabilities: disabilities.map { |disability| Disability.find_by(name: disability) },
+      disabilities: disabilities.map { |disability| Disability.find_by(name: disability) }.compact,
     }
   end
 


### PR DESCRIPTION
### Context
This is the first year that HESA has supported multiple disabilities. They might not have thought to add validation that some of the options are mutually exclusive. For example, one trainee had "Mental health condition" and "No known disability" which shouldn't be possible. "No known disability" is not in the database of disabilities therefore Disability.find_by(name: disability) return nil and that led to a ActiveRecord error AssociationTypeMismatch during the save operation. Using `compact` will ensure nil values are removed, but hopefully HESA will implement validation in the future.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
