### PR TITLE
[xxx] Fix DQT update migration

### DIFF
--- a/db/data/20221108114154_update_dqt.rb
+++ b/db/data/20221108114154_update_dqt.rb
@@ -16,9 +16,9 @@ class UpdateDqt < ActiveRecord::Migration[6.1]
     trainees = AcademicCycle.current.trainees_starting.where.not(hesa_id: nil).where.not(trn: nil)
 
     trainees.find_in_batches(batch_size: 100).with_index do |group, batch|
-      next if trns_to_ignore.include?(trainee.trn) || !trainee_changed?(trainee)
-
       group.each do |trainee|
+        next if trns_to_ignore.include?(trainee.trn) || !trainee_changed?(trainee)
+
         Dqt::UpdateTraineeJob.set(wait: 30.seconds * batch).perform_later(trainee)
       end
     end


### PR DESCRIPTION
### Context
https://trello.com/c/wFWg0GfD/4912-investigate-if-we-are-sending-updates-for-hesa-records-to-dqt

### Changes proposed in this pull request
- Move `next` statement into its correct position so it can access `trainee`. The batch approach was added towards the end due to the 300/minute DQT API rate limit, so the position of `next` was overlooked during refactoring.
- Also forget to recalculate the academic cycle dates as part of https://trello.com/c/tQj4nowc/4893-2022-23-itt-record-export-showing-different-value-compared-to-on-screen.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
