### PR TITLE
[xxxx] - fix bulk recommend guidance broken link

### DIFF
--- a/app/views/guidance/bulk_recommend_trainees.md
+++ b/app/views/guidance/bulk_recommend_trainees.md
@@ -3,7 +3,7 @@ page_title: Bulk recommend trainees for QTS or EYTS
 title: Bulk recommend trainees for QTS or EYTS
 ---
 
-You can [bulk recommend](/bulk-update/recommend/upload) multiple trainees at the same time for qualified teacher status (QTS) or early years teacher status (EYTS).
+You can [bulk recommend](/bulk-update/recommend/choose-who-to-recommend) multiple trainees at the same time for qualified teacher status (QTS) or early years teacher status (EYTS).
 
 {inset-text}
 You cannot use this process to record other training outcomes or to change trainee or course details.


### PR DESCRIPTION
### Context

the bulk recommend guidance page has a broken link `/guidance/bulk-recommend-trainees`

### Changes proposed in this pull request

corrects the link to `/bulk-update/recommend/choose-who-to-recommend`
