### PR TITLE
[xxx] Only run RemoveDeadDuplicatesJob in prod

### DIFF
--- a/app/jobs/sidekiq/remove_dead_duplicates_job.rb
+++ b/app/jobs/sidekiq/remove_dead_duplicates_job.rb
@@ -5,6 +5,8 @@ module Sidekiq
     queue_as :default
 
     def perform
+      return unless ::Rails.env.production?
+
       RemoveDeadDuplicates.call
     end
   end

--- a/spec/jobs/sidekiq/remove_dead_duplicates_job_spec.rb
+++ b/spec/jobs/sidekiq/remove_dead_duplicates_job_spec.rb
@@ -4,7 +4,11 @@ require "rails_helper"
 
 module Sidekiq
   describe RemoveDeadDuplicatesJob do
-    it "calls the RemoveDeadDuplicates service" do
+    before do
+      allow(::Rails.env).to receive(:production?).and_return(true)
+    end
+
+    it "calls the RemoveDeadDuplicates service in production" do
       expect(RemoveDeadDuplicates).to receive(:call)
       described_class.new.perform
     end


### PR DESCRIPTION
### Context

This is causing an error per minute in QA.

### Changes proposed in this pull request

Only run dead de-duping job in prod.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
