### PR TITLE
[5547] Use disability reference data for Apply imports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,8 +112,7 @@ gem "govuk_markdown"
 
 gem "mechanize" # interact with HESA
 
-# pinned to a commit as v1 doesn't contain the Doctor of Philosophy disambiguation
-gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v2.2.0"
+gem "dfe-reference-data", require: "dfe/reference_data", github: "DFE-Digital/dfe-reference-data", tag: "v2.3.0"
 
 # for sending analytics data to the analytics platform
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/dfe-reference-data.git
-  revision: 3aceede63039e0f5120898960166fc3f366e5adc
-  tag: v2.2.0
+  revision: 4ef58a61ea29102c9decd5f300984af7f446943a
+  tag: v2.3.0
   specs:
-    dfe-reference-data (2.2.0)
+    dfe-reference-data (2.3.0)
       activesupport
       tzinfo
 

--- a/app/forms/degree_form.rb
+++ b/app/forms/degree_form.rb
@@ -30,9 +30,9 @@ class DegreeForm
   validates :subject, :institution, autocomplete: true, allow_nil: true
   validates :country, autocomplete: true, allow_nil: true
 
-  validates :institution, inclusion: { in: Degrees::DfEReference::INSTITUTIONS.all.map(&:name) }, allow_nil: true
-  validates :subject, inclusion: { in: Degrees::DfEReference::SUBJECTS.all.map(&:name) }, allow_nil: true
-  validates :uk_degree, inclusion: { in: Degrees::DfEReference::TYPES.all.map(&:name) }, allow_nil: true
+  validates :institution, inclusion: { in: DfEReference::DegreesQuery::INSTITUTIONS.all.map(&:name) }, allow_nil: true
+  validates :subject, inclusion: { in: DfEReference::DegreesQuery::SUBJECTS.all.map(&:name) }, allow_nil: true
+  validates :uk_degree, inclusion: { in: DfEReference::DegreesQuery::TYPES.all.map(&:name) }, allow_nil: true
 
   validate :validate_with_degree_model
 
@@ -136,10 +136,10 @@ private
 
   def uuids
     {
-      subject_uuid: Degrees::DfEReference.find_subject(name: subject)&.id,
-      institution_uuid: Degrees::DfEReference.find_institution(name: institution)&.id,
-      uk_degree_uuid: Degrees::DfEReference.find_type(name: uk_degree)&.id,
-      grade_uuid: Degrees::DfEReference.find_grade(name: grade)&.id,
+      subject_uuid: DfEReference::DegreesQuery.find_subject(name: subject)&.id,
+      institution_uuid: DfEReference::DegreesQuery.find_institution(name: institution)&.id,
+      uk_degree_uuid: DfEReference::DegreesQuery.find_type(name: uk_degree)&.id,
+      grade_uuid: DfEReference::DegreesQuery.find_grade(name: grade)&.id,
     }
   end
 end

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -4,12 +4,12 @@ module DegreesHelper
   include ApplicationHelper
 
   def degree_type_options
-    to_enhanced_options(Degrees::DfEReference::TYPES.all) do |ref_data|
+    to_enhanced_options(DfEReference::DegreesQuery::TYPES.all) do |ref_data|
       synonyms = Array(ref_data[:match_synonyms]) + Array(ref_data[:suggestion_synonyms]) + Array(ref_data[:abbreviation])
       data = {
         "data-synonyms" => synonyms.join("|"),
         "data-append" => ref_data[:abbreviation] && tag.strong("(#{ref_data[:abbreviation]})"),
-        "data-boost" => (Degrees::DfEReference::COMMON_TYPES.include?(ref_data[:name]) ? 1.5 : 1),
+        "data-boost" => (DfEReference::DegreesQuery::COMMON_TYPES.include?(ref_data[:name]) ? 1.5 : 1),
         "data-hint" => ref_data[:hint] && tag.span(ref_data[:hint], class: "autocomplete__option--hint"),
       }.compact
       [ref_data[:name], ref_data[:name], data]
@@ -17,7 +17,7 @@ module DegreesHelper
   end
 
   def institutions_options
-    to_enhanced_options(Degrees::DfEReference::INSTITUTIONS.all) do |ref_data|
+    to_enhanced_options(DfEReference::DegreesQuery::INSTITUTIONS.all) do |ref_data|
       [ref_data[:name],
        ref_data[:name],
        { "data-synonyms" => (Array(ref_data[:match_synonyms]) + Array(ref_data[:suggestion_synonyms])).join("|") }]
@@ -25,7 +25,7 @@ module DegreesHelper
   end
 
   def subjects_options
-    to_enhanced_options(Degrees::DfEReference::SUBJECTS.all) do |ref_data|
+    to_enhanced_options(DfEReference::DegreesQuery::SUBJECTS.all) do |ref_data|
       [ref_data[:name],
        ref_data[:name],
        { "data-synonyms" => (Array(ref_data[:match_synonyms]) + Array(ref_data[:suggestion_synonyms])).join("|") }]
@@ -34,9 +34,9 @@ module DegreesHelper
 
   def grade_options(trainee)
     if current_user.system_admin? && trainee.hesa_record?
-      Degrees::DfEReference::GRADES
+      DfEReference::DegreesQuery::GRADES
     else
-      Degrees::DfEReference::SUPPORTED_GRADES_WITH_OTHER
+      DfEReference::DegreesQuery::SUPPORTED_GRADES_WITH_OTHER
     end
   end
 

--- a/app/lib/dfe_reference/degrees_query.rb
+++ b/app/lib/dfe_reference/degrees_query.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Degrees
-  class DfEReference
+module DfEReference
+  class DegreesQuery
     OTHER = "Other"
 
     COMMON_TYPES = ["Bachelor of Arts", "Bachelor of Science", "Master of Arts", "PhD"].freeze
@@ -51,7 +51,7 @@ module Degrees
       end
 
       def find_item(list_type, filters)
-        ref_dataset = Degrees::DfEReference.const_get(list_type.to_s.upcase)
+        ref_dataset = const_get(list_type.to_s.upcase)
 
         return ref_dataset.one(filters[:id]) if filters[:id].present?
 

--- a/app/lib/dfe_reference/disabilities_query.rb
+++ b/app/lib/dfe_reference/disabilities_query.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DfEReference
+  class DisabilitiesQuery
+    # See dfe-reference gem - dfe/reference_data/equality_and_diversity/disabilities.rb
+    NO_DISABILITY_UUID = "b14e142a-adfe-4646-af5d-8236b6a5b48d"
+    PREFER_NOT_TO_SAY_UUID = "d3f0f6de-b9be-4299-ade0-b40eef5d9ef2"
+    OTHER_DISABILITY_UUID = "3451285e-972b-464c-9726-84cae27b82ea"
+
+    DATA_SET = DfE::ReferenceData::EqualityAndDiversity::DISABILITIES_AND_HEALTH_CONDITIONS
+
+    class << self
+      def all
+        DATA_SET.all
+      end
+
+      def find_disability(filters)
+        return DATA_SET.one(filters[:id]) if filters[:id].present?
+
+        DATA_SET.some(filters).first if filters.any?
+      end
+    end
+  end
+end

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -159,7 +159,7 @@ module Dqt
       end
 
       def subject_code
-        DfEReference.find_subject(name: degree.subject)&.hecos_code
+        DfEReference::DegreesQuery.find_subject(name: degree.subject)&.hecos_code
       end
 
       def graduation_date

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -159,7 +159,7 @@ module Dqt
       end
 
       def subject_code
-        Degrees::DfEReference.find_subject(name: degree.subject)&.hecos_code
+        DfEReference.find_subject(name: degree.subject)&.hecos_code
       end
 
       def graduation_date
@@ -171,7 +171,7 @@ module Dqt
       def institution_ukprn
         return if degree.institution_uuid.nil?
 
-        Degrees::DfEReference::INSTITUTIONS.one(degree.institution_uuid)&.ukprn
+        DfEReference::DegreesQuery::INSTITUTIONS.one(degree.institution_uuid)&.ukprn
       end
 
       def country_code

--- a/app/models/disability.rb
+++ b/app/models/disability.rb
@@ -7,6 +7,7 @@
 #  id          :bigint           not null, primary key
 #  description :string
 #  name        :string           not null
+#  uuid        :uuid
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/app/services/degrees/create_from_csv_row.rb
+++ b/app/services/degrees/create_from_csv_row.rb
@@ -67,7 +67,7 @@ module Degrees
     end
 
     def subject
-      @subject ||= DfEReference.find_subject(name: raw_subject)
+      @subject ||= DfEReference::DegreesQuery.find_subject(name: raw_subject)
     end
 
     def raw_subject
@@ -78,16 +78,16 @@ module Degrees
     def institution
       @institution ||= begin
         institution = csv_row["Degree: UK awarding institution"]
-        DfEReference.find_institution(name: institution, ukprn: institution)
+        DfEReference::DegreesQuery.find_institution(name: institution, ukprn: institution)
       end
     end
 
     def degree_grade
-      @degree_grade ||= DfEReference.find_grade(name: csv_row["Degree: UK grade"])
+      @degree_grade ||= DfEReference::DegreesQuery.find_grade(name: csv_row["Degree: UK grade"])
     end
 
     def uk_degree_type
-      @uk_degree_type ||= DfEReference.find_type(name: csv_row["Degree: UK degree types"])
+      @uk_degree_type ||= DfEReference::DegreesQuery.find_type(name: csv_row["Degree: UK degree types"])
     end
 
     def non_uk_degree_type

--- a/app/services/degrees/create_from_hesa.rb
+++ b/app/services/degrees/create_from_hesa.rb
@@ -35,7 +35,7 @@ module Degrees
         hesa_degrees.each do |hesa_degree|
           next unless importable?(hesa_degree)
 
-          subject = DfEReference.find_subject(hecos_code: hesa_degree[:subject_one])
+          subject = DfEReference::DegreesQuery.find_subject(hecos_code: hesa_degree[:subject_one])
           degree = trainee.degrees.new(
             subject: subject&.name,
             subject_uuid: subject&.id,
@@ -52,7 +52,7 @@ module Degrees
 
     def set_country_specific_attributes(degree, hesa_degree)
       country = Hesa::CodeSets::Countries::MAPPING[hesa_degree[:country]]
-      degree_type = DfEReference.find_type(hesa_code: degree_type_hesa_code(hesa_degree))
+      degree_type = DfEReference::DegreesQuery.find_type(hesa_code: degree_type_hesa_code(hesa_degree))
 
       # Country code is not always provided, so we have to fallback to institution which is always UK based
       if uk_country?(country) || institution_hesa_code(hesa_degree).present?
@@ -75,7 +75,7 @@ module Degrees
     end
 
     def set_grade_attributes(degree, hesa_degree)
-      grade = DfEReference.find_grade(hesa_code: grade_hesa_code(hesa_degree))
+      grade = DfEReference::DegreesQuery.find_grade(hesa_code: grade_hesa_code(hesa_degree))
 
       degree.grade = grade&.name
       degree.grade_uuid = grade&.id
@@ -107,9 +107,9 @@ module Degrees
 
     def find_institution(hesa_degree)
       hesa_code = institution_hesa_code(hesa_degree)
-      institution = DfEReference.find_institution(hesa_code:)
+      institution = DfEReference::DegreesQuery.find_institution(hesa_code:)
 
-      institution || DfEReference.find_institution(name: "Other UK institution")
+      institution || DfEReference::DegreesQuery.find_institution(name: "Other UK institution")
     end
   end
 end

--- a/app/services/degrees/map_from_apply.rb
+++ b/app/services/degrees/map_from_apply.rb
@@ -81,7 +81,7 @@ module Degrees
       if grade
         { grade: grade.name, grade_uuid: grade.id, other_grade: nil }
       else
-        { grade: Degrees::DfEReference::OTHER, grade_uuid: nil, other_grade: attributes["grade"] }
+        { grade: DfEReference::DegreesQuery::OTHER, grade_uuid: nil, other_grade: attributes["grade"] }
       end
     end
 
@@ -94,27 +94,27 @@ module Degrees
     end
 
     def find_dfe_reference_subject
-      DfEReference.find_subject(uuid: attributes["subject_uuid"],
-                                name: attributes["subject"],
-                                hecos_code: attributes["hesa_degsbj"])
+      DfEReference::DegreesQuery.find_subject(uuid: attributes["subject_uuid"],
+                                              name: attributes["subject"],
+                                              hecos_code: attributes["hesa_degsbj"])
     end
 
     def find_dfe_reference_type
-      DfEReference.find_type(uuid: attributes["degree_type_uuid"],
-                             abbreviation: attributes["qualification_type"],
-                             hesa_code: attributes["hesa_degtype"])
+      DfEReference::DegreesQuery.find_type(uuid: attributes["degree_type_uuid"],
+                                           abbreviation: attributes["qualification_type"],
+                                           hesa_code: attributes["hesa_degtype"])
     end
 
     def find_dfe_reference_institution
-      DfEReference.find_institution(uuid: attributes["institution_uuid"],
-                                    name: attributes["institution_details"].split(",").first,
-                                    hesa_code: attributes["hesa_degest"])
+      DfEReference::DegreesQuery.find_institution(uuid: attributes["institution_uuid"],
+                                                  name: attributes["institution_details"].split(",").first,
+                                                  hesa_code: attributes["hesa_degest"])
     end
 
     def find_dfe_reference_grade
-      DfEReference.find_grade(uuid: attributes["grade_uuid"],
-                              name: attributes["grade"],
-                              hesa_code: attributes["hesa_degclss"])
+      DfEReference::DegreesQuery.find_grade(uuid: attributes["grade_uuid"],
+                                            name: attributes["grade"],
+                                            hesa_code: attributes["hesa_degclss"])
     end
 
     def country

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -137,7 +137,8 @@ module Trainees
     end
 
     def not_provided?
-      disability_uuids.include?(DfEReference::DisabilitiesQuery::PREFER_NOT_TO_SAY_UUID)
+      disability_uuids.blank? ||
+        disability_uuids.include?(DfEReference::DisabilitiesQuery::PREFER_NOT_TO_SAY_UUID)
     end
 
     def no_disabilities?

--- a/app/views/trainees/degrees/_uk_degree_form.html.erb
+++ b/app/views/trainees/degrees/_uk_degree_form.html.erb
@@ -59,7 +59,7 @@
         classes: "degree-grade") do %>
 
     <% grade_options(@trainee).all.each_with_index do |item, index| %>
-      <% if item[:name] == Degrees::DfEReference::OTHER %>
+      <% if item[:name] == DfEReference::DegreesQuery::OTHER %>
         <%= f.govuk_radio_button :grade, item[:name], label: { text: item[:name] } do %>
           <%= f.govuk_text_field :other_grade, label: { text: "Enter the degree grade" }, width: "two-thirds" %>
         <% end %>

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -70,6 +70,7 @@
   :disabilities:
   - name
   - description
+  - uuid
   :dttp_accounts:
   - id
   - dttp_id

--- a/db/data/20220803141230_backfill_missing_degree_uuids.rb
+++ b/db/data/20220803141230_backfill_missing_degree_uuids.rb
@@ -6,7 +6,7 @@ class BackfillMissingDegreeUuids < ActiveRecord::Migration[6.1]
       uuid_attribute = "#{attribute}_uuid"
       Degree.uk.where.not(attribute => nil).where(uuid_attribute => nil).each do |degree|
         find_method_name = attribute == :uk_degree ? :find_type : "find_#{attribute}"
-        attribute_uuid = Degrees::DfEReference.public_send(find_method_name, name: degree[attribute])&.id
+        attribute_uuid = DfEReference::DegreesQuery.public_send(find_method_name, name: degree[attribute])&.id
         degree.update_column(uuid_attribute, attribute_uuid) if attribute_uuid
       end
     end

--- a/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
+++ b/db/data/20221025133503_add_other_to_no_country_no_institution_degrees.rb
@@ -16,7 +16,7 @@ class AddOtherToNoCountryNoInstitutionDegrees < ActiveRecord::Migration[6.1]
 private
 
   def institution
-    ::Degrees::DfEReference.find_institution(name: "Other UK institution")
+    DfEReference::DegreesQuery.find_institution(name: "Other UK institution")
   end
 
   def degrees

--- a/db/data/20221025155728_backfill_uk_degrees_with_other_institution.rb
+++ b/db/data/20221025155728_backfill_uk_degrees_with_other_institution.rb
@@ -15,7 +15,7 @@ class BackfillUkDegreesWithOtherInstitution < ActiveRecord::Migration[6.1]
 private
 
   def institution
-    ::Degrees::DfEReference.find_institution(name: "Other UK institution")
+    DfEReference::DegreesQuery.find_institution(name: "Other UK institution")
   end
 
   def degrees

--- a/db/data/20230123100908_fix_unmapped_trainee_degree_subjects.rb
+++ b/db/data/20230123100908_fix_unmapped_trainee_degree_subjects.rb
@@ -16,7 +16,7 @@ class FixUnmappedTraineeDegreeSubjects < ActiveRecord::Migration[7.0]
       degree_subject_hesa_codes.each do |subject_hesa_code|
         next unless UNKNOWN_NOT_APPLICABLE_SUBJECT_HESA_CODES.include?(subject_hesa_code)
 
-        subject = Degrees::DfEReference.find_subject(hecos_code: subject_hesa_code)
+        subject = DfEReference::DegreesQuery.find_subject(hecos_code: subject_hesa_code)
         degree.subject = subject&.name
         degree.subject_uuid = subject&.id
         degree.save

--- a/db/data/20230612133512_backfill_disability_uuids_from_dfe_reference_gem.rb
+++ b/db/data/20230612133512_backfill_disability_uuids_from_dfe_reference_gem.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BackfillDisabilityUuidsFromDfEReferenceGem < ActiveRecord::Migration[7.0]
+  def up
+    DfEReference::DisabilitiesQuery.all.each do |reference_data|
+      name = Hesa::CodeSets::Disabilities::MAPPING[reference_data.hesa_code]
+      disability = Disability.find_by(name:)
+      disability&.update(uuid: reference_data.id)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20230612131445_add_uuid_to_disabilities.rb
+++ b/db/migrate/20230612131445_add_uuid_to_disabilities.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUuidToDisabilities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :disabilities, :uuid, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_12_131445) do
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
-  enable_extension "uuid-ossp"
 
   create_table "academic_cycles", force: :cascade do |t|
     t.date "start_date", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -249,9 +249,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_12_131445) do
     t.index ["uuid"], name: "index_courses_on_uuid", unique: true
   end
 
-  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
-  end
-
   create_table "degrees", force: :cascade do |t|
     t.integer "locale_code", null: false
     t.string "uk_degree"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_21_101632) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_12_131445) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "academic_cycles", force: :cascade do |t|
     t.date "start_date", null: false
@@ -231,9 +232,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_21_101632) do
     t.integer "duration_in_years", null: false
     t.string "course_length"
     t.integer "qualification", null: false
+    t.integer "level", null: false
     t.integer "route", null: false
     t.string "summary", null: false
-    t.integer "level", null: false
     t.string "accredited_body_code", null: false
     t.integer "min_age"
     t.integer "max_age"
@@ -247,6 +248,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_21_101632) do
     t.index ["code", "accredited_body_code"], name: "index_courses_on_code_and_accredited_body_code"
     t.index ["recruitment_cycle_year"], name: "index_courses_on_recruitment_cycle_year"
     t.index ["uuid"], name: "index_courses_on_uuid", unique: true
+  end
+
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "degrees", force: :cascade do |t|
@@ -279,6 +283,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_21_101632) do
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "uuid"
     t.index ["name"], name: "index_disabilities_on_name", unique: true
   end
 
@@ -667,8 +672,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_21_101632) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "dttp_id"
-    t.boolean "apply_sync_enabled", default: false
     t.string "code"
+    t.boolean "apply_sync_enabled", default: false
     t.string "ukprn"
     t.string "accreditation_id"
     t.index ["accreditation_id"], name: "index_providers_on_accreditation_id", unique: true
@@ -781,14 +786,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_21_101632) do
     t.text "course_subject_two"
     t.text "course_subject_three"
     t.datetime "awarded_at", precision: nil
-    t.boolean "applying_for_bursary"
     t.integer "training_initiative"
+    t.boolean "applying_for_bursary"
     t.integer "bursary_tier"
     t.integer "study_mode"
     t.boolean "ebacc", default: false
     t.string "region"
-    t.integer "course_education_phase"
     t.boolean "applying_for_scholarship"
+    t.integer "course_education_phase"
     t.boolean "applying_for_grant"
     t.uuid "course_uuid"
     t.boolean "lead_school_not_applicable", default: false

--- a/spec/factories/degrees.rb
+++ b/spec/factories/degrees.rb
@@ -12,21 +12,21 @@ FactoryBot.define do
 
     trait :uk_degree_type do
       locale_code { :uk }
-      uk_degree { uk_degree_uuid && Degrees::DfEReference::TYPES.one(uk_degree_uuid).name }
+      uk_degree { uk_degree_uuid && DfEReference::DegreesQuery::TYPES.one(uk_degree_uuid).name }
       uk_degree_uuid do
-        Degrees::DfEReference::TYPES.all.reject { |type| type[:name].include?("Foundation") }.sample.id
+        DfEReference::DegreesQuery::TYPES.all.reject { |type| type[:name].include?("Foundation") }.sample.id
       end
     end
 
     trait :uk_degree_with_details do
       uk_degree_type
 
-      subject_uuid { Degrees::DfEReference::SUBJECTS.all.sample.id }
-      grade_uuid { Degrees::DfEReference::SUPPORTED_GRADES_WITH_OTHER.all.sample.id }
+      subject_uuid { DfEReference::DegreesQuery::SUBJECTS.all.sample.id }
+      grade_uuid { DfEReference::DegreesQuery::SUPPORTED_GRADES_WITH_OTHER.all.sample.id }
       institution_uuid { DfE::ReferenceData::Degrees::INSTITUTIONS.all.sample.id }
 
-      subject { subject_uuid && Degrees::DfEReference::SUBJECTS.one(subject_uuid).name }
-      grade { grade_uuid && Degrees::DfEReference::SUPPORTED_GRADES_WITH_OTHER.one(grade_uuid).name }
+      subject { subject_uuid && DfEReference::DegreesQuery::SUBJECTS.one(subject_uuid).name }
+      grade { grade_uuid && DfEReference::DegreesQuery::SUPPORTED_GRADES_WITH_OTHER.one(grade_uuid).name }
       institution { institution_uuid && DfE::ReferenceData::Degrees::INSTITUTIONS.one(institution_uuid).name }
 
       graduation_year { rand(NEXT_YEAR - Degree::MAX_GRAD_YEARS..NEXT_YEAR) }
@@ -40,15 +40,15 @@ FactoryBot.define do
 
     trait :non_uk_degree_with_details do
       non_uk_degree_type
-      subject { Degrees::DfEReference::SUBJECTS.all.sample.name }
-      grade { Degrees::DfEReference::SUPPORTED_GRADES_WITH_OTHER.all.sample.name }
+      subject { DfEReference::DegreesQuery::SUBJECTS.all.sample.name }
+      grade { DfEReference::DegreesQuery::SUPPORTED_GRADES_WITH_OTHER.all.sample.name }
       country { Dttp::CodeSets::Countries::MAPPING.keys.sample }
       graduation_year { rand(NEXT_YEAR - Degree::MAX_GRAD_YEARS..NEXT_YEAR) }
     end
 
     trait :uk_foundation do
       transient do
-        degree_type { Degrees::DfEReference::TYPES.all.select { |type| type[:name].include?("Foundation") }.sample }
+        degree_type { DfEReference::DegreesQuery::TYPES.all.select { |type| type[:name].include?("Foundation") }.sample }
       end
 
       locale_code { :uk }

--- a/spec/forms/degree_form_spec.rb
+++ b/spec/forms/degree_form_spec.rb
@@ -115,7 +115,7 @@ describe DegreeForm, type: :model do
       let(:degree) { trainee.degrees.first }
 
       before do
-        degree.institution = Degrees::DfEReference::INSTITUTIONS.all.sample.name
+        degree.institution = DfEReference::DegreesQuery::INSTITUTIONS.all.sample.name
       end
 
       it "deletes the invalid degree" do
@@ -126,10 +126,10 @@ describe DegreeForm, type: :model do
     end
 
     context "UUID attributes" do
-      let(:dfe_institution) { Degrees::DfEReference::INSTITUTIONS.all.sample }
-      let(:dfe_subject) { Degrees::DfEReference::SUBJECTS.all.sample }
-      let(:dfe_type) { Degrees::DfEReference::TYPES.all.sample }
-      let(:dfe_grade) { Degrees::DfEReference::GRADES.all.sample }
+      let(:dfe_institution) { DfEReference::DegreesQuery::INSTITUTIONS.all.sample }
+      let(:dfe_subject) { DfEReference::DegreesQuery::SUBJECTS.all.sample }
+      let(:dfe_type) { DfEReference::DegreesQuery::TYPES.all.sample }
+      let(:dfe_grade) { DfEReference::DegreesQuery::GRADES.all.sample }
 
       let(:degree) do
         build(:degree,

--- a/spec/helpers/degree_helper_spec.rb
+++ b/spec/helpers/degree_helper_spec.rb
@@ -12,7 +12,7 @@ describe DegreesHelper do
     let(:suggestion_synonym) { "Bachelor" }
 
     before do
-      stub_const("Degrees::DfEReference::TYPES",
+      stub_const("DfEReference::DegreesQuery::TYPES",
                  DfE::ReferenceData::HardcodedReferenceList.new({
                    SecureRandom.uuid => {
                      name: degree_type,
@@ -21,7 +21,7 @@ describe DegreesHelper do
                      suggestion_synonyms: [suggestion_synonym],
                    },
                  }))
-      stub_const("Degrees::DfEReference::COMMON_TYPES", [degree_type])
+      stub_const("DfEReference::DegreesQuery::COMMON_TYPES", [degree_type])
     end
 
     it "iterates over array and prints out correct degree options" do
@@ -46,7 +46,7 @@ describe DegreesHelper do
     let(:match_synonym) { "UCL" }
 
     before do
-      stub_const("Degrees::DfEReference::INSTITUTIONS",
+      stub_const("DfEReference::DegreesQuery::INSTITUTIONS",
                  DfE::ReferenceData::HardcodedReferenceList.new({
                    SecureRandom.uuid => {
                      name: institution,
@@ -70,7 +70,7 @@ describe DegreesHelper do
     let(:match_synonym) { "Maths" }
 
     before do
-      stub_const("Degrees::DfEReference::SUBJECTS",
+      stub_const("DfEReference::DegreesQuery::SUBJECTS",
                  DfE::ReferenceData::HardcodedReferenceList.new({
                    SecureRandom.uuid => {
                      name: degree_subject,

--- a/spec/lib/dfe_reference/degrees_query_spec.rb
+++ b/spec/lib/dfe_reference/degrees_query_spec.rb
@@ -2,11 +2,11 @@
 
 require "rails_helper"
 
-module Degrees
-  describe DfEReference do
+module DfEReference
+  describe DegreesQuery do
     describe ".find_subject" do
       let(:degree_subject) do
-        Degrees::DfEReference::SUBJECTS.all.find { |item| item[:hecos_code].present? }
+        DfEReference::DegreesQuery::SUBJECTS.all.find { |item| item[:hecos_code].present? }
       end
 
       it "can find the subject by UUID" do
@@ -24,7 +24,7 @@ module Degrees
 
     describe ".find_type" do
       let(:degree_type) do
-        Degrees::DfEReference::TYPES.all.find do |item|
+        DfEReference::DegreesQuery::TYPES.all.find do |item|
           item[:hesa_itt_code].present? && item[:abbreviation].present?
         end
       end
@@ -48,7 +48,7 @@ module Degrees
 
     describe ".find_institution" do
       let(:degree_institution) do
-        Degrees::DfEReference::INSTITUTIONS.all.find { |item| item[:hesa_itt_code].present? }
+        DfEReference::DegreesQuery::INSTITUTIONS.all.find { |item| item[:hesa_itt_code].present? }
       end
 
       it "can find the institution by UUID" do
@@ -66,7 +66,7 @@ module Degrees
 
     describe ".find_grade" do
       let(:degree_grade) do
-        Degrees::DfEReference::SUPPORTED_GRADES_WITH_OTHER.all.find { |item| item[:hesa_code].present? }
+        DfEReference::DegreesQuery::SUPPORTED_GRADES_WITH_OTHER.all.find { |item| item[:hesa_code].present? }
       end
 
       it "can find the grade by UUID" do

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -7,7 +7,7 @@ module Dqt
     describe TrnRequest do
       let(:trainee_attributes) { {} }
       let(:degree) { build(:degree, :uk_degree_with_details) }
-      let(:hesa_code) { Degrees::DfEReference::SUBJECTS.all.find { _1.name == degree.subject }&.hecos_code }
+      let(:hesa_code) { DfEReference::DegreesQuery::SUBJECTS.all.find { _1.name == degree.subject }&.hecos_code }
       let(:hesa_metadatum) { build(:hesa_metadatum) }
       let(:trainee) do
         create(:trainee,
@@ -149,7 +149,7 @@ module Dqt
         end
 
         it "returns a hash including degree attributes" do
-          allow(Degrees::DfEReference::INSTITUTIONS).to receive(:one).with(degree.institution_uuid).and_return(double(ukprn: "12345678"))
+          allow(DfEReference::DegreesQuery::INSTITUTIONS).to receive(:one).with(degree.institution_uuid).and_return(double(ukprn: "12345678"))
 
           expect(subject["qualification"]).to include({
             "providerUkprn" => "12345678",
@@ -189,7 +189,7 @@ module Dqt
           let(:degree) { build(:degree, :uk_degree_with_details, institution_uuid: nil) }
 
           before do
-            allow(Degrees::DfEReference::INSTITUTIONS).to receive(:one).with(nil).and_return(nil)
+            allow(DfEReference::DegreesQuery::INSTITUTIONS).to receive(:one).with(nil).and_return(nil)
           end
 
           it "sets the providerUkprn to nil" do

--- a/spec/lib/dqt/params/update_spec.rb
+++ b/spec/lib/dqt/params/update_spec.rb
@@ -7,8 +7,8 @@ module Dqt
     describe Update do
       let(:trainee) { create(:trainee, :completed, sex: "female", hesa_id: 1) }
       let(:degree) { trainee.degrees.first }
-      let(:hesa_code) { Degrees::DfEReference::SUBJECTS.all.find { _1.name == degree.subject }&.hecos_code }
-      let(:ukprn) { Degrees::DfEReference::INSTITUTIONS.one(degree.institution_uuid)[:ukprn] }
+      let(:hesa_code) { DfEReference::DegreesQuery::SUBJECTS.all.find { _1.name == degree.subject }&.hecos_code }
+      let(:ukprn) { DfEReference::DegreesQuery::INSTITUTIONS.one(degree.institution_uuid)[:ukprn] }
       let(:dqt_degree_type) { "BachelorOfArts" }
       let(:uk_degree_uuid) { "db695652-c197-e711-80d8-005056ac45bb" }
 

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -137,7 +137,7 @@ module Trainees
       it { is_expected.to have_attributes(course_education_phase: COURSE_EDUCATION_PHASE_ENUMS[:primary]) }
     end
 
-    context "disabilties" do
+    context "disabilities" do
       before do
         DfEReference::DisabilitiesQuery.all.each do |reference_data|
           Disability.create!(name: reference_data.name, uuid: reference_data.id)

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -161,6 +161,18 @@ module Trainees
         end
       end
 
+      context "when the application has an empty list of disabilities" do
+        let(:candidate_attributes) do
+          {
+            disabilities_and_health_conditions: [],
+          }
+        end
+
+        it "sets the disability disclosure to not provided" do
+          expect(trainee).to be_disability_not_provided
+        end
+      end
+
       context "when the application has no disabilities" do
         let(:candidate_attributes) do
           {

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -137,77 +137,107 @@ module Trainees
       it { is_expected.to have_attributes(course_education_phase: COURSE_EDUCATION_PHASE_ENUMS[:primary]) }
     end
 
-    context "when the application is diversity disclosed with disabilities" do
-      before { Disability.create!(Diversities::SEED_DISABILITIES.map(&:to_h)) }
-
-      it "adds the trainee's disabilities" do
-        expect(trainee.disabilities.map(&:name)).to match_array(["Blind", "Long-standing illness"])
+    context "disabilties" do
+      before do
+        DfEReference::DisabilitiesQuery.all.each do |reference_data|
+          Disability.create!(name: reference_data.name, uuid: reference_data.id)
+        end
       end
 
-      it "sets the diversity disclosure to disclosed" do
-        expect(trainee).to be_diversity_disclosed
+      context "when the application is diversity disclosed with disabilities" do
+        it "adds the trainee's disabilities" do
+          disability_names = trainee.disabilities.pluck(:name)
+
+          expect(disability_names).to include("Blindness or a visual impairment not corrected by glasses")
+          expect(disability_names).to include("Long-term illness")
+        end
+
+        it "sets the diversity disclosure to disclosed" do
+          expect(trainee).to be_diversity_disclosed
+        end
+
+        it "sets the disability disclosure to provided" do
+          expect(trainee).to be_disabled
+        end
       end
 
-      it "sets the disability disclosure to provided" do
-        expect(trainee).to be_disabled
-      end
-    end
-
-    context "when the application has no disabilities" do
-      let(:candidate_attributes) { { disabilities: [Diversities::NO_DISABILITY] } }
-
-      it "sets the disability disclosure to not disabled" do
-        expect(trainee).to be_no_disability
-      end
-
-      context "application is 2022 or earlier" do
-        let(:recruitment_cycle_year) { 2022 }
-        let(:candidate_attributes) { { disabilities: [] } }
+      context "when the application has no disabilities" do
+        let(:candidate_attributes) do
+          {
+            disabilities_and_health_conditions: [
+              {
+                uuid: DfEReference::DisabilitiesQuery::NO_DISABILITY_UUID,
+              },
+            ],
+          }
+        end
 
         it "sets the disability disclosure to not disabled" do
           expect(trainee).to be_no_disability
         end
+      end
 
-        context "continues to support older disability mappings" do
-          let(:candidate_attributes) { { disabilities: ["blind"] } }
+      context "when the application has no disabilities and a disability" do
+        let(:candidate_attributes) do
+          {
+            disabilities_and_health_conditions: [
+              {
+                uuid: DfEReference::DisabilitiesQuery::NO_DISABILITY_UUID,
+              },
+              {
+                name: "Blindness or a visual impairment not corrected by glasses",
+                uuid: "a31b75e7-659d-4547-9654-5fc1015ad2a5",
+              },
+            ],
+          }
+        end
 
-          it "adds the trainee's disabilities" do
-            expect(trainee.disabilities.map(&:name)).to match_array(["Blind"])
-          end
+        it "sets the disability disclosure to not disabled" do
+          expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability])
         end
       end
-    end
 
-    context "when the application has no disabilities and a disability" do
-      let(:candidate_attributes) do
-        { disabilities: ["I do not have any of these disabilities or health conditions", "Blindness or a visual impairment not corrected by glasses"] }
+      context "when the application is diversity disclosed with no disability information" do
+        let(:candidate_attributes) do
+          {
+            disabilities_and_health_conditions: [
+              {
+                uuid: DfEReference::DisabilitiesQuery::PREFER_NOT_TO_SAY_UUID,
+              },
+            ],
+          }
+        end
+
+        it "sets the disability disclosure to not provided" do
+          expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided])
+        end
       end
 
-      before { Disability.create!(Diversities::SEED_DISABILITIES.map(&:to_h)) }
+      context "when the application has a custom disability" do
+        let(:custom_disability) { "Long term pain" }
+        let(:generic_disability) do
+          DfEReference::DisabilitiesQuery.find_disability(id: DfEReference::DisabilitiesQuery::OTHER_DISABILITY_UUID)
+        end
 
-      it "sets the disability disclosure to not disabled" do
-        expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:no_disability])
-      end
-    end
+        let(:candidate_attributes) do
+          {
+            disabilities_and_health_conditions: [
+              generic_disability.to_h.merge(text: custom_disability, uuid: generic_disability.id),
+            ],
+          }
+        end
 
-    context "when the application is diversity disclosed with no disability information" do
-      let(:candidate_attributes) { { disabilities: ["Prefer not to say"] } }
+        it "sets the disability as generic" do
+          expect(trainee.disabilities.pluck(:uuid)).to include(DfEReference::DisabilitiesQuery::OTHER_DISABILITY_UUID)
+        end
 
-      it "sets the disability disclosure to not provided" do
-        expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:not_provided])
-      end
-    end
+        it "sets the disability to the custom value" do
+          expect(trainee.trainee_disabilities.pluck(:additional_disability)).to include(custom_disability)
+        end
 
-    context "when the application is has a custom disability" do
-      let(:custom_disability) { "Long term pain" }
-      let(:candidate_attributes) { { disabilities: [custom_disability] } }
-
-      it "sets the disability to the custom value" do
-        expect(trainee.disabilities.pluck(:name)).to include(custom_disability)
-      end
-
-      it "sets the disability disclosure to not provided" do
-        expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled])
+        it "sets the disability disclosure to not provided" do
+          expect(trainee.disability_disclosure).to eq(Diversities::DISABILITY_DISCLOSURE_ENUMS[:disabled])
+        end
       end
     end
 

--- a/spec/support/api_stubs/apply_api.rb
+++ b/spec/support/api_stubs/apply_api.rb
@@ -122,6 +122,20 @@ module ApiStubs
         disability_disclosure: "I am dyslexic",
         gender: "female",
         disabilities: ["Blindness or a visual impairment not corrected by glasses", "Long-term illness"],
+        disabilities_and_health_conditions: [
+          {
+            text: "",
+            hesa_code: "58",
+            name: "Blindness or a visual impairment not corrected by glasses",
+            uuid: "a31b75e7-659d-4547-9654-5fc1015ad2a5",
+          },
+          {
+            text: "",
+            hesa_code: "54",
+            name: "Long-term illness",
+            uuid: "9955ea7d-e147-4b12-8913-d0c4ec925409",
+          },
+        ],
         ethnic_group: "Asian or Asian British",
         ethnic_background: "Chinese",
       }.merge(candidate_attributes)


### PR DESCRIPTION
### Context
https://trello.com/c/pr1UWEdo/5547-l-add-disability-reference-data-to-register

### Changes proposed in this pull request
- Rename `Degrees::DfEReference` to `DfEReference::DegreesQuery`. This class is actually not a service like the other services with a `call` method. Moving it into `lib` because more classes will be added under the namespace `DfEReference`
- Update `Trainees::CreateFromApply` to use the newly added disability UUID's from Apply to map trainees to the `disabilities` table
- Migration to add `uuid` column to `disabilities` table
- Data migration to populate `uuid` fields
 



### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
