### PR TITLE
[5449] Allow admins to delete records

### DIFF
--- a/app/components/confirm_trainee_delete/view.html.erb
+++ b/app/components/confirm_trainee_delete/view.html.erb
@@ -1,0 +1,7 @@
+<%= render MappableSummary::View.new(
+  trainee: trainee,
+  title: "Delete trainee record",
+  rows: record_detail_rows,
+  editable: true,
+  has_errors: false,
+) %>

--- a/app/components/confirm_trainee_delete/view.rb
+++ b/app/components/confirm_trainee_delete/view.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ConfirmTraineeDelete
+  class View < GovukComponent::Base
+    attr_reader :trainee, :delete_reason, :ticket
+
+    def initialize(trainee:, delete_reason: nil, ticket: nil)
+      @trainee = trainee
+      @delete_reason = delete_reason
+      @ticket = ticket
+    end
+
+    def record_detail_rows
+      [
+        status_row,
+        reason_row,
+        ticket_row,
+      ]
+    end
+
+  private
+
+    def status_row
+      {
+        field_label: "New record status",
+        field_value: '<strong class="govuk-tag govuk-tag--red">Deleted</strong>'.html_safe,
+      }
+    end
+
+    def reason_row
+      {
+        field_label: "Reason for deletion",
+        field_value: delete_reason,
+        action_url: edit_trainee_deletions_reason_path(trainee),
+      }
+    end
+
+    def ticket_row
+      {
+        field_label: "Zendesk ticket URL",
+        field_value: ticket.presence || "Not provided",
+        action_url: edit_trainee_deletions_reason_path(trainee),
+      }
+    end
+  end
+end

--- a/app/controllers/system_admin/trainee_deletions/confirmations_controller.rb
+++ b/app/controllers/system_admin/trainee_deletions/confirmations_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  module TraineeDeletions
+    class ConfirmationsController < ApplicationController
+      before_action :load_trainee, :authorize_delete
+
+      def show
+        @delete_trainee_form = DeleteTraineeForm.new(@trainee)
+      end
+
+      def update
+        @delete_trainee_form = DeleteTraineeForm.new(@trainee, user: current_user)
+
+        if @delete_trainee_form.save!
+          redirect_to(trainees_path, flash: { success: "Record deleted" })
+        else
+          render(:show)
+        end
+      end
+
+      def destroy
+        undo_withdrawal_form.clear_stash
+        redirect_to(trainee_admin_path(@trainee))
+      end
+
+    private
+
+      def load_trainee
+        @trainee = Trainee.from_param(params[:id])
+      end
+
+      def authorize_delete
+        authorize(@trainee, :destroy_with_reason?)
+      end
+    end
+  end
+end

--- a/app/controllers/system_admin/trainee_deletions/reasons_controller.rb
+++ b/app/controllers/system_admin/trainee_deletions/reasons_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  module TraineeDeletions
+    class ReasonsController < ApplicationController
+      before_action :load_trainee, :authorize_delete
+
+      def edit
+        @delete_trainee_form = DeleteTraineeForm.new(@trainee)
+      end
+
+      def update
+        @delete_trainee_form = DeleteTraineeForm.new(@trainee, params: delete_params, user: current_user)
+
+        if @delete_trainee_form.stash
+          redirect_to(trainee_deletions_confirmation_path(@trainee))
+        else
+          render(:edit)
+        end
+      end
+
+    private
+
+      def load_trainee
+        @trainee = Trainee.from_param(params[:id])
+      end
+
+      def delete_params
+        params.require(:system_admin_delete_trainee_form).permit(:delete_reason, :additional_delete_reason, :ticket)
+      end
+
+      def authorize_delete
+        authorize(@trainee, :destroy_with_reason?)
+      end
+    end
+  end
+end

--- a/app/forms/system_admin/delete_trainee_form.rb
+++ b/app/forms/system_admin/delete_trainee_form.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class DeleteTraineeForm < TraineeForm
+    ANOTHER_REASON = "Another reason"
+    DELETE_REASONS = [
+      "Duplicate record",
+      "Record added in error",
+      "Trainee already has QTS",
+      "Trainee did not start training",
+    ].freeze
+
+    FIELDS = %i[
+      delete_reason
+      additional_delete_reason
+      ticket
+    ].freeze
+
+    attr_accessor(*FIELDS)
+
+    validate :delete_reason_valid
+    validate :additional_delete_reason_valid
+
+    def save!
+      return false unless valid?
+
+      trainee.update(discarded_at: Time.current, audit_comment: audit_comment)
+
+      clear_stash
+    end
+
+    def delete_reason_or_other
+      for_another_reason? ? additional_delete_reason : delete_reason
+    end
+
+  private
+
+    def compute_fields
+      new_attributes
+    end
+
+    def audit_comment
+      [delete_reason_or_other, ticket].compact.join("\n")
+    end
+
+    def for_another_reason?
+      delete_reason == ANOTHER_REASON
+    end
+
+    def delete_reason_valid
+      errors.add(:delete_reason, :invalid) if delete_reason.blank?
+    end
+
+    def additional_delete_reason_valid
+      errors.add(:additional_delete_reason, :blank) if for_another_reason? && additional_delete_reason.blank?
+    end
+
+    def form_store_key
+      :delete_trainee
+    end
+  end
+end

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -97,6 +97,10 @@ class TraineePolicy
     user_is_system_admin? || (user_in_provider_context? && trainee.awaiting_action?)
   end
 
+  def destroy_with_reason?
+    user_is_system_admin? && !trainee.recommended_for_award? && !trainee.awarded?
+  end
+
   alias_method :index?, :show?
   alias_method :edit?, :update?
   alias_method :destroy?, :update?

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -36,6 +36,7 @@ class FormStore
     training_details
     iqts_country
     training_routes
+    delete_trainee
   ].freeze
 
   class << self

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -20,8 +20,8 @@ module Trainees
 
     attr_reader :trainees, :filters
 
-    def remove_empty_trainees(trainees)
-      trainees.where.not(id: FindEmptyTrainees.call(trainees: trainees, ids_only: true))
+    def remove_empty_or_discarded_trainees(trainees)
+      trainees.where.not(id: FindEmptyTrainees.call(trainees: trainees, ids_only: true)).undiscarded
     end
 
     def remove_hesa_trn_data_trainees(trainees)
@@ -30,7 +30,7 @@ module Trainees
     end
 
     def remove_hesa_trn_data_trainees_and_empty_trainees(trainees)
-      remove_hesa_trn_data_trainees(remove_empty_trainees(trainees))
+      remove_hesa_trn_data_trainees(remove_empty_or_discarded_trainees(trainees))
     end
 
     def academic_year(trainees, academic_years)

--- a/app/views/system_admin/trainee_deletions/confirmations/show.html.erb
+++ b/app/views/system_admin/trainee_deletions/confirmations/show.html.erb
@@ -1,0 +1,26 @@
+<%= render PageTitle::View.new(text: t("system_admin.trainee_deletions.confirmations.show.heading")) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t("back"), href: edit_trainee_deletions_reason_path(@trainee)) %>
+<% end %>
+
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l">
+    <%= trainee_name(@trainee) %>
+  </span>
+  <%= t("system_admin.trainee_deletions.confirmations.show.heading") %>
+</h1>
+
+<%= render ConfirmTraineeDelete::View.new(trainee: @trainee,
+                                          delete_reason: @delete_trainee_form.delete_reason_or_other,
+                                          ticket: @delete_trainee_form.ticket) %>
+
+<%= govuk_button_to "Delete record", trainee_deletions_confirmation_path(@trainee),
+                    method: :patch,
+                    class: "govuk-button--warning" %>
+
+<%= register_form_with model: @trainee, url: trainee_deletions_confirmation_path(@trainee),
+                       method: :delete,
+                       local: true do |f| %>
+  <%= f.submit "Cancel and return to record", class: "govuk-link app-button--link govuk-body", role: "link" %>
+<% end %>

--- a/app/views/system_admin/trainee_deletions/reasons/edit.html.erb
+++ b/app/views/system_admin/trainee_deletions/reasons/edit.html.erb
@@ -1,0 +1,51 @@
+<%= render PageTitle::View.new(text: t("system_admin.trainee_deletions.reasons.edit.heading"),
+                               has_errors: @delete_trainee_form.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t("back"), href: trainee_admin_path(@trainee)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: @delete_trainee_form,
+                           url: trainee_deletions_reason_path(@trainee),
+                           method: :put,
+                           local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">
+          <%= trainee_name(@trainee) %>
+        </span>
+        <%= t("system_admin.trainee_deletions.reasons.edit.heading") %>
+      </h1>
+
+      <%= f.govuk_radio_buttons_fieldset(:delete_reason,
+                                         legend: {
+                                           text: t("views.forms.delete_trainee_reasons.headings.delete_reason")
+                                         }) do %>
+        <% SystemAdmin::DeleteTraineeForm::DELETE_REASONS.each_with_index do |delete_reason, index| %>
+          <%= f.govuk_radio_button(:delete_reason, delete_reason,
+                                   label: { text: delete_reason },
+                                   link_errors: index.zero?) %>
+        <% end %>
+
+        <%= f.govuk_radio_divider %>
+
+        <%= f.govuk_radio_button :delete_reason, SystemAdmin::DeleteTraineeForm::ANOTHER_REASON,
+                                 label: { text: SystemAdmin::DeleteTraineeForm::ANOTHER_REASON } do %>
+          <%= f.govuk_text_field :additional_delete_reason,
+                                 label: { text: "Reason" },
+                                 autocomplete: :off %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_text_field :ticket, label: { text: 'Zendesk ticket URL (optional)', tag: :h2, size: 'm' },
+                             hint: { text: "For example, https://becomingateacher.zendesk.com/agent/tickets/12345" } %>
+
+      <%= f.govuk_submit t("views.forms.common.continue") %>
+    <% end %>
+  </div>
+</div>
+
+<p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee)) %></p>

--- a/app/views/trainees/admins/show.html.erb
+++ b/app/views/trainees/admins/show.html.erb
@@ -25,3 +25,11 @@
       </div>
    </section>
 <% end %>
+
+<% if policy(trainee).destroy_with_reason? %>
+  <p class="govuk-body">
+    <%= govuk_link_to "Delete this trainee",
+                      edit_trainee_deletions_reason_path(trainee),
+                      class: "app-link--warning delete" %>
+  </p>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -853,6 +853,9 @@ en:
         labels:
           additional_reason: Enter the reason for withdrawal
           <<: *withdrawal_reasons
+      delete_trainee_reasons:
+        headings:
+          delete_reason: Reason for deletion
       training_details:
         title: *trainee_id
         trainee_id:
@@ -1324,6 +1327,12 @@ en:
               blank: Enter a school unique reference number (URN), name or postcode
             no_results_search_again_query:
               blank: Enter a school unique reference number (URN), name or postcode
+        system_admin/delete_trainee_form:
+          attributes:
+            delete_reason:
+              invalid: Select a delete reason
+            additional_delete_reason:
+              blank: Enter another reason
         contact_details_form:
           attributes:
             locale_code:
@@ -1706,6 +1715,13 @@ en:
         attribute_error: Attribute error
         error_count: Error count
         form: Form
+    trainee_deletions:
+      reasons:
+        edit:
+          heading: Delete trainee record
+      confirmations:
+        show:
+          heading: Confirm deletion of trainee record
   api:
     errors:
       bad_request: The query param needs to be at least %{length} characters

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -55,6 +55,11 @@ module SystemAdminRoutes
         end
 
         resources :uploads, only: %i[index new create show destroy]
+
+        namespace :trainee_deletions, path: "trainee-deletions" do
+          resources :reasons, only: %i[edit update]
+          resources :confirmations, only: %i[show update destroy]
+        end
       end
     end
   end

--- a/spec/features/system_admin/trainees/delete_a_trainee_spec.rb
+++ b/spec/features/system_admin/trainees/delete_a_trainee_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Deleting a trainee" do
+  let(:system_admin) { create(:user, system_admin: true) }
+
+  before do
+    given_i_am_authenticated(user: system_admin)
+  end
+
+  scenario "can be done by an admin" do
+    given_a_trainee_exists(:trn_received)
+    and_i_am_on_the_trainee_record_page
+    and_i_click_on_the_admin_tab
+    and_i_click_delete_this_trainee
+    when_i_select_a_delete_reason_and_continue
+    then_i_should_be_on_the_confirmation_page
+    when_i_confirm_delete
+    then_i_should_be_on_trainees_index_page
+    and_the_trainee_should_be_soft_deleted
+  end
+
+private
+
+  def and_i_click_on_the_admin_tab
+    record_page.admin_tab.click
+  end
+
+  def and_i_click_delete_this_trainee
+    trainee_admin_page.delete.click
+  end
+
+  def when_i_select_a_delete_reason_and_continue
+    admin_delete_trainee_reasons_page.delete_reasons.first.choose
+    admin_delete_trainee_reasons_page.continue.click
+  end
+
+  def then_i_should_be_on_the_confirmation_page
+    expect(admin_delete_trainee_confirmation_page).to be_displayed(id: trainee.slug)
+  end
+
+  def when_i_confirm_delete
+    admin_delete_trainee_confirmation_page.confirm.click
+  end
+
+  def then_i_should_be_on_trainees_index_page
+    expect(trainee_index_page).to be_displayed
+  end
+
+  def and_the_trainee_should_be_soft_deleted
+    expect(trainee.reload.discarded_at).not_to be_nil
+  end
+end

--- a/spec/forms/system_admin/delete_trainee_form_spec.rb
+++ b/spec/forms/system_admin/delete_trainee_form_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module SystemAdmin
+  describe DeleteTraineeForm, type: :model do
+    let(:params) { {} }
+    let(:trainee) { create(:trainee, :trn_received) }
+    let(:form_store_params) { nil }
+    let(:form_store) { class_double(FormStore) }
+    let(:delete_reason) { described_class::DELETE_REASONS.sample }
+
+    subject { described_class.new(trainee, params: params, store: form_store) }
+
+    before do
+      allow(form_store).to receive(:get).and_return(form_store_params)
+      allow(form_store).to receive(:set).with(trainee.id, :delete_trainee, nil)
+    end
+
+    describe "validations" do
+      context "delete reason not given" do
+        it { is_expected.not_to be_valid }
+      end
+
+      context "specific delete reason given" do
+        let(:params) { { delete_reason: } }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "another reason specified but not given" do
+        let(:params) { { delete_reason: described_class::ANOTHER_REASON } }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "another reason is specified" do
+        let(:params) { { delete_reason: described_class::ANOTHER_REASON, additional_delete_reason: "something" } }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    describe "#save!" do
+      let(:ticket) { "http://example.org" }
+      let(:form_store_params) { { "delete_reason" => delete_reason, "ticket" => ticket } }
+
+      before { subject.save! }
+
+      it "updates the trainee's discarded_at field" do
+        expect(trainee.discarded_at).not_to be_nil
+      end
+
+      it "adds the delete reason to audit trail" do
+        expect(trainee.audits.last.comment).to eq("#{delete_reason}\n#{ticket}")
+      end
+    end
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -430,6 +430,14 @@ module Features
       @admin_remove_lead_school_access_page ||= PageObjects::SystemAdmin::LeadSchools::RemoveAccessConfirmation.new
     end
 
+    def admin_delete_trainee_reasons_page
+      @admin_delete_trainee_reasons_page ||= PageObjects::SystemAdmin::TraineeDeletions::Reasons.new
+    end
+
+    def admin_delete_trainee_confirmation_page
+      @admin_delete_trainee_confirmation_page ||= PageObjects::SystemAdmin::TraineeDeletions::Confirmation.new
+    end
+
     def admin_uploads_page
       @admin_uploads_index_page ||= PageObjects::SystemAdmin::Uploads::Index.new
     end

--- a/spec/support/page_objects/system_admin/trainee_deletions/confirmation.rb
+++ b/spec/support/page_objects/system_admin/trainee_deletions/confirmation.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module SystemAdmin
+    module TraineeDeletions
+      class Confirmation < PageObjects::Base
+        set_url "/system-admin/trainee-deletions/confirmations/{id}"
+
+        element :confirm, "button[type='submit']"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/system_admin/trainee_deletions/reasons.rb
+++ b/spec/support/page_objects/system_admin/trainee_deletions/reasons.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module SystemAdmin
+    module TraineeDeletions
+      class Reasons < PageObjects::Base
+        set_url "/system-admin/trainee-deletions/reasons/{id}"
+
+        class ReasonRadio < SitePrism::Section
+          element :input, "input"
+          element :label, "label"
+        end
+
+        sections :delete_reasons, ReasonRadio, ".govuk-radios__item"
+
+        element :continue, "button[type='submit']"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/trainees/admin.rb
+++ b/spec/support/page_objects/trainees/admin.rb
@@ -7,6 +7,7 @@ module PageObjects
 
       element :collection_name, ".govuk-summary-list__key"
       element :collection, "details"
+      element :delete, ".govuk-link.delete"
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/uog5bcBM/5449-l-add-feature-to-allow-admins-to-delete-records

### Changes proposed in this pull request
- New journey to soft delete non-awarded traineea

### Guidance to review
- Log in as admin
- Pick a non-awarded trainee and remember the name for later
- Click the admin table and click "Delete this trainee" link at the bottom
- Follow the journey and play around looking for bugs
- If everything goes as expected the trainee should be delete and not show up on the trainees index page

### Screenshots
<img width="988" alt="Screenshot 2023-05-12 at 14 34 14" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/28728/764a6431-d923-4fff-bffc-ff844f943e0a">

<img width="989" alt="Screenshot 2023-05-12 at 14 34 58" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/28728/5ef029ae-b07a-4e77-aa88-1f2dad076c76">


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
