### PR TITLE
Add application probes

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,10 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
-  config.ssl_options = { hsts: { preload: true } }
+  config.ssl_options = {
+    hsts: { preload: true },
+    redirect: { exclude: ->(request) { request.path.include?("ping") } },
+  }
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -92,8 +92,6 @@ variable "main_app" {
   default = {}
 }
 
-variable "probe_path" { default = [] }
-
 variable "azure_maintenance_window" { default = null }
 variable "postgres_flexible_server_sku" { default = "B_Standard_B1ms" }
 variable "postgres_enable_high_availability" { default = false }

--- a/terraform/aks/workspace-variables/dv_review_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/dv_review_aks.tfvars.json
@@ -11,6 +11,7 @@
   "main_app": {
     "main": {
       "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+      "probe_path": "/ping",
       "replicas": 1,
       "memory_max": "1Gi"
     }

--- a/terraform/aks/workspace-variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/production_aks.tfvars.json
@@ -10,6 +10,7 @@
   "main_app": {
     "main": {
       "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+      "probe_path": "/ping",
       "replicas": 4,
       "memory_max": "1536Mi"
     }

--- a/terraform/aks/workspace-variables/productiondata_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/productiondata_aks.tfvars.json
@@ -10,6 +10,7 @@
   "main_app": {
     "main": {
       "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+      "probe_path": "/ping",
       "replicas": 2,
       "memory_max": "1536Mi"
     }

--- a/terraform/aks/workspace-variables/qa_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/qa_aks.tfvars.json
@@ -10,6 +10,7 @@
   "main_app": {
     "main": {
       "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+      "probe_path": "/ping",
       "replicas": 2,
       "memory_max": "1Gi"
     }

--- a/terraform/aks/workspace-variables/review_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/review_aks.tfvars.json
@@ -11,6 +11,8 @@
   "db_sslmode": "prefer",
   "main_app": {
     "main": {
+      "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+      "probe_path": "/ping",
       "replicas": 1,
       "memory_max": "1Gi"
     }

--- a/terraform/aks/workspace-variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/staging_aks.tfvars.json
@@ -10,6 +10,7 @@
   "main_app": {
     "main": {
       "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+      "probe_path": "/ping",
       "replicas": 2,
       "memory_max": "1Gi"
     }


### PR DESCRIPTION
### Context

Add application startup/liveness probes
Without the startup probe review apps can fail as the deploy workflow continues while db:migrate is still running

### Changes proposed in this pull request

Add /ping as the probe_path for each aks env
Remove rails ssl https redirect for /ping as this causes aks probe issues as requires http internally

### Guidance to review

deploy_v2 aks workflow
https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5090080650/jobs/9148643474
deploy paas workflow
https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5090250366/jobs/9149000656

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
