### PR TITLE
[5442] Date QTS award is met is not showing on some awarded trainees

### DIFF
--- a/app/components/award_details/view.html.erb
+++ b/app/components/award_details/view.html.erb
@@ -1,0 +1,10 @@
+<%= render SummaryCard::View.new(
+  title: "#{trainee.award_type} details",
+  rows: [
+    {
+      key: "Award date",
+      value: award_date,
+      action_visually_hidden_text: 'award date',
+    },
+  ]
+) %>

--- a/app/components/award_details/view.rb
+++ b/app/components/award_details/view.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AwardDetails
+  class View < GovukComponent::Base
+    include SummaryHelper
+
+    attr_reader :trainee
+
+    def initialize(trainee)
+      @trainee = trainee
+    end
+
+    def award_date
+      date_for_summary_view(trainee.awarded_at)
+    end
+  end
+end

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -24,9 +24,9 @@
   </div>
 <% end %>
 
-<% if @trainee.awarded? or @trainee.recommended_for_award? %>
+<% if @trainee.awarded? || @trainee.recommended_for_award? %>
   <div class="award-details">
-    <%= render OutcomeDetails::View.new(OutcomeDateForm.new(@trainee), editable: trainee_editable?) %>
+    <%= render AwardDetails::View.new(@trainee) %>
   </div>
 <% end %>
 

--- a/spec/components/award_details/view_spec.rb
+++ b/spec/components/award_details/view_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module AwardDetails
+  describe View do
+    include SummaryHelper
+
+    alias_method :component, :page
+
+    let(:trainee) { build(:trainee, :awarded) }
+
+    before do
+      render_inline(View.new(trainee))
+    end
+
+    it "renders the award date" do
+      expect(component.find(summary_card_row_for("award-date"))).to have_text(date_for_summary_view(trainee.awarded_at))
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/dXYprQwW/5442-date-qts-award-is-met-is-not-showing-on-some-awarded-trainees

### Changes proposed in this pull request
- Display award date instead of outcome date

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
