### PR TITLE
[5864] Delete addresses we hold in register schema change part 2/2

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -7,8 +7,6 @@
 #  id                              :bigint           not null, primary key
 #  additional_dttp_data            :jsonb
 #  additional_ethnic_background    :text
-#  address_line_one                :text
-#  address_line_two                :text
 #  applying_for_bursary            :boolean
 #  applying_for_grant              :boolean
 #  applying_for_scholarship        :boolean
@@ -38,16 +36,13 @@
 #  first_names                     :text
 #  hesa_editable                   :boolean          default(FALSE)
 #  hesa_updated_at                 :datetime
-#  international_address           :text
 #  iqts_country                    :string
 #  itt_end_date                    :date
 #  itt_start_date                  :date
 #  last_name                       :text
 #  lead_school_not_applicable      :boolean          default(FALSE)
-#  locale_code                     :integer
 #  middle_names                    :text
 #  outcome_date                    :date
-#  postcode                        :text
 #  progress                        :jsonb
 #  recommended_for_award_at        :datetime
 #  record_source                   :string
@@ -60,7 +55,6 @@
 #  study_mode                      :integer
 #  submission_ready                :boolean          default(FALSE)
 #  submitted_for_trn_at            :datetime
-#  town_city                       :text
 #  trainee_start_date              :date
 #  training_initiative             :integer
 #  training_route                  :integer
@@ -100,7 +94,6 @@
 #  index_trainees_on_hesa_id                                       (hesa_id)
 #  index_trainees_on_hesa_trn_submission_id                        (hesa_trn_submission_id)
 #  index_trainees_on_lead_school_id                                (lead_school_id)
-#  index_trainees_on_locale_code                                   (locale_code)
 #  index_trainees_on_progress                                      (progress) USING gin
 #  index_trainees_on_provider_id                                   (provider_id)
 #  index_trainees_on_sex                                           (sex)

--- a/db/migrate/20230818092637_drop_trainee_address_columns.rb
+++ b/db/migrate/20230818092637_drop_trainee_address_columns.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class DropTraineeAddressColumns < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :trainees, :address_line_one, :text
+      remove_column :trainees, :address_line_two, :text
+      remove_column :trainees, :town_city, :text
+      remove_column :trainees, :postcode, :text
+      remove_column :trainees, :locale_code, :integer
+      remove_column :trainees, :international_address, :text
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_31_090931) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_18_092637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -751,16 +751,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_090931) do
     t.date "date_of_birth"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "address_line_one"
-    t.text "address_line_two"
-    t.text "town_city"
-    t.text "postcode"
     t.text "email"
     t.uuid "dttp_id"
     t.text "middle_names"
     t.integer "training_route"
-    t.text "international_address"
-    t.integer "locale_code"
     t.integer "sex"
     t.integer "diversity_disclosure"
     t.integer "ethnic_group"
@@ -837,7 +831,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_090931) do
     t.index ["hesa_id"], name: "index_trainees_on_hesa_id"
     t.index ["hesa_trn_submission_id"], name: "index_trainees_on_hesa_trn_submission_id"
     t.index ["lead_school_id"], name: "index_trainees_on_lead_school_id"
-    t.index ["locale_code"], name: "index_trainees_on_locale_code"
     t.index ["progress"], name: "index_trainees_on_progress", using: :gin
     t.index ["provider_id"], name: "index_trainees_on_provider_id"
     t.index ["sex"], name: "index_trainees_on_sex"


### PR DESCRIPTION
### Context
Two earlier PRs (https://github.com/DFE-Digital/register-trainee-teachers/pull/3516 and https://github.com/DFE-Digital/register-trainee-teachers/pull/3504) cleaned up references to trainee address fields in Register. This PR is the final part - it just drops the 6 address columns in the `trainees` database table.

### Changes proposed in this pull request
Drop the following columns using safe migrations:

- `address_line_one`
- `address_line_two`
- `town_city`
- `postcode`
- `locale_code`
- `international_address`

### Guidance to review
- Is there anything missing?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
