### PR TITLE
Refactor sign off wording

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -2,7 +2,7 @@
 
 class GuidanceController < ApplicationController
   skip_before_action :authenticate
-  helper_method :signing_off_data
+  helper_method :signing_off_period
 
   def show
     render(layout: "application")
@@ -47,15 +47,6 @@ private
 
   def current_academic_cycle
     @current_academic_cycle ||= AcademicCycle.current
-  end
-
-  def signing_off_data
-    @signing_off_data ||= case sign_off_period
-                          when :census_period, :outside_period
-                            "Signing off your list of trainees for the performance profiles publication"
-                          when :performance_period
-                            "Sign off your list of trainees for the performance profiles publication"
-                          end
   end
 
   def valid_tabs

--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -2,7 +2,7 @@
 
 class GuidanceController < ApplicationController
   skip_before_action :authenticate
-  helper_method :signing_off_period
+  helper_method :sign_off_period
 
   def show
     render(layout: "application")

--- a/app/views/guidance/show.html.erb
+++ b/app/views/guidance/show.html.erb
@@ -60,21 +60,21 @@
       </li>
     </ul>
 
-    <% census_sign_off = sign_off_period == :census_period ? "Sign" : "Signing" %>
-    <% performance_sign_off = sign_off_period == :performance_period ? "Sign" : "Signing" %>
+    <% @census_sign_off = sign_off_period == :census_period ? "Sign" : "Signing" %>
+    <% @performance_sign_off = sign_off_period == :performance_period ? "Sign" : "Signing" %>
 
     <h2 class="govuk-heading-m">Signing off data</h2>
 
     <ul class="govuk-list govuk-list--spaced">
       <li>
         <%= govuk_link_to(
-              "#{census_sign_off} off your list of trainees for the initial teacher training census",
+              "#{@census_sign_off} off your list of trainees for the initial teacher training census",
               census_sign_off_guidance_path,
               ) %>
       </li>
       <li>
         <%= govuk_link_to(
-              "#{performance_sign_off} off your list of trainees for the performance profiles publication",
+              "#{@performance_sign_off} off your list of trainees for the performance profiles publication",
               performance_profiles_guidance_path,
             ) %>
       </li>

--- a/app/views/guidance/show.html.erb
+++ b/app/views/guidance/show.html.erb
@@ -60,17 +60,21 @@
       </li>
     </ul>
 
+    <% census_sign_off = sign_off_period == :census_period ? "Sign" : "Signing" %>
+    <% performance_sign_off = sign_off_period == :performance_period ? "Sign" : "Signing" %>
+
     <h2 class="govuk-heading-m">Signing off data</h2>
+
     <ul class="govuk-list govuk-list--spaced">
       <li>
         <%= govuk_link_to(
-              "Signing off your list of trainees for the initial teacher training census",
+              "#{census_sign_off} off your list of trainees for the initial teacher training census",
               census_sign_off_guidance_path,
               ) %>
       </li>
       <li>
         <%= govuk_link_to(
-              "Signing off your list of trainees for the performance profiles publication",
+              "#{performance_sign_off} off your list of trainees for the performance profiles publication",
               performance_profiles_guidance_path,
             ) %>
       </li>


### PR DESCRIPTION
### Context

The wording for the sign-off link(s) was made dynamic in #3496 and static in #3535 this reverts it back to being dynamic base the period determined in `app/services/determine_sign_off_period.rb`