### PR TITLE
[5194] Link to trainees from dead job viewer

### DIFF
--- a/app/services/dead_jobs/base.rb
+++ b/app/services/dead_jobs/base.rb
@@ -38,6 +38,10 @@ module DeadJobs
       @name ||= identifier.titleize.gsub("Dqt", "DQT")
     end
 
+    def identifier
+      @identifier ||= self.class.name.demodulize
+    end
+
     delegate :count, to: :dead_jobs
 
   private
@@ -45,10 +49,6 @@ module DeadJobs
     attr_reader :dead_set, :include_dqt_status
 
     DEFAULT_HEADERS = %i[register_id trainee_name trainee_trn trainee_dob trainee_state provider_name provider_ukprn].freeze
-
-    def identifier
-      @identifier ||= self.class.name.demodulize
-    end
 
     def trainees
       Trainee.includes(:provider).find(dead_jobs.keys)

--- a/app/views/system_admin/dead_jobs/index.html.erb
+++ b/app/views/system_admin/dead_jobs/index.html.erb
@@ -30,8 +30,9 @@
               <%= render GovukButtonLinkTo::View.new(
                 body: "View",
                 url: dead_job_path(service.class),
+                id: "view_#{service.identifier}",
                 class_option: "govuk-!-margin-bottom-0",
-              ) %>
+                ) %>
 
               <%= render GovukButtonLinkTo::View.new(
                 body: "Download (.csv)",
@@ -40,10 +41,11 @@
               ) %>
 
               <%= render GovukButtonLinkTo::View.new(
+
                 body: "Download (.csv) with DQT status",
                 url: dead_job_path(service.class, format: :csv, include_dqt_status: true),
                 class_option: "govuk-!-margin-bottom-0 govuk-button--warning",
-              ) %>
+                ) %>
               <% end %>
           </td>
         </tr>

--- a/app/views/system_admin/dead_jobs/show.html.erb
+++ b/app/views/system_admin/dead_jobs/show.html.erb
@@ -26,15 +26,23 @@
         <% end %>
       </tr>
     </thead>
+
     <tbody class="govuk-table__body">
       <% dead_job_service.rows&.each do |row| %>
         <tr class="govuk-table__row">
           <% row.each do |data| %>
             <td class="govuk-table__cell"><%= data[-1] %></td>
           <% end %>
+          <td class="govuk-table__cell">
+            <%= render GovukButtonLinkTo::View.new(
+              body: "View",
+              id: "view_#{row[:register_id]}",
+              url: trainee_path(Trainee.find(row[:register_id]),
+                                class_option: "govuk-!-margin-bottom-0"
+              )) %>
+          </td>
         </tr>
       <% end %>
     </tbody>
   </table>
-
 <% end %>

--- a/spec/features/system_admin/dead_jobs/viewing_dead_jobs_spec.rb
+++ b/spec/features/system_admin/dead_jobs/viewing_dead_jobs_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Viewing sidekiq dead jobs" do
+  let(:user) { create(:user, system_admin: true) }
+  let!(:trainee) { create(:trainee, :submitted_for_trn, first_names: "James Blint", id: 10001) }
+
+  before do
+    given_i_am_authenticated(user:)
+    and_dead_jobs_exist
+    when_i_visit_the_dead_jobs_tab
+  end
+
+  scenario "shows dead_jobs page" do
+    then_i_see_the_dead_jobs_page
+    when_i_click_view
+    then_i_am_taken_to_the_dqt_update_page
+    then_i_see_the_trainee
+    and_the_trainee_view_link_is_visibile
+    and_when_i_click_view
+    then_i_am_redirected_to_the_record_page
+  end
+
+  def when_i_visit_the_dead_jobs_tab
+    admin_dead_jobs_page.load
+  end
+
+  def and_dead_jobs_exist
+    allow(Sidekiq::DeadSet).to receive(:new).and_return(
+      [
+        OpenStruct.new(
+          item: {
+            wrapped: "Dqt::UpdateTraineeJob",
+            args:
+              [
+                {
+                  arguments: [
+                    { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee.id}" },
+                    { _aj_serialized: "ActiveJob::Serializers::TimeWithZoneSerializer", value: "2023-01-15T00:00:42.798653522Z" },
+                  ],
+                },
+              ],
+            error_message: 'status: 400, body: {"title":"Teacher has no incomplete ITT record","status":400,"errorCode":10005}, headers: ',
+          }.with_indifferent_access,
+        ),
+      ],
+    )
+  end
+
+  def then_i_see_the_dead_jobs_page
+    expect(admin_dead_jobs_page).to have_text("Dead background Jobs")
+  end
+
+  def when_i_click_view
+    admin_dead_jobs_page.dqt_update_trainee_dead_jobs_view_button.click
+  end
+
+  def then_i_am_taken_to_the_dqt_update_page
+    expect(admin_dead_jobs_dqt_update_trainee).to be_displayed
+  end
+
+  def then_i_see_the_trainee
+    expect(admin_dead_jobs_dqt_update_trainee).to have_text("James Blint")
+  end
+
+  def and_the_trainee_view_link_is_visibile
+    expect(admin_dead_jobs_dqt_update_trainee).to have_text("View")
+  end
+
+  def and_when_i_click_view
+    admin_dead_jobs_dqt_update_trainee.view_trainee_button.click
+  end
+
+  def then_i_am_redirected_to_the_record_page
+    expect(record_page).to be_displayed(id: trainee.slug)
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -382,6 +382,14 @@ module Features
       @lead_schools_trainee_summary_page ||= PageObjects::SystemAdmin::Funding::LeadSchoolsTraineeSummary.new
     end
 
+    def admin_dead_jobs_page
+      @admin_dead_jobs_page ||= PageObjects::SystemAdmin::DeadJobs::DeadBackgroundJobs.new
+    end
+
+    def admin_dead_jobs_dqt_update_trainee
+      @admin_dead_jobs_dqt_update_trainee ||= PageObjects::SystemAdmin::DeadJobs::DqtUpdateTrainee.new
+    end
+
     def admin_users_index_page
       @admin_users_index_page ||= PageObjects::SystemAdmin::Users::Index.new
     end

--- a/spec/support/page_objects/system_admin/dead_jobs/dead_background_jobs_summary.rb
+++ b/spec/support/page_objects/system_admin/dead_jobs/dead_background_jobs_summary.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module SystemAdmin
+    module DeadJobs
+      class DeadBackgroundJobs < PageObjects::Base
+        set_url "/system-admin/dead_jobs"
+
+        element :dqt_update_trainee_dead_jobs_view_button, "a", id: "view_DqtUpdateTrainee", text: "View"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/system_admin/dead_jobs/dead_jobs_dqt_update_trainee.rb
+++ b/spec/support/page_objects/system_admin/dead_jobs/dead_jobs_dqt_update_trainee.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module SystemAdmin
+    module DeadJobs
+      class DqtUpdateTrainee < PageObjects::Base
+        set_url "/system-admin/dead_jobs/DeadJobs::DqtUpdateTrainee"
+
+        element :view_trainee_button, "a", id: "view_10001", text: "View"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Link to trainees from the show page of dead job viewer.

### Changes proposed in this pull request

Add a button to link to the trainee from the dead job viewer.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
