### PR TITLE
[5081] Add autocomplete to lead school admin index page

### DIFF
--- a/app/components/form_components/schools_autocomplete/script.js
+++ b/app/components/form_components/schools_autocomplete/script.js
@@ -92,8 +92,13 @@ const setupAutoComplete = (form) => {
         },
         templates: renderTemplate,
         onConfirm: (value) => {
-          tracker.sendTrackingEvent(value, fieldName)
-          setSchoolHiddenField(value)
+          if (value?.id && element.dataset.systemAdminRedirectLeadSchool) {
+            window.location.assign(`/system-admin/lead-schools/${value.id}`);
+          }
+          else {
+            tracker.sendTrackingEvent(value, fieldName)
+            setSchoolHiddenField(value)
+          }
         },
         tNoResults: () => statusMessage
       })

--- a/app/views/system_admin/lead_schools/index.html.erb
+++ b/app/views/system_admin/lead_schools/index.html.erb
@@ -4,6 +4,25 @@
 
 <%= render "system_admin/tab_nav" %>
 
+<%= register_form_with url: lead_schools_path,
+                       local: true,
+                       method: :get,
+                       html: { data: { module: "app-schools-autocomplete" } } do |f| %>
+  <%= f.hidden_field :lead_school_id, id: "school-id" %>
+  <%= f.govuk_text_field(
+    :query,
+    form_group: { class: "govuk-form-group app-js-only" },
+    label: { text: "Search for a lead school", size: "s" },
+    hint: { text: "Search for a school by its unique reference number (URN), name or postcode" },
+    value: params[:query],
+    "data-field" => "schools-autocomplete",
+    width: "three-quarters",
+  )%>
+  <div id="schools-autocomplete-element" class="govuk-!-width-three-quarters" data-only-lead-schools=true
+      data-system-admin-redirect-lead-school="true"
+      data-default-value="<%= params[:query] %>" data-field-name="system_admin_user_lead_schools_form[query]"></div>
+<% end %>
+
 <table class="govuk-table" summary="Lead schools list">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">


### PR DESCRIPTION
### Context

As a quick fix we want to add the autocomplete to the lead school index page in System Admin. This will enable the support team to find lead schools more easily.

There will be a future piece of work to build an autocomplete for all schools and consolidate the schools/lead schools lists into one index page. 

Currently I have not built the no-js equivalent as we hope to replace this with something nicer soon. If a user disables javascript, we hide the autocomplete.

### Changes proposed in this pull request

* Update `schools_autocomplete/script.js`
* Update index page to add new autocomplete

### Guidance to review

* Log in as an admin
* Navigate to the system-admin/lead-schools
* Observe autocomplete
* Use autocomplete to find a school by name, URN or postcode
* Select a school
* Observe you are taken to the show page for that school
* Double check that there aren't any non-lead schools in the list
* Double check that the existing autocompletes on system-admin/users/{user_id}/lead-schools/new and /trainees/{slug}/lead-schools/edit still work (and any others I might have missed)

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
- [ ] ~~Do we need to send any updates to DQT as part of the work in this PR?~~
- [ ] ~~Does this PR need an ADR?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
