### PR TITLE
Fixes the locale key for the diversity form validator

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1424,7 +1424,7 @@ en:
           attributes:
             disability_ids:
               empty_disabilities: Select at least one disability
-        diversities/flow_validator:
+        diversities/form_validator:
           attributes:
             disclosure_section:
               not_valid: The disclosure section is not valid for this trainee


### PR DESCRIPTION
Currently breaking [this build](https://github.com/DFE-Digital/register-trainee-teachers/pull/3347), but presumably not for any reason to do with a minor version upgrade to Faker.

### Changes proposed in this pull request

Change a locale key from `flow_validator` to `form_validator`

### Guidance to review

If the tests pass, life is good.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
