### PR TITLE
[4945] Return HESA incomplete trainees in filter

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -218,8 +218,8 @@ class Trainee < ApplicationRecord
 
   scope :imported_from_hesa_trn_data, -> { where(record_source: RecordSources::HESA_TRN_DATA) }
 
-  scope :complete_for_filter, -> { where(submission_ready: true).or(where(state: COMPLETE_STATES)).or(where(id: imported_from_hesa)) }
-  scope :incomplete_for_filter, -> { where.not(id: complete_for_filter) }
+  scope :complete, -> { where(submission_ready: true).or(where(state: COMPLETE_STATES)) }
+  scope :incomplete, -> { where.not(id: complete) }
 
   scope :on_early_years_routes, -> { where(training_route: EARLY_YEARS_TRAINING_ROUTES.keys) }
 

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -131,9 +131,9 @@ module Trainees
       return trainees if record_completion.blank? || record_completion.size > 1
 
       if record_completion.include?("complete")
-        trainees.complete_for_filter
+        trainees.complete
       else
-        trainees.incomplete_for_filter
+        trainees.incomplete
       end
     end
 

--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -112,7 +112,7 @@ private
 
   def incomplete_size
     Rails.cache.fetch("#{@trainees.cache_key_with_version}/incomplete_size") do
-      trainees.not_draft.incomplete_for_filter.size
+      trainees.not_draft.incomplete.size
     end
   end
 

--- a/spec/features/trainee_actions/filtering_trainees_spec.rb
+++ b/spec/features/trainee_actions/filtering_trainees_spec.rb
@@ -341,13 +341,12 @@ private
 
   def then_only_complete_records_are_visible
     expect(trainee_index_page).to have_text(full_name(@complete_trainee)) &
-      have_text(full_name(@incomplete_hesa_trainee)) &
       have_text(full_name(@incomplete_withdrawn_trainee))
   end
 
   def then_only_incomplete_records_are_visible
     expect(trainee_index_page).to have_text(full_name(@incomplete_trainee))
-    expect(trainee_index_page).not_to have_text(full_name(@incomplete_hesa_trainee))
+    expect(trainee_index_page).to have_text(full_name(@incomplete_hesa_trainee))
     expect(trainee_index_page).not_to have_text(full_name(@incomplete_withdrawn_trainee))
   end
 

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -154,6 +154,22 @@ describe Trainee do
         expect(described_class.course_not_yet_started).not_to include(draft_trainee, recommended_for_award_trainee_in_past)
       end
     end
+
+    describe ".complete" do
+      let!(:complete_trainee) { create(:trainee, :completed) }
+      let!(:incomplete_recommended_trainee) { create(:trainee, :recommended_for_award, :incomplete) }
+      let!(:incomplete_awarded_trainee) { create(:trainee, :awarded, :incomplete) }
+      let!(:incomplete_withdrawn_trainee) { create(:trainee, :withdrawn, :incomplete) }
+      let!(:incomplete_trn_received) { create(:trainee, :trn_received, :incomplete) }
+
+      it "returns complete trainees, incomplete recommended trainees, incomplete awarded trainees, incomplete withdrawn trainees" do
+        expect(described_class.complete).to include(complete_trainee, incomplete_recommended_trainee, incomplete_awarded_trainee, incomplete_withdrawn_trainee)
+      end
+
+      it "does not return incomplete trainees" do
+        expect(described_class.complete).not_to include(incomplete_trn_received)
+      end
+    end
   end
 
   context "associations" do

--- a/spec/view_objects/home_view_spec.rb
+++ b/spec/view_objects/home_view_spec.rb
@@ -200,8 +200,8 @@ describe HomeView do
     end
 
     describe "#incomplete_size" do
-      it "returns the same value as the #count of the ::not_draft and ::incomplete_for_filter scopes" do
-        expect(subject.send(:incomplete_size)).to eq(Trainee.not_draft.incomplete_for_filter.count)
+      it "returns the same value as the #count of the ::not_draft and ::incomplete scopes" do
+        expect(subject.send(:incomplete_size)).to eq(Trainee.not_draft.incomplete.count)
       end
     end
 


### PR DESCRIPTION
### Context

https://trello.com/c/yrVGKZ2r/5020-hesa-user-seeing-incomplete-on-record-shouldnt-incomplete-be-suppressed-for-hesa-records-can-we-check

### Changes proposed in this pull request

- Return incomplete HESA trainees in the incomplete filter since we're showing the incomplete tag for these trainees
- Rename filter because it does return incomplete/complete trainees now
- Add missing tests for scope

### Guidance to review

- Find an incomplete HESA trainee
- Check that they are returned in the incomplete filter

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml