### PR TITLE
[5261] Prevent update to trainee after award

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -23,7 +23,7 @@ module Trainees
 
     def call
       Audited.audit_class.as_user(USERNAME) do
-        trainee.assign_attributes(mapped_attributes)
+        trainee.assign_attributes(mapped_attributes) unless @current_trainee_state == :awarded
 
         if trainee.save!
           create_degrees!

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -471,5 +471,13 @@ module Trainees
         end
       end
     end
+
+    context "trainee is already awarded with conflicting data to hesa" do
+      let(:create_custom_state) { create(:trainee, :awarded, itt_end_date: DateTime.new(2024, 5, 11), hesa_id: student_attributes[:hesa_id]) }
+
+      it "does not update the trainee" do
+        expect(trainee.itt_end_date).to eq(DateTime.new(2024, 5, 11))
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

An awarded trainee has been updated for some of their fields after an award. This should not be possible.

Add a guard clause to not allow trainees to be updated from hesa once they are awarded.

### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
