### PR TITLE
[4147798659] - only show undo-withdraw timeline events for non-HESA audits

### DIFF
--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -131,7 +131,7 @@ module Trainees
     attr_reader :audit, :current_user
 
     def withdrawal_undone?
-      return unless audited_changes.is_a?(Hash)
+      return unless audited_changes.is_a?(Hash) && username
 
       audited_changes.any? do |key, value|
         key == "state" &&
@@ -143,7 +143,7 @@ module Trainees
     end
 
     def undo_withdraw_message
-      [["Comment:", undo_withdraw_comment]]
+      [["Comment:", undo_withdraw_comment]] if comment.present?
     end
 
     def undo_withdraw_comment


### PR DESCRIPTION
### Context

https://dfe-teacher-services.sentry.io/issues/4147798659/events/37c2ea14daac427a8be47ddd372a53cf/?project=5552118

### Changes proposed in this pull request

only use the `withdrawal_undone?` timeline event block for un-withdraws that have a user associated (and thus a comment)