### PR TITLE
[5166] Allow changes to withdrawal dates and reasons for system admins

### DIFF
--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -84,10 +84,18 @@ module RecordDetails
     def trainee_status_row
       return unless trainee.deferred? || trainee.withdrawn?
 
-      {
-        field_label: t(".trainee_status"),
-        field_value: render(StatusTag::View.new(trainee: trainee, classes: "govuk-!-margin-bottom-2")) + tag.br + status_date,
-      }
+      if trainee.withdrawn?
+        mappable_field(trainee_status_tag, t(".trainee_status"), trainee_withdrawal_path(trainee))
+      else
+        {
+          field_label: t(".trainee_status"),
+          field_value: trainee_status_tag,
+        }
+      end
+    end
+
+    def trainee_status_tag
+      render(StatusTag::View.new(trainee: trainee, classes: "govuk-!-margin-bottom-2")) + tag.br + status_date
     end
 
     def last_updated_row

--- a/app/controllers/trainees/confirm_withdrawals_controller.rb
+++ b/app/controllers/trainees/confirm_withdrawals_controller.rb
@@ -9,7 +9,7 @@ module Trainees
 
     def update
       if withdrawal.save!
-        trainee.withdraw!
+        trainee.withdraw! unless trainee.withdrawn?
         flash[:success] = I18n.t("flash.trainee_withdrawn")
         redirect_to(trainee_path(trainee))
       end

--- a/app/forms/withdrawal_form.rb
+++ b/app/forms/withdrawal_form.rb
@@ -15,7 +15,7 @@ class WithdrawalForm < MultiDateForm
     if valid?
       assign_attributes_to_trainee
       Trainees::Update.call(trainee: trainee, update_dqt: false)
-      Trainees::Withdraw.call(trainee:)
+      Trainees::Withdraw.call(trainee:) unless trainee.withdrawn?
       clear_stash
     else
       false

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -60,7 +60,7 @@ class TraineePolicy
   end
 
   def withdraw?
-    write? && (defer? || trainee.deferred?)
+    write? && (defer? || trainee.deferred? || user_is_system_admin?)
   end
 
   def defer?

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -53,6 +53,7 @@ module Trainees
       lead_school_id
       employing_school_id
       iqts_country
+      withdraw_date
     ].freeze
 
     delegate :user, :created_at, :auditable_type, :audited_changes, :auditable, to: :audit

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -193,6 +193,21 @@ feature "Withdrawing a trainee" do
     and_i_see_my_date(Time.zone.today)
   end
 
+  scenario "trainee is already withdrawn" do
+    given_i_am_authenticated
+    given_a_trainee_exists_that_is_already_withdrawn
+    and_i_am_on_the_trainee_record_page
+    then_i_cannot_see_the_withdraw_link
+    then_i_cannot_see_the_edit_withdrawal_link
+  end
+
+  scenario "as a system admin trainee is already withdrawn" do
+    given_i_am_authenticated_as_system_admin
+    given_a_trainee_exists_that_is_already_withdrawn
+    and_i_am_on_the_trainee_record_page
+    then_i_can_see_the_edit_withdrawal_link
+  end
+
   def when_i_am_on_the_withdrawal_page
     given_i_am_authenticated
     given_a_trainee_exists_to_be_withdrawn
@@ -326,6 +341,10 @@ feature "Withdrawing a trainee" do
     given_a_trainee_exists(:deferred)
   end
 
+  def given_a_trainee_exists_that_is_already_withdrawn
+    @trainee ||= create(:trainee, :withdrawn)
+  end
+
   def and_the_trainee_has_a_duplicate
     @trainee.dup.tap { |t| t.slug = t.generate_slug }.save
   end
@@ -392,6 +411,18 @@ feature "Withdrawing a trainee" do
 
   def then_i_am_redirected_to_start_date_verification_page
     expect(start_date_verification_page).to be_displayed(id: trainee.slug)
+  end
+
+  def then_i_cannot_see_the_withdraw_link
+    expect(record_page).not_to have_text(t("views.trainees.edit.withdraw"))
+  end
+
+  def then_i_cannot_see_the_edit_withdrawal_link
+    expect(record_page).not_to have_change_trainee_status
+  end
+
+  def then_i_can_see_the_edit_withdrawal_link
+    expect(record_page).to have_change_trainee_status
   end
 
   def and_i_select_no_they_started_later

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -110,7 +110,7 @@ describe TraineePolicy do
       it { is_expected.not_to permit(provider_user, provider_trainee) }
       it { is_expected.not_to permit(other_provider_user, provider_trainee) }
       it { is_expected.not_to permit(lead_school_user, provider_trainee) }
-      it { is_expected.not_to permit(system_admin_user, provider_trainee) }
+      it { is_expected.to permit(system_admin_user, provider_trainee) }
     end
   end
 

--- a/spec/support/page_objects/trainees/record.rb
+++ b/spec/support/page_objects/trainees/record.rb
@@ -28,6 +28,7 @@ module PageObjects
       element :change_lead_school, "a", text: "Change lead school", visible: false
       element :change_employing_school, "a", text: "Change employing school", visible: false
       element :change_course_details, "a", text: "Change course", visible: false
+      element :change_trainee_status, "a", text: "Change trainee status", visible: false
     end
   end
 end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/Ux0SXTjs/5166-m-allow-for-withdrawal-dates-on-withdrawn-trainees-to-be-edited-by-system-admin-support

We want to make withdrawal details for trainees editable to system admins (but not provider users). If a trainee is withdrawn, add a change link that allows for withdrawal details to be edited. Add an event to the timeline if withdrawal date is edited.

If a trainee is already in a withdrawn state, don't run the withdrawal service. This means a job will not be kicked off to DQT.

### Changes proposed in this pull request

* Update record view trainee status row
* Update `def withdraw?` in trainee policy to relax permissions if a trainee is already withdrawn
* Add logic to WithdrawalForm and ConfirmWithdrawalsController to prevent re-withdrawing the trainee and sending to DQT
* Add new timeline event for `withdraw_date`

### Guidance to review

as an admin:
* navigate to a withdrawn trainee record
* observe and click on edit link on status row
* go through withdrawal flow
* observe dates save correctly
* observe timeline entry
* also try withdrawing an 'in training' trainee to make sure no regressions

as a regular user:
* as above, except observe that you cannot see the change link

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
