### PR TITLE
Remove references to the `digital.education.gov.uk` subdomain

### DIFF
--- a/app/views/guidance/performance_profiles.html.erb
+++ b/app/views/guidance/performance_profiles.html.erb
@@ -57,19 +57,19 @@
     <h3 class="govuk-heading-s">Providers of school centred initial teacher training (SCITTs)</h3> 
     <p class="govuk-body">
       If the trainee is shown in this service as awarded or withdrawn, you should email
-      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@digital.education.gov.uk</a>.
+      <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@education.gov.uk</a>.
     </p>
     <p class="govuk-body">If the trainee is shown in this service as actively training or deferred, you should make the change in this service.</p>
     
     <h3 class="govuk-heading-s">Higher education institutions (HEIs)</h3>
     <p class="govuk-body">If the trainee is shown in this service as awarded or withdrawn, you should email
-      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@digital.education.gov.uk</a>.
+      <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@education.gov.uk</a>.
     </p>
     <p class="govuk-body">If the trainee is shown in this service as actively training or deferred, you should:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>make the change through the Higher Education Statistics Agency (HESA) if the trainee was registered through HESA and is in the <%= @current_academic_cycle_label %> initial teacher training (ITT) collection</li>
       <li>email
-      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@digital.education.gov.uk</a>
+      <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@education.gov.uk</a>
       if the trainee was registered through HESA but is not in the <%= @current_academic_cycle_label %> ITT collection</li>
       <li>make the change in this service if the trainee was not registered through HESA</li>
     </ul>

--- a/app/views/request_an_account/index.html.erb
+++ b/app/views/request_an_account/index.html.erb
@@ -27,7 +27,7 @@
     <h2 class="govuk-heading-m">2. Get a Register account</h2>
     <p class="govuk-body">Once you have a DfE Sign-in account, ask a colleague with a Register account to send an email requesting an account for you.</p>
     <p class="govuk-body">If nobody in your organisation has a Register account, you can send the email yourself.</p>
-    <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Request a Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>. It should say that you want to start using Register and include:</p>
+    <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@education.gov.uk?subject=Request a Register account" class="govuk-link">becomingateacher@education.gov.uk</a>. It should say that you want to start using Register and include:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>the name of the accredited provider or lead school you work for</li>
       <li>the email address used for your DfE Sign-in account</li>
@@ -38,6 +38,6 @@
     <p class="govuk-body">Once you have a Register account, you can request access to additional accredited providers or lead schools. You do not need a separate Register account for each organisation.</p>
     <p class="govuk-body">Ask someone with a Register account in the organisation you want to access to send an email requesting access for you.</p>
     <p class="govuk-body">If nobody in the organisation has a Register account, you can send the email yourself.</p>
-    <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Add multiple organisations to Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.</p>    
+    <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@education.gov.uk?subject=Add multiple organisations to Register account" class="govuk-link">becomingateacher@education.gov.uk</a>.</p>    
   </div>  
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1392,7 +1392,7 @@ en:
         bulk_update:
           recommendations_uploads:
             validate_trainee:
-              multiple_trainees_trn_received: "%{count} trainee records with TRN received status have the same %{found_with} - contact becomingateacher@digital.education.gov.uk to fix this"
+              multiple_trainees_trn_received: "%{count} trainee records with TRN received status have the same %{found_with} - contact becomingateacher@education.gov.uk to fix this"
               multiple_trainees_found_via: "%{count} trainee records have the same %{found_with} but none have TRN received status - you can only recommend trainees with TRN received status"
               trainee_wrong_state: "The trainee has %{state} status - you can only recommend trainees with TRN received status"
               no_trainee_matched: "%{id_available} must match a trainee record"

--- a/config/locales/pages/accessibility/en.yml
+++ b/config/locales/pages/accessibility/en.yml
@@ -20,13 +20,13 @@ en:
 
         <h2 class='govuk-heading-m'>Feedback and contact information</h2>
 
-        <p class='govuk-body'>If you need information on this service in a different format like accessible PDF, large print, easy read, audio recording or braille, contact <a class='govuk-link' href='mailto:becomingateacher@digital.education.gov.uk?subject=Accessibility%20issues%20'>becomingateacher@digital.education.gov.uk</a>.</p>
+        <p class='govuk-body'>If you need information on this service in a different format like accessible PDF, large print, easy read, audio recording or braille, contact <a class='govuk-link' href='mailto:becomingateacher@education.gov.uk?subject=Accessibility%20issues%20'>becomingateacher@education.gov.uk</a>.</p>
         <p class='govuk-body'>We’ll consider your request and get back to you in 5 days.</p>
         <p class='govuk-body'>This service was built following GOV.UK design guidelines, which meet the <a href='https://www.w3.org/TR/WCAG21/' class='govuk-link'>Web Content Accessibility Guidelines (WCAG) 2.1 (level AA)</a>.</p>
 
         <h2 class='govuk-heading-m'>Reporting accessibility problems with Register trainee teachers</h2>
 
-        <p class='govuk-body govuk-!-margin-bottom-7'>We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact <a class='govuk-link' href='mailto:becomingateacher@digital.education.gov.uk?subject=Accessibility%20issues%20'>becomingateacher@digital.education.gov.uk</a>. Include ‘Accessibility’ in the subject line of your email.</p>
+        <p class='govuk-body govuk-!-margin-bottom-7'>We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact <a class='govuk-link' href='mailto:becomingateacher@education.gov.uk?subject=Accessibility%20issues%20'>becomingateacher@education.gov.uk</a>. Include ‘Accessibility’ in the subject line of your email.</p>
 
         <h2 class='govuk-heading-m'>Enforcement procedure</h2>
 

--- a/config/locales/pages/data_sharing_agreement/en.yml
+++ b/config/locales/pages/data_sharing_agreement/en.yml
@@ -428,7 +428,7 @@ en:
         <p class='govuk-body'>
           Data subjects wanting to make an SAR can email the DfE at
           <a class='govuk-link'
-          href='mailto:becomingateacher@digital.education.gov.uk.?subject=Subject%20access%20request'>becomingateacher@digital.education.gov.uk</a>.
+          href='mailto:becomingateacher@education.gov.uk.?subject=Subject%20access%20request'>becomingateacher@education.gov.uk</a>.
         </p>
         <h2 class='govuk-heading-m' id='#handling-freedom-of-information-act-requests'>
           Handling freedom of information requests
@@ -503,7 +503,7 @@ en:
           </p>
           <p class='govuk-body'>
             All communication should be sent by email to <a class='govuk-link'
-            href='mailto:becomingateacher@digital.education.gov.uk.?subject=Security%20incident'>becomingateacher@digital.education.gov.uk</a>.
+            href='mailto:becomingateacher@education.gov.uk.?subject=Security%20incident'>becomingateacher@education.gov.uk</a>.
           </p>
           <p class='govuk-body'>
             The designated points of contact will discuss and agree the next steps relating to the incident, taking specialist advice where appropriate. Such arrangements will include (but will not be limited to):
@@ -587,7 +587,7 @@ en:
         <p class='govuk-body'>
           To notify the DfE with your consent to the terms of this data sharing
           agreement, email <a class='govuk-link'
-          href='mailto:becomingateacher@digital.education.gov.uk.?subject=Register%20DSA%20consent'>becomingateacher@digital.education.gov.uk</a> with
+          href='mailto:becomingateacher@education.gov.uk.?subject=Register%20DSA%20consent'>becomingateacher@education.gov.uk</a> with
           confirmation.
         </p>
         <h3 class='govuk-heading-s'>

--- a/config/locales/pages/guidance/en.yml
+++ b/config/locales/pages/guidance/en.yml
@@ -35,7 +35,7 @@ en:
       <ol class='govuk-list govuk-list--number'>
         <li>Add a first subject as PE, or a PE based subject.</li>
         <li>Add a second subject as their EBacc subject.</li>
-        <li>Email us at <a class='govuk-notification-banner__link' href='mailto:becomingateacher@digital.education.gov.uk'>becomingateacher@digital.education.gov.uk</a> stating their trainee ID and that they are doing PE with EBacc.</li>
+        <li>Email us at <a class='govuk-notification-banner__link' href='mailto:becomingateacher@education.gov.uk'>becomingateacher@education.gov.uk</a> stating their trainee ID and that they are doing PE with EBacc.</li>
       </ol>
 
       <h3 class='govuk-heading-m'>Getting a teacher reference number (TRN)</h3>
@@ -62,7 +62,7 @@ en:
 
       <p class='govuk-body'>The census happens in September and October every year. We‘ll notify you about the exact dates each year, including the deadline when your data needs to be signed off by a responsible officer.</p>
 
-      <p class='govuk-body'>To sign your organisation‘s data off, the responsible officer needs to email us at <a class='govuk-notification-banner__link' href='mailto:becomingateacher@digital.education.gov.uk'>becomingateacher@digital.education.gov.uk</a>.</p>
+      <p class='govuk-body'>To sign your organisation‘s data off, the responsible officer needs to email us at <a class='govuk-notification-banner__link' href='mailto:becomingateacher@education.gov.uk'>becomingateacher@education.gov.uk</a>.</p>
 
       <p class='govuk-body'>The subject line must state ‘Census 2021 to 2022’ and the name of your organisation.</p>
 

--- a/config/locales/pages/no_organisation/en.yml
+++ b/config/locales/pages/no_organisation/en.yml
@@ -6,7 +6,7 @@ en:
 
       <p class='govuk-body'>Your account needs to be linked to an organisation so you can use Register.</p>
 
-      <p class='govuk-body'>To be added to an organisation, email us at <a class='govuk-link' href='mailto:becomingateacher@digital.education.gov.uk?subject=Accessibility%20issues%20'>becomingateacher@digital.education.gov.uk</a></p>
+      <p class='govuk-body'>To be added to an organisation, email us at <a class='govuk-link' href='mailto:becomingateacher@education.gov.uk?subject=Accessibility%20issues%20'>becomingateacher@education.gov.uk</a></p>
 
       <p class='govuk-body'>In your email tell us:</p>
 

--- a/config/locales/pages/privacy_policy/en.yml
+++ b/config/locales/pages/privacy_policy/en.yml
@@ -137,11 +137,11 @@ en:
 
       <p class='govuk-body'>You can find more information about how we handle personal data in our personal information charter.</p>
 
-      <p class='govuk-body'>Contact the Register trainee teachers team at <a class='govuk-link' href='mailto:becomingateacher@digital.education.gov.uk'>becomingateacher@digital.education.gov.uk</a> if you have any concerns about your personal data.</p>
+      <p class='govuk-body'>Contact the Register trainee teachers team at <a class='govuk-link' href='mailto:becomingateacher@education.gov.uk'>becomingateacher@education.gov.uk</a> if you have any concerns about your personal data.</p>
 
       <h2 class='govuk-heading-m' id='getting-help-raising-a-concern'>Getting help raising a concern</h2>
 
-      <p class='govuk-body'>If you would like to exercise any of your rights, you can email us at <a href='mailto:becomingateacher@digital.education.gov.uk?subject=Raising a concern - personal data in Register!' class='govuk-link'>becomingateacher@digital.education.gov.uk</a></p>
+      <p class='govuk-body'>If you would like to exercise any of your rights, you can email us at <a href='mailto:becomingateacher@education.gov.uk?subject=Raising a concern - personal data in Register!' class='govuk-link'>becomingateacher@education.gov.uk</a></p>
 
       <p class='govuk-body'>You can also use our <a href='https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen' class='govuk-link'>contact form</a> to get in touch with our Data Protection Officer.</p>
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,8 +7,8 @@ base_url: https://localhost:5000
 feedback_link_url: "https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-XoQTPfbQ2dGrsruj75vocFUOFhUQUE4SkpBNlo2Q1hGMlBKVFNLOTlVSi4u"
 
 # The email address for support queries
-support_email: becomingateacher@digital.education.gov.uk
-data_email: registerateacher@digital.education.gov.uk
+support_email: becomingateacher@education.gov.uk
+data_email: registerateacher@education.gov.uk
 
 dttp:
   client_id: "application-registration-client-id-from-env"

--- a/db/service_updates.yml
+++ b/db/service_updates.yml
@@ -37,7 +37,7 @@
   content: |
      We’ve extended the deadline to sign off your new trainee data to <span class="no-wrap">Tuesday, 1 November 2022.</span>
      
-     This is due to Register being briefly unavailable leading up to the deadline. If you have any questions or concerns, email [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+     This is due to Register being briefly unavailable leading up to the deadline. If you have any questions or concerns, email [becomingateacher@education.gov.uk](mailto:becomingateacher@education.gov.uk).
 
 - date: '2022-09-28'
   title: Deadline for first data submission to HESA is extended to 17 October 2022
@@ -67,7 +67,7 @@
   content: |
      If you’re a higher education institute (HEI), you can start updating your trainee data through HESA from 18 to 29 July.
     
-     You’ll first need to have your data decommitted in HESA. Email our support team who will decommit your data and let you know when it’s ready to update. Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=Decommit%20trainee%20data%20in%20HESA%20for%20July%20update%20period).
+     You’ll first need to have your data decommitted in HESA. Email our support team who will decommit your data and let you know when it’s ready to update. Email us at [becomingateacher@education.gov.uk](mailto:becomingateacher@education.gov.uk?subject=Decommit%20trainee%20data%20in%20HESA%20for%20July%20update%20period).
 
 - date: '2022-07-05'
   title: Improvements to Register’s homepage and filters
@@ -100,7 +100,7 @@
   content: |
     The import from HESA to Register is working normally. This means if you’re a Higher Education Institute (HEI), you can use Register to see data that you have updated and uploaded to HESA. This will allow you to complete your April census update by 13 May.
 
-    If you have updated any data about placements in HESA, you will not be able to see this in Register yet, but this will be available in future. If you identify any further issues with your data, contact [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=HESA%20import%20issues%20in%20Register).
+    If you have updated any data about placements in HESA, you will not be able to see this in Register yet, but this will be available in future. If you identify any further issues with your data, contact [becomingateacher@education.gov.uk](mailto:becomingateacher@education.gov.uk?subject=HESA%20import%20issues%20in%20Register).
 
 - date: '2022-04-29'
   title: April HESA census update extended to Friday 13 May 2022
@@ -136,7 +136,7 @@
     The support desk will close at 2pm on Friday 24 December 2021. It will open again on Tuesday 4 January 2022.
 
     If you have an urgent problem during this time, you can still contact us at
-    [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+    [becomingateacher@education.gov.uk](mailto:becomingateacher@education.gov.uk).
 
 - date: '2021-12-03'
   title: The Department for Education (DfE) has published the provisional data for the 2021 initial teacher training (ITT) census

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -87,7 +87,7 @@ When testing this step against a review environment a manual backup will need to
 # space is the name of the environment in GOV.UK PaaS, eg 'bat-prod'
 # env is the target environment in the make file e.g. 'production'
 az login
-cf login -o dfe -s <space> -u my.name@digital.education.gov.uk
+cf login -o dfe -s <space> -u my.name@education.gov.uk
 make <env> restore-data-from-nightly-backup BACKUP_DATE="yyyy-mm-dd" CONFIRM_PRODUCTION=YES CONFIRM_RESTORE=YES
 ```
 
@@ -154,7 +154,7 @@ The following commands combine the makefile recipes above to initiate the restor
 # env is the target environment in the make file e.g. 'production'
 # space is the name of the environment in GOV.UK PaaS, eg 'bat-prod'
 az login
-cf login -o dfe -s <space> -u my.name@digital.education.gov.uk
+cf login -o dfe -s <space> -u my.name@education.gov.uk
 PASSCODE=xxxx # obtain from https://login.london.cloud.service.gov.uk/passcode
 DB_INSTANCE_GUID=$(make <env> get-postgres-instance-guid)
 TAG=$(make <env> get-image-tag)

--- a/docs/govuk_paas.md
+++ b/docs/govuk_paas.md
@@ -5,7 +5,7 @@ It uses the open source Cloud Foundry platform and run on AWS.
 
 ## Getting a PaaS account
 You can get an account by requesting in the `#digital-tools-support` channel. 
-Request for an account with a `SpaceDeveloper` role to be created under your `@digital.education.gov.uk` email address and access to the `dfe-teacher-services` organisation and the below spaces:
+Request for an account with a `SpaceDeveloper` role to be created under your `@education.gov.uk` email address and access to the `dfe-teacher-services` organisation and the below spaces:
 
 |Spaces       |
 |:------------|

--- a/docs/maintenance-mode.md
+++ b/docs/maintenance-mode.md
@@ -15,7 +15,7 @@ When enabled, all requests will receive the [service unavailable page](/service_
 
 NB: the maintenance page is deployed from your local machine. There is no need to open a PR, CI etc during the deployment.
 
-* Login to PaaS: `cf login --sso` or `cf login -o dfe -u my.name@digital.education.gov.uk`
+* Login to PaaS: `cf login --sso` or `cf login -o dfe -u my.name@education.gov.uk`
 
 * Run the make command: `make prod enable-maintenance CONFIRM_PRODUCTION=y`
 

--- a/service_unavailable_page/web/public/internal/index.html
+++ b/service_unavailable_page/web/public/internal/index.html
@@ -107,7 +107,7 @@
             -->
 
             <p class="govuk-body">If you need to contact us urgently, email us at<br>
-              <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Register trainee teachers">becomingateacher@digital.education.gov.uk</a>.
+              <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk?subject=Register trainee teachers">becomingateacher@education.gov.uk</a>.
             </p>
 
           </div>
@@ -126,7 +126,7 @@
                   Get support
                 </h2>
                 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                  <li>Email: <a class="govuk-link govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20support">becomingateacher@digital.education.gov.uk</a></li>
+                  <li>Email: <a class="govuk-link govuk-footer__link" href="mailto:becomingateacher@education.gov.uk?subject=Register%20trainee%20teachers%20support">becomingateacher@education.gov.uk</a></li>
                   <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
                 </ul>
               </div>

--- a/service_unavailable_page/web/public/internal/traineeteacherportal.html
+++ b/service_unavailable_page/web/public/internal/traineeteacherportal.html
@@ -45,7 +45,7 @@
               From Thursday 31 March, all trainee data from the 2020 to 2021 academic year onwards will be available
               in Register. </p>
             <p class="govuk-body">If you have any questions, email us at<br>
-            <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=DTTP to Register transition">becomingateacher@digital.education.gov.uk</a>.</p>
+            <a class="govuk-link" href="mailto:becomingateacher@education.gov.uk?subject=DTTP to Register transition">becomingateacher@education.gov.uk</a>.</p>
           </div>
         </div>
       </main>
@@ -59,7 +59,7 @@
               <div class=" govuk-grid-column-one-half">
                 <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Email</h2>
                 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                  <li><a class="govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> </li>
+                  <li><a class="govuk-footer__link" href="mailto:becomingateacher@education.gov.uk">becomingateacher@education.gov.uk</a> </li>
                   <li>You’ll get a response within 5 working days, or one working day for urgent requests.</li>
                 </ul>
               </div>

--- a/spec/helpers/support_email_helper_spec.rb
+++ b/spec/helpers/support_email_helper_spec.rb
@@ -11,7 +11,7 @@ describe SupportEmailHelper do
       subject { helper.support_email }
 
       it has_correct_formatting do
-        expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk\">becomingateacher@digital.education.gov.uk</a>"
+        expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@education.gov.uk\">becomingateacher@education.gov.uk</a>"
         expect(subject).to eq(expected_output)
       end
     end
@@ -20,7 +20,7 @@ describe SupportEmailHelper do
       subject { helper.support_email(subject: "Register trainee teachers support") }
 
       it has_correct_formatting do
-        expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20support\">becomingateacher@digital.education.gov.uk</a>"
+        expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@education.gov.uk?subject=Register%20trainee%20teachers%20support\">becomingateacher@education.gov.uk</a>"
         expect(subject).to eq(expected_output)
       end
 
@@ -28,7 +28,7 @@ describe SupportEmailHelper do
         subject { helper.support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback") }
 
         it "has the correct formatting" do
-          expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
+          expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
           expect(subject).to eq(expected_output)
         end
 
@@ -36,7 +36,7 @@ describe SupportEmailHelper do
           subject { helper.support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback", classes: "govuk-link--no-visited-state") }
 
           it has_correct_formatting do
-            expected_output = "<a class=\"govuk-link govuk-link--no-visited-state\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
+            expected_output = "<a class=\"govuk-link govuk-link--no-visited-state\" href=\"mailto:becomingateacher@education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
             expect(subject).to eq(expected_output)
           end
         end

--- a/spec/services/bulk_update/recommendations_uploads/validate_trainee_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_trainee_spec.rb
@@ -184,7 +184,7 @@ module BulkUpdate
           end
 
           describe "#messages" do
-            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same TRN - contact becomingateacher@digital.education.gov.uk to fix this"] }
+            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same TRN - contact becomingateacher@education.gov.uk to fix this"] }
           end
 
           describe "#trainee" do
@@ -208,7 +208,7 @@ module BulkUpdate
           end
 
           describe "#messages" do
-            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same HESA ID - contact becomingateacher@digital.education.gov.uk to fix this"] }
+            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same HESA ID - contact becomingateacher@education.gov.uk to fix this"] }
           end
 
           describe "#trainee" do
@@ -230,7 +230,7 @@ module BulkUpdate
           end
 
           describe "#messages" do
-            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same provider trainee ID - contact becomingateacher@digital.education.gov.uk to fix this"] }
+            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same provider trainee ID - contact becomingateacher@education.gov.uk to fix this"] }
           end
 
           describe "#trainee" do


### PR DESCRIPTION
### Context

This subdomain is no longer used by the DfE, and is replaced by `education.gov.uk`.

Trello: https://trello.com/c/ZKqm9Qwy/5767-remove-old-digital-becomingateacherdigitaleducationgovuk-email-address
