### PR TITLE
[xxx] Fix: Trainees::CreateFromHesa creating unnecessary DQT withdrawal jobs

### DIFF
--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -391,6 +391,14 @@ module Trainees
           it "enqueues Dqt::WithdrawTraineeJob" do
             expect(Dqt::WithdrawTraineeJob).to have_received(:perform_later).with(trainee)
           end
+
+          context "trainee has already been withdrawn" do
+            let(:create_custom_state) { create(:trainee, :withdrawn, hesa_id: student_attributes[:hesa_id]) }
+
+            it "does not enqueue Dqt::WithdrawTraineeJob" do
+              expect(Dqt::WithdrawTraineeJob).not_to have_received(:perform_later).with(trainee)
+            end
+          end
         end
 
         context "and the reason for completion is 'Left but award of credit or a qualification not yet known'" do


### PR DESCRIPTION
### Context
We're getting a lot of DQT withdrawal jobs fail recently. The source of the problem is partly due to lots of unnecessary jobs been created when the trainee has already been withdrawn.

### Changes proposed in this pull request
- Update `Trainees::CreateFromHesa` so it only creates a withdrawal job if the trainee is transititioning to `:withdrawn` from another state 

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
