### PR TITLE
[5213] Paginate dead job view

### DIFF
--- a/app/controllers/system_admin/dead_jobs_controller.rb
+++ b/app/controllers/system_admin/dead_jobs_controller.rb
@@ -2,7 +2,7 @@
 
 module SystemAdmin
   class DeadJobsController < ApplicationController
-    helper_method :dead_job_service, :dead_job_services
+    helper_method :dead_job_service, :dead_job_services, :trainees
 
     def show
       respond_to do |format|
@@ -21,6 +21,10 @@ module SystemAdmin
 
     def dead_job_service
       @dead_job_service ||= params[:id]&.constantize&.new(include_dqt_status:)
+    end
+
+    def trainees
+      @trainees = Kaminari.paginate_array(dead_job_service.trainees).page(params[:page] || 1)
     end
 
     def include_dqt_status

--- a/app/services/dead_jobs/base.rb
+++ b/app/services/dead_jobs/base.rb
@@ -49,15 +49,15 @@ module DeadJobs
       @identifier ||= self.class.name.demodulize
     end
 
+    def trainees
+      Trainee.includes(:provider).find(dead_jobs.keys)
+    end
+
     delegate :count, to: :dead_jobs
 
   private
 
     attr_reader :dead_set, :include_dqt_status
-
-    def trainees
-      Trainee.includes(:provider).find(dead_jobs.keys)
-    end
 
     def build_csv(includes:)
       CSV.generate do |csv|

--- a/app/views/system_admin/dead_jobs/show.html.erb
+++ b/app/views/system_admin/dead_jobs/show.html.erb
@@ -28,21 +28,26 @@
     </thead>
 
     <tbody class="govuk-table__body">
-      <% dead_job_service.rows&.each do |row| %>
-        <tr class="govuk-table__row">
-          <% row.each do |data| %>
-            <td class="govuk-table__cell"><%= data[-1] %></td>
-          <% end %>
-          <td class="govuk-table__cell">
-            <%= render GovukButtonLinkTo::View.new(
-              body: "View",
-              id: "view_#{row[:register_id]}",
-              url: trainee_path(Trainee.find(row[:register_id]),
-                                class_option: "govuk-!-margin-bottom-0"
-              )) %>
-          </td>
-        </tr>
-      <% end %>
+      <% trainees.each do |trainee| %>
+        <% row = dead_job_service.rows.select{|row| row[:register_id] == trainee.id}.first %>
+          <tr class="govuk-table__row">
+            <% row.each do |data| %>
+              <td class="govuk-table__cell"><%= data[-1] %></td>
+            <% end %>
+            <td class="govuk-table__cell">
+              <%= render GovukButtonLinkTo::View.new(
+                body: "View",
+                id: "view_#{row[:register_id]}",
+                url: trainee_path(Trainee.find(row[:register_id]),
+                                  class_option: "govuk-!-margin-bottom-0"
+                )) %>
+            </td>
+          </tr>
+        <% end %>
     </tbody>
   </table>
+
 <% end %>
+
+<%= render Paginator::View.new(scope: trainees) %>
+


### PR DESCRIPTION
### Context
Add pagination to dead job view. 
<img width="1792" alt="Screenshot 2023-02-16 at 12 08 41" src="https://user-images.githubusercontent.com/44261976/219360927-9d4def0e-8779-4c69-a9e3-4b7c2fd655d4.png">

### Changes proposed in this pull request

Dead job view now paginates (30 items per page). Please note that testing this in browser is quite annoying. Happy to demonstrate. Unsure of how best to test this feature; I couldnt find any other tests for pagination. It should be covered by the base pagination tests.

### Guidance to review

Spoof the dead jobs set in dead jobs base.rb. Happy to demonstrate. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
