### PR TITLE
[5211] Show the output from the DQT API for a trainee

### DIFF
--- a/app/components/dqt_data_summary/view.html.erb
+++ b/app/components/dqt_data_summary/view.html.erb
@@ -1,0 +1,80 @@
+<div class="app-summary-card__body">
+  <dl class="govuk-summary-list" style="overflow:hidden;">
+    <% if dqt_data.present? %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Name
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= dqt_data["name"] %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Date of birth
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= Date.parse(dqt_data["dob"]).strftime("%e %B %Y") %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          ITT result
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= dqt_data["initial_teacher_training"]["result"] %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          QTS date
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= dqt_data["qts_date"].present? ? Date.parse(dqt_data["qts_date"]) : "-" %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Full API response
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                <%= date %>
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <h3 class="govuk-heading-m">General</h3>
+              <%= govuk_summary_list(rows: general) %>
+
+              <h3 class="govuk-heading-m govuk-!-margin-top-6">Qualified teacher status</h3>
+              <%= govuk_summary_list(rows: qualified_teacher_status) %>
+
+              <h3 class="govuk-heading-m govuk-!-margin-top-6">Induction</h3>
+              <% if induction.present? %>
+                <%= govuk_summary_list(rows: induction) %>
+              <% else %>
+                No induction data
+              <% end %>
+
+              <h3 class="govuk-heading-m govuk-!-margin-top-6">Initial teacher training</h3>
+              <%= govuk_summary_list(rows: initial_teacher_training) %>
+
+              <h3 class="govuk-heading-m govuk-!-margin-top-6"><%= "Qualification".pluralize(qualification_count) %></h3>
+              <%= govuk_summary_list(rows: qualifications) %>
+            </div>
+          </details>
+        </dd>
+      </div>
+    <% else %>
+      <p class="govuk-body">
+        Data not available
+      </p>
+    <% end %>
+  </dl>
+</div>

--- a/app/components/dqt_data_summary/view.rb
+++ b/app/components/dqt_data_summary/view.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module DqtDataSummary
+  class View < GovukComponent::Base
+    def initialize(dqt_data:)
+      @dqt_data = dqt_data
+    end
+
+  private
+
+    attr_reader :trainee, :dqt_data
+
+    def general
+      @general ||= summarise(dqt_data.except("qualified_teacher_status", "induction", "initial_teacher_training", "qualifications"))
+    end
+
+    def qualified_teacher_status
+      @qualified_teacher_status ||= summarise(dqt_data["qualified_teacher_status"])
+    end
+
+    def induction
+      return [] if dqt_data["induction"].nil?
+
+      @induction ||= summarise(dqt_data["induction"])
+    end
+
+    def initial_teacher_training
+      return [] if dqt_data["initial_teacher_training"].nil?
+
+      @initial_teacher_training ||= summarise(dqt_data["initial_teacher_training"])
+    end
+
+    def qualifications
+      return [] if dqt_data["qualifications"].nil?
+
+      @qualifications ||= dqt_data["qualifications"].map { |qualification| summarise(qualification) }.flatten
+    end
+
+    def qualification_count
+      return if dqt_data["qualifications"].empty?
+
+      dqt_data["qualifications"].count
+    end
+
+    # 4 December 2022 at 1:07pm
+    def date
+      Time.zone.now.strftime("%e %B %Y at %I:%M%P")
+    end
+
+    def summarise(data)
+      summary = []
+
+      data.each do |key, value|
+        summary << { key: { text: key, classes: "no-wrap govuk-!-width-one-third" }, value: { text: value.presence || "-" } }
+      end
+
+      summary
+    end
+  end
+end

--- a/app/components/hesa_student_summary/view.html.erb
+++ b/app/components/hesa_student_summary/view.html.erb
@@ -1,30 +1,30 @@
 <% if hesa_trainee.present? %>
   <div class="govuk-summary-list__row">
-     <dt class="govuk-summary-list__key">
-        Collection <%= collection %>
-     </dt>
-       <dd class="govuk-summary-list__value">
-          <details class="govuk-details" data-module="govuk-details">
-             <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                <%= date %>
-                </span>
-             </summary>
-             <div class="govuk-details__text">
-                <h3 class="govuk-heading-m">Student</h3>
-                <%= govuk_summary_list(rows: student) %>
-                
-                <% if degrees.present? %>
-                  <h3 class="govuk-heading-m govuk-!-margin-top-6"><%= "Degree".pluralize(degree_count) %></h3>
-                  <%= govuk_summary_list(rows: degrees) %>
-                <% end %>
+    <dt class="govuk-summary-list__key">
+      Collection <%= collection %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            <%= date %>
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <h3 class="govuk-heading-m">Student</h3>
+          <%= govuk_summary_list(rows: student) %>
 
-                <% if placements.present? %>
-                  <h3 class="govuk-heading-m govuk-!-margin-top-6"><%= "Placement".pluralize(placement_count) %></h3>
-                  <%= govuk_summary_list(rows: placements) %>
-                <% end %>
-             </div>
-          </details>
-       </dd>
+          <% if degrees.present? %>
+            <h3 class="govuk-heading-m govuk-!-margin-top-6"><%= "Degree".pluralize(degree_count) %></h3>
+            <%= govuk_summary_list(rows: degrees) %>
+          <% end %>
+
+          <% if placements.present? %>
+            <h3 class="govuk-heading-m govuk-!-margin-top-6"><%= "Placement".pluralize(placement_count) %></h3>
+            <%= govuk_summary_list(rows: placements) %>
+          <% end %>
+        </div>
+      </details>
+    </dd>
   </div>
 <% end %>

--- a/app/controllers/trainees/admins_controller.rb
+++ b/app/controllers/trainees/admins_controller.rb
@@ -2,7 +2,7 @@
 
 module Trainees
   class AdminsController < BaseController
-    helper_method :trainee, :collections
+    helper_method :trainee, :collections, :dqt_data
 
     def show
       return redirect_to(trainees_path) unless current_user.system_admin?
@@ -14,6 +14,14 @@ module Trainees
 
     def collections
       @collections ||= Hesa::Student.where.not(collection_reference: nil).distinct.pluck(:collection_reference).sort.reverse
+    end
+
+    def dqt_data
+      return unless FeatureService.enabled?(:integrate_with_dqt)
+
+      @dqt_data ||= Dqt::RetrieveTeacher.call(trainee:)
+    rescue Dqt::Client::HttpError
+      false
     end
   end
 end

--- a/app/views/trainees/admins/show.html.erb
+++ b/app/views/trainees/admins/show.html.erb
@@ -1,3 +1,14 @@
+<% if trainee.trn.present? %>
+   <section class="app-summary-card govuk-!-margin-bottom-6">
+      <header class="app-summary-card__header">
+         <h2 class="app-summary-card__title">
+            DQT
+         </h2>
+      </header>
+      <%= render DqtDataSummary::View.new(dqt_data:) %>
+   </section>
+<% end %>
+
 <% if trainee.hesa_student.present? %>
    <section class="app-summary-card govuk-!-margin-bottom-6">
       <header class="app-summary-card__header">

--- a/spec/components/dqt_data_summary/view_preview.rb
+++ b/spec/components/dqt_data_summary/view_preview.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module DqtDataSummary
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render(View.new(dqt_data: mock_dqt_data))
+    end
+
+  private
+
+    def mock_dqt_data
+      {
+        "trn" => "1234567",
+        "ni_number" => nil,
+        "qualified_teacher_status" => {
+          "name" => "Trainee Teacher",
+          "state" => "Active",
+          "state_name" => "Active",
+          "qts_date" => nil,
+        },
+        "induction" => {
+          "start_date" => "2023-09-19T00:00:00Z",
+          "completion_date" => nil,
+          "status" => nil,
+          "state" => "Active",
+          "state_name" => nil,
+        },
+        "initial_teacher_training" => {
+          "state" => "Active",
+          "state_code" => "Active",
+          "programme_start_date" => "2022-09-19T00:00:00Z",
+          "programme_end_date" => "2026-05-22T00:00:00Z",
+          "programme_type" => "Provider-led (undergrad)",
+          "result" => "In Training",
+          "subject1" => "primary teaching",
+          "subject2" => nil,
+          "subject3" => nil,
+          "qualification" => "BA (Hons)",
+          "subject1_code" => "100511",
+          "subject2_code" => nil,
+          "subject3_code" => nil,
+        },
+        "qualifications" => [
+          {
+            "name" => "Higher Education",
+            "date_awarded" => nil,
+            "he_qualification_name" => "First Degree",
+            "he_subject1" => nil,
+            "he_subject2" => nil,
+            "he_subject3" => nil,
+            "he_subject1_code" => nil,
+            "he_subject2_code" => nil,
+            "he_subject3_code" => nil,
+            "class" => nil,
+          },
+        ],
+        "name" => "Abigail McPhillips",
+        "dob" => "1990-04-27T00:00:00",
+        "active_alert" => false,
+        "state" => "Active",
+        "state_name" => "Active",
+      }
+    end
+  end
+end

--- a/spec/components/dqt_data_summary/view_spec.rb
+++ b/spec/components/dqt_data_summary/view_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module DqtDataSummary
+  describe View, type: :component do
+    context "when there is no data" do
+      before do
+        render_inline(described_class.new(dqt_data: nil))
+      end
+
+      it "renders 'Data not available' content" do
+        expect(rendered_component).to have_text("Data not available")
+      end
+    end
+
+    context "when has_errors is false" do
+      let(:dqt_data) do
+        {
+          "trn" => "1234567",
+          "qualified_teacher_status" => {
+            "name" => "Trainee Teacher",
+            "state" => "Active",
+            "state_name" => "Active",
+            "qts_date" => nil,
+          },
+          "induction" => nil,
+          "initial_teacher_training" => {
+            "state" => "Active",
+            "state_code" => "Active",
+            "programme_start_date" => "2022-09-19T00:00:00Z",
+            "programme_end_date" => "2026-05-22T00:00:00Z",
+            "programme_type" => "Provider-led (undergrad)",
+            "result" => "In Training",
+            "subject1" => "primary teaching",
+            "qualification" => "BA (Hons)",
+            "subject1_code" => "100511",
+          },
+          "qualifications" => [
+            {
+              "name" => "Higher Education",
+              "he_qualification_name" => "First Degree",
+            },
+          ],
+          "name" => "Abigail McPhillips",
+          "dob" => "1990-04-27T00:00:00",
+        }
+      end
+
+      before do
+        render_inline(described_class.new(dqt_data:))
+      end
+
+      it "renders the data" do
+        expect(rendered_component).to have_text("Abigail McPhillips")
+        expect(rendered_component).to have_text("No induction data")
+        expect(rendered_component).to have_text("In Training")
+        expect(rendered_component).to have_text("First Degree")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/8clT8XTR/5211-show-the-output-from-the-dqt-api-for-a-trainee

### Changes proposed in this pull request

- Create new DqtDataSummary component, a table which displays
  the response of the DQT get teacher API
- Call the get teacher API endpoint from the trainee admin controller
  rescuing any exceptions
- Render the data summary on the trainee show page

### Guidance to review

You can't view this in dev / review / QA etc, but you can view the component with mock data here: 

https://register-pr-3084.london.cloudapps.digital/view_components/dqt_data_summary/view/default

Head to a registered trainee show page, admin tab to see where it would render, and how the 'no data' scenario is handled.

<img width="1093" alt="Screenshot 2023-01-31 at 19 24 49" src="https://user-images.githubusercontent.com/18436946/216047706-2cf1817d-e75a-4c39-9040-057df74f033a.png">

<img width="1093" alt="Screenshot 2023-01-31 at 19 24 54" src="https://user-images.githubusercontent.com/18436946/216047727-48f87869-9fb0-43eb-8a5c-075953171309.png">

<img width="1323" alt="Screenshot 2023-02-01 at 12 27 12" src="https://user-images.githubusercontent.com/18436946/216047863-c8c4f637-d981-444d-b455-4620e16e49e9.png">

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml