### PR TITLE
Change app config to use AKS Redis instances without disrupting paas app

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -5,7 +5,7 @@ class RedisSetting
 
   def initialize(config = nil)
     @config = {
-      url: ENV.fetch("REDIS_URL", nil),
+      url: ENV.fetch("REDIS_CACHE_URL", nil),
     }.merge(parse_config(config))
   end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,19 +5,22 @@ if ENV.key?("VCAP_SERVICES")
   redis_config = service_config["redis"]
   redis_worker_config = redis_config.select { |r| r["instance_name"].include?("worker") }.first
   redis_credentials = redis_worker_config["credentials"]
+  queue_url = redis_credentials["uri"]
+else
+  queue_url = ENV.fetch("REDIS_QUEUE_URL", nil)
+end
 
-  Sidekiq.configure_server do |config|
-    config.redis = {
-      url: redis_credentials["uri"],
-    }
-    config.logger.level = Logger::WARN
-  end
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: queue_url,
+  }
+  config.logger.level = Logger::WARN
+end
 
-  Sidekiq.configure_client do |config|
-    config.redis = {
-      url: redis_credentials["uri"],
-    }
-  end
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: queue_url,
+  }
 end
 
 # Sidekiq Cron

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - DB_HOSTNAME=db
       - DB_USERNAME=postgres
       - DB_PASSWORD=developmentpassword
-      - REDIS_URL=redis://redis:6379
+      - REDIS_CACHE_URL=redis://redis:6379
       - SENTRY_DSN=${SENTRY_DSN}
 
   bg-jobs:
@@ -43,4 +43,4 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=developmentpassword
       - SETTINGS__APPLICATION=register-trainee-teachers-bg-jobs
-      - REDIS_URL=redis://redis:6379
+      - REDIS_QUEUE_URL=redis://redis:6379

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -3,7 +3,7 @@ module "redis-cache" {
 
   name                  = "cache"
   namespace             = var.namespace
-  environment           = "${var.paas_app_environment}"
+  environment           = local.app_name_suffix
   azure_resource_prefix = var.azure_resource_prefix
   service_short         = var.service_short
   config_short          = var.config_short
@@ -19,7 +19,7 @@ module "redis-queue" {
 
   name                  = "queue"
   namespace             = var.namespace
-  environment           = "${var.paas_app_environment}"
+  environment           = local.app_name_suffix
   azure_resource_prefix = var.azure_resource_prefix
   service_short         = var.service_short
   config_short          = var.config_short
@@ -28,4 +28,6 @@ module "redis-queue" {
 
   use_azure               = var.deploy_azure_backing_services
   azure_enable_monitoring = var.enable_monitoring
+  azure_maxmemory_policy  = "noeviction"
+
 }

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -146,8 +146,8 @@ locals {
     {
       DATABASE_URL        = local.database_url
       BLAZER_DATABASE_URL = local.database_url
-      REDIS_URL           = "${var.redis_queue_url}"
-      REDIS_CACHE_URL     = "${var.redis_cache_url}"
+      REDIS_QUEUE_URL     = var.redis_queue_url
+      REDIS_CACHE_URL     = var.redis_cache_url
     }
   )
   # Create a unique name based on the values to force recreation when they change


### PR DESCRIPTION
### Context
The current app configuration looks for an environment var called REDIS_URL or gets the redis url from VCAP services for the redis cache instance and only uses VCAP services to get the redis url for the redis queue instance.

This needs to be updated to use the AKS redis instances so app can point to these instances when migrated to aks from paas

### Changes proposed in this pull request
App code has been updated to point to environment variables for the redis cache and redis queue instances for aks migration.

### Guidance to review
Deploy in PAAS and aks to verify all is working as expeceted.
### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
