### PR TITLE
[5295] Include DQT inactive training records during sync

### DIFF
--- a/app/models/dqt/teacher_training.rb
+++ b/app/models/dqt/teacher_training.rb
@@ -5,6 +5,7 @@
 # Table name: dqt_teacher_trainings
 #
 #  id                   :bigint           not null, primary key
+#  active               :boolean
 #  programme_end_date   :string
 #  programme_start_date :string
 #  programme_type       :string

--- a/app/services/dqt/retrieve_teacher.rb
+++ b/app/services/dqt/retrieve_teacher.rb
@@ -9,7 +9,7 @@ module Dqt
     end
 
     def call
-      Client.get("/v2/teachers/#{trainee.trn}?birthdate=#{trainee.date_of_birth}")
+      Client.get("/v2/teachers/#{trainee.trn}?birthdate=#{trainee.date_of_birth}&includeInactive=true")
     end
 
     attr_reader :trainee

--- a/app/services/dqt/retrieve_training.rb
+++ b/app/services/dqt/retrieve_training.rb
@@ -2,6 +2,7 @@
 
 module Dqt
   class NoTrainingInstanceError < StandardError; end
+  class DuplicateTrainingInstanceError < StandardError; end
 
   class RetrieveTraining
     include ServicePattern
@@ -11,17 +12,18 @@ module Dqt
     end
 
     def call
-      raise(NoTrainingInstanceError) if trainings.blank? || training.nil?
+      raise(NoTrainingInstanceError) if trainings.blank? || trainings_with_matching_criteria.empty?
+      raise(DuplicateTrainingInstanceError) if trainings_with_matching_criteria.size > 1
 
-      training
+      trainings_with_matching_criteria.first
     end
 
     attr_reader :trainee
 
   private
 
-    def training
-      @training ||= trainings.find do |training|
+    def trainings_with_matching_criteria
+      @trainings_with_matching_criteria ||= trainings.select do |training|
         training.dig("provider", "ukprn") == trainee.provider.ukprn &&
           training["programmeType"] == programme_type(trainee)
       end

--- a/app/services/dqt/sync_teacher.rb
+++ b/app/services/dqt/sync_teacher.rb
@@ -30,18 +30,19 @@ module Dqt
                                     eyts_date: dqt_data["eytsDate"],
                                     early_years_status_name: dqt_data.dig("earlyYearsStatus", "name"),
                                     early_years_status_value: dqt_data.dig("earlyYearsStatus", "value"))
-      dqt_teacher.save
 
-      dqt_data["initialTeacherTraining"].each do |training_data|
-        dqt_teacher_training = TeacherTraining.find_or_initialize_by(dqt_teacher:)
-        dqt_teacher_training.assign_attributes(programme_start_date: training_data["programmeStartDate"],
-                                               programme_end_date: training_data["programmeEndDate"],
-                                               programme_type: training_data["programmeType"],
-                                               result: training_data["result"],
-                                               hesa_id: training_data["husId"], # associated with that period of training
-                                               provider_ukprn: training_data.dig("provider", "ukprn"))
-        dqt_teacher_training.save
+      dqt_teacher.dqt_trainings = dqt_data["initialTeacherTraining"].map do |training_data|
+        TeacherTraining.new(dqt_teacher: dqt_teacher,
+                            programme_start_date: training_data["programmeStartDate"],
+                            programme_end_date: training_data["programmeEndDate"],
+                            programme_type: training_data["programmeType"],
+                            result: training_data["result"],
+                            active: training_data["active"],
+                            hesa_id: training_data["husId"], # associated with that period of training
+                            provider_ukprn: training_data.dig("provider", "ukprn"))
       end
+
+      dqt_teacher.save
     end
   end
 end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -372,6 +372,7 @@
   - programme_end_date
   - programme_type
   - result
+  - active
   - provider_ukprn
   - created_at
   - updated_at

--- a/db/migrate/20230302155425_add_active_column_to_dqt_teacher_trainings.rb
+++ b/db/migrate/20230302155425_add_active_column_to_dqt_teacher_trainings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddActiveColumnToDqtTeacherTrainings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dqt_teacher_trainings, :active, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_28_135922) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_02_155425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -258,6 +258,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_28_135922) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "hesa_id"
+    t.boolean "active"
     t.index ["dqt_teacher_id"], name: "index_dqt_teacher_trainings_on_dqt_teacher_id"
   end
 

--- a/spec/services/dqt/retrieve_training_spec.rb
+++ b/spec/services/dqt/retrieve_training_spec.rb
@@ -58,6 +58,14 @@ module Dqt
         it "returns the correct training instance" do
           expect(subject).to eq(current_training_instance)
         end
+
+        context "more than one training instance matches the search criteria" do
+          let(:training_instances) { [current_training_instance, current_training_instance] }
+
+          it "raises an duplicate training instance error" do
+            expect { subject }.to raise_error(Dqt::DuplicateTrainingInstanceError)
+          end
+        end
       end
 
       context "when there's no matching training instance" do


### PR DESCRIPTION
### Context
https://trello.com/c/VDMGU0fw/5302-download-inactive-dqt-training-records

### Changes proposed in this pull request
- Update `Dqt::RetrieveTeacher` to include inactive training records
- Update `Dqt::SyncTeacher` to capture the `active` field in `initialTeacherTraining`
- Migration to add `active` column to `dqt_teacher_trainings` table

### Guidance to review
Tested locally. Works as expected.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
