### PR TITLE
[5412] Prevent Excel from using scientific notation when displaying HESA IDs

### DIFF
--- a/app/models/reports/bulk_recommend_report.rb
+++ b/app/models/reports/bulk_recommend_report.rb
@@ -93,7 +93,7 @@ module Reports
       row = [
         trainee_report.trn,
         trainee_report.provider_trainee_id,
-        trainee_report.hesa_id,
+        trainee_report.hesa_id&.gsub(/(.*)/, "'\\1"), # prevent Excel from converting it to scientific notation
         trainee_report.last_names,
         trainee_report.first_names,
         trainee_report.lead_school_name,

--- a/app/services/bulk_update/recommendations_uploads/row.rb
+++ b/app/services/bulk_update/recommendations_uploads/row.rb
@@ -14,8 +14,10 @@ module BulkUpdate
       def initialize(csv_row)
         ::Reports::BulkRecommendReport::DEFAULT_HEADERS.each do |header|
           method_name = header.downcase.gsub(" ", "_")
+          method_value = csv_row[header.downcase]
+          method_value = method_value&.tr("'", "") if method_name == "hesa_id"
 
-          instance_variable_set("@#{method_name}", csv_row[header.downcase])
+          instance_variable_set("@#{method_name}", method_value)
           self.class.send(:attr_reader, method_name)
         end
       end

--- a/spec/services/exports/bulk_recommend_export_spec.rb
+++ b/spec/services/exports/bulk_recommend_export_spec.rb
@@ -79,7 +79,7 @@ describe Exports::BulkRecommendExport, type: :model do
       end
 
       it "includes the HESA ID" do
-        expect(trainee_csv_row["HESA ID"]).to end_with(trainee_report.hesa_id)
+        expect(trainee_csv_row["HESA ID"]).to end_with("'#{trainee_report.hesa_id}'")
       end
 
       it "includes the Last names" do


### PR DESCRIPTION
### Context
https://trello.com/c/G1JsHEus/5412-s-handle-17-digit-hesaids-in-the-bulk-recommendation-csvs

### Changes proposed in this pull request
- Prefix HESA IDs with a single quote character to to prevent Excel from displaying it in scientific notation
- Modify CSV importer to ignore single quote character 

### Guidance to review
- Log in as a provider
- Go through the bulk recommendation process and open CSV files in Excel to confirm that HESA IDs are no longer show in scientific notation

### Important business
- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
