### PR TITLE
[5869] Rename early years routes

### DIFF
--- a/app/services/exports/funding_trainee_summary_data.rb
+++ b/app/services/exports/funding_trainee_summary_data.rb
@@ -53,7 +53,7 @@ module Exports
     end
 
     def funding_type_prefix(row)
-      early_years_routes = ["Early years assessment only", "Early years graduate entry", "Early years graduate employment based", "Early years (undergrad)"]
+      early_years_routes = ["Early years assessment only", "Early years graduate entry", "Early years graduate employment based", "Early years undergraduate"]
       if early_years_routes.include?(row.route)
         "EYITT "
       else

--- a/app/services/exports/funding_trainee_summary_data.rb
+++ b/app/services/exports/funding_trainee_summary_data.rb
@@ -53,7 +53,7 @@ module Exports
     end
 
     def funding_type_prefix(row)
-      early_years_routes = ["Early years (assessment only)", "Early years (postgrad)", "Early years (salaried)", "Early years (undergrad)"]
+      early_years_routes = ["Early years assessment only", "Early years (postgrad)", "Early years (salaried)", "Early years (undergrad)"]
       if early_years_routes.include?(row.route)
         "EYITT "
       else

--- a/app/services/exports/funding_trainee_summary_data.rb
+++ b/app/services/exports/funding_trainee_summary_data.rb
@@ -53,7 +53,7 @@ module Exports
     end
 
     def funding_type_prefix(row)
-      early_years_routes = ["Early years assessment only", "Early years (postgrad)", "Early years (salaried)", "Early years (undergrad)"]
+      early_years_routes = ["Early years assessment only", "Early years graduate entry", "Early years (salaried)", "Early years (undergrad)"]
       if early_years_routes.include?(row.route)
         "EYITT "
       else

--- a/app/services/exports/funding_trainee_summary_data.rb
+++ b/app/services/exports/funding_trainee_summary_data.rb
@@ -53,7 +53,7 @@ module Exports
     end
 
     def funding_type_prefix(row)
-      early_years_routes = ["Early years assessment only", "Early years graduate entry", "Early years (salaried)", "Early years (undergrad)"]
+      early_years_routes = ["Early years assessment only", "Early years graduate entry", "Early years graduate employment based", "Early years (undergrad)"]
       if early_years_routes.include?(row.route)
         "EYITT "
       else

--- a/app/services/trainees/create_from_csv_row.rb
+++ b/app/services/trainees/create_from_csv_row.rb
@@ -10,7 +10,7 @@ module Trainees
 
     TRAINING_ROUTES = {
       "Assessment only" => TRAINING_ROUTE_ENUMS[:assessment_only],
-      "Early years (assessment only)" => TRAINING_ROUTE_ENUMS[:early_years_assessment_only],
+      "Early years assessment only" => TRAINING_ROUTE_ENUMS[:early_years_assessment_only],
       "Early years (postgrad)" => TRAINING_ROUTE_ENUMS[:early_years_postgrad],
       "Early years (salaried)" => TRAINING_ROUTE_ENUMS[:early_years_salaried],
       "Early years (undergrad)" => TRAINING_ROUTE_ENUMS[:early_years_undergrad],

--- a/app/services/trainees/create_from_csv_row.rb
+++ b/app/services/trainees/create_from_csv_row.rb
@@ -12,7 +12,7 @@ module Trainees
       "Assessment only" => TRAINING_ROUTE_ENUMS[:assessment_only],
       "Early years assessment only" => TRAINING_ROUTE_ENUMS[:early_years_assessment_only],
       "Early years graduate entry" => TRAINING_ROUTE_ENUMS[:early_years_postgrad],
-      "Early years (salaried)" => TRAINING_ROUTE_ENUMS[:early_years_salaried],
+      "Early years graduate employment based" => TRAINING_ROUTE_ENUMS[:early_years_salaried],
       "Early years (undergrad)" => TRAINING_ROUTE_ENUMS[:early_years_undergrad],
       "Opt-in (undergrad)" => TRAINING_ROUTE_ENUMS[:opt_in_undergrad],
       "Provider-led (postgrad)" => TRAINING_ROUTE_ENUMS[:provider_led_postgrad],

--- a/app/services/trainees/create_from_csv_row.rb
+++ b/app/services/trainees/create_from_csv_row.rb
@@ -11,7 +11,7 @@ module Trainees
     TRAINING_ROUTES = {
       "Assessment only" => TRAINING_ROUTE_ENUMS[:assessment_only],
       "Early years assessment only" => TRAINING_ROUTE_ENUMS[:early_years_assessment_only],
-      "Early years (postgrad)" => TRAINING_ROUTE_ENUMS[:early_years_postgrad],
+      "Early years graduate entry" => TRAINING_ROUTE_ENUMS[:early_years_postgrad],
       "Early years (salaried)" => TRAINING_ROUTE_ENUMS[:early_years_salaried],
       "Early years (undergrad)" => TRAINING_ROUTE_ENUMS[:early_years_undergrad],
       "Opt-in (undergrad)" => TRAINING_ROUTE_ENUMS[:opt_in_undergrad],

--- a/app/services/trainees/create_from_csv_row.rb
+++ b/app/services/trainees/create_from_csv_row.rb
@@ -13,7 +13,7 @@ module Trainees
       "Early years assessment only" => TRAINING_ROUTE_ENUMS[:early_years_assessment_only],
       "Early years graduate entry" => TRAINING_ROUTE_ENUMS[:early_years_postgrad],
       "Early years graduate employment based" => TRAINING_ROUTE_ENUMS[:early_years_salaried],
-      "Early years (undergrad)" => TRAINING_ROUTE_ENUMS[:early_years_undergrad],
+      "Early years undergraduate" => TRAINING_ROUTE_ENUMS[:early_years_undergrad],
       "Opt-in (undergrad)" => TRAINING_ROUTE_ENUMS[:opt_in_undergrad],
       "Provider-led (postgrad)" => TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
       "Provider-led (undergrad)" => TRAINING_ROUTE_ENUMS[:provider_led_undergrad],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1198,7 +1198,7 @@ en:
         trainee_id: *trainee_id
         training_routes:
           assessment_only: Assessment only
-          early_years_assessment_only: Early years (assessment only)
+          early_years_assessment_only: Early years assessment only
           early_years_postgrad: Early years (postgrad)
           early_years_salaried: Early years (salaried)
           early_years_undergrad: Early years (undergrad)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -902,7 +902,7 @@ en:
             early_years_description: "%{training_route} has a grant available of %{amount}. You need to check if the trainee is eligible for this grant."
             title: Funding Type
           tiered:
-            description: Early years (postgrad) has bursaries available. You need to check if the trainee is eligible for any of these.
+            description: Early years graduate entry has bursaries available. You need to check if the trainee is eligible for any of these.
             title: Funding type
             tier_one:
               label: Yes - Tier 1 (£5,000)
@@ -1199,7 +1199,7 @@ en:
         training_routes:
           assessment_only: Assessment only
           early_years_assessment_only: Early years assessment only
-          early_years_postgrad: Early years (postgrad)
+          early_years_postgrad: Early years graduate entry
           early_years_salaried: Early years (salaried)
           early_years_undergrad: Early years (undergrad)
           iqts: International qualified teacher status (iQTS)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1201,7 +1201,7 @@ en:
           early_years_assessment_only: Early years assessment only
           early_years_postgrad: Early years graduate entry
           early_years_salaried: Early years graduate employment based
-          early_years_undergrad: Early years (undergrad)
+          early_years_undergrad: Early years undergraduate
           iqts: International qualified teacher status (iQTS)
           provider_led_postgrad: Provider-led (postgrad)
           provider_led_undergrad: Provider-led (undergrad)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1200,7 +1200,7 @@ en:
           assessment_only: Assessment only
           early_years_assessment_only: Early years assessment only
           early_years_postgrad: Early years graduate entry
-          early_years_salaried: Early years (salaried)
+          early_years_salaried: Early years graduate employment based
           early_years_undergrad: Early years (undergrad)
           iqts: International qualified teacher status (iQTS)
           provider_led_postgrad: Provider-led (postgrad)

--- a/spec/factories/funding/trainee_summary_rows.rb
+++ b/spec/factories/funding/trainee_summary_rows.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     end
 
     trait :with_tiered_bursary_amount do
-      route { "Early years (salaried)" }
+      route { "Early years graduate employment based" }
       amounts do
         [build(:trainee_summary_row_amount, :with_tiered_bursary)]
       end

--- a/spec/fixtures/files/bulk_update/recommendations_upload/complete.csv
+++ b/spec/fixtures/files/bulk_update/recommendations_upload/complete.csv
@@ -2,5 +2,5 @@ TRN,Provider trainee ID,HESA ID,Last names,First names,Lead school,QTS or EYTS,R
 Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,"For example, 20/7/2022
 
 Delete row if the trainee has not met the standards"
-2413295,22/23-1076,'54382678848074464',Barröws,Courtney,-,EYTS,Early years (salaried),Early years,0 to 5,Early years teaching,20/7/2022
+2413295,22/23-1076,'54382678848074464',Barröws,Courtney,-,EYTS,Early years graduate employment based,Early years,0 to 5,Early years teaching,20/7/2022
 4814731,22/23-1589,'15124865380965941',Bęrgstrom,Cliff,Bluemeadow High,QTS,School direct (salaried),Secondary,11 to 16,Biology,21/7/2022

--- a/spec/fixtures/files/bulk_update/recommendations_upload/date_in_future.csv
+++ b/spec/fixtures/files/bulk_update/recommendations_upload/date_in_future.csv
@@ -2,5 +2,5 @@ TRN,Provider trainee ID,Last names,First names,Lead school,QTS or EYTS,Route,Pha
 Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,"For example, 20/7/2022
 
 Delete row if the trainee has not met the standards"
-2413295,22/23-1076,Barrows,Courtney,-,EYTS,Early years (salaried),Early years,0 to 5,Early years teaching,20/7/7000
+2413295,22/23-1076,Barrows,Courtney,-,EYTS,Early years graduate employment based,Early years,0 to 5,Early years teaching,20/7/7000
 4814731,22/23-1589,Bergstrom,Cliff,Bluemeadow High,QTS,School direct (salaried),Secondary,11 to 16,Biology,20/7/2022

--- a/spec/fixtures/files/bulk_update/recommendations_upload/missing_date.csv
+++ b/spec/fixtures/files/bulk_update/recommendations_upload/missing_date.csv
@@ -2,5 +2,5 @@ TRN,Provider trainee ID,Last names,First names,Lead school,QTS or EYTS,Route,Pha
 Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,"For example, 20/7/2022
 
 Delete row if the trainee has not met the standards"
-2413295,22/23-1076,Barrows,Courtney,-,EYTS,Early years (salaried),Early years,0 to 5,Early years teaching,20/7/2022
+2413295,22/23-1076,Barrows,Courtney,-,EYTS,Early years graduate employment based,Early years,0 to 5,Early years teaching,20/7/2022
 4814731,22/23-1589,Bergstrom,Cliff,Bluemeadow High,QTS,School direct (salaried),Secondary,11 to 16,Biology,

--- a/spec/fixtures/files/bulk_update/recommendations_upload/missing_do_not_edit_row.csv
+++ b/spec/fixtures/files/bulk_update/recommendations_upload/missing_do_not_edit_row.csv
@@ -1,3 +1,3 @@
 TRN,Provider trainee ID,Last names,First names,Lead school,QTS or EYTS,Route,Phase,Age range,Subject,Date QTS or EYTS standards met
-2413295,22/23-1076,Barrows,Courtney,-,EYTS,Early years (salaried),Early years,0 to 5,Early years teaching,20/7/2022
+2413295,22/23-1076,Barrows,Courtney,-,EYTS,Early years graduate employment based,Early years,0 to 5,Early years teaching,20/7/2022
 4814731,22/23-1589,Bergstrom,Cliff,Bluemeadow High,QTS,School direct (salaried),Secondary,11 to 16,Biology,21/7/2022

--- a/spec/fixtures/files/bulk_update/recommendations_upload/missing_required_header.csv
+++ b/spec/fixtures/files/bulk_update/recommendations_upload/missing_required_header.csv
@@ -2,5 +2,5 @@ Provider trainee ID,Last names,First names,Lead school,QTS or EYTS,Route,Phase,A
 Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,"For example, 20/7/2022
 
 Delete row if the trainee has not met the standards"
-22/23-1076,Barrows,Courtney,-,EYTS,Early years (salaried),Early years,0 to 5,Early years teaching,20/7/2022
+22/23-1076,Barrows,Courtney,-,EYTS,Early years graduate employment based,Early years,0 to 5,Early years teaching,20/7/2022
 22/23-1589,Bergstrom,Cliff,Bluemeadow High,QTS,School direct (salaried),Secondary,11 to 16,Biology,21/7/2022

--- a/spec/fixtures/files/bulk_update/recommendations_upload/no_date.csv
+++ b/spec/fixtures/files/bulk_update/recommendations_upload/no_date.csv
@@ -2,5 +2,5 @@ TRN,Provider trainee ID,Last names,First names,Lead school,QTS or EYTS,Route,Pha
 Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,"For example, 20/7/2022
 
 Delete row if the trainee has not met the standards"
-2413295,22/23-1076,Barrows,Courtney,-,EYTS,Early years (salaried),Early years,0 to 5,Early years teaching,
+2413295,22/23-1076,Barrows,Courtney,-,EYTS,Early years graduate employment based,Early years,0 to 5,Early years teaching,
 4814731,22/23-1589,Bergstrom,Cliff,Bluemeadow High,QTS,School direct (salaried),Secondary,11 to 16,Biology,

--- a/spec/fixtures/files/bulk_update/recommendations_upload/with_invalid_trn.csv
+++ b/spec/fixtures/files/bulk_update/recommendations_upload/with_invalid_trn.csv
@@ -2,5 +2,5 @@ TRN,Provider trainee ID,Last names,First names,Lead school,QTS or EYTS,Route,Pha
 Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,Do not edit,"For example, 20/7/2022
 
 Delete row if the trainee has not met the standards"
-241a295,22/23-1076,Barrows,Courtney,-,EYTS,Early years (salaried),Early years,0 to 5,Early years teaching,20/7/2022
+241a295,22/23-1076,Barrows,Courtney,-,EYTS,Early years graduate employment based,Early years,0 to 5,Early years teaching,20/7/2022
 4814731,22/23-1589,Bergstrom,Cliff,Bluemeadow High,QTS,School direct (salaried),Secondary,11 to 16,Biology,21/7/2022


### PR DESCRIPTION
### Context
Rename early years routes

### Changes proposed in this pull request
Amended `Early years (undergrad)` to `Early years undergraduate`
Amended `Early years (salaried)` to `Early years graduate employment based`
Amended `Early years (postgrad)` to `Early years graduate entry`
Amended `Early years (assessment only)` to `Early years assessment only`

### Guidance to review


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
