### PR TITLE
[5864] Delete addresses we hold in register (part 1/2)

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -122,7 +122,7 @@
 #  fk_rails_...  (start_academic_cycle_id => academic_cycles.id)
 #
 class Trainee < ApplicationRecord
-  self.ignored_columns += %w[withdraw_reason previous_hesa_id] # rubocop:disable Rails/UnusedIgnoredColumns
+  self.ignored_columns += %w[withdraw_reason previous_hesa_id address_line_one address_line_two town_city postcode international_address locale_code] # rubocop:disable Rails/UnusedIgnoredColumns
 
   include Sluggable
   include PgSearch::Model

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -212,8 +212,6 @@ class Trainee < ApplicationRecord
 
   enum bursary_tier: BURSARY_TIERS
 
-  enum locale_code: { uk: 0, non_uk: 1 }
-
   enum sex: {
     male: 0,
     female: 1,
@@ -344,12 +342,7 @@ class Trainee < ApplicationRecord
     :first_names,
     :middle_names,
     :last_name,
-    :address_line_one,
-    :address_line_two,
-    :town_city,
-    :postcode,
     :email,
-    :international_address,
     :ethnic_background,
     :additional_ethnic_background,
     :trn,

--- a/app/services/degrees/create_from_dttp_placement_assignment.rb
+++ b/app/services/degrees/create_from_dttp_placement_assignment.rb
@@ -42,14 +42,14 @@ module Degrees
 
     def uk_degree_params
       {
-        locale_code: Trainee.locale_codes[:uk],
+        locale_code: Degree.locale_codes[:uk],
         uk_degree: degree_type,
       }
     end
 
     def non_uk_degree_params
       {
-        locale_code: Trainee.locale_codes[:non_uk],
+        locale_code: Degree.locale_codes[:non_uk],
         non_uk_degree: degree_type,
         country: country,
       }

--- a/app/services/degrees/map_from_apply.rb
+++ b/app/services/degrees/map_from_apply.rb
@@ -31,7 +31,7 @@ module Degrees
 
     def uk_degree_params
       {
-        locale_code: Trainee.locale_codes[:uk],
+        locale_code: Degree.locale_codes[:uk],
       }.merge(qualification_type_params)
        .merge(grade_params)
        .merge(institution_params)
@@ -39,7 +39,7 @@ module Degrees
 
     def non_uk_degree_params
       {
-        locale_code: Trainee.locale_codes[:non_uk],
+        locale_code: Degree.locale_codes[:non_uk],
         non_uk_degree: attributes["comparable_uk_degree"],
         country: country,
       }

--- a/app/services/degrees/map_from_dttp.rb
+++ b/app/services/degrees/map_from_dttp.rb
@@ -53,7 +53,7 @@ module Degrees
 
     def uk_degree_params
       {
-        locale_code: Trainee.locale_codes[:uk],
+        locale_code: Degree.locale_codes[:uk],
         uk_degree: degree_type,
         institution: institution,
         grade: grade.presence || Dttp::CodeSets::Grades::OTHER,
@@ -62,7 +62,7 @@ module Degrees
 
     def non_uk_degree_params
       {
-        locale_code: Trainee.locale_codes[:non_uk],
+        locale_code: Degree.locale_codes[:non_uk],
         non_uk_degree: non_uk_degree,
         country: country,
       }

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -236,10 +236,8 @@ shared:
     - itt_start_date
     - lead_school_id
     - lead_school_not_applicable
-    - locale_code
     - outcome_date
     - placement_assignment_dttp_id
-    - postcode
     - progress
     - provider_id
     - recommended_for_award_at
@@ -252,7 +250,6 @@ shared:
     - study_mode
     - submission_ready
     - submitted_for_trn_at
-    - town_city
     - training_initiative
     - training_route
     - trn

--- a/spec/components/contact_details/view_spec.rb
+++ b/spec/components/contact_details/view_spec.rb
@@ -21,7 +21,6 @@ describe ContactDetails::View do
 
   context "UK based trainee" do
     before do
-      mock_trainee.locale_code = "uk"
       @result ||= render_inline(ContactDetails::View.new(data_model: mock_trainee, editable: true))
     end
 
@@ -43,7 +42,6 @@ describe ContactDetails::View do
   context "HESA trainee" do
     before do
       mock_trainee.hesa_id = "XXX"
-      mock_trainee.locale_code = "uk"
       @result ||= render_inline(ContactDetails::View.new(data_model: mock_trainee))
     end
 

--- a/spec/components/pages/trainees/check_details/view_preview.rb
+++ b/spec/components/pages/trainees/check_details/view_preview.rb
@@ -90,7 +90,6 @@ module Pages
                       additional_ethnic_background: "additional_ethnic_background",
                       sex: 1,
                       date_of_birth: Time.zone.now,
-                      postcode: "BN1 1AA",
                       email: "email@example.com",
                       course_min_age: 0,
                       course_max_age: 5,

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -63,7 +63,6 @@ FactoryBot.define do
       disability_disclosure { "disabled" }
       disabled_with_disabilites_disclosed
       training_initiative { "transition_to_teach" }
-      international_address { "Test addr" }
       itt_start_date { compute_valid_past_itt_start_date }
       itt_end_date { itt_start_date + 2.years }
     end

--- a/spec/models/trainee_spec.rb
+++ b/spec/models/trainee_spec.rb
@@ -24,7 +24,6 @@ describe Trainee do
       )
     end
 
-    it { is_expected.to define_enum_for(:locale_code).with_values(uk: 0, non_uk: 1) }
     it { is_expected.to define_enum_for(:sex).with_values(male: 0, female: 1, other: 2, sex_not_provided: 3, prefer_not_to_say: 4) }
 
     it do

--- a/spec/services/degrees/map_from_apply_spec.rb
+++ b/spec/services/degrees/map_from_apply_spec.rb
@@ -56,7 +56,7 @@ module Degrees
     context "with a uk degree" do
       let(:expected_uk_degree_attributes) do
         {
-          locale_code: Trainee.locale_codes[:uk],
+          locale_code: Degree.locale_codes[:uk],
           uk_degree: dfe_degree_type_reference_data[:name],
           uk_degree_uuid: dfe_degree_type_reference_data[:id],
           institution: dfe_degree_institution_reference_data[:name],
@@ -123,7 +123,7 @@ module Degrees
 
       let(:expected_non_uk_degree_attributes) do
         {
-          locale_code: Trainee.locale_codes[:non_uk],
+          locale_code: Degree.locale_codes[:non_uk],
           country: "St Kitts and Nevis",
           non_uk_degree: degree_attributes["comparable_uk_degree"],
         }
@@ -141,7 +141,7 @@ module Degrees
 
         let(:expected_non_uk_degree_attributes) do
           {
-            locale_code: Trainee.locale_codes[:non_uk],
+            locale_code: Degree.locale_codes[:non_uk],
             non_uk_degree: degree_attributes["comparable_uk_degree"],
           }
         end

--- a/spec/services/degrees/map_from_dttp_spec.rb
+++ b/spec/services/degrees/map_from_dttp_spec.rb
@@ -64,7 +64,7 @@ module Degrees
 
       let(:uk_degree_attributes) do
         {
-          locale_code: Trainee.locale_codes[:uk],
+          locale_code: Degree.locale_codes[:uk],
           uk_degree: degree_type,
           institution: institution,
           grade: grade,
@@ -157,7 +157,7 @@ module Degrees
 
       let(:non_uk_degree_attributes) do
         {
-          locale_code: Trainee.locale_codes[:non_uk],
+          locale_code: Degree.locale_codes[:non_uk],
           non_uk_degree: api_degree_qualification["dfe_name"],
           country: country,
         }


### PR DESCRIPTION
### Context

We are removing address fields from Register. We don't need them any longer.

This PR https://github.com/DFE-Digital/register-trainee-teachers/pull/3504 has done the bulk of the work to remove the UI and various API interactions. We now need to remove the columns from the database and this PR is the first of two steps to do that (safely).

NOTE THAT THIS PR CANNOT BE MERGED UNTIL https://github.com/DFE-Digital/register-trainee-teachers/pull/3504 IS MERGED AND DEPLOYED.

### Changes proposed in this pull request

* Add address attributes to the list of `ignored_attributes`.
* Remove address attributes from `analytics.yml` (only 3 of them were present because I guess `address_line_one` etc. is PII).

### Guidance to review

Is there anything more to do here?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
