### PR TITLE
[5346] Bulk recommend - Support users removing (or moving) "Do not edit" row

### DIFF
--- a/app/models/reports/bulk_recommend_report.rb
+++ b/app/models/reports/bulk_recommend_report.rb
@@ -2,6 +2,8 @@
 
 module Reports
   class BulkRecommendReport < TemplateClassCsv
+    DO_NOT_EDIT = "Do not edit"
+
     # required headers
     TRN = "TRN"
     TRAINEE_ID = "Provider trainee ID"
@@ -69,7 +71,7 @@ module Reports
       TEXT
 
       # ["Do not edit", "Do not edit" ... last_row]
-      csv << [*(headers.count - 1).times.map { "Do not edit" }, last_row]
+      csv << [*(headers.count - 1).times.map { DO_NOT_EDIT }, last_row]
     end
 
     def add_report_rows

--- a/app/services/bulk_update/recommendations_uploads/create_csv_with_errors.rb
+++ b/app/services/bulk_update/recommendations_uploads/create_csv_with_errors.rb
@@ -5,6 +5,8 @@ module BulkUpdate
     class CreateCsvWithErrors
       include ServicePattern
 
+      FIRST_CSV_ROW_NUMBER = 2
+
       def initialize(recommendations_upload:)
         @recommendations_upload = recommendations_upload
       end
@@ -13,13 +15,11 @@ module BulkUpdate
         table = download_csv
 
         table.each.with_index do |row, index|
-          # The first row in the table is the "Do not edit" row
-          if index.zero?
-            row["Errors"] = "Do not edit"
+          # If we're dealing with a "Do not edit" row, add another "Do not edit"
+          if row.any? { |cell| cell.include?(Reports::BulkRecommendReport::DO_NOT_EDIT) }
+            row["Errors"] = Reports::BulkRecommendReport::DO_NOT_EDIT
           else
-            # We add 2 here because the first data row is actually the third
-            # csv row (after headers and "Do not edit" row)
-            row["Errors"] = errors_for_row(index + 2)
+            row["Errors"] = errors_for_row(index + FIRST_CSV_ROW_NUMBER)
           end
         end
 

--- a/app/services/bulk_update/recommendations_uploads/create_recommendations_upload_rows.rb
+++ b/app/services/bulk_update/recommendations_uploads/create_recommendations_upload_rows.rb
@@ -7,21 +7,24 @@ module BulkUpdate
     class CreateRecommendationsUploadRows
       include ServicePattern
 
+      FIRST_CSV_ROW_NUMBER = 2
+
       def initialize(recommendations_upload:, csv:)
         @recommendations_upload = recommendations_upload
         @csv = csv
       end
 
-      # we skip the first non-header row as this will just contain "do not edit" warning.
       def call
-        csv[1..].map.with_index(3) do |row, row_number|
-          # validate row and (matched) trainee
+        csv.map.with_index do |row, index|
+          next if row.any? { |cell| cell.include?(Reports::BulkRecommendReport::DO_NOT_EDIT) }
+
           row = Row.new(row)
+          # validate row and (matched) trainee
           trainee_validator = ValidateTrainee.new(row: row, provider: recommendations_upload.provider)
           csv_row_validator = ValidateCsvRow.new(csv: csv, row: row, trainee: trainee_validator.trainee)
 
           # create the recommendations_upload_row and associate it with the matched trainee (if any)
-          upload_row = create_recommendations_upload_row!(trainee_validator.trainee, row, row_number)
+          upload_row = create_recommendations_upload_row!(trainee_validator.trainee, row, index + FIRST_CSV_ROW_NUMBER)
 
           # create any validation errors and associate them with the recommendations_upload_row just created
           create_validation_errors!(upload_row, csv_row_validator.messages) unless csv_row_validator.valid?

--- a/spec/fixtures/files/bulk_update/recommendations_upload/missing_do_not_edit_row.csv
+++ b/spec/fixtures/files/bulk_update/recommendations_upload/missing_do_not_edit_row.csv
@@ -1,0 +1,3 @@
+TRN,Provider trainee ID,Last names,First names,Lead school,QTS or EYTS,Route,Phase,Age range,Subject,Date QTS or EYTS standards met
+2413295,22/23-1076,Barrows,Courtney,-,EYTS,Early years (salaried),Early years,0 to 5,Early years teaching,20/7/2022
+4814731,22/23-1589,Bergstrom,Cliff,Bluemeadow High,QTS,School direct (salaried),Secondary,11 to 16,Biology,21/7/2022

--- a/spec/services/bulk_update/recommendations_uploads/create_recommendations_upload_rows_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/create_recommendations_upload_rows_spec.rb
@@ -17,7 +17,7 @@ module BulkUpdate
         context "given a valid CSV" do
           let(:file) { file_fixture("bulk_update/recommendations_upload/complete.csv") }
 
-          it "creates the row records" do
+          it "creates the rows with the correct row numbers" do
             expect(provider.recommendations_upload_rows.pluck(:trn, :csv_row_number, :standards_met_at)).to eql(
               [
                 ["2413295", 3, "20-07-2022".to_date],
@@ -40,6 +40,19 @@ module BulkUpdate
 
             row_errors = RecommendationsUploadRow.find_by(trn: "241a295").row_errors
             expect(row_errors.first.message).to eql "TRN must be 7 characters long and contain only numbers"
+          end
+        end
+
+        context "given a CSV with no 'Do not edit' row" do
+          let(:file) { file_fixture("bulk_update/recommendations_upload/missing_do_not_edit_row.csv") }
+
+          it "creates the rows with the correct row numbers" do
+            expect(provider.recommendations_upload_rows.pluck(:trn, :csv_row_number, :standards_met_at)).to eql(
+              [
+                ["2413295", 2, "20-07-2022".to_date],
+                ["4814731", 3, "21-07-2022".to_date],
+              ],
+            )
           end
         end
       end


### PR DESCRIPTION
### Context

https://trello.com/c/3w7vmdwc/5346-m-bulk-recommend-support-users-removing-the-do-not-edit-row

### Changes proposed in this pull request

- Update `CreateRecommendationsUploadRows` service to detect whether a row contains
  "Do not edit" and skip creating row if it does.
- Update `CreateCsvWithErrors` services to detect whether a row contains "Do not edit" and
  add correct string if it does.

Before, both of these services skipped the first row assuming it was the "Do not edit" row.

### Guidance to review

- Upload a file with the "Do not edit" row missing and an error in one of your trainees
- Check that the summary counts look correct
- Click to 'Fix errors'
- Check that the download does not contain the "Do not edit" row and that the error is against the correct trainee

Now do the same checks but move the "Do not edit" row to somewhere in the middle (as if the user has sorted the spreadsheet on a column)

This should still work.

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml