### PR TITLE
[xxx] Remove sentry rspec code

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,20 +55,5 @@ RSpec.configure do |config|
     if ex.metadata[:js]
       Capybara.reset!
     end
-
-    # Allow Sentry to pick up messages triggered in our CI test build (and not locally).
-    # Sends a warning when tests are retried so we can track indeterminate tests.
-    if ENV.key?("SENTRY_DSN") && ex.metadata[:retry_exceptions]
-      # Disable WebMock so we can send events to Sentry
-      # Add sleep to avoid race condition
-      WebMock.disable!
-      sleep(3.seconds)
-      SentryForRSpec.report_retry(ex, config)
-      sleep(3.seconds)
-      WebMock.enable!
-      sleep(3.seconds)
-      WebMock.disable_net_connect!(allow_localhost: true)
-      sleep(3.seconds)
-    end
   end
 end


### PR DESCRIPTION
### Context

We seem to have enough data in Sentry to point us in the direction of common flakey tests https://dfe-teacher-services.sentry.io/issues/?environment=test&project=5552118&query=is%3Aunresolved&referrer=issue-stream&stream_index=1. 

Removing this code to reduce the noise in Sentry so we can make a plan on what to do re: above. 
