### PR TITLE
[5022] Add EU Cypriot nationality for HESA trainees

### DIFF
--- a/db/data/20221125160837_backfill_cyprus_nationality_for_hesa_trainees.rb
+++ b/db/data/20221125160837_backfill_cyprus_nationality_for_hesa_trainees.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class BackfillCyprusNationalityForHesaTrainees < ActiveRecord::Migration[6.1]
+  def up
+    trainee_slugs = %w[HMpx9gnWFi6F9Ly1gDhE9s4M
+                       MUozuNAGH9JagVXDc2Ug6KmK
+                       yPJQwC9MV9SZBuLy6wCUtU4P
+                       Jjg7aL7hSbEEj3eHUzZHyhBw
+                       AUtftGGgGPxU5P8KBD3zVpMm
+                       swkip8c7sDn5KWbcgGcEraC1
+                       7rNc9FbPWPW4ZqGRk9f9xLq1
+                       4PbhFvi6hWDoyHDt5gjBZJ64
+                       LWAjcAn25UoEL5JrTUAUrZvZ
+                       1nmBBzzAhgQzuEGtwWvvRY4K
+                       aYs192hH2eo2gb9M1qfFr9Xu
+                       j5kxXR83MPdHcX2EqPF4KvKg
+                       nSij7nDthp1dohW9hjMs1H4T
+                       atkEWxJrjKC1W7ampwVa6Tkd
+                       ZTyNbFGd72SA4zxhRADdDX17
+                       QAQsLzF3PvuQH85Rpx1TCHSx
+                       LmSv3kSRd3NKTTLyF1V7bwrs
+                       dqxeHjMXfByxPJuStmvXjgi3
+                       M58XSGXHspYYHmtTh6zJdXZM
+                       SayMCZstFxdjQiYe9Mjzm6sh
+                       6H78owDosf8CZsKz1CDoSAJV
+                       FKLG6UYjjLRSj1upzioqyEpN]
+
+    eu_cypriot = Nationality.find_by(name: "cypriot (european union)")
+
+    return unless eu_cypriot
+
+    trainee_slugs.each do |slug|
+      trainee = Trainee.find_by(slug: slug)
+
+      if trainee
+        Nationalisation.find_or_create_by!(trainee_id: trainee.id, nationality_id: eu_cypriot.id)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

HESA trainees with nationality code "XA" have not had their nationality mapped. This fixes that. I got the ids of the relevant trainees and this adds the Cypriot EU nationalisation for them.

### Changes proposed in this pull request

* Data migration to add Cypriot EU nationalisations for relevant trainees

### Guidance to review

* Run data migration, see nothing explodes

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
