### PR TITLE
Change github token used for dependabot merge

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -291,7 +291,7 @@ jobs:
       - name: Merge minor dependency updates
         uses: fastify/github-action-merge-dependabot@v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.API_TOKEN_FOR_GITHUB_ACTION }}
           target: minor
           exclude: 'govuk-components,govuk_design_system_formbuilder,govuk-frontend,@ministryofjustice/frontend'
           merge-method: merge


### PR DESCRIPTION
### Context

The dependabot merge step in the build-and-deploy workflow needs to use a token with the appropriate rights,
otherwise it won't trigger a deployment on merge

### Changes proposed in this pull request

Change secret to use a valid token

### Guidance to review

Confirm workflows triggered after merge.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
