### PR TITLE
[5858] Handle Teach First programme type when submitting data to DQT

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -21,7 +21,7 @@ module Dqt
         TRAINING_ROUTE_ENUMS[:early_years_postgrad] => "EYITTGraduateEntry",
         TRAINING_ROUTE_ENUMS[:early_years_salaried] => "EYITTGraduateEmploymentBased",
         TRAINING_ROUTE_ENUMS[:early_years_undergrad] => "EYITTUndergraduate",
-        TRAINING_ROUTE_ENUMS[:hpitt_postgrad] => "TeachFirstProgramme",
+        TRAINING_ROUTE_ENUMS[:hpitt_postgrad] => "HighPotentialITT",
         TRAINING_ROUTE_ENUMS[:opt_in_undergrad] => "UndergraduateOptIn",
         TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship] => "Apprenticeship",
         TRAINING_ROUTE_ENUMS[:provider_led_postgrad] => "ProviderLedPostgrad",


### PR DESCRIPTION
### Context

https://trello.com/c/jbTLFoT1/5858-handle-teach-first-programme-type-when-submitting-data-to-dqt

### Changes proposed in this pull request

- Uses the new HPITT specific DQT programme type sourced from https://qualified-teachers-api-preprod.london.cloudapps.digital/swagger/v2.json (search for `IttProgrammeType`)

### Guidance to review

Could be tested on staging by sending a HPITT trainee to DQT pre-prod (but will need to be done separately outside of this PR or deploy directly to staging)
