### PR TITLE
[5475] Handle impossible dates in bulk upload

### DIFF
--- a/app/services/bulk_update/recommendations_uploads/validate_csv_row.rb
+++ b/app/services/bulk_update/recommendations_uploads/validate_csv_row.rb
@@ -64,6 +64,8 @@ module BulkUpdate
       def standards_met_at
         case row.standards_met_at
         when VALID_STANDARDS_MET_AT
+          return @messages << error_message(:award_date_not_valid) unless valid_date?(row.standards_met_at)
+
           @date = row.standards_met_at.to_date
           today = Time.zone.today.to_date
           ago_12_months = 12.months.ago.to_date
@@ -78,6 +80,13 @@ module BulkUpdate
 
       def gds_date(date)
         date.strftime(Date::DATE_FORMATS[:govuk])
+      end
+
+      def valid_date?(date_str)
+        Date.strptime(date_str, "%d/%m/%Y")
+        true
+      rescue ArgumentError
+        false
       end
 
       def column_exists?(column_name)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1366,6 +1366,7 @@ en:
             validate_csv_row:
               trn_format: TRN must be 7 numbers
               hesa_id_format: HESA ID must be 13 or 17 numbers
+              award_date_not_valid: Date QTS or EYTS standards met must be a valid date
               award_date_future: Date QTS or EYTS standards met must be today or in the past
               award_date_past: Date QTS or EYTS standards met must be within the past 12 months to bulk recommend - you can recommend the trainee separately in their trainee record
               date_standards_met: Date QTS or EYTS standards met must be after trainee’s ITT start date

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -80,7 +80,7 @@ development:
 
 test:
   <<: *default
-  compile: false
+  compile: true
   cache_manifest: true
   public_output_path: packs-test
 

--- a/spec/services/bulk_update/recommendations_uploads/validate_csv_row_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_csv_row_spec.rb
@@ -37,6 +37,25 @@ module BulkUpdate
           end
         end
 
+        context "When date is invalid" do
+          let(:row) do
+            Row.new({
+              "trn" => "1234567",
+              "hesa id" => "12345678912345678",
+              "provider trainee id" => "1234567",
+              "date qts or eyts standards met" => "21/85/2022",
+            })
+          end
+
+          describe "#valid?" do
+            it { expect(service.valid?).to be false }
+          end
+
+          describe "messages" do
+            it { expect(service.messages).to eql ["Date QTS or EYTS standards met must be a valid date"] }
+          end
+        end
+
         context "When row is invalid" do
           let(:row) do
             Row.new({


### PR DESCRIPTION
### Context

When bulk recommending trainees, if you give dates that don’t make any sense, like ‘01/85/2022’, it’s an unhandled error. This means you’ll just see the ‘Sorry, something has gone wrong’ page, rather than specific error on the bulk recommend error CSV to correct your mistake.

This PR fixes that; adding an error and handling the issue with a popup message.

### Changes proposed in this pull request

Add new error to handle impossible date.

### Guidance to review

Add new error; try to upload an impossible date.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
