### PR TITLE
Add AKS productiondata environment

### DIFF
--- a/.github/actions/deploy_v2/action.yml
+++ b/.github/actions/deploy_v2/action.yml
@@ -129,10 +129,7 @@ runs:
       if: ${{ inputs.environment == 'productiondata_aks' && env.worker_app_instances == 0 }}
       run: |
         sudo apt-get install -y redis-tools redis-server
-        redis-cli --version
-        bin/konduit.sh -h
-#       below to be confirmed
-#        bin/konduit.sh register-productiondata -- redis-cli del queues
+        bin/konduit.sh -r REDIS_QUEUE_URL register-productiondata -- redis-cli del queues
 
     - name: Run Smoke Tests for ${{ inputs.environment }}
       uses: ./.github/actions/smoke-test_v2/

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -382,3 +382,26 @@ jobs:
         environment: productiondata
         sha: ${{ github.sha }}
         slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+
+  deploy-aks-after-production:
+    name: Deployment after production v2
+    environment:
+      name: productiondata_aks
+      url: ${{ steps.deploy_app_after_production_v2.outputs.deploy-url }}
+    if: ${{ success() && github.ref == 'refs/heads/main' }}
+    needs: [deploy-aks-before-production]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Deploy app to productiondata v2
+      id: deploy_app_after_production_v2
+      uses: ./.github/actions/deploy_v2/
+      with:
+        arm-access-key: ${{ secrets.ARM_ACCESS_KEY_PRODUCTIONDATA_AKS }}
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS_PRODUCTIONDATA_AKS }}
+        environment: productiondata_aks
+        sha: ${{ github.sha }}
+        slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -12,6 +12,7 @@ on:
         options:
         - qa_aks
         - staging_aks
+        - productiondata_aks
       sha:
         description: Commit sha to be deployed
         required: true

--- a/.github/workflows/scheduled-aks-db-restore.yml
+++ b/.github/workflows/scheduled-aks-db-restore.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [qa,staging]
+        environment: [qa,staging,productiondata]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Backup and Restore action for ${{ matrix.environment }} to AKS prod cluster
-        if: matrix.environment == 'sandbox' || matrix.environment == 'prod'
+        if: matrix.environment == 'productiondata' || matrix.environment == 'production'
         id: backup_and_restore_env_prod
         uses: ./.github/actions/backup_and_restore/
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ dump.rdb
 
 bin/fetch_config.rb
 bin/terrafile
+bin/konduit.sh
 
 # Downloaded terraform modules
 terraform/aks/vendor/

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -55,4 +55,5 @@ module "postgres" {
 
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_maintenance_window       = var.azure_maintenance_window
+  azure_enable_backup_storage    = var.azure_enable_backup_storage
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -95,6 +95,7 @@ variable "main_app" {
 variable "azure_maintenance_window" { default = null }
 variable "postgres_flexible_server_sku" { default = "B_Standard_B1ms" }
 variable "postgres_enable_high_availability" { default = false }
+variable "azure_enable_backup_storage" { default = true }
 
 locals {
   app_name_suffix  = var.app_name == null ? var.paas_app_environment : var.app_name

--- a/terraform/aks/workspace-variables/productiondata_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/productiondata_aks.tfvars.json
@@ -28,6 +28,7 @@
     "start_minute": 0
   },
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "azure_enable_backup_storage": false,
   "deploy_temp_data_storage_account": true,
   "azure_tempdata_storage_account_name": "s189p01registerpdttmp",
   "azure_resource_group_name": "s189p01-rtt-pdt-rg",


### PR DESCRIPTION
### Context

Create AKS productiondata env

### Changes proposed in this pull request

Add productiondata_aks env to workflows
It will be deployed in merge to main, but failure to deploy the env will not cause a workflow failure.
Productiondata postgres db will be reloaded from the paas env db daily
No worker process.
Secrets copied from paas env, with some modifications.

### Guidance to review

make productiondata_aks deploy-plan
check workflow on merge.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
