### PR TITLE
[5582] Amended `current_recruitment_cycle_year` to `2023`

### DIFF
--- a/app/controllers/trainees/publish_course_details_controller.rb
+++ b/app/controllers/trainees/publish_course_details_controller.rb
@@ -55,7 +55,7 @@ module Trainees
       @year ||= params[:year].presence ||
         trainee.published_course&.recruitment_cycle_year ||
         trainee.start_academic_cycle&.start_year ||
-        Settings.current_default_course_year
+        Settings.current_recruitment_cycle_year
     end
 
     def course_uuid

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -78,7 +78,7 @@ features:
   # For the 3 months prior to an academic cycle, we're not sure
   # which year the user wants courses listed for. This feature
   # makes sure the correct year is selected before listing courses.
-  show_draft_trainee_course_year_choice: false
+  show_draft_trainee_course_year_choice: true
 dfe_sign_in:
   # Our service name
   identifier: rtt

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -94,7 +94,7 @@ apply_api:
   auth_token: "auth-token-from-env"
 
 current_recruitment_cycle_year: 2022
-current_default_course_year: 2022
+current_default_course_year: 2023
 
 apply_applications:
   import:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,7 +93,7 @@ apply_api:
   base_url: "https://www.apply-for-teacher-training.service.gov.uk/register-api"
   auth_token: "auth-token-from-env"
 
-current_recruitment_cycle_year: 2022
+current_recruitment_cycle_year: 2023
 current_default_course_year: 2023
 
 apply_applications:

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -80,9 +80,9 @@ namespace :example_data do
     REAL_PUBLISH_COURSES_WITH_SUBJECTS.values.flatten.uniq.map { |name| FactoryBot.create(:subject, name:) }
 
     recruitment_cycle_years = [
-      Settings.current_default_course_year - 1,
-      Settings.current_default_course_year,
-      Settings.current_default_course_year + 1,
+      Settings.current_recruitment_cycle_year - 1,
+      Settings.current_recruitment_cycle_year,
+      Settings.current_recruitment_cycle_year + 1,
     ]
 
     # For each persona...
@@ -177,14 +177,14 @@ namespace :example_data do
                 # Make *roughly* half of draft trainees apply drafts
                 if sample_index >= sample_size / 2
                   # Create apply drafts for *next* academic cycle
-                  courses = courses.where(recruitment_cycle_year: Settings.current_default_course_year + 1)
+                  courses = courses.where(recruitment_cycle_year: Settings.current_recruitment_cycle_year + 1)
 
                   attrs.merge!(
                     apply_application: FactoryBot.build(:apply_application, accredited_body_code: provider.code),
                   )
                 else
                   # Create manual drafts for *current* academic cycle
-                  courses = courses.where(recruitment_cycle_year: Settings.current_default_course_year)
+                  courses = courses.where(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
                 end
               end
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -65,7 +65,7 @@ FactoryBot.define do
         subjects_count { 1 }
         subject_names { [] }
         study_mode { "full_time" }
-        recruitment_cycle_year { Settings.current_default_course_year }
+        recruitment_cycle_year { Settings.current_recruitment_cycle_year }
       end
 
       before(:create) do |course, evaluator|

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :abstract_trainee, class: "Trainee" do
     transient do
       randomise_subjects { false }
-      potential_itt_start_date { itt_start_date || compute_valid_itt_start_date }
+      potential_itt_start_date { itt_start_date || compute_valid_past_itt_start_date }
     end
 
     sequence :trainee_id do |n|
@@ -65,7 +65,7 @@ FactoryBot.define do
       disabled_with_disabilites_disclosed
       training_initiative { "transition_to_teach" }
       international_address { "Test addr" }
-      itt_start_date { compute_valid_itt_start_date }
+      itt_start_date { compute_valid_past_itt_start_date }
       itt_end_date { itt_start_date + 2.years }
     end
 
@@ -228,13 +228,17 @@ FactoryBot.define do
       with_course_allocation_subject
     end
 
+    trait :with_valid_itt_start_date do
+      itt_start_date { compute_valid_itt_start_date }
+    end
+
     trait :with_course_allocation_subject do
       course_allocation_subject { SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject }
     end
 
     trait :with_study_mode_and_course_dates do
       study_mode { TRAINEE_STUDY_MODE_ENUMS.keys.sample }
-      itt_start_date { compute_valid_itt_start_date }
+      itt_start_date { compute_valid_past_itt_start_date }
       itt_end_date do
         additional_years = if [2, 9, 10].include?(training_route)
                              3
@@ -273,7 +277,7 @@ FactoryBot.define do
         if itt_start_date.present?
           Faker::Date.between(from: itt_start_date, to: itt_start_date + rand(20).days)
         else
-          compute_valid_itt_start_date
+          compute_valid_past_itt_start_date
         end
       end
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -496,7 +496,7 @@ FactoryBot.define do
         courses_count { 5 }
         subject_names { [] }
         study_mode { "full_time" }
-        recruitment_cycle_year { Settings.current_default_course_year }
+        recruitment_cycle_year { Settings.current_recruitment_cycle_year }
       end
 
       after(:create) do |trainee, evaluator|

--- a/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
@@ -3,24 +3,32 @@
 require "rails_helper"
 
 feature "provider-led (postgrad) end-to-end journey" do
-  let(:itt_start_date) { 1.month.from_now }
-  let(:itt_end_date) { itt_start_date + 1.year }
+  context "non overlapping `Academic Cycles`" do
+    around do |example|
+      Timecop.freeze(Settings.current_recruitment_cycle_year, 8, 1) do
+        example.run
+      end
+    end
 
-  background { given_i_am_authenticated }
+    let(:itt_start_date) { 1.month.from_now }
+    let(:itt_end_date) { itt_start_date + 1.year }
 
-  scenario "submit for TRN", "feature_routes.provider_led_postgrad": true, feature_publish_course_details: true do
-    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-    given_i_have_created_a_provider_led_trainee
-    and_the_personal_details_is_complete
-    and_the_contact_details_is_complete
-    and_the_diversity_information_is_complete
-    and_the_degree_details_is_complete
-    and_the_publish_course_details_is_complete
-    and_the_trainee_id_is_complete
-    and_the_funding_details_is_complete
-    and_the_draft_record_has_been_reviewed
-    and_all_sections_are_complete
-    when_i_submit_for_trn
-    then_i_am_redirected_to_the_trn_success_page
+    background { given_i_am_authenticated }
+
+    scenario "submit for TRN", "feature_routes.provider_led_postgrad": true, feature_publish_course_details: true do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+      given_i_have_created_a_provider_led_trainee
+      and_the_personal_details_is_complete
+      and_the_contact_details_is_complete
+      and_the_diversity_information_is_complete
+      and_the_degree_details_is_complete
+      and_the_publish_course_details_is_complete
+      and_the_trainee_id_is_complete
+      and_the_funding_details_is_complete
+      and_the_draft_record_has_been_reviewed
+      and_all_sections_are_complete
+      when_i_submit_for_trn
+      then_i_am_redirected_to_the_trn_success_page
+    end
   end
 end

--- a/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
+++ b/spec/features/end_to_end/provider_led_postgrad_journey_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 feature "provider-led (postgrad) end-to-end journey" do
-  context "non overlapping `Academic Cycles`" do
+  context "non overlapping `Academic Cycles`", feature_show_draft_trainee_course_year_choice: false do
     around do |example|
       Timecop.freeze(Settings.current_recruitment_cycle_year, 8, 1) do
         example.run

--- a/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "apply registrations" do
   include CourseDetailsHelper
 
-  let(:itt_start_date) { Date.new(Settings.current_default_course_year, 9, 1) }
+  let(:itt_start_date) { Date.new(Settings.current_recruitment_cycle_year, 9, 1) }
   let(:itt_end_date) { itt_start_date + 1.year }
 
   background do

--- a/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
@@ -89,6 +89,7 @@ private
   def and_a_trainee_exists_created_from_apply
     given_a_trainee_exists(:with_apply_application,
                            :with_related_courses,
+                           :with_valid_itt_start_date,
                            courses_count: 1,
                            subject_names: subjects,
                            training_route: training_route)

--- a/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
@@ -25,7 +25,7 @@ feature "apply registrations" do
   describe "with a missing course code against the trainee" do
     let(:subjects) { ["History"] }
 
-    scenario "reviewing course" do
+    scenario "reviewing course", feature_show_draft_trainee_course_year_choice: false do
       given_the_trainee_does_not_have_a_course_uuid
       when_i_enter_the_course_details_page
       then_i_am_on_the_publish_course_details_page
@@ -45,17 +45,25 @@ feature "apply registrations" do
       then_i_am_redirected_to_the_review_draft_page
     end
 
-    scenario "changing course with a different route via the confirm course page" do
-      given_my_provider_has_courses_for_other_training_routes
-      when_i_enter_the_course_details_page
-      and_i_confirm_the_course_details
-      and_i_enter_itt_dates
-      when_i_click_change_course_on_the_confirm_course_page
-      and_i_select_a_different_route
-      and_i_choose_a_course_on_a_different_route
-      and_i_enter_itt_dates
-      and_i_confirm_the_course
-      then_the_school_direct_training_route_is_the_route
+    context "non overlapping `Academic Cycles`", feature_show_draft_trainee_course_year_choice: false do
+      around do |example|
+        Timecop.freeze(Settings.current_recruitment_cycle_year, 8, 1) do
+          example.run
+        end
+      end
+
+      scenario "changing course with a different route via the confirm course page" do
+        given_my_provider_has_courses_for_other_training_routes
+        when_i_enter_the_course_details_page
+        and_i_confirm_the_course_details
+        and_i_enter_itt_dates
+        when_i_click_change_course_on_the_confirm_course_page
+        and_i_select_a_different_route
+        and_i_choose_a_course_on_a_different_route
+        and_i_enter_itt_dates
+        and_i_confirm_the_course
+        then_the_school_direct_training_route_is_the_route
+      end
     end
   end
 

--- a/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/apply_applications_spec.rb
@@ -14,6 +14,14 @@ feature "apply registrations" do
     given_i_am_on_the_review_draft_page
   end
 
+  before do
+    FormStore.clear_all(trainee.id)
+  end
+
+  after do
+    FormStore.clear_all(trainee.id)
+  end
+
   describe "with a missing course code against the trainee" do
     let(:subjects) { ["History"] }
 

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -8,7 +8,7 @@ feature "publish course details", feature_publish_course_details: true do
   let(:subjects) { [] }
   let(:training_route) { TRAINING_ROUTE_ENUMS[:provider_led_postgrad] }
   let(:study_mode) { "full_time" }
-  let(:itt_start_date) { Date.new(Settings.current_default_course_year, 9, 1) }
+  let(:itt_start_date) { Date.new(Settings.current_recruitment_cycle_year, 9, 1) }
   let(:itt_end_date) { itt_start_date + 1.year }
 
   background do

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -25,7 +25,7 @@ feature "publish course details", feature_publish_course_details: true do
     FormStore.clear_all(trainee.id)
   end
 
-  context "non overlapping `Academic Cycles`" do
+  context "non overlapping `Academic Cycles`", feature_show_draft_trainee_course_year_choice: false do
     around do |example|
       Timecop.freeze(Settings.current_recruitment_cycle_year, 8, 1) do
         example.run

--- a/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_publish_course_details_spec.rb
@@ -25,407 +25,415 @@ feature "publish course details", feature_publish_course_details: true do
     FormStore.clear_all(trainee.id)
   end
 
-  describe "tracking the progress" do
-    scenario "renders a 'incomplete' status when no details provided" do
-      when_i_visit_the_review_draft_page
-      then_the_section_should_be(incomplete)
+  context "non overlapping `Academic Cycles`" do
+    around do |example|
+      Timecop.freeze(Settings.current_recruitment_cycle_year, 8, 1) do
+        example.run
+      end
     end
 
-    context "with a course that doesn't require selecting a specialism" do
-      let(:subjects) { [AllocationSubjects::HISTORY] }
-      let!(:subject_specialism) { create(:subject_specialism, name: subjects[0].downcase) }
+    describe "tracking the progress" do
+      scenario "renders a 'incomplete' status when no details provided" do
+        when_i_visit_the_review_draft_page
+        then_the_section_should_be(incomplete)
+      end
 
-      scenario "renders a 'completed' status when details fully provided" do
+      context "with a course that doesn't require selecting a specialism" do
+        let(:subjects) { [AllocationSubjects::HISTORY] }
+        let!(:subject_specialism) { create(:subject_specialism, name: subjects[0].downcase) }
+
+        scenario "renders a 'completed' status when details fully provided" do
+          when_i_visit_the_publish_course_details_page
+          and_i_select_a_course
+          and_i_submit_the_form
+          and_i_enter_itt_dates
+          then_i_should_see_the_subject_described_as("History")
+          and_i_confirm_the_course
+          and_i_visit_the_review_draft_page
+          then_the_section_should_be(completed)
+        end
+      end
+
+      context "with a language course that doesn't require selecting a specialism" do
+        let(:subjects) { [PublishSubjects::FRENCH] }
+
+        scenario "renders a 'completed' status when details fully provided" do
+          when_i_visit_the_publish_course_details_page
+          and_i_select_a_course
+          and_i_submit_the_form
+          and_i_enter_itt_dates
+          then_i_should_see_the_subject_described_as("French")
+          and_i_confirm_the_course
+          and_i_visit_the_review_draft_page
+          then_the_section_should_be(completed)
+        end
+      end
+
+      context "with a course that requires selecting a single specialism" do
+        let(:subjects) { [AllocationSubjects::COMPUTING] }
+        let!(:subject_specialism) { create(:subject_specialism, name: "Computer science".downcase) }
+
+        scenario "renders a 'completed' status when details fully provided" do
+          when_i_visit_the_publish_course_details_page
+          and_i_select_a_course
+          and_i_submit_the_form
+          and_i_select_a_specialism("Computer science")
+          and_i_submit_the_specialism_form
+          and_i_enter_itt_dates
+          then_i_should_see_the_subject_described_as("Computer science")
+          and_i_confirm_the_course
+          and_i_visit_the_review_draft_page
+          then_the_section_should_be(completed)
+        end
+      end
+
+      context "with a course that requires selecting multiple specialisms" do
+        let(:subjects) { [AllocationSubjects::COMPUTING, AllocationSubjects::MATHEMATICS] }
+        let!(:subject_specialism) { create(:subject_specialism, name: "Applied computing".downcase) }
+
+        scenario "renders a 'completed' status when details fully provided" do
+          when_i_visit_the_publish_course_details_page
+          and_i_select_a_course
+          and_i_submit_the_form
+          and_i_select_a_specialism("Applied computing")
+          and_i_submit_the_specialism_form
+          and_i_select_a_specialism("Mathematics")
+          and_i_submit_the_specialism_form
+          and_i_enter_itt_dates
+          then_i_should_see_the_subject_described_as("Applied computing with mathematics")
+          and_i_confirm_the_course
+          and_i_visit_the_review_draft_page
+          then_the_section_should_be(completed)
+        end
+      end
+
+      context "with a course that requires selecting language specialisms" do
+        let(:subjects) { ["Modern languages (other)"] }
+        let!(:subject_specialism1) { create(:subject_specialism, name: "Arabic languages") }
+        let!(:subject_specialism2) { create(:subject_specialism, name: "Portuguese language") }
+        let!(:subject_specialism3) { create(:subject_specialism, name: "Welsh language") }
+
+        scenario "renders a 'completed' status when details fully provided" do
+          when_i_visit_the_publish_course_details_page
+          and_i_select_a_course
+          and_i_submit_the_form
+          and_i_select_languages("Arabic languages", "Welsh", "Portuguese")
+          and_i_submit_the_language_specialism_form
+          and_i_enter_itt_dates
+          then_i_should_see_the_subject_described_as("Arabic languages with Portuguese and Welsh")
+          and_i_confirm_the_course
+          and_i_visit_the_review_draft_page
+          then_the_section_should_be(completed)
+        end
+      end
+
+      context "with a course that has a mixture of multiple specalism subjects single specialism ones" do
+        let(:subjects) do
+          [
+            AllocationSubjects::MUSIC,
+            AllocationSubjects::COMPUTING,
+            AllocationSubjects::HISTORY,
+          ]
+        end
+        let!(:subject_specialism1) { create(:subject_specialism, name: "music education and teaching") }
+        let!(:subject_specialism2) { create(:subject_specialism, name: "applied computing") }
+        let!(:subject_specialism3) { create(:subject_specialism, name: "history") }
+
+        scenario "renders a 'completed' status when details fully provided" do
+          when_i_visit_the_publish_course_details_page
+          and_i_select_a_course
+          and_i_submit_the_form
+          and_i_select_a_specialism("Applied computing")
+          and_i_submit_the_specialism_form
+          and_i_enter_itt_dates
+          then_i_should_see_the_subject_described_as("Music education and teaching with applied computing and history")
+          and_i_confirm_the_course
+          and_i_visit_the_review_draft_page
+          then_the_section_should_be(completed)
+        end
+      end
+    end
+
+    describe "available courses" do
+      scenario "there aren't any courses for the trainee's provider and route" do
+        given_there_arent_any_courses
+        when_i_visit_the_review_draft_page
+        then_the_link_takes_me_to_the_course_education_phase_page
+      end
+
+      scenario "there are some courses for the trainee's provider and route" do
+        when_i_visit_the_review_draft_page
+        then_the_link_takes_me_to_the_publish_course_details_page
+      end
+    end
+
+    describe "selecting a course" do
+      scenario "not selecting anything" do
+        given_a_trainee_exists_with_some_courses
         when_i_visit_the_publish_course_details_page
-        and_i_select_a_course
         and_i_submit_the_form
-        and_i_enter_itt_dates
-        then_i_should_see_the_subject_described_as("History")
-        and_i_confirm_the_course
-        and_i_visit_the_review_draft_page
-        then_the_section_should_be(completed)
-      end
-    end
-
-    context "with a language course that doesn't require selecting a specialism" do
-      let(:subjects) { [PublishSubjects::FRENCH] }
-
-      scenario "renders a 'completed' status when details fully provided" do
-        when_i_visit_the_publish_course_details_page
-        and_i_select_a_course
-        and_i_submit_the_form
-        and_i_enter_itt_dates
-        then_i_should_see_the_subject_described_as("French")
-        and_i_confirm_the_course
-        and_i_visit_the_review_draft_page
-        then_the_section_should_be(completed)
-      end
-    end
-
-    context "with a course that requires selecting a single specialism" do
-      let(:subjects) { [AllocationSubjects::COMPUTING] }
-      let!(:subject_specialism) { create(:subject_specialism, name: "Computer science".downcase) }
-
-      scenario "renders a 'completed' status when details fully provided" do
-        when_i_visit_the_publish_course_details_page
-        and_i_select_a_course
-        and_i_submit_the_form
-        and_i_select_a_specialism("Computer science")
-        and_i_submit_the_specialism_form
-        and_i_enter_itt_dates
-        then_i_should_see_the_subject_described_as("Computer science")
-        and_i_confirm_the_course
-        and_i_visit_the_review_draft_page
-        then_the_section_should_be(completed)
-      end
-    end
-
-    context "with a course that requires selecting multiple specialisms" do
-      let(:subjects) { [AllocationSubjects::COMPUTING, AllocationSubjects::MATHEMATICS] }
-      let!(:subject_specialism) { create(:subject_specialism, name: "Applied computing".downcase) }
-
-      scenario "renders a 'completed' status when details fully provided" do
-        when_i_visit_the_publish_course_details_page
-        and_i_select_a_course
-        and_i_submit_the_form
-        and_i_select_a_specialism("Applied computing")
-        and_i_submit_the_specialism_form
-        and_i_select_a_specialism("Mathematics")
-        and_i_submit_the_specialism_form
-        and_i_enter_itt_dates
-        then_i_should_see_the_subject_described_as("Applied computing with mathematics")
-        and_i_confirm_the_course
-        and_i_visit_the_review_draft_page
-        then_the_section_should_be(completed)
-      end
-    end
-
-    context "with a course that requires selecting language specialisms" do
-      let(:subjects) { ["Modern languages (other)"] }
-      let!(:subject_specialism1) { create(:subject_specialism, name: "Arabic languages") }
-      let!(:subject_specialism2) { create(:subject_specialism, name: "Portuguese language") }
-      let!(:subject_specialism3) { create(:subject_specialism, name: "Welsh language") }
-
-      scenario "renders a 'completed' status when details fully provided" do
-        when_i_visit_the_publish_course_details_page
-        and_i_select_a_course
-        and_i_submit_the_form
-        and_i_select_languages("Arabic languages", "Welsh", "Portuguese")
-        and_i_submit_the_language_specialism_form
-        and_i_enter_itt_dates
-        then_i_should_see_the_subject_described_as("Arabic languages with Portuguese and Welsh")
-        and_i_confirm_the_course
-        and_i_visit_the_review_draft_page
-        then_the_section_should_be(completed)
-      end
-    end
-
-    context "with a course that has a mixture of multiple specalism subjects single specialism ones" do
-      let(:subjects) do
-        [
-          AllocationSubjects::MUSIC,
-          AllocationSubjects::COMPUTING,
-          AllocationSubjects::HISTORY,
-        ]
-      end
-      let!(:subject_specialism1) { create(:subject_specialism, name: "music education and teaching") }
-      let!(:subject_specialism2) { create(:subject_specialism, name: "applied computing") }
-      let!(:subject_specialism3) { create(:subject_specialism, name: "history") }
-
-      scenario "renders a 'completed' status when details fully provided" do
-        when_i_visit_the_publish_course_details_page
-        and_i_select_a_course
-        and_i_submit_the_form
-        and_i_select_a_specialism("Applied computing")
-        and_i_submit_the_specialism_form
-        and_i_enter_itt_dates
-        then_i_should_see_the_subject_described_as("Music education and teaching with applied computing and history")
-        and_i_confirm_the_course
-        and_i_visit_the_review_draft_page
-        then_the_section_should_be(completed)
-      end
-    end
-  end
-
-  describe "available courses" do
-    scenario "there aren't any courses for the trainee's provider and route" do
-      given_there_arent_any_courses
-      when_i_visit_the_review_draft_page
-      then_the_link_takes_me_to_the_course_education_phase_page
-    end
-
-    scenario "there are some courses for the trainee's provider and route" do
-      when_i_visit_the_review_draft_page
-      then_the_link_takes_me_to_the_publish_course_details_page
-    end
-  end
-
-  describe "selecting a course" do
-    scenario "not selecting anything" do
-      given_a_trainee_exists_with_some_courses
-      when_i_visit_the_publish_course_details_page
-      and_i_submit_the_form
-      then_i_see_an_error_message
-    end
-
-    describe "selecting a course with one specialism" do
-      let(:subjects) { [AllocationSubjects::MUSIC] }
-
-      before do
-        when_i_visit_the_publish_course_details_page
-        and_some_courses_for_other_providers_or_routes_exist
-        then_i_see_the_route_message
-        and_i_only_see_the_courses_for_my_provider_and_route
-        when_i_select_a_course
-        and_i_submit_the_form
+        then_i_see_an_error_message
       end
 
-      context "filling in ITT start and end dates" do
-        context "course study_mode is full_time_or_part_time" do
-          let(:study_mode) { "full_time_or_part_time" }
+      describe "selecting a course with one specialism" do
+        let(:subjects) { [AllocationSubjects::MUSIC] }
 
-          scenario do
-            then_i_see_the_study_mode_edit_page
-            and_i_choose_an_study_mode_option
+        before do
+          when_i_visit_the_publish_course_details_page
+          and_some_courses_for_other_providers_or_routes_exist
+          then_i_see_the_route_message
+          and_i_only_see_the_courses_for_my_provider_and_route
+          when_i_select_a_course
+          and_i_submit_the_form
+        end
+
+        context "filling in ITT start and end dates" do
+          context "course study_mode is full_time_or_part_time" do
+            let(:study_mode) { "full_time_or_part_time" }
+
+            scenario do
+              then_i_see_the_study_mode_edit_page
+              and_i_choose_an_study_mode_option
+              then_i_see_the_itt_dates_edit_page
+              and_i_enter_itt_dates
+              and_i_continue
+            end
+          end
+
+          scenario "invalid ITT start date" do
             then_i_see_the_itt_dates_edit_page
-            and_i_enter_itt_dates
+            and_i_enter_itt_start_date("32/01/2020")
             and_i_continue
+            then_i_see_the_error_message_for_start_date(:invalid)
+          end
+
+          scenario "blank submission" do
+            then_i_see_the_itt_dates_edit_page
+            and_i_enter_itt_start_date(nil)
+            and_i_continue
+            then_i_see_the_error_message_for_start_date(:blank)
           end
         end
+      end
 
-        scenario "invalid ITT start date" do
-          then_i_see_the_itt_dates_edit_page
-          and_i_enter_itt_start_date("32/01/2020")
-          and_i_continue
-          then_i_see_the_error_message_for_start_date(:invalid)
+      describe "selecting a course with multiple possible specialisms" do
+        let(:subjects) { [AllocationSubjects::COMPUTING] }
+
+        scenario do
+          when_i_visit_the_publish_course_details_page
+          and_some_courses_for_other_providers_or_routes_exist
+          and_i_only_see_the_courses_for_my_provider_and_route
+          when_i_select_a_course
+          and_i_submit_the_form
+          then_i_see_the_subject_specialism_page
         end
+      end
 
-        scenario "blank submission" do
-          then_i_see_the_itt_dates_edit_page
-          and_i_enter_itt_start_date(nil)
-          and_i_continue
-          then_i_see_the_error_message_for_start_date(:blank)
+      scenario "selecting 'Another course not listed'" do
+        when_i_visit_the_publish_course_details_page
+        and_i_select_another_course_not_listed
+        and_i_submit_the_form
+        then_i_see_the_course_education_phase_page
+        and_i_visit_the_review_draft_page
+        then_the_link_takes_me_to_the_publish_course_details_page
+      end
+
+      describe "selecting a new course from the confirm page" do
+        let(:subjects) { [AllocationSubjects::COMPUTING] }
+
+        scenario do
+          given_a_course_exists(with_subjects: ["Modern languages (other)"])
+          when_i_visit_the_publish_course_details_page
+          when_i_select_a_course("Computing")
+          and_i_submit_the_form
+          and_i_select_a_specialism("Applied computing")
+          and_i_submit_the_specialism_form
+          and_i_enter_itt_dates
+          then_i_should_see_the_subject_described_as("Applied computing")
+          when_i_visit_the_publish_course_details_page
+          when_i_select_a_course("Modern languages (other)")
+          and_i_submit_the_form
+          and_i_select_languages("Arabic languages", "Welsh", "Portuguese")
+          and_i_submit_the_language_specialism_form
+          and_i_enter_itt_dates
+          then_i_should_see_the_subject_described_as("Arabic languages with Portuguese and Welsh")
         end
       end
     end
 
-    describe "selecting a course with multiple possible specialisms" do
-      let(:subjects) { [AllocationSubjects::COMPUTING] }
+  private
 
-      scenario do
-        when_i_visit_the_publish_course_details_page
-        and_some_courses_for_other_providers_or_routes_exist
-        and_i_only_see_the_courses_for_my_provider_and_route
-        when_i_select_a_course
-        and_i_submit_the_form
-        then_i_see_the_subject_specialism_page
+    def given_a_trainee_exists_with_some_courses(with_subjects: [],
+                                                 with_training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
+      given_a_trainee_exists(:with_related_courses,
+                             :with_secondary_education,
+                             subject_names: with_subjects,
+                             training_route: with_training_route)
+      @matching_courses = trainee.provider.courses.where(route: trainee.training_route)
+      @matching_courses.update_all(study_mode:)
+    end
+
+    def given_a_course_exists(with_subjects: [])
+      create_list(:course_with_subjects, 1,
+                  subject_names: with_subjects,
+                  accredited_body_code: @trainee.provider.code,
+                  route: @trainee.training_route)
+    end
+
+    def then_the_section_should_be(status)
+      expect(review_draft_page.course_details.status.text).to eq(status)
+    end
+
+    def then_the_link_takes_me_to_the_course_education_phase_page
+      expect(review_draft_page.course_details.link[:href]).to eq edit_trainee_course_education_phase_path(trainee)
+    end
+
+    def then_the_link_takes_me_to_the_publish_course_details_page
+      expect(review_draft_page.course_details.link[:href]).to eq edit_trainee_publish_course_details_path(trainee)
+    end
+
+    def when_i_visit_the_publish_course_details_page
+      publish_course_details_page.load(id: trainee.slug)
+    end
+
+    def and_i_select_a_course(course_title = nil)
+      if course_title
+        option = publish_course_details_page.course_options.find { |o| o.label.text.include?(course_title) }
+        option.choose
+      else
+        publish_course_details_page.course_options.first.choose
       end
     end
 
-    scenario "selecting 'Another course not listed'" do
-      when_i_visit_the_publish_course_details_page
-      and_i_select_another_course_not_listed
-      and_i_submit_the_form
-      then_i_see_the_course_education_phase_page
-      and_i_visit_the_review_draft_page
-      then_the_link_takes_me_to_the_publish_course_details_page
-    end
+    alias_method :when_i_select_a_course, :and_i_select_a_course
 
-    describe "selecting a new course from the confirm page" do
-      let(:subjects) { [AllocationSubjects::COMPUTING] }
-
-      scenario do
-        given_a_course_exists(with_subjects: ["Modern languages (other)"])
-        when_i_visit_the_publish_course_details_page
-        when_i_select_a_course("Computing")
-        and_i_submit_the_form
-        and_i_select_a_specialism("Applied computing")
-        and_i_submit_the_specialism_form
-        and_i_enter_itt_dates
-        then_i_should_see_the_subject_described_as("Applied computing")
-        when_i_visit_the_publish_course_details_page
-        when_i_select_a_course("Modern languages (other)")
-        and_i_submit_the_form
-        and_i_select_languages("Arabic languages", "Welsh", "Portuguese")
-        and_i_submit_the_language_specialism_form
-        and_i_enter_itt_dates
-        then_i_should_see_the_subject_described_as("Arabic languages with Portuguese and Welsh")
+    def and_i_select_languages(*languages)
+      options = language_specialism_page.language_specialism_options.select do |option|
+        languages.include?(option.label.text)
       end
+
+      options.each { |checkbox| click(checkbox.input) }
     end
-  end
 
-private
+    def and_i_submit_the_form
+      publish_course_details_page.submit_button.click
+    end
 
-  def given_a_trainee_exists_with_some_courses(with_subjects: [],
-                                               with_training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad])
-    given_a_trainee_exists(:with_related_courses,
-                           :with_secondary_education,
-                           subject_names: with_subjects,
-                           training_route: with_training_route)
-    @matching_courses = trainee.provider.courses.where(route: trainee.training_route)
-    @matching_courses.update_all(study_mode:)
-  end
+    def and_i_submit_the_specialism_form
+      subject_specialism_page.submit_button.click
+    end
 
-  def given_a_course_exists(with_subjects: [])
-    create_list(:course_with_subjects, 1,
-                subject_names: with_subjects,
-                accredited_body_code: @trainee.provider.code,
-                route: @trainee.training_route)
-  end
+    def and_i_submit_the_language_specialism_form
+      language_specialism_page.submit_button.click
+    end
 
-  def then_the_section_should_be(status)
-    expect(review_draft_page.course_details.status.text).to eq(status)
-  end
+    def and_i_confirm_the_course
+      confirm_publish_course_details_page.confirm.click
+      confirm_publish_course_details_page.continue_button.click
+    end
 
-  def then_the_link_takes_me_to_the_course_education_phase_page
-    expect(review_draft_page.course_details.link[:href]).to eq edit_trainee_course_education_phase_path(trainee)
-  end
+    def and_i_select_another_course_not_listed
+      publish_course_details_page.course_options.last.choose
+    end
 
-  def then_the_link_takes_me_to_the_publish_course_details_page
-    expect(review_draft_page.course_details.link[:href]).to eq edit_trainee_publish_course_details_path(trainee)
-  end
+    def and_i_visit_the_review_draft_page
+      review_draft_page.load(id: trainee.slug)
+    end
 
-  def when_i_visit_the_publish_course_details_page
-    publish_course_details_page.load(id: trainee.slug)
-  end
-
-  def and_i_select_a_course(course_title = nil)
-    if course_title
-      option = publish_course_details_page.course_options.find { |o| o.label.text.include?(course_title) }
+    def and_i_select_a_specialism(specialism)
+      option = subject_specialism_page.specialism_options.find { |o| o.label.text == specialism }
       option.choose
-    else
-      publish_course_details_page.course_options.first.choose
-    end
-  end
-
-  alias_method :when_i_select_a_course, :and_i_select_a_course
-
-  def and_i_select_languages(*languages)
-    options = language_specialism_page.language_specialism_options.select do |option|
-      languages.include?(option.label.text)
     end
 
-    options.each { |checkbox| click(checkbox.input) }
-  end
+    alias_method :when_i_visit_the_review_draft_page, :and_i_visit_the_review_draft_page
 
-  def and_i_submit_the_form
-    publish_course_details_page.submit_button.click
-  end
+    def then_i_see_an_error_message
+      translation_key_prefix = "activemodel.errors.models.publish_course_details_form.attributes"
 
-  def and_i_submit_the_specialism_form
-    subject_specialism_page.submit_button.click
-  end
+      expect(publish_course_details_page).to have_content(
+        I18n.t("#{translation_key_prefix}.course_uuid.blank"),
+      )
+    end
 
-  def and_i_submit_the_language_specialism_form
-    language_specialism_page.submit_button.click
-  end
+    def then_i_see_the_course_education_phase_page
+      expect(course_education_phase_page).to be_displayed(id: trainee.slug)
+    end
 
-  def and_i_confirm_the_course
-    confirm_publish_course_details_page.confirm.click
-    confirm_publish_course_details_page.continue_button.click
-  end
+    def given_there_arent_any_courses
+      CourseSubject.destroy_all
+      Course.destroy_all
+    end
 
-  def and_i_select_another_course_not_listed
-    publish_course_details_page.course_options.last.choose
-  end
+    def and_some_courses_for_other_providers_or_routes_exist
+      other_route = TRAINING_ROUTES_FOR_COURSE.keys.excluding(trainee.training_route).sample
+      create(:course, accredited_body_code: trainee.provider.code, route: other_route)
+      create(:course, route: trainee.training_route)
+    end
 
-  def and_i_visit_the_review_draft_page
-    review_draft_page.load(id: trainee.slug)
-  end
+    def and_i_only_see_the_courses_for_my_provider_and_route
+      course_codes_on_page = publish_course_details_page.course_options
+        .map { |o| o.label.text.match(/\((.{4})\)/) }
+        .compact
+        .map { |m| m[1] }
+        .sort
 
-  def and_i_select_a_specialism(specialism)
-    option = subject_specialism_page.specialism_options.find { |o| o.label.text == specialism }
-    option.choose
-  end
+      expect(@matching_courses.map(&:code).sort).to eq(course_codes_on_page)
+    end
 
-  alias_method :when_i_visit_the_review_draft_page, :and_i_visit_the_review_draft_page
+    def and_i_enter_itt_start_date(date)
+      itt_dates_edit_page.set_date_fields(:start_date, date.respond_to?(:strftime) ? date.strftime("%d/%m/%Y") : date)
+    end
 
-  def then_i_see_an_error_message
-    translation_key_prefix = "activemodel.errors.models.publish_course_details_form.attributes"
+    def and_i_enter_itt_end_date(date)
+      itt_dates_edit_page.set_date_fields(:end_date, date.respond_to?(:strftime) ? date.strftime("%d/%m/%Y") : date)
+    end
 
-    expect(publish_course_details_page).to have_content(
-      I18n.t("#{translation_key_prefix}.course_uuid.blank"),
-    )
-  end
+    def and_i_continue
+      itt_dates_edit_page.continue.click
+    end
 
-  def then_i_see_the_course_education_phase_page
-    expect(course_education_phase_page).to be_displayed(id: trainee.slug)
-  end
+    def then_i_see_the_error_message_for_start_date(type)
+      expect(itt_dates_edit_page).to have_content(
+        I18n.t("activemodel.errors.models.itt_dates_form.attributes.start_date.#{type}"),
+      )
+    end
 
-  def given_there_arent_any_courses
-    CourseSubject.destroy_all
-    Course.destroy_all
-  end
+    def then_i_see_the_route_message
+      expected_message = t("views.forms.publish_course_details.route_message", route: route_title(@trainee.training_route))
+      expect(publish_course_details_page.route_message.text).to eq(expected_message)
+    end
 
-  def and_some_courses_for_other_providers_or_routes_exist
-    other_route = TRAINING_ROUTES_FOR_COURSE.keys.excluding(trainee.training_route).sample
-    create(:course, accredited_body_code: trainee.provider.code, route: other_route)
-    create(:course, route: trainee.training_route)
-  end
+    def then_i_see_the_confirm_publish_course_details_page
+      expect(confirm_publish_course_details_page).to be_displayed(trainee_id: trainee.slug)
+    end
 
-  def and_i_only_see_the_courses_for_my_provider_and_route
-    course_codes_on_page = publish_course_details_page.course_options
-      .map { |o| o.label.text.match(/\((.{4})\)/) }
-      .compact
-      .map { |m| m[1] }
-      .sort
+    def then_i_see_the_study_mode_edit_page
+      expect(study_mode_edit_page).to be_displayed(trainee_id: trainee.slug)
+    end
 
-    expect(@matching_courses.map(&:code).sort).to eq(course_codes_on_page)
-  end
+    def then_i_see_the_itt_dates_edit_page
+      expect(itt_dates_edit_page).to be_displayed(trainee_id: trainee.slug)
+    end
 
-  def and_i_enter_itt_start_date(date)
-    itt_dates_edit_page.set_date_fields(:start_date, date.respond_to?(:strftime) ? date.strftime("%d/%m/%Y") : date)
-  end
+    def then_i_see_the_subject_specialism_page
+      expect(subject_specialism_page).to be_displayed(trainee_id: trainee.slug, position: 1)
+    end
 
-  def and_i_enter_itt_end_date(date)
-    itt_dates_edit_page.set_date_fields(:end_date, date.respond_to?(:strftime) ? date.strftime("%d/%m/%Y") : date)
-  end
+    def then_i_see_the_language_specialism_page
+      expect(language_specialism_page).to be_displayed(trainee_id: trainee.slug)
+    end
 
-  def and_i_continue
-    itt_dates_edit_page.continue.click
-  end
+    def then_i_should_see_the_subject_described_as(description)
+      expect(confirm_publish_course_details_page.subject_description).to eq(description)
+    end
 
-  def then_i_see_the_error_message_for_start_date(type)
-    expect(itt_dates_edit_page).to have_content(
-      I18n.t("activemodel.errors.models.itt_dates_form.attributes.start_date.#{type}"),
-    )
-  end
+    def and_i_submit_the_course_details_form
+      course_details_page.submit_button.click
+    end
 
-  def then_i_see_the_route_message
-    expected_message = t("views.forms.publish_course_details.route_message", route: route_title(@trainee.training_route))
-    expect(publish_course_details_page.route_message.text).to eq(expected_message)
-  end
-
-  def then_i_see_the_confirm_publish_course_details_page
-    expect(confirm_publish_course_details_page).to be_displayed(trainee_id: trainee.slug)
-  end
-
-  def then_i_see_the_study_mode_edit_page
-    expect(study_mode_edit_page).to be_displayed(trainee_id: trainee.slug)
-  end
-
-  def then_i_see_the_itt_dates_edit_page
-    expect(itt_dates_edit_page).to be_displayed(trainee_id: trainee.slug)
-  end
-
-  def then_i_see_the_subject_specialism_page
-    expect(subject_specialism_page).to be_displayed(trainee_id: trainee.slug, position: 1)
-  end
-
-  def then_i_see_the_language_specialism_page
-    expect(language_specialism_page).to be_displayed(trainee_id: trainee.slug)
-  end
-
-  def then_i_should_see_the_subject_described_as(description)
-    expect(confirm_publish_course_details_page.subject_description).to eq(description)
-  end
-
-  def and_i_submit_the_course_details_form
-    course_details_page.submit_button.click
-  end
-
-  def and_i_choose_an_study_mode_option
-    study_mode_edit_page.options.sample.choose
-    study_mode_edit_page.continue.click
+    def and_i_choose_an_study_mode_option
+      study_mode_edit_page.options.sample.choose
+      study_mode_edit_page.continue.click
+    end
   end
 end

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 feature "Change course", feature_publish_course_details: true do
-  let(:itt_start_date) { Date.new(Settings.current_default_course_year, 9, 1) }
+  let(:itt_start_date) { Date.new(Settings.current_recruitment_cycle_year, 9, 1) }
   let(:itt_end_date) { itt_start_date + 1.year }
 
   scenario "TRN received" do

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -23,7 +23,7 @@ feature "Change course", feature_publish_course_details: true do
 
   scenario "published course not selected" do
     given_i_am_authenticated
-    and_a_trainee_exists
+    and_a_trainee_exists_for_valid_itt_start_date
     and_trainee_related_courses_exist
     and_courses_on_another_route_exist
     and_i_am_on_the_trainee_record_page
@@ -95,6 +95,10 @@ private
 
   def and_a_trainee_exists
     given_a_trainee_exists(:trn_received, :school_direct_salaried, :with_secondary_education)
+  end
+
+  def and_a_trainee_exists_for_valid_itt_start_date
+    given_a_trainee_exists(:trn_received, :school_direct_salaried, :with_secondary_education, :with_valid_itt_start_date)
   end
 
   def when_i_click_to_change_course_details

--- a/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
+++ b/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "editing a trainee training route" do
   background do
     given_i_am_authenticated
-    given_a_trainee_exists(traits)
+    given_a_trainee_exists(*traits)
   end
 
   context "draft-trainee" do
@@ -51,6 +51,8 @@ feature "editing a trainee training route" do
       end
 
       context "and the route has published courses" do
+        let(:traits) { %i[completed with_valid_itt_start_date] }
+
         scenario "redirects to the publish course path" do
           and_i_select_school_direct_salaried
           and_i_submit_the_new_route

--- a/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
+++ b/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
@@ -53,7 +53,7 @@ feature "editing a trainee training route" do
       context "and the route has published courses" do
         let(:traits) { %i[completed with_valid_itt_start_date] }
 
-        scenario "redirects to the publish course path" do
+        scenario "redirects to the publish course path", feature_show_draft_trainee_course_year_choice: false do
           and_i_select_school_direct_salaried
           and_i_submit_the_new_route
           then_i_am_redirected_to_the_publish_course_details_path

--- a/spec/services/exports/funding_trainee_summary_data_spec.rb
+++ b/spec/services/exports/funding_trainee_summary_data_spec.rb
@@ -30,7 +30,7 @@ module Exports
         }
       end
 
-      let(:csv_title) { "fussington-academy-trainee-summary-#{Settings.current_recruitment_cycle_year}-to-#{Settings.current_recruitment_cycle_year + 1}.csv" }
+      let(:csv_title) { "fussington-academy-trainee-summary-#{current_academic_year}-to-#{current_academic_year + 1}.csv" }
 
       it "sets the correct headers" do
         expect(subject.csv).to include(expected_output.keys.join(","))

--- a/spec/support/current_academic_cycle.rb
+++ b/spec/support/current_academic_cycle.rb
@@ -4,11 +4,22 @@ def current_academic_year
   Time.zone.now.month >= ACADEMIC_CYCLE_START_MONTH ? Time.zone.now.year : Time.zone.now.year - 1
 end
 
-def compute_valid_itt_start_date
-  # The itt_start_date always needs to be in the past.
+def compute_valid_past_itt_start_date
   if Time.zone.now.month == ACADEMIC_CYCLE_START_MONTH
     Faker::Date.between(from: Time.zone.now.beginning_of_month, to: Time.zone.now.yesterday)
   else
     Faker::Date.in_date_period(month: ACADEMIC_CYCLE_START_MONTH, year: current_academic_year)
   end
+end
+
+def compute_valid_future_itt_start_date
+  if Settings.current_recruitment_cycle_year > current_academic_year
+    Faker::Date.in_date_period(month: ACADEMIC_CYCLE_START_MONTH, year: Settings.current_recruitment_cycle_year)
+  elsif Settings.apply_applications.create.recruitment_cycle_year > current_academic_year
+    Faker::Date.in_date_period(month: ACADEMIC_CYCLE_START_MONTH, year: Settings.apply_applications.create.recruitment_cycle_year)
+  end
+end
+
+def compute_valid_itt_start_date
+  compute_valid_future_itt_start_date || compute_valid_past_itt_start_date
 end


### PR DESCRIPTION

### Context
Preparing 2023-2024 academic year

### Changes proposed in this pull request
Amended `current_recruitment_cycle_year` to `2023`
This is for the 2022 to 2023 recruitment cycle courses in order to serve the 2023-2024 academic year to register a trainee

### Guidance to review

Specs was realigned as
1. A trainee by default when created from scratch will fall into `current` academic cycle based on today date instead of allowing for `next`academic cycle
2. Some of the forms bypass the creating a trainee and ends up using stale trainee from previous
3. Certain specs was locked down to a particular time as there are 2 academic cycles in play and the specs are designed for a singular academic cycle


### Important business

Don't think there any below is applicable. 

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
