### PR TITLE
[xxx] Fix DQT admin view when there's missing data

### DIFF
--- a/app/components/dqt_data_summary/view.html.erb
+++ b/app/components/dqt_data_summary/view.html.erb
@@ -15,7 +15,7 @@
           Date of birth
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= Date.parse(dqt_data["dob"]).strftime("%e %B %Y") %>
+          <%= date_of_birth %>
         </dd>
       </div>
 
@@ -24,7 +24,7 @@
           ITT result
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= dqt_data["initial_teacher_training"]["result"] %>
+          <%= itt_result %>
         </dd>
       </div>
 
@@ -33,7 +33,7 @@
           QTS date
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= dqt_data["qts_date"].present? ? Date.parse(dqt_data["qts_date"]) : "-" %>
+          <%= qts_date %>
         </dd>
       </div>
 
@@ -53,20 +53,37 @@
               <%= govuk_summary_list(rows: general) %>
 
               <h3 class="govuk-heading-m govuk-!-margin-top-6">Qualified teacher status</h3>
-              <%= govuk_summary_list(rows: qualified_teacher_status) %>
+
+              <% if qualified_teacher_status.present? %>
+                <%= govuk_summary_list(rows: qualified_teacher_status) %>
+              <% else %>
+                No data
+              <% end %>
 
               <h3 class="govuk-heading-m govuk-!-margin-top-6">Induction</h3>
+
               <% if induction.present? %>
                 <%= govuk_summary_list(rows: induction) %>
               <% else %>
-                No induction data
+                No data
               <% end %>
 
               <h3 class="govuk-heading-m govuk-!-margin-top-6">Initial teacher training</h3>
-              <%= govuk_summary_list(rows: initial_teacher_training) %>
 
-              <h3 class="govuk-heading-m govuk-!-margin-top-6"><%= "Qualification".pluralize(qualification_count) %></h3>
-              <%= govuk_summary_list(rows: qualifications) %>
+              <% if initial_teacher_training.present? %>
+                <%= govuk_summary_list(rows: initial_teacher_training) %>
+              <% else %>
+                No data
+              <% end %>
+
+              <h3 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-4"><%= "Qualification".pluralize(qualification_count) %></h3>
+
+              <% if qualifications.present? %>
+                <%= govuk_summary_list(rows: qualifications) %>
+              <% else %>
+                No data
+              <% end %>
+
             </div>
           </details>
         </dd>

--- a/app/components/dqt_data_summary/view.rb
+++ b/app/components/dqt_data_summary/view.rb
@@ -15,6 +15,8 @@ module DqtDataSummary
     end
 
     def qualified_teacher_status
+      return [] if dqt_data["qualified_teacher_status"].nil?
+
       @qualified_teacher_status ||= summarise(dqt_data["qualified_teacher_status"])
     end
 
@@ -40,6 +42,18 @@ module DqtDataSummary
       return if dqt_data["qualifications"].empty?
 
       dqt_data["qualifications"].count
+    end
+
+    def itt_result
+      dqt_data["initial_teacher_training"].present? ? dqt_data["initial_teacher_training"]["result"] : "-"
+    end
+
+    def qts_date
+      dqt_data["qts_date"].present? ? Date.parse(dqt_data["qts_date"]) : "-"
+    end
+
+    def date_of_birth
+      Date.parse(dqt_data["dob"]).strftime("%e %B %Y")
     end
 
     # 4 December 2022 at 1:07pm

--- a/spec/components/dqt_data_summary/view_spec.rb
+++ b/spec/components/dqt_data_summary/view_spec.rb
@@ -14,7 +14,29 @@ module DqtDataSummary
       end
     end
 
-    context "when has_errors is false" do
+    context "when there is some missing data" do
+      let(:dqt_data) do
+        {
+          "trn" => "1234567",
+          "qualified_teacher_status" => nil,
+          "induction" => nil,
+          "initial_teacher_training" => nil,
+          "qualifications" => [],
+          "name" => "Abigail McPhillips",
+          "dob" => "1990-04-27T00:00:00",
+        }
+      end
+
+      before do
+        render_inline(described_class.new(dqt_data:))
+      end
+
+      it "renders 'Data not available' content" do
+        expect(rendered_component).to have_text("No data")
+      end
+    end
+
+    context "when there is data" do
       let(:dqt_data) do
         {
           "trn" => "1234567",
@@ -53,7 +75,7 @@ module DqtDataSummary
 
       it "renders the data" do
         expect(rendered_component).to have_text("Abigail McPhillips")
-        expect(rendered_component).to have_text("No induction data")
+        expect(rendered_component).to have_text("No data")
         expect(rendered_component).to have_text("In Training")
         expect(rendered_component).to have_text("First Degree")
       end


### PR DESCRIPTION
### Context

Fix the DQT API view for trainees who are missing ITT / QTS info etc

### Changes proposed in this pull request

Render "No data" when whole sections are nil.

### Guidance to review

Hard to view on review app, but this is what it looks like when initial_teacher_training, induction, qualified_teacher_status and qualifications are all empty:

<img width="1609" alt="Screenshot 2023-02-03 at 16 38 15" src="https://user-images.githubusercontent.com/18436946/216658699-26250277-b307-411a-9c20-785432f2507c.png">

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?`
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
