### PR TITLE
[5273] Bulk recommend trainees

### DIFF
--- a/app/controllers/bulk_update/recommendations_controller.rb
+++ b/app/controllers/bulk_update/recommendations_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  class RecommendationsController < ApplicationController
+    def create
+      Recommend.call(recommendations_upload:)
+
+      redirect_to(bulk_update_recommendations_upload_confirmation_path(recommendations_upload))
+    end
+
+  private
+
+    def provider
+      @provider ||= current_user.organisation
+    end
+
+    def recommendations_upload
+      @recommendations_upload ||= provider.recommendations_uploads.find(params[:recommendations_upload_id])
+    end
+  end
+end

--- a/app/controllers/bulk_update/recommendations_uploads_controller.rb
+++ b/app/controllers/bulk_update/recommendations_uploads_controller.rb
@@ -5,8 +5,9 @@ module BulkUpdate
     helper_method :bulk_recommend_count, :recommendations_upload_form
     before_action :redirect
 
-    # TODO: Find the user's upload and pick out counts
-    def show; end
+    def show
+      @recommendations_upload = provider.recommendations_uploads.find(params[:recommendations_upload_id])
+    end
 
     def new
       @recommendations_upload_form = RecommendationsUploadForm.new
@@ -17,7 +18,7 @@ module BulkUpdate
 
       if recommendations_upload_form.save
         create_rows!
-        redirect_to(root_path)
+        redirect_to(bulk_update_recommendations_upload_summary_path(recommendations_upload))
       else
         render(:new)
       end

--- a/app/models/bulk_update/recommendations_upload.rb
+++ b/app/models/bulk_update/recommendations_upload.rb
@@ -27,4 +27,9 @@ class BulkUpdate::RecommendationsUpload < ApplicationRecord
            inverse_of: :recommendations_upload
 
   alias rows recommendations_upload_rows
+
+  # TODO: Also, ones with no errors
+  def awardable_rows
+    rows.where.not(standards_met_at: nil)
+  end
 end

--- a/app/models/bulk_update/recommendations_upload_row.rb
+++ b/app/models/bulk_update/recommendations_upload_row.rb
@@ -28,6 +28,4 @@ class BulkUpdate::RecommendationsUploadRow < ApplicationRecord
              inverse_of: :recommendations_upload_rows
 
   has_many :row_errors, as: :errored_on, class_name: "BulkUpdate::RowError"
-
-  validates :standards_met_at, presence: true
 end

--- a/app/services/bulk_update/recommend.rb
+++ b/app/services/bulk_update/recommend.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  class Recommend
+    include ServicePattern
+
+    def initialize(recommendations_upload:)
+      @awardable_rows = recommendations_upload.awardable_rows
+    end
+
+    def call
+      return if awardable_rows.empty?
+
+      awardable_rows.find_each do |row|
+        # TODO: this will actually be an association on the row
+        trainee = Trainee.find_by(trn: row.trn)
+
+        next if trainee.nil? || !trainee.trn_received?
+
+        trainee.outcome_date = row.standards_met_at
+
+        if trainee.save!
+          trainee.recommend_for_award!
+
+          if FeatureService.enabled?(:integrate_with_dqt)
+            Dqt::RecommendForAwardJob.perform_later(trainee)
+          end
+        end
+      end
+    end
+
+  private
+
+    attr_reader :awardable_rows
+  end
+end

--- a/app/services/bulk_update/recommendations_uploads/create_recommendations_upload_rows.rb
+++ b/app/services/bulk_update/recommendations_uploads/create_recommendations_upload_rows.rb
@@ -16,7 +16,7 @@ module BulkUpdate
           ::BulkUpdate::RecommendationsUploadRow.create(
             bulk_update_recommendations_upload_id: recommendations_upload_id,
             csv_row_number: row_number,
-            standards_met_at: row["Date QTS or EYTS standards met"].to_date,
+            standards_met_at: row["Date QTS or EYTS standards met"]&.to_date,
             trn: row["TRN"],
             hesa_id: row["HESA ID"],
           )

--- a/app/views/bulk_update/recommendations_uploads/check.html.erb
+++ b/app/views/bulk_update/recommendations_uploads/check.html.erb
@@ -11,6 +11,8 @@
       Check who you’ll recommend for QTS or EYTS
     </h1>
 
-    <%= govuk_link_to("Recommend {COUNT} trainees for QTS or EYTS", "#", class: "govuk-button") %>
+    <%= register_form_with url: bulk_update_recommendations_upload_recommendations_path, method: :post, local: true do |f| %>
+      <%= f.govuk_submit("Recommend {COUNT} trainees for QTS or EYTS", id: "recommend") %>
+    <% end %>
   </div>
 </div>

--- a/app/views/bulk_update/recommendations_uploads/confirmation.html.erb
+++ b/app/views/bulk_update/recommendations_uploads/confirmation.html.erb
@@ -1,0 +1,32 @@
+<%= render PageTitle::View.new(text: "{COUNT} trainees recommended for QTS or EYTS") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div class="govuk-panel govuk-panel--confirmation qts-submission-success-panel govuk-!-margin-bottom-6">
+      <h1 class="govuk-panel__title">
+        {COUNT} trainees recommended for QTS or EYTS
+      </h1>
+    </div>
+
+    <p class="govuk-body">
+      The Department for Education will award QTS or EYTS within 3 working days.
+    </p>
+
+    <h2 class="govuk-heading-m">Next steps</h2>
+
+    <% if bulk_recommend_count.zero? %>
+      <p class="govuk-body">
+        You can now <%= govuk_link_to("view your list of registered trainees", trainees_path) %>
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        You can recommend <%= bulk_recommend_count %> more <%= "trainees".pluralize(bulk_recommend_count) %>. You can now:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li><%= govuk_link_to("bulk recommend more trainees", new_bulk_update_recommendations_upload_path) %></li>
+        <li><%= govuk_link_to("view your list of registered trainees", trainees_path) %></li>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/app/views/bulk_update/recommendations_uploads/show.html.erb
+++ b/app/views/bulk_update/recommendations_uploads/show.html.erb
@@ -28,6 +28,6 @@
       </li>
     </ul>
 
-    <%= govuk_link_to("Check who you’ll recommend", bulk_update_recommendations_upload_check_path(1), class: "govuk-button") %>
+    <%= govuk_link_to("Check who you’ll recommend", bulk_update_recommendations_upload_check_path(@recommendations_upload), class: "govuk-button") %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,8 @@ Rails.application.routes.draw do
     resources :recommendations_uploads, only: %i[new create edit update], path: "recommend", path_names: { new: "upload", edit: "upload-changes" } do
       get "upload-summary", to: "recommendations_uploads#show", as: "summary"
       get "check-pending-updates", to: "recommendations_uploads#check", as: "check"
+      get "confirmation"
+      resource :recommendations, only: :create
     end
   end
 

--- a/spec/factories/bulk_update/recommendations_upload_row.rb
+++ b/spec/factories/bulk_update/recommendations_upload_row.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :bulk_update_recommendations_upload_row, class: "BulkUpdate::RecommendationsUploadRow" do
-    bulk_update_recommendations_upload
+    association :recommendations_upload, factory: :bulk_update_recommendations_upload
     csv_row_number { 1 }
     trn { "12345" }
     hesa_id { "54321" }

--- a/spec/features/bulk_upload/recommending_trainees_spec.rb
+++ b/spec/features/bulk_upload/recommending_trainees_spec.rb
@@ -33,8 +33,8 @@ private
   end
 
   def given_multiple_trainees_exist_to_recommend
-    create(:trainee, :trn_received, itt_end_date: Time.zone.today, provider: current_user.organisation)
-    create(:trainee, :trn_received, itt_end_date: Time.zone.today + 1.month, provider: current_user.organisation)
+    create(:trainee, :trn_received, trn: "2413295", itt_end_date: Time.zone.today, provider: current_user.organisation)
+    create(:trainee, :trn_received, trn: "4814731", itt_end_date: Time.zone.today + 1.month, provider: current_user.organisation)
   end
 
   def then_i_see_how_many_trainees_i_can_recommend

--- a/spec/models/bulk_update/recommendations_upload_row_spec.rb
+++ b/spec/models/bulk_update/recommendations_upload_row_spec.rb
@@ -7,8 +7,4 @@ RSpec.describe BulkUpdate::RecommendationsUploadRow do
     it { is_expected.to belong_to(:recommendations_upload) }
     it { is_expected.to have_many(:row_errors) }
   end
-
-  describe "validations" do
-    it { validate_presence_of(:standards_met_at) }
-  end
 end

--- a/spec/services/bulk_update/recommend_spec.rb
+++ b/spec/services/bulk_update/recommend_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module BulkUpdate
+  describe Recommend do
+    let(:recommendations_upload_row) { create(:bulk_update_recommendations_upload_row) }
+    let(:recommendations_upload) { recommendations_upload_row.recommendations_upload }
+    # TODO: Update this when there's an association between row and trainee
+    let(:trainee) { create(:trainee, :trn_received, trn: recommendations_upload_row.trn) }
+
+    subject { described_class.call(recommendations_upload:) }
+
+    before do
+      allow(Dqt::RecommendForAwardJob).to receive(:perform_later)
+    end
+
+    describe "#call", feature_integrate_with_dqt: true do
+      it "updates the trainees state and outcome date" do
+        expect { subject }
+          .to change { trainee.reload.state }
+          .from("trn_received").to("recommended_for_award")
+          .and change { trainee.outcome_date }
+          .from(nil).to(recommendations_upload_row.standards_met_at)
+      end
+
+      it "kicks off a job to recommend them for award with DQT" do
+        expect(Dqt::RecommendForAwardJob).to receive(:perform_later).with(trainee)
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/skZsrbIS/5273-bulk-qts-service-to-send-the-recommendations-to-dqt

### Changes proposed in this pull request

- Add new BulkUpdate::RecommendationsController responsible for recommending the trainees in bulk
- Add new BulkUpdate::Recommend service that recommends all trainees given a recommendations_uplpad
- Add a new confirmation page

### Guidance to review

With more trainees to recommend:

<img width="1107" alt="Screenshot 2023-02-23 at 14 58 03" src="https://user-images.githubusercontent.com/18436946/222178247-ce4efebd-1e3d-404f-bfad-911722e9ccf3.png">

With no more trainees to recommend:

<img width="1107" alt="Screenshot 2023-02-23 at 15 00 46" src="https://user-images.githubusercontent.com/18436946/222178200-4de75e6a-8503-4560-9775-97912cb79c9d.png">

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml