### PR TITLE
[xxxx] - Fix empty attribute withdrawal reasons migration

### DIFF
--- a/db/data/20230515083653_trainee_withdrawal_reasons.rb
+++ b/db/data/20230515083653_trainee_withdrawal_reasons.rb
@@ -22,10 +22,7 @@ class TraineeWithdrawalReasons < ActiveRecord::Migration[7.0]
     end
 
     # Perform bulk insert
-    TraineeWithdrawalReason.insert_all(trainee_withdrawal_reasons)
-
-    # Now nullify the old enum values
-    Trainee.update_all(withdraw_reason: nil)
+    TraineeWithdrawalReason.insert_all(trainee_withdrawal_reasons) unless trainee_withdrawal_reasons.empty?
   end
 
   def down


### PR DESCRIPTION
### Context

[This migration error occurs in staging](https://dfe-teacher-services.sentry.io/issues/4307396315/?environment=staging_aks&project=5552118&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=0)

### Changes proposed in this pull request

Don't try and `insert_all` unless there are attributes to pass in.