### PR TITLE
[5248] New models and jobs to pull down data from DQT

### DIFF
--- a/app/jobs/dqt/sync_teacher_job.rb
+++ b/app/jobs/dqt/sync_teacher_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Dqt
+  class SyncTeacherJob < ApplicationJob
+    queue_as :dqt_sync
+
+    def perform(trainee)
+      return unless FeatureService.enabled?("dqt_import.sync_teachers")
+
+      Dqt::SyncTeacher.call(trainee:)
+    end
+  end
+end

--- a/app/jobs/dqt/sync_teachers_batch_job.rb
+++ b/app/jobs/dqt/sync_teachers_batch_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Dqt
+  class SyncTeachersBatchJob < ApplicationJob
+    queue_as :dqt_sync
+
+    def perform(trainee_ids)
+      return unless FeatureService.enabled?("dqt_import.sync_teachers")
+
+      Trainee.where(id: trainee_ids).each do |trainee|
+        Dqt::SyncTeacherJob.perform_later(trainee)
+      end
+    end
+  end
+end

--- a/app/jobs/dqt/sync_teachers_job.rb
+++ b/app/jobs/dqt/sync_teachers_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Dqt
+  class SyncTeachersJob < ApplicationJob
+    queue_as :dqt_sync
+
+    def perform(batch_size = 500, interval = 30.seconds)
+      return unless FeatureService.enabled?("dqt_import.sync_teachers")
+
+      trainees = Trainee.where.not(trn: nil).where("length(trn) = 7").in_training.or(Trainee.deferred)
+
+      trainees.find_in_batches(batch_size:).with_index do |group, batch|
+        # The API rate limit is 3000 requests per minute so by default we're
+        # kicking off 500 trainees every 30 seconds to stay within that without
+        # affecting day-to-day DQT requests from other Register services.
+        Dqt::SyncTeachersBatchJob.set(wait: interval * batch).perform_later(group.pluck(:id))
+      end
+    end
+  end
+end

--- a/app/jobs/dqt/withdraw_trainee_job.rb
+++ b/app/jobs/dqt/withdraw_trainee_job.rb
@@ -43,7 +43,7 @@ module Dqt
     end
 
     def already_withdrawn_in_dqt?
-      RetrieveTrainingInstance.call(trainee:)["result"] == "Withdrawn"
+      RetrieveTraining.call(trainee:)["result"] == "Withdrawn"
     end
   end
 end

--- a/app/models/dqt/teacher.rb
+++ b/app/models/dqt/teacher.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: dqt_teachers
+#
+#  id                       :bigint           not null, primary key
+#  date_of_birth            :string
+#  early_years_status_name  :string
+#  early_years_status_value :string
+#  eyts_date                :string
+#  first_name               :string
+#  last_name                :string
+#  qts_date                 :string
+#  trn                      :string
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+module Dqt
+  class Teacher < ApplicationRecord
+    self.table_name = "dqt_teachers"
+
+    belongs_to :trainee,
+               foreign_key: :trn,
+               primary_key: :trn,
+               inverse_of: :dqt_teacher,
+               optional: true
+
+    has_many :dqt_trainings,
+             primary_key: :id,
+             foreign_key: :dqt_teacher_id,
+             class_name: "Dqt::TeacherTraining",
+             inverse_of: :dqt_teacher
+  end
+end

--- a/app/models/dqt/teacher_training.rb
+++ b/app/models/dqt/teacher_training.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: dqt_teacher_trainings
+#
+#  id                   :bigint           not null, primary key
+#  programme_end_date   :string
+#  programme_start_date :string
+#  programme_type       :string
+#  provider_ukprn       :string
+#  result               :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  dqt_teacher_id       :bigint
+#
+# Indexes
+#
+#  index_dqt_teacher_trainings_on_dqt_teacher_id  (dqt_teacher_id)
+#
+module Dqt
+  class TeacherTraining < ApplicationRecord
+    self.table_name = "dqt_teacher_trainings"
+
+    belongs_to :dqt_teacher, class_name: "Dqt::Teacher", inverse_of: :dqt_trainings
+  end
+end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -150,20 +150,26 @@ class Trainee < ApplicationRecord
   belongs_to :end_academic_cycle, optional: true, class_name: "AcademicCycle"
   belongs_to :hesa_trn_submission, optional: true, class_name: "Hesa::TrnSubmission"
 
+  has_one :hesa_metadatum, class_name: "Hesa::Metadatum"
+  has_one :dqt_trn_request, class_name: "Dqt::TrnRequest", dependent: :destroy
+  has_one :dqt_teacher,
+          class_name: "Dqt::Teacher",
+          foreign_key: :trn,
+          primary_key: :trn,
+          inverse_of: :trainee
+
   has_many :degrees, dependent: :destroy
   has_many :nationalisations, dependent: :destroy, inverse_of: :trainee
   has_many :nationalities, through: :nationalisations
   has_many :trainee_disabilities, dependent: :destroy, inverse_of: :trainee
   has_many :disabilities, through: :trainee_disabilities
+  has_many :dqt_teacher_trainings, class_name: "Dqt::TeacherTraining", through: :dqt_teacher, source: :dqt_trainings
 
   has_many :hesa_students,
            foreign_key: :hesa_id,
            primary_key: :hesa_id,
            inverse_of: :trainee,
            class_name: "Hesa::Student"
-
-  has_one :hesa_metadatum, class_name: "Hesa::Metadatum"
-  has_one :dqt_trn_request, class_name: "Dqt::TrnRequest", dependent: :destroy
 
   attribute :progress, Progress.to_type
 

--- a/app/services/dead_jobs/base.rb
+++ b/app/services/dead_jobs/base.rb
@@ -110,7 +110,7 @@ module DeadJobs
     def dqt_status(trainee)
       return unless include_dqt_status && trainee.trn.present?
 
-      Dqt::RetrieveTrainingInstance.call(trainee:)["result"]&.to_s&.gsub('"', "'")
+      Dqt::RetrieveTraining.call(trainee:)["result"]&.to_s&.gsub('"', "'")
     rescue StandardError => e
       "error: #{e.message}"
     end

--- a/app/services/dqt/retrieve_training.rb
+++ b/app/services/dqt/retrieve_training.rb
@@ -3,7 +3,7 @@
 module Dqt
   class NoTrainingInstanceError < StandardError; end
 
-  class RetrieveTrainingInstance
+  class RetrieveTraining
     include ServicePattern
 
     def initialize(trainee:)
@@ -11,17 +11,17 @@ module Dqt
     end
 
     def call
-      raise(NoTrainingInstanceError) if training_instances.blank? || training_instance.nil?
+      raise(NoTrainingInstanceError) if trainings.blank? || training.nil?
 
-      training_instance
+      training
     end
 
     attr_reader :trainee
 
   private
 
-    def training_instance
-      @training_instance ||= training_instances.find do |training|
+    def training
+      @training ||= trainings.find do |training|
         training.dig("provider", "ukprn") == trainee.provider.ukprn &&
           training["programmeType"] == programme_type(trainee)
       end
@@ -31,8 +31,8 @@ module Dqt
       Dqt::Params::TrnRequest::PROGRAMME_TYPE[trainee.training_route]
     end
 
-    def training_instances
-      @training_instances ||= RetrieveTeacher.call(trainee:)["initialTeacherTraining"]
+    def trainings
+      @trainings ||= RetrieveTeacher.call(trainee:)["initialTeacherTraining"]
     end
   end
 end

--- a/app/services/dqt/sync_state.rb
+++ b/app/services/dqt/sync_state.rb
@@ -5,7 +5,7 @@
 #
 # Before using this service again (for example if we turn back on
 # Dqt::SyncStatesJob) we need to be comparing the result from
-# Dqt::RetrieveTrainingInstance rather than Dqt::RetrieveTeacher.
+# Dqt::RetrieveTraining rather than Dqt::RetrieveTeacher.
 module Dqt
   class SyncState
     include ServicePattern

--- a/app/services/dqt/sync_teacher.rb
+++ b/app/services/dqt/sync_teacher.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Dqt
+  class SyncTeacher
+    include ServicePattern
+
+    attr_reader :trainee
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      dqt_data = RetrieveTeacher.call(trainee:)
+      dqt_teacher = Teacher.find_or_initialize_by(trn: dqt_data["trn"], date_of_birth: dqt_data["dateOfBirth"])
+      dqt_teacher.assign_attributes(first_name: dqt_data["firstName"],
+                                    last_name: dqt_data["dateOfBirth"],
+                                    qts_date: dqt_data["qtsDate"],
+                                    eyts_date: dqt_data["eytsDate"],
+                                    early_years_status_name: dqt_data.dig("earlyYearsStatus", "name"),
+                                    early_years_status_value: dqt_data.dig("earlyYearsStatus", "value"))
+      dqt_teacher.save
+
+      dqt_data["initialTeacherTraining"].each do |training_data|
+        dqt_teacher_training = TeacherTraining.find_or_initialize_by(dqt_teacher:)
+        dqt_teacher_training.assign_attributes(programme_start_date: training_data["programmeStartDate"],
+                                               programme_end_date: training_data["programmeEndDate"],
+                                               programme_type: training_data["programmeType"],
+                                               result: training_data["result"],
+                                               provider_ukprn: training_data.dig("provider", "ukprn"))
+        dqt_teacher_training.save
+      end
+    end
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -351,3 +351,25 @@
   - user_id
   - created_at
   - updated_at
+  :dqt_teachers:
+  - id
+  - trn
+  - first_name
+  - last_name
+  - date_of_birth
+  - qts_date
+  - eyts_date
+  - early_years_status_name
+  - early_years_status_value
+  - created_at
+  - updated_at
+  :dqt_teacher_trainings:
+  - id
+  - dqt_teacher_id
+  - programme_start_date
+  - programme_end_date
+  - programme_type
+  - result
+  - provider_ukprn
+  - created_at
+  - updated_at

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -73,6 +73,8 @@ features:
     test_mode: false
     sync_collection: false
     sync_trn_data: false
+  dqt_import:
+    sync_teachers: false
   # For the 3 months prior to an academic cycle, we're not sure
   # which year the user wants courses listed for. This feature
   # makes sure the correct year is selected before listing courses.

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -43,6 +43,8 @@ features:
   hesa_import:
     sync_collection: true
     sync_trn_data: true
+  dqt_import:
+    sync_teachers: true
 environment:
   name: beta
 

--- a/db/migrate/20230216153013_create_dqt_teachers.rb
+++ b/db/migrate/20230216153013_create_dqt_teachers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateDqtTeachers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :dqt_teachers do |t|
+      t.column :trn, :string
+      t.column :first_name, :string
+      t.column :last_name, :string
+      t.column :date_of_birth, :string
+      t.column :qts_date, :string
+      t.column :eyts_date, :string
+      t.column :early_years_status_name, :string
+      t.column :early_years_status_value, :string
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230216154509_create_dqt_teacher_trainings.rb
+++ b/db/migrate/20230216154509_create_dqt_teacher_trainings.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateDqtTeacherTrainings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :dqt_teacher_trainings do |t|
+      t.belongs_to :dqt_teacher
+      t.column :programme_start_date, :string
+      t.column :programme_end_date, :string
+      t.column :programme_type, :string
+      t.column :result, :string
+      t.column :provider_ukprn, :string
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_26_110151) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_16_154509) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -246,6 +246,31 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_26_110151) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_disabilities_on_name", unique: true
+  end
+
+  create_table "dqt_teacher_trainings", force: :cascade do |t|
+    t.bigint "dqt_teacher_id"
+    t.string "programme_start_date"
+    t.string "programme_end_date"
+    t.string "programme_type"
+    t.string "result"
+    t.string "provider_ukprn"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dqt_teacher_id"], name: "index_dqt_teacher_trainings_on_dqt_teacher_id"
+  end
+
+  create_table "dqt_teachers", force: :cascade do |t|
+    t.string "trn"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "date_of_birth"
+    t.string "qts_date"
+    t.string "eyts_date"
+    t.string "early_years_status_name"
+    t.string "early_years_status_value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "dqt_trn_requests", force: :cascade do |t|

--- a/spec/jobs/dqt/sync_teacher_job_spec.rb
+++ b/spec/jobs/dqt/sync_teacher_job_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dqt
+  describe SyncTeacherJob do
+    let!(:trainee) { create(:trainee) }
+
+    before do
+      allow(SyncTeacher).to receive(:call)
+      enable_features("dqt_import.sync_teachers")
+    end
+
+    it "calls the SyncTeacher service" do
+      described_class.perform_now(trainee)
+      expect(SyncTeacher).to have_received(:call).with(trainee:)
+    end
+  end
+end

--- a/spec/jobs/dqt/sync_teachers_batch_job_spec.rb
+++ b/spec/jobs/dqt/sync_teachers_batch_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dqt
+  describe SyncTeachersBatchJob do
+    let!(:trainee) { create(:trainee) }
+
+    before do
+      enable_features("dqt_import.sync_teachers")
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+    end
+
+    after { ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true }
+
+    it "enqueues job per trainee" do
+      expect {
+        described_class.perform_now([trainee.id])
+      }.to enqueue_job(SyncTeacherJob).with(trainee)
+    end
+  end
+end

--- a/spec/jobs/dqt/sync_teachers_job_spec.rb
+++ b/spec/jobs/dqt/sync_teachers_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Dqt
+  describe SyncTeachersJob do
+    let!(:trainee1) { create(:trainee, :trn_received) }
+    let!(:trainee2) { create(:trainee, :trn_received) }
+
+    before do
+      enable_features("dqt_import.sync_teachers")
+    end
+
+    it "queues up at intervals with the trainee batches" do
+      Timecop.freeze(Time.zone.now) do
+        described_class.perform_now(1)
+        expect(SyncTeachersBatchJob).to have_been_enqueued.with([trainee1.id])
+        expect(SyncTeachersBatchJob).to have_been_enqueued.at(30.seconds.from_now).with([trainee2.id])
+      end
+    end
+  end
+end

--- a/spec/jobs/dqt/withdraw_trainee_job_spec.rb
+++ b/spec/jobs/dqt/withdraw_trainee_job_spec.rb
@@ -13,7 +13,7 @@ module Dqt
 
     before do
       allow(WithdrawTrainee).to receive(:call).with(trainee:).and_return(nil)
-      allow(RetrieveTrainingInstance).to receive(:call).with(trainee:).and_return(dqt_response)
+      allow(RetrieveTraining).to receive(:call).with(trainee:).and_return(dqt_response)
     end
 
     context "with the `integrate_with_dqt` feature flag inactive" do

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -176,6 +176,7 @@ describe Trainee do
   context "associations" do
     it { is_expected.to belong_to(:provider) }
     it { is_expected.to belong_to(:apply_application).optional }
+    it { is_expected.to have_one(:dqt_teacher) }
     it { is_expected.to have_many(:degrees).dependent(:destroy) }
     it { is_expected.to have_many(:nationalisations).dependent(:destroy).inverse_of(:trainee) }
     it { is_expected.to have_many(:nationalities).through(:nationalisations) }
@@ -183,6 +184,7 @@ describe Trainee do
     it { is_expected.to have_many(:disabilities).through(:trainee_disabilities) }
     it { is_expected.to have_many(:hesa_students).inverse_of(:trainee) }
     it { is_expected.to have_one(:dqt_trn_request).dependent(:destroy) }
+    it { is_expected.to have_many(:dqt_teacher_trainings) }
     it { is_expected.to belong_to(:lead_school).class_name("School").optional }
     it { is_expected.to belong_to(:employing_school).class_name("School").optional }
 

--- a/spec/services/dqt/retrieve_training_spec.rb
+++ b/spec/services/dqt/retrieve_training_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 module Dqt
-  describe RetrieveTrainingInstance do
+  describe RetrieveTraining do
     let(:provider) { create(:provider) }
     let(:trainee) { create(:trainee, :trn_received, :early_years_postgrad, provider:) }
     let(:dqt_response) do

--- a/spec/support/shared_examples/dead_jobs.rb
+++ b/spec/support/shared_examples/dead_jobs.rb
@@ -74,7 +74,7 @@ shared_examples "DeadJobs" do
       let(:include_dqt_status) { true }
 
       before do
-        allow(Dqt::RetrieveTrainingInstance).to receive(:call).with(trainee:).and_return(
+        allow(Dqt::RetrieveTraining).to receive(:call).with(trainee:).and_return(
           { "result" => "Pass" },
         )
       end


### PR DESCRIPTION
### Context
https://trello.com/c/tM1y9DnR/5248-l-create-way-to-check-how-and-if-trainees-in-register-are-synced-to-dqt

### Changes proposed in this pull request
- New models: `Dqt::Teacher` and `Dqt::TeacherTraining` (`has_many` association)
- New `Trainee` associations:
  - `Trainee#dqt_teacher`
  - `Trainee#dqt_teacher_trainings`
- Background jobs to pull data down from DQT

### Guidance to review
- Tested it locally. Works as expected.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
