### PR TITLE
[xxx] Do not use HESA TRN to set state

### DIFF
--- a/app/services/trainees/map_state_from_hesa.rb
+++ b/app/services/trainees/map_state_from_hesa.rb
@@ -7,7 +7,7 @@ module Trainees
     def initialize(hesa_trainee:, trainee:)
       @hesa_trainee = hesa_trainee
       @trainee = trainee
-      @trn = trainee.trn || hesa_trainee[:trn]
+      @trn = trainee.trn
     end
 
     def call
@@ -39,6 +39,9 @@ module Trainees
     end
 
     def trn_received?
+      # Whilst providers can provide a TRN, it's not to be trusted. Only Register and DQT are
+      # responsible for the allocation of TRNs. Therefore we do not check for the presence of
+      # TRN in the HESA trainee data.
       (reason_for_leaving.blank? || completed_with_unknown_result?) && trn.present?
     end
 

--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -202,6 +202,16 @@ trainee.audits.last.destroy # if appropriate
 
 Register support may need to communicate with the trainee and provider to ensure that they understand the error and the resolution.
 
+## HESA integration
+
+Sometimes we receive TRNs from HESA. These TRNs cannot be trusted as they are entered by providers, and may be incorrect. Only DQT should be the source of TRNs. You might see this alert in Sentry:
+
+`HESA TRN (2181587) different to trainee TRN (2159484)`
+
+We might want to start looking at the mismatches and letting providers know they are inputting the wrong TRN.
+
+We made a decision to disregard TRNs sent from HESA. If we receive a TRN for a trainee from HESA, and we do not already have a TRN for them in Register, we kick off a RegisterForTrnJob to DQT to get the correct TRN. 
+
 ## Managing the siqekiq queue
 
 ### via the UI

--- a/spec/services/trainees/map_state_from_hesa_spec.rb
+++ b/spec/services/trainees/map_state_from_hesa_spec.rb
@@ -19,7 +19,7 @@ module Trainees
       let(:trainee) { build(:trainee) }
 
       context "when the trainee has no 'reason for leaving'" do
-        context "and has no TRN" do
+        context "and has no HESA TRN" do
           let(:hesa_stub_attributes) do
             { reason_for_leaving: nil, trn: nil }
           end
@@ -27,17 +27,17 @@ module Trainees
           it { is_expected.to eq(:submitted_for_trn) }
         end
 
-        context "and has a TRN" do
+        context "and has a HESA TRN but does not have a Register TRN" do
           let(:hesa_stub_attributes) do
             { reason_for_leaving: nil, trn: hesa_trn }
           end
 
-          it { is_expected.to eq(:trn_received) }
+          it { is_expected.to eq(:submitted_for_trn) }
         end
       end
 
       context "when the trainee's reason for leaving is COMPLETED_WITH_CREDIT_OR_AWARD" do
-        context "and has a TRN" do
+        context "and has a HESA TRN but does not have a Register TRN" do
           let(:hesa_stub_attributes) do
             {
               reason_for_leaving: hesa_reason_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::COMPLETED_WITH_CREDIT_OR_AWARD],
@@ -45,10 +45,10 @@ module Trainees
             }
           end
 
-          it { is_expected.to eq(:trn_received) }
+          it { is_expected.to eq(:submitted_for_trn) }
         end
 
-        context "and has no TRN" do
+        context "and has no HESA TRN" do
           let(:hesa_stub_attributes) do
             {
               reason_for_leaving: hesa_reason_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::COMPLETED_WITH_CREDIT_OR_AWARD],
@@ -61,7 +61,7 @@ module Trainees
       end
 
       context "when the trainee's reason for leaving is COMPLETED_WITH_CREDIT_OR_AWARD_UNKNOWN" do
-        context "and they have a TRN" do
+        context "and they have a HESA TRN but do not have Register TRN" do
           let(:hesa_stub_attributes) do
             {
               reason_for_leaving: hesa_reason_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::COMPLETED_WITH_CREDIT_OR_AWARD_UNKNOWN],
@@ -69,10 +69,10 @@ module Trainees
             }
           end
 
-          it { is_expected.to eq(:trn_received) }
+          it { is_expected.to eq(:submitted_for_trn) }
         end
 
-        context "and they have no TRN" do
+        context "and they have no HESA TRN" do
           let(:hesa_stub_attributes) do
             {
               reason_for_leaving: hesa_reason_for_leaving_codes[Hesa::CodeSets::ReasonsForLeavingCourse::COMPLETED_WITH_CREDIT_OR_AWARD_UNKNOWN],


### PR DESCRIPTION
### Context

HESA sometimes send us TRNs. These can't be trusted, so don't include them in our decision to set the trainee's state/register for TRN on our end. 

### Changes proposed in this pull request

* Remove `hesa_trainee[:trn]` from our `MapStateFromHesa` service

### Guidance to review

### Important business

- [ ] ~~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~~
- [ ] ~~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~~
- [ ] ~~Do we need to send any updates to DQT as part of the work in this PR?~~
- [ ] ~~Does this PR need an ADR?~~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
