### PR TITLE
Use hidden span rather than class to fix NVDA bug

### DIFF
--- a/app/views/funding/payment_schedules/_month_breakdown.html.erb
+++ b/app/views/funding/payment_schedules/_month_breakdown.html.erb
@@ -2,7 +2,7 @@
   <p class="govuk-body"><%= t('funding.payment_schedule.no_payments', month_and_year: month_breakdown.title) %></p>
 <%- else -%>
   <table class="govuk-table app-table__in-accordion govuk-!-margin-bottom-6">
-    <caption class="govuk-table__caption govuk-visually-hidden"><%= month_breakdown.title %> payments</caption>
+    <caption class="govuk-table__caption"><span class="govuk-visually-hidden"><%= month_breakdown.title %> payments</span></caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header app-table__column-50">Payment type</th>


### PR DESCRIPTION
### Context

From the cross government slack:

> Placing the visually-hidden class directly on the <caption> tag causes the NVDA screen reader to read the table with an incorrect number of rows.

The [bug appears to be in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=995888).

### Changes proposed in this pull request

Moves the visually hidden class to a span to avoid this bug. NB this may mildly affect the margins.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
