### PR TITLE
[5525][BUG FIX] Fix form degrees validation mechanism

### DIFF
--- a/app/forms/degrees_form.rb
+++ b/app/forms/degrees_form.rb
@@ -38,20 +38,20 @@ class DegreesForm
   end
 
   def degrees
-    @degrees = {}
+    slug_degree_forms_map = {}
 
     trainee.degrees.order(created_at: :asc).each do |degree|
-      @degrees[degree.slug] = DegreeForm.new(degrees_form: self, degree: degree)
+      slug_degree_forms_map[degree.slug] = DegreeForm.new(degrees_form: self, degree: degree)
     end
 
     get_store.each do |slug, attrs|
       # Initialize stored unsaved degree
-      @degrees[slug] ||= build_degree(attrs)
+      slug_degree_forms_map[slug] ||= build_degree(attrs)
       # Load any stored attributes
-      @degrees[slug].attributes = attrs
+      slug_degree_forms_map[slug].attributes = attrs
     end
 
-    @degrees.values
+    slug_degree_forms_map.values
   end
 
   def stash_degree_on_store(slug, fields)
@@ -73,7 +73,7 @@ class DegreesForm
   def missing_fields(include_degree_id: false)
     return [] if valid?
 
-    degree_forms.map do |degree_form|
+    degrees.map do |degree_form|
       degree_form.valid?
       if include_degree_id
         { degree_form.slug => degree_form.errors.attribute_names }
@@ -107,13 +107,7 @@ private
     errors.add(:degree_ids, :invalid) unless all_degrees_are_valid?
   end
 
-  def degree_forms
-    trainee.degrees.map do |degree|
-      DegreeForm.new(degrees_form: self, degree: degree)
-    end
-  end
-
   def all_degrees_are_valid?
-    degree_forms.all?(&:valid?)
+    degrees.all?(&:valid?)
   end
 end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -380,6 +380,8 @@ class Trainee < ApplicationRecord
   before_save :set_submission_ready, if: :awaiting_action?
   before_save :set_academic_cycles
 
+  after_touch :set_submission_ready, :save
+
   def hesa_student_for_collection(collection_reference)
     Hesa::Student.where(hesa_id:, collection_reference:).order(created_at: :asc).first
   end

--- a/spec/forms/degrees_form_spec.rb
+++ b/spec/forms/degrees_form_spec.rb
@@ -9,6 +9,10 @@ describe DegreesForm, type: :model do
   subject { described_class.new(trainee, form_store) }
 
   describe "validations" do
+    before do
+      allow(form_store).to receive(:get).and_return({})
+    end
+
     context "degrees" do
       before do
         subject.valid?
@@ -23,8 +27,11 @@ describe DegreesForm, type: :model do
       end
 
       context "with invalid degrees" do
+        let(:degree_form) { instance_double(DegreeForm) }
+
         before do
-          trainee.degrees << create(:degree, subject: "")
+          allow(degree_form).to receive(:valid?).and_return(false)
+          allow(subject).to receive(:degrees).and_return([degree_form])
         end
 
         it { is_expected.not_to be_valid }


### PR DESCRIPTION
### Context

The details confirmation form was not working properly when degrees where updated from the UI as the cached values were not applied to the `DegreeForm`.

### Changes proposed in this pull request

Remove thew original degree_forms method as it was not applying the values for the cache store.

Also refactor some methods to avoid the confusion between degrees and degree_forms.

### Guidance to review

Pick any TRN form the ticket and try to manually update the missing attributes.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
