### PR TITLE
[5782] Addressing exporting large number of trainees on report page issues

### DIFF
--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -427,7 +427,10 @@ module Reports
     def trainee_allocation_subject(subject)
       return if subject.blank?
 
-      SubjectSpecialism.find_by("lower(name) = ?", subject.downcase)&.allocation_subject&.name
+      subject_name = subject.downcase
+      Rails.cache.fetch("TraineeReport.trainee_allocation_subject(#{subject_name})", expires_in: 1.day) do
+        SubjectSpecialism.find_by("lower(name) = ?", subject_name)&.allocation_subject&.name
+      end
     end
 
     def placements

--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -159,10 +159,18 @@ module Reports
     def course_allocation_subject
       return if course.blank? || course.subjects.blank?
 
-      subject = CalculateSubjectSpecialisms.call(subjects: course.subjects.pluck(:name))
-        .values.map(&:first).first
+      trainee_allocation_subject(calculated_subject)
+    end
 
-      trainee_allocation_subject(subject)
+    def course_subject_names
+      @course_subject_names ||= course.subjects.pluck(:name)
+    end
+
+    def calculated_subject
+      Rails.cache.fetch("TraineeReport.calculated_subject(#{course_subject_names.join('-')})", expires_in: 1.day) do
+        CalculateSubjectSpecialisms.call(subjects: course.subjects.pluck(:name))
+        .values.map(&:first).first
+      end
     end
 
     def course_training_route

--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -223,7 +223,7 @@ module Reports
     def disabilities
       trainee.disabilities.map do |disability|
         if disability.name == Diversities::OTHER
-          trainee.trainee_disabilities.select { |x| x.disability_id == disability.id }.first.additional_disability
+          trainee.trainee_disabilities.find { |x| x.disability_id == disability.id }.additional_disability
         else
           disability.name
         end

--- a/app/models/reports/trainees_report.rb
+++ b/app/models/reports/trainees_report.rb
@@ -97,7 +97,7 @@ module Reports
       return csv << ["No trainee data to export"] if trainees.blank? # TODO: move text to translation file
 
       trainees.strict_loading.includes(:apply_application,
-                                       { course_allocation_subject: [:subject_specialisms] },
+                                       { course_allocation_subject: %i[subject_specialisms funding_methods] },
                                        :degrees, :disabilities,
                                        :employing_school,
                                        :end_academic_cycle,


### PR DESCRIPTION
### Context
Addressing exporting large number of trainees on report page issues

### Changes proposed in this pull request
Fix the low hanging fruits

### Guidance to review

[Amended select then first to be just find](https://github.com/DFE-Digital/register-trainee-teachers/commit/0f21069be98bb82c90da29e2306455286e349c36) 

It's an array Just find the first rather then select the filter then return first.

[[5782] Added additional caching for trainee_allocation_subject](https://github.com/DFE-Digital/register-trainee-teachers/commit/22952f13c1eef637b582d347f032cd7efa375612)

[[5782] Added additional caching for calculated_subject](https://github.com/DFE-Digital/register-trainee-teachers/commit/1b3ba7f725a9d5cc6e1fffb5367ad61f9e033d66)

Lookup for the sake of lookup, once looked at there is no point in second journey to database calls. Cache it for the day so any other users can benefit

[[5782] Added funding_methods for includes](https://github.com/DFE-Digital/register-trainee-teachers/pull/3494/commits/3ffe8d96494d5c7a007c8f088a18c82f5678ee56)
To reduce additional database calls

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
