### PR TITLE
[5717] - disable deploys to staging whilst HESA testing

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -363,7 +363,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [qa_aks,staging_aks]
+        environment: [qa_aks] #[qa_aks,staging_aks]
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
Disables automatic deploys to staging when merging to main. This is until we have finished testing the HESA integration for the 2023-24 academic year mappings.