### PR TITLE
[5348] Bulk recommend - add error for no trainees in file

### DIFF
--- a/app/models/bulk_update/recommendations_upload_row.rb
+++ b/app/models/bulk_update/recommendations_upload_row.rb
@@ -51,10 +51,10 @@ class BulkUpdate::RecommendationsUploadRow < ApplicationRecord
   end
 
   def qts?
-    trainee.award_type == "QTS"
+    trainee&.award_type == "QTS"
   end
 
   def eyts?
-    trainee.award_type == "EYTS"
+    trainee&.award_type == "EYTS"
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1328,6 +1328,7 @@ en:
               no_id_header: At least one identifying column is required (TRN, HESA ID or Trainee provider ID)
               no_date_header: Date QTS or EYTS standards met is required
               no_dates_given: No dates have been provided in this CSV
+              no_trainees: The selected file must contain at least one trainee
         bulk_update:
           recommendations_uploads:
             validate_trainee:

--- a/spec/services/bulk_update/recommendations_uploads/validate_csv_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_csv_spec.rb
@@ -41,7 +41,14 @@ module BulkUpdate
         it { expect(record.errors.first.message).to eql "No dates have been provided in this CSV" }
       end
 
-      context "given a CSV with no trainees" do
+      context "given a CSV with only headers, no trainees" do
+        let(:headers) { Reports::BulkRecommendReport::DEFAULT_HEADERS.join(",") }
+        let(:csv) { CSV.new(headers, **BulkUpdate::RecommendationsUploadForm::CSV_ARGS).read }
+
+        it { expect(record.errors.first.message).to eql "The selected file must contain at least one trainee" }
+      end
+
+      context "given a CSV with headers and 'No trainee data to export'" do
         let(:csv) { create_recommendations_upload_csv!(trainees: []) }
 
         it { expect(record.errors.first.message).to eql "The selected file must contain at least one trainee" }

--- a/spec/services/bulk_update/recommendations_uploads/validate_csv_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_csv_spec.rb
@@ -10,7 +10,7 @@ module BulkUpdate
       subject(:service) { described_class.new(csv:, record:) }
 
       let(:record) { ::BulkUpdate::RecommendationsUploadForm.new }
-      let(:csv)    { create_recommendations_upload_csv!(columns_to_delete:) }
+      let(:csv) { create_recommendations_upload_csv!(columns_to_delete:) }
 
       before do
         create(:trainee, :bulk_recommend_from_hesa)
@@ -39,6 +39,12 @@ module BulkUpdate
         let(:csv) { create_recommendations_upload_csv! }
 
         it { expect(record.errors.first.message).to eql "No dates have been provided in this CSV" }
+      end
+
+      context "given a CSV with no trainees" do
+        let(:csv) { create_recommendations_upload_csv!(trainees: []) }
+
+        it { expect(record.errors.first.message).to eql "The selected file must contain at least one trainee" }
       end
     end
   end


### PR DESCRIPTION
### Context

https://trello.com/c/z08URxkV/5348-s-show-error-when-there-are-0-trainees-in-the-csv-file-when-bulk-recommending-for-qts-or-eyts

### Changes proposed in this pull request

- Add validation and error message for when there are the expected header / headers but no trainees
- Fix for row methods (there's not always a `matched_trainee`)

### Guidance to review

- Upload a file with just the header row and check the error
- Upload a file with just the header row and the "Do not edit" row and check the error
- Check for regressions in other scenarios

<img width="777" alt="Screenshot 2023-04-05 at 11 51 18" src="https://user-images.githubusercontent.com/18436946/230059878-af1df776-c2d3-4855-8f8a-bb0d0729bfb8.png">


### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml