### PR TITLE
[xxxx] Switch to schema load for review app

### DIFF
--- a/terraform/aks/workspace-variables/review_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/review_aks.tfvars.json
@@ -11,7 +11,7 @@
   "db_sslmode": "prefer",
   "main_app": {
     "main": {
-      "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],
+      "startup_command": ["/bin/sh", "-c", "bundle exec rails db:schema:load && bundle exec rails server -b 0.0.0.0"],
       "probe_path": "/ping",
       "replicas": 1,
       "memory_max": "1Gi"


### PR DESCRIPTION
### Context

Review apps are currently failing to deploy due to the strong migrations gem causing an error when trying to run every migration and marking some as unsafe. 

Ideally, for review/preview apps, we should be loading the latest schema rather than try to run every migration defined in the app. The schema represents the latest state of the database so we should use it. It also helps avoid complaints by gems such as the strong migrations.

### Changes proposed in this pull request

- Switch AKS review app startup command to use `db:schema:load`

### Guidance to review

- The review app builds and deploys
- The seed and example data are still populated successfully
