### PR TITLE
[5454] Allow upload of csv with blank rows

### DIFF
--- a/app/controllers/bulk_update/recommendations_base_controller.rb
+++ b/app/controllers/bulk_update/recommendations_base_controller.rb
@@ -35,7 +35,7 @@ module BulkUpdate
     end
 
     def total_rows_count
-      @total_rows_count ||= recommendations_upload.rows.size
+      @total_rows_count ||= recommendations_upload.rows.size - recommendations_upload.empty_row_ids.size
     end
 
     def recommendations_upload

--- a/app/models/bulk_update/recommendations_upload.rb
+++ b/app/models/bulk_update/recommendations_upload.rb
@@ -32,8 +32,12 @@ class BulkUpdate::RecommendationsUpload < ApplicationRecord
     rows.where.not(standards_met_at: nil).where.missing(:row_errors)
   end
 
+  def empty_row_ids
+    rows.select(&:all_parameters_blank?).pluck(:id)
+  end
+
   def missing_date_rows
-    rows.where(standards_met_at: nil).where.missing(:row_errors)
+    rows.where(standards_met_at: nil).where.missing(:row_errors).where.not(id: empty_row_ids)
   end
 
   def error_rows

--- a/app/models/bulk_update/recommendations_upload_row.rb
+++ b/app/models/bulk_update/recommendations_upload_row.rb
@@ -50,6 +50,10 @@ class BulkUpdate::RecommendationsUploadRow < ApplicationRecord
     row_errors.map(&:message).join("\n")
   end
 
+  def all_parameters_blank?
+    %w[first_names last_names lead_school phase qts_or_eyts route standards_met_at subject trn hesa_id].all? { |attr| self[attr].blank? }
+  end
+
   def qts?
     trainee&.award_type == "QTS"
   end

--- a/app/services/bulk_update/recommendations_uploads/row.rb
+++ b/app/services/bulk_update/recommendations_uploads/row.rb
@@ -28,6 +28,13 @@ module BulkUpdate
       def sanitised_hesa_id
         send("hesa_id")&.gsub(/[^\d]/, "")
       end
+
+      def empty?
+        instance_variables.all? do |variable|
+          value = instance_variable_get(variable)
+          value.blank? || value.to_s.strip.empty?
+        end
+      end
     end
   end
 end

--- a/app/services/bulk_update/recommendations_uploads/validate_csv_row.rb
+++ b/app/services/bulk_update/recommendations_uploads/validate_csv_row.rb
@@ -25,6 +25,10 @@ module BulkUpdate
       attr_reader :trainee, :csv, :row
 
       def validate!
+        if row.empty?
+          return
+        end
+
         trn_format
         hesa_id_format
         standards_met_at

--- a/app/services/bulk_update/recommendations_uploads/validate_trainee.rb
+++ b/app/services/bulk_update/recommendations_uploads/validate_trainee.rb
@@ -36,6 +36,7 @@ module BulkUpdate
       end
 
       def validate!
+        return if row.empty?
         return if trainee
         # if no singular trainee in state trn_recevied was found then check if there are multiple in trn_received
         return @messages << error_message(:multiple_trainees_trn_recieved, found_with:) if trainees.size > 1

--- a/spec/services/bulk_update/recommendations_uploads/validate_csv_row_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_csv_row_spec.rb
@@ -63,6 +63,43 @@ module BulkUpdate
             end
           end
         end
+
+        context "When row is empty" do
+          let(:row) do
+            Row.new({})
+          end
+
+          describe "#valid?" do
+            it { expect(service.valid?).to be true }
+          end
+
+          describe "messages" do
+            it do
+              expect(service.messages).to eql([])
+            end
+          end
+        end
+
+        context "When row contains blank strings" do
+          let(:row) do
+            Row.new({
+              "trn" => "",
+              "hesa id" => "",
+              "provider trainee id" => "",
+              "date qts or eyts standards met" => "",
+            })
+          end
+
+          describe "#valid?" do
+            it { expect(service.valid?).to be true }
+          end
+
+          describe "messages" do
+            it do
+              expect(service.messages).to eql([])
+            end
+          end
+        end
       end
 
       context "with a matched trainee" do

--- a/spec/services/bulk_update/recommendations_uploads/validate_trainee_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_trainee_spec.rb
@@ -10,6 +10,22 @@ module BulkUpdate
       context "with a single trainee" do
         let(:trainee) { create(:trainee, :bulk_recommend) }
 
+        context "and an empty row" do
+          let(:row) do
+            Row.new({
+              "trn" => "",
+            })
+          end
+
+          describe "#valid?" do
+            it { expect(service.valid?).to be true }
+          end
+
+          describe "#messages" do
+            it { expect(service.messages).to eql [] }
+          end
+        end
+
         context "and a row with only TRN" do
           let(:row) do
             Row.new({


### PR DESCRIPTION
### Context

Submitting a CSV with a blank row leads to the error message ”  must match a trainee record”.

However the csv file should instead be accepted.

### Changes proposed in this pull request

Add a guard method to ensure that a blank row csv is accepted.

### Guidance to review

Try to submit a blank row csv.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
