### PR TITLE
[5749] Add previous hesa id field

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -80,6 +80,7 @@
 #  hesa_trn_submission_id          :bigint
 #  lead_school_id                  :bigint
 #  placement_assignment_dttp_id    :uuid
+#  previous_hesa_id                :string
 #  provider_id                     :bigint           not null
 #  start_academic_cycle_id         :bigint
 #  trainee_id                      :text

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -228,6 +228,7 @@ shared:
     - end_academic_cycle_id
     - sex
     - hesa_id
+    - previous_hesa_id
     - hesa_updated_at
     - id
     - iqts_country

--- a/db/migrate/20230726105546_add_alternative_hesa_id_to_trainees.rb
+++ b/db/migrate/20230726105546_add_alternative_hesa_id_to_trainees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAlternativeHesaIdToTrainees < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trainees, :previous_hesa_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_20_111602) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_26_105546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -821,6 +821,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_20_111602) do
     t.boolean "hesa_editable", default: false
     t.string "withdraw_reasons_dfe_details"
     t.datetime "slug_sent_to_dqt_at"
+    t.string "previous_hesa_id"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["course_allocation_subject_id"], name: "index_trainees_on_course_allocation_subject_id"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"


### PR DESCRIPTION
### Context

https://trello.com/c/dPHAQP0z/5749-add-alternative-hesa-id-field

Providers can sometimes change the `hesa_id` field for hesa trainees which can lead us to creating duplicate records. We're tightening up the matching rules but if the `hesa_id` has changed, we'll need to capture the old one.

### Changes proposed in this pull request

- Add a `previous_hesa_id` field to `trainees`. This by default will and should ideally be empty. It's only used for situations where the current `hesa_id` has been changed and it becomes the `previous_hesa_id`.

### Notes

As far as the ticket goes, we've only ever seen an original `hesa_id` and a new/alternative one in the data. We don't yet know if we need to capture many old ids. One additional field seems low risk than drastically changing the implementation to support many old ids right now (we don't understand enough if there is any value in doing this).
