### PR TITLE
[5600] Fix for a 1+n query on the providers index page

### DIFF
--- a/app/components/provider_card/view.html.erb
+++ b/app/components/provider_card/view.html.erb
@@ -3,6 +3,6 @@
     <%= govuk_link_to provider.name, provider_path(provider) %>
   </h2>
   <p class="govuk-body govuk-hint">
-    <%= pluralize(provider.users.kept.count, "user") %>
+    <%= pluralize(user_count, "user") %>
   </p>
 </div>

--- a/app/components/provider_card/view.rb
+++ b/app/components/provider_card/view.rb
@@ -8,6 +8,14 @@ module ProviderCard
 
     attr_reader :provider
 
+    def user_count
+      if provider.respond_to?(:user_count)
+        provider.user_count
+      else
+        provider.users.kept.count
+      end
+    end
+
     def initialize(provider:)
       @provider = provider
     end

--- a/app/controllers/system_admin/providers_controller.rb
+++ b/app/controllers/system_admin/providers_controller.rb
@@ -5,7 +5,14 @@ module SystemAdmin
     before_action :set_provider, only: %i[show edit update]
 
     def index
-      @providers = authorize(Provider.all.order(:name))
+      @providers = authorize(
+        Provider
+          .select("providers.*, count(users.id) as user_count")
+          .left_outer_joins(:users)
+          .where("users.discarded_at": nil)
+          .group("providers.id")
+          .order(:name),
+      )
     end
 
     def show

--- a/spec/components/provider_card/view_spec.rb
+++ b/spec/components/provider_card/view_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ProviderCard
+  describe View do
+    include SummaryHelper
+
+    context "with a provider" do
+      let(:provider) { create(:provider, name: "University of Wantage") }
+      let(:bob) { create(:user) }
+      let(:alice) { create(:user) }
+      let(:norman) { create(:user, discarded_at: 2.weeks.ago) }
+
+      before do
+        provider.users << bob << alice << norman
+
+        render_inline(View.new(provider:))
+      end
+
+      it "render the correct provider details" do
+        expect(rendered_component).to have_text("University of Wantage")
+        expect(rendered_component).to have_text("2 users")
+      end
+    end
+  end
+end


### PR DESCRIPTION



### Context

The view component that renders each provider on this page also looks up the `provider.users.kept.count`.

### Changes proposed in this pull request

Adding a join to the users table and a customer select list we can pull this information back in a single query.

### Guidance to review

Visit: `/system-admin/providers`

Log extract before
```
2023-06-28 17:25:44.399007 D [44813:puma srv tp 001] (0.708ms) ActiveRecord -- Provider Load -- { :sql => "SELECT \"providers\".* FROM \"providers\" ORDER BY \"providers\".\"name\" ASC", :allocations => 242, :cached => nil }
2023-06-28 17:25:44.403723 D [44813:puma srv tp 001] (0.992ms) ActiveRecord -- User Count -- { :sql => "SELECT COUNT(*) FROM \"users\" INNER JOIN \"provider_users\" ON \"users\".\"id\" = \"provider_users\".\"user_id\" WHERE \"provider_users\".\"provider_id\" = $1 AND \"users\".\"discarded_at\" IS NULL", :binds => { :provider_id => 1 }, :allocations => 214, :cached => nil }
2023-06-28 17:25:44.405061 D [44813:puma srv tp 001] (0.923ms) ActiveRecord -- User Count -- { :sql => "SELECT COUNT(*) FROM \"users\" INNER JOIN \"provider_users\" ON \"users\".\"id\" = \"provider_users\".\"user_id\" WHERE \"provider_users\".\"provider_id\" = $1 AND \"users\".\"discarded_at\" IS NULL", :binds => { :provider_id => 2 }, :allocations => 492, :cached => nil }
2023-06-28 17:25:44.406761 D [44813:puma srv tp 001] (0.886ms) ActiveRecord -- User Count -- { :sql => "SELECT COUNT(*) FROM \"users\" INNER JOIN \"provider_users\" ON \"users\".\"id\" = \"provider_users\".\"user_id\" WHERE \"provider_users\".\"provider_id\" = $1 AND \"users\".\"discarded_at\" IS NULL", :binds => { :provider_id => 3 }, :allocations => 492, :cached => nil }
2023-06-28 17:25:44.408074 D [44813:puma srv tp 001] (0.912ms) ActiveRecord -- User Count -- { :sql => "SELECT COUNT(*) FROM \"users\" INNER JOIN \"provider_users\" ON \"users\".\"id\" = \"provider_users\".\"user_id\" WHERE \"provider_users\".\"provider_id\" = $1 AND \"users\".\"discarded_at\" IS NULL", :binds => { :provider_id => 4 }, :allocations => 492, :cached => nil }
2023-06-28 17:25:44.408193 D [44813:puma srv tp 001] (28.6ms) ActionView -- Rendered -- { :template => "system_admin/providers/index.html.erb", :within => "layouts/application", :allocations => 15385 }
```

After:

```
2023-06-28 17:27:15.658640 D [44813:puma srv tp 004] (1.402ms) ActiveRecord -- Provider Load -- { :sql => "SELECT providers.*, count(users.id) as user_count FROM \"providers\" LEFT OUTER JOIN \"provider_users\" ON \"provider_users\".\"provider_id\" = \"providers\".\"id\" LEFT OUTER JOIN \"users\" ON \"users\".\"id\" = \"provider_users\".\"user_id\" WHERE \"users\".\"discarded_at\" IS NULL GROUP BY \"providers\".\"id\" ORDER BY \"providers\".\"name\" ASC", :allocations => 243, :cached => nil }
2023-06-28 17:27:15.661980 D [44813:puma srv tp 004] (55.9ms) ActionView -- Rendered -- { :template => "system_admin/providers/index.html.erb", :within
```

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
