### PR TITLE
[5010] Improve uniqueness check on trainee id

### DIFF
--- a/app/forms/training_details_form.rb
+++ b/app/forms/training_details_form.rb
@@ -43,6 +43,7 @@ private
   def trainee_id_uniqueness
     return if trainee_id.blank?
     return if existing_trainee_with_id.blank?
+    return if existing_trainee_with_id.discarded_at.present?
     return if existing_trainee_with_id.inactive?
 
     errors.add(:trainee_id, duplicate_error_message)

--- a/app/services/find_empty_trainees.rb
+++ b/app/services/find_empty_trainees.rb
@@ -88,6 +88,7 @@ private
     # Finds all the draft trainees that do not have any degrees, disabilities and nationalities.
     trainees
       .draft
+      .where(trainee_id: nil)
       .includes(:degrees, :disabilities, :nationalities)
       .where(degrees: { id: nil }, disabilities: { id: nil }, nationalities: { id: nil })
       .where(empty_fields_query)

--- a/spec/forms/training_details_form_spec.rb
+++ b/spec/forms/training_details_form_spec.rb
@@ -50,7 +50,12 @@ describe TrainingDetailsForm, type: :model do
 
       context "duplicate active trainee" do
         let!(:existing_trainee) { create(:trainee, trainee_id: "Test123") }
-        let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: existing_trainee.trainee_id) }
+        let(:trainee) do
+          build(:trainee,
+                provider: existing_trainee.provider,
+                trainee_id: existing_trainee.trainee_id,
+                state: "submitted_for_trn")
+        end
 
         it "existing trainee remains active" do
           expect(existing_trainee.inactive?).to be(false)
@@ -61,6 +66,22 @@ describe TrainingDetailsForm, type: :model do
             I18n.t("#{error_attr}.trainee_id.uniqueness"),
           )
           expect(subject.duplicate_error?).to be_truthy
+        end
+      end
+
+      context "duplicate id from a discarded trainee" do
+        let!(:existing_trainee) { create(:trainee, :discarded, trainee_id: "Test123") }
+        let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: existing_trainee.trainee_id) }
+
+        it "existing trainee remains active" do
+          expect(existing_trainee.inactive?).to be(false)
+        end
+
+        it "returns no duplicate error message" do
+          expect(subject.errors[:trainee_id]).not_to include(
+            I18n.t("#{error_attr}.trainee_id.uniqueness"),
+          )
+          expect(subject.duplicate_error?).to be(false)
         end
       end
 
@@ -135,7 +156,11 @@ describe TrainingDetailsForm, type: :model do
 
     context "yesterday" do
       let!(:existing_trainee) { create(:trainee, trainee_id: "Test123", created_at: 1.day.ago) }
-      let(:trainee) { build(:trainee, provider: existing_trainee.provider, trainee_id: "TEST123") }
+      let(:trainee) do
+        build(:trainee,
+              provider: existing_trainee.provider,
+              trainee_id: "TEST123")
+      end
 
       it "returns yesterday" do
         expect(subject.existing_created).to eql("yesterday")

--- a/spec/services/find_empty_trainees_spec.rb
+++ b/spec/services/find_empty_trainees_spec.rb
@@ -44,4 +44,15 @@ describe FindEmptyTrainees do
 
     it { is_expected.to match_array(draft_trainee_with_no_data) }
   end
+
+  context "for trainees with a trainee_id" do
+    # trainees with a trainee_id should not be classed as empty
+    let!(:draft_trainee_with_no_data) do
+      Trainee.create(provider: provider, training_route: TRAINING_ROUTE_ENUMS[:assessment_only], trainee_id: 1)
+    end
+
+    subject { described_class.call }
+
+    it { is_expected.to be_empty }
+  end
 end


### PR DESCRIPTION
### Context

Our previous trainee_id uniqueness check is inadequate as when there's an existing deleted record with the same trainee id, it will prevent the reuse of that ID. Additionally if one makes a draft trainee with a given ID, clicks return to this trainee later and tries to reuse the ID an error would be thrown.

This PR also covers a bug whereby if a trainee_id was entered for a record with no other details the record would be supressed as an empty record; but the uniqueness constraint would ensure the provider could never reuse that id. Trainees with a trainee_id will no longer be considered empty or supressed.

### Changes proposed in this pull request

* Providers are prevented from having two 'active' records with the same trainee id. 
* Should be able to register a new trainee with a trainee id that is already on a withdrawn or deleted record.

### Guidance to review

Try to reuse ids from withdrawn and deleted record. Check that no two "active" ids can be repeated. 

Additionally check to ensure draft records created with a trainee id are not hidden. This is to ensure the case where a draft trainee with a trainee id is not present in the db but inaccessible; meaning the trainee_id cannot be reused whilst the first record remains inaccessible.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
