### PR TITLE
[5771] Reinstate Bullet gem for 1+N query detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,6 +152,8 @@ group :development, :test do
   # Better use of test helpers such as save_and_open_page/screenshot
   gem "launchy"
 
+  gem "bullet"
+
   # Testing framework
   gem "rspec-rails", "~> 6.0.3"
 
@@ -167,6 +169,8 @@ group :development, :test do
   gem "dotenv-rails"
 
   gem "timecop", "~> 0.9.6"
+
+  gem "bullet"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -169,8 +169,6 @@ group :development, :test do
   gem "dotenv-rails"
 
   gem "timecop", "~> 0.9.6"
-
-  gem "bullet"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,9 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.7)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     bundle-audit (0.1.0)
       bundler-audit
     bundler-audit (0.9.1)
@@ -693,6 +696,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
+    uniform_notifier (1.16.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
@@ -748,6 +752,7 @@ DEPENDENCIES
   benchmark-memory
   blazer
   bootsnap (>= 1.1.0)
+  bullet
   bundle-audit
   byebug
   canonical-rails

--- a/app/services/trainees/create_timeline.rb
+++ b/app/services/trainees/create_timeline.rb
@@ -43,7 +43,7 @@ module Trainees
     # created e.g. when a user saves more than one disability for a trainee.
     # For now, just show one 'create' timeline entry.
     def grouped_audits
-      audits.includes(:user).group_by(&:request_uuid).map { |_, audits| audits.first }
+      audits.includes(:user, :auditable).group_by(&:request_uuid).map { |_, audits| audits.first }
     end
 
     def audits

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,6 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.rails_logger = true
     Bullet.unused_eager_loading_enable = false
-    Bullet.raise = true
   end
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,14 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger = true
+    Bullet.unused_eager_loading_enable = false
+    Bullet.raise = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,14 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger = true
+    Bullet.raise = true
+    Bullet.unused_eager_loading_enable = false
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,4 +56,15 @@ RSpec.configure do |config|
   end
 
   Faker::Config.locale = "en-GB"
+
+  if Bullet.enable?
+    config.before do
+      Bullet.start_request
+    end
+
+    config.after do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+    end
+  end
 end


### PR DESCRIPTION
### Context
We are currently investigating a few 1+N queries that have been flagged in Sentry. We don't have a means of detecting 1+N queries as part of our CI/build process. We've tried to implement this with `bullet` in the past but it's proved to be too noisy. This PR reinstates the `bullet` gem without detection of unused eager loads (so just focused on N+1 queries) with a view to making it a part of our CI build.

We are also looking at an alternative gem to `bullet` called `prosopite` and there is a corresponding PR here...
https://github.com/DFE-Digital/register-trainee-teachers/pull/3482

### Changes proposed in this pull request
Bullet is setup here for `development` and `test` environments. In `test` it raises an error when a 1+N query is detected. In `development` the error is logged.

For now we've disabled the detection of unused eager loading (i.e. over-zealous use of `includes`).

### Guidance to review

Does this look like more effort to get right that `prosopite`?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
