### PR TITLE
fix csv row drift in dead jobs CSV export

### DIFF
--- a/app/services/dead_jobs/base.rb
+++ b/app/services/dead_jobs/base.rb
@@ -16,7 +16,7 @@ module DeadJobs
           provider_name: trainee.provider.name,
           provider_ukprn: trainee.provider.ukprn,
           error_message: dead_jobs[trainee.id],
-        }.compact
+        }
       end
     end
 

--- a/spec/support/shared_examples/dead_jobs.rb
+++ b/spec/support/shared_examples/dead_jobs.rb
@@ -2,12 +2,12 @@
 
 shared_examples "DeadJobs" do |klass, name|
   let(:service) { described_class.new(dead_set) }
-  let(:trainee) { create(:trainee, :trn_received) }
+  let(:trainee) { create(:trainee) }
   let(:result) do
     {
       register_id: trainee.id,
       trainee_name: trainee.full_name,
-      trainee_trn: trainee.trn,
+      trainee_trn: nil,
       trainee_dob: trainee.date_of_birth,
       provider_name: trainee.provider.name,
       provider_ukprn: trainee.provider.ukprn,
@@ -45,7 +45,7 @@ shared_examples "DeadJobs" do |klass, name|
   end
 
   describe "#to_csv" do
-    it do
+    it "returns the expected CSV" do
       expect(service.to_csv).to eq(
         <<~CSV # rubocop:disable Style/TrailingCommaInArguments
           register_id,trainee_name,trainee_trn,trainee_dob,provider_name,provider_ukprn,error_message


### PR DESCRIPTION
fixes row drift from compacting dead jobs `.to_a`

<img width="811" alt="Screenshot 2023-01-25 at 15 15 59" src="https://user-images.githubusercontent.com/6339025/214601517-fd0ceec2-f5cd-430f-8678-58c9aecfc788.png">
