### PR TITLE
Stop using set-output in check_sp workflow

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -34,16 +34,16 @@ runs:
         if [ -n "${{ inputs.pr-number }}" ]; then
           APP_NAME=pr-${{ inputs.pr-number }}
           echo "APP_NAME=${APP_NAME}" >> $GITHUB_ENV
-          echo "::set-output name=deploy_url::https://register-${APP_NAME}.london.cloudapps.digital"
+          echo "deploy_url=https://register-${APP_NAME}.london.cloudapps.digital" >> $GITHUB_OUTPUT
           echo "DEPLOY_REF=${{ github.head_ref }}" >> $GITHUB_ENV
         else
           echo "DEPLOY_REF=${{ github.ref }}" >> $GITHUB_ENV
 
           hostname=$(jq -r '.paas_web_app_hostname | first' ${tf_vars_file})
           if [[ $hostname != null ]]; then
-            echo "::set-output name=deploy_url::https://${hostname}.register-trainee-teachers.service.gov.uk"
+            echo "deploy_url=https://${hostname}.register-trainee-teachers.service.gov.uk" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=deploy_url::https://register-${{ inputs.environment }}.london.cloudapps.digital"
+            echo "deploy_url=https://register-${{ inputs.environment }}.london.cloudapps.digital" >> $GITHUB_OUTPUT
           fi
         fi
 


### PR DESCRIPTION
### Context
The set-output command is being deprecated soon.

### Changes proposed in this pull request
Resolution is to use $GITHUB_OUTPUT as per the workflow commands docs.

### Guidance to review
Confirm impacted workflows work as expected:

- [x] Deploy

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
