### PR TITLE
[4733] Hide funding row if troops to teachers initiative trainee

### DIFF
--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -45,7 +45,7 @@ module Funding
     end
 
     def funding_method_row
-      return if no_funding_methods? && data_model.bursary_tier.blank?
+      return if (no_funding_methods? && data_model.bursary_tier.blank?) || data_model.training_initiative == "troops_to_teachers"
 
       if can_apply_for_grant?
         grant_funding_row


### PR DESCRIPTION
### Context

Troops to teachers bursary currently doesnt show the correct funding value in the register UI. This will need to be changed eventually - probably with a refactor of the funding work. In order not to confuse users we should hide the funding value for trainees on the troops to teachers initiative. 

### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
