### PR TITLE
[5500] Fix "Re-request for TRN" button

### DIFF
--- a/app/controllers/system_admin/pending_trns/request_trns_controller.rb
+++ b/app/controllers/system_admin/pending_trns/request_trns_controller.rb
@@ -3,7 +3,7 @@
 module SystemAdmin
   module PendingTrns
     class RequestTrnsController < BaseController
-      def create
+      def update
         trn_request.destroy!
 
         trn_request = Dqt::RegisterForTrnJob.perform_now(trainee.reload)

--- a/app/controllers/system_admin/pending_trns_controller.rb
+++ b/app/controllers/system_admin/pending_trns_controller.rb
@@ -5,7 +5,7 @@ module SystemAdmin
     add_flash_types :dqt_error
 
     def index
-      @trainees = Trainee.submitted_for_trn
+      @trainees = Trainee.includes(:dqt_trn_request).submitted_for_trn
     end
   end
 end

--- a/app/jobs/dqt/update_trainee_job.rb
+++ b/app/jobs/dqt/update_trainee_job.rb
@@ -22,7 +22,7 @@ module Dqt
   private
 
     def trainee_updatable?(trainee)
-      VALID_STATES.include?(trainee.state)
+      VALID_STATES.include?(trainee.reload.state)
     end
   end
 end

--- a/app/views/system_admin/pending_trns/index.html.erb
+++ b/app/views/system_admin/pending_trns/index.html.erb
@@ -34,7 +34,7 @@
                                   class: "govuk-!-margin-0 govuk-button--secondary" %>
             </td>
             <td class="govuk-table__cell">
-              <%= govuk_button_to "Re-request for TRN",
+              <%= govuk_button_to "Re-submit for TRN",
                                   pending_trns_request_trn_path(trainee),
                                   method: :put,
                                   class: "govuk-!-margin-0 govuk-button--secondary" %>

--- a/app/views/system_admin/pending_trns/index.html.erb
+++ b/app/views/system_admin/pending_trns/index.html.erb
@@ -25,7 +25,7 @@
             <td class="govuk-table__cell"><%= trainee.first_names %></td>
             <td class="govuk-table__cell"><%= trainee.last_name %></td>
             <td class="govuk-table__cell">
-              <%= (Date.current - trainee.dqt_trn_request.created_at.to_date).to_i %>
+              <%= (Date.current - trainee.dqt_trn_request.created_at.to_date).to_i if trainee.dqt_trn_request.present? %>
             </td>
             <td class="govuk-table__cell">
               <%= govuk_button_to "Check for TRN",
@@ -35,8 +35,8 @@
             </td>
             <td class="govuk-table__cell">
               <%= govuk_button_to "Re-request for TRN",
-                                  pending_trns_request_trns_path(trainee),
-                                  method: :post,
+                                  pending_trns_request_trn_path(trainee),
+                                  method: :put,
                                   class: "govuk-!-margin-0 govuk-button--secondary" %>
             </td>
           </tr>

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -64,7 +64,7 @@ module SystemAdminRoutes
 
         namespace :pending_trns, path: "pending-trns" do
           resources :retrieve_trns, only: %i[update], path: "retrieve-trns"
-          resources :request_trns, only: %i[create], path: "request-trns"
+          resources :request_trns, only: %i[update], path: "request-trns"
         end
       end
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -403,6 +403,8 @@ FactoryBot.define do
       submitted_for_trn_at { Time.zone.now }
       state { "submitted_for_trn" }
       submission_ready
+
+      association :dqt_trn_request
     end
 
     trait :trn_received do

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -403,8 +403,12 @@ FactoryBot.define do
       submitted_for_trn_at { Time.zone.now }
       state { "submitted_for_trn" }
       submission_ready
+    end
 
-      association :dqt_trn_request
+    trait :with_dqt_trn_request do
+      after(:create) do |trainee|
+        create(:dqt_trn_request, trainee:)
+      end
     end
 
     trait :trn_received do

--- a/spec/features/system_admin/pending_trns/pending_trns_spec.rb
+++ b/spec/features/system_admin/pending_trns/pending_trns_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "pending TRNs" do
+  let(:user) { create(:user, system_admin: true) }
+  let(:trainee) { create(:trainee, :submitted_for_trn, first_names: "James Blint", id: 10001) }
+  let(:trn_request) { trainee.dqt_trn_request }
+
+  before do
+    given_i_am_authenticated(user:)
+    and_i_have_a_trainee_with_a_pending_trn
+    when_i_visit_the_pending_trns_page
+  end
+
+  scenario "shows pending TRNs page" do
+    then_i_see_the_pending_trns_page
+    and_i_see_the_trainee
+  end
+
+  scenario "can check for TRN" do
+    then_i_see_the_pending_trns_page
+    when_i_click_check_for_trn
+    then_i_see_the_pending_trns_page
+  end
+
+  scenario "can resubmit for TRN" do
+    then_i_see_the_pending_trns_page
+    when_i_click_resubmit_for_trn
+    then_i_see_the_pending_trns_page
+  end
+
+  def and_i_have_a_trainee_with_a_pending_trn
+    allow(Dqt::RegisterForTrnJob).to receive(:perform_now).and_return(
+      OpenStruct.new(
+        failed?: false,
+      ),
+    )
+    trainee
+  end
+
+  def when_i_visit_the_pending_trns_page
+    admin_pending_trns_page.load
+  end
+
+  def then_i_see_the_pending_trns_page
+    expect(admin_pending_trns_page).to have_text("Trainees Pending TRN")
+  end
+
+  def and_i_see_the_trainee
+    expect(admin_pending_trns_page).to have_text(trainee.first_names)
+    expect(admin_pending_trns_page).to have_text(trainee.last_name)
+  end
+
+  def when_i_click_check_for_trn
+    expect(Dqt::RetrieveTrn).to receive(:call).with(trn_request:)
+    admin_pending_trns_page.check_for_trn_button.click
+  end
+
+  def when_i_click_resubmit_for_trn
+    expect(Dqt::RegisterForTrnJob).to receive(:perform_now).with(trainee)
+    admin_pending_trns_page.resumbit_for_trn_button.click
+  end
+end

--- a/spec/features/system_admin/pending_trns/pending_trns_spec.rb
+++ b/spec/features/system_admin/pending_trns/pending_trns_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 feature "pending TRNs" do
   let(:user) { create(:user, system_admin: true) }
-  let(:trainee) { create(:trainee, :submitted_for_trn, first_names: "James Blint", id: 10001) }
+  let(:trainee) { create(:trainee, :submitted_for_trn, :with_dqt_trn_request, first_names: "James Blint", id: 10001) }
   let(:trn_request) { trainee.dqt_trn_request }
 
   before do

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -402,6 +402,10 @@ module Features
       @admin_dead_jobs_dqt_update_trainee ||= PageObjects::SystemAdmin::DeadJobs::DqtUpdateTrainee.new
     end
 
+    def admin_pending_trns_page
+      @admin_pending_trns_page ||= PageObjects::SystemAdmin::PendingTrns::PendingTrnsSummary.new
+    end
+
     def admin_users_index_page
       @admin_users_index_page ||= PageObjects::SystemAdmin::Users::Index.new
     end

--- a/spec/support/page_objects/system_admin/pending_trns/pending_trns.rb
+++ b/spec/support/page_objects/system_admin/pending_trns/pending_trns.rb
@@ -7,7 +7,7 @@ module PageObjects
         set_url "/system-admin/pending_trns"
 
         element :check_for_trn_button, "button", text: "Check for TRN"
-        element :resumbit_for_trn_button, "button", text: "Re-request for TRN"
+        element :resumbit_for_trn_button, "button", text: "Re-submit for TRN"
       end
     end
   end

--- a/spec/support/page_objects/system_admin/pending_trns/pending_trns.rb
+++ b/spec/support/page_objects/system_admin/pending_trns/pending_trns.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module SystemAdmin
+    module PendingTrns
+      class PendingTrnsSummary < PageObjects::Base
+        set_url "/system-admin/pending_trns"
+
+        element :check_for_trn_button, "button", text: "Check for TRN"
+        element :resumbit_for_trn_button, "button", text: "Re-request for TRN"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

There was a bug in a previous PR https://github.com/DFE-Digital/register-trainee-teachers/pull/3303

The "Re-request for TRN" button did not function as expected.

<img width="692" alt="image" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/420873/97286d64-ce14-4c83-85c2-b0a00ae672fe">

### Changes proposed in this pull request

- Fix the broken button
- Add relevant tests
- Rename the button to "Re-submit for TRN"

### Guidance to review

- As this is an admin only feature it can be tested in production

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
