### PR TITLE
Add pen environment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
         options:
         - qa
         - staging
+        - pen
         - production
         - productiondata
       sha:

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,11 @@ staging:
 	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-test)
 	$(eval DTTP_HOSTNAME=traineeteacherportal-pp)
 
+pen:
+	$(eval DEPLOY_ENV=pen)
+	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-test)
+	$(eval DTTP_HOSTNAME=traineeteacherportal-pp)
+
 production:
 	$(if $(CONFIRM_PRODUCTION), , $(error Can only run with CONFIRM_PRODUCTION))
 	$(eval DEPLOY_ENV=production)

--- a/config/environments/pen.rb
+++ b/config/environments/pen.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require Rails.root.join("config/environments/production")

--- a/config/settings/pen.yml
+++ b/config/settings/pen.yml
@@ -1,0 +1,43 @@
+# The url for this app, also used by `dfe_sign_in`
+base_url: https://pen.register-trainee-teachers.service.gov.uk
+
+dttp:
+  scope: https://dttp-ppad.crm4.dynamics.com/.default
+  api_base_url: https://dttp-ppad.crm4.dynamics.com/api/data/v9.1
+  portal_host: traineeteacherportal-pp.education.gov.uk
+
+dfe_sign_in:
+  # URL that the users are redirected to for signing in
+  issuer: https://pp-oidc.signin.education.gov.uk
+  # URL of the users profile
+  profile: https://pp-profile.signin.education.gov.uk
+
+dqt:
+  base_url: https://qualified-teachers-api-preprod.london.cloudapps.digital/
+
+features:
+  basic_auth: false
+  sign_in_method: persona
+  import_courses_from_ttapi: true
+  import_applications_from_apply: true
+  publish_course_details: true
+  routes:
+    early_years_assessment_only: true
+    early_years_postgrad: true
+    early_years_salaried: true
+    early_years_undergrad: true
+    opt_in_undergrad: true
+    pg_teaching_apprenticeship: true
+    provider_led_postgrad: true
+    provider_led_undergrad: true
+    school_direct_salaried: true
+    school_direct_tuition_fee: true
+  google:
+    send_data_to_big_query: false
+
+environment:
+  name: pen
+
+google_tag_manager:
+  auth_id: h9MLvalp6AuXoRufPTHO_A
+  env_id: 12

--- a/config/settings/pen.yml
+++ b/config/settings/pen.yml
@@ -17,7 +17,7 @@ dqt:
 
 features:
   basic_auth: false
-  sign_in_method: persona
+  sign_in_method: otp
   import_courses_from_ttapi: true
   import_applications_from_apply: true
   publish_course_details: true

--- a/terraform/workspace-variables/app_config.yml
+++ b/terraform/workspace-variables/app_config.yml
@@ -11,6 +11,11 @@ staging:
   RAILS_ENV: staging
   RACK_ENV: staging
 
+pen:
+  <<: *default
+  RAILS_ENV: pen
+  RACK_ENV: pen
+
 production:
   <<: *default
   RAILS_ENV: production

--- a/terraform/workspace-variables/pen.tfvars.json
+++ b/terraform/workspace-variables/pen.tfvars.json
@@ -1,0 +1,21 @@
+{
+  "env_config": "pen",
+  "key_vault_app_secret_name": "REGISTER-APP-SECRETS-STAGING",
+  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING",
+  "key_vault_name": "s121t01-shared-kv-01",
+  "key_vault_resource_group": "s121t01-shared-rg",
+  "paas_app_environment": "pen",
+  "paas_app_start_timeout": 180,
+  "paas_postgres_service_plan_13": "tiny-unencrypted-13",
+  "paas_redis_service_plan": "tiny-ha-5_x",
+  "paas_space_name": "bat-staging",
+  "paas_web_app_hostname": ["pen"],
+  "paas_dttp_portal": ["traineeteacherportal-staging"],
+  "paas_web_app_instances": 2,
+  "paas_web_app_memory": 1024,
+  "paas_worker_app_instances": 1,
+  "paas_worker_app_memory": 512,
+  "paas_worker_app_stopped": false,
+  "azure_tempdata_storage_account_name": "s121t01registerpentmp",
+  "azure_resource_group_name": "s121t01-reg-pen-rg"
+}

--- a/terraform/workspace-variables/pen_backend.tfvars
+++ b/terraform/workspace-variables/pen_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s121t01-register"
+storage_account_name = "s121t01registerterraform"
+container_name       = "tfstate"
+key                  = "pen-bat.tfstate"


### PR DESCRIPTION
### Context

A dedicated environment is required to support pen testing.

### Changes proposed in this pull request

- Add the environment to the deploy workflow inputs
- Add the config to the `Makefile`
- Add Ruby config
- Add Terraform app config
- Add Terraform variable and backend files

### Outside this pull request

https://github.com/DFE-Digital/bat-infrastructure/pull/124

### Guidance to review

Confirm the environment is available on https://pen.register-trainee-teachers.service.gov.uk and https://pen.register-trainee-teachers.education.gov.uk redirects to the service domain.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
