### PR TITLE
[5782] Amended so that the csv is downloaded as a stream

### DIFF
--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -4,6 +4,6 @@ class PersonasController < ApplicationController
   skip_before_action :authenticate
 
   def index
-    @personas = Persona.all.order(:first_name)
+    @personas = Persona.includes([:providers], [:lead_schools]).all.order(:first_name)
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,11 +22,16 @@ class ReportsController < BaseTraineeController
 
       format.csv do
         authorize(:trainee, :export?)
-        send_data(
-          Exports::ExportTraineesService.call(itt_new_starter_trainees),
-          filename: itt_new_starter_filename,
-          disposition: :attachment,
-        )
+        headers["X-Accel-Buffering"] = "no"
+        headers["Cache-Control"] = "no-cache"
+        headers["Content-Type"] = "text/csv; charset=utf-8"
+        headers["Content-Disposition"] =
+          %(attachment; filename="#{itt_new_starter_filename}")
+        headers["Last-Modified"] = Time.zone.now.ctime.to_s
+
+        response.status = 200
+
+        self.response_body = Exports::ReportCsvEnumeratorService.call(itt_new_starter_trainees)
       end
     end
   end
@@ -42,11 +47,16 @@ class ReportsController < BaseTraineeController
 
       format.csv do
         authorize(:trainee, :export?)
-        send_data(
-          Exports::ExportTraineesService.call(performance_profiles_trainees),
-          filename: performance_profiles_filename,
-          disposition: :attachment,
-        )
+        headers["X-Accel-Buffering"] = "no"
+        headers["Cache-Control"] = "no-cache"
+        headers["Content-Type"] = "text/csv; charset=utf-8"
+        headers["Content-Disposition"] =
+          %(attachment; filename="#{performance_profiles_filename}")
+        headers["Last-Modified"] = Time.zone.now.ctime.to_s
+
+        response.status = 200
+
+        self.response_body = Exports::ReportCsvEnumeratorService.call(performance_profiles_trainees)
       end
     end
   end

--- a/app/models/persona.rb
+++ b/app/models/persona.rb
@@ -27,5 +27,7 @@
 #  index_users_on_discarded_at     (discarded_at)
 #
 class Persona < User
-  default_scope { where(email: PERSONA_EMAILS) }
+  def self.sanitised_user_ids = %w[600 874 296 732 846 605 1302 567 56 1199]
+
+  default_scope { where(email: PERSONA_EMAILS).or(where(id: sanitised_user_ids)) }
 end

--- a/app/services/exports/report_csv_enumerator_service.rb
+++ b/app/services/exports/report_csv_enumerator_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Exports
+  class ReportCsvEnumeratorService
+    include ServicePattern
+
+    def initialize(data, csv = CSV)
+      @data = data
+      @csv = csv
+    end
+
+    def call
+      Enumerator.new do |yielder|
+        yielder << csv.generate_line(headers)
+        trainees.find_each do |trainee|
+          yielder << csv.generate_line(trainee_report(trainee))
+        end
+        yielder
+      end
+    end
+
+  private
+
+    attr_accessor :data, :csv
+
+    def trainees
+      @trainees ||= data.strict_loading.includes(:apply_application,
+                                                 { course_allocation_subject: %i[subject_specialisms funding_methods] },
+                                                 :degrees, :disabilities,
+                                                 :employing_school,
+                                                 :end_academic_cycle,
+                                                 :lead_school,
+                                                 { nationalisations: :nationality },
+                                                 :nationalities,
+                                                 :provider,
+                                                 :start_academic_cycle,
+                                                 :trainee_disabilities,
+                                                 { placements: :school },
+                                                 :hesa_students,
+                                                 :withdrawal_reasons)
+    end
+
+    def headers = Reports::TraineesReport.headers
+
+    def trainee_report(trainee)
+      trainee_report = Reports::TraineeReport.new(trainee)
+      headers.map { |header| CsvValueSanitiser.new(trainee_report.public_send(header)).sanitise }
+    end
+  end
+end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -36,7 +36,7 @@ describe ReportsController do
 
     it "renders a csv" do
       get :itt_new_starter_data_sign_off, params: { format: :csv }
-      expect(response.content_type).to eq("text/csv")
+      expect(response.content_type).to eq("text/csv; charset=utf-8")
     end
   end
 

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -53,7 +53,7 @@ describe ReportsController do
 
     it "renders a csv" do
       get :performance_profiles, params: { format: :csv }
-      expect(response.content_type).to eq("text/csv")
+      expect(response.content_type).to eq("text/csv; charset=utf-8")
     end
   end
 

--- a/spec/services/exports/report_csv_enumerator_service_spec.rb
+++ b/spec/services/exports/report_csv_enumerator_service_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Exports::ReportCsvEnumeratorService do
+  let(:trainee) { create(:trainee, :for_export) }
+  let(:trainees) do
+    trainee
+    Trainee.all
+  end
+  let(:headers) { Reports::TraineesReport.headers }
+  let(:csv) { double(:csv, generate_line: "") }
+
+  subject { described_class.call(trainees, csv) }
+
+  describe "#call" do
+    it "returns an Enumerator" do
+      expect(subject).to be_an Enumerator
+      expect(subject.each).to be_an Enumerator
+      expect(csv).to have_received(:generate_line).exactly(0)
+      expect(subject.to_a.count).to eq 2
+      expect(csv).to have_received(:generate_line).exactly(2)
+    end
+  end
+end


### PR DESCRIPTION
### Context
Return csv as a stream

### Changes proposed in this pull request
Amended to return csv as a stream
The end points `performance_profiles` &`itt_new_starter_data_sign_off` now support streaming.

### Guidance to review

Log in as a persona and head to https://register-pr-3495.test.teacherservices.cloud/reports/performance-profiles, the available persona are from the sanitised backup which will reflect a closer real life experience. Click on the `Export` button should trigger the download without any delay.

All the current one does the calculation and generation before the file can be saved.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
