### PR TITLE
Change the TTL to 60 for Register EDU and SVC CNAME Records

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/register_audit.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/register_audit.tfvars.json
@@ -14,11 +14,11 @@
       "cnames": {
         "audit": {
           "target": "d1g6p51l52so6s.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_269bbd07e998d083500ccf6a7f9bdc25.audit": {
           "target": "_1913ff1a294ea2f7326e181a336f1736.nfyddsqlcy.acm-validations.aws",
-          "ttl": 300
+          "ttl": 60
         }
       }
     }

--- a/terraform/custom_domains/environment_domains/workspace_variables/register_pen.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/register_pen.tfvars.json
@@ -13,11 +13,11 @@
         "cnames": {
           "pen": {
             "target": "djxjlkprikj8.cloudfront.net",
-            "ttl": 300
+            "ttl": 60
           },
           "_a79697fa0df835bfa14dd9f19a3f53d8.pen": {
             "target": "_b777aa3f1abb2213d3a28d52c1f955a8.wggjkglgrm.acm-validations.aws",
-            "ttl": 86400
+            "ttl": 60
           }
         }
       },
@@ -35,11 +35,11 @@
         "cnames": {
           "pen": {
             "target": "djxjlkprikj8.cloudfront.net",
-            "ttl": 300
+            "ttl": 60
           },
           "_9335bdb73caf5e52b0df1c42f1bd280d.pen": {
             "target": "_0db6c3a97d958d49641dc36b439e6b27.dbspspvlns.acm-validations.aws.",
-            "ttl": 86400
+            "ttl": 60
           }
         }
       }

--- a/terraform/custom_domains/environment_domains/workspace_variables/register_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/register_production.tfvars.json
@@ -19,11 +19,11 @@
       "cnames": {
         "www": {
         "target": "d3ikbzozms3bbf.cloudfront.net",
-        "ttl": 300
+        "ttl": 60
         },
         "_1191f61775c66c9eec91175aa294cdbb.www": {
         "target": "_d0ee22f81c78ffe76df87d4ffa134644.mybbdzzyvz.acm-validations.aws.",
-        "ttl": 86400
+        "ttl": 60
         }
       }
     },
@@ -41,11 +41,11 @@
         "cnames": {
           "www": {
             "target": "d3kffbwt0ldx12.cloudfront.net",
-            "ttl": 300
+            "ttl": 60
           },
           "_5aea97ded46b011053a0318e78abf7aa.www": {
             "target": "_462e6161fa2dd45d12b0692f50f76a11.wggjkglgrm.acm-validations.aws",
-            "ttl": 300
+            "ttl": 60
           }
         }
     }

--- a/terraform/custom_domains/environment_domains/workspace_variables/register_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/register_qa.tfvars.json
@@ -20,11 +20,11 @@
       "cnames": {
         "qa": {
           "target": "d1g6p51l52so6s.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_d9b4a9afdf0fe1c7ba2aa5dc8e712cbb.qa": {
           "target": "_8170547b3aec12093341bf5b9c6fe9ce.wggjkglgrm.acm-validations.aws",
-          "ttl": 86400
+          "ttl": 60
         }
       }
     },
@@ -42,11 +42,11 @@
       "cnames": {
         "qa": {
           "target": "d1r6ei57mr48qv.cloudfront.net",
-          "ttl": 300
+          "ttl": 60
         },
         "_a66959f8322304020cea85097566d3be.qa": {
           "target": "_4c3ae74e94b29fe9ad84d2cd152fd0ac.xdvyhgsvzs.acm-validations.aws",
-          "ttl": 86400
+          "ttl": 60
         }
       }
     }

--- a/terraform/custom_domains/environment_domains/workspace_variables/register_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/register_staging.tfvars.json
@@ -20,11 +20,11 @@
         "cnames": {
           "staging": {
             "target": "d192luriw5sv7r.cloudfront.net",
-            "ttl": 300
+            "ttl": 60
           },
           "_f3e61e36cb2c60bf14631de73dff9f3b.staging": {
             "target": "_75d94039eb16d9b3afd946ddb5860f59.wggjkglgrm.acm-validations.aws",
-            "ttl": 86400
+            "ttl": 60
           }
         }
       },
@@ -42,11 +42,11 @@
         "cnames": {
           "staging": {
             "target": "dtqc3lqt3mfcv.cloudfront.net",
-            "ttl": 300
+            "ttl": 60
           },
           "_bff11f4ee081539b0be0c64e46536b44.staging": {
             "target": "_b99cd2877b98c9d2633f83a775bb2bdf.xdvyhgsvzs.acm-validations.aws",
-            "ttl": 86400
+            "ttl": 60
           }
         }
       }


### PR DESCRIPTION
### Context
Change to the default TTL to 60 for all register CNAMES
### Changes proposed in this pull request
TTL Changed to 60
### Guidance to review
- Azure portal dns zone CNAME records to display TTL value of 60
### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
