### PR TITLE
reset SNYK default app scan setting

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -101,7 +101,7 @@ jobs:
         SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
       with:
         image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
-        args: --file=Dockerfile --severity-threshold=high
+        args: --file=Dockerfile --severity-threshold=high --exclude-app-vulns
 
     - name: Push ${{ env.DOCKER_IMAGE }} images
       if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') }}

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -71,7 +71,7 @@ jobs:
           SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
         with:
           image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
-          args: --file=Dockerfile
+          args: --file=Dockerfile --exclude-app-vulns
 
       - name: Push ${{ env.DOCKER_IMAGE }} images
         if: ${{ success() }}


### PR DESCRIPTION
### Context

SNYK have changed the default setting for scanning app vulnerabilities
https://snyk.io/blog/securing-container-applications-using-the-snyk-cli/

We only check o/s image vulnerabilities with SNYK, so need to reset this to the previous setting

### Changes proposed in this pull request

Add --exclude-app-vulns to the SNYK scan step in the build workflows

### Guidance to review

Check the build workflows

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
