### PR TITLE
[5724] Add migration to creating missing funding methods

### DIFF
--- a/db/data/20230809161841_add_funding_method_subjects_for_early_years_postgrad.rb
+++ b/db/data/20230809161841_add_funding_method_subjects_for_early_years_postgrad.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AddFundingMethodSubjectsForEarlyYearsPostgrad < ActiveRecord::Migration[7.0]
+  def up
+    allocation_subject = AllocationSubject.find_by(
+      name: "Early years ITT",
+    )
+
+    FundingMethod.where(training_route: "early_years_salaried").each do |salaried_funding_method|
+      postgrad_funding_method = FundingMethod.find_or_create_by(
+        training_route: "early_years_postgrad",
+        academic_cycle_id: salaried_funding_method.academic_cycle_id,
+        amount: salaried_funding_method.amount,
+        funding_type: salaried_funding_method.funding_type,
+      )
+      FundingMethodSubject.find_or_create_by(
+        funding_method: postgrad_funding_method,
+        allocation_subject: allocation_subject,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### Context
Grant funding methods should be available for _Early years ITT_ for the _early_years_postgrad_ training route as well as the _early_years_salaried_ training route.

### Changes proposed in this pull request
The PR adds a data migration to create the missing funding methods if they are not already present.

### Guidance to review
I've tested this data migration manually. What is the testing best practice for these kinds of data migration?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
