### PR TITLE
[4983] New rake task to update `hesa_students` table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,8 @@ gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/df
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.5.3"
 
+gem "ruby-progressbar" # useful for tracking long running rake tasks
+
 group :qa, :review, :staging, :production do
   # Pull list of CloudFront proxies so request.remote_ip returns the correct IP.
   gem "cloudfront-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -709,6 +709,7 @@ DEPENDENCIES
   rspec-retry!
   rubocop-rails
   rubocop-rspec
+  ruby-progressbar
   scss_lint-govuk
   sentry-rails
   sentry-ruby

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -193,7 +193,6 @@
   - course_age_range
   - trainee_start_date
   - training_initiative
-  - disability
   - end_date
   - reason_for_leaving
   - bursary_level
@@ -215,6 +214,17 @@
   - created_at
   - updated_at
   - collection_reference
+  - commencement_date
+  - itt_commencement_date
+  - disability1
+  - disability2
+  - disability3
+  - disability4
+  - disability5
+  - disability6
+  - disability7
+  - disability8
+  - disability9
   :hesa_trn_requests:
   - id
   - collection_reference

--- a/db/migrate/20221114121151_add_more_columns_to_hesa_students.rb
+++ b/db/migrate/20221114121151_add_more_columns_to_hesa_students.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddMoreColumnsToHesaStudents < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :hesa_students, :disability, :disability1
+    change_table :hesa_students, bulk: true do |t|
+      t.column :commencement_date, :string, null: true
+      t.column :itt_commencement_date, :string, null: true
+      t.column :disability2, :string, null: true
+      t.column :disability3, :string, null: true
+      t.column :disability4, :string, null: true
+      t.column :disability5, :string, null: true
+      t.column :disability6, :string, null: true
+      t.column :disability7, :string, null: true
+      t.column :disability8, :string, null: true
+      t.column :disability9, :string, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_09_100055) do
+ActiveRecord::Schema.define(version: 2022_11_14_121151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
@@ -464,7 +464,7 @@ ActiveRecord::Schema.define(version: 2022_11_09_100055) do
     t.string "course_age_range"
     t.string "trainee_start_date"
     t.string "training_initiative"
-    t.string "disability"
+    t.string "disability1"
     t.string "end_date"
     t.string "reason_for_leaving"
     t.string "bursary_level"
@@ -486,6 +486,16 @@ ActiveRecord::Schema.define(version: 2022_11_09_100055) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "collection_reference"
+    t.string "commencement_date"
+    t.string "itt_commencement_date"
+    t.string "disability2"
+    t.string "disability3"
+    t.string "disability4"
+    t.string "disability5"
+    t.string "disability6"
+    t.string "disability7"
+    t.string "disability8"
+    t.string "disability9"
   end
 
   create_table "hesa_trn_requests", force: :cascade do |t|

--- a/lib/tasks/update_hesa_students_table.rake
+++ b/lib/tasks/update_hesa_students_table.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :hesa do
+  desc "Update hesa_students table with the latest collection data from HESA"
+  task update_students_table: :environment do
+    from_date = Settings.hesa.current_collection_start_date
+    collection_reference = Settings.hesa.current_collection_reference
+    url = "#{Settings.hesa.collection_base_url}/#{collection_reference}/#{from_date}"
+    xml_response = Hesa::Client.get(url: url)
+
+    total_nodes = Nokogiri::XML(xml_response).root.children.size
+    puts "Total student nodes: #{total_nodes}"
+    bar = ProgressBar.create(total: total_nodes)
+
+    Nokogiri::XML::Reader(xml_response).each do |node|
+      next unless node.name == "Student" && node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+
+      student_node = Nokogiri::XML(node.outer_xml).at("./Student")
+      hesa_trainee = Hesa::Parsers::IttRecord.to_attributes(student_node: student_node)
+      hesa_student = Hesa::Student.find_or_initialize_by(hesa_id: hesa_trainee[:hesa_id])
+      hesa_student.assign_attributes(hesa_trainee)
+      hesa_student.collection_reference = collection_reference
+      hesa_student.save
+
+      bar.increment
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/45l1fWTK/4983-refresh-the-hesastudents-table-with-the-records-for-c22053-collection

There is work been done to remove the duplicate HESA trainees from Register after providers mistakely submitted trainees with the wrong HESA ID. Populating the `hesa_students` table with the latest HESA collection will help facilate this goal.

### Changes proposed in this pull request
- New rake task `hesa:update_students_table`
- Migration file to add more fields to the `hesa_students` table after recent updates to `Hesa::Parsers::IttRecord::TAG_MAP`

### Guidance to review
- Run `rake hesa:update_students_table`
- XML should be fetched and processed (takes awhile, but there is a progress bar)

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
