### PR TITLE
[4737] Support: add autocomplete to search for users

### DIFF
--- a/app/components/form_components/users_autocomplete/script.js
+++ b/app/components/form_components/users_autocomplete/script.js
@@ -1,0 +1,132 @@
+import accessibleAutocomplete from 'accessible-autocomplete'
+import { nodeListForEach } from 'govuk-frontend/govuk/common'
+
+const $allAutocompleteElements = document.querySelectorAll('[data-module="app-users-autocomplete"]')
+
+let statusMessage = ' '
+let userSelected = false
+
+const guard = (data) => {
+  if (data === undefined) {
+    return new Error('An error occurred')
+  }
+
+  return data
+}
+
+// Sort two things alphabetically, not case-sensitive
+const sortAlphabetical = (x, y) => {
+  if(x.toLowerCase() !== y.toLowerCase()) {
+    x = x.toLowerCase();
+    y = y.toLowerCase();
+  }
+  return x > y ? 1 : (x < y ? -1 : 0);
+}
+
+const tryUpdateStatusMessage = (users) => {
+  if (users.length === 0) {
+    statusMessage = 'No results found'
+  }
+
+  return users
+}
+
+// The autocomplete plugin prevents the user from submitting the form on enter
+const overrideEnterKey = (form, autocompleteElement) => {
+  form.addEventListener('keydown', function(event) {
+    if (event.keyCode === 13 && !userSelected) {
+      const input = autocompleteElement.querySelector('input')
+      const searchField = document.createElement('input')
+      searchField.setAttribute("type", "hidden");
+      searchField.setAttribute("name", "search");
+      searchField.setAttribute("value", input.value);
+      form.appendChild(searchField)
+      input.removeAttribute('name')
+      form.submit()
+    }
+  });
+}
+
+const findUsers = ({ query, populateResults }) => {
+  const encodedQuery = encodeURIComponent(query)
+
+  statusMessage = 'Loading...'
+
+  window.fetch(`/api/users?query=${encodedQuery}`)
+    .then(response => response.json())
+    .then(guard)
+    .then(data => data.users)
+    .then(tryUpdateStatusMessage)
+    .then(populateResults)
+    .catch(console.log)
+}
+
+const inputTemplate = (user) => {
+  return user && `${user['first_name']} ${user['last_name']}`
+}
+
+const suggestionTemplate = (user) => {
+  if (typeof user === 'object' && 'first_name' in user) {
+    const providerNames = user['providers'].map(provider => provider.name).sort(sortAlphabetical)
+    const leadSchools = user['lead_schools'].map(school => school.name).sort(sortAlphabetical)
+    const name = `${user['first_name']} ${user['last_name']}`
+    const allOrgs = providerNames.concat(leadSchools)
+
+    return `${name} <span class="autocomplete__option--hint">${user.email}<br>${allOrgs.join(', ')}</span>`
+  } else {
+    return 'No results found'
+  }
+}
+
+const renderTemplate = {
+  inputValue: inputTemplate,
+  suggestion: suggestionTemplate
+}
+
+
+const setupAutoComplete = (form) => {
+  const inputs = form.querySelectorAll('[data-field="users-autocomplete"]')
+  const autocompleteElement = form.querySelector('#users-autocomplete-element')
+  const fieldName = autocompleteElement.getAttribute('data-field-name') || ''
+  const defaultValue = autocompleteElement.getAttribute('data-default-value') || ''
+  const inputFormGroup = autocompleteElement.previousElementSibling
+
+  try {
+    inputs.forEach(input => {
+      accessibleAutocomplete({
+        element: autocompleteElement,
+        id: input.id,
+        minLength: 2,
+        name: fieldName,
+        defaultValue: defaultValue,
+        source: (query, populateResults) => {
+          return findUsers({
+            query,
+            populateResults,
+          })
+        },
+        templates: renderTemplate,
+        onConfirm: (user) => {
+          if (user) {
+            userSelected = true
+            window.location.assign(`/system-admin/users/${user.id}`);
+          }
+        },
+        tNoResults: () => statusMessage
+      })
+
+      // Move autocomplete to the form group containing the input to be replaced
+      if (inputFormGroup.contains(input)) {
+        inputFormGroup.appendChild(autocompleteElement)
+      }
+
+      input.remove()
+
+      overrideEnterKey(form, autocompleteElement)
+    })
+  } catch (err) {
+    console.error('Could not enhance:', err)
+  }
+}
+
+nodeListForEach($allAutocompleteElements, setupAutoComplete)

--- a/app/controllers/api/schools_controller.rb
+++ b/app/controllers/api/schools_controller.rb
@@ -25,7 +25,8 @@ module Api
     end
 
     def error_response
-      render_json_error(message: I18n.t("api.schools.errors.bad_request", length: SchoolSearch::MIN_QUERY_LENGTH), status: :bad_request)
+      render_json_error(message: I18n.t("api.errors.bad_request", length: SchoolSearch::MIN_QUERY_LENGTH),
+                        status: :bad_request)
     end
 
     def lead_schools_only

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Api
+  class UsersController < Api::ApplicationController
+    def index
+      return error_response if invalid_query?
+
+      @user_search = UserSearch.call(**args).users
+
+      render(json: { users: @user_search.as_json(only: %i[id first_name last_name email],
+                                                 include: { providers: { only: [:name] },
+                                                            lead_schools: { only: [:name] } }) })
+    end
+
+  private
+
+    def args
+      { query: params[:query], limit: params[:limit] }.compact
+    end
+
+    def invalid_query?
+      params[:query].present? && params[:query].length < UserSearch::MIN_QUERY_LENGTH
+    end
+
+    def error_response
+      message = I18n.t("api.errors.bad_request", length: SchoolSearch::MIN_QUERY_LENGTH)
+      render_json_error(message: message, status: :bad_request)
+    end
+  end
+end

--- a/app/controllers/system_admin/users_controller.rb
+++ b/app/controllers/system_admin/users_controller.rb
@@ -43,11 +43,7 @@ module SystemAdmin
     end
 
     def filtered_users(users)
-      if params[:search]
-        users.where("last_name like ? or email like ?", "%#{params[:search]}%", "%#{params[:search]}%")
-      else
-        users
-      end
+      UserSearch.call(query: params[:search], scope: users).users
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   include Discard::Model
+  include PgSearch::Model
 
   has_many :provider_users, inverse_of: :user
   has_many :providers, through: :provider_users
@@ -22,6 +23,11 @@ class User < ApplicationRecord
   validate do |record|
     EmailFormatValidator.new(record).validate
   end
+
+  pg_search_scope :search,
+                  against: %i[first_name last_name email],
+                  associated_against: { providers: [:name], lead_schools: [:name] },
+                  using: { trigram: { word_similarity: true } }
 
   def name
     "#{first_name} #{last_name}"

--- a/app/services/user_search.rb
+++ b/app/services/user_search.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class UserSearch
+  include ServicePattern
+
+  class Result
+    attr_reader :users, :limit
+
+    def initialize(users:, limit:)
+      @users = users
+      @limit = limit
+    end
+  end
+
+  MIN_QUERY_LENGTH = 2
+  DEFAULT_LIMIT = 15
+
+  def initialize(query: nil, limit: DEFAULT_LIMIT, scope: User.all)
+    @query = ReplaceAbbreviation.call(string: StripPunctuation.call(string: query))
+    @limit = limit
+    @scope = scope
+  end
+
+  def call
+    Result.new(users: specified_users, limit: limit)
+  end
+
+  def specified_users
+    users = scope
+    users = users.search(query) if query
+    users = users.limit(limit) if limit
+    users
+  end
+
+private
+
+  attr_reader :query, :limit, :scope
+end

--- a/app/views/system_admin/users/index.html.erb
+++ b/app/views/system_admin/users/index.html.erb
@@ -17,18 +17,21 @@
     ) %>
     </p>
 
-    <div class="govuk-grid-row">
-      <div class ="govuk-grid-column-full">
-        <%= register_form_with url: users_path, method: :get do |f| %>
-          <%= f.govuk_text_field :search,
-                                 label: { text: "Search for a user"},
-                                 hint: { text: "Search using the person’s email address or surname", size: "s" },
-                                 value: params[:search],
-                                 width: "two-thirds" %>
-          <%= f.govuk_submit "Search", class: "submit-search" %>
-        <% end %>
-      </div>
-    </div>
+    <% if params[:search].present? %>
+      <h2 class="govuk-heading-m">Results for ‘<%= params[:search] %>’</h2>
+      <p class="govuk-body"><%= link_to "Clear search", users_path, class: "govuk-link govuk-link--no-visited-state" %></p>
+    <% end %>
+    <%= register_form_with url: users_path,
+                           method: :get,
+                           html: { data: { module: "app-users-autocomplete" } } do |f| %>
+      <%= f.govuk_text_field :search,
+                             label: { text: "Search for a user", size: "s" },
+                             hint: { text: "Search using the person’s name, email, provider or lead school", size: "s" },
+                             width: "one-half",
+                             "data-field" => "users-autocomplete" %>
+      <div id="users-autocomplete-element" class="govuk-!-width-one-half" data-field-name="search"></div>
+      <%= f.govuk_submit "Search", class: "submit-search app-no-js-only" %>
+    <% end %>
 
   <table class="govuk-table" summary="Users list">
     <thead class="govuk-table__head">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1649,9 +1649,8 @@ en:
         error_count: Error count
         form: Form
   api:
-    schools:
-      errors:
-        bad_request: The query param needs to be at least %{length} characters
+    errors:
+      bad_request: The query param needs to be at least %{length} characters
   layouts:
     trainee_record:
       hesa_uneditable_heading: This record was imported from HESA and cannot be edited

--- a/config/routes/api_routes.rb
+++ b/config/routes/api_routes.rb
@@ -5,6 +5,7 @@ module ApiRoutes
     router.instance_exec do
       namespace :api do
         resources :schools, only: :index
+        resources :users, only: :index
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/PbsihW8T/4737-m-support-add-autocomplete-to-search-for-users

### Changes proposed in this pull request
- Add autocomplete functionality to user search input field on `/system-admin/users`

### Guidance to review
- Login as system admin
- Visit the users page
- Begin search for users
- Suggestions should appear
- Choose one
- Page should automatically redirect to user page

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
