### PR TITLE
[5181] Backfill missing trainee nationalities

### DIFF
--- a/db/data/20230420144916_backfill_missing_trainee_nationalities.rb
+++ b/db/data/20230420144916_backfill_missing_trainee_nationalities.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class BackfillMissingTraineeNationalities < ActiveRecord::Migration[7.0]
+  def up
+    Trainee.where.missing(:nationalities).joins(:hesa_students).find_each do |trainee|
+      nationality = trainee.hesa_students.last.nationality
+
+      next unless nationality
+
+      nationality_name = ApplyApi::CodeSets::Nationalities::MAPPING[nationality]
+      trainee.nationalities = Nationality.where(name: nationality_name)
+      trainee.save
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/a7f7uoGB/5181-hesa-trainee-shows-missing-nationality-but-it-seems-to-be-in-hesastudents-table

### Changes proposed in this pull request
- Data migration to finds those trainees that have a missing nationality and uses their HESA students records to backfill the missing data assuming the nationality information is available

### Guidance to review
- Ran locally - fixed trainee mentioned in the card and also fixed 1118 other trainees that have the same issue
- Takes about 20 seconds to run

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
