### PR TITLE
[5063] Create report for performance profiles

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -4,6 +4,7 @@ class GuidanceController < ApplicationController
   skip_before_action :authenticate
 
   def show
+    @previous_academic_cycle_label = previous_academic_cycle.label
     render(layout: "application")
   end
 
@@ -25,7 +26,19 @@ class GuidanceController < ApplicationController
     render(layout: "application")
   end
 
+  def performance_profiles
+    @previous_academic_cycle_label = previous_academic_cycle.label
+    @academic_cycle_for_filter = previous_academic_cycle.start_year
+    @sign_off_deadline = Date.new(AcademicCycle.current.end_year, 1, 31).strftime("%d %B %Y")
+    @sign_off_url = Settings.sign_off_performance_profiles_url
+    render(layout: "application")
+  end
+
 private
+
+  def previous_academic_cycle
+    @previous_academic_cycle ||= AcademicCycle.previous
+  end
 
   def valid_tabs
     %w[course_details database_only funding schools trainee_progress personal_details]

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -14,9 +14,8 @@ class ReportsController < BaseTraineeController
 
     respond_to do |format|
       format.html do
-        @current_academic_cycle_start_year = AcademicCycle.current.start_year
         @sign_off_url = Settings.sign_off_trainee_data_url
-        @census_date = census_date(@current_academic_cycle_start_year).strftime("%d %B %Y")
+        @census_date = census_date(current_academic_cycle_start_year).strftime("%d %B %Y")
       end
       format.csv do
         authorize(:trainee, :export?)
@@ -34,7 +33,7 @@ class ReportsController < BaseTraineeController
 
     respond_to do |format|
       format.html do
-        @sign_off_date = Date.new(AcademicCycle.current.end_year, 1, 31).strftime("%d %B %Y")
+        @sign_off_date = Date.new(current_academic_cycle.end_year, 1, 31).strftime("%d %B %Y")
       end
       format.csv do
         authorize(:trainee, :export?)
@@ -50,15 +49,15 @@ class ReportsController < BaseTraineeController
 private
 
   def itt_new_starter_trainees
-    policy_scope(FindNewStarterTrainees.new(census_date(AcademicCycle.current.start_year)).call)
+    policy_scope(FindNewStarterTrainees.new(census_date(current_academic_cycle_start_year)).call)
   end
 
   def performance_profiles_trainees
-    policy_scope(FindNewStarterTrainees.new(census_date(AcademicCycle.current.start_year)).call)
+    policy_scope(FindNewStarterTrainees.new(census_date(current_academic_cycle_start_year)).call)
   end
 
   def itt_new_starter_filename
-    "#{Time.zone.now.strftime('%F_%H_%M_%S')}_New-trainees-#{AcademicCycle.current.label.parameterize}-#{AcademicCycle.current.end_year}-sign-off-Register-trainee-teachers_exported_records.csv"
+    "#{Time.zone.now.strftime('%F_%H_%M_%S')}_New-trainees-#{current_academic_cycle_start_year}-#{current_academic_cycle.end_year}-sign-off-Register-trainee-teachers_exported_records.csv"
   end
 
   def performance_profiles_filename
@@ -70,7 +69,19 @@ private
   end
 
   def set_year_labels
-    @current_academic_cycle_label = AcademicCycle.current.label
-    @previous_academic_cycle_label = AcademicCycle.previous.label
+    @current_academic_cycle_label = current_academic_cycle.label
+    @previous_academic_cycle_label = previous_academic_cycle.label
+  end
+
+  def current_academic_cycle
+    @current_academic_cycle ||= AcademicCycle.current
+  end
+
+  def current_academic_cycle_start_year
+    @current_academic_cycle_start_year ||= current_academic_cycle.start_year
+  end
+
+  def previous_academic_cycle
+    @previous_academic_cycle ||= AcademicCycle.previous
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -3,7 +3,7 @@
 class ReportsController < BaseTraineeController
   include DateOfTheNthWeekdayHelper
 
-  before_action :set_year_labels
+  before_action :set_cycle_variables
 
   def index
     authorize(current_user, :reports?)
@@ -15,8 +15,9 @@ class ReportsController < BaseTraineeController
     respond_to do |format|
       format.html do
         @sign_off_url = Settings.sign_off_trainee_data_url
-        @census_date = census_date(current_academic_cycle_start_year).strftime("%d %B %Y")
+        @census_date = census_date(@current_academic_cycle.start_year).strftime("%d %B %Y")
       end
+
       format.csv do
         authorize(:trainee, :export?)
         send_data(
@@ -33,8 +34,9 @@ class ReportsController < BaseTraineeController
 
     respond_to do |format|
       format.html do
-        @sign_off_date = Date.new(current_academic_cycle.end_year, 1, 31).strftime("%d %B %Y")
+        @sign_off_date = Date.new(@current_academic_cycle.end_year, 1, 31).strftime("%d %B %Y")
       end
+
       format.csv do
         authorize(:trainee, :export?)
         send_data(
@@ -49,39 +51,33 @@ class ReportsController < BaseTraineeController
 private
 
   def itt_new_starter_trainees
-    policy_scope(FindNewStarterTrainees.new(census_date(current_academic_cycle_start_year)).call)
+    policy_scope(FindNewStarterTrainees.new(census_date(@current_academic_cycle.start_year)).call)
   end
 
   def performance_profiles_trainees
-    policy_scope(FindNewStarterTrainees.new(census_date(current_academic_cycle_start_year)).call)
+    Trainees::Filter.call(trainees: base_trainee_scope, filters: { academic_year: [@previous_academic_cycle.start_year] })
   end
 
   def itt_new_starter_filename
-    "#{Time.zone.now.strftime('%F_%H_%M_%S')}_New-trainees-#{current_academic_cycle_start_year}-#{current_academic_cycle.end_year}-sign-off-Register-trainee-teachers_exported_records.csv"
+    "#{Time.zone.now.strftime('%F_%H_%M_%S')}_New-trainees-#{@current_academic_cycle.label('-')}-sign-off-Register-trainee-teachers_exported_records.csv"
   end
 
   def performance_profiles_filename
-    "#{Time.zone.now.strftime('%F_%H_%M_%S')}_Performance-profiles-sign-off-Register-trainee-teachers_exported_records.csv"
+    "#{Time.zone.now.strftime('%F_%H_%M_%S')}_#{@previous_academic_cycle.label('-')}_trainees_performance-profiles-sign-off_register-trainee-teachers.csv"
   end
 
   def census_date(year)
     date_of_nth_weekday(10, year, 3, 2)
   end
 
-  def set_year_labels
-    @current_academic_cycle_label = current_academic_cycle.label
-    @previous_academic_cycle_label = previous_academic_cycle.label
+  def set_cycle_variables
+    @current_academic_cycle = AcademicCycle.current
+    @previous_academic_cycle = AcademicCycle.previous
+    @current_academic_cycle_label = @current_academic_cycle.label
+    @previous_academic_cycle_label = @previous_academic_cycle.label
   end
 
-  def current_academic_cycle
-    @current_academic_cycle ||= AcademicCycle.current
-  end
-
-  def current_academic_cycle_start_year
-    @current_academic_cycle_start_year ||= current_academic_cycle.start_year
-  end
-
-  def previous_academic_cycle
-    @previous_academic_cycle ||= AcademicCycle.previous
+  def base_trainee_scope
+    policy_scope(Trainee.includes({ provider: [:courses] }, :start_academic_cycle, :end_academic_cycle).not_draft)
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -35,6 +35,7 @@ class ReportsController < BaseTraineeController
     respond_to do |format|
       format.html do
         @sign_off_date = Date.new(@current_academic_cycle.end_year, 1, 31).strftime("%d %B %Y")
+        @sign_off_url = Settings.sign_off_performance_profiles_url
       end
 
       format.csv do

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -3,6 +3,8 @@
 class ReportsController < BaseTraineeController
   include DateOfTheNthWeekdayHelper
 
+  before_action :set_year_labels
+
   def index
     authorize(current_user, :reports?)
   end
@@ -12,7 +14,6 @@ class ReportsController < BaseTraineeController
 
     respond_to do |format|
       format.html do
-        @current_academic_cycle_label = AcademicCycle.current.label
         @current_academic_cycle_start_year = AcademicCycle.current.start_year
         @sign_off_url = Settings.sign_off_trainee_data_url
         @census_date = census_date(@current_academic_cycle_start_year).strftime("%d %B %Y")
@@ -64,5 +65,10 @@ private
 
   def census_date(year)
     date_of_nth_weekday(10, year, 3, 2)
+  end
+
+  def set_year_labels
+    @current_academic_cycle_label = AcademicCycle.current.label
+    @previous_academic_cycle_label = AcademicCycle.previous.label
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -33,7 +33,9 @@ class ReportsController < BaseTraineeController
     authorize(current_user, :reports?)
 
     respond_to do |format|
-      format.html
+      format.html do
+        @sign_off_date = Date.new(AcademicCycle.current.end_year, 1, 31).strftime("%d %B %Y")
+      end
       format.csv do
         authorize(:trainee, :export?)
         send_data(

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -61,7 +61,7 @@ private
   end
 
   def trainee_search_scope
-    Trainee.includes({ provider: [:courses] }, :start_academic_cycle, :end_academic_cycle).where.not(state: "draft")
+    Trainee.includes({ provider: [:courses] }, :start_academic_cycle, :end_academic_cycle).not_draft
   end
 
   def export_results_path

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -7,6 +7,7 @@ module NavigationHelper
     {
       drafts: -> { trainee&.draft? && segment == "drafts" },
       trainees: -> { url.include?("/#{segment}") && !trainee&.draft? },
+      reports: -> { url.include?("reports") },
       funding: -> { ["/funding/monthly-payments", "/funding/trainee-summary"].include?(url) },
     }[segment.to_sym].call
   end

--- a/app/models/academic_cycle.rb
+++ b/app/models/academic_cycle.rb
@@ -51,8 +51,8 @@ class AcademicCycle < ApplicationRecord
     end_date.year
   end
 
-  def label
-    "#{start_year} to #{start_year + 1}"
+  def label(text = " to ")
+    "#{start_year}#{text}#{start_year + 1}"
   end
 
   def current?

--- a/app/views/guidance/performance_profiles.html.erb
+++ b/app/views/guidance/performance_profiles.html.erb
@@ -1,0 +1,81 @@
+<%= render PageTitle::View.new(text: "Sign off your list of trainees from #{@previous_academic_cycle_label} for the performance profiles publication") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "How to use this service",
+    href: guidance_path,
+    ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">
+      Sign off your list of trainees from <%= @previous_academic_cycle_label %> for the performance profiles publication
+    </h1>
+    <p class="govuk-body">
+      You need to sign off your list of trainee teachers from the
+      <%= @previous_academic_cycle_label %> academic year by
+      <%= @sign_off_deadline %> at 11:59pm.
+    </p>
+    <p class="govuk-body">
+      This is so that the data can be included in the annual initial teacher
+      training performance profiles publication. This will be published on
+      GOV.UK.
+    </p>
+
+    <h2 class="govuk-heading-m">Find your trainee data</h2>
+    <p class="govuk-body">
+      You need a list of all registered trainees who studied in the
+      <%= @previous_academic_cycle_label %> academic year. You can get this by
+      either:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        downloading a
+        <a href=<%= performance_profiles_reports_path %> class="govuk-link">report with the data you need to check</a>
+      </li>
+      <li>
+        exporting a
+        <a href=<%= trainees_path(academic_year: [@academic_cycle_for_filter]) %> class="govuk-link">list of registered trainees filtered to show the <%= @previous_academic_cycle_label %> academic year</a>
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-m">Check your trainee data</h2>
+    <p class="govuk-body">
+      Check that all your <%= @previous_academic_cycle_label %> trainees are
+      listed. For each trainee you should check:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>course details</li>
+      <li>status</li>
+      <li>the date they were awarded qualified teacher status (QTS) or early years teacher status (EYTS), or deferred or withdrew from the course - unless they're still studying</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">Fix mistakes in your trainee data</h2>
+    <p class="govuk-body">You need to fix any mistakes before you sign off the data.</p>
+    <p class="govuk-body">
+      If the trainee is shown in this service as awarded or withdrawn, you should email
+      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@digital.education.gov.uk</a>.
+    </p>
+    <p class="govuk-body">If the trainee is shown in this service as actively training or deferred, you should make the change:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>in this service if your organisation is a provider of school-centred initial teacher training (SCITT)</li>
+      <li>through the Higher Education Statistics Agency (HESA) if your organisation is a higher education institution (HEI) and the trainee was registered through HESA</li>
+      <li>in this service if your organisation is an HEI and the trainee was not registered through HESA</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">Sign off your trainee data</h2>
+    <p class="govuk-body">
+      A senior person from your organisation must
+      <a href=<%= @sign_off_url %> class="govuk-link" rel="noreferrer noopener" target="_blank">complete a form to sign off
+      the data (opens in a new tab)</a>. This should not be the same person who entered the data.
+    </p>
+
+    <h2 class="govuk-heading-m">How your trainee data will be used</h2>
+    <p class="govuk-body">
+      Read the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-performance-profiles-methodology" class="govuk-link" rel="noreferrer noopener" target="_blank">ITT performance profiles methodology (opens in a new tab)</a> to find out how your trainee data will be used.
+    </p>
+    <p class="govuk-body">Some trainees will not be included in the ITT performance profiles publication. For example, trainees who withdrew within 90 days of the course start will not be included.</p>
+  </div>
+  </div>
+</div>

--- a/app/views/guidance/show.html.erb
+++ b/app/views/guidance/show.html.erb
@@ -23,6 +23,10 @@
               dates_and_deadlines_guidance_path,
             )%>
           </li>
+        </ul>
+
+        <h2 class="govuk-heading-m">Registering trainees</h2>
+        <ul class="govuk-list govuk-list--spaced">
           <li>
             <%= govuk_link_to(
               "Registering trainees manually in this service",
@@ -41,6 +45,21 @@
               registering_trainees_through_hesa_guidance_path,
             )%>
           </li>
+        </ul>
+
+        <h2 class="govuk-heading-m">Signing off data</h2>
+        <ul class="govuk-list govuk-list--spaced">
+          <li>
+            <%= govuk_link_to(
+              "Sign off your list of trainees from #{@previous_academic_cycle_label} for the performance profiles publication",
+              performance_profiles_guidance_path,
+              )%>
+          </li>
+        </ul>
+
+
+        <h2 class="govuk-heading-m">Understanding data</h2>
+        <ul class="govuk-list govuk-list--spaced">
           <li>
             <%= govuk_link_to(
               "Check the data mapping between HESA and Register trainee teachers",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
           { name: "Home", url: root_path },
           ({ name: "Draft trainees", url: drafts_path, current: active_link_for("drafts", @trainee) } if can_view_drafts?),
           { name: "Registered trainees", url: trainees_path, current: active_link_for("trainees", @trainee) },
-          ({ name: "Reports", url: reports_path } if can_view_reports?),
+          ({ name: "Reports", url: reports_path, current: active_link_for("reports") } if can_view_reports?),
           ({ name: "Funding", url: funding_payment_schedule_path, current: active_link_for("funding") } if can_view_funding?),
           ({ name: current_user.organisation.name, url: organisations_path, align_right: true } if show_organisation_link?),
         ],

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -10,5 +10,10 @@
       <%= govuk_link_to "Export new trainee data for the 2022 to 2023 academic year for sign off", itt_new_starter_data_sign_off_reports_path %>
     </p>
   </li>
+  <li>
+    <p>
+      <%= govuk_link_to "Export trainee data for the 2021 to 2022 academic year for performance profiles sign off", performance_profiles_reports_path %>
+    </p>
+  </li>
 </ul>
 

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -7,12 +7,12 @@
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <p>
-      <%= govuk_link_to "Export new trainee data for the #{@current_academic_cycle_label} academic year for sign off", itt_new_starter_data_sign_off_reports_path %>
+      <%= govuk_link_to "Export new trainee data for the #{@current_academic_cycle_label} academic year for sign off", itt_new_starter_data_sign_off_reports_path, class: "new-trainee-data" %>
     </p>
   </li>
   <li>
     <p>
-      <%= govuk_link_to "Export trainee data for the #{@previous_academic_cycle_label} academic year for performance profiles sign off", performance_profiles_reports_path %>
+      <%= govuk_link_to "Export trainee data for the #{@previous_academic_cycle_label} academic year for performance profiles sign off", performance_profiles_reports_path, class: "performance-profiles" %>
     </p>
   </li>
 </ul>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -7,12 +7,12 @@
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <p>
-      <%= govuk_link_to "Export new trainee data for the 2022 to 2023 academic year for sign off", itt_new_starter_data_sign_off_reports_path %>
+      <%= govuk_link_to "Export new trainee data for the #{@current_academic_cycle_label} academic year for sign off", itt_new_starter_data_sign_off_reports_path %>
     </p>
   </li>
   <li>
     <p>
-      <%= govuk_link_to "Export trainee data for the 2021 to 2022 academic year for performance profiles sign off", performance_profiles_reports_path %>
+      <%= govuk_link_to "Export trainee data for the #{@previous_academic_cycle_label} academic year for performance profiles sign off", performance_profiles_reports_path %>
     </p>
   </li>
 </ul>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,19 +1,29 @@
 <%= render PageTitle::View.new(text: "Reports") %>
 
-<h1 class="govuk-heading-l">
-    Reports
-</h1>
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: "Home", href: root_path) %>
+<% end %>
 
-<ul class="govuk-list govuk-list--spaced">
-  <li>
-    <p>
-      <%= govuk_link_to "Export new trainee data for the #{@current_academic_cycle_label} academic year for sign off", itt_new_starter_data_sign_off_reports_path, class: "new-trainee-data" %>
-    </p>
-  </li>
-  <li>
-    <p>
-      <%= govuk_link_to "Export trainee data for the #{@previous_academic_cycle_label} academic year for performance profiles sign off", performance_profiles_reports_path, class: "performance-profiles" %>
-    </p>
-  </li>
-</ul>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop" >
 
+    <h1 class="govuk-heading-l">
+        Reports
+    </h1>
+
+    <ul class="govuk-list govuk-list--spaced">
+      <li>
+        <p>
+          <%= govuk_link_to "New trainees for the #{@current_academic_cycle_label} academic year", itt_new_starter_data_sign_off_reports_path, class: "new-trainee-data" %>
+          - for census sign off
+        </p>
+      </li>
+      <li>
+        <p>
+          <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year", performance_profiles_reports_path, class: "performance-profiles" %>
+          - for performance profiles sign off
+        </p>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/reports/itt_new_starter_data_sign_off.html.erb
+++ b/app/views/reports/itt_new_starter_data_sign_off.html.erb
@@ -3,13 +3,13 @@
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: t("back"),
-    href: root_path,
+    href: reports_path,
     ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-  <h1 class="govuk-heading-l">Export new trainee data for sign off for the <%= @current_academic_cycle_label %> academic year</h1>
+    <h1 class="govuk-heading-l">Export new trainee data for sign off for the <%= @current_academic_cycle_label %> academic year</h1>
     <p class="govuk-body">This export will show the new trainee data you’ve provided to the DfE for trainees who’ve started their initial teacher training (ITT) in the <%= @current_academic_cycle_label %> academic year, and have a trainee start date on or before the second Wednesday of October <%= @current_academic_cycle_start_year %> (sometimes called the census date).</p>
     <div class="govuk-inset-text">For the <%= @current_academic_cycle_label %> academic year, the ITT census date is
       <p class="no-wrap"> Wednesday <%= @census_date %>.</p>

--- a/app/views/reports/itt_new_starter_data_sign_off.html.erb
+++ b/app/views/reports/itt_new_starter_data_sign_off.html.erb
@@ -1,8 +1,8 @@
-<%= render PageTitle::View.new(text: "Export new trainee data for sign off for the 2022 to 2023 academic year") %>
+<%= render PageTitle::View.new(text: "Export new trainee data for sign off for the #{@current_academic_cycle_label} academic year") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
-    text: t("back"),
+    text: "Reports",
     href: reports_path,
     ) %>
 <% end %>

--- a/app/views/reports/itt_new_starter_data_sign_off.html.erb
+++ b/app/views/reports/itt_new_starter_data_sign_off.html.erb
@@ -38,6 +38,6 @@
       </li>
     </ul>
     <p class="govuk-body">If a trainee does not have a trainee start date, they will also be included in this export.</p>
-    <%= govuk_link_to "Export new trainee data (CSV)", itt_new_starter_data_sign_off_reports_path(:csv), class: "govuk-button" %>
+    <%= govuk_link_to "Export new trainee data", itt_new_starter_data_sign_off_reports_path(:csv), class: "govuk-button" %>
   </div>
 </div>

--- a/app/views/reports/performance_profiles.html.erb
+++ b/app/views/reports/performance_profiles.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: "Export trainee data for the #{@previous_academic_cycle_label} academic year for performance profiles sign off") %>
+<%= render PageTitle::View.new(text: "Trainees who studied in the #{@previous_academic_cycle_label} academic") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
@@ -13,15 +13,15 @@
       Trainees who studied in the <%= @previous_academic_cycle_label %> academic year
     </h1>
     <p class="govuk-body">
-      You can use this report to help you sign off your data for the initial
-      teacher training (ITT) performance profiles publication.
+      Use this report to help you sign off your data for the initial teacher
+      training performance profiles publication.
     </p>
+
+    <h2 class="govuk-heading-m">
+      Which trainees are included in this report
+    </h2>
     <p class="govuk-body">
-      You must check it, fix any mistakes and sign it off by 4pm on
-      <%= @sign_off_date %>.
-    </p>
-    <p class="govuk-body">
-      This export includes all trainees who:
+      This report includes all trainees who:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
@@ -33,99 +33,15 @@
     </ul>
 
     <h2 class="govuk-heading-m">
-      Check your trainee data
+      How to use this report
     </h2>
     <p class="govuk-body">
-      You need to check that:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        all your <%= @previous_academic_cycle_label %> trainees are listed, including any who deferred or
-        withdrew from the course
-      </li>
-      <li>
-        the number of trainees awarded qualified teacher status (QTS) or early
-        years teacher status (EYTS) is accurate
-      </li>
-    </ul>
-    <p class="govuk-body">
-      For each trainee you need to check:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        course details
-      </li>
-      <li>
-        status
-      </li>
-      <li>
-        the date they were awarded QTS, deferred or withdrew from the course,
-        unless they are still studying
-      </li>
-    </ul>
-
-    <h2 class="govuk-heading-m">
-      Fix mistakes
-    </h2>
-    <p class="govuk-body">
-      If the trainee has been awarded or withdrawn, email
-      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Accessibility%20issues%20">becomingateacher@digital.education.gov.uk</a>
-      .
+      You can read about
+      <a href=<%= performance_profiles_guidance_path %> class="govuk-link">how to check, fix and sign off your data</a>.
     </p>
     <p class="govuk-body">
-      If a trainee is still studying or has deferred, how you fix a mistake
-      depends on whether you registered the trainee using HESA or this service.
+      You must sign off your data by <%= @sign_off_date %> at 11:59pm.
     </p>
-
-    <h3 class="govuk-heading-s">
-      Trainees registered using HESA
-    </h3>
-    <p class="govuk-body">
-      TBD
-    </p>
-
-    <h3 class="govuk-heading-s">
-      Trainees registered using this service
-    </h3>
-    <p class="govuk-body">
-      If the trainee is still studying or has deferred, you should update their
-      details with the correct information.
-    </p>
-
-    <h2 class="govuk-heading-m">
-      Sign off your trainee data
-    </h2>
-    <p class="govuk-body">
-      Once you’ve checked your data, a senior person from your organisation
-      should sign it off
-      <a href=<%=@sign_off_url %> class="govuk-link" rel="noreferrer noopener" target="_blank">using this form (opens in a new tab)</a>
-      .
-    </p>
-    <p class="govuk-body">
-      You must sign off your data on or before <%= @sign_off_date %>.
-    </p>
-    <p class="govuk-body">
-      If you do not do this then your trainees may be excluded from the ITT
-      performance profiles publication.
-    </p>
-
-    <h2 class="govuk-heading-m">
-      How will trainee data be used in the ITT performance profiles publication
-    </h2>
-    <p class="govuk-body">
-      Some trainees listed in this export will not be included in the ITT
-      performance profiles publication. For example, trainees who withdrew
-      within 90 days of the course start will not be included.
-    </p>
-    <p class="govuk-body">
-      To find out how the data will be used, read the
-      <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-performance-profiles-methodology" class="govuk-link" rel="noreferrer noopener" target="_blank">Initial Teacher Training performance profiles methodology (opens in a new tab)</a>
-      .
-    </p>
-    <p class="govuk-body">
-      You need to check and sign off all the trainee data in the export.
-    </p>
-
-    <%= govuk_link_to "Export new trainee data (CSV)", performance_profiles_reports_path(:csv), class: "govuk-button" %>
+    <%= govuk_link_to "Export trainee data", performance_profiles_reports_path(:csv), class: "govuk-button" %>
   </div>
 </div>

--- a/app/views/reports/performance_profiles.html.erb
+++ b/app/views/reports/performance_profiles.html.erb
@@ -68,7 +68,7 @@
       Fix mistakes
     </h2>
     <p class="govuk-body">
-      If the trainee has beed awarded or withdrawn, email
+      If the trainee has been awarded or withdrawn, email
       <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Accessibility%20issues%20">becomingateacher@digital.education.gov.uk</a>
       .
     </p>

--- a/app/views/reports/performance_profiles.html.erb
+++ b/app/views/reports/performance_profiles.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: "Export trainee data for the 2021 to 2022 academic year for performance profiles sign off") %>
+<%= render PageTitle::View.new(text: "Export trainee data for the #{@previous_academic_cycle_label} academic year for performance profiles sign off") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">
-      Trainees who studied in the 2021 to 2022 academic year
+      Trainees who studied in the <%= @previous_academic_cycle_label %> academic year
     </h1>
     <p class="govuk-body">
       You can use this report to help you sign off your data for the initial
@@ -28,7 +28,7 @@
         have been registered with the Department for Education
       </li>
       <li>
-        studied in the 2021 to 2022 academic year
+        studied in the <%= @previous_academic_cycle_label %> academic year
       </li>
     </ul>
 
@@ -40,7 +40,7 @@
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        all your 2020 to 2021 trainees are listed, including any who deferred or
+        all your <%= @previous_academic_cycle_label %> trainees are listed, including any who deferred or
         withdrew from the course
       </li>
       <li>

--- a/app/views/reports/performance_profiles.html.erb
+++ b/app/views/reports/performance_profiles.html.erb
@@ -18,7 +18,7 @@
     </p>
     <p class="govuk-body">
       You must check it, fix any mistakes and sign it off by 4pm on
-      31 January 2023.
+      <%= @sign_off_date %>.
     </p>
     <p class="govuk-body">
       This export includes all trainees who:
@@ -102,7 +102,7 @@
       .
     </p>
     <p class="govuk-body">
-      You must sign off your data on or before 31 January 2023.
+      You must sign off your data on or before <%= @sign_off_date %>.
     </p>
     <p class="govuk-body">
       If you do not do this then your trainees may be excluded from the ITT

--- a/app/views/reports/performance_profiles.html.erb
+++ b/app/views/reports/performance_profiles.html.erb
@@ -98,7 +98,7 @@
     <p class="govuk-body">
       Once you’ve checked your data, a senior person from your organisation
       should sign it off
-      <a href="#" class="govuk-link">using this form (opens in a new tab)</a>
+      <a href=<%=@sign_off_url %> class="govuk-link" rel="noreferrer noopener" target="_blank">using this form (opens in a new tab)</a>
       .
     </p>
     <p class="govuk-body">

--- a/app/views/reports/performance_profiles.html.erb
+++ b/app/views/reports/performance_profiles.html.erb
@@ -110,7 +110,7 @@
     </p>
 
     <h2 class="govuk-heading-m">
-      How will trainee data by used in the ITT performance profiles publication
+      How will trainee data be used in the ITT performance profiles publication
     </h2>
     <p class="govuk-body">
       Some trainees listed in this export will not be included in the ITT

--- a/app/views/reports/performance_profiles.html.erb
+++ b/app/views/reports/performance_profiles.html.erb
@@ -1,0 +1,131 @@
+<%= render PageTitle::View.new(text: "Export trainee data for the 2021 to 2022 academic year for performance profiles sign off") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Reports",
+    href: reports_path,
+    ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">
+      Trainees who studied in the 2021 to 2022 academic year
+    </h1>
+    <p class="govuk-body">
+      You can use this report to help you sign off your data for the initial
+      teacher training (ITT) performance profiles publication.
+    </p>
+    <p class="govuk-body">
+      You must check it, fix any mistakes and sign it off by 4pm on
+      31 January 2023.
+    </p>
+    <p class="govuk-body">
+      This export includes all trainees who:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        have been registered with the Department for Education
+      </li>
+      <li>
+        studied in the 2021 to 2022 academic year
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-m">
+      Check your trainee data
+    </h2>
+    <p class="govuk-body">
+      You need to check that:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        all your 2020 to 2021 trainees are listed, including any who deferred or
+        withdrew from the course
+      </li>
+      <li>
+        the number of trainees awarded qualified teacher status (QTS) or early
+        years teacher status (EYTS) is accurate
+      </li>
+    </ul>
+    <p class="govuk-body">
+      For each trainee you need to check:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        course details
+      </li>
+      <li>
+        status
+      </li>
+      <li>
+        the date they were awarded QTS, deferred or withdrew from the course,
+        unless they are still studying
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-m">
+      Fix mistakes
+    </h2>
+    <p class="govuk-body">
+      If the trainee has beed awarded or withdrawn, email
+      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Accessibility%20issues%20">becomingateacher@digital.education.gov.uk</a>
+      .
+    </p>
+    <p class="govuk-body">
+      If a trainee is still studying or has deferred, how you fix a mistake
+      depends on whether you registered the trainee using HESA or this service.
+    </p>
+
+    <h3 class="govuk-heading-s">
+      Trainees registered using HESA
+    </h3>
+    <p class="govuk-body">
+      TBD
+    </p>
+
+    <h3 class="govuk-heading-s">
+      Trainees registered using this service
+    </h3>
+    <p class="govuk-body">
+      If the trainee is still studying or has deferred, you should update their
+      details with the correct information.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      Sign off your trainee data
+    </h2>
+    <p class="govuk-body">
+      Once you’ve checked your data, a senior person from your organisation
+      should sign it off
+      <a href="#" class="govuk-link">using this form (opens in a new tab)</a>
+      .
+    </p>
+    <p class="govuk-body">
+      You must sign off your data on or before 31 January 2023.
+    </p>
+    <p class="govuk-body">
+      If you do not do this then your trainees may be excluded from the ITT
+      performance profiles publication.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      How will trainee data by used in the ITT performance profiles publication
+    </h2>
+    <p class="govuk-body">
+      Some trainees listed in this export will not be included in the ITT
+      performance profiles publication. For example, trainees who withdrew
+      within 90 days of the course start will not be included.
+    </p>
+    <p class="govuk-body">
+      To find out how the data will be used, read the
+      <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-performance-profiles-methodology" class="govuk-link" rel="noreferrer noopener" target="_blank">Initial Teacher Training performance profiles methodology (opens in a new tab)</a>
+      .
+    </p>
+    <p class="govuk-body">
+      You need to check and sign off all the trainee data in the export.
+    </p>
+
+    <%= govuk_link_to "Export new trainee data (CSV)", performance_profiles_reports_path(:csv), class: "govuk-button" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
 
   resources :reports, only: :index do
     get "itt-new-starter-data-sign-off", to: "reports#itt_new_starter_data_sign_off", on: :collection
+    get "performance-profiles", to: "reports#performance_profiles", on: :collection
   end
 
   resources :trainees, except: :edit do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,7 @@ Rails.application.routes.draw do
     get "/registering-trainees-through-hesa", to: "guidance#registering_trainees_through_hesa"
     get "/check-data", to: "guidance#check_data"
     get "/hesa-register-data-mapping/:tab", to: "guidance#hesa_register_data_mapping", as: "hesa_register_data_mapping"
+    get "/performance-profiles", to: "guidance#performance_profiles"
   end
 
   if FeatureService.enabled?("funding")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -154,6 +154,7 @@ google:
     table_name: events
 
 sign_off_trainee_data_url: https://example.com/trainee-data-sign-off
+sign_off_performance_profiles_url: https://forms.gle/AtAvteRTKJu3mbXS7
 
 trainee_export:
   record_limit: 100

--- a/spec/controllers/guidance_controller_spec.rb
+++ b/spec/controllers/guidance_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 describe GuidanceController do
+  before { create(:academic_cycle, previous_cycle: true) }
+
   describe "#show" do
     it "returns a 200 status code" do
       get :show

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -6,6 +6,8 @@ describe ReportsController do
   let(:user) { build_current_user }
 
   before do
+    create(:academic_cycle, previous_cycle: true)
+    create(:academic_cycle, :current)
     allow(controller).to receive(:current_user).and_return(user)
   end
 
@@ -22,10 +24,6 @@ describe ReportsController do
   end
 
   describe "#itt_new_starter_data_sign_off" do
-    before do
-      create(:academic_cycle, :current)
-    end
-
     it "returns a 200 status code" do
       get :itt_new_starter_data_sign_off
       expect(response).to have_http_status(:ok)
@@ -38,6 +36,23 @@ describe ReportsController do
 
     it "renders a csv" do
       get :itt_new_starter_data_sign_off, params: { format: :csv }
+      expect(response.content_type).to eq("text/csv")
+    end
+  end
+
+  describe "#performance_profiles" do
+    it "returns a 200 status code" do
+      get :performance_profiles
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the application template" do
+      get :performance_profiles
+      expect(response).to render_template("application")
+    end
+
+    it "renders a csv" do
+      get :performance_profiles, params: { format: :csv }
       expect(response.content_type).to eq("text/csv")
     end
   end

--- a/spec/features/reports/viewing_performance_profiles_spec.rb
+++ b/spec/features/reports/viewing_performance_profiles_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "viewing performance profiles" do
+  let!(:previous_cycle) { create(:academic_cycle, previous_cycle: true) }
+  let!(:current_cycle) { create(:academic_cycle, :current) }
+  let!(:trainee) { create(:trainee, :trn_received, start_academic_cycle: previous_cycle, end_academic_cycle: previous_cycle) }
+
+  background do
+    given_i_am_authenticated
+    given_i_am_on_the_reports_page
+    and_i_click_the_performance_profiles_link
+  end
+
+  scenario "shows the correct year" do
+    then_i_should_see_the_correct_performance_profiles_guidance
+  end
+
+private
+
+  def given_i_am_on_the_reports_page
+    reports_page.load
+  end
+
+  def and_i_click_the_performance_profiles_link
+    reports_page.performance_profiles_link.click
+  end
+
+  def then_i_should_see_the_correct_performance_profiles_guidance
+    expect(performance_profiles_page).to have_text(previous_cycle.label)
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -418,6 +418,14 @@ module Features
       @admin_uploads_show_page ||= PageObjects::SystemAdmin::Uploads::Show.new
     end
 
+    def reports_page
+      @reports_page ||= PageObjects::Reports::Index.new
+    end
+
+    def performance_profiles_page
+      @performance_profiles_page ||= PageObjects::Reports::PerformanceProfiles.new
+    end
+
   private
 
     def progress_with_prefix(status)

--- a/spec/support/page_objects/reports/index.rb
+++ b/spec/support/page_objects/reports/index.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Reports
+    class Index < PageObjects::Base
+      set_url "/reports"
+
+      element :performance_profiles_link, ".performance-profiles"
+    end
+  end
+end

--- a/spec/support/page_objects/reports/performance_profiles.rb
+++ b/spec/support/page_objects/reports/performance_profiles.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Reports
+    class PerformanceProfiles < PageObjects::Base
+      set_url "/reports/performance-profiles"
+
+      element :export_link, ".govuk-button", text: "Export new trainee data (CSV)"
+    end
+  end
+end

--- a/spec/support/page_objects/reports/performance_profiles.rb
+++ b/spec/support/page_objects/reports/performance_profiles.rb
@@ -5,7 +5,7 @@ module PageObjects
     class PerformanceProfiles < PageObjects::Base
       set_url "/reports/performance-profiles"
 
-      element :export_link, ".govuk-button", text: "Export new trainee data (CSV)"
+      element :export_link, ".govuk-button", text: "Export trainee data"
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/zx8ed8hy/5063-m-create-report-for-performance-profiles

### Changes proposed in this pull request

- Add link on reports index for performance profiles
- Add new page and content for performance profile sign off
- Use new academic cycles filter to return trainees for performance profiles export
- Add new guidance page
- Fixed active link 'Reports' in nav
- Made more dates dynamic

### Guidance to review

- Sign in as a provider
- Click on the reports tab
- Check the link to the performance profiles sign off
- Click through and review the content
- Download the CSV and check the data
- Navigate to guidance, check the new list format
- Click into performance profiles guidance, check the content

<img width="636" alt="Screenshot 2022-12-23 at 11 53 30" src="https://user-images.githubusercontent.com/18436946/209332087-0d0fffec-0ace-4c0c-9d65-9b97f2a6f445.png">

<img width="680" alt="Screenshot 2022-12-23 at 11 53 34" src="https://user-images.githubusercontent.com/18436946/209332108-92a9a2b5-d881-446f-b86c-ea3f0538a557.png">

<img width="701" alt="Screenshot 2022-12-23 at 11 53 24" src="https://user-images.githubusercontent.com/18436946/209332068-48f943b2-3efe-4640-a752-f992d04dabc3.png">

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml