### PR TITLE
[4733] Fix apply disability mapping

### DIFF
--- a/app/lib/apply_api/code_sets/disabilities.rb
+++ b/app/lib/apply_api/code_sets/disabilities.rb
@@ -3,7 +3,7 @@
 module ApplyApi
   module CodeSets
     module Disabilities
-      MAPPING = {
+      OLD_MAPPING = {
         "blind" => ::Diversities::BLIND,
         "deaf" => ::Diversities::DEAF,
         "learning" => ::Diversities::LEARNING_DIFFICULTY,
@@ -12,6 +12,19 @@ module ApplyApi
         "physical" => ::Diversities::PHYSICAL_DISABILITY,
         "social" => ::Diversities::SOCIAL_IMPAIRMENT,
         "other" => ::Diversities::OTHER,
+      }.freeze
+
+      NEW_MAPPING = {
+        "Blindness or a visual impairment not corrected by glasses" => ::Diversities::BLIND,
+        "Deafness or a serious hearing impairment" => ::Diversities::DEAF,
+        "Dyslexia, dyspraxia or attention deficit hyperactivity disorder (ADHD) or another learning difference" => ::Diversities::LEARNING_DIFFICULTY,
+        "Long-term illness" => ::Diversities::LONG_STANDING_ILLNESS,
+        "Condition affecting motor, cognitive, social and emotional skills, speech or language since childhood" => ::Diversities::DEVELOPMENT_CONDITION,
+        "Mental health condition" => ::Diversities::MENTAL_HEALTH_CONDITION,
+        "Physical disability or mobility issue" => ::Diversities::PHYSICAL_DISABILITY,
+        "Autistic spectrum condition or another condition affecting speech, language, communication or social skills" => ::Diversities::SOCIAL_IMPAIRMENT,
+        "I do not have any of these disabilities or health conditions" => ::Diversities::NO_KNOWN_DISABILITY,
+        "Prefer not to say" => ::Diversities::PREFER_NOT_TO_SAY,
       }.freeze
     end
   end

--- a/config/initializers/diversity_enums.rb
+++ b/config/initializers/diversity_enums.rb
@@ -90,6 +90,8 @@ module Diversities
   MENTAL_HEALTH_CONDITION = "Mental health condition"
   PHYSICAL_DISABILITY = "Physical disability or mobility issue"
   SOCIAL_IMPAIRMENT = "Social or communication impairment"
+  NO_DISABILITY = "I do not have any of these disabilities or health conditions"
+  PREFER_NOT_TO_SAY = "Prefer not to say"
 
   # Internal only - DTTP related
   NO_KNOWN_DISABILITY = "No known disability"

--- a/spec/support/api_stubs/apply_api.rb
+++ b/spec/support/api_stubs/apply_api.rb
@@ -121,7 +121,7 @@ module ApiStubs
         other_languages: "I have a GCSE in French and have a Italian aunt - or should I say zia!",
         disability_disclosure: "I am dyslexic",
         gender: "female",
-        disabilities: %w[blind long_standing],
+        disabilities: ["Blindness or a visual impairment not corrected by glasses", "Long-term illness"],
         ethnic_group: "Asian or Asian British",
         ethnic_background: "Chinese",
       }.merge(candidate_attributes)


### PR DESCRIPTION
### Context

We were using the disability_disclosed field from the apply api to assess whether a trainee had submitted a disability; this is incorrect. The disability_disclosed field was a free text field where a trainee could type the nature of their disability. The new logic is based on fields added to the apply api 'disabilities' fields ('no' and 'opt_out' values for not disabiled and prefer not to say respectively). This should ensure future incoming trainees are correct. 

### Changes proposed in this pull request

### Guidance to review

Pull down some 2023 trainees from the apply api and run the create from apply service on them. There should be some with 'no' and 'opt_out' disability options.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
