### PR TITLE
[5158] Fix trainees showing as missing degree subject for unknown or not applicable HESA codes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ gem "govuk_markdown"
 gem "mechanize" # interact with HESA
 
 # pinned to a commit as v1 doesn't contain the Doctor of Philosophy disambiguation
-gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", ref: "442fe3f"
+gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", ref: "f1a586f"
 
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.5.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,11 +9,12 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: 442fe3f40a15e05edd52aad5254aed7cafa96824
-  ref: 442fe3f
+  revision: f1a586f2170d46c717aca22a52e74c1669a1154a
+  ref: f1a586f
   specs:
-    dfe-reference-data (1.0.0)
+    dfe-reference-data (2.0.0)
       activesupport
+      tzinfo
 
 GIT
   remote: https://github.com/DFE-Digital/rspec-retry.git

--- a/app/services/degrees/dfe_reference.rb
+++ b/app/services/degrees/dfe_reference.rb
@@ -7,7 +7,7 @@ module Degrees
     COMMON_TYPES = ["Bachelor of Arts", "Bachelor of Science", "Master of Arts", "PhD"].freeze
 
     GRADES = DfE::ReferenceData::Degrees::GRADES
-    SUBJECTS = DfE::ReferenceData::Degrees::SINGLE_SUBJECTS
+    SUBJECTS = DfE::ReferenceData::Degrees::SUBJECTS_INCLUDING_GENERICS
     TYPES = DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS
     INSTITUTIONS = DfE::ReferenceData::Degrees::INSTITUTIONS_INCLUDING_GENERICS
 
@@ -83,14 +83,10 @@ module Degrees
 
       def build_hesa_filter(filters)
         {
-          hesa_itt_code: remove_leading_zeros(filters[:hesa_itt_code]),
-          hesa_code: remove_leading_zeros(filters[:hesa_code]),
-          hecos_code: remove_leading_zeros(filters[:hecos_code]),
+          hesa_itt_code: filters[:hesa_itt_code],
+          hesa_code: filters[:hesa_code],
+          hecos_code: filters[:hecos_code],
         }.compact
-      end
-
-      def remove_leading_zeros(code)
-        code && code.to_i.to_s
       end
     end
   end

--- a/db/data/20230123100908_fix_unmapped_trainee_degree_subjects.rb
+++ b/db/data/20230123100908_fix_unmapped_trainee_degree_subjects.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class FixUnmappedTraineeDegreeSubjects < ActiveRecord::Migration[7.0]
+  UNKNOWN_NOT_APPLICABLE_SUBJECT_HESA_CODES = %w[999999 999998].freeze
+
+  def up
+    degrees = Degree.where(subject: nil)
+
+    degrees.find_each do |degree|
+      hesa_student = degree.trainee.hesa_student
+
+      next unless hesa_student
+
+      degree_subject_hesa_codes = hesa_student.degrees.map { |d| d["subject"] }
+
+      degree_subject_hesa_codes.each do |subject_hesa_code|
+        next unless UNKNOWN_NOT_APPLICABLE_SUBJECT_HESA_CODES.include?(subject_hesa_code)
+
+        subject = Degrees::DfEReference.find_subject(hecos_code: subject_hesa_code)
+        degree.subject = subject&.name
+        degree.subject_uuid = subject&.id
+        degree.save
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -92,7 +92,7 @@ module Degrees
               graduation_date: "2003-06-01",
               degree_type: "400",
               subject: "100485",
-              institution: "00429",
+              institution: "0429",
               grade: "02",
               country: nil,
             },
@@ -223,7 +223,7 @@ module Degrees
           [
             {
               graduation_date: "2003-06-01",
-              degree_type: "008",
+              degree_type: "007",
               subject: "100485",
               institution: "00429",
               grade: "02",

--- a/spec/services/degrees/dfe_reference_spec.rb
+++ b/spec/services/degrees/dfe_reference_spec.rb
@@ -10,15 +10,15 @@ module Degrees
       end
 
       it "can find the subject by UUID" do
-        expect(described_class.find_subject(uuid: degree_subject.id)).to eq(degree_subject)
+        expect(described_class.find_subject(uuid: degree_subject.id)).to match(degree_subject)
       end
 
       it "can find the subject by name" do
-        expect(described_class.find_subject(name: degree_subject.name)).to eq(degree_subject)
+        expect(described_class.find_subject(name: degree_subject.name)).to match(degree_subject)
       end
 
       it "can find the subject by hecos_code" do
-        expect(described_class.find_subject(hecos_code: degree_subject.hecos_code)).to eq(degree_subject)
+        expect(described_class.find_subject(hecos_code: degree_subject.hecos_code)).to match(degree_subject)
       end
     end
 
@@ -30,19 +30,19 @@ module Degrees
       end
 
       it "can find the type by UUID" do
-        expect(described_class.find_type(uuid: degree_type.id)).to eq(degree_type)
+        expect(described_class.find_type(uuid: degree_type.id)).to match(degree_type)
       end
 
       it "can find the type by name" do
-        expect(described_class.find_type(abbreviation: degree_type.name)).to eq(degree_type)
+        expect(described_class.find_type(abbreviation: degree_type.name)).to match(degree_type)
       end
 
       it "can find the type by abbreviation" do
-        expect(described_class.find_type(abbreviation: degree_type.abbreviation)).to eq(degree_type)
+        expect(described_class.find_type(abbreviation: degree_type.abbreviation)).to match(degree_type)
       end
 
       it "can find the type by HESA code" do
-        expect(described_class.find_type(hesa_code: degree_type.hesa_itt_code)).to eq(degree_type)
+        expect(described_class.find_type(hesa_code: degree_type.hesa_itt_code)).to match(degree_type)
       end
     end
 
@@ -52,15 +52,15 @@ module Degrees
       end
 
       it "can find the institution by UUID" do
-        expect(described_class.find_institution(uuid: degree_institution.id)).to eq(degree_institution)
+        expect(described_class.find_institution(uuid: degree_institution.id)).to match(degree_institution)
       end
 
       it "can find the institution by name" do
-        expect(described_class.find_institution(name: degree_institution.name)).to eq(degree_institution)
+        expect(described_class.find_institution(name: degree_institution.name)).to match(degree_institution)
       end
 
       it "can find the institution by HESA code" do
-        expect(described_class.find_institution(hesa_code: degree_institution.hesa_itt_code)).to eq(degree_institution)
+        expect(described_class.find_institution(hesa_code: degree_institution.hesa_itt_code)).to match(degree_institution)
       end
     end
 
@@ -70,15 +70,15 @@ module Degrees
       end
 
       it "can find the grade by UUID" do
-        expect(described_class.find_grade(uuid: degree_grade.id)).to eq(degree_grade)
+        expect(described_class.find_grade(uuid: degree_grade.id)).to match(degree_grade)
       end
 
       it "can find the grade by name" do
-        expect(described_class.find_grade(name: degree_grade.name)).to eq(degree_grade)
+        expect(described_class.find_grade(name: degree_grade.name)).to match(degree_grade)
       end
 
       it "can find the grade by HESA code" do
-        expect(described_class.find_grade(hesa_code: degree_grade.hesa_code)).to eq(degree_grade)
+        expect(described_class.find_grade(hesa_code: degree_grade.hesa_code)).to match(degree_grade)
       end
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/iW12D20B/5158-prod-trainees-showing-as-missing-degree-subject-but-it-was-present-in-hesa-update

### Changes proposed in this pull request
- Update `dfe-reference` gem so we get support for "Not known" or "Not applicable" HESA degree subject codes
- Data migration to backfill missing subjects for those degrees that had a "Not known" or "Not applicable" subject

### Guidance to review
- Tested code locally. Works as expected.
- It will fix 183 degree records, not just the 4 mentioned in the card.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
