### PR TITLE
[5381] Tweaks to bulk recommend upload page

### DIFF
--- a/app/views/bulk_update/recommendations_errors/show.html.erb
+++ b/app/views/bulk_update/recommendations_errors/show.html.erb
@@ -1,4 +1,7 @@
-<%= render PageTitle::View.new(text: "Review errors for #{pluralize(error_rows_count, "trainee")} in the CSV file you uploaded") %>
+<%= render PageTitle::View.new(
+  text: "Review errors for #{pluralize(error_rows_count, "trainee")} in the CSV file you uploaded",
+  has_errors: @recommendations_upload_form.errors.present?,
+  ) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(text: "Back", href: bulk_update_recommendations_upload_summary_path(recommendations_upload)) %>

--- a/app/views/bulk_update/recommendations_uploads/_no_trainees.html.erb
+++ b/app/views/bulk_update/recommendations_uploads/_no_trainees.html.erb
@@ -1,6 +1,6 @@
 <p class="govuk-body">
-  You do not have any trainees who can be bulk recommended for for qualified
-  teacher status (QTS) or early years teacher status (EYTS).
+  You do not have any trainees who can be bulk recommended for qualified teacher
+  status (QTS) or early years teacher status (EYTS).
 </p>
 
 <p class="govuk-body">

--- a/app/views/bulk_update/recommendations_uploads/_upload_trainees.html.erb
+++ b/app/views/bulk_update/recommendations_uploads/_upload_trainees.html.erb
@@ -6,10 +6,10 @@
 <ol class="govuk-list govuk-list--number">
   <li>
     <%= govuk_link_to(
-      "Download a CSV file listing #{ pluralize(bulk_recommend_count, "trainee") } you can recommend.",
+      "Download a CSV file listing #{ pluralize(bulk_recommend_count, "trainee") } you can recommend",
       bulk_recommend_export_reports_path(:csv),
       class: "bulk-recommend")
-      %>
+    %>.
   </li>
   <li>
     Fill in the date when each trainee met the QTS or EYTS standards. If a

--- a/app/views/bulk_update/recommendations_uploads/new.html.erb
+++ b/app/views/bulk_update/recommendations_uploads/new.html.erb
@@ -1,4 +1,7 @@
-<%= render PageTitle::View.new(text: "Bulk recommend trainees for QTS or EYTS") %>
+<%= render PageTitle::View.new(
+  text: "Choose who to recommend for QTS or EYTS",
+  has_errors: @recommendations_upload_form.errors.present?,
+  ) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(text: "Home", href: root_path) %>


### PR DESCRIPTION
### Context

https://trello.com/c/nW2ZTgzw/5381-make-changes-to-the-download-csv-page-the-first-page-in-bulk-recommendation

### Changes proposed in this pull request

- Remove extra 'for' on upload page with no trainees
- Move full stop outside link on upload page with trainees
- Ensure page titles get "Error" prepended when upload page (and review errors page) has an error

### Guidance to review

Check content tweaks as above.

No extra "for" on no trainees page:
<img width="648" alt="Screenshot 2023-04-06 at 16 29 06" src="https://user-images.githubusercontent.com/18436946/230427617-c2a8a464-8c97-4015-a332-57e0e5a125d0.png">

Page title in error:

<img width="443" alt="Screenshot 2023-04-06 at 16 35 05" src="https://user-images.githubusercontent.com/18436946/230428014-4d63ea13-b96c-4265-be08-74da97e0604a.png">


### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml