### PR TITLE
[5295] Add HESA ID to DQT tables

### DIFF
--- a/app/models/dqt/teacher.rb
+++ b/app/models/dqt/teacher.rb
@@ -15,6 +15,7 @@
 #  trn                      :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
+#  hesa_id                  :string
 #
 module Dqt
   class Teacher < ApplicationRecord

--- a/app/models/dqt/teacher_training.rb
+++ b/app/models/dqt/teacher_training.rb
@@ -13,6 +13,7 @@
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  dqt_teacher_id       :bigint
+#  hesa_id              :string
 #
 # Indexes
 #

--- a/app/services/dqt/sync_teacher.rb
+++ b/app/services/dqt/sync_teacher.rb
@@ -10,11 +10,22 @@ module Dqt
       @trainee = trainee
     end
 
+    # Why is HESA ID captured in both models?
+    #
+    # Teacher model represents 'contact' details in DQT and TeacherTraining represents 'initialteachertraining'
+    #
+    # So for example:
+    #  - Trainee starts course 1 - contact HESA ID and training course 1 HESA ID align, in other words
+    #    Teacher#hesa_id == TeacherTraining#hesa_id
+    #  - Trainee withdraws from course 1 - contact HESA ID and training course 1 HESA ID remain aligned
+    #  - Trainee starts course 2 - contact HESA ID now matches training course 2 HESA ID, whilst course 1
+    #    HESA ID remains on the now inactivated 'older' withdrawn record
     def call
       dqt_data = RetrieveTeacher.call(trainee:)
       dqt_teacher = Teacher.find_or_initialize_by(trn: dqt_data["trn"], date_of_birth: dqt_data["dateOfBirth"])
       dqt_teacher.assign_attributes(first_name: dqt_data["firstName"],
                                     last_name: dqt_data["lastName"],
+                                    hesa_id: dqt_data["husId"], # related to current training - dynamic
                                     qts_date: dqt_data["qtsDate"],
                                     eyts_date: dqt_data["eytsDate"],
                                     early_years_status_name: dqt_data.dig("earlyYearsStatus", "name"),
@@ -27,6 +38,7 @@ module Dqt
                                                programme_end_date: training_data["programmeEndDate"],
                                                programme_type: training_data["programmeType"],
                                                result: training_data["result"],
+                                               hesa_id: training_data["husId"], # associated with that period of training
                                                provider_ukprn: training_data.dig("provider", "ukprn"))
         dqt_teacher_training.save
       end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -354,6 +354,7 @@
   :dqt_teachers:
   - id
   - trn
+  - hesa_id
   - first_name
   - last_name
   - date_of_birth
@@ -366,6 +367,7 @@
   :dqt_teacher_trainings:
   - id
   - dqt_teacher_id
+  - hesa_id
   - programme_start_date
   - programme_end_date
   - programme_type

--- a/db/migrate/20230228134944_add_hesa_id_to_dqt_teachers.rb
+++ b/db/migrate/20230228134944_add_hesa_id_to_dqt_teachers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHesaIdToDqtTeachers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dqt_teachers, :hesa_id, :string
+  end
+end

--- a/db/migrate/20230228135922_add_hesa_id_to_dqt_teacher_trainings.rb
+++ b/db/migrate/20230228135922_add_hesa_id_to_dqt_teacher_trainings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHesaIdToDqtTeacherTrainings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dqt_teacher_trainings, :hesa_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_16_154509) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_28_135922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -257,6 +257,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_16_154509) do
     t.string "provider_ukprn"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "hesa_id"
     t.index ["dqt_teacher_id"], name: "index_dqt_teacher_trainings_on_dqt_teacher_id"
   end
 
@@ -271,6 +272,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_16_154509) do
     t.string "early_years_status_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "hesa_id"
   end
 
   create_table "dqt_trn_requests", force: :cascade do |t|


### PR DESCRIPTION
### Context
https://trello.com/c/ekLTYXl2/5295-add-hesaid-to-our-dqt-tables-and-re-run-the-sync

### Changes proposed in this pull request
- Update DQT tables and sync job to capture `hesa_id`

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
