### PR TITLE
[xxxx] Add prompt for audited user in production console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -218,3 +218,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
+
+# Rails console colours
+gem "colorize"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,7 @@ GEM
     cloudfront-rails (0.4.0)
       railties (> 4.0)
     coderay (1.1.3)
+    colorize (1.1.0)
     concurrent-ruby (1.2.2)
     config (4.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -754,6 +755,7 @@ DEPENDENCIES
   canonical-rails
   capybara (~> 3.39)
   cloudfront-rails
+  colorize
   config (~> 4.2)
   csv-safe
   cuprite (~> 0.13)

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,0 +1,46 @@
+module RegisterConsole
+  def start
+    show_warning_message_about_environments
+
+    if development?
+      super
+    else
+      puts("Hello! Who are you? This name will be used in the audit log for any changes you make.")
+      who_are_you = $stdin.gets
+      audited_user = "#{who_are_you.chomp} via the Rails console"
+      puts("Any updates to models will be attributed in the audit logs to #{audited_user.inspect}")
+
+      Audited.audit_class.as_user(audited_user) do
+        super
+      end
+    end
+  end
+
+  def show_warning_message_about_environments
+    if production?
+      puts(("*" * 50).red)
+      puts("** You are in the Rails console for PRODUCTION! **".red)
+      puts(("*" * 50).red)
+    else
+      puts(("-" * 65).blue)
+      puts("-- This is the Rails console for the #{environment_name} environment. --".blue)
+      puts(("-" * 65).blue)
+    end
+  end
+
+  def production?
+    environment_name == "production"
+  end
+
+  def development?
+    environment_name == "development"
+  end
+
+  def environment_name
+    Rails.env
+  end
+end
+
+if defined?(Rails::Console)
+  Rails::Console.prepend(RegisterConsole)
+end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module RegisterConsole
   def start
     show_warning_message_about_environments
 
-    if development?
+    if Rails.env.development?
       super
     else
       puts("Hello! Who are you? This name will be used in the audit log for any changes you make.")
@@ -17,7 +19,7 @@ module RegisterConsole
   end
 
   def show_warning_message_about_environments
-    if production?
+    if Rails.env.production?
       puts(("*" * 50).red)
       puts("** You are in the Rails console for PRODUCTION! **".red)
       puts(("*" * 50).red)
@@ -26,14 +28,6 @@ module RegisterConsole
       puts("-- This is the Rails console for the #{environment_name} environment. --".blue)
       puts(("-" * 65).blue)
     end
-  end
-
-  def production?
-    environment_name == "production"
-  end
-
-  def development?
-    environment_name == "development"
   end
 
   def environment_name

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -4,9 +4,7 @@ module RegisterConsole
   def start
     show_warning_message_about_environments
 
-    if Rails.env.development?
-      super
-    else
+    if Rails.env.production?
       puts("Hello! Who are you? This name will be used in the audit log for any changes you make.")
       who_are_you = $stdin.gets
       audited_user = "#{who_are_you.chomp} via the Rails console"
@@ -15,6 +13,8 @@ module RegisterConsole
       Audited.audit_class.as_user(audited_user) do
         super
       end
+    else
+      super
     end
   end
 


### PR DESCRIPTION
### Context
We want to be able to easily attribute changes made in `rails console` on production to the developer that ran them.

### Changes proposed in this pull request
This PR adds a prompt to ask for your name when you open `rails console` in a production environment. It uses the name input to attribute all audit entries generated as a result of any subsequent commands in that console session.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/020ab4bd-d0ca-48b8-9a3f-ea0329c16a14)

### Guidance to review
Have I missed anything?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
