### PR TITLE
[5716] New copy for waiting to be awarded teaching status

### DIFF
--- a/app/components/award_details/view.rb
+++ b/app/components/award_details/view.rb
@@ -11,7 +11,11 @@ module AwardDetails
     end
 
     def award_date
-      date_for_summary_view(trainee.awarded_at)
+      if trainee.awarded_at.present?
+        date_for_summary_view(trainee.awarded_at)
+      elsif trainee.recommended_for_award?
+        "Waiting for award - met standards on #{date_for_summary_view(trainee.recommended_for_award_at)}"
+      end
     end
   end
 end

--- a/app/components/award_details/view.rb
+++ b/app/components/award_details/view.rb
@@ -14,7 +14,10 @@ module AwardDetails
       if trainee.awarded_at.present?
         date_for_summary_view(trainee.awarded_at)
       elsif trainee.recommended_for_award?
-        "Waiting for award - met standards on #{date_for_summary_view(trainee.recommended_for_award_at)}"
+        I18n.t(
+          "components.award_details.waiting_for_award",
+          recommended_for_award_at: date_for_summary_view(trainee.recommended_for_award_at),
+        )
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -190,6 +190,8 @@ en:
         unhappy_with_course_provider_or_employing_school: Unhappy with course, provider or employing school
         another_reason: Another reason
         unknown: Unknown
+    award_details:
+        waiting_for_award: Waiting for award - met standards on %{recommended_for_award_at}
     confirmation:
       not_provided_from_hesa_update: Not provided from HESA update
       missing: missing

--- a/spec/components/award_details/view_spec.rb
+++ b/spec/components/award_details/view_spec.rb
@@ -8,14 +8,26 @@ module AwardDetails
 
     alias_method :component, :page
 
-    let(:trainee) { build(:trainee, :awarded) }
-
     before do
       render_inline(View.new(trainee))
     end
 
-    it "renders the award date" do
-      expect(component.find(summary_card_row_for("award-date"))).to have_text(date_for_summary_view(trainee.awarded_at))
+    context "when trainee has been awarded" do
+      let(:trainee) { build(:trainee, :awarded) }
+
+      it "renders the award date" do
+        expect(component.find(summary_card_row_for("award-date"))).to have_text(date_for_summary_view(trainee.awarded_at))
+      end
+    end
+
+    context "when trainee is recommended for award" do
+      let(:trainee) { build(:trainee, :recommended_for_award, recommended_for_award_at: 10.days.ago) }
+
+      it "renders recommended date if awaiting award" do
+        expect(component.find(summary_card_row_for("award-date"))).to have_text(
+          "Waiting for award - met standards on #{date_for_summary_view(trainee.recommended_for_award_at)}",
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
This PR implements a small copy change to make things clear for trainees that have been recommended for QTS, see https://becoming-a-teacher.design-history.education.gov.uk/register-trainee-teachers/making-it-clearer-that-a-trainee-is-waiting-to-be-awarded-teaching-status/

### Changes proposed in this pull request
Rather than leave the award date field blank we render a message to indicate when the trainee was recommended for qualification.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/94e4884a-d8fc-4530-b028-608798d99429)


### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
