### PR TITLE
[4992] - Improve the performance of the trainees endpoint

### DIFF
--- a/app/components/application_record_card/view.rb
+++ b/app/components/application_record_card/view.rb
@@ -43,9 +43,7 @@ module ApplicationRecordCard
     end
 
     def last_updated_date
-      return record.updated_at if record.draft?
-
-      record.timeline&.first&.date.presence || record.updated_at
+      record.updated_at
     end
 
     def trainee_id
@@ -75,7 +73,7 @@ module ApplicationRecordCard
     end
 
     def start_year
-      academic_cycle = AcademicCycle.for_date(record.trainee_start_date)
+      academic_cycle = record.start_academic_cycle || AcademicCycle.for_date(record.trainee_start_date)
       return unless academic_cycle
 
       tag.p("Start year: #{academic_cycle.label}", class: "govuk-caption-m govuk-!-font-size-16 application-record-card__start_year govuk-!-margin-top-1 govuk-!-margin-bottom-1")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  if FeatureService.performance_testing?
+    prepend ApplicationControllerDev
+    content_security_policy false
+  end
+
   before_action :authenticate
   before_action :track_page
   before_action :check_organisation_context_is_set

--- a/app/controllers/application_controller_dev.rb
+++ b/app/controllers/application_controller_dev.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ApplicationControllerDev
+private
+
+  # Current User set to first admin profile
+  def current_user
+    @current_user ||= begin
+      user = User.where(system_admin: true).first
+      UserWithOrganisationContext.new(user: user, session: session) if user.present?
+    end
+  end
+end

--- a/app/controllers/application_controller_dev.rb
+++ b/app/controllers/application_controller_dev.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# This is prepended into `ApplicationController` if in development environment and the PERFORMANCE_TESTING env is present
+# See `app/controllers/application_controller.rb` and  `app/services/feature_service.rb`
 module ApplicationControllerDev
 private
 

--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -8,5 +8,10 @@ module FeatureService
       segments = feature_name.to_s.split(".")
       segments.reduce(Settings.features) { |config, segment| config[segment] }
     end
+
+    # i.e full data set is loaded locally and you need to log in as an admin (bypassing the persona page)
+    def performance_testing?
+      Rails.env.development? && ENV.fetch("PERFORMANCE_TESTING", false)
+    end
   end
 end


### PR DESCRIPTION
### Context

During the load testing performed after the recent incident that brought register down it was noticed that there were a lot of requests to the `/trainees` endpoint and it is quite an expensive request.

### Changes proposed in this pull request

* remove calls to the audit table for each trainee (a trainees `updated_at` field is now updated through `touch` callbacks where relevant)
* academic cycle year is retrieved via trainee rather than searched for via trainees 
* adds helper module for performance testing (not invested in this if it looks like bloat!)
