### PR TITLE
[5828] - HESA fallback

### DIFF
--- a/app/jobs/hesa/sync_students_job.rb
+++ b/app/jobs/hesa/sync_students_job.rb
@@ -4,7 +4,7 @@ module Hesa
   class SyncStudentsJob < ApplicationJob
     queue_as :hesa
 
-    def perform(upload_id: nil)
+    def perform(upload_id: Settings.hesa.upload_id)
       return unless FeatureService.enabled?("hesa_import.sync_collection")
 
       SyncStudents.call(upload_id:)

--- a/app/services/hesa/sync_students.rb
+++ b/app/services/hesa/sync_students.rb
@@ -12,7 +12,7 @@ module Hesa
 
     attr_reader :collection_reference, :upload, :from_date
 
-    def initialize(upload_id: nil)
+    def initialize(upload_id: Settings.hesa.upload_id)
       @from_date = Settings.hesa.current_collection_start_date
       @collection_reference = Settings.hesa.current_collection_reference
       @upload = Upload.find_by(id: upload_id)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,7 @@ hesa:
   current_collection_start_date: "2022-08-01"
   username: <get from secrets>
   password: <get from secrets>
+  upload_id: null
 
 dqt:
   base_url: https://qualified-teachers-api-dev.london.cloudapps.digital

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -18,6 +18,11 @@ dfe_sign_in:
 dqt:
   base_url: https://teacher-qualifications-api.education.gov.uk/
 
+# While HESA have taken down their collection, this serves as a fallback
+# until we test and deploy the new HESA mapping around 15th August 2023
+hesa:
+  upload_id: 12
+
 features:
   sign_in_method: dfe-sign-in
   basic_auth: false


### PR DESCRIPTION
### Context

HESA are closing their old 22-23 collection API on 9th August.  We need to put in place a fallback until we’re ready to connect to their new 23-24 API (After Thursday’s testing)

### Changes proposed in this pull request

Production will access the current collection via the file we have uploaded (id: 12)
