### PR TITLE
[4974] Data migration to remove duplicate HESA trainees

### DIFF
--- a/db/data/20221117160629_remove_duplicate_hesa_trainees.rb
+++ b/db/data/20221117160629_remove_duplicate_hesa_trainees.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class RemoveDuplicateHesaTrainees < ActiveRecord::Migration[6.1]
+  def up
+    sql = %(
+      SELECT
+          t1.hesa_id AS t1_hesa_id,
+          t2.hesa_id AS t2_hesa_id
+      FROM
+          trainees t1 INNER JOIN trainees t2 ON t1.email = t2.email
+      WHERE
+        t1.hesa_id != t2.hesa_id
+        AND t1.updated_at < t2.updated_at
+        AND t1.provider_id = t2.provider_id
+        AND t1.start_academic_cycle_id = t2.start_academic_cycle_id
+    )
+
+    ActiveRecord::Base.connection.execute(sql).each do |row|
+      original, duplicate = find_original_and_duplicate(row)
+
+      next if original.hesa_student && duplicate.hesa_student # edge case, needs to be fixed manually by HESA/provider
+
+      if original.trn.nil? && duplicate.trn.present?
+        Trainee.with_auditing do
+          original.assign_attributes(state: :trn_received, trn: duplicate.trn)
+          original.dqt_trn_request = duplicate.dqt_trn_request if original.dqt_trn_request.nil?
+          original.save
+        end
+        original.dqt_trn_request&.received! unless original.dqt_trn_request&.received?
+      end
+
+      duplicate.destroy
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def find_original_and_duplicate(row)
+    trainee_a = Trainee.find_by(hesa_id: row["t1_hesa_id"])
+    trainee_b = Trainee.find_by(hesa_id: row["t2_hesa_id"])
+
+    if trainee_a.hesa_student
+      [trainee_a, trainee_b]
+    else
+      [trainee_b, trainee_a]
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/E52FrdFl/4974-l-check-duplicate-hesa-trainees-to-be-deleted-and-then-delete-these-trainees-from-register

### Changes proposed in this pull request
- Data migration to remove duplicate trainees

### Guidance to review
- Takes about 2 minutes to run
- Removes 940 duplicate trainees
- Leaves behind 3 duplicates that have to be dealt with manually because they are each in the HESA collection XML except for their HESA ID (one using 13 digit format, the other the new 17 digit format). We need to go back to HESA to ask the provider to re-commit the data using either the 13 digit HUSID or the 17 digit HUSID, but not both.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
