### PR TITLE
[5041] Update DQT when HESA trainees are withdrawn

### DIFF
--- a/app/jobs/dqt/withdraw_trainee_job.rb
+++ b/app/jobs/dqt/withdraw_trainee_job.rb
@@ -2,21 +2,48 @@
 
 module Dqt
   class WithdrawTraineeJob < ApplicationJob
+    include NotifyOnTimeout
+
     sidekiq_options retry: 0
     queue_as :dqt
 
-    def perform(trainee)
+    class TraineeAttributeError < StandardError; end
+
+    def perform(trainee, timeout_after = nil)
       return unless FeatureService.enabled?(:integrate_with_dqt)
 
-      return unless trainee_updatable?(trainee)
+      @trainee = trainee
+      @timeout_after = timeout_after
 
-      WithdrawTrainee.call(trainee:)
+      if @timeout_after.nil?
+        @timeout_after = trainee.submitted_for_trn_at + Settings.jobs.max_poll_duration_days.days
+        requeue
+        return
+      end
+
+      if trainee.trn.present?
+        WithdrawTrainee.call(trainee:)
+      elsif continue_waiting_for_trn?
+        requeue
+      else
+        send_message_to_slack(trainee, self.class.name)
+      end
     end
 
   private
 
-    def trainee_updatable?(trainee)
-      !trainee.hesa_record?
+    attr_reader :trainee, :timeout_after
+
+    def continue_waiting_for_trn?
+      if trainee.submitted_for_trn_at.nil?
+        raise(TraineeAttributeError, "Trainee#submitted_for_trn_at is nil - it should be timestamped (id: #{trainee.id})")
+      end
+
+      Time.zone.now.utc < timeout_after
+    end
+
+    def requeue
+      self.class.set(wait: Settings.jobs.poll_delay_hours.hours).perform_later(trainee, timeout_after)
     end
   end
 end

--- a/app/services/trainees/withdraw.rb
+++ b/app/services/trainees/withdraw.rb
@@ -9,16 +9,11 @@ module Trainees
     end
 
     def call
-      Dqt::WithdrawTraineeJob.perform_later(trainee) unless hesa_trainee?
-      true
+      Dqt::WithdrawTraineeJob.perform_later(trainee)
     end
 
   private
 
     attr_reader :trainee
-
-    def hesa_trainee?
-      trainee.hesa_record?
-    end
   end
 end

--- a/spec/factories/funding/payment_schedule_row_amounts.rb
+++ b/spec/factories/funding/payment_schedule_row_amounts.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :payment_schedule_row_amount, class: "Funding::PaymentScheduleRowAmount" do
     month { (1..12).to_a.sample }
-    year { Time.zone.now.year }
+    year { current_academic_year }
     amount_in_pence { Faker::Number.number(digits: 6) }
   end
 end

--- a/spec/jobs/dqt/withdraw_trainee_job_spec.rb
+++ b/spec/jobs/dqt/withdraw_trainee_job_spec.rb
@@ -4,27 +4,14 @@ require "rails_helper"
 
 module Dqt
   describe WithdrawTraineeJob do
-    let(:trainee) { create(:trainee, :withdrawn) }
+    include ActiveJob::TestHelper
+
+    let(:trainee) { create(:trainee, :withdrawn, :submitted_for_trn) }
+    let(:configured_poll_timeout_days) { 4 }
+    let(:timeout_date) { configured_poll_timeout_days.days.from_now }
 
     before do
       allow(WithdrawTrainee).to receive(:call).with(trainee:).and_return(nil)
-    end
-
-    context "with the `integrate_with_dqt` feature flag active" do
-      before do
-        enable_features(:integrate_with_dqt)
-      end
-
-      it "calls the WithdrawTrainee service" do
-        expect(WithdrawTrainee).to receive(:call).with(trainee:)
-        described_class.perform_now(trainee)
-      end
-
-      it "does not call the WithdrawTrainee service for a HESA trainee" do
-        trainee.hesa_id = "12345678"
-        expect(WithdrawTrainee).not_to receive(:call).with(trainee:)
-        described_class.perform_now(trainee)
-      end
     end
 
     context "with the `integrate_with_dqt` feature flag inactive" do
@@ -34,7 +21,58 @@ module Dqt
 
       it "does not call the WithdrawTrainee service" do
         expect(WithdrawTrainee).not_to receive(:call).with(trainee:)
-        described_class.perform_now(trainee)
+        described_class.perform_now(trainee, timeout_date)
+      end
+    end
+
+    context "with the `integrate_with_dqt` feature flag active" do
+      before do
+        enable_features(:integrate_with_dqt)
+      end
+
+      context "TRN is available" do
+        let(:trainee) { create(:trainee, :withdrawn, :trn_received) }
+
+        it "calls the WithdrawTrainee service" do
+          expect(WithdrawTrainee).to receive(:call).with(trainee:)
+          described_class.perform_now(trainee, timeout_date)
+        end
+
+        it "doesn't queue another job" do
+          described_class.perform_now(trainee, timeout_date)
+          expect(WithdrawTraineeJob).not_to have_been_enqueued
+        end
+      end
+
+      context "TRN is not available" do
+        let(:trainee) { create(:trainee, :withdrawn, :submitted_for_trn, trn: nil) }
+
+        it "continues to wait until a TRN appears on the trainee record" do
+          Timecop.freeze(Time.zone.now) do
+            described_class.perform_now(trainee, timeout_date)
+            expect(WithdrawTraineeJob).to have_been_enqueued.at(Settings.jobs.poll_delay_hours.hours.from_now)
+                                                            .with(trainee, timeout_date)
+          end
+        end
+
+        context "time_out after has passed" do
+          it "doesn't queue another job" do
+            expect(SlackNotifierService).to receive(:call)
+            described_class.perform_now(trainee, 1.minute.ago)
+            expect(WithdrawTraineeJob).not_to have_been_enqueued
+          end
+        end
+
+        context "the trainee attribute submitted_for_trn_at is nil" do
+          let(:trainee) { create(:trainee, :submitted_for_trn, submitted_for_trn_at: nil) }
+          let(:error_msg) { "Trainee#submitted_for_trn_at is nil - it should be timestamped (id: #{trainee.id})" }
+
+          it "raises a TraineeAttributeError" do
+            expect {
+              described_class.perform_now(trainee, timeout_date)
+            }.to raise_error(WithdrawTraineeJob::TraineeAttributeError, error_msg)
+          end
+        end
       end
     end
   end

--- a/spec/services/trainees/withdraw_spec.rb
+++ b/spec/services/trainees/withdraw_spec.rb
@@ -4,23 +4,12 @@ require "rails_helper"
 
 module Trainees
   describe Withdraw do
-    let(:trainee) { create(:trainee, hesa_id: nil) }
+    let(:trainee) { create(:trainee) }
 
     describe "#call" do
-      context "passed a non-HESA trainee that has had attributes set" do
-        it "queues a withdrawal to DQT when `withdrawal` option is set" do
-          expect(Dqt::WithdrawTraineeJob).to receive(:perform_later).with(trainee)
-          described_class.call(trainee:)
-        end
-      end
-
-      context "passed a HESA trainee that has had attributes set" do
-        let(:trainee) { create(:trainee, hesa_id: "12345678") }
-
-        it "queues a withdrawal to DQT when `withdrawal` option is set" do
-          expect(Dqt::WithdrawTraineeJob).not_to receive(:perform_later).with(trainee)
-          described_class.call(trainee:)
-        end
+      it "queues a withdrawal to DQT when `withdrawal` option is set" do
+        expect(Dqt::WithdrawTraineeJob).to receive(:perform_later).with(trainee)
+        described_class.call(trainee:)
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/qevoV3jl/5041-update-dqt-when-hesa-trainees-are-withdrawn

### Changes proposed in this pull request
- Remove guard clauses to allow withdrawl updates to DQT from `Dqt::WithdrawTraineeJob` and `Trainees::Withdraw`
- Run `Dqt::WithdrawTraineeJob` in `CreateFromHesa` if trainee is in a withdrawn state but only if a TRN is present, otherwise, it will wait until a TRN has been issued

### Guidance to review
- Can't be reviewed manually

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
