### PR TITLE
[xxxx] Removed unneeded code causing `DEPRECATION WARNING`

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,5 +2,4 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
-  include DfE::Analytics::Entities
 end


### PR DESCRIPTION
### Context
`DEPRECATION WARNING`
### Changes proposed in this pull request
Removed unneeded code

### Guidance to review
This was making my :exploding_head: 

https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5576298381/jobs/10187504930?pr=3431#step:4:1279

```
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.340+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (AcademicCycle), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Activity), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (ApplyApplication), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (AllocationSubject), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Course), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (CourseSubject), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Degree), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Disability), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Dqt::TrnRequest), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Dttp::Provider), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Dttp::School), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (FundingMethod), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (FundingMethodSubject), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Hesa::Metadatum), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Hesa::TrnSubmission), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (LeadSchoolUser), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Nationalisation), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Nationality), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (ProviderUser), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Provider), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (School), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (SubjectSpecialism), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Subject), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Trainee), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (User), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Persona), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Hesa::CollectionRequest), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (BulkUpdate::RowError), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (Placement), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (WithdrawalReason), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
***"host":"register-pr-3431-854f66f869-s2g29","application":"Semantic Logger","environment":"review_aks","time":"2023-07-17T14:38:33.341+01:00","level":"info","level_index":2,"pid":24,"thread":"7700","name":"Rails","message":"DEPRECATION WARNING: DfE::Analytics::Entities was manually included in a model (TraineeWithdrawalReason), but it's included automatically since v1.4. You're running v1.10.0. To silence this warning, remove the include from model definitions in app/models."***
```


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
