### PR TITLE
[4740] Fix weird text for trainee start date flash messages

### DIFF
--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -76,15 +76,12 @@ module Trainees
         funding: "funding details",
         course_details: "trainee's course details",
         publish_course_details: "trainee's course details",
-        trainee_start_status: "trainee start date",
+        trainee_start_status: "start date",
       }[trainee_section_key.to_sym] || trainee_section_key.gsub(/_/, " ").gsub(/id/, "ID")
     end
 
     def flash_message_title
-      I18n.t(
-        "components.confirmation.flash.#{trainee_section_key}",
-        default: confirm_section_title.pluralize,
-      )
+      I18n.t("components.confirmation.flash.#{trainee_section_key}", default: confirm_section_title)
     end
 
     def toggle_trainee_progress_field


### PR DESCRIPTION
### Context
https://trello.com/c/APnECMWK/4740-weird-text-for-trainee-start-date-flash-messages

### Changes proposed in this pull request
- Tweak the `Trainees::ConfirmDetailsController#confirm_section_title`

### Guidance to review
- Find a registered trainee without a start date
- Add a start date
- Look at flash message.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
