### PR TITLE
[4927] Backfill correct withdrawn attributes for incorrectly deferred trainees

### DIFF
--- a/app/services/hesa/backfill_trainee_states.rb
+++ b/app/services/hesa/backfill_trainee_states.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Hesa
+  class BackfillTraineeStates
+    include ServicePattern
+
+    def initialize(trainee:)
+      @trainee = trainee
+      @hesa_student = trainee.hesa_student
+    end
+
+    def call
+      if hesa_student && withdrawn?
+        trainee.update_columns(state: "withdrawn", withdraw_reason: reason_for_leaving, withdraw_date: hesa_student.end_date)
+      end
+    end
+
+  private
+
+    attr_reader :hesa_student, :trainee
+
+    def withdrawn?
+      [
+        WithdrawalReasons::TRANSFERRED_TO_ANOTHER_PROVIDER,
+        WithdrawalReasons::DEATH,
+        WithdrawalReasons::FOR_ANOTHER_REASON,
+      ].include?(reason_for_leaving) && hesa_student.end_date.present?
+    end
+
+    def reason_for_leaving
+      Hesa::CodeSets::ReasonsForLeavingCourse::MAPPING[hesa_student.reason_for_leaving]
+    end
+  end
+end

--- a/lib/tasks/fix_incorrect_hesa_trainee_states.rake
+++ b/lib/tasks/fix_incorrect_hesa_trainee_states.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :hesa do
+  task :fix_deferred_states do
+    Trainee.includes(:hesa_student).deferred.where(record_source: %w[hesa_collection hesa_trn_data]).find_each do |trainee|
+      Hesa::BackfillTraineeStates.call(trainee: trainee)
+    end
+  end
+end

--- a/spec/services/hesa/backfill_trainee_states_spec.rb
+++ b/spec/services/hesa/backfill_trainee_states_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Hesa
+  describe BackfillTraineeStates do
+    let(:trainee) { create(:trainee, :trn_received, :imported_from_hesa) }
+    let(:end_date) { Time.zone.today }
+    let(:reason_for_leaving_code) { %w[11 05 03].sample }
+    let(:reason_for_leaving) { Hesa::CodeSets::ReasonsForLeavingCourse::MAPPING[reason_for_leaving_code] }
+
+    subject { described_class.call(trainee: trainee) }
+
+    context "when HESA student is withdrawn" do
+      before do
+        trainee.hesa_student.update_columns(reason_for_leaving: reason_for_leaving_code, end_date: end_date)
+        subject
+      end
+
+      it "updates trainee state" do
+        expect(trainee.state).to eq("withdrawn")
+      end
+
+      it "updates withdraw_reason" do
+        expect(trainee.withdraw_reason).to eq(reason_for_leaving)
+      end
+
+      it "updates withdraw_data" do
+        expect(trainee.withdraw_date).to eq(end_date)
+      end
+    end
+
+    context "when HESA student is not withdrawn" do
+      before do
+        subject
+      end
+
+      it "does not change the state" do
+        expect(trainee.state).to eq("trn_received")
+      end
+
+      it "does not change withdraw_reason" do
+        expect(trainee.withdraw_reason).to be_nil
+      end
+
+      it "does not change withdraw_data" do
+        expect(trainee.withdraw_date).to be_nil
+      end
+    end
+
+    context "when there is no hesa_student for the trainee" do
+      let(:trainee) { create(:trainee, :trn_received) }
+
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "does not change the trainee" do
+        expect { subject }.not_to change { trainee.state }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/JBDzn2SU/4927-records-not-transitioning-from-deferred-to-withdrawn

Some HESA trainees that we classified as deferred should actually have been classed as withdrawn. This happened because if a trainee has transitioned from deferred -> withdrawn in HESA, they still send us the dormant code for MODE. Our check wasn't robust enough to recognise that these trainees were actually withdrawn (they had dormant code in addition to withdrawal information). We fixed the root issue but making the check stricter.

This is a rake task to backfill the correct withdrawal attributes on those incorrectly deferred trainees. We have no way of knowing which deferred HESA trainees have been affected, so the rake will run against all deferred HESA trainees (approx 3090).

### Changes proposed in this pull request

* Add lib/tasks/fix_incorrect_hesa_trainee_states.rake
* Add app/services/hesa/backfill_trainee_states.rb 

### Guidance to review

* Run the rake
* Check my logic for changing the deferred trainee state. I am assuming what is in hesa_students is the correct data. 
* I ran this locally with a prod DB copy. It updated approx 89 records. I checked the ones which we knew to be incorrect - they had all updated successfully.

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
