### PR TITLE
[5286] Add support for DQT programme type InternationalQualifiedTeacherStatus

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -5,6 +5,7 @@ module Dqt
     class TrnRequest
       UNITED_KINGDOM = "United Kingdom"
       UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED = "United Kingdom, not otherwise specified"
+      DQT_IQTS_PROGRAMME_TYPE = "InternationalQualifiedTeacherStatus"
 
       GENDER_CODES = {
         male: "Male",
@@ -27,6 +28,7 @@ module Dqt
         TRAINING_ROUTE_ENUMS[:provider_led_undergrad] => "ProviderLedUndergrad",
         TRAINING_ROUTE_ENUMS[:school_direct_salaried] => "SchoolDirectTrainingProgrammeSalaried",
         TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee] => "SchoolDirectTrainingProgramme",
+        TRAINING_ROUTE_ENUMS[:iqts] => DQT_IQTS_PROGRAMME_TYPE,
       }.freeze
 
       DEGREE_CLASSES = {
@@ -70,6 +72,8 @@ module Dqt
       end
 
     private
+
+      attr_reader :trainee, :degree
 
       def build_params
         {
@@ -120,7 +124,7 @@ module Dqt
           "ageRangeFrom" => trainee.course_min_age,
           "ageRangeTo" => trainee.course_max_age,
           "ittQualificationAim" => ITT_QUALIFICATION_AIMS[trainee.hesa_metadatum&.itt_aim],
-          "ittQualificationType" => ITT_QUALIFICATION_TYPES[trainee.hesa_metadatum&.itt_qualification_aim],
+          "ittQualificationType" => itt_qualification_type,
         }
       end
 
@@ -136,6 +140,12 @@ module Dqt
           "date" => graduation_date,
           "heQualificationType" => CodeSets::DegreeTypes::MAPPING[degree.uk_degree_uuid],
         }
+      end
+
+      def itt_qualification_type
+        return DQT_IQTS_PROGRAMME_TYPE if iqts_programme_type? && trainee.hesa_metadatum&.itt_qualification_aim.nil?
+
+        ITT_QUALIFICATION_TYPES[trainee.hesa_metadatum&.itt_qualification_aim]
       end
 
       def course_subject_code(subject_name)
@@ -186,7 +196,9 @@ module Dqt
         10.months
       end
 
-      attr_reader :trainee, :degree
+      def iqts_programme_type?
+        PROGRAMME_TYPE[trainee.training_route] == DQT_IQTS_PROGRAMME_TYPE
+      end
     end
   end
 end

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -61,6 +61,26 @@ module Dqt
           })
         end
 
+        context "iQTS trainee" do
+          let(:trainee_attributes) { { training_route: "iqts" } }
+
+          it "sets the programme type to international qualified teacher status" do
+            expect(subject["initialTeacherTraining"]).to include({
+              "programmeType" => "InternationalQualifiedTeacherStatus",
+            })
+          end
+
+          context "ITT qualification aim is not specified" do
+            let(:hesa_metadatum) { build(:hesa_metadatum, itt_qualification_aim: nil) }
+
+            it "sets the itt qualification type to international qualified teacher status" do
+              expect(subject["initialTeacherTraining"]).to include({
+                "ittQualificationType" => "InternationalQualifiedTeacherStatus",
+              })
+            end
+          end
+        end
+
         context "itt_end_date is missing" do
           let(:hesa_metadatum) { build(:hesa_metadatum) }
           let(:trainee_attributes) { { itt_end_date: nil, hesa_metadatum: hesa_metadatum, training_route: training_route, study_mode: study_mode } }


### PR DESCRIPTION
### Context
https://trello.com/c/u3EeymlA/5286-s-send-iqts-trainees-when-registered-to-dqt

### Changes proposed in this pull request
- Map iQTS training route to DQT programme type `InternationalQualifiedTeacherStatus`

### Important business
- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
