### PR TITLE
[5434] - new guidance for outside sign-off period

### DIFF
--- a/app/views/guidance/performance_profiles_outside.html.erb
+++ b/app/views/guidance/performance_profiles_outside.html.erb
@@ -1,4 +1,4 @@
-<%= render PageTitle::View.new(text: "Sign off your list of trainees from #{@previous_academic_cycle_label} for the performance profiles publication") %>
+<%= render PageTitle::View.new(text: "Signing off your list of trainees for the performance profiles publication") %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(

--- a/app/views/guidance/performance_profiles_outside.html.erb
+++ b/app/views/guidance/performance_profiles_outside.html.erb
@@ -1,0 +1,32 @@
+<%= render PageTitle::View.new(text: "Sign off your list of trainees from #{@previous_academic_cycle_label} for the performance profiles publication") %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "How to use this service",
+    href: guidance_path,
+    ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+   <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h1 class="govuk-heading-l" id="signing-off-your-list-of-trainees-for-the-performance-profiles-publication">Signing off your list of trainees for the performance profiles publication</h1>
+      <p class="govuk-body">Each year you need to sign off your list of trainee teachers from the previous academic year. You’ll be told by email when you need to do this.</p>
+      <p class="govuk-body">The data you sign off will be included in the annual initial teacher training performance profiles publication. This will be published on GOV.UK.</p>
+      <h2 class="govuk-heading-m" id="finding-your-trainee-data">Finding your trainee data</h2>
+      <p class="govuk-body">You’ll need a list of all registered trainees who studied in the previous academic year. A report will be available showing the data you need to check.</p>
+      <h2 class="govuk-heading-m" id="checking-your-trainee-data">Checking your trainee data</h2>
+      <p class="govuk-body">You’ll need to check that all your trainees for the previous academic year are listed. For each trainee you’ll need to check:</p>
+      <ul class="govuk-list govuk-list--bullet">
+         <li>course details</li>
+         <li>status</li>
+         <li>the date they were awarded qualified teacher status (QTS) or early years teacher status (EYTS), or deferred or withdrew from the course - unless they’re still studying</li>
+      </ul>
+      <h2 class="govuk-heading-m" id="fixing-mistakes-in-your-trainee-data">Fixing mistakes in your trainee data</h2>
+      <p class="govuk-body">You’ll need to fix any mistakes before you sign off the data. How you’ll do this depends on whether you’re a provider of school centred initial teacher training (SCITT) or a higher education institution (HEI).</p>
+      <h2 class="govuk-heading-m" id="signing-off-your-trainee-data">Signing off your trainee data</h2>
+      <p class="govuk-body">A senior person from your organisation will need to complete a form to sign off the data. This should not be the same person who entered the data.</p>
+      <h2 class="govuk-heading-m" id="how-your-trainee-data-will-be-used">How your trainee data will be used</h2>
+      <p class="govuk-body">Read the ITT performance profiles methodology (opens in a new tab) to find out how your trainee data will be used.</p>
+      <p class="govuk-body">Some trainees will not be included in the ITT performance profiles publication. For example, trainees who withdrew within 90 days of the course start will not be included.</p>
+   </div>
+</div>

--- a/app/views/guidance/show.html.erb
+++ b/app/views/guidance/show.html.erb
@@ -48,7 +48,7 @@
     <ul class="govuk-list govuk-list--spaced">
       <li>
         <%= govuk_link_to(
-              "Sign off your list of trainees from #{@previous_academic_cycle_label} for the performance profiles publication",
+              signing_off_data,
               performance_profiles_guidance_path,
             ) %>
       </li>

--- a/app/views/reports/_inside.html.erb
+++ b/app/views/reports/_inside.html.erb
@@ -1,0 +1,14 @@
+<ul class="govuk-list govuk-list--spaced">
+  <li>
+    <p>
+      <%= govuk_link_to "New trainees for the #{@current_academic_cycle_label} academic year", itt_new_starter_data_sign_off_reports_path, class: "new-trainee-data" %>
+      - for census sign off
+    </p>
+  </li>
+  <li>
+    <p>
+      <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year", performance_profiles_reports_path, class: "performance-profiles" %>
+      - for performance profiles sign off
+    </p>
+  </li>
+</ul>

--- a/app/views/reports/_outside.html.erb
+++ b/app/views/reports/_outside.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">No reports are currently available.</p>
+<p class="govuk-body">When they’re available, you’ll be able to download reports showing:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>new trainees for the 2022 to 2023 academic year - for census sign off</li>
+  <li>trainees who studied in the 2021 to 2022 academic year - for performance profiles sign off</li>
+</ul>
+<p class="govuk-body">You can read <%= govuk_link_to "guidance about signing off performance profiles", performance_profiles_guidance_path, id: "performance-profiles-guidance" %>.</p>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -10,20 +10,10 @@
     <h1 class="govuk-heading-l">
         Reports
     </h1>
-
-    <ul class="govuk-list govuk-list--spaced">
-      <li>
-        <p>
-          <%= govuk_link_to "New trainees for the #{@current_academic_cycle_label} academic year", itt_new_starter_data_sign_off_reports_path, class: "new-trainee-data" %>
-          - for census sign off
-        </p>
-      </li>
-      <li>
-        <p>
-          <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year", performance_profiles_reports_path, class: "performance-profiles" %>
-          - for performance profiles sign off
-        </p>
-      </li>
-    </ul>
+    <% if Settings.in_sign_off_period? %>
+      <%= render "inside" %>
+    <% else %>
+      <%= render "outside" %>
+    <% end %>
   </div>
 </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -156,6 +156,7 @@ google:
 
 sign_off_trainee_data_url: https://example.com/trainee-data-sign-off
 sign_off_performance_profiles_url: https://forms.gle/AtAvteRTKJu3mbXS7
+in_sign_off_period?: false
 
 trainee_export:
   record_limit: 100

--- a/spec/features/reports/viewing_performance_profiles_spec.rb
+++ b/spec/features/reports/viewing_performance_profiles_spec.rb
@@ -7,14 +7,32 @@ feature "viewing performance profiles" do
   let!(:current_cycle) { create(:academic_cycle, :current) }
   let!(:trainee) { create(:trainee, :trn_received, start_academic_cycle: previous_cycle, end_academic_cycle: previous_cycle) }
 
-  background do
-    given_i_am_authenticated
-    given_i_am_on_the_reports_page
-    and_i_click_the_performance_profiles_link
+  context "inside sign-off period" do
+    before { allow(Settings).to receive(:in_sign_off_period?).and_return(true) }
+
+    background do
+      given_i_am_authenticated
+      given_i_am_on_the_reports_page
+      and_i_click_the_performance_profiles_link
+    end
+
+    scenario "shows the correct year" do
+      then_i_should_see_the_correct_performance_profiles_guidance
+    end
   end
 
-  scenario "shows the correct year" do
-    then_i_should_see_the_correct_performance_profiles_guidance
+  context "outside sign-off period" do
+    before { allow(Settings).to receive(:in_sign_off_period?).and_return(false) }
+
+    background do
+      given_i_am_authenticated
+      given_i_am_on_the_reports_page
+      and_i_click_the_performance_profiles_guidance_link
+    end
+
+    scenario "shows the correct content" do
+      then_i_should_see_the_correct_performance_profiles_guidance_outside_of_sign_off_period
+    end
   end
 
 private
@@ -27,7 +45,15 @@ private
     reports_page.performance_profiles_link.click
   end
 
+  def and_i_click_the_performance_profiles_guidance_link
+    reports_page.performance_profiles_guidance_link.click
+  end
+
   def then_i_should_see_the_correct_performance_profiles_guidance
     expect(performance_profiles_page).to have_text(previous_cycle.label)
+  end
+
+  def then_i_should_see_the_correct_performance_profiles_guidance_outside_of_sign_off_period
+    expect(performance_profiles_page).to have_text("Each year you need to sign off your list of trainee teachers from the previous academic year.")
   end
 end

--- a/spec/support/page_objects/reports/index.rb
+++ b/spec/support/page_objects/reports/index.rb
@@ -6,6 +6,7 @@ module PageObjects
       set_url "/reports"
 
       element :performance_profiles_link, ".performance-profiles"
+      element :performance_profiles_guidance_link, "#performance-profiles-guidance"
     end
   end
 end


### PR DESCRIPTION
### Context

Some of the guidance and reports content only makes sense inside the census or performance profiles sign off periods. For example, the performance profiles guidance mentions a deadline which is now in the past.

### Changes proposed in this pull request

* defines new copy in views
* adds `Setting` for `in_sign_off_period?` set to `false` for now

