### PR TITLE
[4907] Add HESA Cyprus codes

### DIFF
--- a/app/controllers/trainees/personal_details_controller.rb
+++ b/app/controllers/trainees/personal_details_controller.rb
@@ -13,11 +13,6 @@ module Trainees
       "date_of_birth(1i)" => "year",
     }.freeze
 
-    NATIONALITIES = [
-      Dttp::CodeSets::Nationalities::BRITISH,
-      Dttp::CodeSets::Nationalities::IRISH,
-    ].freeze
-
     def show
       page_tracker.save_as_origin!
       clear_form_stash(trainee)
@@ -49,8 +44,8 @@ module Trainees
     end
 
     def load_all_nationalities
-      @nationalities = Nationality.where(name: NATIONALITIES)
-      @other_nationalities = Nationality.all
+      @nationalities = Nationality.default
+      @other_nationalities = Nationality.other
     end
 
     def personal_details_params

--- a/app/lib/apply_api/code_sets/nationalities.rb
+++ b/app/lib/apply_api/code_sets/nationalities.rb
@@ -65,6 +65,8 @@ module ApplyApi
         "croatian" => "HR",
         "cuban" => "CU",
         "cypriot" => "CY",
+        "cypriot (european union)" => "XA",
+        "cypriot (non european union)" => "XB",
         "cymraes" => "GB",
         "cymro" => "GB",
         "czech" => "CZ",

--- a/app/lib/dttp/code_sets/nationalities.rb
+++ b/app/lib/dttp/code_sets/nationalities.rb
@@ -16,6 +16,8 @@ module Dttp
       BRITISH_INDIAN_OCEAN_TERRITORY = "British Indian Ocean Territory (BIOT)"
       FALKLAND_ISLANDS = "Falkland Islands [Falkland Islands (Malvinas)]"
 
+      CYPRIOT = "cypriot"
+
       NOT_KNOWN = "Not known"
 
       AMERICAN = "american"
@@ -102,7 +104,11 @@ module Dttp
         "cuban" => { entity_id: "a37d640e-5c62-e711-80d1-005056ac45bb" },
         CYMRAES => { entity_id: "d17d640e-5c62-e711-80d1-005056ac45bb" },
         CYMRO => { entity_id: "d17d640e-5c62-e711-80d1-005056ac45bb" },
-        "cypriot" => { entity_id: "ff7e640e-5c62-e711-80d1-005056ac45bb" },
+        CYPRIOT => { entity_id: "ff7e640e-5c62-e711-80d1-005056ac45bb" },
+        # entity_id is no longer relevant as we no longer need to map to DTTP.
+        # Left blank because we do not have an entity_id for cypriot non EU.
+        "cypriot (non european union)" => { entity_id: "" },
+        "cypriot (european union)" => { entity_id: "017f640e-5c62-e711-80d1-005056ac45bb" },
         "czech" => { entity_id: "a77d640e-5c62-e711-80d1-005056ac45bb" },
         "danish" => { entity_id: "ad7d640e-5c62-e711-80d1-005056ac45bb" },
         "djiboutian" => { entity_id: "ab7d640e-5c62-e711-80d1-005056ac45bb" },
@@ -274,7 +280,6 @@ module Dttp
         BRITISH_INDIAN_OCEAN_TERRITORY => { entity_id: "057e640e-5c62-e711-80d1-005056ac45bb" },
         "Channel Islands not otherwise specified" => { entity_id: "057f640e-5c62-e711-80d1-005056ac45bb" },
         "Czechoslovakia not otherwise specified" => { entity_id: "077f640e-5c62-e711-80d1-005056ac45bb" },
-        "Cyprus (Non-European Union)" => { entity_id: "017f640e-5c62-e711-80d1-005056ac45bb" },
         "Cyprus not otherwise specified" => { entity_id: "037f640e-5c62-e711-80d1-005056ac45bb" },
         ENGLAND => { entity_id: "40ad2d33-4787-e711-80e8-3863bb349ac0" },
         GUERNSEY => { entity_id: "d77d640e-5c62-e711-80d1-005056ac45bb" },

--- a/app/models/nationality.rb
+++ b/app/models/nationality.rb
@@ -3,4 +3,16 @@
 class Nationality < ApplicationRecord
   has_many :nationalisations, inverse_of: :nationality
   has_many :trainees, through: :nationalisations
+
+  NATIONALITIES = [
+    Dttp::CodeSets::Nationalities::BRITISH,
+    Dttp::CodeSets::Nationalities::IRISH,
+  ].freeze
+
+  EXCLUDED_NATIONALITIES = [
+    Dttp::CodeSets::Nationalities::CYPRIOT,
+  ].freeze
+
+  scope :default, -> { where(name: NATIONALITIES) }
+  scope :other, -> { where.not(name: EXCLUDED_NATIONALITIES) }
 end

--- a/db/data/20221125114348_add_cypriot_nationalities.rb
+++ b/db/data/20221125114348_add_cypriot_nationalities.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddCypriotNationalities < ActiveRecord::Migration[6.1]
+  CYPRIOT_NATIONALITIES = [
+    { name: "cypriot (european union)" },
+    { name: "cypriot (non european union)" },
+  ].freeze
+
+  def up
+    CYPRIOT_NATIONALITIES.each do |n|
+      Nationality.find_or_create_by!(name: n[:name])
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/models/nationality_spec.rb
+++ b/spec/models/nationality_spec.rb
@@ -9,4 +9,34 @@ describe Nationality do
     it { is_expected.to have_many(:nationalisations).inverse_of(:nationality) }
     it { is_expected.to have_many(:trainees).through(:nationalisations) }
   end
+
+  describe "scopes" do
+    describe "default" do
+      let(:british) { create(:nationality, name: "british") }
+      let(:irish) { create(:nationality, name: "irish") }
+      let(:afghan) { create(:nationality, name: "afghan") }
+
+      it "returns British and Irish nationalities" do
+        expect(Nationality.default).to contain_exactly(british, irish)
+      end
+
+      it "does not return non default nationalities" do
+        expect(Nationality.default).not_to include(afghan)
+      end
+    end
+
+    describe "other" do
+      let(:cypriot) { create(:nationality, name: "cypriot") }
+      let(:eu_cypriot) { create(:nationality, name: "cypriot (european union)") }
+      let(:non_eu_cypriot) { create(:nationality, name: "cypriot (non european union)") }
+
+      it "does not return generic Cypriot option" do
+        expect(Nationality.other).not_to include(cypriot)
+      end
+
+      it "returns other nationalities" do
+        expect(Nationality.other).to contain_exactly(eu_cypriot, non_eu_cypriot)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/edXQJ5f4/4907-itt-register-portal-data-check-for-c22053

Cypriot nationality did not map for some HESA trainees because we did not hold the HESA codes XA and XB in Register. Apply also does not currently hold them in their nationalities mapping, but does in their countries and territories: https://github.com/DFE-Digital/apply-for-teacher-training/pull/6584

I spoke with Duncan and we agreed that Register should accept the valid HESA nationality codes for Cyprus, and allow them to be added to our seeded nationalities. They will also display in our nationality autocomplete. We should hide the existing generic 'cypriot' option from the autocomplete so that providers must choose between EU or non-EU.

We do not need to alter any existing Cypriot trainee nationalisations as we have no real way of knowing who is EU or non-EU.

**One issue with this new implementation - because I have removed 'cypriot' from the loaded nationalities and therefore the autocomplete, if an existing trainee with 'Cypriot' as nationality has their personal details edited, the user will be told that the nationality is invalid, and they'll need to pick between EU and non-EU variants in order to save the form.**

I'm going to have a look at the HESA data and see if I can see them sending us any invalid codes (CY or XC) so we can contact HESA about that. Will do this in a separate ticket.

### Changes proposed in this pull request

* Add new cyprus options to `ApplyApi::CodeSets::Nationalities::MAPPING`
* Add data migration to add the two new Cypriot nationalities
* Add cyprus options to `DTTP::CodeSets::Nationalities:MAPPING` for the seeds
* Move some logic from controller to model and create `default` and `other` scope
* Use new scopes to exclude 'cyprus' so it does not display in autocomplete

### Guidance to review

* Check we are happy with the consequences for existing cypriot trainees

Prod review:
* Edit a draft and registered trainees' nationality to be cypriot EU and cypriot non-EU - observe it selects and saves correctly
* Observe the generic 'cypriot' option does not appear in the autocomplete

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
