### PR TITLE
[5579] Sync an initial batch of 500 trainees to DQT

### DIFF
--- a/db/data/20230703103109_sync_intraining_trainees_to_dqt_prior_to_feb2023.rb
+++ b/db/data/20230703103109_sync_intraining_trainees_to_dqt_prior_to_feb2023.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SyncIntrainingTraineesToDqtPriorToFeb2023 < ActiveRecord::Migration[7.0]
+  def up
+    in_training = Trainee.where.not(trn: nil).where("length(trn) = 7").in_training.where("updated_at <= ?", Date.new(2023, 2).end_of_month).limit(500)
+
+    in_training.find_in_batches(batch_size: 500).with_index do |group, batch|
+      group.each do |trainee|
+        Dqt::UpdateTraineeJob.set(wait: 30.seconds * batch).perform_later(trainee)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

Rob wants us to send an initial 500 trainee updates as a smoke check. This is a slim down version of the larger update to follow on from this https://github.com/DFE-Digital/register-trainee-teachers/pull/3367. 
