### PR TITLE
[338] Manage terraform modules via terrafile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ config/localhost/https/localhost.crt
 dump.rdb
 
 bin/fetch_config.rb
+bin/terrafile
+
+# Downloaded terraform modules
+terraform/aks/vendor/
 
 Procfile.dev
 missing-location-graph-from-dttp.json

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@ nodejs 16.14.0
 ruby 3.1.3
 yarn 1.22.18
 bundler 2.1.4
-terraform 1.2.8
+terraform 1.3.5
 cf 8.4.0
 az 2.36.0
 jq 1.6

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ifndef VERBOSE
 endif
 SERVICE_SHORT=rtt
 SERVICE_NAME=register
+TERRAFILE_VERSION=0.8
 
 help:
 	@echo "Environment setup targets:"
@@ -33,6 +34,12 @@ install-konduit: ## Install the konduit script, for accessing backend services
 	[ ! -f bin/konduit.sh ] \
 		&& curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/master/scripts/konduit.sh -o bin/konduit.sh \
 		&& chmod +x bin/konduit.sh \
+		|| true
+
+install-terrafile: ## Install terrafile to manage terraform modules
+	[ ! -f bin/terrafile ] \
+		&& curl -sL https://github.com/coretech/terrafile/releases/download/v${TERRAFILE_VERSION}/terrafile_${TERRAFILE_VERSION}_$$(uname)_x86_64.tar.gz \
+		| tar xz -C ./bin terrafile \
 		|| true
 
 .PHONY: review
@@ -203,14 +210,15 @@ deploy: terraform-init
 destroy: terraform-init
 	terraform -chdir=terraform/$(PLATFORM) destroy -var-file=./workspace-variables/$(DEPLOY_ENV).tfvars.json -var-file=./workspace-variables/$(DEPLOY_ENV)_backend.tfvars ${TF_VARS} $(AUTO_APPROVE)
 
-terraform-init:
+terraform-init: install-terrafile
 	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=main))
 	$(eval export TF_VAR_paas_app_docker_image=ghcr.io/dfe-digital/register-trainee-teachers:$(IMAGE_TAG))
 	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
 	$(eval export TF_VAR_paas_sso_passcode=$(PASSCODE))
 
-	az account set -s $(AZ_SUBSCRIPTION) && az account show \
-	&& terraform -chdir=terraform/$(PLATFORM) init -reconfigure -backend-config=./workspace-variables/$(DEPLOY_ENV)_backend.tfvars $(backend_key)
+	az account set -s $(AZ_SUBSCRIPTION) && az account show
+	./bin/terrafile -p terraform/$(PLATFORM)/vendor/modules -f terraform/$(PLATFORM)/workspace-variables/$(DEPLOY_ENV)_Terrafile
+	terraform -chdir=terraform/$(PLATFORM) init -reconfigure -backend-config=./workspace-variables/$(DEPLOY_ENV)_backend.tfvars $(backend_key)
 
 get-cluster-credentials: read-cluster-config set-azure-account ## make <config> get-cluster-credentials [ENVIRONMENT=<clusterX>]
 	az aks get-credentials --overwrite-existing -g ${RESOURCE_NAME_PREFIX}-tsc-${CLUSTER_SHORT}-rg -n ${RESOURCE_NAME_PREFIX}-tsc-${CLUSTER}-aks

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ terraform-init: install-terrafile
 
 	az account set -s $(AZ_SUBSCRIPTION) && az account show
 	./bin/terrafile -p terraform/$(PLATFORM)/vendor/modules -f terraform/$(PLATFORM)/workspace-variables/$(DEPLOY_ENV)_Terrafile
-	terraform -chdir=terraform/$(PLATFORM) init -reconfigure -backend-config=./workspace-variables/$(DEPLOY_ENV)_backend.tfvars $(backend_key)
+	terraform -chdir=terraform/$(PLATFORM) init -reconfigure -upgrade -backend-config=./workspace-variables/$(DEPLOY_ENV)_backend.tfvars $(backend_key)
 
 get-cluster-credentials: read-cluster-config set-azure-account ## make <config> get-cluster-credentials [ENVIRONMENT=<clusterX>]
 	az aks get-credentials --overwrite-existing -g ${RESOURCE_NAME_PREFIX}-tsc-${CLUSTER_SHORT}-rg -n ${RESOURCE_NAME_PREFIX}-tsc-${CLUSTER}-aks

--- a/docs/aks_modules.md
+++ b/docs/aks_modules.md
@@ -1,0 +1,18 @@
+## AKS terraform modules
+
+The deployment relies on [terraform modules](https://github.com/DFE-Digital/terraform-modules/) to deploy applications and services to Kubernetes.
+They follow this release cycle:
+- main: all updates
+- testing: updates under test in multiple environments
+- stable: tested updates
+
+To be able to detect breaking changes as soon as possible, the Register environments are configured with different versions:
+- review: main
+- qa, staging: testing
+- production, productiondata: stable
+
+This is achieved by setting `version:` in the Terrafiles in the `terraform/aks/workspace-variables` folder. The version can point at a branch such as
+main or a feature branch. Or a tag such as testing, stable or any other tag pointing at the desired commit id. The simple commit id cannot be used directly.
+
+If an environment fails because of a module update, report it to the infra team. If it's blocking delivery, change the version to testing or stable
+while this is being investigated.

--- a/terraform/aks/.terraform.lock.hcl
+++ b/terraform/aks/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.24.0"
   hashes = [
     "h1:DfQtILx+kjaSiNt6JzOyUpJ0PlQOw85GG0CxKBUtsgQ=",
+    "h1:RiHgx0YLywgAJJPgY4hCTnAMD+tOb3lxP5RF9EsplP0=",
     "zh:178d9118d6b97f353836da25beb1d0a084375ba21af1107b01c0447083480bbf",
     "zh:2ada465ad8c44dbcb665137b8985ea576a306a60b9fb1754e282b861f9839351",
     "zh:5732804bb44262cb953938954b3fd46ebc8710d257aa2f9e47c42f6f49df5a54",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "2.17.0"
   hashes = [
     "h1:I1L2R+OPgGSh+P6uBSycvvoyRIey/FqMwSvlJ9ccw0o=",
+    "h1:p2sgF62c2svJSKuImL3/zq/SSPOZFyd4Vj7K0UF2VrQ=",
     "zh:1cbafea8c404195d8ad2490d75dbeebef131563d3e38dec87231ceb3923a3012",
     "zh:26d9584423ee77e607999b082de7d9dc3e937934aa83341e0832e7253caf4f51",
     "zh:333527fc15fb43bbf1898a2f058598c596468a01d88c415627bb617878dc4d4d",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   constraints = "2.0.4"
   hashes = [
     "h1:IoK/VG1iAyMnsR1mgG0Ku1F/NlkJEnzfADCfZAFRYQ0=",
+    "h1:y2dthcfU+b/p0q6ZCa2u61cp1QnmeX1k63cylKEQ+KY=",
     "zh:0a0962aff7c3112c8b32182e3e80974f1d334a73570450c8a834cde905b804f6",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
     "zh:27a7b65fdd0e662ec1948ecd8ef52214b396e388f4d733221f2e8016dbc3e154",

--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -1,7 +1,7 @@
 module "web_application" {
   for_each = var.main_app
 
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application?ref=main"
+  source = "./vendor/modules/aks//aks/application"
 
   is_web = true
 
@@ -25,7 +25,7 @@ module "web_application" {
 module "worker_application" {
   for_each = var.worker_apps
 
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application?ref=main"
+  source = "./vendor/modules/aks//aks/application"
 
   name   = "worker"
   is_web = false
@@ -48,7 +48,7 @@ module "worker_application" {
 
 module "application_configuration" {
 
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application_configuration?ref=main"
+  source = "./vendor/modules/aks//aks/application_configuration"
 
   namespace             = var.namespace
   environment           = local.app_name_suffix

--- a/terraform/aks/cluster_data.tf
+++ b/terraform/aks/cluster_data.tf
@@ -1,4 +1,4 @@
 module "cluster_data" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/cluster_data?ref=stable"
+  source = "./vendor/modules/aks//aks/cluster_data"
   name   = var.cluster
 }

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -1,5 +1,5 @@
 module "redis-cache" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis?ref=main"
+  source = "./vendor/modules/aks//aks/redis"
 
   name                  = "cache"
   namespace             = var.namespace
@@ -15,7 +15,7 @@ module "redis-cache" {
 }
 
 module "redis-queue" {
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis?ref=main"
+  source = "./vendor/modules/aks//aks/redis"
 
   name                  = "queue"
   namespace             = var.namespace

--- a/terraform/aks/workspace-variables/dv_review_aks_Terrafile
+++ b/terraform/aks/workspace-variables/dv_review_aks_Terrafile
@@ -1,0 +1,3 @@
+aks:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "main"

--- a/terraform/aks/workspace-variables/production_aks_Terrafile
+++ b/terraform/aks/workspace-variables/production_aks_Terrafile
@@ -1,0 +1,3 @@
+aks:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"

--- a/terraform/aks/workspace-variables/productiondata_aks_Terrafile
+++ b/terraform/aks/workspace-variables/productiondata_aks_Terrafile
@@ -1,0 +1,3 @@
+aks:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"

--- a/terraform/aks/workspace-variables/qa_aks_Terrafile
+++ b/terraform/aks/workspace-variables/qa_aks_Terrafile
@@ -1,0 +1,3 @@
+aks:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "testing"

--- a/terraform/aks/workspace-variables/review_aks_Terrafile
+++ b/terraform/aks/workspace-variables/review_aks_Terrafile
@@ -1,0 +1,3 @@
+aks:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "main"

--- a/terraform/aks/workspace-variables/staging_aks_Terrafile
+++ b/terraform/aks/workspace-variables/staging_aks_Terrafile
@@ -1,0 +1,3 @@
+aks:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"


### PR DESCRIPTION
### Context
We want to be able to use different module versions depending on the environment. Unfortunately the reference cannot be a variable as terraform fails with `variable not allowed here`.

### Changes proposed in this pull request
Use [terrafile](https://github.com/coretech/terrafile) to manage versions and use main/testing/stable depending on the environment

### Guidance to review
Run deploy-plan with the review app
