### PR TITLE
[5074] Send HESA awards to DQT

### DIFF
--- a/app/jobs/dqt/recommend_for_award_job.rb
+++ b/app/jobs/dqt/recommend_for_award_job.rb
@@ -8,22 +8,16 @@ module Dqt
     def perform(trainee)
       return unless FeatureService.enabled?(:integrate_with_dqt)
 
-      if trainee.hesa_record?
-        message = "Trainee id: #{trainee.id}, slug: #{trainee.slug} has been recommended for award but is a HESA trainee"
-        username = "Register Trainee Teachers: Job Failure"
-        SlackNotifierService.call(message:, username:)
-      else
-        award_date = RecommendForAward.call(trainee:)
+      award_date = RecommendForAward.call(trainee:)
 
-        if award_date
-          trainee.award_qts!(award_date)
-          Trainees::Update.call(trainee: trainee, update_dqt: false)
-        else
-          raise(
-            DqtNoAwardDateError,
-            "failed to retrieve award date from DQT for trainee: #{trainee.id}",
-          )
-        end
+      if award_date
+        trainee.award_qts!(award_date)
+        Trainees::Update.call(trainee: trainee, update_dqt: false)
+      else
+        raise(
+          DqtNoAwardDateError,
+          "failed to retrieve award date from DQT for trainee: #{trainee.id}",
+        )
       end
     end
   end

--- a/spec/jobs/dqt/recommend_for_award_job_spec.rb
+++ b/spec/jobs/dqt/recommend_for_award_job_spec.rb
@@ -42,5 +42,18 @@ module Dqt
         }.to raise_error(DqtNoAwardDateError)
       end
     end
+
+    context "with a HESA trainee" do
+      let(:award_date) { Time.zone.today.iso8601 }
+
+      before do
+        allow(trainee).to receive(:hesa_record?).and_return(true)
+      end
+
+      it "sends the trainee to DQT" do
+        expect(RecommendForAward).to receive(:call)
+        described_class.perform_now(trainee)
+      end
+    end
   end
 end

--- a/spec/jobs/dqt/recommend_for_award_job_spec.rb
+++ b/spec/jobs/dqt/recommend_for_award_job_spec.rb
@@ -42,21 +42,5 @@ module Dqt
         }.to raise_error(DqtNoAwardDateError)
       end
     end
-
-    context "with a HESA trainee" do
-      before do
-        allow(trainee).to receive(:hesa_record?).and_return(true)
-      end
-
-      it "reports to Slack" do
-        expect(SlackNotifierService).to receive(:call).with(message: "Trainee id: #{trainee.id}, slug: #{trainee.slug} has been recommended for award but is a HESA trainee", username: "Register Trainee Teachers: Job Failure")
-        described_class.perform_now(trainee)
-      end
-
-      it "doesn't send the trainee to DQT" do
-        expect(RecommendForAward).not_to receive(:call)
-        described_class.perform_now(trainee)
-      end
-    end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/LvA4GAK4/5074-if-a-hesa-trainee-record-is-recommended-for-qts-in-support-we-should-allow-it-to-send-to-dqt

### Changes proposed in this pull request

- Remove the guard clause that stopped HESA trainees from being awarded on HESA

### Guidance to review

View of HESA trainee as a normal user, still no award button:

<img width="996" alt="Screenshot 2022-12-19 at 12 47 00" src="https://user-images.githubusercontent.com/18436946/208429884-5e3987b0-254f-449b-ac04-c4519f041774.png">

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml