### PR TITLE
Attempt to fix flakey JS tests

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -4,11 +4,11 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation, except: %w[ar_internal_metadata])
+    DatabaseCleaner[:active_record, db: "register_trainee_teacher_data_test#{ENV.fetch('TEST_ENV_NUMBER', nil)}".to_sym].clean_with(:truncation, except: %w[ar_internal_metadata])
   end
 
   config.before do |example|
-    DatabaseCleaner.strategy =
+    DatabaseCleaner[:active_record, db: "register_trainee_teacher_data_test#{ENV.fetch('TEST_ENV_NUMBER', nil)}".to_sym].strategy =
       if example.metadata[:type] == :feature &&
           Capybara.current_driver != :rack_test
         :truncation
@@ -16,11 +16,11 @@ RSpec.configure do |config|
         :transaction
       end
 
-    DatabaseCleaner.start
+    DatabaseCleaner[:active_record, db: "register_trainee_teacher_data_test#{ENV.fetch('TEST_ENV_NUMBER', nil)}".to_sym].start
   end
 
   config.append_after do
-    DatabaseCleaner.clean
+    DatabaseCleaner[:active_record, db: "register_trainee_teacher_data_test#{ENV.fetch('TEST_ENV_NUMBER', nil)}".to_sym].clean
   end
 
   config.around do |example|


### PR DESCRIPTION
### Context
This is an attempt to fix several flakey JS tests. It's not been possible to reproduce these locally by running individual tests. On CI they behave as though database cleaner is configured to use the `transaction` strategy when `truncation` is needed to make features specs with JS work.

### Changes proposed in this pull request

Use recommended database cleaner config

https://github.com/DatabaseCleaner/database_cleaner#rspec-with-capybara-example

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
