### PR TITLE
[5578] - Update view and LanguageSpecialismsForm for multiple selects

### DIFF
--- a/app/controllers/trainees/apply_applications/course_details_controller.rb
+++ b/app/controllers/trainees/apply_applications/course_details_controller.rb
@@ -36,9 +36,13 @@ module Trainees
       end
 
       def subject_specialism_path
-        return edit_trainee_language_specialisms_path(trainee) if specialism_type == :language
+        return edit_trainee_language_specialisms_path(trainee) if language_specialism?
 
         edit_trainee_subject_specialism_path(trainee, 1)
+      end
+
+      def language_specialism?
+        specialism_type == :language || specialism_type == :language_and_other
       end
 
       def specialism_type

--- a/app/controllers/trainees/language_specialisms_controller.rb
+++ b/app/controllers/trainees/language_specialisms_controller.rb
@@ -42,7 +42,9 @@ module Trainees
     end
 
     def language_specialism_params
-      params.fetch(:language_specialisms_form, {}).permit(language_specialisms: [])
+      params.fetch(:language_specialisms_form, {}).permit(
+        %i[course_subject_one course_subject_two course_subject_three],
+      )
     end
 
     def course_uuid

--- a/app/controllers/trainees/language_specialisms_controller.rb
+++ b/app/controllers/trainees/language_specialisms_controller.rb
@@ -4,32 +4,53 @@ module Trainees
   class LanguageSpecialismsController < BaseController
     include Publishable
 
+    before_action :setup_form
     before_action :skip_manual_selection, if: :course_has_one_language_specialism?
 
-    def edit
-      @language_specialisms_form = LanguageSpecialismsForm.new(trainee)
-    end
+    def edit; end
 
     def update
-      @language_specialisms_form = LanguageSpecialismsForm.new(trainee,
-                                                               params: language_specialism_params,
-                                                               user: current_user)
-
       if @language_specialisms_form.stash_or_save!
-        redirect_to(edit_trainee_course_details_study_mode_path(trainee))
+        redirect_to(next_path_after_update(trainee))
       else
         render(:edit)
       end
     end
 
+    def non_language_subject
+      @language_specialisms_form.non_language_subject
+    end
+
+    helper_method :non_language_subject
+
   private
+
+    def setup_form
+      @language_specialisms_form = LanguageSpecialismsForm.new(
+        trainee,
+        params: language_specialism_params,
+        user: current_user,
+      )
+    end
+
+    def next_path_after_update(trainee)
+      if non_language_subject
+        edit_trainee_subject_specialism_path(trainee, language_specialisms_count + 1)
+      else
+        edit_trainee_course_details_study_mode_path(trainee)
+      end
+    end
+
+    def language_specialisms_count
+      language_specialism_params.values.count
+    end
 
     def skip_manual_selection
       LanguageSpecialismsForm.new(trainee, params: {
         language_specialisms: subject_specialisms[:course_subject_one],
       }).stash_or_save!
 
-      redirect_to(edit_trainee_course_details_study_mode_path(trainee))
+      redirect_to(next_path_after_update(trainee))
     end
 
     def course_has_one_language_specialism?

--- a/app/controllers/trainees/language_specialisms_controller.rb
+++ b/app/controllers/trainees/language_specialisms_controller.rb
@@ -5,7 +5,6 @@ module Trainees
     include Publishable
 
     before_action :skip_manual_selection, if: :course_has_one_language_specialism?
-    before_action :load_language_specialisms
 
     def edit
       @language_specialisms_form = LanguageSpecialismsForm.new(trainee)
@@ -35,10 +34,6 @@ module Trainees
 
     def course_has_one_language_specialism?
       subject_specialisms.all? { |_, v| v.count < 2 }
-    end
-
-    def load_language_specialisms
-      @language_specialisms = PUBLISH_SUBJECT_SPECIALISM_MAPPING[PublishSubjects::MODERN_LANGUAGES]
     end
 
     def language_specialism_params

--- a/app/controllers/trainees/subject_specialisms_controller.rb
+++ b/app/controllers/trainees/subject_specialisms_controller.rb
@@ -64,8 +64,12 @@ module Trainees
     end
 
     def subject_specialisms_for_position(position)
+      # Fetch the specialisms for the given position
       specialisms = subject_specialisms[course_subject_attribute_name(position)]
 
+      # If there are no specialisms in the given position and the first
+      # course is a modern language and the position is 3, then use the
+      # specialisms for the previous position instead
       if specialisms.blank? && first_course_is_modern_language? && position == 3
         specialisms = subject_specialisms[course_subject_attribute_name(position - 1)]
       end
@@ -74,8 +78,12 @@ module Trainees
     end
 
     def subject_for_position(position)
+      # Fetch the subject for the given position
       @subject = course_subjects[position - 1]
 
+      # If there is no subject in the given position and the first course is
+      # a modern language and the position is 3, then use the subject for the
+      # previous position instead
       if @subject.blank? && first_course_is_modern_language? && position == 3
         @subject = course_subjects[position - 2]
       end

--- a/app/controllers/trainees/subject_specialisms_controller.rb
+++ b/app/controllers/trainees/subject_specialisms_controller.rb
@@ -17,7 +17,7 @@ module Trainees
         return redirect_to(next_step_path)
       end
 
-      @subject = course_subjects[position - 1]
+      @subject = subject_for_position(position)
       @subject_specialism_form = SubjectSpecialismForm.new(trainee, position)
     end
 
@@ -27,7 +27,7 @@ module Trainees
       if @subject_specialism_form.stash_or_save!
         redirect_to(next_step_path)
       else
-        @subject = course_subjects[position - 1]
+        @subject = subject_for_position(position)
         @specialisms = subject_specialisms_for_position(position)
 
         render(:edit)
@@ -64,7 +64,27 @@ module Trainees
     end
 
     def subject_specialisms_for_position(position)
-      subject_specialisms[course_subject_attribute_name(position)]
+      specialisms = subject_specialisms[course_subject_attribute_name(position)]
+
+      if specialisms.blank? && first_course_is_modern_language? && position == 3
+        specialisms = subject_specialisms[course_subject_attribute_name(position - 1)]
+      end
+
+      specialisms
+    end
+
+    def subject_for_position(position)
+      @subject = course_subjects[position - 1]
+
+      if @subject.blank? && first_course_is_modern_language? && position == 3
+        @subject = course_subjects[position - 2]
+      end
+
+      @subject
+    end
+
+    def first_course_is_modern_language?
+      course_subjects.first.downcase.include?("modern")
     end
 
     def course_subject_attribute_name(number = position)

--- a/app/forms/language_specialisms_form.rb
+++ b/app/forms/language_specialisms_form.rb
@@ -15,10 +15,11 @@ class LanguageSpecialismsForm < TraineeForm
 
   attr_accessor(*FIELDS)
 
-  validate :language_specialism_count
+  validate :language_specialism_count, :language_specialism_duplicates
 
   def initialize(trainee, params: {}, user: nil, store: FormStore)
     params.merge!(course_subjects(params[:language_specialisms]))
+
     super(trainee, params:, user:, store:)
   end
 
@@ -76,10 +77,14 @@ private
   end
 
   def language_specialism_count
-    if language_specialisms.empty?
-      errors.add(:language_specialisms, :blank)
-    elsif language_specialisms.length > 3
-      errors.add(:language_specialisms, :invalid)
+    if course_subject_one.blank?
+      errors.add(:course_subject_one, :blank)
+    end
+  end
+
+  def language_specialism_duplicates
+    if languages.count > languages.uniq.count
+      errors.add(:course_subject_one, :invalid)
     end
   end
 

--- a/app/forms/language_specialisms_form.rb
+++ b/app/forms/language_specialisms_form.rb
@@ -59,6 +59,10 @@ class LanguageSpecialismsForm < TraineeForm
     super
   end
 
+  def non_language_subject
+    @non_language_subject ||= (@trainee.published_course.subjects.map(&:name) - PUBLISH_MODERN_LANGUAGES).first
+  end
+
 private
 
   def compute_fields

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -70,7 +70,7 @@ class PublishCourseDetailsForm < TraineeForm
   end
 
   def language_specialism?
-    specialism_type == :language || specialism_type == :language_and_other
+    %i[language language_and_other].include?(specialism_type)
   end
 
   def selected_specialisms

--- a/app/forms/publish_course_details_form.rb
+++ b/app/forms/publish_course_details_form.rb
@@ -70,7 +70,7 @@ class PublishCourseDetailsForm < TraineeForm
   end
 
   def language_specialism?
-    specialism_type == :language
+    specialism_type == :language || specialism_type == :language_and_other
   end
 
   def selected_specialisms

--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -63,7 +63,19 @@ module CourseDetailsHelper
     edit_trainee_course_education_phase_path(trainee)
   end
 
+  def language_specialism_options
+    options = language_specialisms.map do |language|
+      [format_language(language).upcase_first, language]
+    end
+
+    [["", ""]] + options
+  end
+
 private
+
+  def language_specialisms
+    PUBLISH_SUBJECT_SPECIALISM_MAPPING[PublishSubjects::MODERN_LANGUAGES]
+  end
 
   def age_ranges(option:, level:)
     Dttp::CodeSets::AgeRanges::MAPPING.select { |_, attributes| attributes[:option] == option && attributes[:levels]&.include?(level&.to_sym) }.keys.map do |age_range|

--- a/app/services/calculate_subject_specialism_type.rb
+++ b/app/services/calculate_subject_specialism_type.rb
@@ -10,6 +10,7 @@ class CalculateSubjectSpecialismType
   def call
     return :primary if primary_subject?
     return :language if language_specialism?
+    return :language_and_other if any_language_specialism?
     return :single if single_subject?
 
     :multiple_subjects
@@ -23,6 +24,10 @@ private
     subject_is_modern_languages? || all_subjects_are_modern_languages?
   end
 
+  def any_language_specialism?
+    any_subjects_are_modern_languages?
+  end
+
   def primary_subject?
     single_subject? && subjects.first.include?(AllocationSubjects::PRIMARY)
   end
@@ -34,6 +39,10 @@ private
 
   def all_subjects_are_modern_languages?
     subjects.all? { |subject| PUBLISH_MODERN_LANGUAGES.include?(subject) }
+  end
+
+  def any_subjects_are_modern_languages?
+    subjects.any? { |subject| PUBLISH_MODERN_LANGUAGES.include?(subject) }
   end
 
   def single_subject?

--- a/app/services/calculate_subject_specialism_type.rb
+++ b/app/services/calculate_subject_specialism_type.rb
@@ -10,7 +10,7 @@ class CalculateSubjectSpecialismType
   def call
     return :primary if primary_subject?
     return :language if language_specialism?
-    return :language_and_other if any_language_specialism?
+    return :language_and_other if any_subjects_are_modern_languages?
     return :single if single_subject?
 
     :multiple_subjects
@@ -22,10 +22,6 @@ private
 
   def language_specialism?
     subject_is_modern_languages? || all_subjects_are_modern_languages?
-  end
-
-  def any_language_specialism?
-    any_subjects_are_modern_languages?
   end
 
   def primary_subject?

--- a/app/services/calculate_subject_specialism_type.rb
+++ b/app/services/calculate_subject_specialism_type.rb
@@ -9,7 +9,7 @@ class CalculateSubjectSpecialismType
 
   def call
     return :primary if primary_subject?
-    return :language if language_specialism?
+    return :language if language_only_specialism?
     return :language_and_other if any_subjects_are_modern_languages?
     return :single if single_subject?
 
@@ -20,7 +20,7 @@ private
 
   attr_reader :subjects
 
-  def language_specialism?
+  def language_only_specialism?
     subject_is_modern_languages? || all_subjects_are_modern_languages?
   end
 

--- a/app/views/trainees/language_specialisms/edit.html.erb
+++ b/app/views/trainees/language_specialisms/edit.html.erb
@@ -13,6 +13,7 @@
 
       <%= render TraineeName::View.new(@trainee) %>
       <div class="govuk-form-group">
+
         <%= f.govuk_check_boxes_fieldset :language_specialisms,
                                           legend: { text: t(".heading"), tag: "h1", size: "l" },
                                           classes: "language-specialisms" do %>
@@ -22,16 +23,29 @@
             <p class="govuk-body govuk-hint"><%= t(".additional_hint") %></p>
           </div>
 
-          <% sort_languages(@language_specialisms).each_with_index do |language, index| %>
-            <%= f.govuk_check_box(
-                :language_specialisms,
-                language,
-                multiple: true,
-                link_errors: index.zero?,
-                checked: f.object.languages.include?(language),
-                label: { text: format_language(language).upcase_first },
-              ) %>
-          <% end %>
+          <%=
+            f.govuk_select(
+              :course_subject_one,
+              @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
+              label: { text: "First language", size: "s" },
+            )
+          %>
+
+          <%=
+            f.govuk_select(
+              :course_subject_two,
+              @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
+              label: { text: "Second language (optional)", size: "s" },
+            )
+          %>
+
+          <%=
+            f.govuk_select(
+              :course_subject_three,
+              @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
+              label: { text: "Third language (optional)", size: "s" },
+            )
+          %>
         <% end %>
       </div>
 

--- a/app/views/trainees/language_specialisms/edit.html.erb
+++ b/app/views/trainees/language_specialisms/edit.html.erb
@@ -14,9 +14,10 @@
       <%= render TraineeName::View.new(@trainee) %>
       <div class="govuk-form-group">
 
-        <%= f.govuk_check_boxes_fieldset :language_specialisms,
-                                          legend: { text: t(".heading"), tag: "h1", size: "l" },
-                                          classes: "language-specialisms" do %>
+        <%= f.govuk_fieldset(
+          legend: { text: t(".heading"), tag: "h1", size: "l" },
+          classes: "language-specialisms"
+        ) do %>
 
           <div class="govuk-hint" id="language-language-specialisms-form-language-specialisms-hint">
             <p class="govuk-body govuk-hint"><%= t(".hint") %></p>
@@ -26,15 +27,16 @@
           <%=
             f.govuk_select(
               :course_subject_one,
-              @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
+              [["", ""]] + @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
               label: { text: "First language", size: "s" },
+              include_blank: true,
             )
           %>
 
           <%=
             f.govuk_select(
               :course_subject_two,
-              @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
+              [["", ""]] + @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
               label: { text: "Second language (optional)", size: "s" },
             )
           %>
@@ -42,7 +44,7 @@
           <%=
             f.govuk_select(
               :course_subject_three,
-              @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
+              [["", ""]] + @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
               label: { text: "Third language (optional)", size: "s" },
             )
           %>

--- a/app/views/trainees/language_specialisms/edit.html.erb
+++ b/app/views/trainees/language_specialisms/edit.html.erb
@@ -20,9 +20,19 @@
         ) do %>
 
           <div class="govuk-hint" id="language-language-specialisms-form-language-specialisms-hint">
-            <p class="govuk-body govuk-hint"><%= t(".hint") %></p>
-            <p class="govuk-body govuk-hint"><%= t(".additional_hint") %></p>
+            <% if non_language_subject.present? %>
+              <p class="govuk-body govuk-hint">
+                Choose the languages the trainee will study with <%= non_language_subject %>.
+              </p>
+              <p class="govuk-body govuk-hint">
+                Choose up to two.
+              </p>
+            <% else %>	
+              <p class="govuk-body govuk-hint"><%= t(".hint") %></p>
+              <p class="govuk-body govuk-hint"><%= t(".additional_hint") %></p>
+            <% end %>	
           </div>
+
 
           <%=
             f.govuk_select(
@@ -41,13 +51,15 @@
             )
           %>
 
-          <%=
-            f.govuk_select(
-              :course_subject_three,
-              language_specialism_options,
-              label: { text: "Third language (optional)", size: "s" },
-            )
-          %>
+          <% unless non_language_subject.present? %>
+            <%=
+              f.govuk_select(
+                :course_subject_three,
+                language_specialism_options,
+                label: { text: "Third language (optional)", size: "s" },
+              )
+            %>
+          <% end %>
         <% end %>
       </div>
 

--- a/app/views/trainees/language_specialisms/edit.html.erb
+++ b/app/views/trainees/language_specialisms/edit.html.erb
@@ -27,7 +27,7 @@
           <%=
             f.govuk_select(
               :course_subject_one,
-              [["", ""]] + @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
+              language_specialism_options,
               label: { text: "First language", size: "s" },
               include_blank: true,
             )
@@ -36,7 +36,7 @@
           <%=
             f.govuk_select(
               :course_subject_two,
-              [["", ""]] + @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
+              language_specialism_options,
               label: { text: "Second language (optional)", size: "s" },
             )
           %>
@@ -44,7 +44,7 @@
           <%=
             f.govuk_select(
               :course_subject_three,
-              [["", ""]] + @language_specialisms.map { |language| [format_language(language).upcase_first, language] },
+              language_specialism_options,
               label: { text: "Third language (optional)", size: "s" },
             )
           %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1351,9 +1351,9 @@ en:
               invalid: Enter an email address in the correct format, like name@example.com
         language_specialisms_form:
           attributes:
-            language_specialisms:
+            course_subject_one:
               blank: Select at least one language
-              invalid: Select a maximum of three languages
+              invalid: You must select different languages
         bulk_update/recommendations_upload_form:
           attributes:
             file:

--- a/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
@@ -71,7 +71,6 @@ feature "apply registrations" do
     let(:subjects) { ["Art and design"] }
 
     scenario "selecting specialisms" do
-      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
       when_i_enter_the_course_details_page
       and_i_confirm_the_course_details
       and_i_select_a_specialism("Graphic design")
@@ -85,7 +84,6 @@ feature "apply registrations" do
     let(:subjects) { ["Modern languages (other)"] }
 
     scenario "selecting languages" do
-      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
       when_i_enter_the_course_details_page
       and_i_confirm_the_course_details
       and_i_choose_my_languages

--- a/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
@@ -85,12 +85,13 @@ feature "apply registrations" do
     let(:subjects) { ["Modern languages (other)"] }
 
     scenario "selecting languages" do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
       when_i_enter_the_course_details_page
       and_i_confirm_the_course_details
       and_i_choose_my_languages
       and_i_enter_itt_dates
       then_i_am_redirected_to_the_apply_applications_confirm_course_page
-      and_i_should_see_the_subject_specialism("Modern languages")
+      and_i_should_see_the_subject_specialism("Welsh with Portuguese")
     end
   end
 
@@ -113,10 +114,6 @@ private
     Course.first.tap do |course|
       trainee.update(course_uuid: course.uuid)
     end
-  end
-
-  def given_i_am_on_an_existing_course
-    given_a_trainee_exists(:with_apply_application, :with_publish_course_details)
   end
 
   def given_the_trainee_does_not_have_a_course_uuid
@@ -168,7 +165,8 @@ private
   end
 
   def and_i_choose_my_languages
-    language_specialism_page.language_specialism_options.first.check
+    select("Welsh", from: language_specialism_page.send(:language_select_one)[:id])
+    select("Portuguese", from: language_specialism_page.send(:language_select_two)[:id])
     language_specialism_page.submit_button.click
   end
 

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -127,6 +127,28 @@ feature "publish course details", feature_publish_course_details: true do
         end
       end
 
+      context "with a course that requires selecting a non-language and language specialisms" do
+        let(:subjects) { ["Modern languages (other)", "Biology"] }
+        let!(:subject_specialism1) { create(:subject_specialism, name: "Welsh languages") }
+        let!(:subject_specialism2) { create(:subject_specialism, name: "Portuguese language") }
+        let!(:subject_specialism3) { create(:subject_specialism, name: "Biology") }
+
+        scenario "renders a 'completed' status when details fully provided" do
+          when_i_visit_the_publish_course_details_page
+          and_i_select_a_course
+          and_i_submit_the_form
+          and_i_select_languages("Welsh", "Portuguese")
+          and_i_submit_the_language_specialism_form
+          and_i_select_a_specialism("Biology")
+          and_i_submit_the_specialism_form
+          and_i_enter_itt_dates
+          then_i_should_see_the_subject_described_as("Welsh with Portuguese and biology")
+          and_i_confirm_the_course
+          and_i_visit_the_review_draft_page
+          then_the_section_should_be(completed)
+        end
+      end
+
       context "with a course that has a mixture of multiple specalism subjects single specialism ones" do
         let(:subjects) do
           [
@@ -309,10 +331,9 @@ feature "publish course details", feature_publish_course_details: true do
 
     def and_i_select_languages(*languages)
       %i[language_select_one language_select_two language_select_three].zip(languages).each do |select_element, language|
-        select(
-          language,
-          from: language_specialism_page.send(select_element)[:id],
-        )
+        if language.present?
+          select(language, from: language_specialism_page.send(select_element)[:id])
+        end
       end
     end
 

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -120,7 +120,7 @@ feature "publish course details", feature_publish_course_details: true do
           and_i_select_languages("Arabic languages", "Welsh", "Portuguese")
           and_i_submit_the_language_specialism_form
           and_i_enter_itt_dates
-          then_i_should_see_the_subject_described_as("Arabic languages with Portuguese and Welsh")
+          then_i_should_see_the_subject_described_as("Arabic languages with Welsh and Portuguese")
           and_i_confirm_the_course
           and_i_visit_the_review_draft_page
           then_the_section_should_be(completed)
@@ -256,7 +256,7 @@ feature "publish course details", feature_publish_course_details: true do
           and_i_select_languages("Arabic languages", "Welsh", "Portuguese")
           and_i_submit_the_language_specialism_form
           and_i_enter_itt_dates
-          then_i_should_see_the_subject_described_as("Arabic languages with Portuguese and Welsh")
+          then_i_should_see_the_subject_described_as("Arabic languages with Welsh and Portuguese")
         end
       end
     end
@@ -308,11 +308,12 @@ feature "publish course details", feature_publish_course_details: true do
     alias_method :when_i_select_a_course, :and_i_select_a_course
 
     def and_i_select_languages(*languages)
-      options = language_specialism_page.language_specialism_options.select do |option|
-        languages.include?(option.label.text)
+      %i[language_select_one language_select_two language_select_three].zip(languages).each do |select_element, language|
+        select(
+          language,
+          from: language_specialism_page.send(select_element)[:id],
+        )
       end
-
-      options.each { |checkbox| click(checkbox.input) }
     end
 
     def and_i_submit_the_form

--- a/spec/forms/language_specialisms_form_spec.rb
+++ b/spec/forms/language_specialisms_form_spec.rb
@@ -15,32 +15,32 @@ describe LanguageSpecialismsForm, type: :model do
 
   describe "validations" do
     context "when no subjects are supplied" do
-      let(:params) { { language_specialisms: [] } }
+      let(:params) { { course_subject_one: nil, course_subject_two: nil, course_subject_three: nil } }
 
       before do
         subject.valid?
       end
 
       it "returns an error" do
-        expect(subject.errors[:language_specialisms]).to include(
+        expect(subject.errors[:course_subject_one]).to include(
           I18n.t(
-            "activemodel.errors.models.language_specialisms_form.attributes.language_specialisms.blank",
+            "activemodel.errors.models.language_specialisms_form.attributes.course_subject_one.blank",
           ),
         )
       end
     end
 
-    context "when more than three subjects are supplied" do
-      let(:params) { { language_specialisms: %w[french german spanish mandarin] } }
+    context "when there are duplicate subjects" do
+      let(:params) { { course_subject_one: "French language", course_subject_two: "German language", course_subject_three: "French language" } }
 
       before do
         subject.valid?
       end
 
       it "returns an error" do
-        expect(subject.errors[:language_specialisms]).to include(
+        expect(subject.errors[:course_subject_one]).to include(
           I18n.t(
-            "activemodel.errors.models.language_specialisms_form.attributes.language_specialisms.invalid",
+            "activemodel.errors.models.language_specialisms_form.attributes.course_subject_one.invalid",
           ),
         )
       end
@@ -48,7 +48,7 @@ describe LanguageSpecialismsForm, type: :model do
   end
 
   context "valid trainee" do
-    let(:params) { { language_specialisms: %w[french german spanish] } }
+    let(:params) { { course_subject_one: "French language", course_subject_two: "German language", course_subject_three: "Spanish language" } }
 
     let(:trainee) { create(:trainee) }
 
@@ -57,9 +57,9 @@ describe LanguageSpecialismsForm, type: :model do
 
       it "uses FormStore to temporarily save the fields under a key combination of trainee ID and language_specialisms" do
         expect(form_store).to receive(:set).with(trainee.id, :language_specialisms, {
-          course_subject_one: params[:language_specialisms][0],
-          course_subject_three: params[:language_specialisms][2],
-          course_subject_two: params[:language_specialisms][1],
+          course_subject_one: params[:course_subject_one],
+          course_subject_two: params[:course_subject_two],
+          course_subject_three: params[:course_subject_three],
         })
 
         subject.stash

--- a/spec/support/page_objects/trainees/language_specialism.rb
+++ b/spec/support/page_objects/trainees/language_specialism.rb
@@ -2,16 +2,13 @@
 
 module PageObjects
   module Trainees
-    class LanguageSpecialismOptions < SitePrism::Section
-      element :input, "input"
-      element :label, "label"
-    end
-
     class LanguageSpecialism < PageObjects::Base
       include PageObjects::Helpers
       set_url "/trainees/{trainee_id}/language-specialisms/edit"
 
-      sections :language_specialism_options, LanguageSpecialismOptions, ".govuk-checkboxes__item"
+      element :language_select_one, "select#language-specialisms-form-course-subject-one-field"
+      element :language_select_two, "select#language-specialisms-form-course-subject-two-field"
+      element :language_select_three, "select#language-specialisms-form-course-subject-three-field"
 
       element :submit_button, "button[type='submit']"
     end


### PR DESCRIPTION
### Context

The current language specialisms form (for modern languages courses) presents a set of check boxes from which the user can select up to 3 language choices. This does not capture the priority order of the languages which will be needed for the next recruitment cycle.

### Changes proposed in this pull request

Change the UI from a field set of checkboxes to three (order significant) `select` elements.

#### Modern languages course

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/32f869c6-7ff6-4e71-b30d-b69fe918daf5)

#### Modern languages and _some other subject_ course

e.g. A fictitious Modern languages with Biology course prompts for 1-2 languages...

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/ea73b090-599a-4a84-87f9-45b099225aa1)

...followed by a Biology specialism:

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/74fc9692-6ff8-4936-92c7-a78e94f86342)

### Guidance to review

- Have I missed anything in the backend form-data mapping?
- Are there any other tests that might be useful here?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
