### PR TITLE
Updated 'request account' page

### DIFF
--- a/app/views/request_an_account/index.html.erb
+++ b/app/views/request_an_account/index.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: t("components.page_titles.pages.request_an_account")) %>
+<%= render PageTitle::View.new(text: "Request an account to use Register trainee teachers") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(
@@ -9,48 +9,35 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-9"><%= t("components.page_titles.pages.request_an_account") %></h1>
-    <h2 class="govuk-heading-m"><%= t("pages.request_an_account.get_account_heading") %></h2>
-    <p class="govuk-body"><%= t("pages.request_an_account.get_account") %></p>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-9"><%= "Request an account to use Register trainee teachers" %></h1>
+    <p class="govuk-body">You can only get a Register trainee teachers (Register) account if you work for either:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li><%= t("pages.request_an_account.bullets1.1") %></li>
-      <li><%= t("pages.request_an_account.bullets1.2") %></li>
+      <li>an initial teacher training (ITT) accredited provider</li>
+      <li>a lead school involved in School Direct teacher training</li>
     </ul>
-    <h2 class="govuk-heading-m"><%= t("pages.request_an_account.steps_heading") %></h2>
-    <p class="govuk-body"><%= t("pages.request_an_account.first_para") %></p>
-    <h2 class="govuk-heading-m"><%= t("pages.request_an_account.step_1_heading") %></h2>
-    <p class="govuk-body"><%= t("pages.request_an_account.second_para") %></p>
-    <p class="govuk-body"><%= t("pages.request_an_account.email_address") %></p>
+    <p class="govuk-body">Follow these steps to get an account to use Register.</p>
+    <h2 class="govuk-heading-m">1. Get a DfE Sign-in account</h2>
+      <p class="govuk-body">You’ll use a DfE Sign-in account to sign in to Register.</p>
+    <p class="govuk-body">The email address you use for your DfE Sign-in account must:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li><%= t("pages.request_an_account.bullets2.1") %></li>
-      <li><%= t("pages.request_an_account.bullets2.2") %></li>
+      <li>be a named individual email address, for example jane.doe@example.com</li>
+      <li>have an email domain belonging to your organisation, for example it cannot end with @gmail.com or @icloud.com</li>
     </ul>
-    <p class="govuk-body">Get a <%= govuk_link_to t("pages.request_an_account.sign_in_account"), "https://services.signin.education.gov.uk" %> if you do not already have one.</p>
-    <h2 class="govuk-heading-m"><%= t("pages.request_an_account.step_2_heading") %></h2>
-    <p class="govuk-body"><%= t("pages.request_an_account.send_email") %>
-    <%= govuk_mail_to(
-      Settings.support_email,
-      Settings.support_email,
-      subject: t("pages.request_an_account.email_subject")
-    ) %>
-    </p>
-    <p class="govuk-body"><%= t("pages.request_an_account.tell_us") %>
+    <p class="govuk-body"><a href="https://services.signin.education.gov.uk/" class="govuk-link">Get a DfE Sign-in account</a> if you do not already have one.</p>
+    <h2 class="govuk-heading-m">2. Get a Register account</h2>
+    <p class="govuk-body">Once you have a DfE Sign-in account, ask a colleague with a Register account to send an email requesting an account for you.</p>
+    <p class="govuk-body">If nobody in your organisation has a Register account, you can send the email yourself.</p>
+    <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Request a Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>. It should say that you want to start using Register and include:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li><%= t("pages.request_an_account.bullets3.1") %></li>
-      <li><%= t("pages.request_an_account.bullets3.2") %></li>
-      <li><%= t("pages.request_an_account.bullets3.3") %></li>
+      <li>the name of the accredited provider or lead school you work for</li>
+      <li>the email address used for your DfE Sign-in account</li>
     </ul>
-    <p class="govuk-body"><%= t("pages.request_an_account.third_para") %></p>
-    <h2 class="govuk-heading-m"><%= t("pages.request_an_account.step_3_heading") %></h2>
-    <p class="govuk-body"><%= t("pages.request_an_account.fourth_para") %></p>
-    <p class="govuk-body"><%= t("pages.request_an_account.fifth_para") %></p>
-    <h2 class="govuk-heading-m"><%= t("pages.request_an_account.step_4_heading") %></h2>
-    <p class="govuk-body"><%= t("pages.request_an_account.sixth_para") %></p>
-    <p class="govuk-body"><%= t("pages.request_an_account.final_para") %>
-    <%= govuk_mail_to(
-      Settings.support_email,
-      Settings.support_email,
-      subject: t("pages.request_an_account.multiple_providers_email_subject")
-    ) %>
-  </p>
+    <p class="govuk-body">If more than one person in your organisation needs a Register account, all the details can be included in the same email.</p>
+    <p class="govuk-body">You’ll be sent an email once your Register account has been set up.</p>
+    <h2 class="govuk-heading-m">3. Get access to additional accredited providers or lead schools in Register (optional)</h2>
+    <p class="govuk-body">Once you have a Register account, you can request access to additional accredited providers or lead schools. You do not need a separate Register account for each organisation.</p>
+    <p class="govuk-body">Ask someone with a Register account in the organisation you want to access to send an email requesting access for you.</p>
+    <p class="govuk-body">If nobody in the organisation has a Register account, you can send the email yourself.</p>
+    <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Add multiple organisations to Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.</p>    
+  </div>  
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,7 +312,6 @@ en:
         privacy_notice: Register trainee teachers privacy notice
         forbidden: &forbidden You do not have permission to perform this action
         home: Home
-        request_an_account: Request an account for Register trainee teachers (Register)
         not_found: Page not found
         internal_server_error: Sorry, something went wrong
         unprocessable_entity: Sorry, the change you wanted was rejected
@@ -888,38 +887,6 @@ en:
               label: No, do not apply for a grant
               hint: For example, the trainee is not eligible or is self-funded
   pages:
-    request_an_account:
-      get_account_heading: Who can get a Register account
-      get_account: "You can only get a Register account if you are one of the following:"
-      bullets1:
-        1: an initial teacher training (ITT) accredited provider
-        2: a lead school involved in School Direct training routes
-      steps_heading: Steps to get an account
-      first_para: Follow these steps to get an account to use Register.
-      step_1_heading: "Step 1: Get a DfE Sign-in account"
-      second_para: To use Register, each person in your organisation will need a DfE Sign-in account.
-      email_address: "The email address you use for your DfE Sign-in account must:"
-      bullets2:
-        1: be a named individual email address, for example jane.doe@example.com
-        2: have an email domain from your organisation, for example we cannot accept emails that end with @gmail.com or @icloud.com
-      sign_in_account: DfE Sign-in account
-      step_2_heading: "Step 2: Email us to request a Register account"
-      send_email: Once you have a DfE Sign-in account with a named email address, email
-      email_subject: Request a Register account
-
-      tell_us: "In your email, tell us:"
-      bullets3:
-        1: the name of the accredited provider or lead school you work for
-        2: that you would like to start using Register
-        3: the email address used for your DfE Sign-in account
-      third_para: If there is more than one person at your organisation who would like to get set up, you can send one email with everyone’s details.
-      step_3_heading: "Step 3: Start using Register"
-      fourth_para: Once you’ve sent us the email in Step 2, we will set up your Register account.
-      fifth_para: We will then email you with a link to start using Register.
-      step_4_heading: "Step 4 (optional): Access to multiple providers or lead schools"
-      sixth_para: If you need access to multiple providers or lead schools, you do not need to create multiple user accounts.
-      final_para: Once your Register account is set up, you can request that the relevant organisations are added to your account by emailing
-      multiple_providers_email_subject: Access to multiple providers or lead schools in Register
     home:
       heading: Your trainee teachers
       draft_heading: Draft trainees


### PR DESCRIPTION
### Context

The content of the 'request account' page said that people should contact us to request their own account. But if their organisation already uses Register then they should ask a colleague with an account to contact us. This is now the most common situation.

### Changes proposed in this pull request

I've made the content accurate and also taken the opportunity to also make minor content improvements throughout.

In addition, this page was referring to content in /config/locales/en.yml. That made it difficult to update and was unnecessary since we do not have other language versions. I've replaced these references with html. In future we may change the page so that it uses markdown.

I removed the content about the request page from /config/locales/en.yml to tidy up the code.