### PR TITLE
[5710] Add `slugid` to DQT `trn_request` calls

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -82,6 +82,7 @@ module Dqt
           "lastName" => trainee.last_name,
           "birthDate" => trainee.date_of_birth.iso8601,
           "emailAddress" => trainee.email,
+          "slugid" => trainee.slug,
           "address" => address_params,
           "husid" => trainee.hesa_id,
           "genderCode" => GENDER_CODES[trainee.sex.to_sym],

--- a/app/services/dqt/register_for_trn.rb
+++ b/app/services/dqt/register_for_trn.rb
@@ -31,6 +31,7 @@ module Dqt
       response = Client.put(path, body:)
       trn_request.response = response
       trn_request.requested!
+      Trainees::SetSlugSentAt.call(trainee:)
     rescue Client::HttpError => e
       # Sometimes we receive a 500 from DQT even though the TRN request is
       # eventually successful. Because of this, we still want to save the

--- a/app/services/trainees/set_slug_sent_at.rb
+++ b/app/services/trainees/set_slug_sent_at.rb
@@ -9,8 +9,7 @@ module Trainees
     end
 
     def call
-      trainee.slug_sent_to_dqt_at ||= Time.zone.now
-      trainee.save!
+      trainee.update!(slug_sent_to_dqt_at: Time.zone.now)
     end
 
   private

--- a/app/services/trainees/set_slug_sent_at.rb
+++ b/app/services/trainees/set_slug_sent_at.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Trainees
+  class SetSlugSentAt
+    include ServicePattern
+
+    def initialize(trainee:)
+      @trainee = trainee
+    end
+
+    def call
+      trainee.slug_sent_to_dqt_at ||= Time.zone.now
+      trainee.save!
+    end
+
+  private
+
+    attr_reader :trainee
+  end
+end

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -40,6 +40,7 @@ module Dqt
             "lastName" => trainee.last_name,
             "birthDate" => trainee.date_of_birth.iso8601,
             "emailAddress" => trainee.email,
+            "slugid" => trainee.slug,
             "genderCode" => "Female",
             "address" => uk_address_hash,
           })

--- a/spec/services/trainees/set_slug_sent_at_spec.rb
+++ b/spec/services/trainees/set_slug_sent_at_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe SetSlugSentAt do
+    let(:trainee) { create(:trainee) }
+
+    around do |example|
+      Timecop.freeze { example.run }
+    end
+
+    context "when the `slug_sent_to_dqt_at` has not previously been set" do
+      it "sets the `slug_sent_to_dqt_at` attribute to the current datetime" do
+        described_class.call(trainee:)
+        expect(trainee.slug_sent_to_dqt_at).to eq(Time.zone.now)
+      end
+    end
+
+    context "when the `slug_sent_to_dqt_at` has previously been set" do
+      let(:trainee) { create(:trainee, slug_sent_to_dqt_at: 1.day.ago) }
+
+      it "does not update the `slug_sent_to_dqt_at` attribute" do
+        described_class.call(trainee:)
+        expect(trainee.slug_sent_to_dqt_at).to eq(1.day.ago)
+      end
+    end
+  end
+end

--- a/spec/services/trainees/set_slug_sent_at_spec.rb
+++ b/spec/services/trainees/set_slug_sent_at_spec.rb
@@ -13,16 +13,16 @@ module Trainees
     context "when the `slug_sent_to_dqt_at` has not previously been set" do
       it "sets the `slug_sent_to_dqt_at` attribute to the current datetime" do
         described_class.call(trainee:)
-        expect(trainee.slug_sent_to_dqt_at).to eq(Time.zone.now)
+        expect(trainee.slug_sent_to_dqt_at).to be_within(1.second).of(Time.zone.now)
       end
     end
 
     context "when the `slug_sent_to_dqt_at` has previously been set" do
       let(:trainee) { create(:trainee, slug_sent_to_dqt_at: 1.day.ago) }
 
-      it "does not update the `slug_sent_to_dqt_at` attribute" do
+      it "updates the `slug_sent_to_dqt_at` attribute" do
         described_class.call(trainee:)
-        expect(trainee.slug_sent_to_dqt_at).to eq(1.day.ago)
+        expect(trainee.slug_sent_to_dqt_at).to be_within(1.second).of(Time.zone.now)
       end
     end
   end


### PR DESCRIPTION
### Context
We have a plan to use `slug` values to identify DQT records in order to help match trainee records more accurately between Register and DQT. This PR deals with sending the `Trainee#slug` to DQT service when we create a new trainee record in Register.

### Changes proposed in this pull request
We send the `slugid` attribute in requests to the `/v2/trn-requests/...` (request a TRN) DQT endpoint.

We also set the `Trainee#slug_sent_to_dqt_at` attribute so that we can track whether or not DQT has been sent the `slug` for a given trainee record.

This PR depends on https://github.com/DFE-Digital/register-trainee-teachers/pull/3447 and will remain in draft until that gets merged.

### Guidance to review
- Is there anything missing?
- Does this need to be behind a feature flag? (I've assumed not but can change that).

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
