### PR TITLE
[xxxx] - guard against empty withdraw_date

### DIFF
--- a/app/components/withdrawal/view.rb
+++ b/app/components/withdrawal/view.rb
@@ -31,7 +31,7 @@ module Withdrawal
 
     def start_date
       mappable_field(
-        data_model.trainee_start_date&.strftime(Date::DATE_FORMATS[:govuk]),
+        data_model.trainee_start_date&.strftime(Date::DATE_FORMATS[:govuk]) || "-",
         "Trainee start date",
         (trainee_start_date_verification_path(trainee, context: :withdraw) unless deferred),
       )
@@ -39,7 +39,7 @@ module Withdrawal
 
     def withdraw_date
       mappable_field(
-        data_model.withdraw_date.strftime(Date::DATE_FORMATS[:govuk]),
+        data_model.withdraw_date&.strftime(Date::DATE_FORMATS[:govuk]) || "-",
         "Date the trainee withdrew",
         edit_trainee_withdrawal_date_path(trainee),
       )

--- a/spec/components/withdrawal/view_spec.rb
+++ b/spec/components/withdrawal/view_spec.rb
@@ -46,5 +46,13 @@ describe Withdrawal::View do
     it "renders the reason for withdrawal" do
       expect(rendered_component).to have_text(I18n.t("components.withdrawal_details.reasons.#{withdrawal_reasons.first.name}"))
     end
+
+    context "with no withdrawal date present" do
+      let(:withdraw_date) { nil }
+
+      it "renders no date of withdrawal" do
+        expect(rendered_component).to have_selector("#date-the-trainee-withdrew", text: "-")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

a handful of trainees are withdrawn with no withdraw_date. See [sentry error here](https://dfe-teacher-services.sentry.io/issues/4330366485/?alert_rule_id=4544549&alert_type=issue&project=5552118&referrer=slack)

Prior to investigating data issues ([trello ticket here](https://trello.com/c/3QcB6p7n/1365-some-trainees-are-withdrawn-but-missing-a-withdrawdate)) we should guard against this.

### Changes proposed in this pull request

Adds safe navigation to view component