### PR TITLE
[5666] Fix incorrectly awarded and recommended trainees

### DIFF
--- a/db/data/20230710091532_fix_incorrectly_awarded_trainees_5666.rb
+++ b/db/data/20230710091532_fix_incorrectly_awarded_trainees_5666.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class FixIncorrectlyAwardedTrainees5666 < ActiveRecord::Migration[7.0]
+  def up
+    %w[9kW3JDjd3XvQ4UQ4Qoig3H7Q
+       EQZ3B78pT867gjyvEFWe2ecD
+       Bgy75pnatWHNn2VJqa3rubqa
+       j1BZfrxA22qu4pkW8Xy3zNsS
+       o9TxoTP1ZytvKn6qNgVNSgDr
+       z9yyVAqh9hJpk4yJK7SsqWb1
+       j4Nh24pAzmKabPEkufXcNq4x
+       fYXkbTZUcxaW6tkwNzdtoNWC
+       8A8YooHgnq2yfZvAWJi6NXNc].each do |slug|
+      Trainee.find_by(slug:)&.update!(state: :trn_received, awarded_at: nil, outcome_date: nil, recommended_for_award_at: nil, audit_comment: "Provider awarded the trainee in error")
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/FI7dTdr8/5666-status-change
https://trello.com/c/KyHB4tnP/5669-incorrect-recommendation-for-qts
https://trello.com/c/hnPIBXju/5670-qts-recommendation-in-error
https://trello.com/c/MCOztjmA/5665-mistakes-after-trainees-have-been-recommended

We have a few trainees which have been incorrectly awarded/recommended. Some will need to be withdrawn but need to be put into an `in training` state so the provider can properly withdraw the trainee.

### Changes proposed in this pull request

- Data migration to put these trainees back into an `in training` state, in this case `trn_received`.

### Guidance to review

Tested locally

### Important business

DQT have already updated the trainees on their end
