### PR TITLE
[5157] Data migration to fix Trainee#submission_ready values

### DIFF
--- a/db/data/20230127111000_fix_trainees_with_incorrect_submission_ready_value.rb
+++ b/db/data/20230127111000_fix_trainees_with_incorrect_submission_ready_value.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class FixTraineesWithIncorrectSubmissionReadyValue < ActiveRecord::Migration[7.0]
+  def up
+    trainees = Trainee.not_draft.where(submission_ready: false).where.not(state: Trainee::COMPLETE_STATES)
+
+    trainees.find_each do |trainee|
+      next if Submissions::MissingDataValidator.new(trainee:).missing_fields.any?
+
+      trainee.send(:set_submission_ready)
+      trainee.save!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/VtgFbdjq/5157-prod-trainees-showing-as-incomplete-but-with-no-banner-saying-whats-missing

There is a small number (127 approximately) of trainees that for some unknown reason ended with the wrong value for `Trainee#submission_ready` (should be `true` instead of `false`). This data migration will correct those values and we will revisit the database in the future to see if this type of problem resurfaces. If it does, hopefully the audit trail will gives us more insight on what's going on.

### Changes proposed in this pull request
- Data migration to re-run `Trainee#set_submission_ready` on a selected number of trainees

### Guidance to review
Tested it locally. Works as expected.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
