### PR TITLE
[5414] Fix TODO - recommend matched trainees

### DIFF
--- a/app/services/bulk_update/recommend.rb
+++ b/app/services/bulk_update/recommend.rb
@@ -12,9 +12,7 @@ module BulkUpdate
       return if awardable_rows.empty?
 
       awardable_rows.find_each do |row|
-        # TODO: this will actually be an association on the row
-        trainee = Trainee.find_by(trn: row.trn)
-
+        trainee = row.trainee
         next if trainee.nil? || !trainee.trn_received?
 
         trainee.outcome_date = row.standards_met_at


### PR DESCRIPTION
### Context

https://trello.com/c/GXQbFvD3/5414-s-fix-the-to-dos-when-recommending-find-the-matched-trainee-instead-of-finding-just-on-trn

### Changes proposed in this pull request

- When bulk recommending trainees, use the rows matched trainee now we have
  that association
- Update the test and add a new test for when the trainee is already awarded
  (maybe by another user in another tab)

### Guidance to review

### Important business

- [ ] ~Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?~
- [ ] ~Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?~
- [ ] ~Do we need to send any updates to DQT as part of the work in this PR?~
- [ ] ~Does this PR need an ADR?~

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml