### PR TITLE
[4994] Change schooldirecttuitionfee mapping in dqt api

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -26,7 +26,7 @@ module Dqt
         TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => "ProviderLedPostgrad",
         TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => "ProviderLedUndergrad",
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => "SchoolDirectTrainingProgrammeSalaried",
-        TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => "SchoolDirectTrainingProgrammeSelfFunded",
+        TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => "SchoolDirectTrainingProgramme",
       }.freeze
 
       DEGREE_CLASSES = {

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -245,6 +245,24 @@ module Dqt
             end
           end
         end
+
+        context "when training route is school direct tuition fees" do
+          let(:trainee) do
+            create(:trainee,
+                   :completed,
+                   training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+                   sex: "female",
+                   hesa_metadatum: hesa_metadatum,
+                   degrees: [degree],
+                   **trainee_attributes)
+          end
+
+          subject { described_class.new(trainee: trainee).params }
+
+          it "maps the training route to SchoolDirectTrainingProgramme" do
+            expect(subject["initialTeacherTraining"]["programmeType"]).to eq("SchoolDirectTrainingProgramme")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

@robertcollier13 reported to us that we currently map school_direct_tuition_fee to school direct training programme (self funded) in the Register to DQT API

This is incorrect - self-funded is a niche course that isn't used anymore.

We should change the mapping for these routes from SchoolDirectTrainingProgrammeSelfFunded to  SchoolDirectTrainingProgrammeSalaried.