### PR TITLE
terraform aks db modules name using service_name

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -7,6 +7,7 @@ module "redis-cache" {
   azure_resource_prefix = var.azure_resource_prefix
   service_short         = var.service_short
   config_short          = var.config_short
+  service_name          = var.service_name
 
   cluster_configuration_map = module.cluster_data.configuration_map
 
@@ -24,6 +25,7 @@ module "redis-queue" {
   azure_resource_prefix = var.azure_resource_prefix
   service_short         = var.service_short
   config_short          = var.config_short
+  service_name          = var.service_name
 
   cluster_configuration_map = module.cluster_data.configuration_map
 
@@ -41,6 +43,7 @@ module "postgres" {
   azure_resource_prefix = var.azure_resource_prefix
   service_short         = var.service_short
   config_short          = var.config_short
+  service_name          = var.service_name
 
   cluster_configuration_map = module.cluster_data.configuration_map
 

--- a/terraform/aks/workspace-variables/production_aks_Terrafile
+++ b/terraform/aks/workspace-variables/production_aks_Terrafile
@@ -1,3 +1,3 @@
 aks:
     source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "stable"
+    version: "testing"

--- a/terraform/aks/workspace-variables/productiondata_aks_Terrafile
+++ b/terraform/aks/workspace-variables/productiondata_aks_Terrafile
@@ -1,3 +1,3 @@
 aks:
     source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "stable"
+    version: "testing"

--- a/terraform/aks/workspace-variables/staging_aks_Terrafile
+++ b/terraform/aks/workspace-variables/staging_aks_Terrafile
@@ -1,3 +1,3 @@
 aks:
     source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "stable"
+    version: "testing"


### PR DESCRIPTION
### Context

AKS database modules will use long service name in resource name, instead of short service name.
see https://github.com/DFE-Digital/terraform-modules/pull/30

### Changes proposed in this pull request

Update aks modules to pass service_name
change aks modules using stable to testing

### Guidance to review

ran make against module branch
deploy aks_review app when above PR merged

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
