### PR TITLE
[5008] HESA lead and employing schools not mapping codes

### DIFF
--- a/db/data/20221124151149_backfill_non_applicable_schools_for_trainees.rb
+++ b/db/data/20221124151149_backfill_non_applicable_schools_for_trainees.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BackfillNonApplicableSchoolsForTrainees < ActiveRecord::Migration[6.1]
+  def up
+    urns = Trainees::CreateFromHesa::NOT_APPLICABLE_SCHOOL_URNS
+
+    hesa_ids = Hesa::Student.where(lead_school_urn: urns).pluck(:hesa_id)
+    Trainee.where(hesa_id: hesa_ids).update_all(lead_school_not_applicable: true) if hesa_ids.any?
+
+    hesa_ids = Hesa::Student.where(employing_school_urn: urns).pluck(:hesa_id)
+    Trainee.where(hesa_id: hesa_ids).update_all(employing_school_not_applicable: true) if hesa_ids.any?
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -109,6 +109,26 @@ module Trainees
         expect(trainee.hesa_metadatum.year_of_course).to eq("0")
       end
 
+      context "leading and employing schools not applicable" do
+        let(:not_applicable_or_not_available_hesa_code) { "900010" }
+        let(:establishment_outside_england_and_wales_hesa_code) { "900000" }
+
+        let(:hesa_stub_attributes) do
+          {
+            lead_school_urn: not_applicable_or_not_available_hesa_code,
+            employing_school_urn: establishment_outside_england_and_wales_hesa_code,
+          }
+        end
+
+        it "marks the trainee's lead school as not applicable" do
+          expect(trainee.lead_school_not_applicable).to be(true)
+        end
+
+        it "marks the trainee's employing school as not applicable" do
+          expect(trainee.employing_school_not_applicable).to be(true)
+        end
+      end
+
       context "when there's an itt_commencement_date provided" do
         let(:hesa_stub_attributes) { { itt_commencement_date: "2022-09-10" } }
 


### PR DESCRIPTION
### Context
https://trello.com/c/kWc2qlIL/5008-hesa-lead-and-employing-schools-not-mapping-codes

### Changes proposed in this pull request
- Update `Trainees::CreateFromHesa` so it can handle the schools URN's 900000 and 900010 and map it as not applicable
- Data migration to fix existing trainees using their HESA student record

### Notes
After the data migration:

- 177 trainees will have `lead_school_not_applicable` set to `true`
- 5 trainees will have `employing_school_not_applicable` set to `true`

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
