### PR TITLE
[5771] Add `prosopite` gem for 1+N query detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,6 +152,9 @@ group :development, :test do
   # Better use of test helpers such as save_and_open_page/screenshot
   gem "launchy"
 
+  gem "pg_query"
+  gem "prosopite"
+
   # Testing framework
   gem "rspec-rails", "~> 6.0.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,6 +311,7 @@ GEM
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.3.1)
+    google-protobuf (3.23.4)
     googleauth (1.7.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
@@ -456,12 +457,15 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.3)
+    pg_query (4.2.1)
+      google-protobuf (>= 3.22.3)
     pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     progress_bar (1.3.3)
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
+    prosopite (1.3.2)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -787,8 +791,10 @@ DEPENDENCIES
   omniauth_openid_connect
   parallel_tests
   pg (>= 0.18, < 2.0)
+  pg_query
   pg_search (~> 2.3)
   progress_bar
+  prosopite
   pry-byebug
   puma (~> 6.3)
   pundit

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,13 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Prosopite.raise = true
+    Prosopite.rails_logger = true
+    Prosopite.prosopite_logger = true
+    Prosopite.stderr_logger = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/spec/factories/funding/trainee_summaries.rb
+++ b/spec/factories/funding/trainee_summaries.rb
@@ -2,7 +2,10 @@
 
 FactoryBot.define do
   factory :trainee_summary, class: "Funding::TraineeSummary" do
-    academic_year { "#{(AcademicCycle.current || create(:academic_cycle, :current)).start_date.year}/#{(AcademicCycle.current || create(:academic_cycle, :current)).end_date.year % 100}" }
+    academic_year do
+      academic_cycle = AcademicCycle.current || create(:academic_cycle, :current)
+      "#{academic_cycle.start_date.year % 100}/#{academic_cycle.end_date.year % 100}"
+    end
 
     trait :for_provider do
       payable { |p| p.association(:provider) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,4 +56,8 @@ RSpec.configure do |config|
   end
 
   Faker::Config.locale = "en-GB"
+
+  # Configure prosopite
+  config.before { Prosopite.scan }
+  config.after { Prosopite.finish }
 end


### PR DESCRIPTION
### Context

We are currently investigating a few 1+N queries that have been flagged in Sentry. We don't have a means of detecting 1+N queries as part of our CI/build process. We've tried to implement this with `bullet` in the past but it's proved to be too noisy.

### Changes proposed in this pull request

This PR adds the `prosopite` gem to try it out as a `bullet` alternative.

### Guidance to review

This PR is not ready to merge because there are a number of test failures now that `prosopite` has been added. We need to take a view on whether `prosopite` is worthwhile adding before taking time to fix the failures.

It looks like there are a couple of drawbacks with `prosopite`, though they can likely be overcome.

Firstly I found the error messages a little unhelpful because the call stack appears to be truncated, e.g. 

```
N+1 queries detected:
[499](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5737133505/job/15548320856?pr=3482#step:11:500)
  SELECT "academic_cycles".* FROM "academic_cycles" WHERE (end_date >= '2023-08-02 09:39:14.490563' AND start_date <= '2023-08-02 09:39:14.490563') ORDER BY "academic_cycles"."id" ASC LIMIT $1
[500](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5737133505/job/15548320856?pr=3482#step:11:501)
  SELECT "academic_cycles".* FROM "academic_cycles" WHERE (end_date >= '2023-08-02 09:39:14.491982' AND start_date <= '2023-08-02 09:39:14.491982') ORDER BY "academic_cycles"."id" ASC LIMIT $1
[501](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5737133505/job/15548320856?pr=3482#step:11:502)
Call stack:
[502](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5737133505/job/15548320856?pr=3482#step:11:503)
  app/models/academic_cycle.rb:30:in `for_date'
[503](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5737133505/job/15548320856?pr=3482#step:11:504)
  app/models/academic_cycle.rb:34:in `current'
```

In this case the call stack is only 2 deep, and it's hard to see where this code is being invoked from. It turns out this is because the call stack is 'cleaned up' in the gem using `ActiveSupport::BacktraceCleaner`. This doesn't seem to be a configuration option but there is probably a workaround here.

There seem to be quite a few false positives cropping when running `prosopite` in our test suite. e.g.

```
N+1 queries detected:
[23](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5738576657/job/15552542149?pr=3482#step:11:24)
  SELECT "sessions".* FROM "sessions" WHERE "sessions"."session_id" = $1 ORDER BY "sessions"."id" ASC LIMIT $2
[24](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5738576657/job/15552542149?pr=3482#step:11:25)
  SELECT "sessions".* FROM "sessions" WHERE "sessions"."session_id" = $1 ORDER BY "sessions"."id" ASC LIMIT $2
[25](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5738576657/job/15552542149?pr=3482#step:11:26)
Call stack:
[26](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5738576657/job/15552542149?pr=3482#step:11:27)
  app/models/dfe_sign_in_user.rb:29:in `load_from_session'
[27](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5738576657/job/15552542149?pr=3482#step:11:28)
  app/controllers/application_controller.rb:47:in `sign_in_user'
[28](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5738576657/job/15552542149?pr=3482#step:11:29)
  app/controllers/application_controller.rb:53:in `current_user'
[29](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5738576657/job/15552542149?pr=3482#step:11:30)
  app/controllers/application_controller.rb:66:in `authenticated?'
[30](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/5738576657/job/15552542149?pr=3482#step:11:31)
  app/controllers/application_controller.rb:79:in `authenticate'
```

In this example we are calling DfESignInUser#load_from_session multiple times within the same test. So it's not a classic 1+N query, more like a missed opportunity to cache a database query. (I don't think you can fix these by just adding an `includes` on some query). So it may be that we have to introduce caching or add these cases to the white list of 'allowed 1+Ns'.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
