### PR TITLE
Remove address references from guidance page

### DIFF
--- a/app/views/guidance/check_data.md
+++ b/app/views/guidance/check_data.md
@@ -16,15 +16,6 @@ You’ll need the following information about a trainee to register them manuall
 <li> Date of birth  </li> 
 <li> Sex </li>
 <li>Nationality</li>
-</ul>
-
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-## Contact details
-
-<ul class="govuk-list">
-<li> Address  </li>
-<li> Email address</li>
 <li>Personal email address</li>
 </ul>
 

--- a/app/views/guidance/check_data.md
+++ b/app/views/guidance/check_data.md
@@ -25,6 +25,7 @@ You’ll need the following information about a trainee to register them manuall
 <ul class="govuk-list">
 <li> Address  </li>
 <li> Email address</li>
+<li>Personal email address</li>
 </ul>
 
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">


### PR DESCRIPTION
### Context

*Ticket #5859*
We are removing address from trainee records so that old trainee data no longer has it, and new trainees also will no longer require it.

[Design ref](https://github.com/DFE-Digital/register-trainee-teachers-prototype/pull/639)

### Changes proposed in this pull request

Minor content change to guidance page
* Specify *Personal* Email Address
* Remove Contact details section

Further logic changes in other PRs

### Guidance to review
N/A

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
