### PR TITLE
Added news entry about academic year filter

### DIFF
--- a/db/service_updates.yml
+++ b/db/service_updates.yml
@@ -1,4 +1,4 @@
-- date: '2022-01-11'
+- date: '2023-01-11'
   title: Trainee list can now be filtered by academic year
   content: |
      You can now filter your list of registered trainees to show only those training in a specific academic year.

--- a/db/service_updates.yml
+++ b/db/service_updates.yml
@@ -1,3 +1,10 @@
+- date: '2022-01-11'
+  title: Trainee list can now be filtered by academic year
+  content: |
+     You can now filter your list of registered trainees to show only those training in a specific academic year.
+     
+     Exported lists of trainees now include academic years.
+
 - date: '2022-10-25'
   title: Sign off deadline extended to 1 November 2022
   content: |


### PR DESCRIPTION
### Context

I've added a news item about the new academic year filter.

### Changes proposed in this pull request

The news item tells users that: 

- they can now filter the trainee list by academic year
- academic years now appear in the trainee data export 