### PR TITLE
Add aks production env to workflows

### DIFF
--- a/.github/actions/deploy_v2/action.yml
+++ b/.github/actions/deploy_v2/action.yml
@@ -131,6 +131,14 @@ runs:
         sudo apt-get install -y redis-tools redis-server
         bin/konduit.sh -r REDIS_QUEUE_URL register-productiondata -- redis-cli del queues
 
+# temporary will running alongside paas env
+    - name: Delete redis queues for production
+      shell: bash
+      if: ${{ inputs.environment == 'production_aks' && env.worker_app_instances == 0 }}
+      run: |
+        sudo apt-get install -y redis-tools redis-server
+        bin/konduit.sh -r REDIS_QUEUE_URL register-production -- redis-cli del queues
+
     - name: Run Smoke Tests for ${{ inputs.environment }}
       uses: ./.github/actions/smoke-test_v2/
       with:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -371,6 +371,29 @@ jobs:
         sha: ${{ github.sha }}
         slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
 
+  deploy-aks-production:
+    name: Production deployment v2
+    environment:
+      name: production_aks
+      url: ${{ steps.deploy_app_v2.outputs.deploy-url }}
+    if: ${{ success() && github.ref == 'refs/heads/main' }}
+    needs: [deploy-aks-before-production]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Deploy app to production v2
+      id: deploy_app_v2
+      uses: ./.github/actions/deploy_v2/
+      with:
+        arm-access-key: ${{ secrets.ARM_ACCESS_KEY_PRODUCTION_AKS }}
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS_PRODUCTION_AKS }}
+        environment: production_aks
+        sha: ${{ github.sha }}
+        slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+
   deploy-after-production:
     name: Deployment after production
     environment:
@@ -399,7 +422,7 @@ jobs:
       name: productiondata_aks
       url: ${{ steps.deploy_app_after_production_v2.outputs.deploy-url }}
     if: ${{ success() && github.ref == 'refs/heads/main' }}
-    needs: [deploy-aks-before-production]
+    needs: [deploy-aks-production]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/deploy-v2.yml
+++ b/.github/workflows/deploy-v2.yml
@@ -13,6 +13,7 @@ on:
         - qa_aks
         - staging_aks
         - productiondata_aks
+        - production_aks
       sha:
         description: Commit sha to be deployed
         required: true

--- a/.github/workflows/scheduled-aks-db-restore.yml
+++ b/.github/workflows/scheduled-aks-db-restore.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [qa,staging,productiondata]
+        environment: [qa,staging,productiondata,production]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/config/settings/production_aks.yml
+++ b/config/settings/production_aks.yml
@@ -20,7 +20,7 @@ dqt:
 
 features:
   sign_in_method: dfe-sign-in
-  basic_auth: false
+  basic_auth: true
   enable_feedback_link: true
   import_courses_from_ttapi: true
   import_applications_from_apply: true
@@ -38,8 +38,8 @@ features:
     school_direct_tuition_fee: true
     iqts: true
   google:
-    send_data_to_big_query: true
-  integrate_with_dqt: true
+    send_data_to_big_query: false
+  integrate_with_dqt: false
   hesa_trn_requests: true
   hesa_import:
     sync_collection: true
@@ -48,7 +48,3 @@ features:
     sync_teachers: true
 environment:
   name: beta
-
-google_tag_manager:
-  auth_id: XYyafYf931M1IT_2vjH8DA
-  env_id: 1

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -57,3 +57,29 @@ module "postgres" {
   azure_maintenance_window       = var.azure_maintenance_window
   azure_enable_backup_storage    = var.azure_enable_backup_storage
 }
+
+module "postgres_snapshot" {
+  count = var.snapshot_databases_to_deploy
+
+  source = "./vendor/modules/aks//aks/postgres"
+
+  name                  = "analysis"
+  namespace             = var.namespace
+  environment           = "analysis"
+  azure_resource_prefix = var.azure_resource_prefix
+  service_short         = var.service_short
+  config_short          = var.config_short
+  service_name          = var.service_name
+
+  cluster_configuration_map = module.cluster_data.configuration_map
+
+  use_azure               = true
+  azure_enable_monitoring = var.enable_monitoring
+  azure_extensions        = ["PGCRYPTO","BTREE_GIST","CITEXT","PG_TRGM"]
+  server_version          = var.postgres_version
+  azure_sku_name          = var.postgres_flexible_server_sku
+
+  azure_enable_high_availability      = false
+  azure_maintenance_window            = var.azure_maintenance_window
+  azure_enable_backup_storage         = false
+}

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -11,7 +11,7 @@ variable "paas_app_environment" {}
 
 variable "paas_app_docker_image" {}
 
-variable "paas_snapshot_databases_to_deploy" { default = 0 }
+variable "snapshot_databases_to_deploy" { default = 0 }
 
 variable "prometheus_app" { default = null }
 
@@ -123,11 +123,12 @@ locals {
   app_secrets = merge(
     local.kv_app_secrets,
     {
-      DATABASE_URL        = module.postgres.url
-      BLAZER_DATABASE_URL = module.postgres.url
-      REDIS_QUEUE_URL     = module.redis-queue.url
-      REDIS_CACHE_URL     = module.redis-cache.url
-    }
+      DATABASE_URL          = module.postgres.url
+      BLAZER_DATABASE_URL   = module.postgres.url
+      REDIS_QUEUE_URL       = module.redis-queue.url
+      REDIS_CACHE_URL       = module.redis-cache.url
+    },
+    var.snapshot_databases_to_deploy == 1 ? { ANALYSIS_DATABASE_URL = module.postgres_snapshot[0].url } : {}
   )
 }
 

--- a/terraform/aks/workspace-variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/production_aks.tfvars.json
@@ -29,6 +29,7 @@
   },
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_enable_high_availability": true,
+  "snapshot_databases_to_deploy": 1,
   "deploy_temp_data_storage_account": true,
   "azure_tempdata_storage_account_name": "s189p01registerpdtmp",
   "azure_resource_group_name": "s189p01-rtt-pd-rg",


### PR DESCRIPTION
### Context

Create AKS production env

differences from paas prod
- send_data_to_big_query: false
- integrate_with_dqt: false
- google-tag-manager removed
- extra basic auth added
- notify apikey removed from secrets

### Changes proposed in this pull request

Add production_aks env to workflows
It will be deployed in merge to main, but failure to deploy the env will not cause a workflow failure.
Production postgres db will be reloaded from the paas env db daily
Secrets copied from paas env, with some modifications.
Builds analysis postgres db.

### Guidance to review

make production_aks deploy-plan
check workflow on merge.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
