### PR TITLE
[5661] Refactor dead job export logic to use DQT tables

### DIFF
--- a/app/jobs/dqt/sync_teachers_job.rb
+++ b/app/jobs/dqt/sync_teachers_job.rb
@@ -7,7 +7,9 @@ module Dqt
     def perform(batch_size = 500, interval = 30.seconds)
       return unless FeatureService.enabled?("dqt_import.sync_teachers")
 
-      trainees = Trainee.where.not(trn: nil).where("length(trn) = 7").in_training.or(Trainee.deferred)
+      trainees = Trainee.where.not(trn: nil).where("length(trn) = 7").in_training.or(
+        Trainee.where.not(trn: nil).where("length(trn) = 7").deferred,
+      )
 
       trainees.find_in_batches(batch_size:).with_index do |group, batch|
         # The API rate limit is 3000 requests per minute so by default we're

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -38,6 +38,10 @@ sync_hesa_students:
   cron: "0 5 * * *"
   class: "Hesa::SyncStudentsJob"
   queue: hesa
+sync_dqt_teachers:
+  cron: "0 0 1 * *"
+  class: "Dqt::SyncTeachersJob"
+  queue: default
 remove_duplicate_dead_jobs:
   cron: "* * * * *"
   class: "Sidekiq::RemoveDeadDuplicatesJob"

--- a/spec/factories/dqt/dqt_teacher_trainings.rb
+++ b/spec/factories/dqt/dqt_teacher_trainings.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dqt_training, class: "Dqt::TeacherTraining" do
+    dqt_teacher
+    programme_start_date { Faker::Date.in_date_period(month: 1) }
+    programme_end_date { Faker::Date.in_date_period(month: 9) }
+    programme_type { "ProviderLedPostgrad" }
+    result { "InTraining" }
+    provider_ukprn { Faker::Number.number(digits: 8) }
+    active { true }
+    hesa_id { Faker::Number.number(digits: 13) }
+  end
+end

--- a/spec/factories/dqt/dqt_teachers.rb
+++ b/spec/factories/dqt/dqt_teachers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dqt_teacher, class: "Dqt::Teacher" do
+    trn { Faker::Number.number(digits: 7) }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    date_of_birth { Faker::Date.birthday(min_age: 18, max_age: 65) }
+
+    trait :with_hesa do
+      hesa_id { Faker::Number.number(digits: 13) }
+    end
+
+    trait :with_teacher_training do
+      dqt_trainings { [build(:dqt_training)] }
+    end
+  end
+end

--- a/spec/support/shared_examples/dead_jobs.rb
+++ b/spec/support/shared_examples/dead_jobs.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.shared_examples "Dead jobs" do |dead_jobs_klass, name|
   let(:job_id) { SecureRandom.hex }
   let(:trainee) { create(:trainee, :completed, :trn_received, sex: "female", hesa_id: 1) }
+  let!(:dqt_teacher) { create(:dqt_teacher, :with_teacher_training, trn: trainee.trn) }
+  let(:dqt_teacher_training) { dqt_teacher.dqt_trainings.first }
   let(:csv) { CSV.parse(subject.to_csv, headers: true) }
 
   let(:dead_set) do
@@ -26,37 +28,14 @@ RSpec.shared_examples "Dead jobs" do |dead_jobs_klass, name|
     ]
   end
 
-  let(:dqt_response) do
-    { "trn" => "1234567",
-      "firstName" => "Bobby",
-      "lastName" => "Burger",
-      "middleName" => "Chrystal",
-      "dateOfBirth" => "1989-11-01",
-      "hasActiveSanctions" => false,
-      "initialTeacherTraining" =>
-      [{ "programmeStartDate" => "2022-09-03",
-         "programmeEndDate" => "2023-07-01",
-         "programmeType" => "InternationalQualifiedTeacherStatus",
-         "result" => "InTraining",
-         "provider" => { "ukprn" => "10007159" },
-         "husId" => nil,
-         "active" => true }] }
-  end
-
   let(:dqt_response_humanised) do
     <<~TEXT
-      trn: 1234567
-      firstName: Bobby
-      lastName: Burger
-      middleName: Chrystal
-      dateOfBirth: 1989-11-01
-      hasActiveSanctions: false
-      initialTeacherTraining: [{"programmeStartDate"=>"2022-09-03", "programmeEndDate"=>"2023-07-01", "programmeType"=>"InternationalQualifiedTeacherStatus", "result"=>"InTraining", "provider"=>{"ukprn"=>"10007159"}, "husId"=>nil, "active"=>true}]
+      trn: #{dqt_teacher.trn}
+      first_name: #{dqt_teacher.first_name}
+      last_name: #{dqt_teacher.last_name}
+      date_of_birth: #{dqt_teacher.date_of_birth}
+      dqt_teacher_trainings: [{"programme_start_date"=>"#{dqt_teacher_training.programme_start_date}", "programme_end_date"=>"#{dqt_teacher_training.programme_end_date}", "programme_type"=>"#{dqt_teacher_training.programme_type}", "result"=>"#{dqt_teacher_training.result}", "provider_ukprn"=>"#{dqt_teacher_training.provider_ukprn}", "hesa_id"=>"#{dqt_teacher_training.hesa_id}", "active"=>#{dqt_teacher_training.active}}]
     TEXT
-  end
-
-  before do
-    allow(Dqt::RetrieveTeacher).to receive(:call).with(trainee:).and_return(dqt_response)
   end
 
   subject { described_class.new(dead_set: dead_set, include_dqt_status: true) }


### PR DESCRIPTION
### Context

https://trello.com/c/w10d50pf/5661-spike-dead-jobs-export-failing-for-large-volume-of-updatejobs

When we have a lot of dead jobs, the export timeouts due to having to make network requests to DQT to fetch the trainee's record to be compared with for each one in the set.

We introduced a pattern in early register days when working with DTTP to keep local sync tables so we can query third party data we needed quicker. We currently have a couple for the DQT teacher/teacher training records in Register. We should probably use these to look up the information instead of having to fetch them over the wire every time.

### Changes proposed in this pull request

The changes here build on top of this PR https://github.com/DFE-Digital/register-trainee-teachers/pull/3114, which had the same idea. The team discussed having a job which ran periodically to keep the tables up to date but left it and ran it manually.

This PR proposes adding that job as periodic run (currently set to weekly but can be changed). The job fetches the latest DQT records for trainees in training/deferred and stores them in the local sync tables. 

I've made some changes to the export logic to look up the tables instead of fetching directly from DQT since we'll be able to leverage those now.

### Guidance to review

- You can run the job locally against the dqt dev environment but it is difficult to re-create the dead job set unless it is explicitly pulled down from Redis into your local dev environment
- There's a nice test which asserts a specific shape for the DQT data, I've made sure to return and match the same structure

### Important business (does not apply)
