### PR TITLE
[5476] Improve bulk QTS recommend performance

### DIFF
--- a/app/controllers/trainees/award_recommendations_controller.rb
+++ b/app/controllers/trainees/award_recommendations_controller.rb
@@ -6,9 +6,7 @@ module Trainees
       if OutcomeDateForm.new(trainee).save! && trainee.submission_ready?
         trainee.recommend_for_award!
 
-        if FeatureService.enabled?(:integrate_with_dqt)
-          Dqt::RecommendForAwardJob.perform_later(trainee)
-        end
+        Dqt::RecommendForAwardJob.perform_later(trainee)
 
         redirect_to(recommended_trainee_outcome_details_path(trainee))
       end

--- a/app/jobs/auditing/trainee_auditor_job.rb
+++ b/app/jobs/auditing/trainee_auditor_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Auditing
+  class TraineeAuditorJob < ApplicationJob
+    def perform(trainee, audited_changes, user, remote_address)
+      Audited.audit_class.as_user(user) do
+        # Not ideal to be calling a private method, but it's a trade-off to allow us to create audit records
+        # asynchronously. The audit gem degrades performance massively when updating 1000's of records.
+        trainee.send(:write_audit, action: "update", audited_changes: audited_changes, remote_address: remote_address)
+      end
+    end
+  end
+end

--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -2,17 +2,10 @@
 
 module Reports
   class TraineeReport
-    attr_reader :trainee, :degree, :funding_manager, :course
+    attr_reader :trainee
 
     def initialize(trainee)
       @trainee = trainee
-      @degree = trainee.degrees.first
-      @funding_manager = FundingManager.new(trainee)
-
-      # In rails 6 we can't preload the `published_course`, because it is instance dependent. This is supported in rails 7.
-      #  The association scope 'published_course' is instance dependent (the scope block takes an argument).
-      #  Preloading instance dependent scopes is not supported.
-      @course = Course.includes(:provider).find_by(uuid: trainee.course_uuid)
     end
 
     # rubocop:disable Naming/VariableNumber
@@ -39,6 +32,18 @@ module Reports
              :course_subject_three,
              to: :trainee,
              allow_nil: true
+
+    def degree
+      @degree ||= trainee.degrees.first
+    end
+
+    def course
+      @course ||= Course.includes(:provider).find_by(uuid: trainee.course_uuid)
+    end
+
+    def funding_manager
+      @funding_manager ||= FundingManager.new(trainee)
+    end
 
     def academic_years
       return unless trainee.start_academic_cycle && trainee.end_academic_cycle

--- a/app/services/bulk_update/recommend.rb
+++ b/app/services/bulk_update/recommend.rb
@@ -5,30 +5,55 @@ module BulkUpdate
     include ServicePattern
 
     def initialize(recommendations_upload:)
-      @awardable_rows = recommendations_upload.awardable_rows
+      @trainees = trainees_with_changed_attributes(recommendations_upload.awardable_rows.includes(:trainee))
     end
 
     def call
-      return if awardable_rows.empty?
+      return if trainees.empty?
 
-      awardable_rows.find_each do |row|
-        trainee = row.trainee
-        next if trainee.nil? || !trainee.trn_received?
+      Trainee.upsert_all(build_upsert_attributes(trainees), unique_by: :slug)
 
-        trainee.outcome_date = row.standards_met_at
-
-        if trainee.save!
-          trainee.recommend_for_award!
-
-          if FeatureService.enabled?(:integrate_with_dqt)
-            Dqt::RecommendForAwardJob.perform_later(trainee)
-          end
-        end
-      end
+      enqueue_background_jobs!(trainees)
     end
 
   private
 
-    attr_reader :awardable_rows
+    attr_reader :trainees
+
+    def trainees_with_changed_attributes(awardable_rows)
+      awardable_rows.filter_map do |row|
+        trainee = row.trainee
+
+        next unless trainee&.trn_received?
+
+        trainee.outcome_date = row.standards_met_at
+        trainee.state = :recommended_for_award
+        trainee.recommended_for_award_at = Time.zone.now
+
+        trainee
+      end
+    end
+
+    def build_upsert_attributes(trainees)
+      trainees.map do |trainee|
+        {
+          slug: trainee.slug,
+          provider_id: trainee.provider_id,
+          outcome_date: trainee.outcome_date,
+          state: :recommended_for_award,
+          recommended_for_award_at: Time.zone.now,
+        }
+      end
+    end
+
+    def enqueue_background_jobs!(trainees)
+      trainees.each do |trainee|
+        Auditing::TraineeAuditorJob.perform_later(trainee,
+                                                  trainee.send(:audited_changes),
+                                                  Audited.store[:current_user]&.call,
+                                                  Audited.store[:current_remote_address])
+        Dqt::RecommendForAwardJob.perform_later(trainee)
+      end
+    end
   end
 end

--- a/app/services/bulk_update/recommendations_uploads/trainee_lookup.rb
+++ b/app/services/bulk_update/recommendations_uploads/trainee_lookup.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  module RecommendationsUploads
+    class TraineeLookup
+      include Config
+
+      def initialize(rows, provider)
+        @rows = rows
+        @scope = provider.trainees.where.not(state: :draft).strict_loading.includes(:lead_school, :provider)
+      end
+
+      def [](key)
+        case key
+        when VALID_TRN
+          trainees_trn_map.fetch(key, [])
+        when VALID_HESA_ID
+          trainees_hesa_id_map.fetch(key, [])
+        else
+          trainees_trainee_id_map.fetch(key, [])
+        end
+      end
+
+    private
+
+      attr_reader :rows, :scope
+
+      # Only build the appropriate hash maps when needed
+
+      def trainees_trn_map
+        @trainees_trn_map ||= build_trainee_hash_map(:trn)
+      end
+
+      def trainees_hesa_id_map
+        @trainees_hesa_id_map ||= build_trainee_hash_map(:hesa_id)
+      end
+
+      def trainees_trainee_id_map
+        @trainees_trainee_id_map ||= build_trainee_hash_map(:trainee_id)
+      end
+
+      def build_trainee_hash_map(key)
+        scope.where(key => rows.map(&row_attribute(key))).inject({}) do |hash, trainee|
+          hash[trainee[key]] ||= []
+          hash[trainee[key]] << trainee
+          hash
+        end
+      end
+
+      def row_attribute(lookup_key)
+        case lookup_key
+        when :hesa_id then :sanitised_hesa_id
+        when :trainee_id then :provider_trainee_id
+        else lookup_key
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/files/bulk_update/recommendations_upload/complete.csv
+++ b/spec/fixtures/files/bulk_update/recommendations_upload/complete.csv
@@ -1,6 +1,6 @@
-TRN,Provider trainee ID,Last names,First names,Lead school,QTS or EYTS,Route,Phase,Age range,Subject,Date QTS or EYTS standards met
-Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,"For example, 20/7/2022
+TRN,Provider trainee ID,HESA ID,Last names,First names,Lead school,QTS or EYTS,Route,Phase,Age range,Subject,Date QTS or EYTS standards met
+Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,"For example, 20/7/2022
 
 Delete row if the trainee has not met the standards"
-2413295,22/23-1076,Barröws,Courtney,-,EYTS,Early years (salaried),Early years,0 to 5,Early years teaching,20/7/2022
-4814731,22/23-1589,Bęrgstrom,Cliff,Bluemeadow High,QTS,School direct (salaried),Secondary,11 to 16,Biology,21/7/2022
+2413295,22/23-1076,'54382678848074464',Barröws,Courtney,-,EYTS,Early years (salaried),Early years,0 to 5,Early years teaching,20/7/2022
+4814731,22/23-1589,'15124865380965941',Bęrgstrom,Cliff,Bluemeadow High,QTS,School direct (salaried),Secondary,11 to 16,Biology,21/7/2022

--- a/spec/jobs/auditing/trainee_auditor_job_spec.rb
+++ b/spec/jobs/auditing/trainee_auditor_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Auditing
+  describe TraineeAuditorJob do
+    include ActiveJob::TestHelper
+
+    let(:trainee) { create(:trainee, :trn_received) }
+    let(:user) { build(:user) }
+    let(:remote_address) { "127.0.0.1" }
+
+    let(:audited_changes) do
+      trainee.outcome_date = Date.yesterday
+      trainee.state = :recommended_for_award
+      trainee.recommended_for_award_at = Time.zone.now
+      trainee.send(:audited_changes)
+    end
+
+    it "creates a trainee audit record" do
+      expect(trainee).to receive(:write_audit).with(action: "update",
+                                                    audited_changes: audited_changes,
+                                                    remote_address: remote_address)
+
+      described_class.perform_now(trainee, audited_changes, user, remote_address)
+    end
+  end
+end

--- a/spec/services/bulk_update/recommend_spec.rb
+++ b/spec/services/bulk_update/recommend_spec.rb
@@ -7,11 +7,11 @@ module BulkUpdate
     let(:recommendations_upload_row) { create(:bulk_update_recommendations_upload_row, trainee:) }
     let(:recommendations_upload) { recommendations_upload_row.recommendations_upload }
 
-    subject { described_class.call(recommendations_upload:) }
-
     before do
       allow(Dqt::RecommendForAwardJob).to receive(:perform_later)
     end
+
+    subject { described_class.call(recommendations_upload:) }
 
     describe "#call", feature_integrate_with_dqt: true do
       context "when the trainee is trn_received" do
@@ -28,6 +28,28 @@ module BulkUpdate
         it "kicks off a job to recommend them for award with DQT" do
           expect(Dqt::RecommendForAwardJob).to receive(:perform_later).with(trainee)
           subject
+        end
+
+        context "audit record" do
+          around do |example|
+            Timecop.freeze do
+              example.run
+            end
+          end
+
+          let(:audited_changes) do
+            {
+              "outcome_date" => [nil, Date.parse("2023-02-16")],
+              "recommended_for_award_at" => [nil, Time.zone.now],
+              "state" => [Trainee.states[:trn_received], Trainee.states[:recommended_for_award]],
+            }
+          end
+
+          it "kicks off a job to create an audit record" do
+            expect(Auditing::TraineeAuditorJob).to receive(:perform_later).with(trainee, audited_changes, nil, nil)
+
+            subject
+          end
         end
       end
 

--- a/spec/services/bulk_update/recommendations_uploads/trainee_lookup_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/trainee_lookup_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module BulkUpdate
+  module RecommendationsUploads
+    describe TraineeLookup do
+      let(:file) { file_fixture("bulk_update/recommendations_upload/complete.csv") }
+      let(:csv) { CSV.new(file.read, headers: true, header_converters: :downcase, strip: true).read }
+      let(:rows) do
+        csv.filter_map do |row|
+          next if row.any? { |cell| cell.include?(Reports::BulkRecommendReport::DO_NOT_EDIT) }
+
+          Row.new(row)
+        end
+      end
+
+      let(:trainee) do
+        row = rows.sample
+        create(:trainee,
+               :trn_received,
+               trn: row.trn,
+               hesa_id: row.sanitised_hesa_id,
+               trainee_id: row.provider_trainee_id)
+      end
+
+      subject { described_class.new(rows, trainee.provider) }
+
+      it "returns the trainees with matching TRN" do
+        expect(subject[trainee.trn]).to eq([trainee])
+      end
+
+      it "returns the trainees with matching HESA ID" do
+        expect(subject[trainee.hesa_id]).to eq([trainee])
+      end
+
+      it "returns the trainees with matching Trainee ID" do
+        expect(subject[trainee.trainee_id]).to eq([trainee])
+      end
+    end
+  end
+end

--- a/spec/services/bulk_update/recommendations_uploads/validate_trainee_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_trainee_spec.rb
@@ -5,7 +5,11 @@ require "rails_helper"
 module BulkUpdate
   module RecommendationsUploads
     describe ValidateTrainee do
-      subject(:service) { described_class.new(row: row, provider: trainee.provider) }
+      let(:trainee_lookup) { TraineeLookup.new([row], trainee.provider) }
+
+      subject(:service) do
+        described_class.new(row: row, provider: trainee.provider, trainee_lookup: trainee_lookup)
+      end
 
       context "with a single trainee" do
         let(:trainee) { create(:trainee, :bulk_recommend) }
@@ -226,7 +230,7 @@ module BulkUpdate
           end
 
           describe "#messages" do
-            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same the provider trainee ID - contact becomingateacher@digital.education.gov.uk to fix this"] }
+            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same provider trainee ID - contact becomingateacher@digital.education.gov.uk to fix this"] }
           end
 
           describe "#trainee" do


### PR DESCRIPTION
### Context
https://trello.com/c/cP6Ojw7t/5476-when-bulk-recommending-308-trainees-it-took-a-long-time-performance-test-bulk-recommendation

### Changes proposed in this pull request
- Speed up the processing time for the action `BulkUpdate::RecommendationsUploadsController#update`
- New class `BulkUpdate::RecommendationsUploads::TraineeLookup` which uses hash maps built on-demand supporting trainee lookup by TRN, HESA ID or Trainee ID
- Change `Reports::TraineeReport` so it only loads `degree` and `course` on demand (prevents hundreds of unnecessary DB calls during the creation of each row)

**The processing time has gone from on average 30 seconds to 10-12 seconds.** 

### Guidance to review
- Go through the bulk recommend process locally using prod data to get an realistic idea of performance
- Run the test on `main` branch and then switch to this PR branch to compare times

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
