### PR TITLE
Handle `nil` `disabilities_and_health_conditions`

### DIFF
--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -12,7 +12,7 @@ module Trainees
       @course = application_record.provider.courses.find_by(uuid: @raw_course["course_uuid"])
       @raw_trainee = application_record.application.dig("attributes", "candidate")
       @raw_contact_details = application_record.application.dig("attributes", "contact_details")
-      @disability_uuids = raw_trainee["disabilities_and_health_conditions"].filter_map { |d| d["uuid"] }
+      @disability_uuids = raw_trainee["disabilities_and_health_conditions"]&.filter_map { |d| d["uuid"] } || []
       @study_mode = TRAINEE_STUDY_MODE_ENUMS[@raw_course["study_mode"]]
       @disabilities = Disability.where(uuid: disability_uuids)
       @trainee = Trainee.new(mapped_attributes)

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -161,10 +161,22 @@ module Trainees
         end
       end
 
-      context "when the application has an empty list of disabilities" do
+      context "when the application has an empty list of disabilities_and_health_conditions" do
         let(:candidate_attributes) do
           {
             disabilities_and_health_conditions: [],
+          }
+        end
+
+        it "sets the disability disclosure to not provided" do
+          expect(trainee).to be_disability_not_provided
+        end
+      end
+
+      context "when the application has a nil value for disabilities_and_health_conditions" do
+        let(:candidate_attributes) do
+          {
+            disabilities_and_health_conditions: nil,
           }
         end
 


### PR DESCRIPTION
### Context

When importing trainees from Apply we had previously assumed that the `disabilities_and_health_conditions` attribute would contain a non-nil value. This turns out not to be the case and is leading to errors:

https://dfe-teacher-services.sentry.io/issues/4272037653/?project=5552118&referrer=slack

### Changes proposed in this pull request

We need to interpret `nil` `disabilities_and_health_conditions` values as an empty list of disabilities.

### Guidance to review

Is there anything missing here?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
