### PR TITLE
[4979] Add funding rules for 2023/24

### DIFF
--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -411,3 +411,208 @@ GRANTS_2022_TO_2023 = [
     ],
   ),
 ].freeze
+
+BURSARIES_2023_TO_2024 = [
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_undergrad],
+    amount: 9_000,
+    allocation_subjects: [
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 27_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 25_000,
+    allocation_subjects: [
+      AllocationSubjects::GEOGRAPHY,
+      AllocationSubjects::MODERN_LANGUAGES,
+      AllocationSubjects::ANCIENT_LANGUAGES,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 20_000,
+    allocation_subjects: [
+      AllocationSubjects::BIOLOGY,
+      AllocationSubjects::DESIGN_AND_TECHNOLOGY,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 15_000,
+    allocation_subjects: [
+      AllocationSubjects::ENGLISH,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:opt_in_undergrad],
+    amount: 9_000,
+    allocation_subjects: [
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MODERN_LANGUAGES,
+      AllocationSubjects::ANCIENT_LANGUAGES,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 27_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 25_000,
+    allocation_subjects: [
+      AllocationSubjects::GEOGRAPHY,
+      AllocationSubjects::MODERN_LANGUAGES,
+      AllocationSubjects::ANCIENT_LANGUAGES,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 20_000,
+    allocation_subjects: [
+      AllocationSubjects::DESIGN_AND_TECHNOLOGY,
+      AllocationSubjects::BIOLOGY,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 15_000,
+    allocation_subjects: [
+      AllocationSubjects::ENGLISH,
+    ],
+  ),
+].freeze
+
+SCHOLARSHIPS_2023_TO_2024 = [
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 29_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+    amount: 27_000,
+    allocation_subjects: [
+      AllocationSubjects::MODERN_LANGUAGES,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 29_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_tuition_fee],
+    amount: 27_000,
+    allocation_subjects: [
+      AllocationSubjects::MODERN_LANGUAGES,
+    ],
+  ),
+].freeze
+
+GRANTS_2023_TO_2024 = [
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:early_years_salaried],
+    amount: 14_000,
+    allocation_subjects: [
+      AllocationSubjects::EARLY_YEARS_ITT,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
+    amount: 27_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
+    amount: 25_000,
+    allocation_subjects: [
+      AllocationSubjects::GEOGRAPHY,
+      AllocationSubjects::MODERN_LANGUAGES,
+      AllocationSubjects::ANCIENT_LANGUAGES,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
+    amount: 20_000,
+    allocation_subjects: [
+      AllocationSubjects::BIOLOGY,
+      AllocationSubjects::DESIGN_AND_TECHNOLOGY,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:school_direct_salaried],
+    amount: 15_000,
+    allocation_subjects: [
+      AllocationSubjects::ENGLISH,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
+    amount: 18_000,
+    allocation_subjects: [
+      AllocationSubjects::CHEMISTRY,
+      AllocationSubjects::COMPUTING,
+      AllocationSubjects::MATHEMATICS,
+      AllocationSubjects::PHYSICS,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
+    amount: 16_000,
+    allocation_subjects: [
+      AllocationSubjects::GEOGRAPHY,
+      AllocationSubjects::MODERN_LANGUAGES,
+      AllocationSubjects::ANCIENT_LANGUAGES,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
+    amount: 11_000,
+    allocation_subjects: [
+      AllocationSubjects::DESIGN_AND_TECHNOLOGY,
+      AllocationSubjects::BIOLOGY,
+    ],
+  ),
+  OpenStruct.new(
+    training_route: TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
+    amount: 6_000,
+    allocation_subjects: [
+      AllocationSubjects::ENGLISH,
+    ],
+  ),
+].freeze

--- a/db/data/20230619122848_add_funding_rules_for_20232024.rb
+++ b/db/data/20230619122848_add_funding_rules_for_20232024.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class AddFundingRulesFor20232024 < ActiveRecord::Migration[7.0]
+  def up
+    academic_cycle = AcademicCycle.for_year(2023)
+
+    BURSARIES_2023_TO_2024.each do |b|
+      bursary = FundingMethod.find_or_create_by!(
+        training_route: b.training_route,
+        amount: b.amount,
+        funding_type: FUNDING_TYPE_ENUMS[:bursary],
+        academic_cycle: academic_cycle,
+      )
+      b.allocation_subjects.map do |subject|
+        allocation_subject = AllocationSubject.find_by!(name: subject)
+        bursary.funding_method_subjects.find_or_create_by!(allocation_subject:)
+      end
+    end
+
+    SCHOLARSHIPS_2023_TO_2024.each do |s|
+      funding_method = FundingMethod.find_or_create_by!(
+        training_route: s.training_route,
+        amount: s.amount,
+        funding_type: FUNDING_TYPE_ENUMS[:scholarship],
+        academic_cycle: academic_cycle,
+      )
+      s.allocation_subjects.map do |subject|
+        allocation_subject = AllocationSubject.find_by!(name: subject)
+        funding_method.funding_method_subjects.find_or_create_by!(allocation_subject:)
+      end
+    end
+
+    GRANTS_2023_TO_2024.each do |s|
+      funding_method = FundingMethod.find_or_create_by!(
+        training_route: s.training_route,
+        amount: s.amount,
+        funding_type: FUNDING_TYPE_ENUMS[:grant],
+        academic_cycle: academic_cycle,
+      )
+      s.allocation_subjects.map do |subject|
+        allocation_subject = AllocationSubject.find_by!(name: subject)
+        funding_method.funding_method_subjects.find_or_create_by!(allocation_subject:)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -74,6 +74,12 @@ SEED_FUNDING_RULES = [
     scholarships: SCHOLARSHIPS_2022_TO_2023,
     grants: GRANTS_2022_TO_2023,
   },
+  {
+    academic_cycle: AcademicCycle.for_year(2023),
+    bursaries: BURSARIES_2023_TO_2024,
+    scholarships: SCHOLARSHIPS_2023_TO_2024,
+    grants: GRANTS_2023_TO_2024,
+  },
 ].freeze
 
 SEED_FUNDING_RULES.each do |rule|


### PR DESCRIPTION
### Context

https://trello.com/c/lRyQNdvc/4979-m-update-register-for-23-24-funding-rules

### Changes proposed in this pull request

- Adds the funding rules for 2023/24 in line with this [spreadsheet](https://educationgovuk.sharepoint.com/:x:/r/sites/TeacherServices/Shared%20Documents/Becoming%20a%20Teacher/TWD-REGISTER/4.%20Business%20Analyst/Routes,%20data%20and%20funding.xlsx?d=wfaaa7ba88b434d2681bb56a19f83aee3&csf=1&web=1&e=BRsRmZ)
- Data migration to seed environments with new values

### Guidance to review

- Create a trainee in the next academic cycle by setting the itt start date correctly (eg 11/9/2023)
- Assert the correct funding information is shown for relevant route (after completing course details)

### Notes

Language specific funding will be handled via copy in the UI, we're treating these under the general Modern Languages allocation subject to simplify things
