### PR TITLE
[xxx] Cancel withdraw job if trainee is already withdrawn in DQT

### DIFF
--- a/app/jobs/dqt/withdraw_trainee_job.rb
+++ b/app/jobs/dqt/withdraw_trainee_job.rb
@@ -22,7 +22,7 @@ module Dqt
       end
 
       if trainee.trn.present?
-        WithdrawTrainee.call(trainee:)
+        WithdrawTrainee.call(trainee:) unless already_withdrawn_in_dqt?
       elsif continue_waiting_for_trn?
         requeue
       else
@@ -40,6 +40,10 @@ module Dqt
 
     def requeue
       self.class.set(wait: Settings.jobs.poll_delay_hours.hours).perform_later(trainee, timeout_after)
+    end
+
+    def already_withdrawn_in_dqt?
+      RetrieveTeacher.call(trainee:).dig("initial_teacher_training", "result") == "Withdrawn"
     end
   end
 end


### PR DESCRIPTION
### Context
We're getting a lot of dead withdraw jobs because the trainee is already withdrawn in DQT. Not sure how the trainee got to be withdrawn before Register knew about it, but for now, this workaround will reduce the workload on support.

The trade-off is the withdraw job may end up doing 2 API calls to DQT which may impact the 3000/per minute rate limit during busy periods.

### Changes proposed in this pull request
- Add DQT check to `Dqt::WithdrawTraineeJob`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
