### PR TITLE
[5453] - Allow quoted and unquoted HESA_IDs on upload

### DIFF
--- a/app/forms/bulk_update/recommendations_upload_form.rb
+++ b/app/forms/bulk_update/recommendations_upload_form.rb
@@ -5,12 +5,10 @@ module BulkUpdate
     include ActiveModel::Model
     include ActiveModel::AttributeAssignment
     include ActiveModel::Validations::Callbacks
+    include RecommendationsUploads::Config
 
     validate :validate_file!
     validate :validate_csv!
-
-    ENCODING = "UTF-8"
-    CSV_ARGS = { headers: true, header_converters: :downcase, strip: true, encoding: ENCODING }.freeze
 
     def initialize(provider: nil, file: nil)
       @provider = provider

--- a/app/services/bulk_update/recommendations_uploads/config.rb
+++ b/app/services/bulk_update/recommendations_uploads/config.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module RecommendationsUploads
+    module Config
+      # regex
+      VALID_HESA_ID = /^["']?[0-9]{13}(?:[0-9]{4})?["']?$/ # 13 or 17 number string with or without quotes
+      VALID_TRN = /^\d{7}$/ # 1234567
+      VALID_STANDARDS_MET_AT = /^\d{1,2}[\/-]\d{1,2}[\/-]\d{4}$/ # dd/mm/yyyy or dd-mm-yyyy or d/m/yyyy etc etc
+
+      # constants
+      ENCODING = "UTF-8"
+      FIRST_CSV_ROW_NUMBER = 2
+      CSV_ARGS = { headers: true, header_converters: :downcase, strip: true, encoding: ENCODING }.freeze
+    end
+  end
+end

--- a/app/services/bulk_update/recommendations_uploads/create_csv_with_errors.rb
+++ b/app/services/bulk_update/recommendations_uploads/create_csv_with_errors.rb
@@ -4,8 +4,7 @@ module BulkUpdate
   module RecommendationsUploads
     class CreateCsvWithErrors
       include ServicePattern
-
-      FIRST_CSV_ROW_NUMBER = 2
+      include Config
 
       def initialize(recommendations_upload:)
         @recommendations_upload = recommendations_upload

--- a/app/services/bulk_update/recommendations_uploads/create_recommendations_upload_rows.rb
+++ b/app/services/bulk_update/recommendations_uploads/create_recommendations_upload_rows.rb
@@ -5,9 +5,8 @@ module BulkUpdate
     # creates recommendations_upload_rows from a CSV
     # validates each row and trainee to create recommendations_upload_row.row_errors
     class CreateRecommendationsUploadRows
+      include Config
       include ServicePattern
-
-      FIRST_CSV_ROW_NUMBER = 2
 
       def initialize(recommendations_upload:, csv:)
         @recommendations_upload = recommendations_upload

--- a/app/services/bulk_update/recommendations_uploads/row.rb
+++ b/app/services/bulk_update/recommendations_uploads/row.rb
@@ -15,7 +15,6 @@ module BulkUpdate
         ::Reports::BulkRecommendReport::DEFAULT_HEADERS.each do |header|
           method_name = header.downcase.gsub(" ", "_")
           method_value = csv_row[header.downcase]
-          method_value = method_value&.tr("'", "") if method_name == "hesa_id"
 
           instance_variable_set("@#{method_name}", method_value)
           self.class.send(:attr_reader, method_name)
@@ -24,6 +23,10 @@ module BulkUpdate
 
       def standards_met_at
         send("date_qts_or_eyts_standards_met")
+      end
+
+      def sanitised_hesa_id
+        send("hesa_id")&.gsub(/[^\d]/, "")
       end
     end
   end

--- a/app/services/bulk_update/recommendations_uploads/validate_trainee.rb
+++ b/app/services/bulk_update/recommendations_uploads/validate_trainee.rb
@@ -4,6 +4,8 @@ module BulkUpdate
   module RecommendationsUploads
     # finds and validates a trainee scoped within provider, via trn/hesa/provider_trainee_id
     class ValidateTrainee
+      include Config
+
       def initialize(row:, provider:)
         @row = row
         @provider = provider
@@ -65,7 +67,7 @@ module BulkUpdate
 
       # rubocop:disable Naming/MemoizedInstanceVariableName
       def trainees_by_trn!
-        return unless row.trn =~ /^\d{7}$/
+        return unless row.trn =~ VALID_TRN
 
         @trainees ||= begin
           t = scope.where(trn: row.trn)
@@ -75,10 +77,10 @@ module BulkUpdate
       end
 
       def trainees_by_hesa_id!
-        return unless row.hesa_id =~ /^[0-9]{13}([0-9]{4})?$/
+        return unless row.hesa_id =~ VALID_HESA_ID
 
         @trainees ||= begin
-          t = scope.where(hesa_id: row.hesa_id)
+          t = scope.where(hesa_id: row.sanitised_hesa_id)
           @found_with = :hesa_id if t.any?
           t
         end

--- a/spec/services/bulk_update/recommendations_uploads/validate_csv_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_csv_spec.rb
@@ -18,7 +18,7 @@ module BulkUpdate
       end
 
       context "given a CSV with no header row" do
-        let(:csv) { CSV.new("", **BulkUpdate::RecommendationsUploadForm::CSV_ARGS).read }
+        let(:csv) { CSV.new("", **Config::CSV_ARGS).read }
 
         it { expect(record.errors.first.message).to eql "No header was detected" }
       end
@@ -43,7 +43,7 @@ module BulkUpdate
 
       context "given a CSV with only headers, no trainees" do
         let(:headers) { Reports::BulkRecommendReport::DEFAULT_HEADERS.join(",") }
-        let(:csv) { CSV.new(headers, **BulkUpdate::RecommendationsUploadForm::CSV_ARGS).read }
+        let(:csv) { CSV.new(headers, **Config::CSV_ARGS).read }
 
         it { expect(record.errors.first.message).to eql "The selected file must contain at least one trainee" }
       end


### PR DESCRIPTION
### Context

https://trello.com/c/DyVuDA2z/5453-bug-ticket

### Changes proposed in this pull request

* moves some constants and regex's into a BulkRecommend config file
* compares sanitised HESA_IDs from a CSV to a trainee's hesa_id

### Guidance to review
* try uploading a bulk update csv with several recommended trainees that have a mix of unquoted and quoted hesa_ids (both at the start and the end of the hesa_id string)