### PR TITLE
Don't make DQT API update call when recommending

### DIFF
--- a/app/controllers/trainees/award_recommendations_controller.rb
+++ b/app/controllers/trainees/award_recommendations_controller.rb
@@ -3,7 +3,7 @@
 module Trainees
   class AwardRecommendationsController < BaseController
     def create
-      if OutcomeDateForm.new(trainee).save! && trainee.submission_ready?
+      if OutcomeDateForm.new(trainee, update_dqt: false).save! && trainee.submission_ready?
         trainee.recommend_for_award!
 
         Dqt::RecommendForAwardJob.perform_later(trainee)

--- a/app/forms/trainee_form.rb
+++ b/app/forms/trainee_form.rb
@@ -5,18 +5,19 @@ class TraineeForm
   include ActiveModel::AttributeAssignment
   include ActiveModel::Validations::Callbacks
 
-  attr_accessor :trainee, :user, :params, :store, :fields
+  attr_accessor :trainee, :user, :params, :store, :fields, :update_dqt
 
   delegate :id, :persisted?, to: :trainee
 
   after_validation :track_validation_error, if: -> { user.present? && errors.any? }
 
-  def initialize(trainee, params: {}, user: nil, store: FormStore)
+  def initialize(trainee, params: {}, user: nil, store: FormStore, update_dqt: true)
     @user = user
     @trainee = trainee
     @params = params
     @store = store
     @fields = compute_fields
+    @update_dqt = update_dqt
     assign_attributes(fields)
   end
 
@@ -31,7 +32,7 @@ class TraineeForm
   def save!
     if valid?
       assign_attributes_to_trainee
-      Trainees::Update.call(trainee:)
+      Trainees::Update.call(trainee:, update_dqt:)
       clear_stash
     else
       false

--- a/app/services/dqt/trainee_update.rb
+++ b/app/services/dqt/trainee_update.rb
@@ -16,7 +16,10 @@ module Dqt
 
       raise(TraineeUpdateMissingTrn, "Cannot update trainee on DQT without a trn (id: #{trainee.id})") if trainee.trn.blank?
 
-      dqt_update("/v2/teachers/update/#{trainee.trn}?birthDate=#{trainee.date_of_birth.iso8601}", payload)
+      dqt_update(
+        "/v2/teachers/update/#{trainee.trn}?birthDate=#{trainee.date_of_birth.iso8601}",
+        payload,
+      )
     end
 
   private

--- a/spec/controllers/trainees/award_recommendations_controller_spec.rb
+++ b/spec/controllers/trainees/award_recommendations_controller_spec.rb
@@ -10,7 +10,7 @@ describe Trainees::AwardRecommendationsController do
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
-    allow(OutcomeDateForm).to receive(:new).with(trainee).and_return(double(save!: true))
+    allow(OutcomeDateForm).to receive(:new).with(trainee, update_dqt: false).and_return(double(save!: true))
   end
 
   describe "#create" do


### PR DESCRIPTION
### Context

We are seeing a few dead jobs (https://www.register-trainee-teachers.service.gov.uk/system-admin/dead_jobs) that indicate a repeatedly failing Sidekiq job caused by a DQT API error that happens when we recommend a trainee. It appears to be a race condition between a call to the `update` and `itt-outcome` endpoints.

### Changes proposed in this pull request

There is already an API call to the `itt-outcome` endpoint and we should not need to make a separate call to `update`. It seems that if the calls happen in the wrong sequence we end up with a dead update job because you can't update a teacher record that has already got a QTS/EYTS date.

This PR skips the update call.

### Guidance to review

For one of the problem cases there are 3 separate updates in the audit trail with the following kinds of changes:

1. `{"outcome_date": [null, "2023-06-14"]}` - this is the one that we've changed in this PR to skip the DQT API update.
2. `{"state": [2, 3], "recommended_for_award_at": [null, "2023-06-19T00:00:00Z"]}`
3. `{"state": [3, 6], "awarded_at": [null, "2023-06-14T00:00:00.00Z"]}` - there is already logic to skip the DQT API update for this one.

Does this make sense?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
