### PR TITLE
Remove course_award column that has been confusing users

### DIFF
--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -78,17 +78,6 @@ module Reports
       }[trainee.bursary_tier]
     end
 
-    def course_award
-      return if trainee.course_uuid.blank? || course&.summary.blank?
-
-      case trainee.study_mode
-      when "part_time"
-        course.summary.gsub(/(full time)/i, "part time")
-      when "full_time"
-        course.summary.gsub(/(part time)/i, "full time")
-      end
-    end
-
     def course_education_phase
       return EARLY_YEARS_ROUTE_NAME_PREFIX.humanize if trainee.early_years_route?
 

--- a/app/models/reports/trainees_report.rb
+++ b/app/models/reports/trainees_report.rb
@@ -65,7 +65,6 @@ module Reports
          itt_start_date
          expected_end_date
          course_duration_in_years
-         course_award
          trainee_start_date
          lead_school_name
          lead_school_urn
@@ -179,7 +178,6 @@ module Reports
         trainee_report.itt_start_date,
         trainee_report.expected_end_date,
         trainee_report.course_duration_in_years,
-        trainee_report.course_award,
         trainee_report.trainee_start_date,
         trainee_report.lead_school_name,
         trainee_report.lead_school_urn,

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -276,10 +276,6 @@ describe Reports::TraineeReport do
       expect(subject.course_duration_in_years).to eq(trainee.course_duration_in_years)
     end
 
-    it "includes the course_award" do
-      expect(subject.course_award).to end_with(trainee.study_mode.gsub("_", " "))
-    end
-
     it "includes the trainee_start_date" do
       expect(subject.trainee_start_date).to eq(trainee.trainee_start_date&.iso8601)
     end

--- a/spec/services/exports/export_trainees_service_spec.rb
+++ b/spec/services/exports/export_trainees_service_spec.rb
@@ -280,10 +280,6 @@ describe Exports::ExportTraineesService, type: :model do
         expect(trainee_csv_row["course_duration_in_years"]).to eq(trainee_report.course_duration_in_years.to_s)
       end
 
-      it "includes the course_award in the csv" do
-        expect(trainee_csv_row["course_award"]).to eq(trainee_report.course_award)
-      end
-
       it "includes the trainee_start_date in the csv" do
         expect(trainee_csv_row["trainee_start_date"]).to eq(trainee_report.trainee_start_date)
       end

--- a/spec/services/exports/export_trainees_to_file_service_spec.rb
+++ b/spec/services/exports/export_trainees_to_file_service_spec.rb
@@ -291,10 +291,6 @@ describe Exports::ExportTraineesToFileService, type: :model do
         expect(trainee_csv_row["course_duration_in_years"]).to eq(trainee_report.course_duration_in_years.to_s)
       end
 
-      it "includes the course_award in the csv" do
-        expect(trainee_csv_row["course_award"]).to eq(trainee_report.course_award)
-      end
-
       it "includes the trainee_start_date in the csv" do
         expect(trainee_csv_row["trainee_start_date"]).to eq(trainee_report.trainee_start_date)
       end


### PR DESCRIPTION
### Context

We've had multiple providers write in to support whilst doing their performance profiles sign off to tell us the value held in `course_award` as shown on the csv export is incorrect.

The value shown is the string text for `course_summary` that we get from Publish. It may be something like `PGCE with QTS full time`. The problem is that trainees may later drop the PGCE. The providers have then seen this in the column and ask us to remove the PGCE bit.

The column was originally added for completeness and to help providers identify courses. But in this situation it's causing concern where the publish course text doesn't match what the trainee is *now* doing. As a short term fix I think it better to just remove this from the export.

@ devs - please let me know if I've done this correctly. I just did a global search for `course_award` and deleted each bit I found.

We may decide to reinstate this in the future after performance profiles - but would probably want to rename it to be clearer if we do.