### PR TITLE
[5546] - Update training initiatives

### DIFF
--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -2,7 +2,7 @@
 
 module FundingHelper
   def training_initiative_options
-    (ROUTE_INITIATIVES_ENUMS.values - ["no_initiative"]).sort
+    (ROUTE_INITIATIVES_ENUMS.values - %w[no_initiative troops_to_teachers maths_physics_chairs_programme_researchers_in_schools]).sort
   end
 
   def funding_options(trainee)

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -23,6 +23,8 @@ ROUTE_INITIATIVES_ENUMS = {
   maths_physics_chairs_programme_researchers_in_schools: "maths_physics_chairs_programme_researchers_in_schools",
   future_teaching_scholars: "future_teaching_scholars",
   no_initiative: "no_initiative",
+  veterans_teaching_undergraduate_bursary: "veterans_teaching_undergraduate_bursary",
+  international_relocation_payment: "international_relocation_payment",
 }.freeze
 
 TRAINING_ROUTES = {
@@ -48,6 +50,8 @@ ROUTE_INITIATIVES = {
   ROUTE_INITIATIVES_ENUMS[:transition_to_teach] => 3,
   ROUTE_INITIATIVES_ENUMS[:no_initiative] => 4,
   ROUTE_INITIATIVES_ENUMS[:troops_to_teachers] => 5,
+  ROUTE_INITIATIVES_ENUMS[:veterans_teaching_undergraduate_bursary] => 6,
+  ROUTE_INITIATIVES_ENUMS[:international_relocation_payment] => 7,
 }.freeze
 
 TRAINING_ROUTES_FOR_COURSE = TRAINING_ROUTES.select { |training_route|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1210,6 +1210,8 @@ en:
           maths_physics_chairs_programme_researchers_in_schools: Maths and Physics Chairs programme / Researchers in Schools
           future_teaching_scholars: Future Teaching Scholars
           no_initiative: Not on a training initiative
+          veterans_teaching_undergraduate_bursary: Veteran teaching undergraduate bursary
+          international_relocation_payment: International Relocation Payment
         levels:
           early_years: Early years
           primary: Primary

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -50,6 +50,8 @@ describe Trainee do
         ROUTE_INITIATIVES_ENUMS[:transition_to_teach] => 3,
         ROUTE_INITIATIVES_ENUMS[:no_initiative] => 4,
         ROUTE_INITIATIVES_ENUMS[:troops_to_teachers] => 5,
+        ROUTE_INITIATIVES_ENUMS[:veterans_teaching_undergraduate_bursary] => 6,
+        ROUTE_INITIATIVES_ENUMS[:international_relocation_payment] => 7,
       )
     end
 


### PR DESCRIPTION
### Context

Update training initiatives

### Changes proposed in this pull request

- Remove “Troops to teach” as a selectable option
- Remove “Maths and Physics/…..“ as a selectable option
- Create “Veteran teaching undergraduate bursary”
- Create “International Relocation Payment “

The trainee records with old training initiatives will remain as they are.

### Guidance to review

![Screenshot 2023-06-13 at 11 55 52](https://github.com/DFE-Digital/register-trainee-teachers/assets/1955084/66bf822b-7ee5-4441-8a10-c3685c636b6b)
![Screenshot 2023-06-13 at 11 56 41](https://github.com/DFE-Digital/register-trainee-teachers/assets/1955084/e208b018-ab3d-402e-9b15-2204fd679b44)


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
