### PR TITLE
[5062] Fix show funding payment schedule

### DIFF
--- a/app/controllers/funding/base_funding_controller.rb
+++ b/app/controllers/funding/base_funding_controller.rb
@@ -13,7 +13,7 @@ module Funding
     def payment_schedule
       return if payment_schedules.blank?
 
-      @payment_schedule ||= payment_schedules.order(:created_at).last
+      @payment_schedule ||= payment_schedules.order(:created_at).includes(rows: :amounts).select { |schedule| schedule.start_year == current_academic_cycle.start_year }.last
     end
 
     def payment_schedules

--- a/spec/features/funding/payment_schedule_spec.rb
+++ b/spec/features/funding/payment_schedule_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 feature "viewing the payment schedule" do
+  let(:next_academic_cycle) { build(:academic_cycle, start_date: Time.zone.yesterday + 1.year, end_date: Time.zone.tomorrow + 1.year) }
+
   background do
     given_i_am_authenticated
     and_funding_data_exists
@@ -19,6 +21,13 @@ feature "viewing the payment schedule" do
     given_i_am_on_the_funding_page
     and_i_export_the_results
     then_i_see_my_exported_data_in_csv_format
+  end
+
+  scenario "no payments this academic year" do
+    allow(AcademicCycle).to receive(:current).and_return(next_academic_cycle)
+
+    given_i_am_on_the_funding_page
+    then_i_should_see_a_message_to_say_there_are_no_payments
   end
 
 private
@@ -39,6 +48,10 @@ private
 
   def then_i_should_see_the_actual_payments
     expect(payment_schedule_page.payments_table.rows.size).to eq(3) # 1 row is the header
+  end
+
+  def then_i_should_see_a_message_to_say_there_are_no_payments
+    expect(payment_schedule_page).to have_text("There are no scheduled payments right now.")
   end
 
   def and_i_should_see_the_predicted_payments


### PR DESCRIPTION
### Context

The provider funding page always shows the `last` cycle of funding whether or not it is for the current academic year

### Changes proposed in this pull request

Scope the funding data to only include the current academic year

### Guidance to review

If you have seeded your local db lately then seed funding data will be for the current academic year. You can bump all funding to the previous year with the following console commands:

```ruby
Funding::PaymentScheduleRowAmount.where(year: 2022).update_all(year: 2021)
Funding::PaymentScheduleRowAmount.where(year: 2023).update_all(year: 2022)
```

Funding data should no longer be visible:

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/420873/208929375-fd40276d-d01d-4163-a461-db956ab39db6.png">


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
