### PR TITLE
5405 - Map DEGTYPE 999 to 'Not Available'

### DIFF
--- a/app/services/degrees/create_from_hesa.rb
+++ b/app/services/degrees/create_from_hesa.rb
@@ -4,8 +4,6 @@ module Degrees
   class CreateFromHesa
     include ServicePattern
 
-    UNKNOWN_DEGREE_TYPE = "999"
-
     # The dfe-reference gem does not include degree types with honours in
     # the name, so we need fallback to the non-honours generic degree types.
     HONOURS_TO_NON_HONOURS_HESA_CODE_MAP = {
@@ -104,9 +102,7 @@ module Degrees
     end
 
     def importable?(hesa_degree)
-      return true unless hesa_degree[:degree_type]&.include?(UNKNOWN_DEGREE_TYPE)
-
-      hesa_degree.compact.size > 1
+      hesa_degree.compact.size.positive?
     end
 
     def find_institution(hesa_degree)

--- a/app/services/degrees/dfe_reference.rb
+++ b/app/services/degrees/dfe_reference.rb
@@ -8,7 +8,50 @@ module Degrees
 
     GRADES = DfE::ReferenceData::Degrees::GRADES
     SUBJECTS = DfE::ReferenceData::Degrees::SUBJECTS_INCLUDING_GENERICS
-    TYPES = DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS
+
+    ## TODO: Remove this once the dfe-reference-data gem is updated to the latest version
+
+    # Extracts the mapping from https://github.com/DFE-Digital/dfe-reference-data/blob/03cb8815684355b1e04f2b0e39faf682d1ba7f7c/lib/dfe/reference_data/degrees/types.rb#L904
+    # This is a temporary solution until we are able to upgrade the gem to its latest version
+
+    UNKNOWN_TYPES_SCHEMA = DfE::ReferenceData::Degrees::TYPES_SCHEMA.merge(
+      {
+        qualification: { kind: :optional, schema: :string },
+        unknown: :boolean,
+      },
+    )
+
+    UNKNOWN_TYPES = DfE::ReferenceData::HardcodedReferenceList.new(
+      {
+        "3e042de2-a453-47dc-9452-90a23399e9ee" =>
+        { name: "Not available",
+          abbreviation: nil,
+          suggestion_synonyms: [],
+          match_synonyms: [],
+          hesa_itt_code: "999",
+          unknown: true },
+      },
+      schema: UNKNOWN_TYPES_SCHEMA,
+      list_description: 'Generic "catch-all" degree types, for approximating degree types not listed in TYPES (eg, "First Degree" to cover any first degree).',
+      list_docs_url: "https://github.com/DFE-Digital/dfe-reference-data/blob/main/docs/lists_degrees.md#dfereferencedatadegreesgeneric_types",
+      field_descriptions: DfE::ReferenceData::Degrees::TYPES_FIELD_DESCRIPTIONS,
+    )
+
+    ##########################################################################
+
+    TYPES = DfE::ReferenceData::JoinedReferenceList.new(
+      [DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS, UNKNOWN_TYPES],
+      schema: DfE::ReferenceData::Degrees::TYPES_SCHEMA.merge(
+        {
+          qualification: { kind: :optional, schema: :string },
+          generic: { kind: :optional, schema: :boolean },
+          unknown: { kind: :optional, schema: :boolean },
+        },
+      ),
+      list_description: "All degree types",
+      field_descriptions: DfE::ReferenceData::Degrees::TYPES_FIELD_DESCRIPTIONS,
+    )
+
     INSTITUTIONS = DfE::ReferenceData::Degrees::INSTITUTIONS_INCLUDING_GENERICS
 
     SUPPORTED_GRADES_BY_HESA_CODES = %w[01 02 03 05 12 13 14].freeze

--- a/db/data/20230504111909_backfill_missing_hesa_degree_types.rb
+++ b/db/data/20230504111909_backfill_missing_hesa_degree_types.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class BackfillMissingHesaDegreeTypes < ActiveRecord::Migration[7.0]
+  def up
+    Trainee.joins(:hesa_students).find_each do |trainee|
+      hesa_student = trainee.hesa_student_for_collection(Settings.hesa.current_collection_reference)
+      hesa_degrees = hesa_student&.degrees&.map(&:with_indifferent_access)
+      if hesa_degrees&.any? { |degree| degree[:degree_type] == "999" }
+        Degrees::CreateFromHesa.call(trainee:, hesa_degrees:)
+
+        # Recalculates the trainee's readiness for submission
+        trainee.send(:set_submission_ready)
+        trainee.save
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/degrees/create_from_hesa_spec.rb
+++ b/spec/services/degrees/create_from_hesa_spec.rb
@@ -192,8 +192,10 @@ module Degrees
             ]
           end
 
-          it "does not save the degree" do
-            expect(trainee.degrees.count).to eq(0)
+          it "saves the degree" do
+            subject
+
+            expect(trainee.degrees.count).to eq(1)
           end
         end
 
@@ -212,6 +214,8 @@ module Degrees
           end
 
           it "saves the degree" do
+            subject
+
             expect(trainee.degrees.count).to eq(1)
             expect(degree.grade).to eq("Pass")
           end


### PR DESCRIPTION
### Context

We show trainees as 'incomplete' when they have DEGTYPE for '999' from HESA. This is a valid entry in HESA for 'Unknown'

We want to  map '999' to 'Not available' for Degree type, and not show the record as incomplete on our platform.

### Changes proposed in this pull request

- Extracts the DEGTYPE mapping from `dfe-reference-data` gem (and sort out the upgrade of the gem at a later date due to complications with lots of specs failing).
- Contains the data migration file that does the backfill.

TICKET: https://trello.com/c/lNjocxMF

### Before

<img width="979" alt="Screenshot 2023-05-04 at 13 25 29" src="https://user-images.githubusercontent.com/1955084/236178797-de47e477-d975-4d87-a25c-666b815ece08.png">

### After

<img width="961" alt="Screenshot 2023-05-04 at 13 25 47" src="https://user-images.githubusercontent.com/1955084/236178847-20199616-6244-41ab-b5b8-0baef154a137.png">

<img width="988" alt="Screenshot 2023-05-04 at 13 25 54" src="https://user-images.githubusercontent.com/1955084/236178852-32b94dc0-13c1-48fd-9134-40950b5ed07d.png">


### Stats

The migration was executed locally. No issues found. 352 trainees affected.

### Guidance to review

- Get a copy of the prod data locally
- Run the migration
- Check the affected trainees

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
