### PR TITLE
[5334] Bulk recommend fix errors renders incorrect page if user gets an error uploading

### DIFF
--- a/app/views/bulk_update/recommendations_errors/show.html.erb
+++ b/app/views/bulk_update/recommendations_errors/show.html.erb
@@ -6,7 +6,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop" >
-    <%= register_form_with(model: @recommendations_upload_form, url: bulk_update_recommendations_uploads_path) do |f| %>
+    <%= register_form_with(model: @recommendations_upload_form,
+                           url: bulk_update_recommendations_upload_recommendations_errors_path(@recommendations_upload)) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ Rails.application.routes.draw do
       get "upload-summary", to: "recommendations_uploads#show", as: "summary"
       resource :recommendations, only: :create
       resource :recommendations_checks, only: :show, path: "check-pending-updates"
-      resource :recommendations_errors, only: :show, path: "fix-errors"
+      resource :recommendations_errors, only: %i[show create], path: "fix-errors"
       member { get :cancel, path: "cancel-bulk-updates" }
     end
   end

--- a/spec/features/bulk_upload/recommending_trainees_spec.rb
+++ b/spec/features/bulk_upload/recommending_trainees_spec.rb
@@ -66,6 +66,8 @@ feature "recommending trainees" do
         and_i_upload_a_csv("bulk_update/recommendations_upload/date_in_future.csv")
         then_i_see_count_errors
         then_i_click_review_errors
+        when_i_submit_form_with_no_file_attached
+        then_i_see_validation_errors
       end
     end
   end
@@ -144,6 +146,14 @@ private
 
   def then_i_am_taken_back_to_the_upload_page
     expect(recommendations_upload_page).to be_displayed
+  end
+
+  def when_i_submit_form_with_no_file_attached
+    recommendations_checks_show_page.upload_button.click
+  end
+
+  def then_i_see_validation_errors
+    expect(recommendations_checks_show_page).to have_text("Please select a file")
   end
 
   def and_i_see_a_list_of_trainees_to_check

--- a/spec/support/page_objects/bulk_update/recommendations_checks/show.rb
+++ b/spec/support/page_objects/bulk_update/recommendations_checks/show.rb
@@ -5,6 +5,7 @@ module PageObjects
     class Show < PageObjects::Base
       set_url "/bulk-update/recommend/{id}/check-pending-updates"
 
+      element :upload_button, ".govuk-button", text: "Upload file and check who you’ll recommend"
       element :change_link, ".govuk-link", text: "Change who you’ll recommend"
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/biSsSqUH/5334-bulk-recommend-fix-errors-renders-incorrect-page-if-user-gets-an-error-uploading

### Changes proposed in this pull request
- Update `BulkUpdate::RecommendationsErrorsController` to handle file uploads separate to `BulkUpdate::RecommendationsUploadsController` 

### Guidance to review
 - Log in as a provider
 - Visit "Bulk recommend"
 - Download CSV
 - Edit CSV and fill the column "Date QTS or EYTS standards met" with at least one cell containing an incorrect future date e.g. 7000-03-01
 - Upload CSV
 - View errors
 - Click the upload button without attaching a file
 - Form errors should appear on the current page

### Screenshot
<img width="661" alt="Screenshot 2023-03-22 at 14 52 53" src="https://user-images.githubusercontent.com/28728/226943633-03b053f7-b6a7-49b2-bbb6-87799dc03e6b.png">

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
