### PR TITLE
[5502] Update DFE Reference gem to v2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ gem "govuk_markdown"
 gem "mechanize" # interact with HESA
 
 # pinned to a commit as v1 doesn't contain the Doctor of Philosophy disambiguation
-gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", ref: "f1a586f"
+gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v2.2.0"
 
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: f1a586f2170d46c717aca22a52e74c1669a1154a
-  ref: f1a586f
+  revision: 3aceede63039e0f5120898960166fc3f366e5adc
+  tag: v2.2.0
   specs:
-    dfe-reference-data (2.0.0)
+    dfe-reference-data (2.2.0)
       activesupport
       tzinfo
 
@@ -340,7 +340,7 @@ GEM
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
-    i18n (1.12.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
     irb (1.6.3)

--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -101,7 +101,7 @@ module RecordDetails
     end
 
     def render_text_with_hint(date)
-      hint_text = tag.span(time_ago_in_words(date).concat(" ago"), class: "govuk-hint")
+      hint_text = tag.span("#{time_ago_in_words(date)} ago", class: "govuk-hint")
 
       sanitize(tag.p(date_for_summary_view(date), class: "govuk-body") + hint_text)
     end

--- a/app/services/degrees/dfe_reference.rb
+++ b/app/services/degrees/dfe_reference.rb
@@ -7,51 +7,8 @@ module Degrees
     COMMON_TYPES = ["Bachelor of Arts", "Bachelor of Science", "Master of Arts", "PhD"].freeze
 
     GRADES = DfE::ReferenceData::Degrees::GRADES
+    TYPES = DfE::ReferenceData::Degrees::ALL_TYPES
     SUBJECTS = DfE::ReferenceData::Degrees::SUBJECTS_INCLUDING_GENERICS
-
-    ## TODO: Remove this once the dfe-reference-data gem is updated to the latest version
-
-    # Extracts the mapping from https://github.com/DFE-Digital/dfe-reference-data/blob/03cb8815684355b1e04f2b0e39faf682d1ba7f7c/lib/dfe/reference_data/degrees/types.rb#L904
-    # This is a temporary solution until we are able to upgrade the gem to its latest version
-
-    UNKNOWN_TYPES_SCHEMA = DfE::ReferenceData::Degrees::TYPES_SCHEMA.merge(
-      {
-        qualification: { kind: :optional, schema: :string },
-        unknown: :boolean,
-      },
-    )
-
-    UNKNOWN_TYPES = DfE::ReferenceData::HardcodedReferenceList.new(
-      {
-        "3e042de2-a453-47dc-9452-90a23399e9ee" =>
-        { name: "Not available",
-          abbreviation: nil,
-          suggestion_synonyms: [],
-          match_synonyms: [],
-          hesa_itt_code: "999",
-          unknown: true },
-      },
-      schema: UNKNOWN_TYPES_SCHEMA,
-      list_description: 'Generic "catch-all" degree types, for approximating degree types not listed in TYPES (eg, "First Degree" to cover any first degree).',
-      list_docs_url: "https://github.com/DFE-Digital/dfe-reference-data/blob/main/docs/lists_degrees.md#dfereferencedatadegreesgeneric_types",
-      field_descriptions: DfE::ReferenceData::Degrees::TYPES_FIELD_DESCRIPTIONS,
-    )
-
-    ##########################################################################
-
-    TYPES = DfE::ReferenceData::JoinedReferenceList.new(
-      [DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS, UNKNOWN_TYPES],
-      schema: DfE::ReferenceData::Degrees::TYPES_SCHEMA.merge(
-        {
-          qualification: { kind: :optional, schema: :string },
-          generic: { kind: :optional, schema: :boolean },
-          unknown: { kind: :optional, schema: :boolean },
-        },
-      ),
-      list_description: "All degree types",
-      field_descriptions: DfE::ReferenceData::Degrees::TYPES_FIELD_DESCRIPTIONS,
-    )
-
     INSTITUTIONS = DfE::ReferenceData::Degrees::INSTITUTIONS_INCLUDING_GENERICS
 
     SUPPORTED_GRADES_BY_HESA_CODES = %w[01 02 03 05 12 13 14].freeze


### PR DESCRIPTION
### Context
https://trello.com/c/arsST5W2/5502-update-dfe-reference-gem-in-register

### Changes proposed in this pull request
- Update `dfe-reference` gem to use latest tagged version `v2.2.0`
- Fix broken tests which was related to an error caused by `RecordDetails::View#render_text_with_hint`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
