### PR TITLE
[5392] Remove trainee and itt start dates from hesa students

### DIFF
--- a/app/models/hesa/student.rb
+++ b/app/models/hesa/student.rb
@@ -39,7 +39,6 @@
 #  itt_end_date                 :string
 #  itt_key                      :string
 #  itt_qualification_aim        :string
-#  itt_start_date               :string
 #  last_name                    :string
 #  lead_school_urn              :string
 #  mode                         :string
@@ -56,7 +55,6 @@
 #  study_length                 :string
 #  study_length_unit            :string
 #  surname16                    :string
-#  trainee_start_date           :string
 #  training_initiative          :string
 #  training_route               :string
 #  trn                          :string

--- a/db/migrate/20230413130025_remove_itt_start_date_and_trainee_start_date_from_hesa_students.rb
+++ b/db/migrate/20230413130025_remove_itt_start_date_and_trainee_start_date_from_hesa_students.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveIttStartDateAndTraineeStartDateFromHesaStudents < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :hesa_students, :trainee_start_date, :string
+    remove_column :hesa_students, :itt_start_date, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_02_155425) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_13_130025) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -512,13 +512,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_155425) do
     t.string "course_subject_one"
     t.string "course_subject_two"
     t.string "course_subject_three"
-    t.string "itt_start_date"
     t.string "itt_end_date"
     t.string "employing_school_urn"
     t.string "lead_school_urn"
     t.string "mode"
     t.string "course_age_range"
-    t.string "trainee_start_date"
     t.string "training_initiative"
     t.string "disability1"
     t.string "end_date"


### PR DESCRIPTION
### Context

itt_start_date and trainee_start_date used to be keys in the Hesa::IttParser and thus have corresponding fields in the hesa_students table.

We renamed these commencement_date and itt_commncement_date to more closely align with what hesa name them. We also added new fields in hesa_students to save them.

However, we didn’t remove the old columns.

### Changes proposed in this pull request

Remove itt_start_date and trainee_start_date from hesa_students.

Note: The trello card mentions "We should also check that this then fixes the HESA admin page for trainees.". I am unsure what was supposed to be broken on the page? Locally when i view students imported from hesa as an admin it seems to be working well. 

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
