### PR TITLE
Change guidance to mention 12 month deadline to bulk recommend

### DIFF
--- a/app/views/guidance/bulk_recommend_trainees.md
+++ b/app/views/guidance/bulk_recommend_trainees.md
@@ -38,6 +38,8 @@ If a trainee’s estimated end date is not in the period covered by the CSV file
 The CSV file has a blank column for you to fill in the date when trainees met QTS or EYTS standards. This may be
 different to the date when they finish their course or get an academic qualification.
 
+You can only bulk recommend trainees who met the QTS or EYTS standards in the past 12 months. If a trainee met the standards longer ago, you need to recommend them separately in their trainee record.
+
 If a trainee has not met the standards, either delete the row or leave the date blank in the CSV file.
 
 Do not make any other changes to the CSV file.


### PR DESCRIPTION
### Context

It’s only possible to bulk recommend trainees who met the standards within the past 12 months. We need to mention this in the guidance.

[Trello card](https://trello.com/c/5UClq1sD/5376-mention-in-guidance-that-its-only-possible-to-bulk-recommend-trainees-who-met-the-standards-within-the-past-12-months)

### Changes proposed in this pull request

I've added a paragraph to the bulk recommendation guidance.

### Guidance to review

None.

### Important business

- [no] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [no] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [no] Do we need to send any updates to DQT as part of the work in this PR?
- [no] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
