### PR TITLE
[xxx] Fix Dqt::WithdrawTraineeJob

### DIFF
--- a/app/jobs/dqt/withdraw_trainee_job.rb
+++ b/app/jobs/dqt/withdraw_trainee_job.rb
@@ -15,8 +15,8 @@ module Dqt
       @trainee = trainee
       @timeout_after = timeout_after
 
-      if @timeout_after.nil?
-        @timeout_after = trainee.submitted_for_trn_at + Settings.jobs.max_poll_duration_days.days
+      if timeout_after.nil?
+        @timeout_after = Settings.jobs.max_poll_duration_days.days.from_now
         requeue
         return
       end
@@ -35,10 +35,6 @@ module Dqt
     attr_reader :trainee, :timeout_after
 
     def continue_waiting_for_trn?
-      if trainee.submitted_for_trn_at.nil?
-        raise(TraineeAttributeError, "Trainee#submitted_for_trn_at is nil - it should be timestamped (id: #{trainee.id})")
-      end
-
       Time.zone.now.utc < timeout_after
     end
 

--- a/spec/jobs/dqt/withdraw_trainee_job_spec.rb
+++ b/spec/jobs/dqt/withdraw_trainee_job_spec.rb
@@ -62,17 +62,6 @@ module Dqt
             expect(WithdrawTraineeJob).not_to have_been_enqueued
           end
         end
-
-        context "the trainee attribute submitted_for_trn_at is nil" do
-          let(:trainee) { create(:trainee, :submitted_for_trn, submitted_for_trn_at: nil) }
-          let(:error_msg) { "Trainee#submitted_for_trn_at is nil - it should be timestamped (id: #{trainee.id})" }
-
-          it "raises a TraineeAttributeError" do
-            expect {
-              described_class.perform_now(trainee, timeout_date)
-            }.to raise_error(WithdrawTraineeJob::TraineeAttributeError, error_msg)
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
### Context
Using `Trainee#submitted_for_trn_at` to calculate the timeout was not a good idea since it sometimes can be nil or it's too far in the past to be useful. This job can we kicked off anytime in the future, so we just need to terminate it after a number of days if unsuccessful.

### Changes proposed in this pull request
- Update `Dqt::WithdrawTraineeJob` to calculate the timeout without using `Trainee#submitted_for_trn_at` 

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
