### PR TITLE
[5042] - send withdrawn HESA trainees to DQT

### DIFF
--- a/db/data/20230118093223_send_withdrawn_hesa_trainees_to_dqt.rb
+++ b/db/data/20230118093223_send_withdrawn_hesa_trainees_to_dqt.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class SendWithdrawnHesaTraineesToDqt < ActiveRecord::Migration[7.0]
+  def up
+    trainees.find_in_batches(batch_size: 100).with_index do |group, batch|
+      group.each do |trainee|
+        Dqt::WithdrawTraineeJob.set(wait: 30.seconds * batch).perform_later(trainee)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+private
+
+  def trainees
+    Trainee.withdrawn.where.not(hesa_id: nil)
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/Nyh180zE/5042-migration-task-to-send-withdrawn-hesa-trainees-to-dqt-successfully

### Changes proposed in this pull request

data migration to make batched calls of the `WithdrawTraineeJob` for all trainees with a hesa id that are withdrawn.
