### PR TITLE
[5082] Add complete? to trainee report

### DIFF
--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -365,9 +365,7 @@ module Reports
       trainee.submitted_for_trn_at&.iso8601
     end
 
-    def complete?
-      trainee.submission_ready?
-    end
+    def complete? = trainee.submission_ready?
 
     def trainee_start_date
       trainee.trainee_start_date&.iso8601

--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -365,6 +365,10 @@ module Reports
       trainee.submitted_for_trn_at&.iso8601
     end
 
+    def complete?
+      trainee.submission_ready?
+    end
+
     def trainee_start_date
       trainee.trainee_start_date&.iso8601
     end

--- a/app/models/reports/trainees_report.rb
+++ b/app/models/reports/trainees_report.rb
@@ -4,7 +4,7 @@ module Reports
   class TraineesReport < TemplateClassCsv
     def self.headers
       %w[register_id
-         is_complete?
+         complete?
          trainee_url
          record_source
          apply_id

--- a/app/models/reports/trainees_report.rb
+++ b/app/models/reports/trainees_report.rb
@@ -4,6 +4,7 @@ module Reports
   class TraineesReport < TemplateClassCsv
     def self.headers
       %w[register_id
+         is_complete?
          trainee_url
          record_source
          apply_id
@@ -117,6 +118,7 @@ module Reports
       trainee_report = Reports::TraineeReport.new(trainee)
       [
         trainee_report.register_id,
+        trainee_report.complete?,
         trainee_report.trainee_url,
         trainee_report.record_source,
         trainee_report.apply_id,

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -28,6 +28,10 @@ describe Reports::TraineeReport do
       expect(subject.funding_manager).to be_a(FundingManager)
     end
 
+    it "includes whether the trainee is complete" do
+      expect(subject.complete?).to eq(trainee.submission_ready?)
+    end
+
     it "sets the correct course" do
       expect(course).to eq(Course.find_by(uuid: trainee.course_uuid))
     end


### PR DESCRIPTION
### Context

https://trello.com/c/mlYZrxEE/5082-add-to-trainee-exports-if-trainee-is-incomplete-complete

Adds a new column for `is_complete` to the trainee export.

### Changes proposed in this pull request

- Expose `submission_ready` from the trainee to the report class

### Guidance to review

You can check this with the example data in QA. Make sure to use sweet old Annie Bell

https://register-pr-3532.test.teacherservices.cloud/reports/performance-profiles

