### PR TITLE
[5516] - improve dead jobs interface

### DIFF
--- a/app/controllers/system_admin/dead_jobs_controller.rb
+++ b/app/controllers/system_admin/dead_jobs_controller.rb
@@ -16,20 +16,22 @@ module SystemAdmin
     end
 
     def update
-      job = Sidekiq::DeadSet.new.find_job(params[:id])
       job&.retry
-      flash[:success] = "Job will be retried imminently"
-      redirect_back_or_to dead_jobs_path
+      flash[:success] = "Job will be retried imminently" # rubocop:disable Rails/I18nLocaleTexts
+      redirect_back_or_to(dead_jobs_path)
     end
 
     def destroy
-      job = Sidekiq::DeadSet.new.find_job(params[:id])
       job&.delete
-      flash[:success] = "Job successfully deleted"
-      redirect_back_or_to dead_jobs_path
+      flash[:success] = "Job successfully deleted" # rubocop:disable Rails/I18nLocaleTexts
+      redirect_back_or_to(dead_jobs_path)
     end
 
   private
+
+    def job
+      Sidekiq::DeadSet.new.find_job(params[:id])
+    end
 
     def dead_job_service
       @dead_job_service ||= params[:id]&.constantize&.new(include_dqt_status:)

--- a/app/services/dead_jobs/base.rb
+++ b/app/services/dead_jobs/base.rb
@@ -2,43 +2,28 @@
 
 module DeadJobs
   class Base
-    DEFAULT_HEADERS = %i[
-      register_id
-      trainee_name
-      trainee_trn
-      trainee_dob
-      trainee_state
-      provider_name
-      provider_ukprn
-      programme_route
-      programme_start_date
-      programme_end_date
-    ].freeze
-
     def initialize(dead_set: Sidekiq::DeadSet.new, include_dqt_status: false)
       @dead_set = dead_set
       @include_dqt_status = include_dqt_status
     end
 
-    # includes the error_message entry using `includes: ...`
-    def to_csv(includes: [])
-      build_csv(includes: %i[job_id error_message] | includes)
+    def to_csv
+      CSV.generate do |csv|
+        csv << csv_headers
+        trainees.each do |trainee|
+          csv << build_csv_row(trainee).values
+        end
+      end
     end
 
-    # by default only use the defined headers in DEFAULT_HEADERS
-    # so as not to clutter the html view
-    def headers(includes: [])
+    def headers
       return if rows.blank?
 
-      rows(includes:).first.keys
+      rows.first.keys
     end
 
-    # by default only use the defined headers in DEFAULT_HEADERS
-    # so as not to clutter the html view
-    def rows(includes: [])
-      build_rows.map do |row|
-        row.slice(*(DEFAULT_HEADERS | includes))
-      end
+    def rows
+      @rows ||= trainees.map { |trainee| build_html_row(trainee) }
     end
 
     def name
@@ -59,39 +44,54 @@ module DeadJobs
 
     attr_reader :dead_set, :include_dqt_status
 
-    def build_csv(includes:)
-      CSV.generate do |csv|
-        csv << headers(includes:)
-        rows(includes:).each do |row|
-          csv << row.values
-        end
-      end
+    def csv_headers
+      build_csv_row(trainees.first).keys
     end
 
-    def build_rows
-      @build_rows ||= trainees.map do |trainee|
-        dqt_trn_params = Dqt::Params::TrnRequest.new(trainee:).params
-        {
-          register_id: trainee.id,
-          trainee_name: trainee.full_name,
-          trainee_trn: trainee.trn,
-          trainee_dob: trainee.date_of_birth,
-          trainee_state: trainee.state,
-          provider_name: trainee.provider.name,
-          provider_ukprn: trainee.provider.ukprn,
-          programme_route: dqt_trn_params.dig("initialTeacherTraining", "programmeType"),
-          programme_start_date: dqt_trn_params.dig("initialTeacherTraining", "programmeStartDate"),
-          programme_end_date: dqt_trn_params.dig("initialTeacherTraining", "programmeEndDate"),
-          job_id: dead_jobs[trainee.id][:job_id],
-          error_message: dead_jobs[trainee.id][:error_message]&.to_s&.gsub('"', "'"),
-        }.tap do |row|
-          row.merge!(yield(trainee)) if block_given?
-          row.merge!(dqt_status: dqt_status(trainee))
-        end
-      end
+    def build_csv_row(trainee)
+      dqt_params = dqt_params(trainee)
+      {
+        id: trainee.id,
+        job_id: dead_jobs[trainee.id][:job_id],
+        url: "#{Settings.base_url}/trainees/#{trainee.slug}",
+        trn: trainee.trn,
+        date_of_birth: trainee.date_of_birth,
+        full_name: trainee.full_name,
+        email: trainee.email,
+        state: trainee.state,
+        provider_name: trainee.provider.name,
+        provider_ukprn: trainee.provider.ukprn,
+        training_route: trainee.training_route,
+        itt_start_date: trainee.itt_start_date,
+        itt_end_date: trainee.itt_start_date,
+        course_min_age: trainee.course_min_age,
+        course_max_age: trainee.course_max_age,
+        course_subject_one: trainee.course_subject_one,
+        course_subject_two: trainee.course_subject_two,
+        course_subject_three: trainee.course_subject_three,
+        dqt_programme_route: (dqt_params.dig("initialTeacherTraining", "programmeType") if include_dqt_status),
+        dqt_programme_start_date: (dqt_params.dig("initialTeacherTraining", "programmeStartDate") if include_dqt_status),
+        dqt_programme_end_date: (dqt_params.dig("initialTeacherTraining", "programmeEndDate") if include_dqt_status),
+        error_message: dead_job_error_message(trainee.id),
+      }
     end
 
-    # returns: [{ record_id => error_message }, ... ]
+    def build_html_row(trainee)
+      {
+        register_id: trainee.id,
+        trn: trainee.trn,
+        name: trainee.full_name,
+        date_of_birth: trainee.date_of_birth,
+        state: trainee.state,
+        job_id: dead_jobs[trainee.id][:job_id],
+      }
+    end
+
+    def dqt_params(trainee)
+      @dqt_params ||= {}
+      @dqt_params[trainee.id] ||= Dqt::Params::TrnRequest.new(trainee:).params
+    end
+
     def dead_jobs
       @dead_jobs ||=
         dead_set
@@ -107,18 +107,14 @@ module DeadJobs
         end
     end
 
-    def dqt_status(trainee)
-      return unless include_dqt_status && trainee.trn.present?
-
-      Dqt::RetrieveTraining.call(trainee:)["result"]&.to_s&.gsub('"', "'")
-    rescue StandardError => e
-      "error: #{e.message}"
+    def dead_job_error_message(trainee_id)
+      dead_jobs[trainee_id][:error_message]&.to_s&.gsub('"', "'")
     end
 
     def parse_error(error)
       return error unless error.include?("body: ")
 
-      JSON.parse(
+      parsed = JSON.parse(
         error.split("body: ")
              .last
              .split(", headers:")
@@ -126,6 +122,18 @@ module DeadJobs
       )
     rescue JSON::ParserError
       error
+    end
+
+    def flatten_hash(hash, parent_key = "", result = "")
+      hash.each do |key, value|
+        new_key = parent_key == "" ? "#{key}" : "#{parent_key}_#{key}"
+        if value.is_a? Hash
+          result = flatten_hash(value, new_key, result)
+        else
+          result += "#{new_key}: #{value}\n"
+        end
+      end
+      result
     end
   end
 end

--- a/app/services/dead_jobs/dqt_update_trainee.rb
+++ b/app/services/dead_jobs/dqt_update_trainee.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
-
 module DeadJobs
   class DqtUpdateTrainee < Base
-    # includes the error_message entry using `includes: ...`
-    def to_csv(includes: [])
-      build_csv(includes: %i[job_id error_message params_sent] | includes)
+
+    private
+
+    def build_csv_row(trainee)
+      super.merge(params_sent: params_sent(trainee))
     end
 
-  private
-
-    def build_rows
-      super do |trainee|
-        { params_sent: Dqt::Params::Update.new(trainee:).to_json&.to_s&.gsub('"', "'") }
-      end
+    def params_sent(trainee)
+      flatten_hash(Dqt::Params::Update.new(trainee:).params.compact)
     end
 
     # full class name to look for in Sidekiq dead jobs

--- a/app/services/dead_jobs/dqt_update_trainee.rb
+++ b/app/services/dead_jobs/dqt_update_trainee.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
+
 module DeadJobs
   class DqtUpdateTrainee < Base
-
-    private
+  private
 
     def build_csv_row(trainee)
       super.merge(params_sent: params_sent(trainee))

--- a/app/views/system_admin/dead_jobs/show.html.erb
+++ b/app/views/system_admin/dead_jobs/show.html.erb
@@ -22,8 +22,11 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <% dead_job_service.headers&.each do |header| %>
+          <% next if header == :job_id %>
+
           <th scope="col" class="govuk-table__header"><%= header.to_s.humanize %></th>
         <% end %>
+        <th scope="col" class="govuk-table__header"> </th>
       </tr>
     </thead>
 
@@ -32,15 +35,16 @@
         <% row = dead_job_service.rows.select{|row| row[:register_id] == trainee.id}.first %>
           <tr class="govuk-table__row">
             <% row.each do |data| %>
+              <% next if data[0] == :job_id %>
+
               <td class="govuk-table__cell"><%= data[-1] %></td>
             <% end %>
             <td class="govuk-table__cell">
-              <%= render GovukButtonLinkTo::View.new(
-                body: "View",
-                id: "view_#{row[:register_id]}",
-                url: trainee_path(Trainee.find(row[:register_id]),
-                                  class_option: "govuk-!-margin-bottom-0"
-                )) %>
+              <div class="govuk-button-group">
+                <%= govuk_button_to "View", trainee_path(Trainee.find(row[:register_id])), method: :get, class: "govuk-button--default govuk-!-margin-bottom-0" %>
+                <%= govuk_button_to "Retry", dead_job_path(row[:job_id]), method: :put, class: "govuk-button--secondary govuk-!-margin-bottom-0" %>
+                <%= govuk_button_to "Delete", dead_job_path(row[:job_id]), method: :delete, class: "govuk-button--warning govuk-!-margin-bottom-0" %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -13,7 +13,7 @@ module SystemAdminRoutes
         mount Sidekiq::Web, at: "/sidekiq", constraints: SystemAdminConstraint.new
         get "/sidekiq", to: redirect("/sign-in"), status: 302
 
-        resources :dead_jobs, only: %i[index show]
+        resources :dead_jobs, only: %i[index show update destroy]
         resources :pending_trns, only: %i[index show]
 
         resources :providers, only: %i[index new create show edit update] do

--- a/spec/services/dead_jobs/dqt_recommend_for_award_spec.rb
+++ b/spec/services/dead_jobs/dqt_recommend_for_award_spec.rb
@@ -2,11 +2,6 @@
 
 require "rails_helper"
 
-module DeadJobs
-  describe DqtRecommendForAward do
-    it_behaves_like "DeadJobs" do
-      let(:klass) { "Dqt::RecommendForAwardJob" }
-      let(:name) { "DQT Recommend For Award" }
-    end
-  end
+RSpec.describe DeadJobs::DqtRecommendForAward do
+  it_behaves_like "Dead jobs", Dqt::RecommendForAwardJob, "DQT Recommend For Award"
 end

--- a/spec/services/dead_jobs/dqt_update_trainee_spec.rb
+++ b/spec/services/dead_jobs/dqt_update_trainee_spec.rb
@@ -2,27 +2,6 @@
 
 require "rails_helper"
 
-module DeadJobs
-  describe DqtUpdateTrainee do
-    it_behaves_like "DeadJobs" do
-      let(:klass) { "Dqt::UpdateTraineeJob" }
-      let(:name) { "DQT Update Trainee" }
-
-      let(:params_sent) { Dqt::Params::Update.new(trainee:).to_json.to_s.gsub('"', "'") }
-
-      let(:csv) do
-        <<~CSV
-          #{headers.join(',')},job_id,error_message,params_sent
-          #{row},#{job_id},"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}","#{params_sent}"
-        CSV
-      end
-
-      let(:csv_with_dqt_status) do
-        <<~CSV
-          #{headers.join(',')},job_id,error_message,params_sent,dqt_status
-          #{row},#{job_id},"{'title'=>'Teacher has no incomplete ITT record', 'status'=>400, 'errorCode'=>10005}","#{params_sent}",Pass
-        CSV
-      end
-    end
-  end
+RSpec.describe DeadJobs::DqtUpdateTrainee do
+  it_behaves_like "Dead jobs", Dqt::UpdateTraineeJob, "DQT Update Trainee"
 end

--- a/spec/services/dead_jobs/dqt_withdraw_trainee_spec.rb
+++ b/spec/services/dead_jobs/dqt_withdraw_trainee_spec.rb
@@ -2,11 +2,6 @@
 
 require "rails_helper"
 
-module DeadJobs
-  describe DqtWithdrawTrainee do
-    it_behaves_like "DeadJobs" do
-      let(:klass) { "Dqt::WithdrawTraineeJob" }
-      let(:name) { "DQT Withdraw Trainee" }
-    end
-  end
+RSpec.describe DeadJobs::DqtWithdrawTrainee do
+  it_behaves_like "Dead jobs", Dqt::WithdrawTraineeJob, "DQT Withdraw Trainee"
 end

--- a/spec/support/page_objects/system_admin/dead_jobs/dead_jobs_dqt_update_trainee.rb
+++ b/spec/support/page_objects/system_admin/dead_jobs/dead_jobs_dqt_update_trainee.rb
@@ -6,7 +6,9 @@ module PageObjects
       class DqtUpdateTrainee < PageObjects::Base
         set_url "/system-admin/dead_jobs/DeadJobs::DqtUpdateTrainee"
 
-        element :view_trainee_button, "a", id: "view_10001", text: "View"
+        element :view_trainee_button, "button", text: "View"
+        element :retry_trainee_button, "button", text: "Retry"
+        element :delete_trainee_button, "button", text: "Delete"
       end
     end
   end


### PR DESCRIPTION
### Context

We want to make it easier for Register and DQT to resolve dead jobs. Some of these should be possible without dev support, if we make the right information and actions available to DQT/TRA operations.

### Changes proposed in this pull request

* adds new fields to the CSV export
* refactors the base class to make it a bit easier to understand
* adds retry and delete actions for individual jobs