### PR TITLE
Migration to add `trainees.slug_sent_to_dqt_at`

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -55,6 +55,7 @@
 #  reinstate_date                  :date
 #  sex                             :integer
 #  slug                            :citext           not null
+#  slug_sent_to_dqt_at             :datetime
 #  state                           :integer          default("draft")
 #  study_mode                      :integer
 #  submission_ready                :boolean          default(FALSE)

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -261,6 +261,7 @@ shared:
     - withdraw_reasons_dfe_details
     - hesa_trn_submission_id
     - hesa_editable
+    - slug_sent_to_dqt_at
   users:
     - created_at
     - dfe_sign_in_uid

--- a/db/migrate/20230719151850_add_trainees_sent_slug_to_dqt.rb
+++ b/db/migrate/20230719151850_add_trainees_sent_slug_to_dqt.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTraineesSentSlugToDqt < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trainees, :slug_sent_to_dqt_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_17_091901) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_19_151850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -819,6 +819,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_17_091901) do
     t.string "iqts_country"
     t.boolean "hesa_editable", default: false
     t.string "withdraw_reasons_dfe_details"
+    t.datetime "slug_sent_to_dqt_at"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["course_allocation_subject_id"], name: "index_trainees_on_course_allocation_subject_id"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"


### PR DESCRIPTION
### Context
We have a plan to use `slug` values to identify DQT records in order to help match trainee records more accurately between Register and DQT. This PR adds a database column that will be needed when we start sending `slug` values to DQT at the point we create a new record so that we know later to include the `slug` when we send, for example, update requests to DQT for that same trainee.

### Changes proposed in this pull request
This is just a migration to add the `trainees.slug_sent_to_dqt_at` (`datetime`) column to the schema. The column is nullable because `null` is a meaningful value, indicating that we have not sent the `slug` for this trainee to DQT yet.

### Guidance to review
- Does a timestamp make sense for this purpose?
- Is there a better name for it?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
