### PR TITLE
[5473] - BUGFIX - Degree recognition issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-debug.log*
 .yarn-integrity
 .jest-cache
 .env
+.env.*
 *.log
 .envrc
 

--- a/db/data/20230518115341_update_institution_on_degrees_with_wrong_mapping.rb
+++ b/db/data/20230518115341_update_institution_on_degrees_with_wrong_mapping.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class UpdateInstitutionOnDegreesWithWrongMapping < ActiveRecord::Migration[7.0]
+  def up
+    # All these degrees have the wrong institution name, so we need to update them
+    # The correct institution name should 'University of St Andrews' not 'University of St. Andrews'
+    Degree.where(id: [92346, 92540, 84446, 83566, 84816, 84808, 85830]).find_each do |degree|
+      degree.institution = "University of St Andrews"
+      degree.save
+
+      # Recalculates the trainee's readiness for submission
+      trainee = degree.trainee
+      trainee.send(:set_submission_ready)
+      trainee.save
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

Update the institution name for given degrees

### Changes proposed in this pull request

We noticed that the given degrees have the wrong institution name.
There seems to be only 7 degrees affected by this.
The institution_uuid is correctly assigned, but the name was not
mapped to the expected value.

The expected correct name is: University of St Andrews.

This issue is causing the affected trainee records to show as incomplete.

This mapping is expected to happen during the Apply Import. We suspect that this data was updated before we have introduced the `match_synonyms`:  https://github.com/DFE-Digital/dfe-reference-data/blob/main/lib/dfe/reference_data/degrees/institutions.rb#L1139 and the apply importer at that time was not doing this mapping.

Proposing to fix these records and monitor the situation moving forward. Please check the ticket to see how all the trainees with this issue were identified.

### Guidance to review

Check the slugs in the ticket.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
