### PR TITLE
Fix layout of notification banner on the start page

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -122,3 +122,7 @@ body:not(.js-enabled) .app-js-only {
 .link--delete {
   color: govuk-colour("red") !important;
 }
+
+.app-start-page-banner + .govuk-width-container > .govuk-notification-banner {
+  margin-top: 40px;
+}


### PR DESCRIPTION
### Context
There is no margin between the start banner and notificaiton bar which doesn't look right. 

### Changes proposed in this pull request
Attempting to fix that here with a custom css rule just of navigation bars following the start page banner.

Before:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/ad09bcc4-0e8b-403a-b918-a529ed61a43e)

After:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/8eaddc01-51df-4ba5-899b-e077bd437b53)

### Guidance to review
Is there a better place to drop CSS rules like this?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
