### PR TITLE
[4727] Improve apply draft import duplicate record check

### DIFF
--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -151,10 +151,14 @@ module Trainees
 
     def trainee_already_exists?
       scope = application_record.provider.trainees.not_withdrawn.or(Trainee.not_awarded)
-      scope
+      potential_duplicates = scope
         .where(date_of_birth: raw_trainee["date_of_birth"])
         .where("last_name ILIKE ?", raw_trainee["last_name"])
-        .exists?
+      filtered_duplicates = potential_duplicates.select do |trainee|
+        trainee.start_academic_cycle&.start_date&.year == raw_course["recruitment_cycle_year"] &&
+          trainee.training_route == course["route"]
+      end
+      filtered_duplicates.present?
     end
 
     def ethnic_background_attributes

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -153,11 +153,8 @@ module Trainees
       scope = application_record.provider.trainees.not_withdrawn.or(Trainee.not_awarded)
       scope
         .where(date_of_birth: raw_trainee["date_of_birth"])
-        .exists?([
-          "first_names ILIKE ? AND last_name ILIKE ?",
-          raw_trainee["first_name"],
-          raw_trainee["last_name"],
-        ])
+        .where("last_name ILIKE ?", raw_trainee["last_name"])
+        .exists?
     end
 
     def ethnic_background_attributes

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -151,9 +151,13 @@ module Trainees
 
     def trainee_already_exists?
       scope = application_record.provider.trainees.not_withdrawn.or(Trainee.not_awarded)
-      scope.exists?(first_names: raw_trainee["first_name"],
-                    last_name: raw_trainee["last_name"],
-                    date_of_birth: raw_trainee["date_of_birth"])
+      scope
+        .where(date_of_birth: raw_trainee["date_of_birth"])
+        .exists?([
+          "first_names ILIKE ? AND last_name ILIKE ?",
+          raw_trainee["first_name"],
+          raw_trainee["last_name"],
+        ])
     end
 
     def ethnic_background_attributes

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -179,11 +179,12 @@ module Trainees
     end
 
     def matching_first_name?(trainee)
-      trainee.first_names == raw_trainee["first_name"]
+      trainee.first_names&.strip&.downcase&.gsub(/[^a-z ]/, "")&.partition(" ")&.first ==
+        raw_trainee["first_name"]&.strip&.downcase&.gsub(/[^a-z ]/, "")&.partition(" ")&.first
     end
 
     def matching_email?(trainee)
-      trainee.email == raw_trainee["email"]
+      trainee.email&.strip&.downcase == raw_trainee["email"]&.strip&.downcase
     end
 
     def ethnic_background_attributes

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -174,8 +174,16 @@ module Trainees
     end
 
     def at_least_one_match_identifying_attribute?(trainee)
-      # TODO:
-      true
+      matching_first_name?(trainee) ||
+        matching_email?(trainee)
+    end
+
+    def matching_first_name?(trainee)
+      trainee.first_names == raw_trainee["first_name"]
+    end
+
+    def matching_email?(trainee)
+      trainee.email == raw_trainee["email"]
     end
 
     def ethnic_background_attributes

--- a/app/services/trainees/find_duplicates.rb
+++ b/app/services/trainees/find_duplicates.rb
@@ -45,12 +45,24 @@ module Trainees
     end
 
     def matching_first_name?(trainee)
-      trainee.first_names&.strip&.downcase&.gsub(/[^a-z ]/, "")&.partition(" ")&.first ==
-        raw_trainee["first_name"]&.strip&.downcase&.gsub(/[^a-z ]/, "")&.partition(" ")&.first
+      extract_first_name(trainee.first_names) ==
+        extract_first_name(raw_trainee["first_name"])
     end
 
     def matching_email?(trainee)
-      trainee.email&.strip&.downcase == raw_trainee["email"]&.strip&.downcase
+      normalise_name(trainee.email) == normalise_name(raw_trainee["email"])
+    end
+
+    def normalise_name(name)
+      name&.strip&.downcase
+    end
+
+    def normalise_and_remove_punctuation(name)
+      normalise_name(name)&.gsub(/[^a-z ]/, "")
+    end
+
+    def extract_first_name(names)
+      normalise_and_remove_punctuation(names)&.partition(" ")&.first
     end
   end
 end

--- a/app/services/trainees/find_duplicates.rb
+++ b/app/services/trainees/find_duplicates.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Trainees
+  class FindDuplicates
+    include ServicePattern
+
+    def initialize(application_record:)
+      @application_record = application_record
+      @raw_course = application_record.application.dig("attributes", "course")
+      @course = application_record.provider.courses.find_by(uuid: @raw_course["course_uuid"])
+      @raw_trainee = application_record.application.dig("attributes", "candidate")
+    end
+
+    def call
+      potential_duplicates.select { |trainee| confirmed_duplicate?(trainee) }
+    end
+
+  private
+
+    attr_reader :application_record, :raw_trainee, :raw_course, :course
+
+    def potential_duplicates
+      application_record.provider.trainees.not_withdrawn.or(Trainee.not_awarded)
+        .where(date_of_birth: raw_trainee["date_of_birth"])
+        .where("last_name ILIKE ?", raw_trainee["last_name"])
+    end
+
+    def confirmed_duplicate?(trainee)
+      matching_recruitment_cycle_year?(trainee) &&
+      matching_qualification_type?(trainee) &&
+      at_least_one_match_identifying_attribute?(trainee)
+    end
+
+    def matching_recruitment_cycle_year?(trainee)
+      trainee.start_academic_cycle&.start_date&.year == raw_course["recruitment_cycle_year"]
+    end
+
+    def matching_qualification_type?(trainee)
+      trainee.training_route == course["route"]
+    end
+
+    def at_least_one_match_identifying_attribute?(trainee)
+      matching_first_name?(trainee) ||
+        matching_email?(trainee)
+    end
+
+    def matching_first_name?(trainee)
+      trainee.first_names&.strip&.downcase&.gsub(/[^a-z ]/, "")&.partition(" ")&.first ==
+        raw_trainee["first_name"]&.strip&.downcase&.gsub(/[^a-z ]/, "")&.partition(" ")&.first
+    end
+
+    def matching_email?(trainee)
+      trainee.email&.strip&.downcase == raw_trainee["email"]&.strip&.downcase
+    end
+  end
+end

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -96,6 +96,24 @@ module Trainees
       end
     end
 
+    context "trainee already exists but name differs by case" do
+      before do
+        create(
+          :trainee,
+          trainee_attributes.merge(
+            first_names: candidate_info["first_name"].upcase,
+            last_name: candidate_info["last_name"].downcase,
+          ),
+        )
+      end
+
+      it "marks the application as a duplicate" do
+        expect {
+          create_trainee_from_apply
+        }.to change(apply_application, :state).to("non_importable_duplicate")
+      end
+    end
+
     context "course doesn't exist" do
       let(:course_uuid) { "c6b9f9f0-f9f9-4f0f-b9e2-f9f9f9f9f9f9" }
 

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -55,12 +55,6 @@ module Trainees
       }
     end
 
-    let(:duplicate_trainee_attributes) do
-      trainee_attributes.merge(
-        itt_start_date: Date.new(recruitment_cycle_year, 9, 1),
-      )
-    end
-
     let(:uk_address_attributes) do
       {
         address_line_one: contact_details["address_line1"],

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -74,8 +74,9 @@ module Trainees
 
     subject(:create_trainee_from_apply) { described_class.call(application: apply_application) }
 
+    let(:duplicates) { [] }
     before do
-      allow(Trainees::FindDuplicates).to receive(:call).and_return([])
+      allow(Trainees::FindDuplicates).to receive(:call).and_return(duplicates)
     end
 
     it "creates a draft trainee" do

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -55,6 +55,12 @@ module Trainees
       }
     end
 
+    let(:duplicate_trainee_attributes) do
+      trainee_attributes.merge(
+        itt_start_date: Date.new(recruitment_cycle_year, 9, 1),
+      )
+    end
+
     let(:uk_address_attributes) do
       {
         address_line_one: contact_details["address_line1"],
@@ -87,7 +93,7 @@ module Trainees
     end
 
     context "trainee already exists" do
-      before { create(:trainee, trainee_attributes) }
+      before { create(:trainee, duplicate_trainee_attributes) }
 
       it "marks the application as a duplicate" do
         expect {
@@ -97,7 +103,7 @@ module Trainees
     end
 
     context "trainee with matching DOB exists but last name differs" do
-      before { create(:trainee, trainee_attributes.merge(last_name: "Jones")) }
+      before { create(:trainee, duplicate_trainee_attributes.merge(last_name: "Jones")) }
 
       it "marks the application as imported" do
         expect {
@@ -107,7 +113,7 @@ module Trainees
     end
 
     context "trainee with matching last_name exists but DOB differs" do
-      before { create(:trainee, trainee_attributes.merge(date_of_birth: "1998-03-19")) }
+      before { create(:trainee, duplicate_trainee_attributes.merge(date_of_birth: "1998-03-19")) }
 
       it "marks the application as imported" do
         expect {
@@ -117,7 +123,7 @@ module Trainees
     end
 
     context "trainee with matching last_name and DOB exists but qualification type differs" do
-      before { create(:trainee, trainee_attributes.merge(training_route: :early_years_undergrad)) }
+      before { create(:trainee, duplicate_trainee_attributes.merge(training_route: :early_years_undergrad)) }
 
       it "marks the application as imported" do
         expect {
@@ -147,7 +153,7 @@ module Trainees
       before do
         create(
           :trainee,
-          trainee_attributes.merge(
+          duplicate_trainee_attributes.merge(
             last_name: candidate_info["last_name"].downcase,
           ),
         )

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -96,12 +96,31 @@ module Trainees
       end
     end
 
-    context "trainee already exists but name differs by case" do
+    context "trainee with matching DOB exists but last name differs" do
+      before { create(:trainee, trainee_attributes.merge(last_name: "Jones")) }
+
+      it "marks the application as imported" do
+        expect {
+          create_trainee_from_apply
+        }.to change(apply_application, :state).to("imported")
+      end
+    end
+
+    context "trainee with matching last_name exists but DOB differs" do
+      before { create(:trainee, trainee_attributes.merge(date_of_birth: "1998-03-19")) }
+
+      it "marks the application as imported" do
+        expect {
+          create_trainee_from_apply
+        }.to change(apply_application, :state).to("imported")
+      end
+    end
+
+    context "trainee already exists but last name only differs by case" do
       before do
         create(
           :trainee,
           trainee_attributes.merge(
-            first_names: candidate_info["first_name"].upcase,
             last_name: candidate_info["last_name"].downcase,
           ),
         )

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -92,7 +92,7 @@ module Trainees
     end
 
     context "trainee already exists" do
-      before { allow(Trainees::FindDuplicates).to receive(:call).and_return([build(:trainee)]) }
+      let(:duplicates) { [build(:trainee)] }
 
       it "marks the application as a duplicate" do
         expect {

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -15,6 +15,7 @@ module Trainees
     let(:subject_names) { [] }
     let(:recruitment_cycle_year) { current_academic_year + 1 }
     let(:course_uuid) { course_info["course_uuid"] }
+    let(:duplicates) { [] }
     let!(:current_academic_cycle) { create(:academic_cycle) }
     let!(:next_academic_cycle) { create(:academic_cycle, next_cycle: true) }
     let!(:after_next_academic_cycle) { create(:academic_cycle, one_after_next_cycle: true) }
@@ -74,7 +75,6 @@ module Trainees
 
     subject(:create_trainee_from_apply) { described_class.call(application: apply_application) }
 
-    let(:duplicates) { [] }
     before do
       allow(Trainees::FindDuplicates).to receive(:call).and_return(duplicates)
     end

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -116,6 +116,16 @@ module Trainees
       end
     end
 
+    context "trainee with matching last_name and DOB exists but recruitment_year differs" do
+      before { create(:trainee, trainee_attributes.merge(recruitment_cycle_year: recruitment_cycle_year - 1)) }
+
+      it "marks the application as imported" do
+        expect {
+          create_trainee_from_apply
+        }.to change(apply_application, :state).to("imported")
+      end
+    end
+
     context "trainee already exists but last name only differs by case" do
       before do
         create(

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -116,8 +116,25 @@ module Trainees
       end
     end
 
-    context "trainee with matching last_name and DOB exists but recruitment_year differs" do
-      before { create(:trainee, trainee_attributes.merge(recruitment_cycle_year: recruitment_cycle_year - 1)) }
+    context "trainee with matching last_name and DOB exists but qualification type differs" do
+      before { create(:trainee, trainee_attributes.merge(training_route: :early_years_undergrad)) }
+
+      it "marks the application as imported" do
+        expect {
+          create_trainee_from_apply
+        }.to change(apply_application, :state).to("imported")
+      end
+    end
+
+    context "trainee with matching last_name and DOB exists but recruitment_cycle_year differs" do
+      before do
+        create(
+          :trainee,
+          trainee_attributes.merge(
+            start_academic_cycle: create(:academic_cycle, previous_cycle: true),
+          ),
+        )
+      end
 
       it "marks the application as imported" do
         expect {

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -120,6 +120,60 @@ module Trainees
       end
     end
 
+    context "trainee with match last name and DOB exists and first name also matches but email differs" do
+      before do
+        create(
+          :trainee,
+          duplicate_trainee_attributes.merge(
+            first_names: "Martin",
+            email: "mwells@mailinator.COM ",
+          ),
+        )
+      end
+
+      it "marks the application as a duplicate" do
+        expect {
+          create_trainee_from_apply
+        }.to change(apply_application, :state).to("non_importable_duplicate")
+      end
+    end
+
+    context "trainee with match last name and DOB exists and first name matches but email and middle names do not" do
+      before do
+        create(
+          :trainee,
+          duplicate_trainee_attributes.merge(
+            first_names: "Martin Derek Clive",
+            email: "mwells@mailinator.COM ",
+          ),
+        )
+      end
+
+      it "marks the application as a duplicate" do
+        expect {
+          create_trainee_from_apply
+        }.to change(apply_application, :state).to("non_importable_duplicate")
+      end
+    end
+
+    context "trainee with match last name and DOB exists but first name and email differ only by case/spacing" do
+      before do
+        create(
+          :trainee,
+          duplicate_trainee_attributes.merge(
+            first_names: " MaRtIn.",
+            email: "martin.wells@mailinator.COM ",
+          ),
+        )
+      end
+
+      it "marks the application as a duplicate" do
+        expect {
+          create_trainee_from_apply
+        }.to change(apply_application, :state).to("non_importable_duplicate")
+      end
+    end
+
     context "trainee with matching DOB exists but last name differs" do
       before { create(:trainee, duplicate_trainee_attributes.merge(last_name: "Jones")) }
 

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -205,11 +205,17 @@ module Trainees
     end
 
     context "trainee with matching last_name and DOB exists but recruitment_cycle_year differs" do
+      around do |example|
+        Timecop.freeze(Date.new(2023, 7, 1)) { example.run }
+      end
+
       before do
+        previous_academic_cycle = create(:academic_cycle, previous_cycle: true)
         create(
           :trainee,
           trainee_attributes.merge(
-            start_academic_cycle: create(:academic_cycle, previous_cycle: true),
+            start_academic_cycle: previous_academic_cycle,
+            itt_start_date: previous_academic_cycle.start_date,
           ),
         )
       end

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -102,6 +102,24 @@ module Trainees
       end
     end
 
+    context "trainee with match last name and DOB exists but first name and email both differ" do
+      before do
+        create(
+          :trainee,
+          duplicate_trainee_attributes.merge(
+            first_names: "Bob",
+            email: "bob@example.com",
+          ),
+        )
+      end
+
+      it "marks the application as imported" do
+        expect {
+          create_trainee_from_apply
+        }.to change(apply_application, :state).to("imported")
+      end
+    end
+
     context "trainee with matching DOB exists but last name differs" do
       before { create(:trainee, duplicate_trainee_attributes.merge(last_name: "Jones")) }
 

--- a/spec/services/trainees/find_duplicates_spec.rb
+++ b/spec/services/trainees/find_duplicates_spec.rb
@@ -172,6 +172,10 @@ module Trainees
           ),
         )
       end
+
+      it "returns no duplicates" do
+        expect(duplicate_trainees).to be_empty
+      end
     end
 
     context "trainee already exists but last name only differs by case" do

--- a/spec/services/trainees/find_duplicates_spec.rb
+++ b/spec/services/trainees/find_duplicates_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe FindDuplicates do
+    let(:candidate_attributes) { {} }
+    let(:course_attributes) { {} }
+    let(:application_record) { create(:apply_application, application: application_data) }
+    let(:candidate_info) { ApiStubs::ApplyApi.candidate_info.as_json }
+    let(:contact_details) { ApiStubs::ApplyApi.contact_details.as_json }
+    let(:course_info) { ApiStubs::ApplyApi.course.as_json }
+    let(:subject_names) { [] }
+    let(:recruitment_cycle_year) { current_academic_year + 1 }
+    let(:course_uuid) { course_info["course_uuid"] }
+    let!(:current_academic_cycle) { create(:academic_cycle) }
+    let!(:next_academic_cycle) { create(:academic_cycle, next_cycle: true) }
+    let!(:after_next_academic_cycle) { create(:academic_cycle, one_after_next_cycle: true) }
+
+    let(:application_data) do
+      JSON.parse(ApiStubs::ApplyApi.application(candidate_attributes: candidate_attributes,
+                                                course_attributes: course_attributes.merge(recruitment_cycle_year:)))
+    end
+
+    let!(:course) do
+      create(
+        :course_with_subjects,
+        uuid: course_uuid,
+        accredited_body_code: application_record.accredited_body_code,
+        route: :school_direct_tuition_fee,
+        subject_names: subject_names,
+      )
+    end
+
+    let(:trainee_attributes) do
+      {
+        trainee_id: nil,
+        first_names: candidate_info["first_name"],
+        last_name: candidate_info["last_name"],
+        date_of_birth: candidate_info["date_of_birth"].to_date,
+        sex: candidate_info["gender"],
+        ethnic_group: "asian_ethnic_group",
+        ethnic_background: candidate_info["ethnic_background"],
+        diversity_disclosure: Diversities::DIVERSITY_DISCLOSURE_ENUMS[:diversity_disclosed],
+        email: contact_details["email"],
+        course_education_phase: course.level,
+        training_route: course.route,
+        course_uuid: course.uuid,
+        course_min_age: course.min_age,
+        course_max_age: course.max_age,
+        study_mode: "full_time",
+        record_source: RecordSources::APPLY,
+      }
+    end
+
+    let(:duplicate_trainee_attributes) do
+      trainee_attributes.merge(
+        itt_start_date: Date.new(recruitment_cycle_year, 9, 1),
+      )
+    end
+
+    subject(:duplicate_trainees) { described_class.call(application_record:) }
+
+    context "trainee already exists" do
+      before { create(:trainee, duplicate_trainee_attributes) }
+
+      it "returns a match" do
+        expect(duplicate_trainees).to be_present
+      end
+    end
+
+    context "trainee with match last name and DOB exists but first name and email both differ" do
+      before do
+        create(
+          :trainee,
+          duplicate_trainee_attributes.merge(
+            first_names: "Bob",
+            email: "bob@example.com",
+          ),
+        )
+      end
+
+      it "returns no duplicates" do
+        expect(duplicate_trainees).to be_empty
+      end
+    end
+
+    context "trainee with match last name and DOB exists and first name also matches but email differs" do
+      before do
+        create(
+          :trainee,
+          duplicate_trainee_attributes.merge(
+            first_names: "Martin",
+            email: "mwells@mailinator.COM ",
+          ),
+        )
+      end
+
+      it "returns a match" do
+        expect(duplicate_trainees).to be_present
+      end
+    end
+
+    context "trainee with match last name and DOB exists and first name matches but email and middle names do not" do
+      before do
+        create(
+          :trainee,
+          duplicate_trainee_attributes.merge(
+            first_names: "Martin Derek Clive",
+            email: "mwells@mailinator.COM ",
+          ),
+        )
+      end
+
+      it "returns a match" do
+        expect(duplicate_trainees).to be_present
+      end
+    end
+
+    context "trainee with match last name and DOB exists but first name and email differ only by case/spacing" do
+      before do
+        create(
+          :trainee,
+          duplicate_trainee_attributes.merge(
+            first_names: " MaRtIn.",
+            email: "martin.wells@mailinator.COM ",
+          ),
+        )
+      end
+
+      it "returns a match" do
+        expect(duplicate_trainees).to be_present
+      end
+    end
+
+    context "trainee with matching DOB exists but last name differs" do
+      before { create(:trainee, duplicate_trainee_attributes.merge(last_name: "Jones")) }
+
+      it "returns no duplicates" do
+        expect(duplicate_trainees).to be_empty
+      end
+    end
+
+    context "trainee with matching last_name exists but DOB differs" do
+      before { create(:trainee, duplicate_trainee_attributes.merge(date_of_birth: "1998-03-19")) }
+
+      it "returns no duplicates" do
+        expect(duplicate_trainees).to be_empty
+      end
+    end
+
+    context "trainee with matching last_name and DOB exists but qualification type differs" do
+      before { create(:trainee, duplicate_trainee_attributes.merge(training_route: :early_years_undergrad)) }
+
+      it "returns no duplicates" do
+        expect(duplicate_trainees).to be_empty
+      end
+    end
+
+    context "trainee with matching last_name and DOB exists but recruitment_cycle_year differs" do
+      around do |example|
+        Timecop.freeze(Date.new(2023, 7, 1)) { example.run }
+      end
+
+      before do
+        previous_academic_cycle = create(:academic_cycle, previous_cycle: true)
+        create(
+          :trainee,
+          trainee_attributes.merge(
+            start_academic_cycle: previous_academic_cycle,
+            itt_start_date: previous_academic_cycle.start_date,
+          ),
+        )
+      end
+    end
+
+    context "trainee already exists but last name only differs by case" do
+      before do
+        create(
+          :trainee,
+          duplicate_trainee_attributes.merge(
+            last_name: candidate_info["last_name"].downcase,
+          ),
+        )
+      end
+
+      it "returns a match" do
+        expect(duplicate_trainees).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
We have a duplicate record check to avoid importing an Apply drafts where the provider has manually registered a trainee. This currently strictly checks the first and last name with DOB.

We saw in 2021 that this duplicate check missed a number of records - primarily where the names didn't 100% match because one side had a middle name and the other didn't.

We also have an issue that our check will block applications from different years. So if someone was recruited (and then withdrew) in one year, then later re-applied to the same provider, the new application will get blocked. Similar for trainees who do EYTS and then QTS.

### Changes proposed in this pull request
This PR updates the duplicate match logic in `Trainees::CreateFromApply` to implement the following strategy:

- Find any `Trainee` records that match the provider, last_name and date of birth of the imported record.
- Check that the `recruitment_cycle_year` matches.
- Check that the `qualification_type` (`training_route`) matches.
- Check that the `first_name` OR `email` matches. Ignore any differences or case, leading and trailing spaces and for `first_name` ignore any middle names and punctuation.

### Guidance to review
- Are the tests sufficient?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
