### PR TITLE
[5871] Add export button component

### DIFF
--- a/app/components/export_with_count_button/view.html.erb
+++ b/app/components/export_with_count_button/view.html.erb
@@ -5,4 +5,4 @@
   <% end %>
 <% end %>
 
-<%= govuk_link_to "#{button_text} (#{count} #{count_label.pluralize(count)})", href, class: "govuk-button" %>
+<%= govuk_button_to "#{button_text} (#{count} #{count_label.pluralize(count)})", href %>

--- a/app/components/export_with_count_button/view.html.erb
+++ b/app/components/export_with_count_button/view.html.erb
@@ -1,0 +1,8 @@
+
+<% if count.zero? %>
+  <%= govuk_inset_text do %>
+    <%= no_record_text %>
+  <% end %>
+<% end %>
+
+<%= govuk_link_to "#{button_text} (#{count} #{count_label.pluralize(count)})", href, class: "govuk-button" %>

--- a/app/components/export_with_count_button/view.rb
+++ b/app/components/export_with_count_button/view.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ExportWithCountButton
+  class View < GovukComponent::Base
+    renders_one :no_record_text
+
+    def initialize(button_text:, count:, count_label:, href:)
+      @button_text = button_text
+      @count = count
+      @count_label = count_label
+      @href = href
+    end
+
+  private
+
+    attr_reader :button_text, :count, :count_label, :href
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,6 +5,8 @@ class ReportsController < BaseTraineeController
 
   before_action :set_cycle_variables
 
+  helper_method :itt_new_starter_trainees
+
   def index
     authorize(current_user, :reports?)
   end
@@ -62,7 +64,7 @@ class ReportsController < BaseTraineeController
 private
 
   def itt_new_starter_trainees
-    policy_scope(FindNewStarterTrainees.new(census_date(@current_academic_cycle.start_year)).call)
+    @itt_new_starter_trainees ||= policy_scope(FindNewStarterTrainees.new(census_date(@current_academic_cycle.start_year)).call)
   end
 
   def performance_profiles_trainees

--- a/app/helpers/exports_helper.rb
+++ b/app/helpers/exports_helper.rb
@@ -16,4 +16,8 @@ module ExportsHelper
   def exceeds_export_limit?(current_user, filtered_trainees_count)
     current_user.system_admin? && filtered_trainees_count > Settings.trainee_export.record_limit
   end
+
+  def itt_new_starter_trainees_count
+    @itt_new_starter_trainees_count ||= itt_new_starter_trainees.count
+  end
 end

--- a/app/views/reports/itt_new_starter_data_sign_off.html.erb
+++ b/app/views/reports/itt_new_starter_data_sign_off.html.erb
@@ -38,6 +38,11 @@
       </li>
     </ul>
     <p class="govuk-body">If a trainee does not have a trainee start date, they will also be included in this export.</p>
-    <%= govuk_link_to "Export new trainee data", itt_new_starter_data_sign_off_reports_path(:csv), class: "govuk-button" %>
+
+    <%= render ExportWithCountButton::View.new(button_text: "Export new trainee data", count: itt_new_starter_trainees_count, count_label: "trainee", href: itt_new_starter_data_sign_off_reports_path(:csv)) do |component| %>
+      <% component.no_record_text do %>
+        <p>You have no trainees available to export. Check you have registered new trainees for the <%= @current_academic_cycle_label %> academic year.</p>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/spec/components/export_with_count_button/view_preview.rb
+++ b/spec/components/export_with_count_button/view_preview.rb
@@ -22,7 +22,7 @@ module ExportWithCountButton
           href: "/export",
         ),
       ) do |component|
-        component.no_record_text { "No trainees found" }
+        component.no_record_text { "No trainees found." }
       end
     end
   end

--- a/spec/components/export_with_count_button/view_preview.rb
+++ b/spec/components/export_with_count_button/view_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ExportWithCountButton
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render(
+        View.new(
+          button_text: "Export",
+          count: 1,
+          count_label: "trainee",
+          href: "/export",
+        ),
+      )
+    end
+
+    def with_no_record_text
+      render(
+        View.new(
+          button_text: "Export",
+          count: 0,
+          count_label: "trainee",
+          href: "/export",
+        ),
+      ) do |component|
+        component.no_record_text { "No trainees found" }
+      end
+    end
+  end
+end

--- a/spec/components/export_with_count_button/view_spec.rb
+++ b/spec/components/export_with_count_button/view_spec.rb
@@ -17,7 +17,7 @@ module ExportWithCountButton
         let(:count) { 0 }
 
         it "renders the count" do
-          expect(page).to have_link("Export (0 trainees)", href:)
+          expect(page).to have_button("Export (0 trainees)")
         end
       end
 
@@ -25,7 +25,7 @@ module ExportWithCountButton
         let(:count) { 1 }
 
         it "renders the count" do
-          expect(page).to have_link("Export (1 trainee)", href:)
+          expect(page).to have_button("Export (1 trainee)")
         end
       end
 
@@ -33,7 +33,7 @@ module ExportWithCountButton
         let(:count) { 2 }
 
         it "renders the count" do
-          expect(page).to have_link("Export (2 trainees)", href:)
+          expect(page).to have_button("Export (2 trainees)")
         end
       end
     end

--- a/spec/components/export_with_count_button/view_spec.rb
+++ b/spec/components/export_with_count_button/view_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ExportWithCountButton
+  describe View do
+    let(:button_text) { "Export" }
+    let(:count_label) { "trainee" }
+    let(:href) { "/export" }
+
+    describe "rendered output" do
+      before do
+        render_inline(described_class.new(button_text:, count:, count_label:, href:))
+      end
+
+      context "with 0 records" do
+        let(:count) { 0 }
+
+        it "renders the count" do
+          expect(page).to have_link("Export (0 trainees)", href:)
+        end
+      end
+
+      context "with 1 record" do
+        let(:count) { 1 }
+
+        it "renders the count" do
+          expect(page).to have_link("Export (1 trainee)", href:)
+        end
+      end
+
+      context "with 2 or more records" do
+        let(:count) { 2 }
+
+        it "renders the count" do
+          expect(page).to have_link("Export (2 trainees)", href:)
+        end
+      end
+    end
+
+    describe "no record text" do
+      before do
+        render_inline(described_class.new(button_text: button_text, count: 0, count_label: count_label, href: href)) do |component|
+          component.no_record_text { "No trainees found" }
+        end
+      end
+
+      it "renders the no record text" do
+        expect(page).to have_content("No trainees found")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/vyMXhAno/5871-show-count-of-trainees-on-report-page

The reports page somewhat assumes providers will have trainees to export - but that may not always be the case.

To help with this, show a count of trainees that will be exported in the export button.

### Changes proposed in this pull request

- Add view component to contain logic for showing count/fallback text

### Guidance to review

A bit fiddly to review as it's behind some conditional logic. 

[This is the page (login with Annie Bell) ](https://register-pr-3514.test.teacherservices.cloud/reports/itt-new-starter-data-sign-off)to check which should show the count of some trainees. With no trainees it'll look like this:

<img width="775" alt="Screenshot 2023-08-16 at 13 21 46" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/c27c6a9b-567c-406a-b8f4-e8350db3be80">
