### PR TITLE
5718] Tighten up hesa matching rules

### DIFF
--- a/app/lib/hesa/parsers/itt_record.rb
+++ b/app/lib/hesa/parsers/itt_record.rb
@@ -24,7 +24,6 @@ module Hesa
         itt_commencement_date: "F_ITTCOMDATE",
         training_initiative: "F_INITIATIVES1",
         hesa_id: "F_HUSID",
-        student_instance_id: "F_NUMHUS",
         end_date: "F_ENDDATE",
         reason_for_leaving: "F_RSNEND",
         bursary_level: "F_BURSLEV",

--- a/app/models/hesa/student.rb
+++ b/app/models/hesa/student.rb
@@ -64,9 +64,9 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  hesa_id                      :string
+#  previous_hesa_id             :string
 #  provider_course_id           :string
 #  rec_id                       :string
-#  student_instance_id          :string
 #  trainee_id                   :string
 #
 # Indexes
@@ -76,6 +76,7 @@
 module Hesa
   class Student < ApplicationRecord
     self.table_name = "hesa_students"
+    self.ignored_columns += %w[student_instance_id] # rubocop:disable Rails/UnusedIgnoredColumns
 
     belongs_to :trainee,
                foreign_key: :hesa_id,

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -80,7 +80,6 @@
 #  hesa_trn_submission_id          :bigint
 #  lead_school_id                  :bigint
 #  placement_assignment_dttp_id    :uuid
-#  previous_hesa_id                :string
 #  provider_id                     :bigint           not null
 #  start_academic_cycle_id         :bigint
 #  trainee_id                      :text
@@ -123,7 +122,7 @@
 #  fk_rails_...  (start_academic_cycle_id => academic_cycles.id)
 #
 class Trainee < ApplicationRecord
-  self.ignored_columns += ["withdraw_reason"] # rubocop:disable Rails/UnusedIgnoredColumns
+  self.ignored_columns += %w[withdraw_reason previous_hesa_id] # rubocop:disable Rails/UnusedIgnoredColumns
 
   include Sluggable
   include PgSearch::Model

--- a/app/services/hesa/sync_students.rb
+++ b/app/services/hesa/sync_students.rb
@@ -43,7 +43,7 @@ module Hesa
 
         hesa_student = find_by_id(hesa_trainee) || find_by_biographic_details(hesa_trainee) || Hesa::Student.new
 
-        hesa_student = update_hesa_ids(hesa_student, hesa_trainee) unless hesa_student.new_record?
+        hesa_student = update_hesa_ids(hesa_student, hesa_trainee) unless student_is_new_or_has_same_hesa_id?(hesa_student, hesa_trainee)
 
         hesa_student.assign_attributes(hesa_trainee)
 
@@ -91,6 +91,10 @@ module Hesa
       hesa_student.hesa_id = hesa_trainee[:hesa_id]
 
       hesa_student
+    end
+
+    def student_is_new_or_has_same_hesa_id?(hesa_student, hesa_trainee)
+      hesa_student.new_record? || hesa_student.hesa_id == hesa_trainee[:hesa_id]
     end
   end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -228,7 +228,6 @@ shared:
     - end_academic_cycle_id
     - sex
     - hesa_id
-    - previous_hesa_id
     - hesa_updated_at
     - id
     - iqts_country

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -195,7 +195,7 @@
   :hesa_students:
   - id
   - hesa_id
-  - student_instance_id
+  - previous_hesa_id
   - first_names
   - last_name
   - email

--- a/db/migrate/20230728103033_add_alternative_hesa_id_to_hesa_students.rb
+++ b/db/migrate/20230728103033_add_alternative_hesa_id_to_hesa_students.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddAlternativeHesaIdToHesaStudents < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      # Remove from the trainees table as it should be on hesa_students
+      remove_column :trainees, :previous_hesa_id, :string
+      # Remove from the hesa_students table as we already have a `numhus` field for it
+      remove_column :hesa_students, :student_instance_id, :string
+    end
+
+    add_column :hesa_students, :previous_hesa_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_26_105546) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_28_103033) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -597,7 +597,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_26_105546) do
     t.string "surname16"
     t.string "ttcid"
     t.string "hesa_committed_at"
-    t.string "student_instance_id"
+    t.string "previous_hesa_id"
     t.index ["hesa_id", "rec_id"], name: "index_hesa_students_on_hesa_id_and_rec_id", unique: true
   end
 
@@ -821,7 +821,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_26_105546) do
     t.boolean "hesa_editable", default: false
     t.string "withdraw_reasons_dfe_details"
     t.datetime "slug_sent_to_dqt_at"
-    t.string "previous_hesa_id"
     t.index ["apply_application_id"], name: "index_trainees_on_apply_application_id"
     t.index ["course_allocation_subject_id"], name: "index_trainees_on_course_allocation_subject_id"
     t.index ["course_uuid"], name: "index_trainees_on_course_uuid"

--- a/spec/lib/hesa/parsers/itt_record_spec.rb
+++ b/spec/lib/hesa/parsers/itt_record_spec.rb
@@ -33,7 +33,6 @@ module Hesa
             itt_commencement_date: nil,
             training_initiative: "009",
             hesa_id: "0310261553101",
-            student_instance_id: "02",
             reason_for_leaving: nil,
             end_date: nil,
             disability1: "95",

--- a/spec/services/hesa/sync_students_spec.rb
+++ b/spec/services/hesa/sync_students_spec.rb
@@ -57,6 +57,16 @@ module Hesa
         end
       end
 
+      context "hesa record with the same hesa id in an existing collection" do
+        let!(:hesa_student) { create(:hesa_student, hesa_id: "0310261553101", rec_id: "16053") }
+
+        it "updates the existing record and does not update the hesa ids" do
+          expect { service }.not_to change { Student.count }
+          expect(hesa_student.reload.hesa_id).to eq "0310261553101"
+          expect(hesa_student.previous_hesa_id).to be_nil
+        end
+      end
+
       context "hesa record with a different hesa_id but matching combined fields in an existing collection" do
         let!(:hesa_student) do
           create(

--- a/spec/services/hesa/sync_students_spec.rb
+++ b/spec/services/hesa/sync_students_spec.rb
@@ -40,6 +40,124 @@ module Hesa
         end
       end
 
+      context "hesa record with an alternative hesa id in an existing collection" do
+        let!(:hesa_student) { create(:hesa_student, hesa_id: "0000000000000", previous_hesa_id: "0310261553101", rec_id: "16053") }
+
+        before do
+          allow(Hesa::Parsers::IttRecord).to receive(:to_attributes).and_return(
+            hesa_id: "0310261553101",
+            rec_id: "16053",
+          )
+        end
+
+        it "updates the existing record and moves the old hesa_id to previous_hesa_id" do
+          expect { service }.not_to change { Student.count }
+          expect(hesa_student.reload.hesa_id).to eq "0310261553101"
+          expect(hesa_student.previous_hesa_id).to eq "0000000000000"
+        end
+      end
+
+      context "hesa record with a different hesa_id but matching combined fields in an existing collection" do
+        let!(:hesa_student) do
+          create(
+            :hesa_student,
+            hesa_id: "0000000000000",
+            rec_id: "16053",
+            first_names: "Dave",
+            last_name: "George",
+            date_of_birth: "1978-08-13",
+            trainee_id: "99157234/2/01",
+            ukprn: "10007713",
+            itt_commencement_date: nil,
+            numhus: "02",
+            email: "student.name@email.com",
+          )
+        end
+
+        it "updates the existing record and moves the old hesa_id to previous_hesa_id" do
+          expect { service }.not_to change { Student.count }
+          expect(hesa_student.reload.hesa_id).to eq "0310261553101"
+          expect(hesa_student.previous_hesa_id).to eq "0000000000000"
+        end
+      end
+
+      context "hesa record with a different hesa_id but matching combined fields in a new collection" do
+        let!(:hesa_student) do
+          create(
+            :hesa_student,
+            hesa_id: "0310261553101",
+            rec_id: "16053",
+            first_names: "Dave",
+            last_name: "George",
+            date_of_birth: "1978-08-13",
+            trainee_id: "99157234/2/01",
+            ukprn: "10007713",
+            itt_commencement_date: nil,
+            numhus: "02",
+            email: "student.name@email.com",
+          )
+        end
+
+        before do
+          allow(Hesa::Parsers::IttRecord).to receive(:to_attributes).and_return(
+            hesa_id: "0310261553101",
+            rec_id: "16054", # different rec_id,
+            first_names: "Dave",
+            last_name: "George",
+            date_of_birth: "1978-08-13",
+            trainee_id: "99157234/2/01",
+            ukprn: "10007713",
+            itt_commencement_date: nil,
+            numhus: "02",
+            email: "student.name@email.com",
+          )
+        end
+
+        it "updates the existing record and moves the old hesa_id to previous_hesa_id" do
+          expect { service }.not_to change { Student.count }
+        end
+      end
+
+      context "hesa record with the same hesa_id but different additional info in an existing collection" do
+        let!(:hesa_student) do
+          create(
+            :hesa_student,
+            hesa_id: "0310261553101",
+            rec_id: "16053",
+            first_names: "Dave",
+            last_name: "George",
+            date_of_birth: "1978-08-13",
+            trainee_id: "99157234/2/01",
+            ukprn: "10007713",
+            itt_commencement_date: nil,
+            numhus: "02",
+            email: "student.name@email.com",
+          )
+        end
+
+        before do
+          allow(Hesa::Parsers::IttRecord).to receive(:to_attributes).and_return(
+            hesa_id: "0310261553101",
+            rec_id: "16053",
+            first_names: "New Name",
+            last_name: "New Surname",
+            date_of_birth: "1980-08-13",
+            trainee_id: "99157234/2/01",
+            ukprn: "10007713",
+            itt_commencement_date: nil,
+            numhus: "02",
+            email: "student.name@email.com",
+          )
+        end
+
+        it "updates the existing record with new additional info" do
+          expect { service }.not_to change { Student.count }
+          expect(hesa_student.reload.first_names).to eq "New Name"
+          expect(hesa_student.last_name).to eq "New Surname"
+          expect(hesa_student.date_of_birth).to eq "1980-08-13"
+        end
+      end
+
       context "with an optional upload" do
         let(:filename) { "itt_record.xml" }
         let(:upload) { create(:upload, name: filename, file: nil) }


### PR DESCRIPTION
### Context

https://trello.com/c/X3UIHFWw/5718-hesa-import-add-secondary-check-for-existing-trainees

Updates from HESA can cause duplicates as some providers change the hesa id for their existing trainees and if we do not have that hesa id in Register we create a new record and therefore a duplicate.

This work is to add a secondary checks to be performed where a `hesa_id` is not found in trainees table.

### Changes proposed in this pull request

- Adds some secondary checks for a record using the `previous_hesa_id` or biographic information before deciding to create a new one
- Moves the `previous_hesa_id` field introduced via https://github.com/DFE-Digital/register-trainee-teachers/pull/3464/files to the `hesa_students` table as that's where it should be (doh)
- Removes the `student_instance_id` field from `hesa_students` to store `NUMHUS` from the hesa collection as we already have a `numhus` field (doh)

### Guidance to review

This is a bit difficult to test unless you do it locally with a hesa collection dump. Essentially, it tries to cover the following scenarios (checked with Claire). So first scenario is where we create a new record and goes from there

#### Scenario 1 - Student arrives as new

Final output will be something like:

```
student.hesa_id = "AAA"
student.previous_hesa_id = empty
```

#### Scenario 2 - Student arrives as existing

`arrival_hesa_id = "AAA"`

Existing hesa student with id AAA from above found so updated. Final output

```
student.hesa_id = "AAA"
student.previous_hesa_id = empty
```

#### Scenario 3 - Student arrives as existing with new hesa id

`arrival_hesa_id = "BBB"`

No match on id but match on additional info so updated. Final output

```
student.hesa_id = "BBB"
student.previous_hesa_id = "AAA"
```

This will loop continously every time there is a new hesa id but the additional info stays the same. The hesa ids will be swapped out with whatver the new one is and the old stored under `previous_hesa_id` in the students table.

#### Scenario 4 - Student with new hesa id and new additional info

`arrival_hesa_id = "CCC"`

No match on id or additional info so new hesa record created. Final output

```
student.hesa_id = "CCC"
student.previous_hesa_id = empty
```
