### PR TITLE
[4947] - redirect with warning if trainee limit is exceeded

### DIFF
--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -29,6 +29,13 @@ class BaseTraineeController < ApplicationController
       format.html
       format.js { render(json: json_response) }
       format.csv do
+        if filtered_trainees.count > Settings.trainee_export.record_limit
+          return redirect_to(
+            search_path(filter_params),
+            flash: { warning: "Exports cannot be run when there are more than #{Settings.trainee_export.record_limit} trainees" },
+          )
+        end
+
         authorize(:trainee, :export?)
         track_activity
         send_data(data_export.data, filename: data_export.filename, disposition: :attachment)

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -15,3 +15,6 @@ features:
 
 environment:
   name: beta
+
+trainee_export:
+  record_limit: 100

--- a/spec/controllers/trainees_controller_spec.rb
+++ b/spec/controllers/trainees_controller_spec.rb
@@ -72,6 +72,20 @@ describe TraineesController do
           expect(response).to have_http_status(:forbidden)
         end
       end
+
+      context "with an export request of over the limit" do
+        before do
+          allow(Settings.trainee_export).to receive(:record_limit).and_return(0)
+          create(:trainee, :submitted_for_trn, provider: user.organisation)
+          get(:index, format: "csv")
+        end
+
+        it "redirects" do
+          enable_features(:user_can_have_multiple_organisations)
+          get(:index, format: "csv")
+          expect(response).to have_http_status(:found) # 302 redirect
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context

We decided to prevent admins from exporting more than 100 trainees. We did this to prevent big SQL queries for large numbers of trainees being run by accident. We did the cosmetic part of that in [this ticket](https://trello.com/c/4W7x9nWU/4858-add-limit-to-number-of-trainees-that-can-be-exported-in-system-admin) where we display the export link based on a conditional. 

We did not restrict this at the permissions level. That means technically an admin could still run the export URL and retrieve lots of trainees. This ticket is to fix this at the permissions level.

### Changes proposed in this pull request

redirect back to search if trainee export limit is exceeded

### Guidance to review

change `Settings.trainee_export.record_limit` to 0 and check the export action redirects with the warning.

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
