### PR TITLE
[5709] - update itt-outcome DQT endpoints with trainee slug

### DIFF
--- a/app/services/dqt/recommend_for_award.rb
+++ b/app/services/dqt/recommend_for_award.rb
@@ -23,7 +23,7 @@ module Dqt
     end
 
     def path
-      @path ||= "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}"
+      @path ||= "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}&birthDate=#{trainee.date_of_birth.iso8601}"
     end
 
     def params

--- a/app/services/dqt/recommend_for_award.rb
+++ b/app/services/dqt/recommend_for_award.rb
@@ -23,7 +23,7 @@ module Dqt
     end
 
     def path
-      @path ||= "/v2/teachers/#{trainee.trn}/itt-outcome?birthDate=#{trainee.date_of_birth.iso8601}"
+      @path ||= "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}"
     end
 
     def params

--- a/app/services/dqt/trainee_update.rb
+++ b/app/services/dqt/trainee_update.rb
@@ -17,7 +17,7 @@ module Dqt
       raise(TraineeUpdateMissingTrn, "Cannot update trainee on DQT without a trn (id: #{trainee.id})") if trainee.trn.blank?
 
       dqt_update(
-        "/v2/teachers/update/#{trainee.trn}?birthDate=#{trainee.date_of_birth.iso8601}",
+        "/v2/teachers/update/#{trainee.trn}?slugId=#{trainee.slug}&birthDate=#{trainee.date_of_birth.iso8601}",
         payload,
       )
     end

--- a/app/services/dqt/withdraw_trainee.rb
+++ b/app/services/dqt/withdraw_trainee.rb
@@ -23,7 +23,7 @@ module Dqt
     end
 
     def path
-      "/v2/teachers/#{trainee.trn}/itt-outcome?birthDate=#{trainee.date_of_birth.iso8601}"
+      "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}"
     end
 
     def params

--- a/app/services/dqt/withdraw_trainee.rb
+++ b/app/services/dqt/withdraw_trainee.rb
@@ -23,7 +23,7 @@ module Dqt
     end
 
     def path
-      "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}"
+      "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}&birthDate=#{trainee.date_of_birth.iso8601}"
     end
 
     def params

--- a/spec/services/dqt/recommend_for_award_spec.rb
+++ b/spec/services/dqt/recommend_for_award_spec.rb
@@ -12,7 +12,7 @@ module Dqt
         "qtsDate" => award_date,
       }
     }
-    let(:expected_path) { "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}" }
+    let(:expected_path) { "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}&birthDate=#{trainee.date_of_birth.iso8601}" }
     let(:json_body_params) { "JSON Donovan" }
 
     subject { described_class.call(trainee:) }

--- a/spec/services/dqt/recommend_for_award_spec.rb
+++ b/spec/services/dqt/recommend_for_award_spec.rb
@@ -12,7 +12,7 @@ module Dqt
         "qtsDate" => award_date,
       }
     }
-    let(:expected_path) { "/v2/teachers/#{trainee.trn}/itt-outcome?birthDate=#{trainee.date_of_birth.iso8601}" }
+    let(:expected_path) { "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}" }
     let(:json_body_params) { "JSON Donovan" }
 
     subject { described_class.call(trainee:) }

--- a/spec/services/dqt/update_spec.rb
+++ b/spec/services/dqt/update_spec.rb
@@ -6,7 +6,7 @@ module Dqt
   describe TraineeUpdate do
     describe "#call" do
       let(:trainee) { create(:trainee, :completed, :with_secondary_course_details, :with_start_date, :with_degree, trn:) }
-      let(:dqt_path) { "/v2/teachers/update/#{trainee.trn}?birthDate=#{trainee.date_of_birth.iso8601}" }
+      let(:dqt_path) { "/v2/teachers/update/#{trainee.trn}?slugId=#{trainee.slug}&birthDate=#{trainee.date_of_birth.iso8601}" }
       let(:dqt_payload) { Params::Update.new(trainee:).to_json }
       let(:dqt_response) { { status: 204 } }
       let(:trn) { "1234567" }

--- a/spec/services/dqt/withdraw_trainee_spec.rb
+++ b/spec/services/dqt/withdraw_trainee_spec.rb
@@ -10,7 +10,7 @@ module Dqt
         "trn" => trainee.trn,
       }
     }
-    let(:expected_path) { "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}" }
+    let(:expected_path) { "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}&birthDate=#{trainee.date_of_birth.iso8601}" }
     let(:json_body_params) { "withdrawing bob" }
 
     subject { described_class.call(trainee:) }

--- a/spec/services/dqt/withdraw_trainee_spec.rb
+++ b/spec/services/dqt/withdraw_trainee_spec.rb
@@ -10,7 +10,7 @@ module Dqt
         "trn" => trainee.trn,
       }
     }
-    let(:expected_path) { "/v2/teachers/#{trainee.trn}/itt-outcome?birthDate=#{trainee.date_of_birth.iso8601}" }
+    let(:expected_path) { "/v2/teachers/#{trainee.trn}/itt-outcome?slugId=#{trainee.slug}" }
     let(:json_body_params) { "withdrawing bob" }
 
     subject { described_class.call(trainee:) }


### PR DESCRIPTION
### Context

We want to use the slug identifier to help us identify records between Register and DQT. This should improve some data problems we’ve had.

When we use the DQT API to update a trainee, we should add the slug identifier as what we check on to send the update, rather than date of birth.

### Changes proposed in this pull request

Replaces trainee `birthdate` with `slug` in calls to the `itt-outcome` endpoint (withdrawal and award)

### Notes

dependant on #3447 and #3449

