### PR TITLE
[5599] Memoize counts in TraineesController#index

### DIFF
--- a/app/controllers/base_trainee_controller.rb
+++ b/app/controllers/base_trainee_controller.rb
@@ -6,6 +6,7 @@ class BaseTraineeController < ApplicationController
     filter_params
     filters
     filtered_trainees
+    filtered_trainees_count
     academic_cycle_options
     available_record_sources
     show_source_filters?
@@ -31,7 +32,7 @@ class BaseTraineeController < ApplicationController
       format.html
       format.js { render(json: json_response) }
       format.csv do
-        if current_user.system_admin? && filtered_trainees.count > Settings.trainee_export.record_limit
+        if current_user.system_admin? && filtered_trainees_count > Settings.trainee_export.record_limit
           return redirect_to(
             search_path(filter_params),
             flash: { warning: "System admins cannot export more than #{Settings.trainee_export.record_limit} trainees" },
@@ -76,10 +77,10 @@ private
   end
 
   def total_trainees_count
-    if filtered_trainees.count == unfiltered_trainees.count
-      filtered_trainees.count.to_s
+    if filtered_trainees_count == unfiltered_trainees_count
+      filtered_trainees_count.to_s
     else
-      "#{filtered_trainees.count} of #{unfiltered_trainees.count}"
+      "#{filtered_trainees_count} of #{unfiltered_trainees_count}"
     end
   end
 
@@ -118,11 +119,19 @@ private
     )
   end
 
+  def filtered_trainees_count
+    @filtered_trainees_count ||= filtered_trainees.count
+  end
+
   def unfiltered_trainees
     @unfiltered_trainees ||= Trainees::Filter.call(
       trainees: policy_scope(trainee_search_scope),
       filters: {},
     )
+  end
+
+  def unfiltered_trainees_count
+    @unfiltered_trainees_count ||= unfiltered_trainees.count
   end
 
   def field

--- a/app/views/trainees/_action_bar.html.erb
+++ b/app/views/trainees/_action_bar.html.erb
@@ -1,7 +1,7 @@
 <% unless paginated_trainees.empty? %>
   <%= render SortLinks::View.new %>
     <% if FeatureService.enabled?(:trainee_export) && policy(:trainee).export? %>
-      <% if exceeds_export_limit?(@current_user, filtered_trainees.count) %>
+      <% if exceeds_export_limit?(@current_user, filtered_trainees_count) %>
         <div class="app-export-link-container govuk-body govuk-hint">
           Admins cannot export more than <%= Settings.trainee_export.record_limit %> trainees
         </div>


### PR DESCRIPTION
### Context

We are seeing a (kind of) 1+n query on the trainees index page. 

https://dfe-teacher-services.sentry.io/issues/4200266000/?environment=production&project=5552118&query=is%3Aunresolved&referrer=issue-stream&stream_index=1

### Changes proposed in this pull request

There are a number of repeated SQL queries that fetch the filtered count of trainees in the `BaseTraineeController`. I think we can safely memoize these on a per request basis to avoid the 1+n query.

### Guidance to review

Does this change look safe?

To reproduce the issue you just need to type something into the search box on the main trainee index page and check the logs for repeating queries that look a bit like this:

```
SELECT trainees.* FROM trainees INNER JOIN
(SELECT trainees.id AS pg_search_id,
  (ts_rank((to_tsvector('simple', coalesce(trainees.first_names::text, ''))
        || to_tsvector('simple', coalesce(trainees.middle_names::text, ''))
        || to_tsvector('simple', coalesce(trainees.last_name::text, ''))
        || to_tsvector('simple', coalesce(trainees.trainee_id::text, ''))
        || to_tsvector('simple', coalesce(trainees.trn::text, ''))),
      (to_tsquery('simple', ''' ' || 'Wisozk' || ' ''' || ':*')), 0))
  AS rank FROM trainees WHERE ((to_tsvector('simple', coalesce(trainees.first_names::text, '')) ||
      to_tsvector('simple', coalesce(trainees.middle_names::text, '')) ||
      to_tsvector('simple', coalesce(trainees.last_name::text, '')) ||
      to_tsvector('simple', coalesce(trainees.trainee_id::text, '')) ||
      to_tsvector('simple', coalesce(trainees.trn::text, ''))) @@ (to_tsquery('simple', ''' ' || 'Wisozk' || ' ''' || ':*'))))
AS pg_search_ce1e79e19561e539ea99e1
ON trainees.id = pg_search_ce1e79e19561e539ea99e1.pg_search_id
WHERE trainees.state != 1
AND trainees.provider_id = 2
AND trainees.discarded_at IS NULL
AND 1=1
AND trainees.discarded_at IS NULL
AND (trainees.record_source IN ('foo')
  OR trainees.record_source IS NULL)
ORDER BY pg_search_ce1e79e19561e539ea99e1.rank DESC, trainees.id ASC;
```

With the changes in this PR the number of similar queries drops from 8 to 2 in my tests. (I'm not sure whether I've missed one or whether we need to run the query twice, once filtered, once unfiltered).

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
