### PR TITLE
[5195] - add job_id, params_sent, state, dqt_status

### DIFF
--- a/app/controllers/system_admin/dead_jobs_controller.rb
+++ b/app/controllers/system_admin/dead_jobs_controller.rb
@@ -8,7 +8,7 @@ module SystemAdmin
       respond_to do |format|
         format.html
         format.csv do
-          send_data(dead_job_service.to_csv, filename: "#{dead_job_service.name}.csv", disposition: :attachment)
+          send_data(dead_job_service.to_csv, filename: "#{dead_job_service.name}_#{DateTime.now.strftime('%F')}.csv", disposition: :attachment)
         end
       end
     end

--- a/app/controllers/system_admin/dead_jobs_controller.rb
+++ b/app/controllers/system_admin/dead_jobs_controller.rb
@@ -16,7 +16,11 @@ module SystemAdmin
   private
 
     def dead_job_service
-      @dead_job_service ||= params[:id]&.constantize&.new
+      @dead_job_service ||= params[:id]&.constantize&.new(include_dqt_status:)
+    end
+
+    def include_dqt_status
+      params[:include_dqt_status].present?
     end
 
     def dead_job_services

--- a/app/controllers/system_admin/dead_jobs_controller.rb
+++ b/app/controllers/system_admin/dead_jobs_controller.rb
@@ -8,12 +8,16 @@ module SystemAdmin
       respond_to do |format|
         format.html
         format.csv do
-          send_data(dead_job_service.to_csv, filename: "#{dead_job_service.name}_#{DateTime.now.strftime('%F')}.csv", disposition: :attachment)
+          send_data(dead_job_service.to_csv(includes:), filename: "#{dead_job_service.name}_#{DateTime.now.strftime('%F')}.csv", disposition: :attachment)
         end
       end
     end
 
   private
+
+    def includes
+      include_dqt_status ? %i[dqt_status] : []
+    end
 
     def dead_job_service
       @dead_job_service ||= params[:id]&.constantize&.new(include_dqt_status:)

--- a/app/services/dead_jobs/base.rb
+++ b/app/services/dead_jobs/base.rb
@@ -8,10 +8,11 @@ module DeadJobs
     end
 
     # includes the error_message entry using `includes: ...`
-    def to_csv
-      @to_csv ||= CSV.generate do |csv|
-        csv << headers(includes: %i[error_message job_id])
-        rows(includes: %i[error_message job_id]).each do |row|
+    def to_csv(includes: [])
+      includes = %i[job_id error_message] | includes
+      CSV.generate do |csv|
+        csv << headers(includes:)
+        rows(includes:).each do |row|
           csv << row.values
         end
       end
@@ -56,7 +57,6 @@ module DeadJobs
     def to_a
       @to_a ||= trainees.map do |trainee|
         {
-          job_id: dead_jobs[trainee.id][:job_id],
           register_id: trainee.id,
           trainee_name: trainee.full_name,
           trainee_trn: trainee.trn,
@@ -64,6 +64,7 @@ module DeadJobs
           trainee_state: trainee.state,
           provider_name: trainee.provider.name,
           provider_ukprn: trainee.provider.ukprn,
+          job_id: dead_jobs[trainee.id][:job_id],
           error_message: dead_jobs[trainee.id][:error_message]&.to_s&.gsub('"', "'"),
           dqt_status: dqt_status(trainee),
         }

--- a/app/services/dead_jobs/dqt_update_trainee.rb
+++ b/app/services/dead_jobs/dqt_update_trainee.rb
@@ -3,10 +3,11 @@
 module DeadJobs
   class DqtUpdateTrainee < Base
     # includes the error_message entry using `includes: ...`
-    def to_csv
-      @to_csv ||= CSV.generate do |csv|
-        csv << headers(includes: %i[error_message job_id params_sent])
-        rows(includes: %i[error_message job_id params_sent]).each do |row|
+    def to_csv(includes: [])
+      includes = %i[job_id error_message params_sent] | includes
+      CSV.generate do |csv|
+        csv << headers(includes:)
+        rows(includes:).each do |row|
           csv << row.values
         end
       end
@@ -17,7 +18,6 @@ module DeadJobs
     def to_a
       @to_a ||= trainees.map do |trainee|
         {
-          job_id: dead_jobs[trainee.id][:job_id],
           register_id: trainee.id,
           trainee_name: trainee.full_name,
           trainee_trn: trainee.trn,
@@ -25,6 +25,7 @@ module DeadJobs
           trainee_state: trainee.state,
           provider_name: trainee.provider.name,
           provider_ukprn: trainee.provider.ukprn,
+          job_id: dead_jobs[trainee.id][:job_id],
           error_message: dead_jobs[trainee.id][:error_message]&.to_s&.gsub('"', "'"),
           params_sent: Dqt::Params::TraineeRequest.new(trainee:).to_json&.to_s&.gsub('"', "'"),
           dqt_status: dqt_status(trainee),

--- a/app/services/dead_jobs/dqt_update_trainee.rb
+++ b/app/services/dead_jobs/dqt_update_trainee.rb
@@ -17,6 +17,7 @@ module DeadJobs
     def to_a
       @to_a ||= trainees.map do |trainee|
         {
+          job_id: dead_jobs[trainee.id][:job_id],
           register_id: trainee.id,
           trainee_name: trainee.full_name,
           trainee_trn: trainee.trn,
@@ -25,8 +26,8 @@ module DeadJobs
           provider_name: trainee.provider.name,
           provider_ukprn: trainee.provider.ukprn,
           error_message: dead_jobs[trainee.id][:error_message]&.to_s&.gsub('"', "'"),
-          job_id: dead_jobs[trainee.id][:job_id],
           params_sent: Dqt::Params::TraineeRequest.new(trainee:).to_json&.to_s&.gsub('"', "'"),
+          dqt_status: dqt_status(trainee),
         }
       end
     end

--- a/app/services/dead_jobs/dqt_update_trainee.rb
+++ b/app/services/dead_jobs/dqt_update_trainee.rb
@@ -2,7 +2,34 @@
 
 module DeadJobs
   class DqtUpdateTrainee < Base
+    # includes the error_message entry using `includes: ...`
+    def to_csv
+      @to_csv ||= CSV.generate do |csv|
+        csv << headers(includes: %i[error_message job_id params_sent])
+        rows(includes: %i[error_message job_id params_sent]).each do |row|
+          csv << row.values
+        end
+      end
+    end
+
   private
+
+    def to_a
+      @to_a ||= trainees.map do |trainee|
+        {
+          register_id: trainee.id,
+          trainee_name: trainee.full_name,
+          trainee_trn: trainee.trn,
+          trainee_dob: trainee.date_of_birth,
+          trainee_state: trainee.state,
+          provider_name: trainee.provider.name,
+          provider_ukprn: trainee.provider.ukprn,
+          error_message: dead_jobs[trainee.id][:error_message]&.to_s&.gsub('"', "'"),
+          job_id: dead_jobs[trainee.id][:job_id],
+          params_sent: Dqt::Params::TraineeRequest.new(trainee:).to_json&.to_s&.gsub('"', "'"),
+        }
+      end
+    end
 
     # full class name to look for in Sidekiq dead jobs
     def klass

--- a/app/views/system_admin/dead_jobs/index.html.erb
+++ b/app/views/system_admin/dead_jobs/index.html.erb
@@ -9,7 +9,7 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header"></th>
-        <th scope="col" class="govuk-table__header">Count</th>
+        <th scope="col" class="govuk-table__header"></th>
         <th scope="col" class="govuk-table__header"></th>
       </tr>
     </thead>
@@ -28,15 +28,21 @@
           <td class="govuk-table__cell">
             <% unless service.count.zero? %>
               <%= render GovukButtonLinkTo::View.new(
+                body: "View",
+                url: dead_job_path(service.class),
+                class_option: "govuk-!-margin-bottom-0",
+              ) %>
+
+              <%= render GovukButtonLinkTo::View.new(
                 body: "Download (.csv)",
                 url: dead_job_path(service.class, format: :csv),
                 class_option: "govuk-!-margin-bottom-0",
               ) %>
 
               <%= render GovukButtonLinkTo::View.new(
-                body: "View",
-                url: dead_job_path(service.class),
-                class_option: "govuk-!-margin-bottom-0",
+                body: "Download (.csv) with DQT status",
+                url: dead_job_path(service.class, format: :csv, include_dqt_status: true),
+                class_option: "govuk-!-margin-bottom-0 govuk-button--warning",
               ) %>
               <% end %>
           </td>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,5 +80,5 @@ Rails.application.configure do
   # We don't use hosts authorization in deployed environments and there's no value to having it in dev.
   config.hosts.clear
 
-  config.active_job.queue_adapter = :async
+  config.active_job.queue_adapter = :sidekiq
 end

--- a/docs/testing_data_migrations.md
+++ b/docs/testing_data_migrations.md
@@ -11,7 +11,7 @@ Data migrations can/should be tested using production data. To download a copy f
 4. Make sure conduit is installed:
    `cf install-plugin conduit`
 5. Download the db:
-   `cf conduit register-postgres-production -- pg_dump -f register-postgres-production.sql --no-acl --no-owner --clean`
+   `cf conduit register-postgres-13-production -- pg_dump -f register-postgres-production.sql --no-acl --no-owner --clean`
 6. Then import:
    `DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rake db:{drop,create} && psql register_trainee_teacher_data_development < register-postgres-production.sql`
 7. This will have overwritten any migrations you have created for the feature you are working on, if so run

--- a/spec/services/dead_jobs/dqt_recommend_for_award_spec.rb
+++ b/spec/services/dead_jobs/dqt_recommend_for_award_spec.rb
@@ -4,6 +4,9 @@ require "rails_helper"
 
 module DeadJobs
   describe DqtRecommendForAward do
-    it_behaves_like "DeadJobs", "Dqt::RecommendForAwardJob", "Dqt recommend for award"
+    it_behaves_like "DeadJobs" do
+      let(:klass) { "Dqt::RecommendForAwardJob" }
+      let(:name) { "Dqt recommend for award" }
+    end
   end
 end

--- a/spec/services/dead_jobs/dqt_recommend_for_award_spec.rb
+++ b/spec/services/dead_jobs/dqt_recommend_for_award_spec.rb
@@ -6,7 +6,7 @@ module DeadJobs
   describe DqtRecommendForAward do
     it_behaves_like "DeadJobs" do
       let(:klass) { "Dqt::RecommendForAwardJob" }
-      let(:name) { "Dqt recommend for award" }
+      let(:name) { "DQT Recommend For Award" }
     end
   end
 end

--- a/spec/services/dead_jobs/dqt_update_trainee_spec.rb
+++ b/spec/services/dead_jobs/dqt_update_trainee_spec.rb
@@ -6,7 +6,7 @@ module DeadJobs
   describe DqtUpdateTrainee do
     it_behaves_like "DeadJobs" do
       let(:klass) { "Dqt::UpdateTraineeJob" }
-      let(:name) { "Dqt update trainee" }
+      let(:name) { "DQT Update Trainee" }
 
       let(:params_sent) { Dqt::Params::TraineeRequest.new(trainee:).to_json.to_s.gsub('"', "'") }
 

--- a/spec/services/dead_jobs/dqt_update_trainee_spec.rb
+++ b/spec/services/dead_jobs/dqt_update_trainee_spec.rb
@@ -8,27 +8,6 @@ module DeadJobs
       let(:klass) { "Dqt::UpdateTraineeJob" }
       let(:name) { "Dqt update trainee" }
 
-      let(:dead_set) do
-        [
-          OpenStruct.new(
-            item: {
-              wrapped: klass,
-              args:
-              [
-                {
-                  arguments: [
-                    { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee.id}" },
-                    { _aj_serialized: "ActiveJob::Serializers::TimeWithZoneSerializer", value: "2023-01-15T00:00:42.798653522Z" },
-                  ],
-                },
-              ],
-              error_message: 'status: 400, body: {"title":"Teacher has no incomplete ITT record","status":400,"errorCode":10005}, headers: ',
-              jid: "jobid1234",
-            }.with_indifferent_access,
-          ),
-        ]
-      end
-
       let(:params_sent) { Dqt::Params::TraineeRequest.new(trainee:).to_json.to_s.gsub('"', "'") }
 
       let(:csv) do

--- a/spec/services/dead_jobs/dqt_update_trainee_spec.rb
+++ b/spec/services/dead_jobs/dqt_update_trainee_spec.rb
@@ -12,8 +12,15 @@ module DeadJobs
 
       let(:csv) do
         <<~CSV
-          register_id,trainee_name,trainee_trn,trainee_dob,trainee_state,provider_name,provider_ukprn,error_message,job_id,params_sent
-          #{trainee.id},#{trainee.full_name},#{trainee.trn},#{trainee.date_of_birth.strftime('%F')},#{trainee.state},#{trainee.provider.name},#{trainee.provider.ukprn},"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}",jobid1234,"#{params_sent}"
+          register_id,trainee_name,trainee_trn,trainee_dob,trainee_state,provider_name,provider_ukprn,job_id,error_message,params_sent
+          #{trainee.id},#{trainee.full_name},#{trainee.trn},#{trainee.date_of_birth.strftime('%F')},#{trainee.state},#{trainee.provider.name},#{trainee.provider.ukprn},jobid1234,"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}","#{params_sent}"
+        CSV
+      end
+
+      let(:csv_with_dqt_status) do
+        <<~CSV
+          register_id,trainee_name,trainee_trn,trainee_dob,trainee_state,provider_name,provider_ukprn,job_id,error_message,params_sent,dqt_status
+          #{trainee.id},#{trainee.full_name},#{trainee.trn},#{trainee.date_of_birth.strftime('%F')},#{trainee.state},#{trainee.provider.name},#{trainee.provider.ukprn},jobid1234,"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}","#{params_sent}",Pass
         CSV
       end
     end

--- a/spec/services/dead_jobs/dqt_update_trainee_spec.rb
+++ b/spec/services/dead_jobs/dqt_update_trainee_spec.rb
@@ -4,6 +4,39 @@ require "rails_helper"
 
 module DeadJobs
   describe DqtUpdateTrainee do
-    it_behaves_like "DeadJobs", "Dqt::UpdateTraineeJob", "Dqt update trainee"
+    it_behaves_like "DeadJobs" do
+      let(:klass) { "Dqt::UpdateTraineeJob" }
+      let(:name) { "Dqt update trainee" }
+
+      let(:dead_set) do
+        [
+          OpenStruct.new(
+            item: {
+              wrapped: klass,
+              args:
+              [
+                {
+                  arguments: [
+                    { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee.id}" },
+                    { _aj_serialized: "ActiveJob::Serializers::TimeWithZoneSerializer", value: "2023-01-15T00:00:42.798653522Z" },
+                  ],
+                },
+              ],
+              error_message: 'status: 400, body: {"title":"Teacher has no incomplete ITT record","status":400,"errorCode":10005}, headers: ',
+              jid: "jobid1234",
+            }.with_indifferent_access,
+          ),
+        ]
+      end
+
+      let(:params_sent) { Dqt::Params::TraineeRequest.new(trainee:).to_json.to_s.gsub('"', "'") }
+
+      let(:csv) do
+        <<~CSV
+          register_id,trainee_name,trainee_trn,trainee_dob,trainee_state,provider_name,provider_ukprn,error_message,job_id,params_sent
+          #{trainee.id},#{trainee.full_name},#{trainee.trn},#{trainee.date_of_birth.strftime('%F')},#{trainee.state},#{trainee.provider.name},#{trainee.provider.ukprn},"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}",jobid1234,"#{params_sent}"
+        CSV
+      end
+    end
   end
 end

--- a/spec/services/dead_jobs/dqt_withdraw_trainee_spec.rb
+++ b/spec/services/dead_jobs/dqt_withdraw_trainee_spec.rb
@@ -4,6 +4,9 @@ require "rails_helper"
 
 module DeadJobs
   describe DqtWithdrawTrainee do
-    it_behaves_like "DeadJobs", "Dqt::WithdrawTraineeJob", "Dqt withdraw trainee"
+    it_behaves_like "DeadJobs" do
+      let(:klass) { "Dqt::WithdrawTraineeJob" }
+      let(:name) { "Dqt withdraw trainee" }
+    end
   end
 end

--- a/spec/services/dead_jobs/dqt_withdraw_trainee_spec.rb
+++ b/spec/services/dead_jobs/dqt_withdraw_trainee_spec.rb
@@ -6,7 +6,7 @@ module DeadJobs
   describe DqtWithdrawTrainee do
     it_behaves_like "DeadJobs" do
       let(:klass) { "Dqt::WithdrawTraineeJob" }
-      let(:name) { "Dqt withdraw trainee" }
+      let(:name) { "DQT Withdraw Trainee" }
     end
   end
 end


### PR DESCRIPTION
### Context

The dead jobs CSV export lacks a few useful attributes and context

### Changes proposed in this pull request

* adds job_id, params_sent (UpdateTrainee only) and trainee state to the CSV export
* adds DQT status and option to retrieve it (with warning) to the CSV export
* names CSV file with current date

### Guidance to review

* only testable in production, unless overriding the `def initialize(dead_set = Sidekiq::DeadSet.new)` in `app/services/dead_jobs/base.rb`
* check specs and make sure new fields are useful/needed and raise any more that could go in.
