### PR TITLE
[5545] - Update HESA Trainees Importer

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -200,8 +200,6 @@ class Trainee < ApplicationRecord
     message: I18n.t("activerecord.errors.models.trainee.attributes.training_route"),
   }
 
-  validates :hesa_id, uniqueness: true, allow_nil: true # rubocop:disable Rails/UniqueValidationWithoutIndex
-
   enum training_route: TRAINING_ROUTES
 
   enum training_initiative: ROUTE_INITIATIVES


### PR DESCRIPTION
### Context

Update the behaviour of HESA importer for trainees.

### Changes proposed in this pull request

The following new rules will apply to the importer:

- if the ITT start date has changed and if the trainee is ‘withdrawn’ or ‘awarded’ in Register THEN create a new record
- if the ITT start date has changed and if the trainee is not in ‘withdrawn’ or ‘awarded’ in Register THEN update the record as normal
- if the ITT start date has not changed and if the trainee is ‘withdrawn’ or ‘awarded’ in Register THEN do not create a new record and do not update the record
- if the ITT start date has not changed and if the trainee is not in ‘withdrawn’ or ‘awarded’ in Register THEN update the record as norma

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
