### PR TITLE
[xxx] Don't override trainee state if HESA importer computes it as nil

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -46,7 +46,8 @@ module Trainees
         state: trainee_state,
         hesa_updated_at: hesa_trainee[:hesa_updated_at],
         record_source: trainee_record_source,
-      }.merge(created_from_hesa_attribute)
+      }.compact # trainee_state can be nil, therefore we don't want to override the current state
+       .merge(created_from_hesa_attribute)
        .merge(personal_details_attributes)
        .merge(provider_attributes)
        .merge(ethnicity_and_disability_attributes)


### PR DESCRIPTION
### Context
If Trainees::MapStateFromHesa returns nil, it means we don't know enough to transition it to withdrawn, so it should stay as deferred or TRN received

### Changes proposed in this pull request
- Add a `compact` statement to remove `nil` values

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
