### PR TITLE
[5500] Support admin feature to manage trainees with pending TRNs

### DIFF
--- a/app/components/dqt_data_summary/view.html.erb
+++ b/app/components/dqt_data_summary/view.html.erb
@@ -3,7 +3,7 @@
     <%= govuk_summary_list(rows: general) %>
 
     <% training_instances&.each_with_index do |training_instance, i| %>
-    <h3 class="govuk-heading-m govuk-!-margin-top-6"><%= "Training instance #{i + 1}" %></h3>
+      <h3 class="govuk-heading-m govuk-!-margin-top-6"><%= "Training instance #{i + 1}" %></h3>
       <%= govuk_summary_list(rows: training_instance) %>
     <% end %>
 

--- a/app/controllers/system_admin/dead_jobs_controller.rb
+++ b/app/controllers/system_admin/dead_jobs_controller.rb
@@ -32,10 +32,10 @@ module SystemAdmin
     end
 
     def dead_job_services
+      # returns Array of DeadJob classes instances, e.g. [::DeadJobs::DqtUpdateTrainee, ...]
       @dead_job_services ||=
         DeadJobs
           .constants
-          # returns Array of DeadJob classes instances, e.g. [::DeadJobs::DqtUpdateTrainee, ...]
           .select { |constant| (DeadJobs.const_get(constant).is_a?(Class) && constant != :Base) }
           .map { |constant| "::DeadJobs::#{constant}".constantize.new }
     end

--- a/app/controllers/system_admin/pending_trns/base_controller.rb
+++ b/app/controllers/system_admin/pending_trns/base_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  module PendingTrns
+    class BaseController < ApplicationController
+      include TraineeHelper
+
+      add_flash_types :dqt_error
+      before_action :load_trainee
+
+    private
+
+      attr_reader :trainee
+
+      def load_trainee
+        @trainee = Trainee.from_param(params[:id])
+      end
+
+      def trn_request
+        @trn_request = trainee.dqt_trn_request
+      end
+    end
+  end
+end

--- a/app/controllers/system_admin/pending_trns/request_trns_controller.rb
+++ b/app/controllers/system_admin/pending_trns/request_trns_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  module PendingTrns
+    class RequestTrnsController < BaseController
+      def create
+        trn_request.destroy!
+
+        trn_request = Dqt::RegisterForTrnJob.perform_now(trainee.reload)
+
+        if trn_request.failed?
+          redirect_to(pending_trns_path, flash: { warning: "TRN request failed for #{trainee_name(trainee)}" })
+        else
+          redirect_to(pending_trns_path, flash: { success: "TRN requested successfully for #{trainee_name(trainee)}" })
+        end
+      rescue Dqt::Client::HttpError => e
+        redirect_to(pending_trns_path, dqt_error: "DQT error: #{e.inspect}")
+      end
+    end
+  end
+end

--- a/app/controllers/system_admin/pending_trns/retrieve_trns_controller.rb
+++ b/app/controllers/system_admin/pending_trns/retrieve_trns_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  module PendingTrns
+    class RetrieveTrnsController < BaseController
+      def update
+        trn = Dqt::RetrieveTrn.call(trn_request:)
+
+        if trn
+          trainee.trn_received!(trn)
+          trn_request.received!
+          redirect_to(pending_trns_path, flash: { success: "TRN successfully retrieved for #{trainee_name(trainee)}" })
+        else
+          redirect_to(pending_trns_path, flash: { warning: "TRN still not available for #{trainee_name(trainee)}" })
+        end
+      rescue Dqt::Client::HttpError => e
+        redirect_to(pending_trns_path, dqt_error: "DQT error: #{e.inspect}")
+      end
+    end
+  end
+end

--- a/app/controllers/system_admin/pending_trns_controller.rb
+++ b/app/controllers/system_admin/pending_trns_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class PendingTrnsController < ApplicationController
+    add_flash_types :dqt_error
+
+    def index
+      @trainees = Trainee.submitted_for_trn
+    end
+  end
+end

--- a/app/jobs/dqt/register_for_trn_job.rb
+++ b/app/jobs/dqt/register_for_trn_job.rb
@@ -11,6 +11,8 @@ module Dqt
 
       trn_request = RegisterForTrn.call(trainee:)
       RetrieveTrnJob.perform_later(trn_request) unless trn_request.failed?
+
+      trn_request
     end
   end
 end

--- a/app/views/system_admin/_tab_nav.html.erb
+++ b/app/views/system_admin/_tab_nav.html.erb
@@ -6,4 +6,5 @@
   { name: "Lead schools", url: lead_schools_path },
   { name: "Uploads", url: uploads_path },
   { name: "Dead Jobs", url: dead_jobs_path },
+  { name: "Pending TRN", url: pending_trns_path },
 ]) %>

--- a/app/views/system_admin/pending_trns/index.html.erb
+++ b/app/views/system_admin/pending_trns/index.html.erb
@@ -1,0 +1,49 @@
+<%= render PageTitle::View.new(i18n_key: "dead_jobs.index") %>
+
+<div class="govuk-grid-row">
+  <div class ="govuk-grid-column-full">
+    <%= render "system_admin/tab_nav" %>
+
+    <%= render ErrorSummary::View.new(renderable: dqt_error.present?) do %>
+      <%= dqt_error %>
+    <% end %>
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Trainees Pending TRN</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">First names</th>
+          <th scope="col" class="govuk-table__header">Last name</th>
+          <th scope="col" class="govuk-table__header">Days waiting</th>
+          <th scope="col" class="govuk-table__header"></th>
+          <th scope="col" class="govuk-table__header"></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @trainees.each do |trainee| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= trainee.first_names %></td>
+            <td class="govuk-table__cell"><%= trainee.last_name %></td>
+            <td class="govuk-table__cell">
+              <%= (Date.current - trainee.dqt_trn_request.created_at.to_date).to_i %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= govuk_button_to "Check for TRN",
+                                  pending_trns_retrieve_trn_path(trainee),
+                                  method: :put,
+                                  class: "govuk-!-margin-0 govuk-button--secondary" %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= govuk_button_to "Re-request for TRN",
+                                  pending_trns_request_trns_path(trainee),
+                                  method: :post,
+                                  class: "govuk-!-margin-0 govuk-button--secondary" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -14,6 +14,7 @@ module SystemAdminRoutes
         get "/sidekiq", to: redirect("/sign-in"), status: 302
 
         resources :dead_jobs, only: %i[index show]
+        resources :pending_trns, only: %i[index show]
 
         resources :providers, only: %i[index new create show edit update] do
           resources :users, controller: "providers/users", only: %i[index edit update]
@@ -59,6 +60,11 @@ module SystemAdminRoutes
         namespace :trainee_deletions, path: "trainee-deletions" do
           resources :reasons, only: %i[edit update]
           resources :confirmations, only: %i[show update destroy]
+        end
+
+        namespace :pending_trns, path: "pending-trns" do
+          resources :retrieve_trns, only: %i[update], path: "retrieve-trns"
+          resources :request_trns, only: %i[create], path: "request-trns"
         end
       end
     end


### PR DESCRIPTION
### Context
https://trello.com/c/PkUZo1w7/5500-spike-for-2-days-think-of-and-create-solutions-for-monitoring-when-trn-requests-fail-trainees-are-left-in-pending-trn

### Changes proposed in this pull request
- New support tab "Pending TRNs"
- Pending TRNs page lists all trainees waiting for TRNs and 2 action buttons to try and retrieve TRN or re-request for TRN

### Guidance to review
- No really possible to test in PR environment. Was tested locally apart from re-requesting TRN

### Screenshots

#### Index page
<img width="982" alt="Screenshot 2023-05-26 at 12 55 48" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/28728/736cae12-b799-4a20-b4e9-e93b4f647c6d">

### Retrieving TRN
<img width="979" alt="Screenshot 2023-05-26 at 12 56 35" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/28728/697b0744-8f2d-4903-b79f-763bea319b40">

### DQT Error example
<img width="992" alt="Screenshot 2023-05-26 at 12 57 01" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/28728/454552d3-bfe0-4061-88ce-d812d130a140">

### Important business
- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
