### PR TITLE
[xxx] Remove error when TRN doesn't match from HESA

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -8,8 +8,6 @@ module Trainees
 
     USERNAME = "HESA"
 
-    TRN_REGEX = /^(\d{6,7})$/
-
     NOT_APPLICABLE_SCHOOL_URNS = %w[900000 900010].freeze
 
     class HesaImportError < StandardError; end
@@ -31,7 +29,6 @@ module Trainees
           create_degrees!
           store_hesa_metadata!
           enqueue_background_jobs!
-          check_for_trn_disparity!
           check_for_missing_hesa_mappings!
         end
       end
@@ -187,14 +184,6 @@ module Trainees
 
     def enqueue_dqt_withdrawal_job?
       current_trainee_state != :withdrawn && mapped_trainee_state == :withdrawn
-    end
-
-    def check_for_trn_disparity!
-      # Whilst providers can provide a TRN, it's not to be trusted. Only Register and DQT are
-      # responsible for the allocation of TRNs.
-      if hesa_trainee[:trn].present? && trainee.trn.present? && hesa_trainee[:trn] != trainee.trn
-        Sentry.capture_message("HESA TRN (#{hesa_trainee[:trn]}) different to trainee TRN (#{trainee.trn})")
-      end
     end
 
     def request_for_trn?

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -218,13 +218,6 @@ module Trainees
       end
 
       context "when the trainee has a previously saved TRN" do
-        context "HESA has a different TRN" do
-          it "captures a message to sentry" do
-            expect(Sentry).to have_received(:capture_message)
-                                .with("HESA TRN (#{hesa_trn}) different to trainee TRN (#{trainee.trn})")
-          end
-        end
-
         context "HESA TRN is nil" do
           let(:hesa_stub_attributes) { { trn: nil } }
 


### PR DESCRIPTION
### Context

We were erroring when a TRN from HESA doesn't match what we have, but we don't actually do anything when this happens so it's just noise.

### Changes proposed in this pull request

Remove the error.
Also remove TRN regex that wasn't used anymore.

### Guidance to review

🚢 

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml