### PR TITLE
[3292] Error summary on check record page should link to sections to complete

### DIFF
--- a/app/components/collapsed_section/view.html.erb
+++ b/app/components/collapsed_section/view.html.erb
@@ -4,7 +4,7 @@
     <%= govuk_link_to link_text, url, name: name %>
   <% end %>
   <% if hint_text.present? %>
-    <div class="govuk-hint">
+    <div id=<%= name if hint_text.present? && url.blank?  %> class="govuk-hint">
       <%= hint_text %>
     </div>
   <% end %>

--- a/app/components/collapsed_section/view.html.erb
+++ b/app/components/collapsed_section/view.html.erb
@@ -4,8 +4,8 @@
     <%= govuk_link_to link_text, url, name: name %>
   <% end %>
   <% if hint_text.present? %>
-    <div id=<%= name if hint_text.present? && url.blank?  %> class="govuk-hint">
+    <%= tag.div(class: "govuk-hint", **{id: (name if hint_text.present? && url.blank? )}) do %>
       <%= hint_text %>
-    </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/components/sections/view.rb
+++ b/app/components/sections/view.rb
@@ -37,7 +37,7 @@ module Sections
     end
 
     def collapsed_funding_inactive_section_args
-      { title: I18n.t("components.sections.titles.funding_inactive"), hint_text: I18n.t("components.sections.link_texts.funding_inactive"), has_errors: form_has_errors? }
+      { title: I18n.t("components.sections.titles.funding_inactive"), hint_text: I18n.t("components.sections.link_texts.funding_inactive"), has_errors: form_has_errors?, name: section }
     end
 
     def collapsed_section_args

--- a/app/forms/submissions/trn_validator.rb
+++ b/app/forms/submissions/trn_validator.rb
@@ -2,6 +2,8 @@
 
 module Submissions
   class TrnValidator < BaseValidator
+    include FundingHelper
+
     def progress_status(progress_key)
       progress_service(progress_key).status.parameterize(separator: "_").to_sym
     end
@@ -12,24 +14,65 @@ module Submissions
     end
 
     def all_sections_complete?
-      validator_keys.all? do |key|
-        progress_is_completed?(key)
+      @all_sections_complete ||= sections_validation_status.values.all? do |status|
+        status == Progress::STATUSES[:completed]
       end
     end
 
   private
 
+    def sections_validation_status
+      @sections_validation_status ||= validator_keys.index_with do |progress_key|
+        progress_service(progress_key).status
+      end
+    end
+
+    def sections
+      if trainee.apply_application?
+        apply_draft_trainee_sections
+      else
+        draft_trainee_sections
+      end
+    end
+
+    def draft_trainee_sections
+      [
+        :personal_details, :contact_details, :diversity,
+        *(:degrees if @trainee.requires_degree?),
+        :course_details, :training_details,
+        *(:schools if trainee.requires_schools?),
+        *(:funding if trainee.requires_funding?),
+        *(:iqts_country if trainee.requires_iqts_country?)
+      ]
+    end
+
+    def apply_draft_trainee_sections
+      [
+        :course_details, :trainee_data,
+        :training_details, *(:schools if trainee.requires_schools?),
+        :funding
+      ]
+    end
+
     def submission_ready
-      errors.add(:trainee, :incomplete) unless all_sections_complete?
+      unless all_sections_complete?
+        sections.each do |section|
+          next unless sections_validation_status[section] != Progress::STATUSES[:completed]
+
+          if section == :funding && funding_options(trainee) == :funding_inactive
+            errors.add(section, I18n.t("components.sections.titles.funding_inactive"))
+          else
+            error_message = "#{I18n.t("components.sections.titles.#{section}")} #{I18n.t("components.sections.statuses.#{sections_validation_status[section]}")}"
+
+            errors.add(section, error_message)
+          end
+        end
+      end
     end
 
     def progress_service(progress_key)
       progress_value = trainee.progress.public_send(progress_key)
       ProgressService.call(validator: validator(progress_key), progress_value: progress_value)
-    end
-
-    def progress_is_completed?(progress_key)
-      progress_service(progress_key).completed?
     end
   end
 end

--- a/app/views/trainees/check_details/show.html.erb
+++ b/app/views/trainees/check_details/show.html.erb
@@ -15,8 +15,8 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <%= render ErrorSummary::View.new(renderable: @form.errors.any?) do %>
-          <% @form.errors.messages.map do |_, messages| %>
-            <%= tag.li(messages.first) %>
+          <% @form.errors.messages.map do |section, messages| %>
+            <%= tag.li(link_to(messages.first, "##{section}")) %>
           <% end %>
         <% end %>
 

--- a/spec/controllers/trainees/personal_details_controller_spec.rb
+++ b/spec/controllers/trainees/personal_details_controller_spec.rb
@@ -36,7 +36,7 @@ describe Trainees::PersonalDetailsController do
       let(:trainee) { create(:trainee, :incomplete_draft, :with_apply_application, provider: user.organisation) }
 
       before do
-        allow(PersonalDetailsForm).to receive(:new).and_return(double(stash_or_save!: true))
+        allow(PersonalDetailsForm).to receive(:new).and_return(double(stash_or_save!: true, fields: {}, valid?: true))
         allow(controller).to receive_messages(page_tracker: double(last_origin_page_path: "/trainees/#{trainee.slug}/relevant-redirect", save!: nil), personal_details_params: nil)
       end
 

--- a/spec/controllers/trainees/training_details_controller_spec.rb
+++ b/spec/controllers/trainees/training_details_controller_spec.rb
@@ -13,13 +13,8 @@ describe Trainees::TrainingDetailsController do
     context "with an apply draft trainee" do
       let(:trainee) { create(:trainee, :incomplete_draft, :with_apply_application, provider: user.organisation) }
 
-      before do
-        allow(TrainingDetailsForm).to receive(:new).and_return(double(save: true))
-        allow(controller).to receive(:trainee_params).and_return(nil)
-      end
-
       it "redirects to /training-details/confirm after update" do
-        expect(put(:update, params: { trainee_id: trainee.slug })).to redirect_to("/trainees/#{trainee.slug}/training-details/confirm")
+        expect(put(:update, params: { trainee_id: trainee.slug, training_details_form: { trainee_id: "test" } })).to redirect_to("/trainees/#{trainee.slug}/training-details/confirm")
       end
     end
   end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -34,6 +34,11 @@ FactoryBot.define do
     email { "#{first_names}.#{last_name}@example.com" }
     applying_for_bursary { nil }
 
+    after(:create) do |trainee, _evaluator|
+      # NOTE: some of the tests circumvent the proper expectations with associations.
+      trainee.reload if trainee.disability_ids.blank? && trainee.trainee_disabilities.present?
+    end
+
     factory :trainee do
       date_of_birth { Faker::Date.birthday(min_age: 18, max_age: 65) }
     end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -293,6 +293,7 @@ FactoryBot.define do
 
       after(:create) do |trainee, evaluator|
         create_list(:trainee_disability, evaluator.disabilities_count, trainee:)
+        trainee.reload
       end
     end
 

--- a/spec/features/trainee_actions/submit_for_trn_spec.rb
+++ b/spec/features/trainee_actions/submit_for_trn_spec.rb
@@ -69,7 +69,7 @@ feature "submit for TRN" do
           and_i_want_to_review_record_before_submitting_for_trn
           then_i_review_the_trainee_data
           and_i_click_the_submit_for_trn_button
-          then_i_see_an_error_message
+          then_i_see_an_error_summary
         end
       end
     end
@@ -135,10 +135,8 @@ feature "submit for TRN" do
     expect(review_draft_page).to be_displayed(id: trainee.slug)
   end
 
-  def then_i_see_an_error_message
-    expect(page).to have_content(
-      I18n.t("activemodel.errors.models.submissions/trn_validator.attributes.trainee.incomplete"),
-    )
+  def then_i_see_an_error_summary
+    expect(page).to have_css(".govuk-error-summary")
   end
 
   def and_i_click_the_submit_for_trn_button

--- a/spec/forms/diversities/form_validator_spec.rb
+++ b/spec/forms/diversities/form_validator_spec.rb
@@ -17,11 +17,11 @@ module Diversities
     describe "validations" do
       context "when disclosed and all diversity forms valid" do
         before do
-          expect(DisclosureForm).to receive(:new).and_return(disclosure)
-          expect(EthnicGroupForm).to receive(:new).and_return(ethnic_group)
-          expect(EthnicBackgroundForm).to receive(:new).and_return(ethnic_background)
-          expect(DisabilityDisclosureForm).to receive(:new).and_return(disability_disclosure)
-          expect(DisabilityDetailForm).to receive(:new).and_return(disability_detail_form)
+          allow(DisclosureForm).to receive(:new).and_return(disclosure)
+          allow(EthnicGroupForm).to receive(:new).and_return(ethnic_group)
+          allow(EthnicBackgroundForm).to receive(:new).and_return(ethnic_background)
+          allow(DisabilityDisclosureForm).to receive(:new).and_return(disability_disclosure)
+          allow(DisabilityDetailForm).to receive(:new).and_return(disability_detail_form)
         end
 
         it { is_expected.to be_valid }

--- a/spec/forms/submissions/trn_validator_spec.rb
+++ b/spec/forms/submissions/trn_validator_spec.rb
@@ -13,10 +13,9 @@ module Submissions
     end
 
     shared_examples "error" do
-      it "is invalid and returns an error message" do
-        expect(subject.valid?).to be false
-        expect(subject.errors.messages[:trainee])
-          .to include(I18n.t("activemodel.errors.models.submissions/trn_validator.attributes.trainee.incomplete"))
+      it "is invalid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors).not_to be_empty
       end
     end
 
@@ -158,7 +157,7 @@ module Submissions
 
                 it "is invalid" do
                   expect(subject.valid?).to be false
-                  expect(subject.errors).not_to be_empty
+                  expect(subject.errors.messages).to include({ schools: ["Schools not marked as complete"] })
                 end
               end
 
@@ -175,7 +174,7 @@ module Submissions
 
                 it "is invalid" do
                   expect(subject.valid?).to be false
-                  expect(subject.errors).not_to be_empty
+                  expect(subject.errors.messages).to include({ schools: ["Schools not marked as complete"] })
                 end
               end
             end
@@ -228,6 +227,26 @@ module Submissions
         let(:progress) { {} }
 
         include_examples "error"
+      end
+
+      context "with incomplete trainee" do
+        let(:trainee) { build(:trainee, :incomplete_draft) }
+        let(:progress) { {} }
+
+        subject { described_class.new(trainee:) }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+          expect(subject.errors.messages).to include(
+            { personal_details: ["Personal details not marked as complete"],
+              contact_details: ["Contact details not marked as complete"],
+              diversity: ["Diversity information not marked as complete"],
+              degrees: ["Degree details not started"],
+              course_details: ["Course details not started"],
+              training_details: ["Trainee ID not marked as complete"],
+              funding: ["Funding details cannot be started yet"] },
+          )
+        end
       end
     end
 


### PR DESCRIPTION
### Context
Error summary links to the section to be completed
### Changes proposed in this pull request
Amended the error summary links to the section to be completed
### Guidance to review

https://register-pr-3544.test.teacherservices.cloud/view_components/pages/trainees/check_details/view
Create a trainee and do not completely fill it in then attempt to submit it for `Register trainee and request for TRN`

#### Before
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/8e561398-a5c0-4d27-9d10-f914e7b1396f)


#### After
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/874db343-170b-4372-94a4-e1ac51cbd9c0)


### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
