### PR TITLE
[5422] Return blank age range for eyts trainees

### DIFF
--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -379,6 +379,9 @@ module Reports
     end
 
     def course_age_range
+      if trainee.award_type == "EYTS"
+        return " "
+      end
       "#{course_minimum_age} to #{course_maximum_age}"
     end
 

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -333,6 +333,15 @@ describe Reports::TraineeReport do
     end
   end
 
+  context "when there is an EYTS trainee" do
+    let!(:trainee) { create(:trainee, :eyts_recommended, start_academic_cycle: current_cycle, end_academic_cycle: nil) }
+
+    it 'returns a blank age range' do
+      p trainee.award_type
+      expect(subject.course_age_range).to eq(" ")
+    end
+  end
+
   describe "#academic_years" do
     before do
       allow(Trainees::SetAcademicCycles).to receive(:call) # deactivate so it doesn't override factories


### PR DESCRIPTION
### Context

In bulk recommendations testing, we found that age range was showing incorrectly for some early years trainees. We need to fix this.

### Changes proposed in this pull request

As eyts trainees dont have age ranges we show a blank value in the export.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
