### PR TITLE
[xxxx] - fix broken link in tiered bursary form

### DIFF
--- a/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
+++ b/app/views/trainees/funding/bursaries/_tiered_bursary_form.html.erb
@@ -9,7 +9,7 @@
     You can
     <%= govuk_link_to(
       t("views.forms.funding.bursaries.guidance_link_text"),
-      t("views.forms.funding.bursaries.guidance_url"),
+      t("views.forms.funding.bursaries.guidance_url") + @bursary_form.funding_guidance_url,
       { target: "_blank", rel: "noreferrer noopener" }
     ) %>.
   </p>


### PR DESCRIPTION
### Context

adds missing academic year declaration to funding guidance link