### PR TITLE
[5781] Add _Days waiting_ column to dead jobs table

### DIFF
--- a/app/services/dead_jobs/base.rb
+++ b/app/services/dead_jobs/base.rb
@@ -108,6 +108,7 @@ module DeadJobs
       @dead_jobs ||=
         dead_set
         .select { |job| job.item["wrapped"] == klass }
+        .sort_by { |job| job.item["enqueued_at"] }
         .to_h do |job|
           [
             job.item["args"].first["arguments"].first["_aj_globalid"].split("/").last.to_i,

--- a/app/services/dead_jobs/base.rb
+++ b/app/services/dead_jobs/base.rb
@@ -81,7 +81,16 @@ module DeadJobs
         date_of_birth: trainee.date_of_birth,
         state: trainee.state,
         job_id: dead_jobs[trainee.id][:job_id],
+        days_waiting: days_waiting_for(dead_jobs[trainee.id][:job_id]),
       }
+    end
+
+    def days_waiting_for(job_id)
+      enqueued_at = Sidekiq::DeadSet.new.find_job(job_id)&.item&.[]("enqueued_at")
+
+      return nil unless enqueued_at
+
+      (Time.zone.today - Time.zone.at(enqueued_at).to_date).to_i
     end
 
     def dqt(trainee)

--- a/app/services/dead_jobs/base.rb
+++ b/app/services/dead_jobs/base.rb
@@ -81,13 +81,11 @@ module DeadJobs
         date_of_birth: trainee.date_of_birth,
         state: trainee.state,
         job_id: dead_jobs[trainee.id][:job_id],
-        days_waiting: days_waiting_for(dead_jobs[trainee.id][:job_id]),
+        days_waiting: days_waiting_for(dead_jobs[trainee.id][:enqueued_at]),
       }
     end
 
-    def days_waiting_for(job_id)
-      enqueued_at = Sidekiq::DeadSet.new.find_job(job_id)&.item&.[]("enqueued_at")
-
+    def days_waiting_for(enqueued_at)
       return nil unless enqueued_at
 
       (Time.zone.today - Time.zone.at(enqueued_at).to_date).to_i
@@ -116,6 +114,7 @@ module DeadJobs
             {
               error_message: parse_error(job.item["error_message"]),
               job_id: job.item["jid"],
+              enqueued_at: job.item["enqueued_at"],
             },
           ]
         end

--- a/spec/features/system_admin/dead_jobs/viewing_dead_jobs_spec.rb
+++ b/spec/features/system_admin/dead_jobs/viewing_dead_jobs_spec.rb
@@ -69,19 +69,6 @@ feature "Viewing sidekiq dead jobs" do
 
   def and_dead_jobs_exist
     allow(Sidekiq::DeadSet).to receive(:new).and_return(dead_jobs_data)
-    without_partial_double_verification do
-      allow(dead_jobs_data).to receive(:find_job).and_return(
-        double(
-          item: {
-            "retry" => 0,
-            "queue" => "dqt",
-            "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
-            "wrapped" => "Dqt::WithdrawTraineeJob",
-            "enqueued_at" => 73.hours.ago.to_i,
-          },
-        ),
-      )
-    end
   end
 
   def then_i_see_the_dead_jobs_page

--- a/spec/support/shared_examples/dead_jobs.rb
+++ b/spec/support/shared_examples/dead_jobs.rb
@@ -101,6 +101,7 @@ RSpec.shared_examples "Dead jobs" do |dead_jobs_klass, name|
           date_of_birth
           state
           job_id
+          days_waiting
         ],
       )
     end


### PR DESCRIPTION
### Context
Support personnel should be able to see how old a dead job is.

### Changes proposed in this pull request
This PR adds a new column to the dead jobs table using Sidekiq's `JobRecord#enqueued_at`.

Before:

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/6bad92df-2e87-4cc1-8ca4-2416456541fd)

After:

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/178f419b-c462-490f-a7c1-de0ab075c17b)

### Guidance to review
Are the tests sufficient?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
