### PR TITLE
[5326] Allow hesa trainees to be deferred reinstated awarded or withdrawn in register

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
 
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
 
-  helper_method :current_user, :authenticated?, :audit_user, :trainee_editable?
+  helper_method :current_user, :authenticated?, :audit_user, :trainee_editable?, :display_record_actions?
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
@@ -97,6 +97,10 @@ private
 
   def trainee_editable?
     @trainee_editable ||= policy(trainee).update?
+  end
+
+  def display_record_actions?
+    @display_record_actions ||= policy(trainee).show_actions?
   end
 
   def ensure_trainee_is_not_draft!

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -87,8 +87,14 @@ class TraineePolicy
     user.lead_school?
   end
 
-  alias_method :index?, :show?
+  # This is a temporary method until HESA trainees are editable
+  def show_actions?
+    return false if user_is_read_only?
 
+    user_is_system_admin? || (user_in_provider_context? && trainee.awaiting_action?)
+  end
+
+  alias_method :index?, :show?
   alias_method :edit?, :update?
   alias_method :destroy?, :update?
   alias_method :confirm?, :update?

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -14,8 +14,12 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <%= render GovukComponent::InsetTextComponent.new(classes: "govuk-!-padding-top-0 govuk-!-padding-bottom-0") do %>
-          <h2 class="govuk-heading-s"><%= t(".hesa_uneditable_heading") %></h2>
-          <%= t(".body_html", award_level: @trainee.early_years_route? ? t(".eyts_award_level") : t(".qts_award_level")).html_safe %>
+          <div class="govuk-body"><%= t(".hesa_inset") %></div>
+          <div class="govuk-body">
+            <% (@trainee.early_years_route? ? t(".eyts_award_level") : t(".qts_award_level")).tap do |award_level| %>
+              <%= t(@trainee.deferred? ? ".hesa_deferred_inset" : ".hesa_in_training_inset", award_level: award_level).html_safe %>
+            <% end %>
+          </div>
         <% end %>
       </div>
     </div>

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -1,4 +1,4 @@
-<% if trainee_editable? %>
+<% if display_record_actions? %>
   <div class="record-outcome-action-bar">
     <%= render RecordActions::View.new(@trainee, has_missing_fields: @missing_fields.present?) %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,8 @@ en:
   not_applicable: Not applicable
   draft: draft
   record: record
+  defer: defer
+  reinstate: reinstate
   header:
     items:
       sign_out: Sign out
@@ -1644,7 +1646,8 @@ en:
       bad_request: The query param needs to be at least %{length} characters
   layouts:
     trainee_record:
-      hesa_uneditable_heading: This record was imported from HESA and cannot be edited
-      body_html: <p class="govuk-body">Updates from HESA are imported regularly.</p>
+      hesa_deferred_inset: You can reinstate or withdraw them. If you reinstate them then you can recommend them for %{award_level}. You cannot make other changes.
+      hesa_in_training_inset: You can defer, withdraw or recommend them for %{award_level}. You cannot make other changes.
+      hesa_inset: This trainee was imported from HESA.
       qts_award_level: QTS
       eyts_award_level: EYTS

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -50,7 +50,6 @@ describe TraineePolicy do
 
   permissions :update?, :edit?, :destroy?, :confirm? do
     it { is_expected.to permit(provider_user, provider_trainee) }
-    it { is_expected.not_to permit(provider_user, hesa_trainee) }
     it { is_expected.not_to permit(lead_school_user, lead_school_trainee) }
     it { is_expected.not_to permit(read_only_provider_user, provider_trainee) }
 

--- a/spec/views/trainees/show.html.erb_spec.rb
+++ b/spec/views/trainees/show.html.erb_spec.rb
@@ -8,6 +8,7 @@ describe "trainees/show", "feature_routes.provider_led_postgrad": true do
     assign(:current_user, current_user)
     without_partial_double_verification do
       allow(view).to receive(:trainee_editable?).and_return(true)
+      allow(view).to receive(:display_record_actions?).and_return(true)
     end
   end
 


### PR DESCRIPTION
### Context
https://trello.com/c/nPzWmher/5326-m-allow-hesa-trainees-to-be-deferred-reinstated-awarded-or-withdrawn-in-register

### Changes proposed in this pull request
- Update trainee policy so the actions bar is avalable to HESA trainees
- Change the HESA inset text to reflect the actions that can now be taken 

### Screenshot
<img width="983" alt="Screenshot 2023-03-20 at 11 39 00" src="https://user-images.githubusercontent.com/28728/226328791-6a2d7883-44f6-44b6-9f1d-a90d38312edf.png">

### Guidance to review
- Log in as a provider
- Find an in-training HESA trainee
- Should see inset text and actions bar

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
