### PR TITLE
[5512] Fix date range bug

### DIFF
--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -400,9 +400,7 @@ module Reports
     end
 
     def course_age_range
-      if trainee.award_type == "EYTS"
-        return " "
-      end
+      return nil if course_minimum_age.blank? && course_maximum_age.blank?
 
       "#{course_minimum_age} to #{course_maximum_age}"
     end

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -411,11 +411,19 @@ describe Reports::TraineeReport do
     end
   end
 
-  context "when there is an EYTS trainee" do
+  context "when there is a trainee with no age range" do
     let!(:trainee) { create(:trainee, :eyts_recommended, start_academic_cycle: current_cycle, end_academic_cycle: nil) }
 
-    it "returns a blank age range" do
-      expect(subject.course_age_range).to eq(" ")
+    it "returns nil for age range" do
+      expect(subject.course_age_range).to be_nil
+    end
+  end
+
+  context "when there is a trainee with an age range" do
+    let!(:trainee) { create(:trainee, :eyts_recommended, start_academic_cycle: current_cycle, end_academic_cycle: nil, course_min_age: 1, course_max_age: 5) }
+
+    it "returns the age range" do
+      expect(subject.course_age_range).to eq("1 to 5")
     end
   end
 


### PR DESCRIPTION
### Context

The current bug:

There was a logic error in the code that was setting
the date range to ' ' for all trainees of type EYTS,
in the CSV export, even for trainees that did in fact
have a date range available.

This behaviour was preventing providers to bulk recommend
EYTS trainees.

### Changes proposed in this pull request

Mark the date range as ' ' only for trainees that have no date range available.

### Guidance to review

- Pick a provider
- Go to bulk recommend
- Download the trainees
- Pick some that have a blank date range
- Try to recommend them
- It should not throw a validation error anymore

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
