### PR TITLE
[5261] Prevent hesa metadata and degrees being updated

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -22,8 +22,10 @@ module Trainees
     end
 
     def call
+      return if @current_trainee_state == :awarded
+
       Audited.audit_class.as_user(USERNAME) do
-        trainee.assign_attributes(mapped_attributes) unless @current_trainee_state == :awarded
+        trainee.assign_attributes(mapped_attributes)
 
         if trainee.save!
           create_degrees!


### PR DESCRIPTION
### Context

The guard clause in the previous PR was placed in the wrong place. This would allow trainees to still be saved, meaning they would have updates made to their hesa metadata and degrees. 

See comments on last PR: 
https://github.com/DFE-Digital/register-trainee-teachers/pull/3135/files#r1144620348

Putting the guard clause right at the front will prevent this from happening.
