### PR TITLE
[5296] Add `outcome` to the DQT trainee update endpoint

### DIFF
--- a/app/controllers/trainees/confirm_deferrals_controller.rb
+++ b/app/controllers/trainees/confirm_deferrals_controller.rb
@@ -9,7 +9,6 @@ module Trainees
 
     def update
       if deferral_form.save!
-        trainee.defer!
         flash[:success] = I18n.t("flash.trainee_deferred")
         redirect_to(trainee_path(trainee))
       end

--- a/app/forms/deferral_form.rb
+++ b/app/forms/deferral_form.rb
@@ -15,6 +15,7 @@ private
 
   def assign_attributes_to_trainee
     trainee.trainee_start_date = itt_start_date if itt_start_date.is_a?(Date)
+    trainee.state = :deferred
     trainee[date_field] = date
   end
 

--- a/app/jobs/dqt/withdraw_trainee_job.rb
+++ b/app/jobs/dqt/withdraw_trainee_job.rb
@@ -22,7 +22,7 @@ module Dqt
       end
 
       if trainee.trn.present?
-        WithdrawTrainee.call(trainee:) unless already_withdrawn_in_dqt?
+        WithdrawTrainee.call(trainee:)
       elsif continue_waiting_for_trn?
         requeue
       else
@@ -40,10 +40,6 @@ module Dqt
 
     def requeue
       self.class.set(wait: Settings.jobs.poll_delay_hours.hours).perform_later(trainee, timeout_after)
-    end
-
-    def already_withdrawn_in_dqt?
-      RetrieveTraining.call(trainee:)["result"] == "Withdrawn"
     end
   end
 end

--- a/app/lib/dqt/params/update.rb
+++ b/app/lib/dqt/params/update.rb
@@ -2,7 +2,7 @@
 
 module Dqt
   module Params
-    class TraineeRequest < TrnRequest
+    class Update < TrnRequest
     private
 
       def build_params

--- a/app/lib/dqt/params/update.rb
+++ b/app/lib/dqt/params/update.rb
@@ -9,9 +9,33 @@ module Dqt
         {
           "trn" => trainee.trn,
           "husid" => trainee.hesa_id,
-          "initialTeacherTraining" => initial_teacher_training_params,
+          "initialTeacherTraining" => initial_teacher_training_params.merge(outcome_params),
           "qualification" => qualification_params,
         }
+      end
+
+      def outcome_params
+        { "outcome" => outcome }.compact
+      end
+
+      def outcome
+        return "Deferred" if trainee.deferred?
+
+        if in_training?
+          if assessment_only_route?
+            "UnderAssessment"
+          else
+            "InTraining"
+          end
+        end
+      end
+
+      def in_training?
+        %w[submitted_for_trn trn_received].include?(trainee.state)
+      end
+
+      def assessment_only_route?
+        trainee.training_route == TRAINING_ROUTE_ENUMS[:assessment_only]
       end
     end
   end

--- a/app/services/dead_jobs/dqt_update_trainee.rb
+++ b/app/services/dead_jobs/dqt_update_trainee.rb
@@ -11,7 +11,7 @@ module DeadJobs
 
     def build_rows
       super do |trainee|
-        { params_sent: Dqt::Params::TraineeRequest.new(trainee:).to_json&.to_s&.gsub('"', "'") }
+        { params_sent: Dqt::Params::Update.new(trainee:).to_json&.to_s&.gsub('"', "'") }
       end
     end
 

--- a/app/services/dqt/trainee_update.rb
+++ b/app/services/dqt/trainee_update.rb
@@ -7,10 +7,8 @@ module Dqt
     class TraineeUpdateMissingTrn < StandardError; end
 
     def initialize(trainee:)
-      return unless FeatureService.enabled?(:integrate_with_dqt)
-
       @trainee = trainee
-      @payload = Params::TraineeRequest.new(trainee:)
+      @payload = Params::Update.new(trainee:)
     end
 
     def call

--- a/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_deferrals_controller_spec.rb
@@ -7,10 +7,11 @@ describe Trainees::ConfirmDeferralsController do
 
   let(:current_user) { build_current_user }
   let(:trainee) { create(:trainee, :trn_received, provider: current_user.organisation) }
+  let(:deferral_form) { double(save!: true) }
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
-    allow(DeferralForm).to receive(:new).with(trainee).and_return(double(save!: true))
+    allow(DeferralForm).to receive(:new).with(trainee).and_return(deferral_form)
   end
 
   describe "#update" do
@@ -19,7 +20,7 @@ describe Trainees::ConfirmDeferralsController do
     end
 
     it "transitions the trainee state to deferred" do
-      expect(trainee.reload).to be_deferred
+      expect(deferral_form).to have_received(:save!)
     end
   end
 end

--- a/spec/forms/deferral_form_spec.rb
+++ b/spec/forms/deferral_form_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe DeferralForm, type: :model do
-  let(:trainee) { create(:trainee, :deferred) }
+  let(:trainee) { create(:trainee, :trn_received) }
   let(:form_store) { class_double(FormStore) }
 
   let(:params) do
@@ -115,11 +115,14 @@ describe DeferralForm, type: :model do
 
     before do
       allow(FormStore).to receive(:get)
+      allow(form_store).to receive(:set).with(trainee.id, :deferral, nil)
+    end
+
+    it "transitions the trainee state to deferred" do
+      expect { subject.save! }.to change(trainee, :state).to("deferred")
     end
 
     it "takes any data from the form store and saves it to the database and clears the store data" do
-      expect(form_store).to receive(:set).with(trainee.id, :deferral, nil)
-
       date_params = params.except("date_string").values.map(&:to_i)
       expect { subject.save! }.to change(trainee, :defer_date).to(Date.new(*date_params))
     end

--- a/spec/jobs/dqt/withdraw_trainee_job_spec.rb
+++ b/spec/jobs/dqt/withdraw_trainee_job_spec.rb
@@ -44,15 +44,6 @@ module Dqt
           described_class.perform_now(trainee, timeout_date)
           expect(WithdrawTraineeJob).not_to have_been_enqueued
         end
-
-        context "trainee is already withdrawn in DQT" do
-          let(:dqt_response) { { "result" => "Withdrawn" } }
-
-          it "doesn't call the WithdrawTrainee service" do
-            expect(WithdrawTrainee).not_to receive(:call).with(trainee:)
-            described_class.perform_now(trainee, timeout_date)
-          end
-        end
       end
 
       context "TRN is not available" do

--- a/spec/lib/dqt/params/update_spec.rb
+++ b/spec/lib/dqt/params/update_spec.rb
@@ -54,6 +54,38 @@ module Dqt
           })
         end
 
+        context "trainee is deferred" do
+          let(:trainee) { create(:trainee, :completed, :deferred) }
+
+          it "sets the outcome param to Deferred" do
+            expect(subject["initialTeacherTraining"]).to include({ "outcome" => "Deferred" })
+          end
+        end
+
+        context "trainee is in training" do
+          let(:trainee) { create(:trainee, :completed, :school_direct_tuition_fee, :submitted_for_trn) }
+
+          it "sets the outcome param to Deferred" do
+            expect(subject["initialTeacherTraining"]).to include({ "outcome" => "InTraining" })
+          end
+
+          context "assessment only route" do
+            let(:trainee) { create(:trainee, :completed, :assessment_only, :trn_received) }
+
+            it "sets the outcome param to Deferred" do
+              expect(subject["initialTeacherTraining"]).to include({ "outcome" => "UnderAssessment" })
+            end
+          end
+        end
+
+        context "trainee is not deferred or in training" do
+          let(:trainee) { create(:trainee, :completed, :withdrawn) }
+
+          it "doesn't add the outcome params" do
+            expect(subject["initialTeacherTraining"]).not_to have_key("outcome")
+          end
+        end
+
         context "when trainee has an international degree" do
           let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details, country: "Albania") }
           let(:trainee) { create(:trainee, :completed, degrees: [non_uk_degree]) }

--- a/spec/lib/dqt/params/update_spec.rb
+++ b/spec/lib/dqt/params/update_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Dqt
   module Params
-    describe TraineeRequest do
+    describe Update do
       let(:trainee) { create(:trainee, :completed, sex: "female", hesa_id: 1) }
       let(:degree) { trainee.degrees.first }
       let(:hesa_code) { Degrees::DfEReference::SUBJECTS.all.find { _1.name == degree.subject }&.hecos_code }

--- a/spec/services/dead_jobs/dqt_update_trainee_spec.rb
+++ b/spec/services/dead_jobs/dqt_update_trainee_spec.rb
@@ -8,7 +8,7 @@ module DeadJobs
       let(:klass) { "Dqt::UpdateTraineeJob" }
       let(:name) { "DQT Update Trainee" }
 
-      let(:params_sent) { Dqt::Params::TraineeRequest.new(trainee:).to_json.to_s.gsub('"', "'") }
+      let(:params_sent) { Dqt::Params::Update.new(trainee:).to_json.to_s.gsub('"', "'") }
 
       let(:csv) do
         <<~CSV

--- a/spec/services/dqt/update_spec.rb
+++ b/spec/services/dqt/update_spec.rb
@@ -7,7 +7,7 @@ module Dqt
     describe "#call" do
       let(:trainee) { create(:trainee, :completed, :with_secondary_course_details, :with_start_date, :with_degree, trn:) }
       let(:dqt_path) { "/v2/teachers/update/#{trainee.trn}?birthDate=#{trainee.date_of_birth.iso8601}" }
-      let(:dqt_payload) { Params::TraineeRequest.new(trainee:).to_json }
+      let(:dqt_payload) { Params::Update.new(trainee:).to_json }
       let(:dqt_response) { { status: 204 } }
       let(:trn) { "1234567" }
 


### PR DESCRIPTION
### Context
https://trello.com/c/09POs7RQ/5296-s-add-outcome-to-the-dqt-trainee-update-endpoint

### Changes proposed in this pull request
- Rename `Dqt::Params::TraineeRequest` to `Dqt::Params::Update` (TraineeRequest doesn't really convey any meaning)
- Add `outcome` param to `Dqt::Params::Update` based on conditional logic
- Remove the check on withdrawing already withdrawn trainees in DQT

### Guidance to review
- Worked with @MrKevJoy to test that we can go between `Deferred` => `InTraining` or `UnderAssessment` and vice versa
- Also confirm that withdrawing a trainee more than once doesn't cause any errors

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
