### PR TITLE
[5848] Improve reliability of Trainees::CreateFromApplyJob

### DIFF
--- a/app/jobs/apply_api/import_application_job.rb
+++ b/app/jobs/apply_api/import_application_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ApplyApi
+  class ImportApplicationJob < ApplicationJob
+    queue_as :apply
+
+    def perform(application_data)
+      ImportApplication.call(application_data:)
+    rescue ApplyApi::ImportApplication::ApplyApiMissingDataError => e
+      Sentry.capture_exception(e)
+    end
+  end
+end

--- a/app/jobs/apply_api/import_applications_job.rb
+++ b/app/jobs/apply_api/import_applications_job.rb
@@ -11,9 +11,7 @@ module ApplyApi
 
       recruitment_cycle_years.each do |recruitment_cycle_year|
         new_applications(recruitment_cycle_year).each do |application_data|
-          ImportApplication.call(application_data:)
-        rescue ApplyApi::ImportApplication::ApplyApiMissingDataError => e
-          Sentry.capture_exception(e)
+          ImportApplicationJob.perform_later(application_data)
         end
       end
     end

--- a/spec/jobs/apply_api/import_application_job_spec.rb
+++ b/spec/jobs/apply_api/import_application_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module ApplyApi
+  describe ImportApplicationJob do
+    include ActiveJob::TestHelper
+
+    let(:application_data) { double("application_data") }
+
+    context "when ImportApplication returns ApplyApiMissingDataError" do
+      before do
+        allow(ImportApplication).to receive(:call).with(application_data:).and_raise ApplyApi::ImportApplication::ApplyApiMissingDataError
+      end
+
+      it "is rescued and captured by Sentry" do
+        expect(Sentry).to receive(:capture_exception).with(ApplyApi::ImportApplication::ApplyApiMissingDataError)
+        described_class.perform_now(application_data)
+      end
+    end
+  end
+end

--- a/spec/jobs/apply_api/import_applications_job_spec.rb
+++ b/spec/jobs/apply_api/import_applications_job_spec.rb
@@ -21,7 +21,7 @@ module ApplyApi
 
         it "calls the RetrieveApplications service with the from_date param" do
           expect(RetrieveApplications).to receive(:call).with(changed_since: from_date, recruitment_cycle_year: recruitment_cycle_year)
-          expect(ImportApplication).to receive(:call).with(application_data:).and_return(application_record)
+          expect(ImportApplicationJob).to receive(:perform_later).with(application_data)
 
           described_class.perform_now(from_date:)
         end
@@ -30,7 +30,7 @@ module ApplyApi
       context "when there have been no previous syncs" do
         it "imports application data from Apply and creates a trainee record" do
           expect(RetrieveApplications).to receive(:call).with(changed_since: nil, recruitment_cycle_year: recruitment_cycle_year)
-          expect(ImportApplication).to receive(:call).with(application_data:).and_return(application_record)
+          expect(ImportApplicationJob).to receive(:perform_later).with(application_data)
 
           described_class.perform_now
         end
@@ -50,7 +50,7 @@ module ApplyApi
 
         it "imports all applications from Apply" do
           expect(RetrieveApplications).to receive(:call).with(changed_since: nil, recruitment_cycle_year: recruitment_cycle_year)
-          expect(ImportApplication).to receive(:call).with(application_data:).and_return(application_record)
+          expect(ImportApplicationJob).to receive(:perform_later).with(application_data)
 
           described_class.perform_now
         end
@@ -70,7 +70,7 @@ module ApplyApi
 
         it "imports just the new applications from Apply" do
           expect(RetrieveApplications).to receive(:call).with(changed_since: last_sync, recruitment_cycle_year: recruitment_cycle_year)
-          expect(ImportApplication).to receive(:call).with(application_data:).and_return(application_record)
+          expect(ImportApplicationJob).to receive(:perform_later).with(application_data)
 
           described_class.perform_now
         end
@@ -97,19 +97,8 @@ module ApplyApi
 
         it "imports just the new applications from Apply" do
           expect(RetrieveApplications).to receive(:call).with(changed_since: last_successful_sync, recruitment_cycle_year: recruitment_cycle_year)
-          expect(ImportApplication).to receive(:call).with(application_data:).and_return(application_record)
+          expect(ImportApplicationJob).to receive(:perform_later).with(application_data)
 
-          described_class.perform_now
-        end
-      end
-
-      context "when ImportApplication returns ApplyApiMissingDataError" do
-        before do
-          allow(ImportApplication).to receive(:call).with(application_data:).and_raise ApplyApi::ImportApplication::ApplyApiMissingDataError
-        end
-
-        it "is rescued and captured by Sentry" do
-          expect(Sentry).to receive(:capture_exception).with(ApplyApi::ImportApplication::ApplyApiMissingDataError)
           described_class.perform_now
         end
       end


### PR DESCRIPTION
### Context

https://trello.com/c/apNQUzHG/5848-improve-reliability-of-traineescreatefromapplyjob

We have a job that runs nightly and loops through importable ApplyApplication-ses and creates trainees from them. Currently if one creation fails the job halts and starts to retry. If there are 300 to import and the first one fails, 299 get stuck. 

This also makes it not immediately obvious which application is failing.

### Changes proposed in this pull request

Fans out the `ImportApplicationsJob` into smaller individual jobs for each application so it's consistent with other import jobs.

### Guidance to review

- Follow this https://github.com/DFE-Digital/register-trainee-teachers/blob/main/docs/setup-development.md#running-apply-application-import-against-example-data (get an auth key from apply sandbox console or dm me)
- Run instructions in the example
- Check Sidekiq dashboard to assert jobs are fanned out
