### PR TITLE
[5372] Add over 16 validation to dob

### DIFF
--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -141,6 +141,8 @@ private
       errors.add(:date_of_birth, :future)
     elsif date_of_birth.year.digits.length != 4
       errors.add(:date_of_birth, :invalid_year)
+    elsif date_of_birth > 16.years.ago
+      errors.add(:date_of_birth, :under16)
     elsif date_of_birth < 100.years.ago
       errors.add(:date_of_birth, :past)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1405,6 +1405,7 @@ en:
             date_of_birth:
               blank: Enter a date of birth
               future: Enter a date of birth that is in the past, for example 31 3 1980
+              under16: Enter a valid date of birth, trainee cannot be younger than 16 years old
               hint_html: For example, 31 3 %{year}
               invalid: Enter a valid date
               invalid_year: The year must include 4 numbers

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -106,6 +106,22 @@ describe PersonalDetailsForm, type: :model do
         end
       end
 
+      context "under 16 years old" do
+        let(:params) { { day: 26, month: 2, year: (Time.zone.now.year - 10) } }
+
+        before do
+          subject.validate
+        end
+
+        it "is invalid" do
+          expect(subject.errors[:date_of_birth]).to include(
+            I18n.t(
+              "activemodel.errors.models.personal_details_form.attributes.date_of_birth.under16",
+            ),
+          )
+        end
+      end
+
       context "invalid date year" do
         let(:params) { { day: 1, month: 4, year: 21 } }
 


### PR DESCRIPTION
### Context

When adding a new trainee manually / editing dates of birth, we should require that the trainee be at least 16 years old.

We've had a handful trainees added with 2022 as a year of birth - this is clearly wrong, but as the date is in the past, Register accepted it. We should prevent this with sensible validation.

16 Chosen as the likely youngest age an undergrad person might start

### Changes proposed in this pull request

Add to the date validator a check for over 16 years old.

### Guidance to review

Try to add a new manual record under 16 years old. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
