### PR TITLE
[5567] Make dttpid field optional in add provider UI

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -32,7 +32,7 @@ class Provider < ApplicationRecord
   has_many :recommendations_upload_rows, class_name: "BulkUpdate::RecommendationsUploadRow", through: :recommendations_uploads
 
   validates :name, presence: true
-  validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }
+  validates :dttp_id, uniqueness: true, format: { with: /\A[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}\z/i }, allow_blank: true
   validates :code, format: { with: /\A[A-Z0-9]+\z/i }, allow_blank: true
   validates :ukprn, format: { with: /\A[0-9]{8}\z/ }
   validates :accreditation_id, presence: true, uniqueness: true

--- a/app/views/system_admin/providers/edit.html.erb
+++ b/app/views/system_admin/providers/edit.html.erb
@@ -11,9 +11,9 @@
       </h1>
 
       <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20, autocomplete: :off %>
-      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID (optional)", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :ukprn, label: { text: "UKPRN", size: "s" }, width: 20, autocomplete: :off %>
-      <%= f.govuk_text_field :code, label: { text: "Provider code", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :code, label: { text: "Provider code (optional)", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :accreditation_id, label: { text: "Provider accreditation ID", size: "s" }, width: 20, autocomplete: :off %>
       <div class="govuk-form-group">
         <%= f.govuk_check_box :apply_sync_enabled, true, multiple: false, label: { text: "Import application data from Apply?", size: "s" } %>

--- a/app/views/system_admin/providers/new.html.erb
+++ b/app/views/system_admin/providers/new.html.erb
@@ -11,9 +11,9 @@
       </h1>
 
       <%= f.govuk_text_field :name, label: { text: "Provider name", size: "s" }, width: 20, autocomplete: :off %>
-      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :dttp_id, label: { text: "DTTP ID (optional)", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :ukprn, label: { text: "UKPRN", size: "s" }, width: 20, autocomplete: :off %>
-      <%= f.govuk_text_field :code, label: { text: "Provider code", size: "s" }, width: 20, autocomplete: :off %>
+      <%= f.govuk_text_field :code, label: { text: "Provider code (optional)", size: "s" }, width: 20, autocomplete: :off %>
       <%= f.govuk_text_field :accreditation_id, label: { text: "Provider accreditation ID", size: "s" }, width: 20, autocomplete: :off %>
       <div class="govuk-form-group">
         <%= f.govuk_check_box :apply_sync_enabled, true, multiple: false, label: { text: "Import application data from Apply?", size: "s" } %>

--- a/spec/factories/dttp/trainees.rb
+++ b/spec/factories/dttp/trainees.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     end
 
     trait :with_provider do
-      provider
+      provider factory: %i[provider with_dttp_id]
     end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
         create_list(:course, evaluator.courses_count, code: evaluator.course_code, accredited_body_code: provider.code)
       end
     end
+
+    trait :with_dttp_id do
+      dttp_id { SecureRandom.uuid }
+    end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     sequence :name do |n|
       "Provider #{n}"
     end
-    dttp_id { SecureRandom.uuid }
     code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     ukprn { Faker::Number.number(digits: 8) }
     sequence(:accreditation_id, "1111")

--- a/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
+++ b/spec/features/system_admin/providers/creating_a_new_provider_spec.rb
@@ -88,9 +88,6 @@ private
       I18n.t("#{translation_key_prefix}.name.blank"),
     )
     expect(new_provider_page).to have_text(
-      I18n.t("#{translation_key_prefix}.dttp_id.invalid"),
-    )
-    expect(new_provider_page).to have_text(
       I18n.t("#{translation_key_prefix}.ukprn.invalid"),
     )
     expect(new_provider_page).to have_text(

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -6,16 +6,13 @@ describe Provider do
   context "fields" do
     it "validates presence" do
       expect(subject).to validate_presence_of(:name).with_message("Enter a provider name")
-      expect(subject).to validate_presence_of(:dttp_id).with_message("Enter a DTTP ID in the correct format, like b77c821a-c12a-4133-8036-6ef1db146f9e")
       expect(subject).to validate_presence_of(:ukprn).with_message("Enter a UKPRN in the correct format, like 12345678")
     end
 
     it "validates format" do
-      subject.dttp_id = "XXX"
       subject.code = "abcd 1234"
       subject.ukprn = "3333"
       subject.valid?
-      expect(subject.errors[:dttp_id]).to include("Enter a DTTP ID in the correct format, like b77c821a-c12a-4133-8036-6ef1db146f9e")
       expect(subject.errors[:code]).to include("Enter a provider code in the correct format, like 12Y")
       expect(subject.errors[:ukprn]).to include("Enter a UKPRN in the correct format, like 12345678")
     end

--- a/spec/services/trainees/create_from_dttp_spec.rb
+++ b/spec/services/trainees/create_from_dttp_spec.rb
@@ -7,7 +7,7 @@ module Trainees
     include SeedHelper
 
     let(:api_trainee) { create(:api_trainee) }
-    let(:provider) { create(:provider) }
+    let(:provider) { create(:provider, :with_dttp_id) }
     let(:api_placement_assignment) { create(:api_placement_assignment) }
     let(:placement_assignment) { create(:dttp_placement_assignment, provider_dttp_id: provider.dttp_id, response: api_placement_assignment) }
     let(:dttp_trainee) { create(:dttp_trainee, placement_assignments: [placement_assignment], api_trainee_hash: api_trainee, provider: provider) }


### PR DESCRIPTION
### Context
DTTP ID

### Changes proposed in this pull request
Amended provider dttp id to be optional
Amended form to state optional

### Guidance to review

For support agent both the add & edit provider page

Te fields that is optional is now called out.
ie
From `DTTP ID` to `DTTP ID (optional)`
From `Provider code` to `Provider code (optional)`

#### Before
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/d4266efd-3d79-451c-b4c6-abb5ab6f0ac1)

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/8b2e548b-02ac-49c2-9b44-fc033ed1787f)

#### After
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/e4fcb69d-35ad-421d-a07b-0674d41d9449)

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/bba21999-9b63-4813-a051-b31a0b7846a7)


### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
