### PR TITLE
Add performance profiles deadline to dates and deadlines

### DIFF
--- a/app/views/guidance/dates_and_deadlines.html.erb
+++ b/app/views/guidance/dates_and_deadlines.html.erb
@@ -21,7 +21,7 @@
       <% table.body do |body| %>
         <% body.row do |row| %>
           <% row.cell do %>
-              <span class="no-wrap">Wednesday 12 October 2022</span>
+              <span class="no-wrap">12 October 2022</span>
           <% end %>
           <% row.cell(text: "The second Wednesday of October every academic year is called the ‘census date’.
           If a new trainee starts their course after this date, they will not be included in the ITT census publication.
@@ -31,9 +31,18 @@
             <% row.cell do %>
               <span class="no-wrap">1 November 2022</span>
             <% end %>
-          <% row.cell(text: "A senior person from your organisation must sign off your new trainee data on or before this date
-          (this should be a different person to who submitted the data).")%>
+          <% row.cell(text: "A senior person from your organisation must sign off your new trainee data on or before this date.
+          This should be a different person to the one who submitted the data.
+          This data will be used for the ITT census publication.")%>
         <% end %>
+        <% body.row do |row| %>
+            <% row.cell do %>
+              <span class="no-wrap">31 January 2023</span>
+            <% end %>
+          <% row.cell(text: "A senior person from your organisation must sign off your 2021 to 2022 trainee data on or before this date.
+          This should be a different person to the one who submitted the data.
+          Some of this data will be used for the ITT performance profiles publication.")%>
+        <% end %>      
       <% end %>
     <% end %>
 


### PR DESCRIPTION
### Context

We currently tell users the deadline for signing off census data but not for signing off performance profile data.

### Changes proposed in this pull request

As well as adding a line about the performance profiles in the same style as the census information, I have:

- made a couple of small tweaks to the 1 November census entry so that I could fit the new one in more easily, for example saying that the data will be used for the census publication
- removed “Wednesday” from the first date, since the ‘what happens’ already explains it’s always on a Wednesday - by removing it we match the other date formats and can make the ‘what happens’ column a bit wider

<img width="846" alt="CleanShot 2022-12-09 at 12 02 31@2x" src="https://user-images.githubusercontent.com/29047487/206736939-f876100a-8c34-400b-b7c2-ac941ee75e92.png">