### PR TITLE
[5514] - Don't show discarded users in system admin UI

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -5,7 +5,7 @@ module Api
     def index
       return error_response if invalid_query?
 
-      @user_search = UserSearch.call(**args).users
+      @user_search = filtered_users
 
       render(json: { users: @user_search.as_json(only: %i[id first_name last_name email],
                                                  include: { providers: { only: [:name] },
@@ -25,6 +25,10 @@ module Api
     def error_response
       message = I18n.t("api.errors.bad_request", length: SchoolSearch::MIN_QUERY_LENGTH)
       render_json_error(message: message, status: :bad_request)
+    end
+
+    def filtered_users
+      UserSearch.call(**args, scope: User.kept).users
     end
   end
 end

--- a/app/controllers/system_admin/users_controller.rb
+++ b/app/controllers/system_admin/users_controller.rb
@@ -39,7 +39,7 @@ module SystemAdmin
     end
 
     def user
-      @user ||= authorize(User.find(params[:id]))
+      @user ||= authorize(User.kept.find(params[:id]))
     end
 
     def filtered_users(users)

--- a/spec/features/system_admin/users/deleting_a_user_spec.rb
+++ b/spec/features/system_admin/users/deleting_a_user_spec.rb
@@ -62,7 +62,7 @@ private
   end
 
   def then_the_user_is_not_returned_in_search
-    admin_users_index_page.search.set(user.last_name + "\n") # hit enter
+    admin_users_index_page.search.set("#{user.last_name}\n") # hit enter
     expect(admin_users_index_page.body_text_excluding_search).not_to have_text(user.last_name)
   end
 end

--- a/spec/features/system_admin/users/deleting_a_user_spec.rb
+++ b/spec/features/system_admin/users/deleting_a_user_spec.rb
@@ -10,7 +10,7 @@ feature "Deleting a user" do
     given_i_am_authenticated(user: system_admin)
   end
 
-  scenario "can be done by an admin" do
+  scenario "can be done by an admin", js: true do
     visiting_the_users_page
     and_i_click_on_delete
     i_am_taken_to_the_delete_user_page
@@ -62,7 +62,7 @@ private
   end
 
   def then_the_user_is_not_returned_in_search
-    admin_users_index_page.search.set(user.last_name)
-    expect(admin_users_index_page).not_to have_text(user.last_name)
+    admin_users_index_page.search.set(user.last_name + "\n") # hit enter
+    expect(admin_users_index_page.body_text_excluding_search).not_to have_text(user.last_name)
   end
 end

--- a/spec/features/system_admin/users/deleting_a_user_spec.rb
+++ b/spec/features/system_admin/users/deleting_a_user_spec.rb
@@ -16,6 +16,7 @@ feature "Deleting a user" do
     i_am_taken_to_the_delete_user_page
     where_i_click_the_delete_button
     and_successfully_delete_the_user
+    then_the_user_is_not_returned_in_search
   end
 
   context "that is a system admin" do
@@ -58,5 +59,10 @@ private
   def delete_page_is_redirected
     admin_user_delete_page.load(id: user.id)
     expect(admin_users_index_page).to be_displayed
+  end
+
+  def then_the_user_is_not_returned_in_search
+    admin_users_index_page.search.set(user.last_name)
+    expect(admin_users_index_page).not_to have_text(user.last_name)
   end
 end

--- a/spec/support/page_objects/system_admin/users/index.rb
+++ b/spec/support/page_objects/system_admin/users/index.rb
@@ -11,14 +11,14 @@ module PageObjects
         end
 
         element :add_a_user, "a", text: "Add a user"
-        element :search, '#search-field', visible: :all
+        element :search, "#search-field", visible: :all
         element :submit_search, ".submit-search"
         sections :users, UserRow, ".user-row"
         element :flash_message, ".govuk-notification-banner__header"
         element :flash_message, ".govuk-notification-banner__header"
 
         def body_text_excluding_search
-          Capybara.current_session.text.gsub(search.text, '')
+          Capybara.current_session.text.gsub(search.text, "")
         end
       end
     end

--- a/spec/support/page_objects/system_admin/users/index.rb
+++ b/spec/support/page_objects/system_admin/users/index.rb
@@ -11,11 +11,15 @@ module PageObjects
         end
 
         element :add_a_user, "a", text: "Add a user"
-        element :search, 'input[name="search"]'
+        element :search, '#search-field', visible: :all
         element :submit_search, ".submit-search"
         sections :users, UserRow, ".user-row"
         element :flash_message, ".govuk-notification-banner__header"
         element :flash_message, ".govuk-notification-banner__header"
+
+        def body_text_excluding_search
+          Capybara.current_session.text.gsub(search.text, '')
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Discarded users show up on the `system-admin/users` index when searching (via the API). They can also be accessed via their `show`

### Changes proposed in this pull request

* API searches only `kept` users
* a user is retrieved using `kept` when they are `shown`

### Guidance to review
* delete a non admin user and try to search for them
* try accessing their show page by visiting their `/system-admin/users/:id`
