### PR TITLE
[5382] Bulk recommend - improvements to the accordion page

### DIFF
--- a/app/helpers/recommendations_upload_helper.rb
+++ b/app/helpers/recommendations_upload_helper.rb
@@ -13,6 +13,10 @@ module RecommendationsUploadHelper
     end
   end
 
+  def from_to(from, to)
+    from == to ? from : "#{from} to #{to}"
+  end
+
   # We can't use url_for(:back) because if the user proceeds to 'Change' and
   # presses back, they would get stuck in a loop between 'Change' and 'Check'.
   def back_url_for_check_page(recommendations_upload)

--- a/app/views/bulk_update/recommendations_checks/_table.html.erb
+++ b/app/views/bulk_update/recommendations_checks/_table.html.erb
@@ -26,6 +26,11 @@
           <div class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
             Provider trainee ID: <%= row.trainee.trainee_id %>
           </div>
+          <% if row.trainee.hesa_id.present? %>
+            <div class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
+              HESA ID: <%= row.trainee.hesa_id %>
+            </div>
+          <% end %>
         </td>
         <td class="govuk-table__cell">
           <div class="govuk-body govuk-!-margin-bottom-1">

--- a/app/views/bulk_update/recommendations_checks/show.html.erb
+++ b/app/views/bulk_update/recommendations_checks/show.html.erb
@@ -25,7 +25,8 @@
                               "data-i18n.hide-all-sections" => "Hide all trainees you’ll recommend",
                             }) do |accordion|
           awardable_rows.each_slice(@table_row_limit).with_index do |(*rows), index|
-            heading_text = "Trainees #{@table_row_limit*index + 1} to #{@table_row_limit*index + rows.count} you’ll recommend for #{qts_or_eyts(recommendations_upload.awardable_rows)}"
+            heading_text = "#{"Trainee".pluralize(rows.count)} #{from_to((@table_row_limit*index) + 1, (@table_row_limit*index) + rows.count)} you’ll recommend for #{qts_or_eyts(recommendations_upload.awardable_rows)}"
+
             accordion.section(heading_text: heading_text) do
               render partial: "table", locals: { rows: rows, caption: heading_text }
             end


### PR DESCRIPTION
### Context

https://trello.com/c/dbm4aTUr/5382-make-changes-to-the-accordion-page-in-bulk-recommendation-for-qts

### Changes proposed in this pull request

- Improve text on section heading if there's only one trainee in section:
  - It should say "Trainee 6" rather than "Trainees 6 to 6" for example
- Include HESA ID in table if the trainee has one

### Guidance to review

- Upload a CSV with 6 trainees to recommend, one being HESA
- Check that on the "check who you'll recommend" page the HESA ID shows for the trainee that has one
- Check that the last section title is correct

<img width="437" alt="Screenshot 2023-04-12 at 13 35 13" src="https://user-images.githubusercontent.com/18436946/231479994-4d1f65b8-cb73-48b7-b71f-e5847f8bee6a.png">

<img width="788" alt="Screenshot 2023-04-12 at 14 06 12" src="https://user-images.githubusercontent.com/18436946/231480056-c828a7a0-2f49-4948-9983-60bde1284e4a.png">

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml