### PR TITLE
[5680] Add banner to warn of downtime

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -90,7 +90,13 @@
     <main class="govuk-main-wrapper " id="main-content" role="main">
       <%= yield :start_page_banner %>
       <div class="govuk-width-container">
-        <%= render(YearChangeBanner::View.new) %>
+        <%= govuk_notification_banner(title_text: "Important") do |banner|
+          banner.heading(text: "Register will be unavailable on Wednesday 19 July from 5pm")
+
+          content_tag(:p, "You will be able to use the service from 9am on Thursday 20 July 2023.", class: "govuk-body")
+        end %>
+
+        <%# <%= render(YearChangeBanner::View.new) %>
         <%= render(FlashBanner::View.new(flash: flash, trainee: @trainee)) %>
         <%= yield %>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -90,13 +90,16 @@
     <main class="govuk-main-wrapper " id="main-content" role="main">
       <%= yield :start_page_banner %>
       <div class="govuk-width-container">
-        <%= govuk_notification_banner(title_text: "Important") do |banner|
-          banner.heading(text: "Register will be unavailable on Wednesday 19 July from 5pm")
+        <% if FeatureService.enabled?(:maintenance_banner) %>
+          <%= govuk_notification_banner(title_text: "Important") do |banner|
+            banner.heading(text: "Register will be unavailable on Wednesday 19 July from 5pm")
 
-          content_tag(:p, "You will be able to use the service from 9am on Thursday 20 July 2023.", class: "govuk-body")
-        end %>
+            content_tag(:p, "You will be able to use the service from 9am on Thursday 20 July 2023.", class: "govuk-body")
+          end %>
+        <% else %>
+          <%= render(YearChangeBanner::View.new) %>
+        <% end %>
 
-        <%# <%= render(YearChangeBanner::View.new) %>
         <%= render(FlashBanner::View.new(flash: flash, trainee: @trainee)) %>
         <%= yield %>
       </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,6 +79,7 @@ features:
   # which year the user wants courses listed for. This feature
   # makes sure the correct year is selected before listing courses.
   show_draft_trainee_course_year_choice: true
+  maintenance_banner: true
 dfe_sign_in:
   # Our service name
   identifier: rtt


### PR DESCRIPTION
### Context

https://trello.com/c/Co1YIN6k/5680-s-monday-17th-july-show-temporary-banner-to-warn-users-of-planned-system-downtime-on-wednesday-19th-july

### Changes proposed in this pull request

- Add a temporary instance of the govuk notification banner with the content
- Comment out the existing year change banner

### Guidance to review

https://register-pr-3431.test.teacherservices.cloud

### Important business (does not apply)
