### PR TITLE
[5418] Swap order of first and last name on csv

### DIFF
--- a/app/models/reports/bulk_recommend_report.rb
+++ b/app/models/reports/bulk_recommend_report.rb
@@ -14,8 +14,8 @@ module Reports
     DATE        = "Date QTS or EYTS standards met"
 
     # additional headers
-    LAST_NAME   = "Last names"
     FIRST_NAME  = "First names"
+    LAST_NAME   = "Last names"
     LEAD_SCHOOL = "Lead school"
     QTS_OR_EYTS = "QTS or EYTS"
     ROUTE       = "Route"
@@ -25,8 +25,8 @@ module Reports
 
     DEFAULT_HEADERS = [
       *IDENTIFIERS,
-      LAST_NAME,
       FIRST_NAME,
+      LAST_NAME,
       LEAD_SCHOOL,
       QTS_OR_EYTS,
       ROUTE,
@@ -94,8 +94,8 @@ module Reports
         trainee_report.trn,
         trainee_report.provider_trainee_id,
         trainee_report.hesa_id&.gsub(/(.*)/, "'\\1"), # prevent Excel from converting it to scientific notation
-        trainee_report.last_names,
         trainee_report.first_names,
+        trainee_report.last_names,
         trainee_report.lead_school_name,
         trainee_report.qts_or_eyts,
         trainee_report.course_training_route,

--- a/app/views/bulk_update/recommendations_checks/_table.html.erb
+++ b/app/views/bulk_update/recommendations_checks/_table.html.erb
@@ -18,7 +18,7 @@
         <td class="govuk-table__cell"><%= row.csv_row_number %></td>
         <td class="govuk-table__cell">
           <div class="govuk-body govuk-!-margin-bottom-1">
-            <%= row.trainee.last_name %>, <%= row.trainee.first_names %>
+            <%= row.trainee.first_names %> <%= row.trainee.last_name %>
           </div>
           <div class="govuk-body govuk-!-margin-bottom-0 govuk-hint">
             TRN: <%= row.trn %>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -400,8 +400,8 @@
   - hesa_id
   - standards_met_at
   - provider_trainee_id
-  - last_names
   - first_names
+  - last_names
   - lead_school
   - qts_or_eyts
   - route

--- a/spec/features/bulk_upload/recommending_trainees_spec.rb
+++ b/spec/features/bulk_upload/recommending_trainees_spec.rb
@@ -181,7 +181,7 @@ private
   def and_i_see_a_list_of_trainees_to_check
     @trainees.each do |trainee|
       training_route = t("activerecord.attributes.trainee.training_routes.#{trainee.training_route}")
-      expect(recommendations_checks_show_page).to have_text("#{trainee.last_name}, #{trainee.first_names}")
+      expect(recommendations_checks_show_page).to have_text("#{trainee.first_names} #{trainee.last_name}")
       expect(recommendations_checks_show_page).to have_text("TRN: #{trainee.trn}")
       expect(recommendations_checks_show_page).to have_text(training_route)
     end


### PR DESCRIPTION
### Context

On the rest of the Register service, we generally put first name before surname. We want bulk recommendation to match this.

### Changes proposed in this pull request

Swap order of last name and first name in the csv and accordion page.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
