### PR TITLE
Bump pkgconf version to fix CVE-2023-24056

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --update --no-cache --virtual build-dependances \
     apk del build-dependances
 
 # Remove once base image ruby:3.1.3-alpine3.15 has been updated with latest libraries
-RUN apk add --no-cache ncurses-libs=6.3_p20211120-r2
+RUN apk add --no-cache ncurses-libs=6.3_p20211120-r2 pkgconf=1.8.1-r0
 
 COPY package.json yarn.lock ./
 RUN  yarn install --frozen-lockfile && \


### PR DESCRIPTION
### Context
Bump pkgconf version to fix CVE-2023-24056

### Changes proposed in this pull request

Update pkgconf to version 1.8.1-r0

### Guidance to review

[Build No Cache](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5382073526/jobs/9766988985) is green

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Inform data insights team due to database changes
