### PR TITLE
[5801] Overhaul README

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -3,7 +3,6 @@ ruby 3.1.3
 yarn 1.22.19
 bundler 2.4.16
 terraform 1.3.5
-cf 8.4.0
 azure-cli 2.50.0
 kubectl 1.27.3
 jq 1.6

--- a/README.md
+++ b/README.md
@@ -1,361 +1,45 @@
-![build](https://github.com/DFE-Digital/register-trainee-teachers/workflows/build/badge.svg)
-![Deploy to PaaS](https://github.com/DFE-Digital/register-trainee-teachers/workflows/Deploy%20to%20PaaS/badge.svg)
-[![View performance data on Skylight](https://badges.skylight.io/status/YttDFt8jHcNT.svg?token=nRTIRMZsne7UqkwqgjCsuh0cT1z572MKKiBtrea6tFA)](https://www.skylight.io/app/applications/YttDFt8jHcNT)
-
-# Register trainee teachers
+# Register
 
 A service for training providers in England to register trainees with the Department for Education and record the outcome of their training.
 
-## Development
-
-### Install build dependencies
-
-The required versions of build tools is defined in
-[.tool-versions](.tool-versions). These can be automatically installed with
-[asdf-vm](https://asdf-vm.com/), see their [installation
-instructions](https://asdf-vm.com/#/core-manage-asdf).
-
-Once installed, run:
-
-```bash
-asdf plugin add ruby
-asdf plugin add nodejs
-asdf plugin add yarn
-asdf install
-```
-
-When the versions are updated on the `main` branch run `asdf install` again to update your
-installation. Use `asdf plugin update --all` to update plugins and get access to
-newer versions of tools.
-
-## Setting up the app in development
-
-1. Run `bundle install` to install the gem dependencies
-2. Run `yarn` to install node dependencies
-3. Run `bin/rails db:setup` to set up the database development and test schemas, and seed with test data
-4. Add a file to config/settings called development.local.yml containing the following:
-
-   ```yml
-       features:
-         use_ssl: false
-   ```
-
-5. Run `bundle exec rails server` to launch the app on http://localhost:5000
-6. Run `./bin/webpack-dev-server` in a separate shell for faster compilation of assets
-
-### Setting up seed records
-
-#### Using a Dev persona (optional)
-
-This will allow you to create a dev persona with your own email address - useful for when testing mailers/notify.
-
-create the file `config/initializers/developer_persona.rb` and add your own credentials in the format:
-
-```ruby
-DEVELOPER_PERSONA = { first_name: "first", last_name: "last", email: "first.last@education.gov.uk", system_admin: true }.freeze
-```
-
-#### Seeding
-
-Run `rake example_data:generate` to generate seed records.
-If you have created a dev persona, this wil be included when generating the persona profiles.
-
-
-## Architectural Decision Record
-
-See the [docs/adr](docs/adr) directory for a list of the Architectural Decision
-Record (ADR). We use [adr-tools](https://github.com/npryce/adr-tools) to manage
-our ADRs, see the link for how to install (hint: `brew install adr-tools` or use
-ASDF).
-
-## Testing
-To ensure webpacker works for you when tests run:
-
-```bash
-RAILS_ENV=test bundle exec rails assets:precompile
-```
-
-Then you can run the full test suite with:
-
-```bash
-bundle exec rake
-```
-
-## Running specs
-
-```bash
-bundle exec rspec
-```
-
-### Running specs in parallel
-
-When running specs in parallel for the first time you will first need to set up
-your test databases.
-
-`bundle exec rails parallel:setup`
-
-To run the specs in parallel:
-`bundle exec rails parallel:spec`
-
-To drop the test databases:
-`bundle exec rails parallel:drop`
-
-You can see the full list of commands with: `bundle exec rails -T | grep parallel`
-
-### rspec-retry
-
-[rspec-retry](https://github.com/NoRedInk/rspec-retry) is a gem that handles
-flakey tests by re-running failing tests a configurable number of times.
-
-It can cause problems when running tests in a development environment due to
-misleading error messages when specs (really) do fail. The workaround is to
-configure the number of attempts to `1` so that no retries happen. Add this
-line to `.env.test.local`:
-
-```
-RSPEC_RETRY_RETRY_COUNT: 1
-```
-
-## Linting
-
-### Ruby
-
-It's best to lint just your app directories and not those belonging to the framework:
-
-```bash
-bundle exec rails lint:ruby
-```
-or
-
-```
-docker-compose exec web /bin/sh -c "bundle exec rails lint:ruby"
-```
-
-To fix Rubocop issues:
-
-```
-bundle exec rubocop -a app config db lib spec --format clang
-```
-
-### JavaScript
-
-To lint the JavaScript files:
-
-```
-yarn standard
-```
-
-To fix JavaScript lint issues:
-
-```
-yarn run standard --fix
-```
-
-### SCSS
-
-To lint the SCSS files:
-
-```
-bundle exec rails lint:scss
-```
-
-### Running all pre-build checks
-
-```
-bundle exec rake
-```
-
-## Secrets vs Settings
-
-Refer to the [the config gem](https://github.com/railsconfig/config#accessing-the-settings-object) to understand the `file based settings` loading order.
-
-To override file based via `Machine based env variables settings`
-
-```bash
-cat config/settings.yml
-file
-  based
-    settings
-      env1: 'foo'
-```
-
-```bash
-export SETTINGS__FILE__BASED__SETTINGS__ENV1="bar"
-```
-
-```ruby
-puts Settings.file.based.setting.env1
-
-bar
-```
-
-Refer to the [settings file](config/settings.yml) for all the settings required to run this app
-
-## Resetting Secrets and passwords
-
-Please visit the [confluence page](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/2351824901/Resetting+Secrets+for+Register-Trainee-Teachers) for instructions
-
-## Feature flags
-
-This repo supports the ability to set up feature flags. To do this, add your feature flag in the [settings file](config/settings.yml) under the `features` property. eg:
-
-```yaml
-features:
-  some_feature: true
-```
-
-You can then use the [feature service](app/services/feature_service.rb) to check whether the feature is enabled or not. Eg. `FeatureService.enabled?(:some_feature)`.
-
-You can also nest features:
-
-```yaml
-features:
-  some:
-    nested_feature: true
-```
-
-And check with `FeatureService.enabled?("some.nested_feature")`.
-
-### Testing with features
-
-Rspec tests can also be tagged with `feature_{name}: true`. This will turn that feature on just for the duration of that test.
-
-## Basic auth
-
-Basic auth is enabled in non-production and non-local environments. The credentials can be found in the Confluence pages.
-
-## SSL https local dev
-
-When running the https local dev environment if you are on Mac and using Chrome you may need to get past an invalid certificate screen. <https://stackoverflow.com/questions/58802767/no-proceed-anyway-option-on-neterr-cert-invalid-in-chrome-on-macos>
-
-### DfE Sign-in
-
-For DfE Signin to work, the below values needs to be set.
-
-```yml
-base_url: base_url required value
-features:
-  use_dfe_sign_in: true
-dfe_sign_in:
-  identifier: identifier required value
-  issuer: issuer required value
-  profile: profile required value
-  secret: secret required value
-
-```
-
-### Hosting
-
-Register is hosted on [GOVUK PAAS](https://www.cloud.service.gov.uk/)
-
-[Additional GOVUK PAAS documentation](docs/govuk_paas.md)
-
-## DTTP settings for testing
-
-Add the following settings to your `development.yml.local` (ask a team member for the secrets):
-
-```yaml
-dttp:
-  client_id: SECRET
-  client_secret: SECRET
-  tenant_id: SECRET
-  scope: "https://dttp-dev.crm4.dynamics.com/.default"
-  api_base_url: "https://dttp-dev.api.crm4.dynamics.com/api/data/v9.1"
-```
-
-## PaaS Space Access and App interaction
-
-In order to login, change space roles and interact with PaaS based application,
-please follow this [instruction](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/2409791489/Changing+set+and+unset+roles+and+interacting+with+App+on+PaaS)
-
-## Schools data
-[Get Information about Schools](https://get-information-schools.service.gov.uk) holds the most complete information for schools.
-[Teacher Training Courses API](https://api.publish-teacher-training-courses.service.gov.uk) holds the most complete information for lead schools.
-
-In order to create and update the schools and the lead schools follow the below steps
-1. [Download Get Information about Schools data](#download-get-information-about-schools-data)
-2. [Generate data/schools_gias.csv from GIAS data](#generate-dataschools_giascsv-from-gias-data)
-3. [Import schools from csv data/schools_gias.cs](#import-schools-from-csv-dataschools_giascsv)
-4. [Generate data/lead_schools_publish.csv from Publish api](#generate-datalead_schools_publishcsv-from-publish-api)
-5. [Update schools to lead schools from publish data/lead_schools_publish.csv](#update-schools-to-lead-schools-from-publish-datalead_schools_publishcsv)
-
-### Download Get Information about Schools data
-1. Go to [Get Information about Schools Download page](https://get-information-schools.service.gov.uk/Downloads)
-2. From `Open academies and free schools data` select `Academies and free school fields CSV`
-3. From `Open state-funded schools data` select `State-funded school fields CSV`
-4. Click on `Download selected files`
-5. Extract content to `./data` directory
-
-### Generate data/schools_gias.csv from GIAS data
-To generate the data/schools_gias.csv from GIAS data, use the following rake task:
-
-```bash
-
-# gias_csv_1_path: path to the GIAS file
-# gias_csv_2_path: path to the GIAS file
-# output_path: optional, path to the output file, default to `data/schools_gias.csv`
-bundle exec rake schools_data:generate_csv_from_gias\[gias_csv_1_path,gias_csv_2_path,output_path\]
-
-# as an example
-bundle exec rake schools_data:generate_csv_from_gias\[./data/edubaseallacademiesandfree20230719.csv,./data/edubaseallstatefunded20230719.csv\]
-
-```
-
-### Import schools from csv data/schools_gias.csv
-To import schools from csv data/schools_gias.csv, use the following rake task:
-
-```bash
-bundle exec rake schools_data:import_gias
-```
-
-### Generate data/lead_schools_publish.csv from Publish api
-
-To generate the data/lead_schools_publish.csv from Publish api data, use the following rake task:
-
-```bash
-
-# output_path: optional, path to the output file, default to `data/lead_schools_publish.csv`
-bundle exec rake schools_data:get_lead_schools_from_publish\[output_path\]
-
-# as an example
-bundle exec rake schools_data:get_lead_schools_from_publish
-
-```
-
-### Update schools to lead schools from publish data/lead_schools_publish.csv
-
-To update schools to lead schools from publish data/lead_schools_publish.csv, use the following rake task:
-```bash
-
-# input_path: optional, path to the input file, default to `data/lead_schools_publish.csv`
-bundle exec rake schools_data:update_lead_schools_from_publish\[input_path\]
-
-bundle exec rake schools_data:update_lead_schools_from_publish
-
-```
-
-
-## Running Apply application import against example data
-
-Add the following to your `development.local.yml`:
-
-```yml
-features:
-  import_applications_from_apply: true
-
-apply_api:
-  base_url: "https://sandbox.apply-for-teacher-training.service.gov.uk/register-api"
-  auth_token: <request token from Apply team>
-```
-
-Running the following script:
-
-```ruby
-ApplyApi::ImportApplication.class_eval do
-  def provider
-    Provider.all.sample
-  end
-end
-ApplyApplicationSyncRequest.delete_all
-ApplyApi::ImportApplicationsJob.perform_now
-```
+## Status
+
+![Build](https://github.com/DFE-Digital/register-trainee-teachers/workflows/Build/badge.svg)
+[![View performance data on Skylight](https://badges.skylight.io/status/YttDFt8jHcNT.svg)](https://oss.skylight.io/app/applications/YttDFt8jHcNT)
+
+## Table of Contents
+
+- [Environments](#environments)
+- [Guides](#guides)
+- [License](#license)
+
+## Environments
+
+| Name        | URL                                                                    | Description
+| ----------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------
+| Production  | [www](https://www.register-trainee-teachers.service.gov.uk/)   | Public site
+| Production Data  | [www](https://register-productiondata.london.cloudapps.digital/)   | For internal use by DFE to validate Register data workflows
+| Staging     | [staging](https://staging.register-trainee-teachers.service.gov.uk/)| For internal use by DfE to test deploys and integrations
+| QA          | [qa](https://qa.register-trainee-teachers.service.gov.uk/)     | For internal use by DfE for testing. Automatically deployed from main
+
+## Guides
+
+- [Configuration](/docs/configuration.md)
+- [Machine Setup](/docs/machine-setup.md)
+- [Setting up the application in development](/docs/setup-development.md)
+- [Testing & Linting](/docs/testing.md)
+- [Authentication](/docs/authentication.md)
+- [Alerting & Monitoring](/docs/alerting_and_monitoring.md)
+- [Transactional Emails](/docs/emails.md)
+- [Healthchecks](/docs/healthcheck_and_ping_endpoints.md)
+- [Maintenance Mode](/docs/maintenance-mode.md)
+- [Disaster Recovery Plan](/docs/disaster-recovery.md)
+- [ADRs](/docs/adr/index.md)
+- [Support Playbook](/docs/support_playbook.md)
+- [AKS Module Information](/docs/aks_modules.md)
+- [AKS Workflows](/docs/aks-cheatsheet.md)
+
+
+## License
+
+[MIT Licence](LICENCE)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Register
+# Register trainee teachers
 
 A service for training providers in England to register trainees with the Department for Education and record the outcome of their training.
 

--- a/docs/alerting_and_monitoring.md
+++ b/docs/alerting_and_monitoring.md
@@ -1,0 +1,28 @@
+# Alerting and Monitoring
+
+## External Integrations
+
+### Skylight
+
+skylight.io provides a rich set of performance monitoring tools, available form
+on the apps [dashboard page](https://www.skylight.io/app/applications/YttDFt8jHcNT).
+Normally we enable skylight only in production.
+
+#### Configuring in deployed environments
+
+In a deployed environment, the environment variable
+`SETTINGS__SKYLIGHT__AUTHENTICATION` should be set to the auth token available
+from the application setting in skylight.io.
+
+#### Configuring for local development
+
+In local development, if you need to test performance monitoring you can enable
+Skylight and set the auth token in a local settings file
+`config/settings.local.yml`, with the token itself availble on the
+[Skylight application setting page](https://www.skylight.io/app/settings/YttDFt8jHcNT/app_settings)
+
+```yaml
+skylight:
+  authentication: "auth_token_goes_here"
+  enable: true
+```

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,29 @@
+# Authentication
+
+## Basic Auth
+
+The Register QA environment is protected by basic auth. The username and password can be provided by a Register team member.
+
+## DfE Sign in
+
+To access the staging, production and production data environments, you will need to sign in with DfE Sign-in.
+
+## Hesa
+
+To work with HESA locally, you will need to set the following information in your `development.local.yml`:
+
+```yml
+hesa:
+  username: dev usernmae
+  password: dev password
+```
+
+## DQT
+
+To work with DQT locally, you will need to set the following information in your `development.local.yml`:
+
+```yml
+dqt:
+  base_url: https://qualified-teachers-api-dev.london.cloudapps.digital
+  api_key: dev password
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,50 @@
+# Configuration
+
+This repo is configured using a file based settings approach via the [config gem](https://github.com/railsconfig/config#accessing-the-settings-object) (see `config/settings.yml` for an example).
+
+## Settings vs Environment variables
+
+Refer to the [the config gem](https://github.com/railsconfig/config#accessing-the-settings-object) to understand the `file based settings` loading order.
+
+To override file based via `Machine based env variables settings`
+
+```bash
+cat config/settings.yml
+file
+  based
+    settings
+      env1: 'some file based value'
+```
+
+```bash
+export SETTINGS__FILE__BASED__SETTINGS__ENV1="machine wins"
+```
+
+```ruby
+puts Settings.file.based.setting.env1
+
+machine wins
+```
+
+Any `Machine based env variables settings` that is not prefixed with `SETTINGS`.\* are not considered for general consumption.
+
+## Feature flags
+
+This repo supports the ability to set up feature flags. To do this, add your feature flag in the [settings file](config/settings.yml) under the `features` property. eg:
+
+```yaml
+features:
+  some_feature: true
+```
+
+You can then use the [feature service](app/services/feature_service.rb) to check whether the feature is enabled or not. Eg. `FeatureService.enabled?(:some_feature)`.
+
+You can also nest features:
+
+```yaml
+features:
+  some:
+    nested_feature: true
+```
+
+And check with `FeatureService.enabled?("some.nested_feature")`.

--- a/docs/emails.md
+++ b/docs/emails.md
@@ -1,0 +1,5 @@
+# Emails
+
+Transactional emails in the application are sent via [Notify](https://www.notifications.service.gov.uk/).
+
+You'll need to get a team member to add you to the service.

--- a/docs/healthcheck_and_ping_endpoints.md
+++ b/docs/healthcheck_and_ping_endpoints.md
@@ -1,0 +1,65 @@
+# Healthcheck and Ping Endpoints
+
+Healthchecks are handled by [`HeartbeatController`](../app/controllers/heartbeat_controller.rb).
+
+## Ping
+
+Use the `/ping` endpoint as a lightweight check to see if the app is up. This
+can be used by load-balancers, for example, which may frequently test whether to
+send traffic to a given host running this app. The response will simply be
+`PONG`, with a 200 status code, and not specific resources are checked when this
+endpoint is activated.
+
+## Healthcheck
+
+Use the `/healthcheck` to check whether that the app's dependencies are working.
+This returns a JSON structure that lists the checks it performs and their
+results. For example:
+
+```json
+{
+  "checks": {
+    "database": true,
+    "redis": true,
+    "sidekiq_processes": true
+  }
+}
+```
+
+The available checks:
+
+### `database`
+
+Check that 'ActiveRecord' connection to the database is active.
+
+### `redis`
+
+Checks that Sidekiq can connect to the Redis server.
+
+### `sidekiq_processes`
+
+Check which queues currently have jobs, as reported by Sidekiq, and checks that
+there is a Sidekiq running for each one. In theory there should be a process for
+each queue that is being used, and we determine which queues are being used by
+looking at what jobs we have queued up.
+
+#### Failures caused by stale jobs
+
+This check will fail if there are stale jobs in a queue that doesn't have a
+processor running. You can check which queues have jobs by starting the Rails
+console and running:
+
+```ruby
+stats = Sidekiq::Stats.new
+processes = Sidekiq::ProcessSet.new
+stats.queues.keys.each do |queue|
+  running = processes.any? { |process| queue.in? process["queues"] }
+  puts "#{queue} running? #{running}"
+end
+```
+
+If you see jobs in a queue that shouldn't be running anymore (e.g. we've retired
+`find_sync` and shouldn't see any jobs for it) then you'll need to remove any
+job queues that exist for it for this test to return `true`. If, on the other
+hand, you only have the queues you expected listed, but no process is listed for
+them, then you have a problem.

--- a/docs/machine-setup.md
+++ b/docs/machine-setup.md
@@ -1,0 +1,36 @@
+# Machine setup
+
+## Prerequisites
+
+You'll need to have the libraries below to be able to develop the application locally. You can install them manually, or using a package manager like [Homebrew](https://brew.sh/). We also have instructions for if you're using ASDF below.
+
+- [Ruby](https://www.ruby-lang.org/en/)
+- [Node.js](https://nodejs.org/en/)
+- [Yarn](https://yarnpkg.com/)
+- [PostgreSQL](https://www.postgresql.org/)
+- [Redis](https://redis.io/)
+- [ChromeDriver](https://chromedriver.chromium.org/)
+- [Terraform](https://www.terraform.io/)
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+- [Make](https://www.gnu.org/software/make/)
+- [JQ](https://stedolan.github.io/jq/)
+- [Docker](https://www.docker.com/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+### Install build dependencies with ASDF
+
+The required versions of build tools is defined in [.tool-versions](.tool-versions). These can be automatically installed with [asdf-vm](https://asdf-vm.com/), see their [installation instructions](https://asdf-vm.com/#/core-manage-asdf).
+
+Install the plugins and versions specified in `.tool-versions`
+
+```bash
+asdf plugin add ruby
+asdf plugin add nodejs
+asdf plugin add yarn
+asdf install
+```
+
+When the versions are updated in main run `asdf install` again to update your
+installation.
+
+(We don't mandate asdf, you can use other tools if you prefer.)

--- a/docs/setup-development.md
+++ b/docs/setup-development.md
@@ -1,0 +1,210 @@
+# Installation
+
+Clone the repo:
+
+    git clone git@github.com:DFE-Digital/register-trainee-teachers.git
+
+## Setup the application libraries and dependencies
+
+Run setup:
+
+```bash
+./bin/setup
+```
+
+Run yarn:
+
+```bash
+yarn install
+```
+
+Add a file to config/settings called development.local.yml containing the following:
+
+```yml
+    features:
+      use_ssl: false
+```
+
+## Start the server
+
+To start all the processes run:
+
+```bash
+./bin/dev
+```
+
+To run the processes seperately, you can do the following:
+
+1. Run `bundle exec rails server` to launch the app on http://localhost:5000
+2. Run `./bin/webpack-dev-server` in a separate shell for faster compilation of assets
+
+## Using Docker
+
+Run this in a shell and leave it running after cloning the repo:
+
+```
+docker-compose up --build --detach
+```
+
+You can then follow the log output with
+
+```
+docker-compose logs --follow
+```
+
+The first time you run the app, you need to set up the databases. With the above command running separately, do:
+
+```
+docker-compose exec web /bin/sh -c "bundle exec rails db:setup"
+```
+
+And make sure to seed the application with whichever data you need.
+
+Then open http://localhost:3001 to see the app.
+
+## Run The Server in SSL Mode
+
+By default the server does not run in SSL mode. If you want to run the local
+server in SSL mode, you can do so by setting the environment variable
+`SETTINGS__USE_SSL`, for example, use this command to run the server:
+
+```bash
+SETTINGS__USE_SSL=1 rails s
+```
+
+### Trust the TLS certificate
+
+Depending on your browser you may need to add the automatically generated SSL certificate to your OS keychain to make the browser trust the local site.
+
+On macOS:
+
+```bash
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain config/localhost/https/localhost.crt
+```
+
+When running the https local dev environment if you are on Mac and using Chrome you may need to get past an invalid certificate screen. <https://stackoverflow.com/questions/58802767/no-proceed-anyway-option-on-neterr-cert-invalid-in-chrome-on-macos>
+
+## Seeding Data
+
+### Example Data
+
+If you want to seed the database with example data, follow the steps below:
+
+```shell
+bin/rails example_data:generate
+```
+
+#### Using a Dev persona (optional)
+
+This will allow you to create a dev persona with your own email address - useful for when testing mailers/notify.
+
+create the file `config/initializers/developer_persona.rb` and add your own credentials in the format:
+
+```ruby
+DEVELOPER_PERSONA = { first_name: "first", last_name: "last", email: "first.last@education.gov.uk", system_admin: true }.freeze
+```
+
+### Sanitised Data
+
+If you want to seed the database with a sanitised production dump, follow the steps below:
+
+- Download the sanitised production dump from the [Github Actions page](https://github.com/DFE-Digital/publish-teacher-training/actions/workflows/database-restore.yml) and download the latest successful run.
+- Unzip the file and you should see a file called `backup_sanitised.sql`.
+
+Then run the following command to populate the database:
+
+```bash
+psql register_trainee_teacher_data_development < ~/Downloads/backup_sanitised.sql
+```
+
+## Schools data
+[Get Information about Schools](https://get-information-schools.service.gov.uk) holds the most complete information for schools.
+[Teacher Training Courses API](https://api.publish-teacher-training-courses.service.gov.uk) holds the most complete information for lead schools.
+
+In order to create and update the schools and the lead schools follow the below steps
+1. [Download Get Information about Schools data](#download-get-information-about-schools-data)
+2. [Generate data/schools_gias.csv from GIAS data](#generate-dataschools_giascsv-from-gias-data)
+3. [Import schools from csv data/schools_gias.cs](#import-schools-from-csv-dataschools_giascsv)
+4. [Generate data/lead_schools_publish.csv from Publish api](#generate-datalead_schools_publishcsv-from-publish-api)
+5. [Update schools to lead schools from publish data/lead_schools_publish.csv](#update-schools-to-lead-schools-from-publish-datalead_schools_publishcsv)
+
+### Download Get Information about Schools data
+1. Go to [Get Information about Schools Download page](https://get-information-schools.service.gov.uk/Downloads)
+2. From `Open academies and free schools data` select `Academies and free school fields CSV`
+3. From `Open state-funded schools data` select `State-funded school fields CSV`
+4. Click on `Download selected files`
+5. Extract content to `./data` directory
+
+### Generate data/schools_gias.csv from GIAS data
+To generate the data/schools_gias.csv from GIAS data, use the following rake task:
+
+```bash
+
+# gias_csv_1_path: path to the GIAS file
+# gias_csv_2_path: path to the GIAS file
+# output_path: optional, path to the output file, default to `data/schools_gias.csv`
+bundle exec rake schools_data:generate_csv_from_gias\[gias_csv_1_path,gias_csv_2_path,output_path\]
+
+# as an example
+bundle exec rake schools_data:generate_csv_from_gias\[./data/edubaseallacademiesandfree20230719.csv,./data/edubaseallstatefunded20230719.csv\]
+
+```
+
+### Import schools from csv data/schools_gias.csv
+To import schools from csv data/schools_gias.csv, use the following rake task:
+
+```bash
+bundle exec rake schools_data:import_gias
+```
+
+### Generate data/lead_schools_publish.csv from Publish api
+
+To generate the data/lead_schools_publish.csv from Publish api data, use the following rake task:
+
+```bash
+
+# output_path: optional, path to the output file, default to `data/lead_schools_publish.csv`
+bundle exec rake schools_data:get_lead_schools_from_publish\[output_path\]
+
+# as an example
+bundle exec rake schools_data:get_lead_schools_from_publish
+
+```
+
+### Update schools to lead schools from publish data/lead_schools_publish.csv
+
+To update schools to lead schools from publish data/lead_schools_publish.csv, use the following rake task:
+```bash
+
+# input_path: optional, path to the input file, default to `data/lead_schools_publish.csv`
+bundle exec rake schools_data:update_lead_schools_from_publish\[input_path\]
+
+bundle exec rake schools_data:update_lead_schools_from_publish
+
+```
+
+
+## Running Apply application import against example data
+
+Add the following to your `development.local.yml`:
+
+```yml
+features:
+  import_applications_from_apply: true
+
+apply_api:
+  base_url: "https://sandbox.apply-for-teacher-training.service.gov.uk/register-api"
+  auth_token: <request token from Apply team>
+```
+
+Running the following script:
+
+```ruby
+ApplyApi::ImportApplication.class_eval do
+  def provider
+    Provider.all.sample
+  end
+end
+ApplyApplicationSyncRequest.delete_all
+ApplyApi::ImportApplicationsJob.perform_now
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,106 @@
+# Testing & Linting
+
+## Running specs
+
+To ensure webpacker works for you when tests run:
+
+```bash
+RAILS_ENV=test bundle exec rails assets:precompile
+```
+
+Then you can run the full test suite with:
+
+```bash
+bundle exec rspec
+```
+
+### Running specs in parallel
+
+When running specs in parallel for the first time you will first need to set up
+your test databases.
+
+`bundle exec rails parallel:setup`
+
+To run the specs in parallel:
+`bundle exec rails parallel:spec`
+
+To drop the test databases:
+`bundle exec rails parallel:drop`
+
+You can see the full list of commands with: `bundle exec rails -T | grep parallel`
+
+### Javascript specs
+
+You can run the JS specs with:
+
+```bash
+yarn run test
+```
+
+### rspec-retry
+
+[rspec-retry](https://github.com/NoRedInk/rspec-retry) is a gem that handles
+flakey tests by re-running failing tests a configurable number of times.
+
+It can cause problems when running tests in a development environment due to
+misleading error messages when specs (really) do fail. The workaround is to
+configure the number of attempts to `1` so that no retries happen. Add this
+line to `.env.test.local`:
+
+```
+RSPEC_RETRY_RETRY_COUNT: 1
+```
+
+### Testing with features
+
+Rspec tests can also be tagged with `feature_{name}: true`. This will turn that feature on just for the duration of that test.
+
+
+## Linting
+
+### Ruby
+
+It's best to lint just your app directories and not those belonging to the framework:
+
+```bash
+bundle exec rails lint:ruby
+```
+or
+
+```
+docker-compose exec web /bin/sh -c "bundle exec rails lint:ruby"
+```
+
+To fix Rubocop issues:
+
+```
+bundle exec rubocop -a app config db lib spec --format clang
+```
+
+### JavaScript
+
+To lint the JavaScript files:
+
+```
+yarn standard
+```
+
+To fix JavaScript lint issues:
+
+```
+yarn run standard --fix
+```
+
+### SCSS
+
+To lint the SCSS files:
+
+```shell
+bundle exec rails lint:scss
+```
+
+## Running all pre-build checks
+
+```
+bundle exec rake
+```


### PR DESCRIPTION
### Context

https://trello.com/c/k5RIs2wr/5801-various-references-to-paas-cloudfoundry-in-the-dev-docs

### Changes proposed in this pull request

- Overhauls the README layout and puts information in specific docs
- Removes references to PaaS/CF
- Removes stuff which is no longer relevant

### Guidance to review

This is a similar structure used in https://github.com/DFE-Digital/get-into-teaching-app, and https://github.com/DFE-Digital/publish-teacher-training providing some sort of consistency across the Bat repos. 