### PR TITLE
[5625] - Update funding UI page for 2023/2024

### DIFF
--- a/app/views/trainees/funding/bursaries/_grant_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_grant_form.html.erb
@@ -3,6 +3,7 @@
 
   <%= render TraineeName::View.new(@trainee) %>
   <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.grants.edit") %></h1>
+
   <p class="govuk-body">
     <%= t(
       (@trainee.early_years_route? ? "views.forms.funding.bursaries.grant.early_years_description" : "views.forms.funding.bursaries.grant.description"),
@@ -10,6 +11,15 @@
       subject: @bursary_form.allocation_subject_name,
       training_route: t("activerecord.attributes.trainee.training_routes.#{@trainee.training_route}"),
     ) %>
+  </p>
+
+  <p class="govuk-body">
+    You can 
+    <%= govuk_link_to(
+      t("views.forms.funding.bursaries.guidance_link_text"),
+      t("views.forms.funding.bursaries.guidance_url") + @bursary_form.funding_guidance_url,
+      { target: "_blank", rel: "noreferrer noopener" }
+    ) %>.
   </p>
 
   <%= f.govuk_radio_buttons_fieldset(:funding_type, legend: { text: t("views.forms.funding.bursaries.grant.title"), size: "m" }) do %>

--- a/app/views/trainees/funding/bursaries/_grant_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_grant_form.html.erb
@@ -12,14 +12,6 @@
     ) %>
   </p>
 
-  <p class="govuk-body">
-    <%= govuk_link_to(
-      t("views.forms.funding.bursaries.guidance_link_text") + @bursary_form.funding_guidance_link_text,
-      t("views.forms.funding.bursaries.guidance_url") + @bursary_form.funding_guidance_url,
-      { target: "_blank", rel: "noreferrer noopener" }
-    ) %>
-  </p>
-
   <%= f.govuk_radio_buttons_fieldset(:funding_type, legend: { text: t("views.forms.funding.bursaries.grant.title"), size: "m" }) do %>
       <%= f.govuk_radio_button(
         :funding_type,
@@ -31,7 +23,6 @@
       <%= f.govuk_radio_button(
         :funding_type,
         f.object.class::NONE_TYPE,
-        hint: { text: t("views.forms.funding.funding_type.grant.none.hint") },
         label: { text: t("views.forms.funding.funding_type.grant.none.label") },
       ) %>
   <% end %>

--- a/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
@@ -3,21 +3,39 @@
 
   <%= render TraineeName::View.new(@trainee) %>
   <h1 class="govuk-heading-l"><%= t("components.page_titles.trainees.funding.bursaries.edit") %></h1>
-  <p class="govuk-body">
-    <%= t(
-      (@trainee.early_years_route? ? "views.forms.funding.bursaries.non_tiered.early_years_description" : "views.forms.funding.bursaries.non_tiered.description"),
-      amount: format_currency(@bursary_form.bursary_amount),
-      subject: @bursary_form.allocation_subject_name,
-      training_route: t("activerecord.attributes.trainee.training_routes.#{@trainee.training_route}"),
-    ) %>
-  </p>
+
+  <% if @bursary_form.can_apply_for_scholarship? %>
+
+    <p class="govuk-body">
+      <%= t("views.forms.funding.bursaries.scholarship_and_bursary.description", subject: @bursary_form.allocation_subject_name) %>
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li> <%= t("views.forms.funding.bursaries.scholarship_and_bursary.bursary", amount: format_currency(@bursary_form.bursary_amount)) %> </li>
+      <li> <%= t("views.forms.funding.bursaries.scholarship_and_bursary.scholarship", amount: format_currency(@bursary_form.scholarship_amount)) %> </li>
+    </ul>
+
+  <% else %>
+
+    <p class="govuk-body">
+      <%= t(
+        (@trainee.early_years_route? ? "views.forms.funding.bursaries.non_tiered.early_years_description" : "views.forms.funding.bursaries.non_tiered.description"),
+        amount: format_currency(@bursary_form.bursary_amount),
+        subject: @bursary_form.allocation_subject_name,
+        training_route: t("activerecord.attributes.trainee.training_routes.#{@trainee.training_route}"),
+      ) %>
+    </p>
+
+  <% end %>
 
   <p class="govuk-body">
+    You can 
     <%= govuk_link_to(
-      t("views.forms.funding.bursaries.guidance_link_text") + @bursary_form.funding_guidance_link_text,
+      t("views.forms.funding.bursaries.guidance_link_text"),
       t("views.forms.funding.bursaries.guidance_url") + @bursary_form.funding_guidance_url,
       { target: "_blank", rel: "noreferrer noopener" }
     ) %>
+    .
   </p>
 
   <%= f.govuk_radio_buttons_fieldset(:funding_type, legend: { text: t("views.forms.funding.bursaries.non_tiered.title"), size: "m" }) do %>
@@ -29,12 +47,9 @@
       ) %>
 
       <% if @bursary_form.can_apply_for_scholarship? %>
-        <div class="govuk-radios__divider">or</div>
-
         <%= f.govuk_radio_button(
           :funding_type,
           FUNDING_TYPE_ENUMS[:scholarship],
-          hint: { text: t("views.forms.funding.funding_type.scholarship.hint", amount: format_currency(@bursary_form.scholarship_amount)) },
           label: { text: t("views.forms.funding.funding_type.scholarship.label") },
         ) %>
       <% end %>
@@ -42,7 +57,6 @@
       <%= f.govuk_radio_button(
         :funding_type,
         f.object.class::NONE_TYPE,
-        hint: { text: t("views.forms.funding.funding_type.bursary.none.hint") },
         label: { text: t("views.forms.funding.funding_type.bursary.none.label") },
       ) %>
   <% end %>

--- a/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_non_tiered_bursary_form.html.erb
@@ -34,8 +34,7 @@
       t("views.forms.funding.bursaries.guidance_link_text"),
       t("views.forms.funding.bursaries.guidance_url") + @bursary_form.funding_guidance_url,
       { target: "_blank", rel: "noreferrer noopener" }
-    ) %>
-    .
+    ) %>.
   </p>
 
   <%= f.govuk_radio_buttons_fieldset(:funding_type, legend: { text: t("views.forms.funding.bursaries.non_tiered.title"), size: "m" }) do %>

--- a/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
@@ -6,11 +6,12 @@
   <p class="govuk-body"><%= t("views.forms.funding.bursaries.tiered.description") %></p>
 
   <p class="govuk-body">
+    You can
     <%= govuk_link_to(
-      t("views.forms.funding.bursaries.guidance_link_text") + @bursary_form.funding_guidance_link_text,
-      t("views.forms.funding.bursaries.guidance_url") + @bursary_form.funding_guidance_url,
+      t("views.forms.funding.bursaries.guidance_link_text"),
+      t("views.forms.funding.bursaries.guidance_url"),
       { target: "_blank", rel: "noreferrer noopener" }
-    ) %>
+    ) %>.
   </p>
 
   <%= f.govuk_radio_buttons_fieldset(:funding_type, legend: { text: t("views.forms.funding.bursaries.tiered.title"), size: "m" }) do %>
@@ -31,7 +32,6 @@
       :funding_type,
       f.object.class::NONE_TYPE,
       ** {
-        hint: { text: t("views.forms.funding.funding_type.bursary.none.hint") },
         label: { text: t("views.forms.funding.funding_type.bursary.none.label") },
       }.merge(@trainee.applying_for_bursary.nil? ? { checked: false } : {} )
     ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -900,8 +900,8 @@ en:
             early_years_description: "%{training_route} has a grant available of %{amount}. You need to check if the trainee is eligible for this grant."
             title: Funding Type
           tiered:
-            description: Early years (postgrad) has a bursary available. You need to check if the trainee is eligible for this bursary.
-            title: Do you want to apply for a bursary for this trainee?
+            description: Early years (postgrad) has bursaries available. You need to check if the trainee is eligible for any of these.
+            title: Funding type
             tier_one:
               label: Yes - Tier 1 (£5,000)
               hint: First-class honours degree, doctoral degree, medical masters (distinction)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -888,13 +888,17 @@ en:
             If you’re not sure if the trainee is on an initiative you could check with a colleague or ask the trainee directly.
         bursaries:
           non_tiered:
-            description: The course you have selected has a bursary available of %{amount} for %{subject}. You need to check if the trainee is eligible for this bursary.
+            description: You can apply now for a %{amount} bursary for the trainee's %{subject} course. You must have checked that they’re eligible.
             early_years_description: "%{training_route} has a bursary available of %{amount}. You need to check if the trainee is eligible for this bursary."
-            title: Do you want to apply for a bursary for this trainee?
+            title: Funding type
+          scholarship_and_bursary:
+            description: "The trainee may get funding for their %{subject} course if either:"
+            bursary: you apply now for a %{amount} bursary - you must have checked that they're eligible
+            scholarship: they apply for a %{amount} scholarship
           grant:
-            description: The course you have selected has a grant available of %{amount} for %{subject}. You need to check if the trainee is eligible for this grant.
+            description: The trainee can apply for a %{amount} grant for their %{subject} course.
             early_years_description: "%{training_route} has a grant available of %{amount}. You need to check if the trainee is eligible for this grant."
-            title: Do you want to apply for a grant for this trainee?
+            title: Funding Type
           tiered:
             description: Early years (postgrad) has a bursary available. You need to check if the trainee is eligible for this bursary.
             title: Do you want to apply for a bursary for this trainee?
@@ -907,22 +911,20 @@ en:
             tier_three:
               label: Yes - Tier 3 (£2,000)
               hint: 2:2 honours degree
-          guidance_link_text: "Funding: initial teacher training (ITT), academic year "
+          guidance_link_text: check the funding rules for this academic year (opens in a new tab)
           guidance_url: https://www.gov.uk/government/publications/funding-initial-teacher-training-itt/funding-initial-teacher-training-itt-academic-year-
         funding_type:
           bursary:
-            label: Yes, apply for a bursary
+            label: Bursary
             none:
-              label: No, do not apply for a bursary
-              hint: For example, the trainee is not eligible or is self-funded
+              label: None
           scholarship:
-            label: No, the trainee has applied for a scholarship
+            label: Scholarship
             hint: "%{amount} estimated scholarship"
           grant:
-            label: Yes, apply for a grant
+            label: Grant
             none:
-              label: No, do not apply for a grant
-              hint: For example, the trainee is not eligible or is self-funded
+              label: None
   pages:
     home:
       heading: Your trainee teachers


### PR DESCRIPTION
### Context

We’ve already updated the funding mapping for 23-24 academic year in this ticket completed last sprint.  Now we want to update the funding UI page for 2023 for two reasons:

- Scholarships for 23/24 are more nuanced and need extra text
- The page is very bursary focused with other stuff tacked on. We want to make it more agnostic to types of funding.
- The page assumes scholarships will always appear with bursaries. It would be better if any the page could work with any type of funding agnostically.

### Changes proposed in this pull request

updates existing locales and partials to reflect new funding outcomes wording

### Guidance to review

There's multiple tracks for the different funding partials and the conditionals within them, I believe this is all of them. To get to each of them, find a draft trainee (or create one and start by changing their training route, then course details, then finally you can see the funding available. You can see [all combinations here](https://educationgovuk.sharepoint.com/:x:/r/sites/TeacherServices/Shared%20Documents/Becoming%20a%20Teacher/TWD-REGISTER/4.%20Business%20Analyst/Routes,%20data%20and%20funding.xlsx?d=wfaaa7ba88b434d2681bb56a19f83aee3&csf=1&web=1&e=AmeYPI)

#### Scholarship/Bursary

training route: Provider Led (postgrad)
course: chemistry 
funding: Not on a training initiative

#### Grant  1
training route: Early years (salaried)
course: N/A
funding: Not on a training initiative

#### Grant  2
training route: School direct (salaried)
course: Chemistry
funding: Not on a training initiative

#### Bursary non-tiered
training route: Provider led (undergrad)
course: Physics
funding: Not on a training initiative

#### Bursary tiered
training route: early years postgrad
course: N/A
funding: Not on a training initiative


go over with @d-a-v-e if unsure!