### PR TITLE
[5223] Zero pad the hesa codes on lookup

### DIFF
--- a/app/services/degrees/dfe_reference.rb
+++ b/app/services/degrees/dfe_reference.rb
@@ -11,7 +11,7 @@ module Degrees
     TYPES = DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS
     INSTITUTIONS = DfE::ReferenceData::Degrees::INSTITUTIONS_INCLUDING_GENERICS
 
-    SUPPORTED_GRADES_BY_HESA_CODES = %w[1 2 3 5 12 13 14].freeze
+    SUPPORTED_GRADES_BY_HESA_CODES = %w[01 02 03 05 12 13 14].freeze
 
     SUPPORTED_GRADES = GRADES.all_as_hash.select { |_, item|
       SUPPORTED_GRADES_BY_HESA_CODES.include?(item[:hesa_code])


### PR DESCRIPTION
### Context

https://trello.com/c/LZzx9IJW/5223-new-degree-form-is-missing-many-degree-grades

The reference data gem zero padded the hesa codes, but we didn't update our lookup code to reflect this:

https://github.com/DFE-Digital/dfe-reference-data/commit/9a3f42d8723e9c44619b006eb04cae7a2553a7cc

### Changes proposed in this pull request

Zero pad the hesa code on the lookup for the form options.

### Guidance to review

Go to add a new degree and see that the full list of grades is there.

<img width="484" alt="Screenshot 2023-02-02 at 10 17 20" src="https://user-images.githubusercontent.com/18436946/216297528-306eb14c-06aa-4f68-94e6-c5d832b8487f.png">

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
