### PR TITLE
[5521] Do not show HESA trainees as incomplete with missing degree information

### DIFF
--- a/app/forms/submissions/base_validator.rb
+++ b/app/forms/submissions/base_validator.rb
@@ -33,7 +33,7 @@ module Submissions
     end
 
     def validate_degree?
-      !apply_application_and_draft? && requires_degree?
+      !trainee.hesa_record? && !apply_application_and_draft? && requires_degree?
     end
 
     def apply_application_and_draft?

--- a/db/data/20230607105025_remove_incomplete_tag_from_hesa_trainees_with_missing_degree_fields.rb
+++ b/db/data/20230607105025_remove_incomplete_tag_from_hesa_trainees_with_missing_degree_fields.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RemoveIncompleteTagFromHesaTraineesWithMissingDegreeFields < ActiveRecord::Migration[7.0]
+  def up
+    Trainee.incomplete.imported_from_hesa.find_each do |trainee|
+      trainee.send(:set_submission_ready)
+      trainee.save
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/forms/submissions/missing_data_validator_spec.rb
+++ b/spec/forms/submissions/missing_data_validator_spec.rb
@@ -63,6 +63,16 @@ module Submissions
           end
         end
       end
+
+      context "HESA trainee with degree having missing fields" do
+        let(:trainee) { create(:trainee, :submitted_with_start_date, :imported_from_hesa) }
+
+        before { Degree.create(trainee: trainee, locale_code: :uk) }
+
+        it "doesn't cause validation errors" do
+          expect(subject.valid?).to be(true)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
This is because a lot of this information is optional over HESA. However, these trainees were still able to get a TRN, so we do not think we should be flagging this as incomplete, until we can make this information compulsory for 2024-2025.

### Changes proposed in this pull request
- Modify `Submissions::BaseValidator` so it ignores degree validation for HESA trainees
- Data migration to recalculate `Trainee#submission_ready`

### Guidance to review
- Data migration affects about 300 trainees

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
