### PR TITLE
[5788] Map British hesa codes to British

### DIFF
--- a/app/lib/apply_api/code_sets/nationalities.rb
+++ b/app/lib/apply_api/code_sets/nationalities.rb
@@ -236,16 +236,10 @@ module ApplyApi
         "zimbabwean" => "ZW",
       }.freeze
 
-      # Apply have the following values for GB, whereas DTTP use just british
-      # British
-      # Cymraes
-      # Cymro
-      # English
-      # Northern Irish
-      # Prydeinig
-      # Scottish
-      # Welsh
-      MAPPING = APPLY_MAPPING.invert.merge("GB" => Dttp::CodeSets::Nationalities::BRITISH)
+      # The following HESA nationality codes need to be mapped to British
+      BRITISH_MAPPING = %w[GB IM JE GG IO FK].index_with { |_code| Dttp::CodeSets::Nationalities::BRITISH }.freeze
+
+      MAPPING = APPLY_MAPPING.invert.merge(BRITISH_MAPPING)
     end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/BkGbAb4t/5788-fix-nationalities-not-mapped-from-hesa

### Changes proposed in this pull request

Maps the following HESA codes to our `british` Nationality value.

- Isle of man
- Jersey
- Guernsey
- British Indian Ocean Territory
- Falkland islands

### Guidance to review

Nothing much, just new keys added to the existing code sets.
