### PR TITLE
Pause staging db restore

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -15,10 +15,10 @@ on:
         required: true
         type: boolean
         default: false
-      restoreToStagingEnv:
-        required: true
-        type: boolean
-        default: false
+      # restoreToStagingEnv:
+      #   required: true
+      #   type: boolean
+      #   default: false
   schedule: # 03:00 UTC
     - cron: '0 3 * * *'
 


### PR DESCRIPTION
While we test the new HESA collection, it would be helpful not to overwrite the staging database every night.