### PR TITLE
[5559] - use DTTP codeset for country code lookup

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -189,6 +189,7 @@ module Dqt
       def find_country_code(country)
         return if country.blank?
 
+        Dttp::CodeSets::Countries::MAPPING.dig(country, :country_code) ||
         Hesa::CodeSets::Countries::MAPPING.find { |_, name| name.start_with?(country) }&.first
       end
     end

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -83,6 +83,17 @@ module Dqt
           end
         end
 
+        context "iQTS trainee East Asia" do
+          let(:trainee_attributes) { { training_route: "iqts", iqts_country: "South Korea" } }
+
+          it "sets the programme type and training country code appropriately" do
+            expect(subject["initialTeacherTraining"]).to include({
+              "trainingCountryCode" => "KR",
+              "programmeType" => "InternationalQualifiedTeacherStatus",
+            })
+          end
+        end
+
         context "itt_end_date is missing" do
           let(:hesa_metadatum) { build(:hesa_metadatum) }
           let(:trainee_attributes) { { itt_end_date: nil, hesa_metadatum: hesa_metadatum, training_route: training_route, study_mode: study_mode } }


### PR DESCRIPTION
### Context

- Several trainees are stuck retrieving a `TRN`
- Their requests failed as they were missing `trainingCountryCode`
- These are blank as `Dqt::Params::TrnRequest` uses the HESA country codeset mappings to retrieve an iqts country code

### Changes proposed in this pull request

Use DTTP codesets to retrieve the country code - this is used to build the autofill iqts country form so should match up correctly all of the time.
