### PR TITLE
[xxx] Fix: rake task to update hesa_students table getting killed for memory usage

### DIFF
--- a/lib/tasks/update_hesa_students_table.rake
+++ b/lib/tasks/update_hesa_students_table.rake
@@ -8,7 +8,7 @@ namespace :hesa do
     url = "#{Settings.hesa.collection_base_url}/#{collection_reference}/#{from_date}"
     xml_response = Hesa::Client.get(url: url)
 
-    total_nodes = Nokogiri::XML(xml_response).root.children.size
+    total_nodes = xml_response.scan(/<Student>.*?<\/Student>/m).size # Uses less memory - prevents task getting killed
     puts "Total student nodes: #{total_nodes}"
     bar = ProgressBar.create(total: total_nodes)
 


### PR DESCRIPTION
### Context
`Nokogiri::XML(xml_response).root.children.size` was causing the rake task to get killed for using too much memory probably because Nokogiri was loading all XML nodes into memory before counting.

### Changes proposed in this pull request
- Use `String#scan` instead of `Nokogiri::XML`

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
