### PR TITLE
[5114] Fix: Trainees::MapStateFromHesa should not override an awarded trainee

### DIFF
--- a/app/services/trainees/map_state_from_hesa.rb
+++ b/app/services/trainees/map_state_from_hesa.rb
@@ -11,6 +11,7 @@ module Trainees
     end
 
     def call
+      return :awarded if trainee.awarded?
       return :deferred if trainee_dormant? && !withdrawn?
       # If the trainee has completed the course, but the result is unknown we
       # do not know enough to transition their state. If it's the first time

--- a/spec/services/trainees/map_state_from_hesa_spec.rb
+++ b/spec/services/trainees/map_state_from_hesa_spec.rb
@@ -12,13 +12,11 @@ module Trainees
     let(:hesa_mode_codes) { Hesa::CodeSets::Modes::MAPPING.invert }
     let(:hesa_trn) { Faker::Number.number(digits: 7) }
     let(:date_today) { Time.zone.today }
-    let(:register_trn) { nil }
-    let(:trainee) { double(persisted?: persisted, trn: register_trn) }
 
     subject { described_class.call(hesa_trainee:, trainee:) }
 
     context "when the trainee is new" do
-      let(:persisted) { false }
+      let(:trainee) { build(:trainee) }
 
       context "when the trainee has no 'reason for leaving'" do
         context "and has no TRN" do
@@ -99,7 +97,8 @@ module Trainees
     end
 
     context "when the trainee is persisted" do
-      let(:persisted) { true }
+      let(:register_trn) { nil }
+      let(:trainee) { create(:trainee, trn: register_trn) }
 
       context "when the trainee's reason for leaving is COMPLETED_WITH_CREDIT_OR_AWARD" do
         let(:hesa_stub_attributes) do
@@ -145,6 +144,12 @@ module Trainees
         end
 
         it { is_expected.to eq(:deferred) }
+      end
+
+      context "when a trainee has already been awarded QTS" do
+        let(:trainee) { create(:trainee, :awarded) }
+
+        it { is_expected.to eq(:awarded) }
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/llFG6p8g/5114-investigate-why-trainees-were-unawarded-on-register

`Trainees::MapStateFromHesa` had a bug whereby awarded trainees that got an update from HESA and the `reason_for_leaving` is empty would revert back to `trn_received` because the logic didn't check if the trainee was already awarded. The logic only returns `awarded` if `reason_for_leaving` meets certain values.

Essentially, we should never 'action' awards of QTS from HESA. We should only get that from DQT.

### Changes proposed in this pull request
-  Update `Trainees::MapStateFromHesa` to check if trainee is already awarded

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
