### PR TITLE
Add HESA ID, start year and end year to trainee record

### DIFF
--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -22,8 +22,11 @@ module RecordDetails
         trainee_id_row,
         region,
         trn_row,
+        hesa_id_row,
         last_updated_row,
         record_created_row,
+        start_year_row,
+        end_year_row,
         trainee_start_date_row,
       ].compact
     end
@@ -98,6 +101,35 @@ module RecordDetails
       end
 
       mappable_field(start_date_text, t(".trainee_start_date"), start_date.link)
+    end
+
+    def start_year_row
+      return if trainee.start_date.blank?
+
+      start_year = AcademicCycle.for_date(trainee.start_date).label
+      {
+        field_label: t(".start_year"),
+        field_value: start_year,
+      }
+    end
+
+    def end_year_row
+      return if trainee.estimated_end_date.blank?
+
+      end_year = AcademicCycle.for_date(trainee.estimated_end_date).label
+      {
+        field_label: t(".end_year"),
+        field_value: end_year,
+      }
+    end
+
+    def hesa_id_row
+      return unless trainee.hesa_record?
+
+      {
+        field_label: t(".hesa_id"),
+        field_value: trainee.hesa_id,
+      }
     end
 
     def render_text_with_hint(date)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,9 @@ en:
       itt_has_not_started: ITT has not started
       not_provided: Not provided
       deferred_before_itt_started: Trainee deferred before starting their ITT
+      hesa_id: HESA ID
+      start_year: Start year
+      end_year: End year
   training_details:
     view:
       title: *trainee_id

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -10,10 +10,23 @@ module RecordDetails
     let(:state) { :trn_received }
     let(:training_route) { TRAINING_ROUTE_ENUMS[:assessment_only] }
     let(:provider) { create(:provider) }
-    let(:trainee) { create(:trainee, state, training_route, trn: Faker::Number.number(digits: 10), provider: provider) }
+    let(:trainee) do
+      create(
+        :trainee,
+        state,
+        training_route,
+        trn: Faker::Number.number(digits: 10),
+        provider: provider,
+        hesa_id: hesa_id,
+        study_mode: TRAINEE_STUDY_MODE_ENUMS["part_time"],
+      )
+    end
+    let(:hesa_id) { Faker::Number.number(digits: 10).to_s }
     let(:trainee_status) { "trainee-status" }
     let(:trainee_progress) { "trainee-progress" }
     let(:timeline_event) { double(date: Time.zone.today) }
+    let!(:current_academic_cycle) { create(:academic_cycle) }
+    let!(:next_academic_cycle) { create(:academic_cycle, next_cycle: true) }
 
     context "when :show_provider is true" do
       before do
@@ -79,8 +92,16 @@ module RecordDetails
         expect(rendered_component).to have_text(date_for_summary_view(timeline_event.date))
       end
 
-      it "renders the trainee record created date" do
-        expect(rendered_component).to have_text(date_for_summary_view(trainee.created_at))
+      it "renders the HESA ID" do
+        expect(rendered_component).to have_text(trainee.hesa_id)
+      end
+
+      it "renders the start year" do
+        expect(rendered_component).to have_text(current_academic_cycle.label)
+      end
+
+      it "renders the end year" do
+        expect(rendered_component).to have_text(next_academic_cycle.label)
       end
 
       context "but the trainee has no trn or submitted_for_trn_at" do

--- a/spec/features/form_sections/teacher_training_data/edit_trainee_start_date_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_trainee_start_date_spec.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/current_academic_cycle"
 
 feature "edit Trainee start date" do
   include SummaryHelper
 
-  let(:new_start_date) { Date.parse("14/09/2021") }
+  let(:new_start_date) { Date.new(current_academic_year - 1, 9, 21) }
 
   background do
     given_i_am_authenticated
   end
 
   scenario "updates the start date" do
-    given_a_trainee_exists(:submitted_for_trn, itt_start_date: Date.parse("14/09/2021"))
+    given_a_trainee_exists(:submitted_for_trn, itt_start_date: new_start_date)
     when_i_visit_the_edit_trainee_start_date_page
     when_i_change_the_start_date
     when_i_click_continue

--- a/spec/features/form_sections/teacher_training_data/edit_trainee_start_status_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_trainee_start_status_spec.rb
@@ -6,7 +6,7 @@ feature "edit Trainee start status" do
   include SummaryHelper
   include ActionView::Helpers::SanitizeHelper
 
-  let(:new_start_date) { Date.parse("1/1/2021") }
+  let(:new_start_date) { Date.new(current_academic_year - 1, 1, 1) }
 
   context "for a non-draft trainee" do
     background do
@@ -26,7 +26,11 @@ feature "edit Trainee start status" do
     end
 
     scenario "when the trainee has started later" do
-      given_a_trainee_exists(:submitted_for_trn, :itt_start_date_in_the_past, itt_start_date: Date.parse("30/12/2020"))
+      given_a_trainee_exists(
+        :submitted_for_trn,
+        :itt_start_date_in_the_past,
+        itt_start_date: new_start_date - 2.days,
+      )
       when_i_visit_the_edit_trainee_start_status_page
       when_i_choose_the_trainee_has_started_later
       when_i_change_the_start_date

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,8 +51,11 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :feature) do
+    create(:academic_cycle, one_before_previous_cycle: true)
+    create(:academic_cycle, previous_cycle: true)
     create(:academic_cycle, :current)
     create(:academic_cycle, next_cycle: true)
+    create(:academic_cycle, one_after_next_cycle: true)
   end
 
   Faker::Config.locale = "en-GB"

--- a/spec/views/trainees/show.html.erb_spec.rb
+++ b/spec/views/trainees/show.html.erb_spec.rb
@@ -9,6 +9,8 @@ describe "trainees/show", "feature_routes.provider_led_postgrad": true do
     without_partial_double_verification do
       allow(view).to receive_messages(trainee_editable?: true, display_record_actions?: true)
     end
+    create(:academic_cycle)
+    create(:academic_cycle, next_cycle: true)
   end
 
   context "placements enabled", feature_placements: true do


### PR DESCRIPTION
### Context

We want the trainee record to be a more complete picture of the trainee that has information contained in the export.

### Changes proposed in this pull request

Add HESA ID, start year, end year to trainee view

### Trello

https://trello.com/c/KQAKFQwY/5474-s-add-metadata-fields-to-trainee-record

### Guidance to review

Check review app
