### PR TITLE
Revert "Bump sidekiq from 6.5.8 to 7.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,10 +52,8 @@ gem "request_store", "~> 1.5"
 gem "govuk-components", "3.0.3"
 gem "govuk_design_system_formbuilder"
 
-gem "redis"
-
 # Background job processor
-gem "sidekiq", "~> 7.0"
+gem "sidekiq", "~> 6.5"
 gem "sidekiq-cron", "~> 1.10"
 
 # UK postcode parsing and validation for Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,8 +534,6 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.6.0)
     redis (4.8.1)
-    redis-client (0.14.1)
-      connection_pool
     regexp_parser (2.8.1)
     reline (0.3.4)
       io-console (~> 0.5)
@@ -634,11 +632,10 @@ GEM
       sidekiq (>= 3.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.0.0)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.9.0)
+    sidekiq (6.5.8)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     sidekiq-cron (1.10.1)
       fugit (~> 1.8)
       globalid (>= 1.0.1)
@@ -801,7 +798,6 @@ DEPENDENCIES
   rails (~> 7.0)
   rails-controller-testing
   rails_semantic_logger (= 4.12.0)
-  redis
   request_store (~> 1.5)
   rotp
   rspec-benchmark
@@ -816,7 +812,7 @@ DEPENDENCIES
   sentry-ruby
   sentry-sidekiq
   shoulda-matchers (~> 5.3)
-  sidekiq (~> 7.0)
+  sidekiq (~> 6.5)
   sidekiq-cron (~> 1.10)
   simplecov (~> 0.22.0)
   site_prism (~> 4.0)

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -35,7 +35,7 @@ private
   end
 
   def redis_alive?
-    Sidekiq.redis(&:ping)
+    Sidekiq.redis_info
     true
   rescue StandardError
     false

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -25,7 +25,7 @@ describe "heartbeat requests" do
       allow(process).to receive(:[]).with("queues").and_return([queue_name])
 
       allow(ActiveRecord::Base.connection).to receive(:active?).and_return(true)
-      allow(Sidekiq).to receive(:redis).and_return({})
+      allow(Sidekiq).to receive(:redis_info).and_return({})
     end
 
     context "when everything is ok" do
@@ -73,7 +73,7 @@ describe "heartbeat requests" do
 
     context "there's no Redis connection" do
       before do
-        allow(Sidekiq).to receive(:redis).and_raise(Errno::ECONNREFUSED)
+        allow(Sidekiq).to receive(:redis_info).and_raise(Errno::ECONNREFUSED)
       end
 
       it("returns 503") do


### PR DESCRIPTION
Reverts DFE-Digital/register-trainee-teachers#3444

Causing deploys to fail due to Redis version being under what's required by the Sidekiq bump:

```shell
You are connecting to Redis 6.0.14, Sidekiq requires Redis 6.2.0 or greater
/usr/local/bundle/gems/sidekiq-7.0.0/lib/sidekiq/cli.rb:77:in `run'
/usr/local/bundle/gems/sidekiq-7.0.0/bin/sidekiq:31:in `<top (required)>'
/usr/local/bundle/bin/sidekiq:25:in `load'
/usr/local/bundle/bin/sidekiq:25:in `<top (required)>'
/usr/local/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `load'
/usr/local/lib/ruby/3.1.0/bundler/cli/exec.rb:58:in `kernel_load'
/usr/local/lib/ruby/3.1.0/bundler/cli/exec.rb:23:in `run'
/usr/local/lib/ruby/3.1.0/bundler/cli.rb:486:in `exec'
/usr/local/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/local/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'
/usr/local/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/local/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'
/usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/libexec/bundle:48:in `block in <top (required)>'
/usr/local/lib/ruby/3.1.0/bundler/friendly_errors.rb:120:in `with_friendly_errors'
/usr/local/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/libexec/bundle:36:in `<top (required)>'
/usr/local/bin/bundle:25:in `load'
/usr/local/bin/bundle:25:in `<main>'
```