### PR TITLE
[xxx] Add programme details to dead job CSV export

### DIFF
--- a/app/services/dead_jobs/dqt_update_trainee.rb
+++ b/app/services/dead_jobs/dqt_update_trainee.rb
@@ -4,32 +4,14 @@ module DeadJobs
   class DqtUpdateTrainee < Base
     # includes the error_message entry using `includes: ...`
     def to_csv(includes: [])
-      includes = %i[job_id error_message params_sent] | includes
-      CSV.generate do |csv|
-        csv << headers(includes:)
-        rows(includes:).each do |row|
-          csv << row.values
-        end
-      end
+      build_csv(includes: %i[job_id error_message params_sent] | includes)
     end
 
   private
 
-    def to_a
-      @to_a ||= trainees.map do |trainee|
-        {
-          register_id: trainee.id,
-          trainee_name: trainee.full_name,
-          trainee_trn: trainee.trn,
-          trainee_dob: trainee.date_of_birth,
-          trainee_state: trainee.state,
-          provider_name: trainee.provider.name,
-          provider_ukprn: trainee.provider.ukprn,
-          job_id: dead_jobs[trainee.id][:job_id],
-          error_message: dead_jobs[trainee.id][:error_message]&.to_s&.gsub('"', "'"),
-          params_sent: Dqt::Params::TraineeRequest.new(trainee:).to_json&.to_s&.gsub('"', "'"),
-          dqt_status: dqt_status(trainee),
-        }
+    def build_rows
+      super do |trainee|
+        { params_sent: Dqt::Params::TraineeRequest.new(trainee:).to_json&.to_s&.gsub('"', "'") }
       end
     end
 

--- a/spec/services/dead_jobs/dqt_update_trainee_spec.rb
+++ b/spec/services/dead_jobs/dqt_update_trainee_spec.rb
@@ -12,15 +12,15 @@ module DeadJobs
 
       let(:csv) do
         <<~CSV
-          register_id,trainee_name,trainee_trn,trainee_dob,trainee_state,provider_name,provider_ukprn,job_id,error_message,params_sent
-          #{trainee.id},#{trainee.full_name},#{trainee.trn},#{trainee.date_of_birth.strftime('%F')},#{trainee.state},#{trainee.provider.name},#{trainee.provider.ukprn},jobid1234,"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}","#{params_sent}"
+          #{headers.join(',')},job_id,error_message,params_sent
+          #{row},#{job_id},"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}","#{params_sent}"
         CSV
       end
 
       let(:csv_with_dqt_status) do
         <<~CSV
-          register_id,trainee_name,trainee_trn,trainee_dob,trainee_state,provider_name,provider_ukprn,job_id,error_message,params_sent,dqt_status
-          #{trainee.id},#{trainee.full_name},#{trainee.trn},#{trainee.date_of_birth.strftime('%F')},#{trainee.state},#{trainee.provider.name},#{trainee.provider.ukprn},jobid1234,"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}","#{params_sent}",Pass
+          #{headers.join(',')},job_id,error_message,params_sent,dqt_status
+          #{row},#{job_id},"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}","#{params_sent}",Pass
         CSV
       end
     end

--- a/spec/support/shared_examples/dead_jobs.rb
+++ b/spec/support/shared_examples/dead_jobs.rb
@@ -4,6 +4,12 @@ shared_examples "DeadJobs" do
   let(:service) { described_class.new(dead_set:, include_dqt_status:) }
   let(:include_dqt_status) { false }
   let(:trainee) { create(:trainee, :completed, :trn_received, sex: "female", hesa_id: 1) }
+  let(:dqt_trn_params) { Dqt::Params::TrnRequest.new(trainee:).params }
+  let(:programme_route) { dqt_trn_params.dig("initialTeacherTraining", "programmeType") }
+  let(:programme_start_date) { dqt_trn_params.dig("initialTeacherTraining", "programmeStartDate") }
+  let(:programme_end_date) { dqt_trn_params.dig("initialTeacherTraining", "programmeEndDate") }
+  let(:job_id) { "jobid1234" }
+
   let(:result) do
     {
       register_id: trainee.id,
@@ -13,6 +19,9 @@ shared_examples "DeadJobs" do
       trainee_state: trainee.state,
       provider_name: trainee.provider.name,
       provider_ukprn: trainee.provider.ukprn,
+      programme_route: programme_route,
+      programme_start_date: programme_start_date,
+      programme_end_date: programme_end_date,
     }
   end
 
@@ -22,36 +31,37 @@ shared_examples "DeadJobs" do
         item: {
           wrapped: klass,
           args:
-          [
-            {
-              arguments: [
-                { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee.id}" },
-                { _aj_serialized: "ActiveJob::Serializers::TimeWithZoneSerializer", value: "2023-01-15T00:00:42.798653522Z" },
-              ],
-            },
-          ],
+            [
+              {
+                arguments: [
+                  { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee.id}" },
+                  { _aj_serialized: "ActiveJob::Serializers::TimeWithZoneSerializer", value: "2023-01-15T00:00:42.798653522Z" },
+                ],
+              },
+            ],
           error_message: 'status: 400, body: {"title":"Teacher has no incomplete ITT record","status":400,"errorCode":10005}, headers: ',
-          jid: "jobid1234",
+          jid: job_id,
         }.with_indifferent_access,
       ),
     ]
   end
 
+  let(:headers) { DeadJobs::Base::DEFAULT_HEADERS }
+  let(:row) { result.dup.merge(trainee_dob: result[:trainee_dob].strftime("%F")).values.join(",") }
+
   let(:csv) do
     <<~CSV
-      register_id,trainee_name,trainee_trn,trainee_dob,trainee_state,provider_name,provider_ukprn,job_id,error_message
-      #{trainee.id},#{trainee.full_name},#{trainee.trn},#{trainee.date_of_birth.strftime('%F')},#{trainee.state},#{trainee.provider.name},#{trainee.provider.ukprn},jobid1234,"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}"
+      #{headers.join(',')},job_id,error_message
+      #{row},#{job_id},"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}"
     CSV
   end
 
   let(:csv_with_dqt_status) do
     <<~CSV
-      register_id,trainee_name,trainee_trn,trainee_dob,trainee_state,provider_name,provider_ukprn,job_id,error_message,dqt_status
-      #{trainee.id},#{trainee.full_name},#{trainee.trn},#{trainee.date_of_birth.strftime('%F')},#{trainee.state},#{trainee.provider.name},#{trainee.provider.ukprn},jobid1234,"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}",Pass
+      #{headers.join(',')},job_id,error_message,dqt_status
+      #{row},#{job_id},"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}",Pass
     CSV
   end
-
-  let(:headers) { %i[register_id trainee_name trainee_trn trainee_dob trainee_state provider_name provider_ukprn] }
 
   describe "#to_csv" do
     context "excluding DQT status" do
@@ -76,7 +86,7 @@ shared_examples "DeadJobs" do
   end
 
   describe "#headers" do
-    it { expect(service.headers).to eq headers }
+    it { expect(service.headers).to eq(headers) }
   end
 
   describe "#rows" do
@@ -86,10 +96,10 @@ shared_examples "DeadJobs" do
   end
 
   describe "#name" do
-    it { expect(service.name).to eq name }
+    it { expect(service.name).to eq(name) }
   end
 
   describe "#count" do
-    it { expect(service.count).to eq 1 }
+    it { expect(service.count).to eq(1) }
   end
 end


### PR DESCRIPTION
### Context
DQT have asked for more information on the programme details.

### Changes proposed in this pull request
- Add `programme_route`, `programme_start_date` and `programme_end_date` to `DeadJobs::Base`

### Guidance to review
- Code was tested manually in production to produce CSV for DQT

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
