### PR TITLE
[xxx] - Add bin/dev for easier startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ config/localhost/https/localhost.key
 config/localhost/https/localhost.crt
 .nvmrc
 .ruby-version
+.node-version
 /.idea
 
 dump.rdb

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! command -v foreman &> /dev/null
+then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
### Context

Make dev startup a little easier.

### Changes proposed in this pull request

- Add `./bin/dev` to fire up all required processes in dev (uses Procfile.dev). This comes out of the box in Rails 7.1 (if using esbuild etc which we'll probably transition into)
- Add `.node-version` to `.gitignore` for those of us who don't use ASDF. 

### Guidance to review

- You can try it out locally

### Important business (does not apply)
