### PR TITLE
[5352] Surface details for awarded, deferred and withdrawn trainees

### DIFF
--- a/app/components/deferral_details/view.html.erb
+++ b/app/components/deferral_details/view.html.erb
@@ -1,4 +1,5 @@
 <%= render SummaryCard::View.new(
   title: t(".summary_title"),
   rows: rows,
+  editable: editable,
 ) %>

--- a/app/components/deferral_details/view.rb
+++ b/app/components/deferral_details/view.rb
@@ -4,17 +4,18 @@ module DeferralDetails
   class View < GovukComponent::Base
     include SummaryHelper
 
-    attr_reader :data_model
+    attr_reader :data_model, :editable
 
-    def initialize(data_model)
+    def initialize(data_model, editable: true, omit_start_date: false)
       @data_model = data_model
+      @omit_start_date = omit_start_date
+      @editable = editable
     end
 
     def rows
-      [
-        trainee_start_date_row,
-        deferral_date_row,
-      ].compact
+      rows = [deferral_date_row]
+      rows.unshift(trainee_start_date_row) unless @omit_start_date
+      rows.compact
     end
 
     def trainee_start_date_row

--- a/app/components/outcome_details/view.html.erb
+++ b/app/components/outcome_details/view.html.erb
@@ -9,4 +9,5 @@
       action_visually_hidden_text: 'outcome date',
     },
   ],
+  editable: editable,
 ) %>

--- a/app/components/outcome_details/view.rb
+++ b/app/components/outcome_details/view.rb
@@ -4,10 +4,11 @@ module OutcomeDetails
   class View < GovukComponent::Base
     include SummaryHelper
 
-    attr_reader :data_model
+    attr_reader :data_model, :editable
 
-    def initialize(data_model)
+    def initialize(data_model, editable: true)
       @data_model = data_model
+      @editable = editable
     end
 
     def outcome_date

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -22,8 +22,6 @@ module RecordDetails
         trainee_id_row,
         region,
         trn_row,
-        trainee_progress_row,
-        trainee_status_row,
         last_updated_row,
         record_created_row,
         trainee_start_date_row,
@@ -68,28 +66,6 @@ module RecordDetails
         {
           field_label: t(".submitted_for_trn"),
           field_value: submission_date,
-        }
-      end
-    end
-
-    def trainee_progress_row
-      return unless trainee.recommended_for_award? || trainee.awarded?
-
-      {
-        field_label: trainee.award_type,
-        field_value: render(StatusTag::View.new(trainee: trainee, classes: "govuk-!-margin-bottom-2")) + tag.br + progress_date,
-      }
-    end
-
-    def trainee_status_row
-      return unless trainee.deferred? || trainee.withdrawn?
-
-      if trainee.withdrawn?
-        mappable_field(trainee_status_tag, t(".trainee_status"), trainee_withdrawal_path(trainee))
-      else
-        {
-          field_label: t(".trainee_status"),
-          field_value: trainee_status_tag,
         }
       end
     end

--- a/app/components/summary_card/view.html.erb
+++ b/app/components/summary_card/view.html.erb
@@ -16,7 +16,7 @@
         <% summary_list.row(html_attributes: { id: row_title(summary_row[:key]) }, classes: row_title(summary_row[:key])) do |row|
           row.key(text: summary_row[:key])
           row.value(text: summary_row[:value])
-          row.action(href: summary_row[:action_href], text: summary_row[:action_text], visually_hidden_text: summary_row[:action_visually_hidden_text] )
+          row.action(href: summary_row[:action_href], text: summary_row[:action_text], visually_hidden_text: summary_row[:action_visually_hidden_text] ) if editable
         end %>
       <% end %>
     <% end %>

--- a/app/components/summary_card/view.rb
+++ b/app/components/summary_card/view.rb
@@ -3,10 +3,11 @@
 class SummaryCard::View < ViewComponent::Base
   renders_one :header_actions
 
-  def initialize(title:, heading_level: 2, rows:, id_suffix: nil)
+  def initialize(title:, heading_level: 2, rows:, id_suffix: nil, editable: true)
     @title = title
     @heading_level = heading_level
     @rows = rows
+    @editable = editable
     @id_suffix = id_suffix
   end
 
@@ -16,7 +17,7 @@ class SummaryCard::View < ViewComponent::Base
 
 private
 
-  attr_accessor :title, :heading_level, :id_suffix
+  attr_accessor :title, :heading_level, :id_suffix, :editable
 
   def row_title(key)
     return key.parameterize if id_suffix.nil?

--- a/app/components/withdrawal_details/view.html.erb
+++ b/app/components/withdrawal_details/view.html.erb
@@ -1,4 +1,5 @@
 <%= render SummaryCard::View.new(
   title: t("components.confirmation.withdrawal_details.summary_title"),
-  rows: rows
-) %>
+  rows: rows,
+  editable: editable,
+  )%>

--- a/app/components/withdrawal_details/view.rb
+++ b/app/components/withdrawal_details/view.rb
@@ -4,11 +4,13 @@ module WithdrawalDetails
   class View < GovukComponent::Base
     include SummaryHelper
 
-    attr_reader :data_model, :deferred, :trainee
+    attr_reader :data_model, :deferred, :trainee, :editable, :omit_start_date_row
 
-    def initialize(data_model)
+    def initialize(data_model, editable: true, omit_start_date_row: false)
       @data_model = data_model
+      @editable = editable
       @trainee = data_model.trainee
+      @omit_start_date_row = omit_start_date_row
       @deferred = data_model.trainee.deferred?
     end
 
@@ -23,11 +25,15 @@ module WithdrawalDetails
     def withdraw_reason
       return data_model.additional_withdraw_reason if data_model.withdraw_reason == WithdrawalReasons::FOR_ANOTHER_REASON
 
+      return I18n.t("components.confirmation.withdrawal_details.reasons.unknown") if data_model.withdraw_reason.nil?
+
       I18n.t("components.confirmation.withdrawal_details.reasons.#{data_model.withdraw_reason}")
     end
 
     def rows
-      [start_date_row, withdrawal_date_row, reason_for_withdrawal_row]
+      rows = [withdrawal_date_row, reason_for_withdrawal_row]
+      rows.unshift(start_date_row) unless @omit_start_date_row
+      rows
     end
 
   private

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -12,6 +12,24 @@
       editable: trainee_editable?) %>
 </div>
 
+<% if @trainee.withdrawn? %>
+  <div class="withdrawal-details">
+    <%= render WithdrawalDetails::View.new(WithdrawalForm.new(@trainee), editable: trainee_editable?, omit_start_date_row: true) %>
+  </div>
+<% end %>
+
+<% if @trainee.deferred? %>
+  <div class="deferral-details">
+    <%= render DeferralDetails::View.new(DeferralForm.new(@trainee), editable: trainee_editable?, omit_start_date: true) %>
+  </div>
+<% end %>
+
+<% if @trainee.awarded? or @trainee.recommended_for_award? %>
+  <div class="award-details">
+    <%= render OutcomeDetails::View.new(OutcomeDateForm.new(@trainee), editable: trainee_editable?) %>
+  </div>
+<% end %>
+
 <div class="course-details">
   <%= render CourseDetails::View.new(data_model: @trainee, editable: trainee_editable?) %>
 </div>

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -214,6 +214,11 @@ namespace :example_data do
               attrs.merge!(trainee_start_date: nil)
             end
 
+            # Make *roughly* 75% of submitted_for_trn trainees have trainee withdraw reason
+            if state == :withdrawn && sample_index < sample_size * 75.0 / 100
+              attrs.merge!(withdraw_reason: (WithdrawalReasons::SPECIFIC + ["unknown"]).sample)
+            end
+
             # Make 75% of drafts (both apply and manual) incomplete
             if state == :draft && (sample_index < sample_size * 75.0 / 100)
               attrs.merge!(

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -87,7 +87,7 @@ module RecordDetails
         let(:trainee) { create(:trainee, :withdrawn, trn: nil, submitted_for_trn_at: nil) }
 
         it "renders the page" do
-          expect(rendered_component).to have_text("withdrawn")
+          expect(rendered_component).to have_text(trainee.trainee_id)
         end
       end
 
@@ -104,38 +104,6 @@ module RecordDetails
 
         it "renders the trainee's region" do
           expect(rendered_component).to have_text(trainee.region)
-        end
-      end
-
-      context "when trainee state is deferred" do
-        let(:state) { :deferred }
-
-        it "renders the trainee deferral date" do
-          expect(rendered_component).to have_text(date_for_summary_view(trainee.defer_date))
-        end
-
-        it "renders the trainee status tag" do
-          expect(rendered_component).to have_text("deferred")
-        end
-
-        context "when trainee did not start ITT" do
-          let(:trainee) { create(:trainee, state, commencement_status: :itt_not_yet_started) }
-
-          it "renders text stating that the trainee deferred before starting" do
-            expect(rendered_component).to have_text(strip_tags(t("deferral_details.view.itt_started_but_trainee_did_not_start")))
-          end
-        end
-      end
-
-      context "when trainee state is withdrawn" do
-        let(:state) { :withdrawn }
-
-        it "renders the trainee withdrawal date" do
-          expect(rendered_component).to have_text(date_for_summary_view(trainee.withdraw_date))
-        end
-
-        it "renders the trainee state" do
-          expect(rendered_component).to have_text(I18n.t("record_details.view.status_date_prefix.#{trainee.state}"))
         end
       end
 

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -205,7 +205,7 @@ feature "Withdrawing a trainee" do
     given_i_am_authenticated_as_system_admin
     given_a_trainee_exists_that_is_already_withdrawn
     and_i_am_on_the_trainee_record_page
-    then_i_can_see_the_edit_withdrawal_link
+    then_i_can_see_the_edit_withdrawal_details_component
   end
 
   def when_i_am_on_the_withdrawal_page
@@ -421,8 +421,8 @@ feature "Withdrawing a trainee" do
     expect(record_page).not_to have_change_trainee_status
   end
 
-  def then_i_can_see_the_edit_withdrawal_link
-    expect(record_page).to have_change_trainee_status
+  def then_i_can_see_the_edit_withdrawal_details_component
+    expect(record_page).to have_withdrawal_details_component
   end
 
   def and_i_select_no_they_started_later

--- a/spec/support/page_objects/trainees/record.rb
+++ b/spec/support/page_objects/trainees/record.rb
@@ -29,7 +29,8 @@ module PageObjects
       element :change_lead_school, "a", text: "Change lead school", visible: false
       element :change_employing_school, "a", text: "Change employing school", visible: false
       element :change_course_details, "a", text: "Change course", visible: false
-      element :change_trainee_status, "a", text: "Change trainee status", visible: false
+      element :change_trainee_status, "a", text: "Change status", visible: false
+      element :withdrawal_details_component, "h2", text: "Withdrawal details", visible: false
     end
   end
 end

--- a/spec/views/trainees/show.html.erb_spec.rb
+++ b/spec/views/trainees/show.html.erb_spec.rb
@@ -69,4 +69,35 @@ describe "trainees/show", "feature_routes.provider_led_postgrad": true do
       end
     end
   end
+
+  context "details components" do
+    let(:trainee) { create(:trainee, state) }
+    let(:current_user) { create(:user, :system_admin) }
+
+    before { render }
+
+    context "withdrawn trainee" do
+      let(:state) { :withdrawn }
+
+      it "renders the check withdrawn component" do
+        expect(rendered).to have_text("Withdrawal details")
+      end
+    end
+
+    context "deferred trainee" do
+      let(:state) { :deferred }
+
+      it "renders the check withdrawn component" do
+        expect(rendered).to have_text("Deferral details")
+      end
+    end
+
+    context "awarded trainee" do
+      let(:state) { :awarded }
+
+      it "renders the check withdrawn component" do
+        expect(rendered).to have_text("QTS details")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Add details components for awarded, withdrawn and deferred trainees to the trainee record page. 

### Changes proposed in this pull request

Should be a new details component on the trainee show page for awarded, deferred and withdrawn trainees/

### Guidance to review

Good candidate to check in the browser.

