### PR TITLE
[5193] Check and remove duplicate jobs in Sidekiq deadset every minute

### DIFF
--- a/app/jobs/sidekiq/remove_dead_duplicates_job.rb
+++ b/app/jobs/sidekiq/remove_dead_duplicates_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  class RemoveDeadDuplicatesJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      RemoveDeadDuplicates.call
+    end
+  end
+end

--- a/app/services/sidekiq/remove_dead_duplicates.rb
+++ b/app/services/sidekiq/remove_dead_duplicates.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  class RemoveDeadDuplicates
+    include ServicePattern
+
+    attr_reader :dead_jobs, :set
+
+    def initialize
+      @set = Set.new
+      @dead_jobs = Sidekiq::DeadSet.new
+    end
+
+    def call
+      dead_jobs.each do |job|
+        error = job.item["error_message"].split(",").first
+        trainee_id = job.args[0]["arguments"][0]["_aj_globalid"].split("/").last
+
+        digest = [error, job.display_class, trainee_id].join
+
+        if set.include?(digest)
+          job.delete
+        else
+          set.add(digest)
+        end
+      end
+    end
+  end
+end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -38,3 +38,7 @@ sync_hesa_students:
   cron: "0 5 * * *"
   class: "Hesa::SyncStudentsJob"
   queue: hesa
+remove_duplicate_dead_jobs:
+  cron: "* * * * *"
+  class: "Sidekiq::RemoveDeadDuplicatesJob"
+  queue: default

--- a/spec/jobs/sidekiq/remove_dead_duplicates_job_spec.rb
+++ b/spec/jobs/sidekiq/remove_dead_duplicates_job_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Sidekiq
+  describe RemoveDeadDuplicatesJob do
+    it "calls the RemoveDeadDuplicates service" do
+      expect(RemoveDeadDuplicates).to receive(:call)
+      described_class.new.perform
+    end
+  end
+end

--- a/spec/services/sidekiq/remove_dead_duplicates_spec.rb
+++ b/spec/services/sidekiq/remove_dead_duplicates_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Sidekiq
+  describe RemoveDeadDuplicates do
+    let(:dead_set) { double }
+    let(:args) { [{ "arguments" => [{ "_aj_globalid" => "gid://register-trainee-teachers/Trainee/12345" }] }] }
+    let(:item) { { "error_message" => "status 404" } }
+    let(:job1) { double(args: args, item: item, display_class: "Dqt::UpdateTraineeJob") }
+    let(:job2) { double(args: args, item: item, display_class: "Dqt::UpdateTraineeJob") }
+    let(:job3) { double(args: args, item: { "error_message" => "status 429" }, display_class: "Dqt::WithdrawTraineeJob") }
+    let(:dead_set_jobs) { [job1, job2, job3] }
+
+    before do
+      allow(Sidekiq::DeadSet).to receive(:new).and_return(dead_set)
+      iterator = allow(dead_set).to receive(:each)
+      dead_set_jobs.each do |job|
+        allow(job).to receive(:delete)
+        iterator.and_yield(job)
+      end
+      described_class.call
+    end
+
+    describe ".call" do
+      it "deletes the duplicate job" do
+        expect(job2).to have_received(:delete)
+      end
+
+      it "doesn't delete non-duplicate jobs" do
+        expect(job1).not_to have_received(:delete)
+        expect(job3).not_to have_received(:delete)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/JPPG3NUI/5193-dead-job-set-cron-tasks

The sidekiq dead queue is frequently polluted by duplicated jobs which makes the support role more tedious when trying to fix and clear those jobs.

### Changes proposed in this pull request
- New service `Sidekiq::RemoveDeadDuplicates` to scan for duplicate dead jobs and remove them
- Background job to run the service every minute

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
