### PR TITLE
[5598] Resolve N+1 issues on drafts/registered page

### DIFF
--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -32,7 +32,7 @@ private
   end
 
   def trainee_search_scope
-    Trainee.draft.includes(provider: [:courses])
+    Trainee.draft.includes(:start_academic_cycle, :end_academic_cycle, :apply_application, provider: [:courses])
   end
 
   def export_results_path

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -61,7 +61,7 @@ private
   end
 
   def trainee_search_scope
-    Trainee.includes({ provider: [:courses] }, :start_academic_cycle, :end_academic_cycle).not_draft
+    Trainee.includes({ provider: [:courses] }, :start_academic_cycle, :apply_application, :end_academic_cycle).not_draft
   end
 
   def export_results_path


### PR DESCRIPTION
### Context

https://trello.com/c/XrhWvkwh/5598-n1-query-traineesreviewdraftscontrollershow

Getting N+1 queries on the drafts/registered pages for academic cycles/apply applications (some cached some aren't). This also happens every time filtering via JavaScript is performed.

### Changes proposed in this pull request

- Add necessary includes

### Guidance to review

Before:

<img width="1930" alt="Screenshot 2023-07-05 at 09 15 46" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/4307560b-a122-40c4-a0f8-94309c0316bf">

<img width="1874" alt="Screenshot 2023-07-05 at 09 16 32" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/8a17a75d-b5b4-4d61-8390-e10fbfeb6b2e">

### Important business (does not apply)
