### PR TITLE
[5782] Improve TraineeReport performance

### DIFF
--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -153,24 +153,11 @@ module Reports
     end
 
     def course_subject_category
-      trainee_allocation_subject(trainee.course_subject_one) || course_allocation_subject
-    end
-
-    def course_allocation_subject
-      return if course.blank? || course.subjects.blank?
-
-      trainee_allocation_subject(calculated_subject)
+      trainee.course_allocation_subject&.name
     end
 
     def course_subject_names
       @course_subject_names ||= course.subjects.pluck(:name)
-    end
-
-    def calculated_subject
-      Rails.cache.fetch("TraineeReport.calculated_subject(#{course_subject_names.join('-')})", expires_in: 1.day) do
-        CalculateSubjectSpecialisms.call(subjects: course.subjects.pluck(:name))
-        .values.map(&:first).first
-      end
     end
 
     def course_training_route
@@ -431,15 +418,6 @@ module Reports
     end
 
   private
-
-    def trainee_allocation_subject(subject)
-      return if subject.blank?
-
-      subject_name = subject.downcase
-      Rails.cache.fetch("TraineeReport.trainee_allocation_subject(#{subject_name})", expires_in: 1.day) do
-        SubjectSpecialism.find_by("lower(name) = ?", subject_name)&.allocation_subject&.name
-      end
-    end
 
     def placements
       @placements ||= trainee.placements.reverse

--- a/db/data/20230822072153_correct_course_allocation_subject_for_non_draft.rb
+++ b/db/data/20230822072153_correct_course_allocation_subject_for_non_draft.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CorrectCourseAllocationSubjectForNonDraft < ActiveRecord::Migration[7.0]
+  def up
+    trainees = Trainee.where.not(state: :draft).where(course_allocation_subject: nil)
+
+    trainees.find_each do |trainee|
+      SubjectSpecialism.find_by("lower(name) = ?", trainee.course_subject_one)&.allocation_subject.tap do |allocation_subject|
+        trainee.update!(course_allocation_subject: allocation_subject)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -49,10 +49,6 @@ FactoryBot.define do
     end
 
     trait :for_export do
-      with_primary_course_details
-      submitted_for_trn
-      trn_received
-      recommended_for_award
       awarded
       with_tiered_bursary
       with_lead_school
@@ -67,6 +63,7 @@ FactoryBot.define do
       international_address { "Test addr" }
       itt_start_date { compute_valid_past_itt_start_date }
       itt_end_date { itt_start_date + 2.years }
+      with_primary_course_details
     end
 
     trait :bulk_recommend do


### PR DESCRIPTION
### Context

https://trello.com/c/xlzSIlfP/5782-spike-test-exporting-large-number-of-trainees-on-report-page

### Changes proposed in this pull request

The current reporting class does some unnecessary calculation of the allocation subject when it's already available via the trainee's `course_allocation_subject` (reference PR is here https://github.com/DFE-Digital/register-trainee-teachers/pull/2250)

- Switch out redundant code to make use of `course_allocation_subject`
- Data migration to correct `course_allocation_subject` on non draft trainees who have it missing (around 92 in prod)
- Fix `for_export` trainee factory as it was not correctly representing the final state of the trainee for an export in tests

### Tech notes

This PR is one part of a two step improvement to this area. This optimises the underlying query but needs to be combined with the streaming work in this PR (the approach we're going forward with) https://github.com/DFE-Digital/register-trainee-teachers/pull/3495 cc @defong .

### Guidance to review

Benchmark figures are below. But it's best to review locally in the streaming PR (once rebased) with a local sanitized data to see the full final behaviour. 