### PR TITLE
[5839] - NULL otp_secret when copying sanitised-prod => staging

### DIFF
--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -27,6 +27,10 @@ SET
 WHERE email NOT LIKE '%@digital.education.gov.uk'
       AND email NOT LIKE '%@education.gov.uk';
 
+UPDATE "users"
+SET
+  otp_secret = NULL;
+
 -- Trainees
 UPDATE "trainees"
 SET


### PR DESCRIPTION
### Context

Logging into staging will fail if the user account has a OTP secret record which can’t be decrypted.

staging should either:

- have the same ACTIVE_RECORD_ENCRYPTION keys as prod so user login doesn’t break
- OR we amend the copy from PROD => STAGING sql copy to NULL `users.otp_secret`

### Changes proposed in this pull request

`NULL`'s `users.otp_secret` in the sanitise script. a new OTP secret is generated if/when we need to test/use OTP sign-in on staging.