### PR TITLE
[5489] Get placements for latest hesa collection per trainee

### DIFF
--- a/app/components/placement_details/view.rb
+++ b/app/components/placement_details/view.rb
@@ -32,8 +32,7 @@ module PlacementDetails
     def urns
       @urns ||=
         trainee
-          .hesa_student_for_collection(Settings.hesa.current_collection_reference)
-          &.placements
+          .placements
           &.map { |placement| placement["school_urn"] }
     end
 

--- a/app/models/hesa/student.rb
+++ b/app/models/hesa/student.rb
@@ -81,5 +81,7 @@ module Hesa
                primary_key: :hesa_id,
                inverse_of: :hesa_students,
                optional: true
+
+    scope :latest, -> { order(collection_reference: :desc).first }
   end
 end

--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -419,8 +419,7 @@ module Reports
       @school_urns ||= begin
         school_urns =
           trainee
-            .hesa_student_for_collection(Settings.hesa.current_collection_reference)
-            &.placements
+            .placements
             &.map { |placement| placement["school_urn"] }
 
         school_urns.nil? ? [] : school_urns

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -539,10 +539,16 @@ class Trainee < ApplicationRecord
     "manual"
   end
 
-  def placement_details?
-    hesa_student = hesa_student_for_collection(Settings.hesa.current_collection_reference)
+  def placements
+    hesa_student = hesa_students.latest
 
-    hesa_student&.placements.present?
+    return nil if hesa_student.blank?
+
+    hesa_student.placements
+  end
+
+  def placement_details?
+    placements.present?
   end
 
   def estimated_end_date

--- a/spec/components/placement_details/view_spec.rb
+++ b/spec/components/placement_details/view_spec.rb
@@ -29,9 +29,7 @@ module PlacementDetails
     end
 
     before do
-      allow(Settings.hesa).to receive(:current_collection_reference).and_return("C22053")
-
-      trainee.hesa_students << hesa_student
+      trainee.hesa_students = [hesa_student]
 
       render_inline(View.new(trainee:))
     end

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -324,9 +324,7 @@ describe Reports::TraineeReport do
       end
 
       before do
-        allow(Settings.hesa).to receive(:current_collection_reference).and_return("C22053")
-
-        trainee.hesa_students << hesa_student
+        trainee.hesa_students = [hesa_student]
       end
 
       context "when there is only one placement" do

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -747,10 +747,6 @@ describe Trainee do
       create(:trainee, :imported_from_hesa)
     }
 
-    before do
-      allow(Settings.hesa).to receive(:current_collection_reference).and_return("C22053")
-    end
-
     context "when no placement data exists" do
       it "returns false" do
         expect(trainee.placement_details?).to be false
@@ -781,11 +777,55 @@ describe Trainee do
       end
 
       before do
-        trainee.hesa_students << hesa_student
+        trainee.hesa_students = [hesa_student]
       end
 
       it "returns true" do
         expect(trainee.placement_details?).to be true
+      end
+    end
+  end
+
+  describe "placements" do
+    subject(:trainee) {
+      create(:trainee, :imported_from_hesa)
+    }
+
+    context "when no placement data exists" do
+      it "returns nil" do
+        expect(trainee.placements).to be_nil
+      end
+    end
+
+    context "when placement data exists" do
+      let(:hesa_student) do
+        create(
+          :hesa_student,
+          collection_reference: "C22053",
+          hesa_id: trainee.hesa_id,
+          first_names: trainee.first_names,
+          last_name: trainee.last_name,
+          degrees: degrees,
+          placements: placements,
+        )
+      end
+
+      let!(:schools) { create_list(:school, 2) }
+
+      let(:placements) do
+        [{ "school_urn" => schools[0].urn }, { "school_urn" => schools[1].urn }]
+      end
+
+      let(:degrees) do
+        [{ "graduation_date" => "2019-06-13", "degree_type" => "051", "subject" => "100318", "institution" => "0012", "grade" => "02", "country" => nil }]
+      end
+
+      before do
+        trainee.hesa_students = [hesa_student]
+      end
+
+      it "returns true" do
+        expect(trainee.placements).to eq([{ "school_urn" => schools[0].urn }, { "school_urn" => schools[1].urn }])
       end
     end
   end


### PR DESCRIPTION
### Context

Get placements for latest hesa collection per trainee

### Changes proposed in this pull request

Get placements for latest hesa collection per trainee instead of using the hesa collection reference from the `Settings.yml` file.

![Screenshot 2023-05-17 at 11 34 44](https://github.com/DFE-Digital/register-trainee-teachers/assets/1955084/59c5bc44-6c15-4a0a-8a0a-701249709ab0)

### Guidance to review

Pick an awarded trainee that finished last year.

`/trainees/fiCo6GaXLPNEcJGwfQNANrSK`

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
