### PR TITLE
Add sign_in_method Setting

### DIFF
--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -17,7 +17,7 @@
     <% case Settings.features.sign_in_method %>
     <% when "otp" %>
       <%= govuk_button_to(t(".otp_sign_in_button"), otp_path, method: :get, class: "qa-otp_sign_in_button") %>
-    <% when "dfe" %>
+    <% when "dfe-sign-in" %>
       <%= govuk_button_to(t(".dfe_sign_in_button"), "/auth/dfe", class: "qa-sign_in_button") %>
     <% when "persona"%>
       <%= render GovukButtonLinkTo::View.new(body: t(".persona_sign_in_button"), url: "/personas", class_option: "qa-sign_in_button") %>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -14,14 +14,13 @@
 
     <p class="govuk-body-m"><%= t(".body") %></p>
 
-    <% if FeatureService.enabled?("use_dfe_sign_in") %>
-      <%= govuk_button_to(t(".dfe_sign_in_button"), "/auth/dfe", class: "qa-sign_in_button") %>
-    <% else %>
-      <%= render GovukButtonLinkTo::View.new(body: t(".persona_sign_in_button"), url: "/personas", class_option: "qa-sign_in_button") %>
-    <% end %>
-
-    <% if FeatureService.enabled?("use_otp_sign_in") %>
+    <% case Settings.features.sign_in_method %>
+    <% when "otp" %>
       <%= govuk_button_to(t(".otp_sign_in_button"), otp_path, method: :get, class: "qa-otp_sign_in_button") %>
+    <% when "dfe" %>
+      <%= govuk_button_to(t(".dfe_sign_in_button"), "/auth/dfe", class: "qa-sign_in_button") %>
+    <% when "persona"%>
+      <%= render GovukButtonLinkTo::View.new(body: t(".persona_sign_in_button"), url: "/personas", class_option: "qa-sign_in_button") %>
     <% end %>
   </div>
 </div>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,7 +3,7 @@
 require_relative "../../app/services/feature_service"
 
 case Settings.features.sign_in_method
-when "dfe"
+when "dfe-sign-in"
 
   OmniAuth.config.logger = Rails.logger
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../app/services/feature_service"
 
-if FeatureService.enabled?("use_dfe_sign_in")
+if Settings.features.sign_in_method == "dfe"
 
   OmniAuth.config.logger = Rails.logger
 
@@ -32,7 +32,7 @@ if FeatureService.enabled?("use_dfe_sign_in")
 
   Rails.application.config.middleware.use(OmniAuth::Strategies::OpenIDConnect, options)
 
-else
+elsif Settings.features.sign_in_method == "persona"
 
   Rails.application.config.middleware.use(OmniAuth::Builder) do
     provider :developer,

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,7 +2,8 @@
 
 require_relative "../../app/services/feature_service"
 
-if Settings.features.sign_in_method == "dfe"
+case Settings.features.sign_in_method
+when "dfe"
 
   OmniAuth.config.logger = Rails.logger
 
@@ -32,12 +33,12 @@ if Settings.features.sign_in_method == "dfe"
 
   Rails.application.config.middleware.use(OmniAuth::Strategies::OpenIDConnect, options)
 
-elsif Settings.features.sign_in_method == "persona"
+when "persona"
 
   Rails.application.config.middleware.use(OmniAuth::Builder) do
-    provider :developer,
+    provider(:developer,
              fields: %i[uid email first_name last_name],
-             uid_field: :uid
+             uid_field: :uid)
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,18 +43,17 @@ Rails.application.routes.draw do
 
   get "request-an-account", to: "request_an_account#index"
 
-  if FeatureService.enabled?("use_otp_sign_in")
-    resource :otp, only: %i[show create], controller: :otp, path: "request-sign-in-code"
-    resource :otp_verifications, only: %i[show create], path: "sign-in-code"
-  end
-
-  if FeatureService.enabled?("use_dfe_sign_in")
-    get "/auth/dfe/callback" => "sessions#callback"
-    get "/auth/dfe/sign-out" => "sessions#signout"
-  else
-    get "/personas", to: "personas#index"
-    get "/auth/developer/sign-out", to: "sessions#signout"
-    post "/auth/developer/callback", to: "sessions#callback"
+  case Settings.features.sign_in_method
+  when "dfe"
+    get("/auth/dfe/callback" => "sessions#callback")
+    get("/auth/dfe/sign-out" => "sessions#signout")
+  when "otp"
+    resource(:otp, only: %i[show create], controller: :otp, path: "request-sign-in-code")
+    resource(:otp_verifications, only: %i[show create], path: "sign-in-code")
+  when "persona"
+    get("/personas", to: "personas#index")
+    get("/auth/developer/sign-out", to: "sessions#signout")
+    post("/auth/developer/callback", to: "sessions#callback")
   end
 
   concern :confirmable do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,7 @@ Rails.application.routes.draw do
   get "request-an-account", to: "request_an_account#index"
 
   case Settings.features.sign_in_method
-  when "dfe"
+  when "dfe-sign-in"
     get("/auth/dfe/callback" => "sessions#callback")
     get("/auth/dfe/sign-out" => "sessions#signout")
   when "otp"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,10 +35,9 @@ dqt:
 features:
   home_text: false
   use_ssl: true
-  use_dfe_sign_in: true
+  sign_in_method: dfe
   enable_feedback_link: true
   basic_auth: true
-  use_otp_sign_in: false
   trainee_export: true
   import_applications_from_apply: false
   import_courses_from_ttapi: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,7 +35,7 @@ dqt:
 features:
   home_text: false
   use_ssl: true
-  sign_in_method: dfe
+  sign_in_method: dfe-sign-in
   enable_feedback_link: true
   basic_auth: true
   trainee_export: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,8 +3,7 @@ dttp:
   portal_host: traineeteacherportal-local.education.gov.uk
 
 features:
-  use_dfe_sign_in: false
-  use_otp_sign_in: true
+  sign_in_method: persona # "dfe", "persona", "otp"
   basic_auth: false
   import_courses_from_ttapi: true
   publish_course_details: true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -19,7 +19,7 @@ dqt:
   base_url: https://teacher-qualifications-api.education.gov.uk/
 
 features:
-  sign_in_method: dfe
+  sign_in_method: dfe-sign-in
   basic_auth: false
   enable_feedback_link: true
   import_courses_from_ttapi: true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -19,6 +19,7 @@ dqt:
   base_url: https://teacher-qualifications-api.education.gov.uk/
 
 features:
+  sign_in_method: dfe
   basic_auth: false
   enable_feedback_link: true
   import_courses_from_ttapi: true

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -16,7 +16,7 @@ dfe_sign_in:
 
 features:
   basic_auth: true
-  sign_in_method: dfe
+  sign_in_method: dfe-sign-in
   enable_feedback_link: false
   import_courses_from_ttapi: true
   import_applications_from_apply: true

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -16,7 +16,7 @@ dfe_sign_in:
 
 features:
   basic_auth: true
-  use_otp_sign_in: true
+  sign_in_method: dfe
   enable_feedback_link: false
   import_courses_from_ttapi: true
   import_applications_from_apply: true

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -11,7 +11,7 @@ dqt:
 
 features:
   home_text: true
-  use_dfe_sign_in: false
+  sign_in_method: persona
   import_courses_from_ttapi: true
   publish_course_details: true
   course_study_mode: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -3,7 +3,7 @@ dqt:
 
 features:
   home_text: true
-  use_dfe_sign_in: false
+  sign_in_method: persona
   enable_feedback_link: true
   publish_course_details: true
   routes:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -17,6 +17,7 @@ dqt:
 
 features:
   basic_auth: false
+  sign_in_method: persona
   import_courses_from_ttapi: true
   import_applications_from_apply: true
   publish_course_details: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,7 +6,7 @@ slack:
   default_channel: "test-channel"
   webhook_url: "https://test-slack-webhook-url.com"
 features:
-  use_otp_sign_in: true
+  sign_in_method: dfe
   basic_auth: false
   routes:
     school_direct_salaried: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,7 +6,7 @@ slack:
   default_channel: "test-channel"
   webhook_url: "https://test-slack-webhook-url.com"
 features:
-  sign_in_method: dfe
+  sign_in_method: dfe-sign-in
   basic_auth: false
   routes:
     school_direct_salaried: true

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -26,7 +26,7 @@ A bunch of fields will be set to `nil`, see `RouteDataManager` class. Ask suppor
 
 Sometimes support will ask a dev to unwithdraw a trainee which has been withdrawn in error. You can find the previous trainee state by running `trainee.audits` and comparing the numbers to the enum in `trainee.rb`.
 
-Here is an examole of unwithdrawing a trainee without leaving an audit trail.
+Here is an example of unwithdrawing a trainee without leaving an audit trail.
 
 ```ruby
 trainee = Trainee.find_by(slug: "XXX")
@@ -51,7 +51,7 @@ If the trainee has a TRN already, call this (where `t` is the trainee):
 Dqt::RetrieveTeacher.call(trainee: t)
 ```
 
-If the trainee doens't have a TRN yet, call this instead:
+If the trainee doesn't have a TRN yet, call this instead:
 
 ```ruby
 Dqt::FindTeacher.call(trainee: t)
@@ -204,6 +204,10 @@ Register support may need to communicate with the trainee and provider to ensure
 
 ## Managing the siqekiq queue
 
+### via the UI
+
+`system-admin/dead_jobs/` uses the methods below to list failed trainees. You can also download the list along with errors via `download (.csv)`.
+
 ### Console commands
 
 #### Inspect jobs in a queue
@@ -230,4 +234,24 @@ ds.map { _1.args[0]["arguments"][0]["_aj_globalid"].split("/").last }.uniq.count
 ds.select { _1.item["error_message"].starts_with? "status: 405" }.count
 # retry
 ds.select { _1.item["error_message"].starts_with? "status: 405" }.map(&:retry)
+```
+
+## Settings
+
+Sometimes we need to toggle/change features and settings. This can be done using the `cf set-env` command. For example:
+
+```sh
+# set the ENV
+cf set-env register-production SETTINGS__FEATURES__SIGN_IN_METHOD otp
+# restart the app server
+cf restage register-production
+```
+
+The format of the ENV you set is important. Double underscores `__` are the equivalent of subsections in `settings.yml` so the above is equivalent to:
+
+```yml
+# config/settings.yml
+
+features:
+  sign_in_method: otp
 ```

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -25,7 +25,7 @@ describe "Settings" do
     features = settings[:features]
 
     include_examples expected_value_test, :use_ssl, features, true
-    include_examples expected_value_test, :sign_in_method, features, "dfe"
+    include_examples expected_value_test, :sign_in_method, features, "dfe-sign-in"
     include_examples expected_value_test, :home_text, features, false
   end
 

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -25,7 +25,7 @@ describe "Settings" do
     features = settings[:features]
 
     include_examples expected_value_test, :use_ssl, features, true
-    include_examples expected_value_test, :use_dfe_sign_in, features, true
+    include_examples expected_value_test, :sign_in_method, features, "dfe"
     include_examples expected_value_test, :home_text, features, false
   end
 

--- a/spec/features/auth/otp_authentication_spec.rb
+++ b/spec/features/auth/otp_authentication_spec.rb
@@ -24,7 +24,7 @@ describe "A user authenticates via Email Sign-in" do
     ).and_return(mailer)
   end
 
-  scenario "signing in successfully", feature_use_otp_sign_in: true do
+  scenario "signing in successfully", feature_sign_in_method: "otp" do
     given_i_am_registered_as_a_user
     and_submit_my_email
     and_enter_my_otp

--- a/spec/features/auth/sign_in_page_spec.rb
+++ b/spec/features/auth/sign_in_page_spec.rb
@@ -13,7 +13,7 @@ feature "sign in page" do
     expect(sign_in_page.sign_in_button.text).to eq("Sign in using Persona")
   end
 
-  scenario "navigate to sign in", feature_sign_in_method: "dfe" do
+  scenario "navigate to sign in", feature_sign_in_method: "dfe-sign-in" do
     expect(sign_in_page.page_heading).to have_text("Sign in")
     expect(sign_in_page).to have_title("Sign in to Register trainee teachers - Register trainee teachers - GOV.UK")
     expect(sign_in_page.sign_in_button.text).to eq("Sign in using DfE Sign-in")

--- a/spec/features/auth/sign_in_page_spec.rb
+++ b/spec/features/auth/sign_in_page_spec.rb
@@ -7,19 +7,19 @@ feature "sign in page" do
     sign_in_page.load
   end
 
-  scenario "navigate to sign in", feature_use_dfe_sign_in: false do
+  scenario "navigate to sign in", feature_sign_in_method: "persona" do
     expect(sign_in_page.page_heading).to have_text("Sign in")
     expect(sign_in_page).to have_title("Sign in to Register trainee teachers - Register trainee teachers - GOV.UK")
     expect(sign_in_page.sign_in_button.text).to eq("Sign in using Persona")
   end
 
-  scenario "navigate to sign in", feature_use_dfe_sign_in: true do
+  scenario "navigate to sign in", feature_sign_in_method: "dfe" do
     expect(sign_in_page.page_heading).to have_text("Sign in")
     expect(sign_in_page).to have_title("Sign in to Register trainee teachers - Register trainee teachers - GOV.UK")
     expect(sign_in_page.sign_in_button.text).to eq("Sign in using DfE Sign-in")
   end
 
-  scenario "navigate to sign in", feature_use_otp_sign_in: true do
+  scenario "navigate to sign in", feature_sign_in_method: "otp" do
     expect(sign_in_page.page_heading).to have_text("Sign in")
     expect(sign_in_page).to have_title("Sign in to Register trainee teachers - Register trainee teachers - GOV.UK")
     expect(sign_in_page.otp_sign_in_button.text).to eq("Sign in using your email")

--- a/spec/requests/dfe_analytics_events_spec.rb
+++ b/spec/requests/dfe_analytics_events_spec.rb
@@ -44,7 +44,6 @@ describe "sending request events" do
   end
 
   after do
-    enable_features("use_dfe_sign_in")
     Rails.application.reload_routes!
   end
 
@@ -66,9 +65,9 @@ describe "sending request events" do
     end
   end
 
-  context "feature is disabled" do
+  context "feature is disabled", feature_sign_in_method: "persona" do
     before {
-      disable_features("google.send_data_to_big_query", "use_dfe_sign_in")
+      disable_features("google.send_data_to_big_query")
     }
 
     it "doesn't send to big query" do

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -30,7 +30,6 @@ RSpec.configure do |config|
   config.around do |example|
     original_features = {}
     features = example.metadata.keys.grep(/^feature_.*/)
-
     features.each do |metadata_key|
       feature = normalise_feature_name.call(metadata_key)
       if settings_has_key.call(feature)
@@ -38,6 +37,7 @@ RSpec.configure do |config|
       end
 
       set_feature.call(feature, example.metadata[metadata_key])
+      Rails.application.reload_routes!
     end
 
     example.run
@@ -45,6 +45,7 @@ RSpec.configure do |config|
     features.each do |metadata_key|
       feature = normalise_feature_name.call(metadata_key)
       set_feature.call(feature, original_features[feature])
+      Rails.application.reload_routes!
     end
   end
 end


### PR DESCRIPTION
### Context

The sign in method is currently determined by two bools: `use_dfe_sign_in` and `use_otp_sign_in` to decide which buttons and routes to expose. This is confusing for development as there is a 3rd sign in `persona` which is exposed dependent on the `use_dfe_sign_in` bool.

### Changes proposed in this pull request

Use a new setting `sign_in_method` to determine which buttons and routes to expose.

### Guidance to review

make sure sign in works as expected using: `otp`, `dfe` and `persona`
