### PR TITLE
[5045] Add new academic year filter to registered trainees index page

### DIFF
--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -6,6 +6,7 @@ class BaseTraineeController < ApplicationController
     filter_params
     filters
     filtered_trainees
+    academic_cycle_options
     available_record_sources
     show_source_filters?
     paginated_trainees
@@ -94,6 +95,14 @@ private
       .sort_by(&TRAINING_ROUTE_ENUMS.values.method(:index))
   end
 
+  def academic_cycle_options
+    current_academic_cycle ||= AcademicCycle.current
+
+    return [] if current_academic_cycle.nil?
+
+    [current_academic_cycle.start_year, current_academic_cycle.start_year - 1]
+  end
+
   def all_trainees_started?
     policy_scope(trainee_search_scope).course_not_yet_started.blank?
   end
@@ -147,6 +156,7 @@ private
       :start_year,
       :end_year,
       {
+        academic_year: [],
         level: [],
         training_route: [],
         status: [],

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -80,6 +80,7 @@ private
       :end_year,
       :sort_by,
       {
+        academic_year: [],
         level: [],
         training_route: [],
         status: [],

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -61,7 +61,7 @@ private
   end
 
   def trainee_search_scope
-    Trainee.includes(provider: [:courses]).where.not(state: "draft")
+    Trainee.includes({ provider: [:courses] }, :start_academic_cycle, :end_academic_cycle).where.not(state: "draft")
   end
 
   def export_results_path

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -52,8 +52,7 @@ module TraineeHelper
   end
 
   def label_for(attribute, value)
-    case attribute
-    when "trainee_start_year"
+    if attribute.include?("trainee_start_year") || attribute.include?("academic_year")
       "#{value.to_i} to #{value.to_i + 1}"
     else
       I18n.t("activerecord.attributes.trainee.#{attribute.pluralize}.#{value}")

--- a/app/models/academic_cycle.rb
+++ b/app/models/academic_cycle.rb
@@ -20,6 +20,17 @@ class AcademicCycle < ApplicationRecord
     for_date(Time.zone.now)
   end
 
+  def self.previous
+    for_date(1.year.ago)
+  end
+
+  def total_trainees
+    trainees_starting.or(trainees_ending).or(Trainee.where("start_cycle.start_date < ?", start_date)
+    .where("end_cycle.start_date > ?", start_date))
+    .joins("INNER JOIN academic_cycles start_cycle ON trainees.start_academic_cycle_id = start_cycle.id")
+    .joins("INNER JOIN academic_cycles end_cycle ON trainees.end_academic_cycle_id = end_cycle.id")
+  end
+
   def trainees_starting
     trainee_scope = Trainee.where(start_academic_cycle: self)
     trainee_scope = trainee_scope.or(Trainee.where(start_academic_cycle: nil)) if current?

--- a/app/models/trainee_filter.rb
+++ b/app/models/trainee_filter.rb
@@ -24,6 +24,7 @@ private
 
   def merged_filters
     @merged_filters ||= text_search.merge(
+      **academic_year,
       **level,
       **training_route,
       **status,
@@ -37,6 +38,22 @@ private
       **trainee_start_years,
       **study_modes,
     ).with_indifferent_access
+  end
+
+  def academic_year
+    return {} unless academic_year_options.any?
+
+    { "academic_year" => academic_year_options }
+  end
+
+  def academic_year_options
+    current_academic_cycle ||= AcademicCycle.current
+
+    return [] if current_academic_cycle.nil?
+
+    [current_academic_cycle.start_year.to_s, (current_academic_cycle.start_year - 1).to_s].each_with_object([]) do |option, arr|
+      arr << option if params[:academic_year]&.include?(option)
+    end
   end
 
   def level

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -33,6 +33,23 @@ module Trainees
       remove_hesa_trn_data_trainees(remove_empty_trainees(trainees))
     end
 
+    def academic_year(trainees, academic_years)
+      return trainees if academic_years.blank?
+
+      scoped_trainees = trainees
+      academic_years.each_with_index do |academic_year, i|
+        academic_cycle = AcademicCycle.for_year(academic_year)
+
+        if i.zero?
+          scoped_trainees = academic_cycle.total_trainees
+        else
+          scoped_trainees = scoped_trainees.or(academic_cycle.total_trainees)
+        end
+      end
+
+      trainees.merge(scoped_trainees)
+    end
+
     def course_education_phase(trainees, course_education_phases)
       return trainees if course_education_phases.blank?
 
@@ -148,6 +165,7 @@ module Trainees
     def filter_trainees
       filtered_trainees = trainees
 
+      filtered_trainees = academic_year(filtered_trainees, filters[:academic_year])
       filtered_trainees = training_route(filtered_trainees, filters[:training_route])
       filtered_trainees = status(filtered_trainees, filters[:status])
       filtered_trainees = subject(filtered_trainees, filters[:subject])

--- a/app/views/trainees/_academic_year_filter.html.erb
+++ b/app/views/trainees/_academic_year_filter.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+      <%= t('components.filter.academic_year') %>
+    </legend>
+    <div class="govuk-checkboxes govuk-checkboxes--small">
+        <% academic_cycle_options.map do |academic_year| %>
+          <div class="govuk-checkboxes__item">
+            <%= check_box_tag "academic_year[]",
+                              academic_year,
+                              checked?(filters, :academic_year, academic_year.to_s),
+                              id: "academic_year-#{academic_year}",
+                              class: "govuk-checkboxes__input" %>
+            <%= label_tag "academic_year-#{academic_year}",
+                          label_for("academic_year", academic_year),
+                          class: "govuk-label govuk-checkboxes__label" %>
+          </div>
+        <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/trainees/_filters.html.erb
+++ b/app/views/trainees/_filters.html.erb
@@ -7,6 +7,20 @@
     <%= text_field_tag "text_search", (filters[:text_search] if filters), spellcheck: false, class: "govuk-input" %>
   </div>
 
+  <% if current_user.system_admin? %>
+    <%= render AdminFeature::View.new(classes: "app-status-box--filter-outdent") do %>
+      <div class="govuk-form-group">
+        <%= label_tag "provider", t("views.trainees.index.filters.provider"), class: "govuk-label govuk-label--s" %>
+        <%= select_tag(
+          :provider,
+          options_from_collection_for_select(providers, :id, :name),
+          include_blank: "All providers",
+          class: "govuk-select"
+        ) %>
+      </div>
+    <% end %>
+  <% end %>
+
   <% if trainee_search_path?(search_path) %>
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">
@@ -25,20 +39,8 @@
         </div>
       </fieldset>
     </div>
-  <% end %>
 
-  <% if current_user.system_admin? %>
-    <%= render AdminFeature::View.new(classes: "app-status-box--filter-outdent") do %>
-      <div class="govuk-form-group">
-        <%= label_tag "provider", t("views.trainees.index.filters.provider"), class: "govuk-label govuk-label--s" %>
-        <%= select_tag(
-          :provider,
-          options_from_collection_for_select(providers, :id, :name),
-          include_blank: "All providers",
-          class: "govuk-select"
-        ) %>
-      </div>
-    <% end %>
+    <%= render "trainees/academic_year_filter" %>
   <% end %>
 
   <% [:start_year, :end_year].each do |field| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -449,6 +449,7 @@ en:
       service_updates: News and updates
       organisations: Choose organisation
     filter:
+      academic_year: Academic year
       level: Education phase
       provider: Provider
       record_source: Record source

--- a/spec/factories/academic_cycles.rb
+++ b/spec/factories/academic_cycles.rb
@@ -3,12 +3,14 @@
 FactoryBot.define do
   factory :academic_cycle do
     transient do
+      one_before_previous_cycle { false }
       previous_cycle { false }
       next_cycle { false }
       one_after_next_cycle { false }
 
       cycle_year do
         cycles = [
+          -> { current_academic_year - 2 if one_before_previous_cycle },
           -> { current_academic_year - 1 if previous_cycle },
           -> { current_academic_year + 1 if next_cycle },
           -> { current_academic_year + 2 if one_after_next_cycle },

--- a/spec/models/academic_cycle_spec.rb
+++ b/spec/models/academic_cycle_spec.rb
@@ -26,6 +26,26 @@ describe AcademicCycle do
     end
   end
 
+  describe "#total_trainees" do
+    let(:current_cycle) { create(:academic_cycle, :current) }
+    let(:previous_cycle) { create(:academic_cycle, previous_cycle: true) }
+    let(:next_cycle) { create(:academic_cycle, next_cycle: true) }
+
+    subject { current_cycle.total_trainees }
+
+    context "a trainee that spans the academic cycle" do
+      let(:trainee) { create(:trainee, start_academic_cycle: previous_cycle, end_academic_cycle: next_cycle) }
+
+      it { is_expected.to match_array([trainee]) }
+    end
+
+    context "a trainee that ends in the cycle" do
+      let(:trainee) { create(:trainee, start_academic_cycle: previous_cycle, end_academic_cycle: current_cycle) }
+
+      it { is_expected.to match_array([trainee]) }
+    end
+  end
+
   describe "#trainees_starting" do
     let(:academic_cycle) { build(:academic_cycle) }
 

--- a/spec/models/academic_cycle_spec.rb
+++ b/spec/models/academic_cycle_spec.rb
@@ -168,5 +168,11 @@ describe AcademicCycle do
     subject { described_class.current }
 
     it { is_expected.to eq(current_academic_year) }
+
+    describe ".previous" do
+      subject { described_class.previous }
+
+      it { is_expected.to eq(past_academic_year) }
+    end
   end
 end

--- a/spec/models/trainee_filter_spec.rb
+++ b/spec/models/trainee_filter_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe TraineeFilter do
   let(:permitted_params) do
     ActionController::Parameters.new(params)
-    .permit(:provider, :start_year, :subject, :text_search, training_route: [], state: [], record_source: [], study_mode: [])
+    .permit(:provider, :start_year, :subject, :text_search, academic_year: [], training_route: [], state: [], record_source: [], study_mode: [])
   end
 
   subject { TraineeFilter.new(params: permitted_params) }
@@ -19,6 +19,10 @@ describe TraineeFilter do
   end
 
   describe "#filters" do
+    before do
+      create(:academic_cycle, :current)
+    end
+
     context "with fully valid parameters" do
       let(:params) do
         {
@@ -40,6 +44,15 @@ describe TraineeFilter do
 
       it "returns the provider from the DB" do
         expect(subject.filters).to eq({ "provider" => provider })
+      end
+    end
+
+    context "with academic years" do
+      let(:academic_year_filter) { "2021" }
+      let(:params) { { academic_year: [academic_year_filter] } }
+
+      it "applies the academic year" do
+        expect(subject.filters).to eq({ "academic_year" => [academic_year_filter] })
       end
     end
 


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/q3r1pMkl/5045-l-add-new-academic-year-filter-to-registered-trainees-index-page

We want to be able to filter registered trainees by their academic year. This PR introduces that. The new trainee filter for academic year can also be used for the performance profile reports.

One thing to note - when selecting trainees by their academic year I have reused `def trainees_starting` and `def trainees_ending`. These methods also return trainees that have no start/end academic cycle in the current academic year. As we are only implementing the filter for registered trainees, this shouldn't really affect the trainees returned (they should all have start and end cycles by this point). But calling `AcademicCycle.current.total_trainees` will return those with nil cycles as well.

New filter:
![Screenshot 2022-12-16 at 14 45 06](https://user-images.githubusercontent.com/43522239/208123552-8e8550e5-86c4-4414-b322-834760c401fb.png)

![Screenshot 2022-12-16 at 14 45 19](https://user-images.githubusercontent.com/43522239/208123567-b648fc80-a187-4671-abb2-f94f6afe27ea.png)


### Changes proposed in this pull request

* Add def self.previous and def total_trainees to AcademicCycle
* Add def academic_year to Trainee::Filter
* Add relevant filter UI

### Guidance to review

* Navigate to registered trainees, observe filter
* Test filter returns correct trainees
* If possible try and create some trainees with start/end cycles that span across academic years - check they are returned correctly
* I've created this record for Annie Bell https://register-pr-2985.london.cloudapps.digital/trainees/ZM5157fsDfCKqfqBHfHwZ7jx which spans both available years so should appear in both
* Check counts make sense
* Test the filter as an admin too

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
- [ ] ~~Do we need to send any updates to DQT as part of the work in this PR?~~
- [ ] ~~Does this PR need an ADR?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
