### PR TITLE
Temporarily remove course columns that are causing confusion

### DIFF
--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -16,7 +16,6 @@ module Reports
     end
 
     # rubocop:disable Naming/VariableNumber
-    delegate :code, :name, to: :course, prefix: true, allow_nil: true
     delegate :country,
              :grade,
              :graduation_year,

--- a/app/models/reports/trainees_report.rb
+++ b/app/models/reports/trainees_report.rb
@@ -49,8 +49,6 @@ module Reports
          degree_1_other_grade
          degree_1_graduation_year
          degrees
-         course_code
-         course_name
          course_training_route
          course_qualification
          course_education_phase
@@ -162,8 +160,6 @@ module Reports
         trainee_report.degree_1_other_grade,
         trainee_report.degree_1_graduation_year,
         trainee_report.degrees,
-        trainee_report.course_code,
-        trainee_report.course_name,
         trainee_report.course_training_route,
         trainee_report.course_qualification,
         trainee_report.course_education_phase,

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -212,14 +212,6 @@ describe Reports::TraineeReport do
       expect(subject.degrees).to be_a(String)
     end
 
-    it "includes the course_code" do
-      expect(subject.course_code).to eq(course.code)
-    end
-
-    it "includes the course_name" do
-      expect(subject.course_name).to eq(course.name)
-    end
-
     it "includes the course_training_route" do
       expect(subject.course_training_route).to eq(I18n.t("activerecord.attributes.trainee.training_routes.#{trainee.training_route}"))
     end

--- a/spec/services/exports/export_trainees_service_spec.rb
+++ b/spec/services/exports/export_trainees_service_spec.rb
@@ -216,14 +216,6 @@ describe Exports::ExportTraineesService, type: :model do
         expect(trainee_csv_row["degrees"]).to eq(trainee_report.degrees)
       end
 
-      it "includes the course_code in the csv" do
-        expect(trainee_csv_row["course_code"]).to eq(trainee_report.course_code)
-      end
-
-      it "includes the course_name in the csv" do
-        expect(trainee_csv_row["course_name"]).to eq(trainee_report.course_name)
-      end
-
       it "includes the course_training_route in the csv" do
         expect(trainee_csv_row["course_training_route"]).to eq(trainee_report.course_training_route)
       end

--- a/spec/services/exports/export_trainees_to_file_service_spec.rb
+++ b/spec/services/exports/export_trainees_to_file_service_spec.rb
@@ -227,14 +227,6 @@ describe Exports::ExportTraineesToFileService, type: :model do
         expect(trainee_csv_row["degrees"]).to eq(trainee_report.degrees)
       end
 
-      it "includes the course_code in the csv" do
-        expect(trainee_csv_row["course_code"]).to eq(trainee_report.course_code)
-      end
-
-      it "includes the course_name in the csv" do
-        expect(trainee_csv_row["course_name"]).to eq(trainee_report.course_name)
-      end
-
       it "includes the course_training_route in the csv" do
         expect(trainee_csv_row["course_training_route"]).to eq(trainee_report.course_training_route)
       end


### PR DESCRIPTION
### Context

We've had a number of queries in to support about populating these columns that are blank, or else changing the data in them. The columns are optional and are only expected to be populated where a trainee is linked to a Publish course. This won't have happened for:

* HESA trainees
* Trainees added prior to Register launching
* Trainees with manual course details

We've done well at describing the columns or that they don't *need* to be populated. As a short term fix we're going to remove them from the export entirely.

We expect to revert this commit at some point in a few weeks time - potentially with some further design changes.
