### PR TITLE
[5098] Turn on iQTS registration

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -125,6 +125,7 @@ module Dqt
           "ageRangeTo" => trainee.course_max_age,
           "ittQualificationAim" => ITT_QUALIFICATION_AIMS[trainee.hesa_metadatum&.itt_aim],
           "ittQualificationType" => itt_qualification_type,
+          "trainingCountryCode" => find_country_code(trainee.iqts_country),
         }
       end
 
@@ -174,8 +175,7 @@ module Dqt
       end
 
       def country_code
-        country = degree.uk? ? UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED : degree.country
-        Hesa::CodeSets::Countries::MAPPING.find { |_, name| name.start_with?(country) }&.first
+        find_country_code(degree.uk? ? UNITED_KINGDOM_NOT_OTHERWISE_SPECIFIED : degree.country)
       end
 
       def itt_end_date
@@ -198,6 +198,12 @@ module Dqt
 
       def iqts_programme_type?
         PROGRAMME_TYPE[trainee.training_route] == DQT_IQTS_PROGRAMME_TYPE
+      end
+
+      def find_country_code(country)
+        return if country.blank?
+
+        Hesa::CodeSets::Countries::MAPPING.find { |_, name| name.start_with?(country) }&.first
       end
     end
   end

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -36,6 +36,7 @@ features:
     provider_led_undergrad: true
     school_direct_salaried: true
     school_direct_tuition_fee: true
+    iqts: true
   google:
     send_data_to_big_query: true
   integrate_with_dqt: true

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -32,6 +32,7 @@ features:
     provider_led_undergrad: true
     school_direct_salaried: true
     school_direct_tuition_fee: true
+    iqts: true
   google:
     send_data_to_big_query: false
   integrate_with_dqt: false

--- a/spec/lib/dqt/params/trainee_request_spec.rb
+++ b/spec/lib/dqt/params/trainee_request_spec.rb
@@ -39,6 +39,7 @@ module Dqt
             "ageRangeTo" => trainee.course_max_age,
             "ittQualificationAim" => nil,
             "ittQualificationType" => nil,
+            "trainingCountryCode" => nil,
           })
         end
 

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -58,14 +58,16 @@ module Dqt
             "ageRangeTo" => trainee.course_max_age,
             "ittQualificationAim" => described_class::ITT_QUALIFICATION_AIMS[hesa_metadatum.itt_aim],
             "ittQualificationType" => described_class::ITT_QUALIFICATION_TYPES[hesa_metadatum.itt_qualification_aim],
+            "trainingCountryCode" => nil,
           })
         end
 
         context "iQTS trainee" do
-          let(:trainee_attributes) { { training_route: "iqts" } }
+          let(:trainee_attributes) { { training_route: "iqts", iqts_country: "Ireland" } }
 
-          it "sets the programme type to international qualified teacher status" do
+          it "sets the programme type and training country code appropriately" do
             expect(subject["initialTeacherTraining"]).to include({
+              "trainingCountryCode" => "IE",
               "programmeType" => "InternationalQualifiedTeacherStatus",
             })
           end


### PR DESCRIPTION
### Context
https://trello.com/c/CZa1lZ29/5098-l-test-and-turn-on-iqts-registration

### Changes proposed in this pull request
- Send `trainingCountryCode` to DQT for iQTS training routes
- Turn on feature flag for `production` and `productiondata` environments

### Guidance to review
- Testing was done to see if DQT would create a TRN using new iQTS training route. I didn't at first because the `trainingCountryCode` was missing. Worked after it was added.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
