### PR TITLE
[5627] Change default course cycle for trainees registered after 1 July

### DIFF
--- a/app/forms/course_years_form.rb
+++ b/app/forms/course_years_form.rb
@@ -11,6 +11,9 @@ class CourseYearsForm
 
   def initialize(trainee: nil, params: {})
     assign_attributes(params)
+    @course_year ||= AcademicCycle.for_date(
+      Time.zone.now + Trainees::SetAcademicCycles::DEFAULT_CYCLE_OFFSET,
+    )&.start_date&.year
     @trainee = trainee
   end
 

--- a/app/services/trainees/set_academic_cycles.rb
+++ b/app/services/trainees/set_academic_cycles.rb
@@ -4,6 +4,8 @@ module Trainees
   class SetAcademicCycles
     include ServicePattern
 
+    DEFAULT_CYCLE_OFFSET = 1.month
+
     def initialize(trainee:)
       @trainee = trainee
     end
@@ -25,7 +27,7 @@ module Trainees
              :itt_end_date, to: :trainee
 
     def start_academic_cycle
-      start_date.present? ? AcademicCycle.for_date(start_date) : AcademicCycle.current
+      start_date.present? ? AcademicCycle.for_date(start_date) : AcademicCycle.for_date(Time.zone.now + DEFAULT_CYCLE_OFFSET)
     end
 
     def end_academic_cycle

--- a/app/views/trainees/course_years/edit.html.erb
+++ b/app/views/trainees/course_years/edit.html.erb
@@ -18,7 +18,6 @@
         <%= f.govuk_radio_buttons_fieldset :course_year, legend: { text: t(".heading"), tag: "h1", size: "l" } do %>
           <% f.object.course_years_options.each do |val, name| %>
             <%= f.govuk_radio_button :course_year, val,
-              checked: (val == params[:year].to_i),
               label: { text: name },
               link_errors: false %>
           <% end %>

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -5,7 +5,9 @@ require "rails_helper"
 module Funding
   describe View do
     let(:data_model) { Funding::FormValidator.new(trainee) }
-    let(:start_academic_cycle) { create(:academic_cycle) }
+    let!(:current_academic_cycle) { create(:academic_cycle) }
+    let!(:next_academic_cycle) { create(:academic_cycle, next_cycle: true) }
+    let(:start_academic_cycle) { next_academic_cycle }
 
     before { render_inline(View.new(data_model: trainee, editable: true)) }
 
@@ -44,7 +46,14 @@ module Funding
 
       let(:subject_specialism) { create(:subject_specialism, name: AllocationSubjects::MATHEMATICS) }
       let(:amount) { 9000 }
-      let(:funding_method) { create(:funding_method, training_route: route, amount: amount) }
+      let(:funding_method) do
+        create(
+          :funding_method,
+          training_route: route,
+          amount: amount,
+          academic_cycle: start_academic_cycle,
+        )
+      end
 
       context "when there is a bursary available" do
         before do
@@ -103,7 +112,7 @@ module Funding
 
         describe "has no bursary" do
           before do
-            create(:funding_method)
+            create(:funding_method, academic_cycle: start_academic_cycle)
             render_inline(View.new(data_model:))
           end
 
@@ -126,7 +135,13 @@ module Funding
 
         describe "has bursary" do
           let(:trainee) {
-            create(:trainee, :with_provider_led_bursary, funding_amount: 24000, applying_for_bursary: applying_for_bursary, start_academic_cycle: start_academic_cycle)
+            create(
+              :trainee,
+              :with_provider_led_bursary,
+              funding_amount: 24000,
+              applying_for_bursary: applying_for_bursary,
+              start_academic_cycle: start_academic_cycle,
+            )
           }
 
           before do
@@ -178,6 +193,7 @@ module Funding
       let(:trainee) { create(:trainee, :with_grant, funding_amount: 25000, applying_for_grant: applying_for_grant, start_academic_cycle: start_academic_cycle) }
 
       before do
+        create(:funding_method, academic_cycle: start_academic_cycle)
         render_inline(View.new(data_model: trainee, editable: true))
       end
 

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -560,7 +560,7 @@ FactoryBot.define do
       applying_for_bursary { true }
 
       after(:create) do |trainee, evaluator|
-        funding_method = create(:funding_method, :bursary, :with_subjects, training_route: :provider_led_postgrad)
+        funding_method = create(:funding_method, :bursary, :with_subjects, training_route: :provider_led_postgrad, academic_cycle: trainee.start_academic_cycle)
         funding_method.amount = evaluator.funding_amount if evaluator.funding_amount.present?
         funding_method.save
 
@@ -574,7 +574,7 @@ FactoryBot.define do
       applying_for_grant { true }
 
       after(:create) do |trainee, _|
-        funding_method = create(:funding_method, :grant, :with_subjects, training_route: :early_years_salaried)
+        funding_method = create(:funding_method, :grant, :with_subjects, training_route: :early_years_salaried, academic_cycle: trainee.start_academic_cycle)
         trainee.course_allocation_subject = funding_method.allocation_subjects.first
         trainee.training_route = funding_method.training_route
         trainee.trainee_start_date = funding_method.academic_cycle.start_date
@@ -585,7 +585,7 @@ FactoryBot.define do
       applying_for_scholarship { true }
 
       after(:create) do |trainee, _|
-        funding_method = create(:funding_method, :scholarship, :with_subjects, training_route: :provider_led_postgrad)
+        funding_method = create(:funding_method, :scholarship, :with_subjects, training_route: :provider_led_postgrad, academic_cycle: trainee.start_academic_cycle)
         trainee.course_allocation_subject = funding_method.allocation_subjects.first
         trainee.training_route = funding_method.training_route
         trainee.trainee_start_date = funding_method.academic_cycle.start_date
@@ -600,7 +600,7 @@ FactoryBot.define do
       applying_for_grant { true }
 
       after(:create) do |trainee, evaluator|
-        funding_method = create(:funding_method, :grant, :with_subjects, training_route: :provider_led_postgrad)
+        funding_method = create(:funding_method, :grant, :with_subjects, training_route: :provider_led_postgrad, academic_cycle: trainee.start_academic_cycle)
         funding_method.amount = evaluator.funding_amount if evaluator.funding_amount.present?
         funding_method.save
 

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -50,6 +50,22 @@ feature "Change course", feature_publish_course_details: true do
       and_i_do_not_change_training_route
       and_i_am_redirected_to_the_publish_course_details_page
     end
+
+    context "within 1 month of the next cycle" do
+      around do |example|
+        Timecop.freeze(Date.new(Time.zone.today.year, 7, 15)) { example.run }
+      end
+
+      scenario "do not show course year choice and default to next cycle", feature_show_draft_trainee_course_year_choice: false do
+        given_i_am_authenticated
+        and_a_draft_trainee_exists
+        and_i_am_on_the_confirm_course_details_page
+        and_i_click_change_course
+        and_i_do_not_change_training_route
+        and_i_am_redirected_to_the_publish_course_details_page
+        then_i_can_pick_a_course_from_the_next_cycle
+      end
+    end
   end
 
 private
@@ -159,5 +175,11 @@ private
 
   def and_i_am_redirected_to_the_publish_course_details_page
     expect(publish_course_details_page).to be_displayed(id: trainee.slug)
+  end
+
+  def then_i_can_pick_a_course_from_the_next_cycle
+    expect(publish_course_details_page.title).to include(
+      "Your school direct salaried courses starting in #{Time.zone.today.year} to #{Time.zone.today.year + 1}",
+    )
   end
 end

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -179,7 +179,7 @@ private
 
   def then_i_can_pick_a_course_from_the_next_cycle
     expect(publish_course_details_page.title).to include(
-      "Your school direct salaried courses starting in #{Time.zone.today.year} to #{Time.zone.today.year + 1}",
+      "Your school direct salaried courses starting in #{Time.zone.today.year} to #{1.year.from_now.year}",
     )
   end
 end

--- a/spec/forms/course_years_form_spec.rb
+++ b/spec/forms/course_years_form_spec.rb
@@ -11,6 +11,42 @@ describe CourseYearsForm, type: :model do
     it { is_expected.to validate_inclusion_of(:course_year).in_array(subject.course_years_options.keys) }
   end
 
+  describe "#course_year" do
+    before do
+      create(:academic_cycle, :current)
+      create(:academic_cycle, previous_cycle: true)
+      create(:academic_cycle, next_cycle: true)
+    end
+
+    context "with a `course_year` param" do
+      let(:params) { { course_year: 2025 } }
+
+      it "params override default" do
+        expect(subject.course_year).to eq(2025)
+      end
+    end
+
+    context "3 months before end of cycle" do
+      around do |example|
+        Timecop.freeze(Date.new(2023, 5, 1)) { example.run }
+      end
+
+      it "defaults to the current cycle" do
+        expect(subject.course_year).to eq(2022)
+      end
+    end
+
+    context "3 weeks before end of cycle" do
+      around do |example|
+        Timecop.freeze(Date.new(2023, 7, 10)) { example.run }
+      end
+
+      it "defaults to the next cycle" do
+        expect(subject.course_year).to eq(2023)
+      end
+    end
+  end
+
   describe "#course_years_options" do
     before do
       allow(Settings).to receive(:current_default_course_year).and_return(2010)

--- a/spec/services/trainees/set_academic_cycles_spec.rb
+++ b/spec/services/trainees/set_academic_cycles_spec.rb
@@ -40,11 +40,23 @@ module Trainees
         end
       end
 
-      context "when a trainee has no trainee_start_date/itt_start_date" do
+      context "when a trainee has no trainee_start_date/itt_start_date and we are 3 months from the new cycle" do
         let(:trainee) { build(:trainee) }
 
         it "favours current academic cycle" do
-          expect(subject).to eq(current_academic_cycle)
+          Timecop.freeze(next_academic_cycle.start_date - 3.months) do
+            expect(subject).to eq(current_academic_cycle)
+          end
+        end
+      end
+
+      context "when a trainee has no trainee_start_date/itt_start_date and we are 3 weeks from the new cycle" do
+        let(:trainee) { build(:trainee) }
+
+        it "favours next academic cycle" do
+          Timecop.freeze(next_academic_cycle.start_date - 3.weeks) do
+            expect(subject).to eq(next_academic_cycle)
+          end
         end
       end
     end


### PR DESCRIPTION
### Context

This PR changes the default recruitment cycle for trainees entered manually in the month before the start of the new academic year.

e.g. In July 23 we are still in the 22-23 recruitment cycle but most providers entering a new trainee will be doing so for the 23-24 recruitment cycle so we should make that the default.

### Changes proposed in this pull request

- [x] Change the `Service::Trainees::SetAcademicCycles` service to look a month ahead when setting the default cycle ebased on current date.
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/f8f8dbb1-f3ff-41db-97e6-37d80762a085)

- [x] Preselect the correct default on the _Which academic year do you want to choose courses from?_ form.
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/de54f0ac-4e80-458e-a61f-5601c34e1056)

- [x] Feature specs to cover this.

### Guidance to review

- Are the changes made in the right places?
- Are the tests sufficient?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
