### PR TITLE
Add temp data Azure storage account to Terraform

### DIFF
--- a/terraform/modules/azure/README.md
+++ b/terraform/modules/azure/README.md
@@ -1,0 +1,8 @@
+# Azure Terraform Module
+
+## Temporary Data Storage Account
+
+The following code defines the Terraform code that creates the temporary data storage account.
+This is commented out because the CI pipeline service principal does not have sufficient permission
+to create Azure resources at present but we wanted to document the temporary data storage account
+in Terraform for when we migrate the service away from GOV.UK PaaS.

--- a/terraform/modules/azure/data.tf
+++ b/terraform/modules/azure/data.tf
@@ -1,0 +1,7 @@
+data "azurerm_resource_group" "group" {
+  name  = azurerm_resource_group.app_group.name
+}
+
+data "azurerm_resource_group" "backend_resource_group_name" {
+  name = var.backend_resource_group_name
+}

--- a/terraform/modules/azure/main.tf
+++ b/terraform/modules/azure/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.24.0"
+    }
+  }
+}
+
+resource "azurerm_resource_group" "app_group" {
+  name     = var.resource_group_name
+  location = var.region_name
+  tags     = data.azurerm_resource_group.backend_resource_group_name.tags
+}

--- a/terraform/modules/azure/storage.tf
+++ b/terraform/modules/azure/storage.tf
@@ -1,0 +1,26 @@
+resource "azurerm_storage_account" "tempdata" {
+  name                              = var.tempdata_storage_account_name
+  resource_group_name               = var.resource_group_name
+  location                          = var.region_name
+  account_replication_type          = var.storage_account_replication_type
+  account_tier                      = "Standard"
+  allow_nested_items_to_be_public   = false
+
+  blob_properties {
+    delete_retention_policy {
+      days = 7
+    }
+
+    container_delete_retention_policy {
+      days = 7
+    }
+  }
+
+  depends_on = [data.azurerm_resource_group.group]
+}
+
+resource "azurerm_storage_container" "tempdata" {
+  name                  = "tempdata"
+  storage_account_name  = azurerm_storage_account.tempdata.name
+  container_access_type = "private"
+}

--- a/terraform/modules/azure/variables.tf
+++ b/terraform/modules/azure/variables.tf
@@ -1,0 +1,28 @@
+variable "environment_name" {
+  type = string
+}
+
+variable "backend_resource_group_name" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "tempdata_storage_account_name" {
+  default = null
+}
+
+variable "storage_account_replication_type" {
+  type = string
+}
+
+variable "region_name" {
+  default = "west europe"
+  type    = string
+}
+
+locals {
+  hosting_environment = var.environment_name
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -43,28 +43,28 @@ provider "azurerm" {
 module "paas" {
   source = "./modules/paas"
 
-  app_environment                = var.paas_app_environment
-  app_docker_image               = var.paas_app_docker_image
-  app_start_timeout              = var.paas_app_start_timeout
-  postgres_service_plan_13       = var.paas_postgres_service_plan_13
+  app_environment                   = var.paas_app_environment
+  app_docker_image                  = var.paas_app_docker_image
+  app_start_timeout                 = var.paas_app_start_timeout
+  postgres_service_plan_13          = var.paas_postgres_service_plan_13
   postgres_snapshot_service_plan_13 = var.paas_postgres_snapshot_service_plan_13
-  snapshot_databases_to_deploy   = var.paas_snapshot_databases_to_deploy
-  redis_service_plan             = var.paas_redis_service_plan
-  space_name                     = var.paas_space_name
-  app_name                       = var.paas_app_name
-  web_app_hostname               = var.paas_web_app_hostname
-  dttp_portal                    = var.paas_dttp_portal
-  deployment_strategy            = var.paas_deployment_strategy
-  web_app_instances              = var.paas_web_app_instances
-  web_app_memory                 = var.paas_web_app_memory
-  worker_app_instances           = var.paas_worker_app_instances
-  worker_app_memory              = var.paas_worker_app_memory
-  log_url                        = local.infra_secrets.LOGSTASH_URL
-  app_secrets_variable           = local.app_secrets
-  app_config_variable            = local.app_config
-  worker_app_stopped             = var.paas_worker_app_stopped
-  restore_from_db_guid           = var.paas_restore_from_db_guid
-  db_backup_before_point_in_time = var.paas_db_backup_before_point_in_time
+  snapshot_databases_to_deploy      = var.paas_snapshot_databases_to_deploy
+  redis_service_plan                = var.paas_redis_service_plan
+  space_name                        = var.paas_space_name
+  app_name                          = var.paas_app_name
+  web_app_hostname                  = var.paas_web_app_hostname
+  dttp_portal                       = var.paas_dttp_portal
+  deployment_strategy               = var.paas_deployment_strategy
+  web_app_instances                 = var.paas_web_app_instances
+  web_app_memory                    = var.paas_web_app_memory
+  worker_app_instances              = var.paas_worker_app_instances
+  worker_app_memory                 = var.paas_worker_app_memory
+  log_url                           = local.infra_secrets.LOGSTASH_URL
+  app_secrets_variable              = local.app_secrets
+  app_config_variable               = local.app_config
+  worker_app_stopped                = var.paas_worker_app_stopped
+  restore_from_db_guid              = var.paas_restore_from_db_guid
+  db_backup_before_point_in_time    = var.paas_db_backup_before_point_in_time
 }
 
 #authenticate into provider
@@ -76,3 +76,19 @@ module "statuscake" {
   source = "./modules/statuscake"
   alerts = var.statuscake_alerts
 }
+
+# The following code imports the Azure module which just creates the temporary data storage account.
+# This is commented out because the CI pipeline service principal does not have sufficient permission
+# to create Azure resources at present but we wanted to document the temporary data storage account
+# in Terraform for when we migrate the service away from GOV.UK PaaS
+
+# module "azure" {
+#   source = "./modules/azure"
+
+#   environment_name                         = var.paas_app_environment
+#   resource_group_name                      = var.azure_resource_group_name
+#   tempdata_storage_account_name            = var.azure_tempdata_storage_account_name
+#   storage_account_replication_type         = var.azure_storage_account_replication_type
+#   region_name                              = var.azure_region_name
+#   backend_resource_group_name              = var.resource_group_name
+# }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,3 +71,15 @@ locals {
 
   azure_credentials = try(jsondecode(var.azure_credentials), null)
 }
+
+# Azure Resource Variables
+
+variable resource_group_name {}
+
+variable azure_resource_group_name {}
+
+variable azure_tempdata_storage_account_name {}
+
+variable azure_storage_account_replication_type { default = "LRS"}
+
+variable azure_region_name { default = "west europe" }

--- a/terraform/workspace-variables/production.tfvars.json
+++ b/terraform/workspace-variables/production.tfvars.json
@@ -23,5 +23,8 @@
       "check_rate": 60,
       "contact_group": [151103]
     }
-  }
+  },
+  "azure_tempdata_storage_account_name": "s121p01registerpdtmp",
+  "azure_resource_group_name": "s121p01-reg-pd-rg",
+  "azure_storage_account_replication_type": "RAGRS"
 }

--- a/terraform/workspace-variables/productiondata.tfvars.json
+++ b/terraform/workspace-variables/productiondata.tfvars.json
@@ -13,5 +13,8 @@
   "paas_web_app_instances": 2,
   "paas_web_app_memory": 1536,
   "paas_worker_app_instances": 0,
-  "paas_worker_app_memory": 512
+  "paas_worker_app_memory": 512,
+  "azure_tempdata_storage_account_name": "s121p01registerpddatatmp",
+  "azure_resource_group_name": "s121p01-reg-pddata-rg",
+  "azure_storage_account_replication_type": "RAGRS"
 }

--- a/terraform/workspace-variables/qa.tfvars.json
+++ b/terraform/workspace-variables/qa.tfvars.json
@@ -22,5 +22,7 @@
       "check_rate": 60,
       "contact_group": [151103]
     }
-  }
+  },
+  "azure_tempdata_storage_account_name": "s121d01registerqatmp",
+  "azure_resource_group_name": "s121d01-reg-qa-rg"
 }

--- a/terraform/workspace-variables/staging.tfvars.json
+++ b/terraform/workspace-variables/staging.tfvars.json
@@ -22,5 +22,7 @@
       "check_rate": 60,
       "contact_group": [151103]
     }
-  }
+  },
+  "azure_tempdata_storage_account_name": "s121t01registerstgtmp",
+  "azure_resource_group_name": "s121t01-reg-stg-rg"
 }


### PR DESCRIPTION
### Context
The team required a storage account that could be used to store temporary data while it is processed by the service. These storage accounts have been created manually in Azure through the Portal or by ARM templates in qa, staging, production and productiondata.

To ensure these are also controlled properly the need adding in to the Terraform code. We are unable to deploy these through the current workflows because the existing service principal does not have contributor privileges. Therefore, the creation of a storage account has been tested locally and the ARM templates of the existing storage account and that created using Terraform compared to ensure they aligned as much as possible.

The new Terraform resources have been commented out and can be brought in to use at a future date or during the PaaS migration.

### Changes proposed in this pull request

- Addition of an Azure module which creates a resource group and storage account
- Added documentation to explain our scenario
- Variables added to each environments tfvar files.

### Guidance to review

- [ ] Confirm review app deploys without issue, despite new Terraform code being present.
- [ ] Terraform highlights the existence of variables in the tfvar files that are not currently used.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
