### PR TITLE
[5626] Add a YearChangeBanner component and render

### DIFF
--- a/app/components/flash_banner/view.html.erb
+++ b/app/components/flash_banner/view.html.erb
@@ -1,7 +1,7 @@
 <% if display? %>
   <% FLASH_TYPES.each do |type| %>
     <% if flash[type] %>
-      <%= render(NotificationBanner::View.new(text: flash[type], type: type)) %>
+      <%= render(NotificationBanner::View.new(text: flash[type], type: type, classes: "app-flash")) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/year_change_banner/view.html.erb
+++ b/app/components/year_change_banner/view.html.erb
@@ -2,4 +2,3 @@
   banner.heading(text: title)
   content
 end %>
-

--- a/app/components/year_change_banner/view.html.erb
+++ b/app/components/year_change_banner/view.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <h3 class="govuk-notification-banner__heading">
+      <%= title %>
+    </h3>
+    <p class="govuk-body"><%= content %></p>
+  </div>
+</div>

--- a/app/components/year_change_banner/view.html.erb
+++ b/app/components/year_change_banner/view.html.erb
@@ -1,13 +1,5 @@
-<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-  <div class="govuk-notification-banner__header">
-    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-      Important
-    </h2>
-  </div>
-  <div class="govuk-notification-banner__content">
-    <h3 class="govuk-notification-banner__heading">
-      <%= title %>
-    </h3>
-    <p class="govuk-body"><%= content %></p>
-  </div>
-</div>
+<%= govuk_notification_banner(title_text: "Important") do |banner| 
+  banner.heading(text: title)
+  content
+end %>
+

--- a/app/components/year_change_banner/view.rb
+++ b/app/components/year_change_banner/view.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module YearChangeBanner
+  class View < GovukComponent::Base
+    def initialize
+      super(classes: "", html_attributes: "")
+    end
+
+    def render?
+      Time.zone.today.month == 7 || Time.zone.today.month == 8
+    end
+
+    def title
+      if Time.zone.today.month == 7
+        "The #{current_year} to #{current_year + 1} academic year will start on 1 August"
+      elsif Time.zone.today.month == 8
+        "The #{current_year} to #{current_year + 1} academic year started on 1 August"
+      end
+    end
+
+    def content
+      if Time.zone.today.month == 7
+        "<a class=\"govuk-notification-banner__link\" href=\"#{dates_and_deadlines_guidance_path}\">View dates and deadlines</a> for the upcoming academic year.".html_safe
+      elsif Time.zone.today.month == 8
+        "<a class=\"govuk-notification-banner__link\" href=\"#{dates_and_deadlines_guidance_path}\">View dates and deadlines</a> for this academic year.".html_safe
+      end
+    end
+
+  private
+
+    def current_month
+      Time.zone.today.month
+    end
+
+    def current_year
+      Time.zone.today.year
+    end
+  end
+end

--- a/app/components/year_change_banner/view.rb
+++ b/app/components/year_change_banner/view.rb
@@ -3,25 +3,26 @@
 module YearChangeBanner
   class View < GovukComponent::Base
     def initialize
+      @today = Time.zone.today
       super(classes: "", html_attributes: "")
     end
 
     def render?
-      Time.zone.today.month == 7 || Time.zone.today.month == 8
+      current_month == 7 || current_month == 8
     end
 
     def title
-      if Time.zone.today.month == 7
+      if current_month == 7
         "The #{current_year} to #{current_year + 1} academic year will start on 1 August"
-      elsif Time.zone.today.month == 8
+      elsif current_month == 8
         "The #{current_year} to #{current_year + 1} academic year started on 1 August"
       end
     end
 
     def content
-      if Time.zone.today.month == 7
+      if current_month == 7
         "<a class=\"govuk-notification-banner__link\" href=\"#{dates_and_deadlines_guidance_path}\">View dates and deadlines</a> for the upcoming academic year.".html_safe
-      elsif Time.zone.today.month == 8
+      elsif current_month == 8
         "<a class=\"govuk-notification-banner__link\" href=\"#{dates_and_deadlines_guidance_path}\">View dates and deadlines</a> for this academic year.".html_safe
       end
     end
@@ -29,11 +30,11 @@ module YearChangeBanner
   private
 
     def current_month
-      Time.zone.today.month
+      @today.month
     end
 
     def current_year
-      Time.zone.today.year
+      @today.year
     end
   end
 end

--- a/app/components/year_change_banner/view.rb
+++ b/app/components/year_change_banner/view.rb
@@ -2,32 +2,42 @@
 
 module YearChangeBanner
   class View < GovukComponent::Base
+    DEFAULT_ACADEMIC_CYCLE_START_DATE = "1 August"
+
     def initialize
       @today = Time.zone.today
       super(classes: "", html_attributes: "")
     end
 
     def render?
-      current_month == 7 || current_month == 8
+      july? || august?
     end
 
     def title
-      if current_month == 7
-        "The #{current_year} to #{current_year + 1} academic year will start on 1 August"
-      elsif current_month == 8
-        "The #{current_year} to #{current_year + 1} academic year started on 1 August"
+      if july?
+        "The #{current_year} to #{current_year + 1} academic year will start on #{cycle_start_date}"
+      elsif august?
+        "The #{current_year} to #{current_year + 1} academic year started on #{cycle_start_date}"
       end
     end
 
     def content
-      if current_month == 7
+      if july?
         "<a class=\"govuk-notification-banner__link\" href=\"#{dates_and_deadlines_guidance_path}\">View dates and deadlines</a> for the upcoming academic year.".html_safe
-      elsif current_month == 8
+      elsif august?
         "<a class=\"govuk-notification-banner__link\" href=\"#{dates_and_deadlines_guidance_path}\">View dates and deadlines</a> for this academic year.".html_safe
       end
     end
 
   private
+
+    def july?
+      current_month == 7
+    end
+
+    def august?
+      current_month == 8
+    end
 
     def current_month
       @today.month
@@ -35,6 +45,10 @@ module YearChangeBanner
 
     def current_year
       @today.year
+    end
+
+    def cycle_start_date
+      @cycle_start_date ||= AcademicCycle.current&.start_date&.to_fs(:govuk_no_year) || DEFAULT_ACADEMIC_CYCLE_START_DATE
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -90,6 +90,7 @@
     <main class="govuk-main-wrapper " id="main-content" role="main">
       <%= yield :start_page_banner %>
       <div class="govuk-width-container">
+        <%= render(YearChangeBanner::View.new) %>
         <%= render(FlashBanner::View.new(flash: flash, trainee: @trainee)) %>
         <%= yield %>
       </div>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 # https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
-Date::DATE_FORMATS[:govuk]        = "%-d %B %Y" # 2 January 1998
-Date::DATE_FORMATS[:govuk_short]  = "%-d %b %Y" # 2 Jan 1998
-Date::DATE_FORMATS[:govuk_approx] = "%B %Y"     # January 1998
+Date::DATE_FORMATS[:govuk]         = "%-d %B %Y" # 2 January 1998
+Date::DATE_FORMATS[:govuk_no_year] = "%-d %B"    # 2 January
+Date::DATE_FORMATS[:govuk_short]   = "%-d %b %Y" # 2 Jan 1998
+Date::DATE_FORMATS[:govuk_approx]  = "%B %Y"     # January 1998
 
 Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
   format = if time >= time.midday && time <= time.midday.end_of_minute

--- a/spec/components/year_change_banner/view_preview.rb
+++ b/spec/components/year_change_banner/view_preview.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class YearChangeBanner::ViewPreview < ViewComponent::Preview
+  def default_state
+    Timecop.freeze(Date.new(Time.zone.today.year, 6, 1)) do
+      render(YearChangeBanner::View.new)
+    end
+  end
+
+  def july
+    Timecop.freeze(Date.new(Time.zone.today.year, 7, 1)) do
+      render(YearChangeBanner::View.new)
+    end
+  end
+
+  def august
+    Timecop.freeze(Date.new(Time.zone.today.year, 8, 1)) do
+      render(YearChangeBanner::View.new)
+    end
+  end
+end

--- a/spec/components/year_change_banner/view_spec.rb
+++ b/spec/components/year_change_banner/view_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe YearChangeBanner::View do
+  let(:current_date) { Date.new(2023, 6, 1) }
+
+  before do
+    Timecop.freeze(current_date) do
+      @result = render_inline(YearChangeBanner::View.new)
+    end
+  end
+
+  context "in June" do
+    it "renders nothing" do
+      expect(@result.text).to be_blank
+    end
+  end
+
+  context "in July" do
+    let(:current_date) { Date.new(2023, 7, 1) }
+
+    it "renders the 'new academic year imminent' banner" do
+      expect(@result.text).to include("The 2023 to 2024 academic year will start on 1 August")
+    end
+  end
+
+  context "in August" do
+    let(:current_date) { Date.new(2023, 8, 15) }
+
+    it "renders the 'new academic year has just started' banner" do
+      expect(@result.text).to include("The 2023 to 2024 academic year started on 1 August")
+    end
+  end
+end

--- a/spec/components/year_change_banner/view_spec.rb
+++ b/spec/components/year_change_banner/view_spec.rb
@@ -7,6 +7,7 @@ describe YearChangeBanner::View do
 
   before do
     Timecop.freeze(current_date) do
+      create(:academic_cycle)
       @result = render_inline(YearChangeBanner::View.new)
     end
   end

--- a/spec/support/page_objects/system_admin/uploads/index.rb
+++ b/spec/support/page_objects/system_admin/uploads/index.rb
@@ -14,8 +14,7 @@ module PageObjects
         element :search, 'input[name="search"]'
         element :submit_search, ".submit-search"
         sections :uploads, UploadRow, ".upload-row"
-        element :flash_message, ".govuk-notification-banner__header"
-        element :flash_message, ".govuk-notification-banner__header"
+        element :flash_message, ".app-flash .govuk-notification-banner__header"
       end
     end
   end

--- a/spec/support/page_objects/system_admin/users/index.rb
+++ b/spec/support/page_objects/system_admin/users/index.rb
@@ -14,8 +14,7 @@ module PageObjects
         element :search, "#search-field", visible: :all
         element :submit_search, ".submit-search"
         sections :users, UserRow, ".user-row"
-        element :flash_message, ".govuk-notification-banner__header"
-        element :flash_message, ".govuk-notification-banner__header"
+        element :flash_message, ".app-flash .govuk-notification-banner__header"
 
         def body_text_excluding_search
           Capybara.current_session.text.gsub(search.text, "")

--- a/spec/support/page_objects/system_admin/users/show.rb
+++ b/spec/support/page_objects/system_admin/users/show.rb
@@ -17,7 +17,7 @@ module PageObjects
         element :add_provider, "a.add-user-to-provider"
         element :add_lead_school, "a.add-user-lead-school"
         element :delete_user, "a", text: "Delete this user"
-        element :flash_message, ".govuk-notification-banner__header"
+        element :flash_message, ".app-flash .govuk-notification-banner__header"
       end
     end
   end


### PR DESCRIPTION
### Context

We want to warn users before the academic year changes, and after it’s just changed, so they’re not surprised by it changing. Many users think that the new year starts in September, when in reality it starts 1 August.

### Changes proposed in this pull request

Add a new component, `YearChangeBanner::View`, to display a banner with a link to the dates guidance page.

This component can be 'rendered' all year round because it works out whether to display itself based on the current date.

#### 1-31 July
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/1fe5ccc3-57bc-43e8-8fdc-e3c0c0bf56af)

#### 1-31 August
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/f9ce3b7c-8bfe-4292-b2c0-c95450967502)

### Guidance to review

I'm not sure whether this should be displayed all the time. The ticket implies that it should be displayed for the full 2 months (on every page). Do we think this is overkill/potentially annoying?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
