### PR TITLE
Add placement details to manual entry guidance

### DIFF
--- a/app/views/guidance/check_data.md
+++ b/app/views/guidance/check_data.md
@@ -118,8 +118,8 @@ Whether the trainee is on a training initiative
 
 <div class="govuk-inset-text">
 
-<p>You should keep a record of the location of the trainee’s placements.</p>
+  <p class="govuk-body">You should keep a record of the location of the trainee’s placements.</p>
 
-<p>You cannot currently provide this data but you’ll be asked to provide it later in the 2022 to 2023 academic year.</p>
+  <p class="govuk-body">You cannot currently provide this data but you’ll be asked to provide it later in the 2022 to 2023 academic year.</p>
   
 </div>


### PR DESCRIPTION
### Context

We want providers to know that they will be asked about placements later in the academic year, so they should keep a record even though they can't add the data now. 

### Changes proposed in this pull request

I've added a section to the page of guidance about data needed to manually register a trainee.

I've used inset text to match the diversity data section. This is information about the data requirement, rather than a list of data items as in most sections.

![CleanShot 2022-11-17 at 16 18 40](https://user-images.githubusercontent.com/29047487/202500026-70210000-9957-4b62-a5da-b6cb77ad22dd.png)
