### PR TITLE
[5113] Allow system admin to edit ITT end date for HESA trainees

### DIFF
--- a/app/forms/itt_dates_form.rb
+++ b/app/forms/itt_dates_form.rb
@@ -19,7 +19,7 @@ class IttDatesForm < TraineeForm
   attr_accessor(*FIELDS, :course)
 
   validate :start_date_valid
-  validate :end_date_valid, if: :end_date_required?
+  validate :end_date_valid
 
   delegate :study_mode, to: :course_details_form
 
@@ -59,13 +59,9 @@ class IttDatesForm < TraineeForm
   end
 
   def end_date
-    if end_date_required?
-      compute_date({ year: end_year, month: end_month, day: end_day })
-    end
-  end
+    return if end_date_not_required? && end_date_not_provided?
 
-  def end_date_required?
-    trainee.hesa_id.blank?
+    compute_date({ year: end_year, month: end_month, day: end_day })
   end
 
 private
@@ -114,6 +110,8 @@ private
   end
 
   def end_date_valid
+    return true if end_date_not_required? && end_date_not_provided?
+
     if [end_day, end_month, end_year].all?(&:blank?)
       errors.add(:end_date, :blank)
     elsif end_year.to_i > max_years

--- a/app/helpers/dates_helper.rb
+++ b/app/helpers/dates_helper.rb
@@ -10,4 +10,16 @@ module DatesHelper
   def valid_date?(date_args)
     Date.valid_date?(*date_args) && date_args.all?(&:positive?)
   end
+
+  def end_date_required?
+    trainee.hesa_id.blank?
+  end
+
+  def end_date_not_required?
+    !end_date_required?
+  end
+
+  def end_date_not_provided?
+    [end_year, end_month, end_day].any?(&:blank?)
+  end
 end

--- a/app/views/trainees/course_details/edit.html.erb
+++ b/app/views/trainees/course_details/edit.html.erb
@@ -59,13 +59,11 @@
                              legend: { text: t("publish_course_details.view.itt_start_date").html_safe, size: "s" },
                              hint: { text: t("activemodel.errors.models.course_details_form.attributes.itt_start_date.hint_html", year: Time.zone.now.year) }) %>
 
-        <% if @course_details_form.end_date_required? %>
-          <%= f.govuk_date_field(:itt_end_date,
-                                date_of_birth: false,
-                                legend: { text: t("publish_course_details.view.itt_end_date").html_safe, size: "s" },
-                                hint: { text: t("activemodel.errors.models.course_details_form.attributes.itt_end_date.hint_html", year: Time.zone.now.next_year.year) }) %>
+      <%= f.govuk_date_field(:itt_end_date,
+                            date_of_birth: false,
+                            legend: { text: t("publish_course_details.view.itt_end_date").html_safe, size: "s" },
+                            hint: { text: t("activemodel.errors.models.course_details_form.attributes.itt_end_date.hint_html", year: Time.zone.now.next_year.year) }) %>
 
-        <% end %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/trainees/itt_dates/edit.html.erb
+++ b/app/views/trainees/itt_dates/edit.html.erb
@@ -25,22 +25,20 @@
                                  text: t("activemodel.errors.models.course_details_form.attributes.itt_start_date.hint_html",
                                          year: Time.zone.now.year)
                                }) %>
-        <% if @itt_dates_form.end_date_required? %>
-          <%= f.govuk_date_field(:end_date,
-                                 date_of_birth: false,
-                                 legend: { text: t("publish_course_details.view.itt_end_date").html_safe, size: "s" },
-                                 hint: {
-                                   text: t("activemodel.errors.models.course_details_form.attributes.itt_end_date.hint_html",
-                                           year: Time.zone.now.next_year.year)
-                                 }) %>
-          <%= f.govuk_check_box(:is_for_all_trainees, "1", "0", multiple: false,
-                                label: { text: t(".is_for_all_courses",
-                                                 course_name: @itt_dates_form.course.name,
-                                                 course_code: @itt_dates_form.course.code,
-                                                 study_mode: t("activerecord.attributes.trainee.study_modes.#{@itt_dates_form.study_mode}").downcase,
-                                                 cycle_year: @itt_dates_form.course.recruitment_cycle_year,
-                                                 next_cycle_year: @itt_dates_form.course.recruitment_cycle_year + 1) }) %>
-        <% end %>
+        <%= f.govuk_date_field(:end_date,
+                                date_of_birth: false,
+                                legend: { text: t("publish_course_details.view.itt_end_date").html_safe, size: "s" },
+                                hint: {
+                                  text: t("activemodel.errors.models.course_details_form.attributes.itt_end_date.hint_html",
+                                          year: Time.zone.now.next_year.year)
+                                }) %>
+        <%= f.govuk_check_box(:is_for_all_trainees, "1", "0", multiple: false,
+                              label: { text: t(".is_for_all_courses",
+                                                course_name: @itt_dates_form.course.name,
+                                                course_code: @itt_dates_form.course.code,
+                                                study_mode: t("activerecord.attributes.trainee.study_modes.#{@itt_dates_form.study_mode}").downcase,
+                                                cycle_year: @itt_dates_form.course.recruitment_cycle_year,
+                                                next_cycle_year: @itt_dates_form.course.recruitment_cycle_year + 1) }) %>
       </div>
       <%= f.govuk_submit %>
     <% end %>

--- a/spec/forms/course_details_form_spec.rb
+++ b/spec/forms/course_details_form_spec.rb
@@ -381,6 +381,17 @@ describe CourseDetailsForm, type: :model do
               expect(subject.errors.messages[:itt_end_date]).to include I18n.t("activemodel.errors.models.course_details_form.attributes.itt_end_date.too_old")
             end
           end
+
+          context "for a trainee where end date is not required and is not provided" do
+            let(:trainee) { build(:trainee, hesa_id: "XXX") }
+            let(:end_date_attributes) do
+              { end_day: "", end_month: "", end_year: "" }
+            end
+
+            it "does not return an error message for end date" do
+              expect(subject.errors[:itt_end_date]).to be_empty
+            end
+          end
         end
       end
     end
@@ -436,6 +447,28 @@ describe CourseDetailsForm, type: :model do
         it "does not validate itt_end_date" do
           expect(subject.errors[:itt_end_date]).to be_empty
         end
+
+        it "returns nil" do
+          expect(subject.itt_end_date).to be_nil
+        end
+      end
+
+      context "itt_end_date invalid" do
+        let(:params) do
+          {
+            end_day: "a",
+            end_month: "b",
+            end_year: "c",
+          }
+        end
+
+        before do
+          subject.valid?
+        end
+
+        it "validates itt_end_date" do
+          expect(subject.errors[:itt_end_date]).not_to be_empty
+        end
       end
 
       context "itt_end_date is set" do
@@ -462,12 +495,8 @@ describe CourseDetailsForm, type: :model do
           subject.valid?
         end
 
-        it "does not validate itt_end_date" do
-          expect(subject.errors[:itt_end_date]).to be_empty
-        end
-
-        it "returns nil" do
-          expect(subject.itt_end_date).to be_nil
+        it "sets the end date correctly" do
+          expect(subject.itt_end_date).to eq(valid_end_date)
         end
       end
     end


### PR DESCRIPTION
### Context

Trello: https://trello.com/c/izTv1bao/5113-cannot-edit-itt-end-date-for-hesa-trainees-in-system-admin

We weren't showing the ITT end date boxes on the course details form for HESA trainees, so system admins could not edit the ITT end date. Allow them to edit this.

I have included HESA trainees in the end date validation but have slightly amended the rules to accept a nil `itt_end_date` for HESA trainees if one is not provided on the form - this is because for historic HESA trainees, it's possible that we don't have an end date. This would be a blocker to submitting the form if we amended something else on the course form for these older records.

Other validation for HESA trainees should work as expected (should only allow nil, or a valid date) and existing validation for other trainees should still work as expected.

Currently only system admins can edit the HESA trainee record.

I have implemented the same approach on the ITT dates form.

### Changes proposed in this pull request

* Move some methods into DatesHelper to be used across both CourseDetailsForm and IttDatesForm
* Remove boolean `end_date_required?` from the form HTML files so we render the ITT end date boxes for all trainees
* Remove `end_date_required?' from the end date validation
* If an ITT end date is not provided on the form for a HESA trainee, set it to be nil - apply all other validation as expected

### Guidance to review

As a system admin:
* Find a HESA trainee
* Edit the ITT end date
* Save, observe successful
* Find a HESA trainee without an ITT end date
* Edit another part of the course (eg start date)
* Do not add an ITT end date
* Save, observe ITT start date is updated and ITT end date is not required/form saves correctly
* Repeat this process for other HESA trainees and try to save an invalid end date (i.e. not a date) and this should error

* Find a non HESA trainee
* Click on change link to edit ITT end date
* Remove ITT end date, save
* Observe validation requiring the ITT end date
* Check other end date validation still works as expected

As a non system admin:
* Find a HESA trainee
* Observe you cannot edit ITT end date
* Find a non HESA trainee
* Observe you can edit ITT end date
* Check validation errors as expected

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
- [ ] ~~Do we need to send any updates to DQT as part of the work in this PR?~~
- [ ] ~~Does this PR need an ADR?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
