### PR TITLE
Throttle DQT Sidekiq job retries

### DIFF
--- a/app/jobs/dqt/base_job.rb
+++ b/app/jobs/dqt/base_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Dqt
+  class BaseJob < ApplicationJob
+    sidekiq_options retry: 10
+  end
+end

--- a/app/jobs/dqt/recommend_for_award_job.rb
+++ b/app/jobs/dqt/recommend_for_award_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class RecommendForAwardJob < ApplicationJob
+  class RecommendForAwardJob < Dqt::BaseJob
     queue_as :dqt
     retry_on Client::HttpError
 

--- a/app/jobs/dqt/register_for_trn_job.rb
+++ b/app/jobs/dqt/register_for_trn_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class RegisterForTrnJob < ApplicationJob
+  class RegisterForTrnJob < Dqt::BaseJob
     sidekiq_options retry: 0
     queue_as :dqt
 

--- a/app/jobs/dqt/retrieve_trn_job.rb
+++ b/app/jobs/dqt/retrieve_trn_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class RetrieveTrnJob < ApplicationJob
+  class RetrieveTrnJob < Dqt::BaseJob
     queue_as :dqt
     retry_on Client::HttpError
     include NotifyOnTimeout

--- a/app/jobs/dqt/sync_states_batch_job.rb
+++ b/app/jobs/dqt/sync_states_batch_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class SyncStatesBatchJob < ApplicationJob
+  class SyncStatesBatchJob < Dqt::BaseJob
     queue_as :dqt_sync
     retry_on Client::HttpError
 

--- a/app/jobs/dqt/sync_states_job.rb
+++ b/app/jobs/dqt/sync_states_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class SyncStatesJob < ApplicationJob
+  class SyncStatesJob < Dqt::BaseJob
     queue_as :dqt_sync
     retry_on Client::HttpError
 

--- a/app/jobs/dqt/sync_teacher_job.rb
+++ b/app/jobs/dqt/sync_teacher_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class SyncTeacherJob < ApplicationJob
+  class SyncTeacherJob < Dqt::BaseJob
     queue_as :dqt_sync
 
     def perform(trainee)

--- a/app/jobs/dqt/sync_teachers_batch_job.rb
+++ b/app/jobs/dqt/sync_teachers_batch_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class SyncTeachersBatchJob < ApplicationJob
+  class SyncTeachersBatchJob < Dqt::BaseJob
     queue_as :dqt_sync
 
     def perform(trainee_ids)

--- a/app/jobs/dqt/sync_teachers_job.rb
+++ b/app/jobs/dqt/sync_teachers_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class SyncTeachersJob < ApplicationJob
+  class SyncTeachersJob < Dqt::BaseJob
     queue_as :dqt_sync
 
     def perform(batch_size = 500, interval = 30.seconds)

--- a/app/jobs/dqt/sync_trainee_state_job.rb
+++ b/app/jobs/dqt/sync_trainee_state_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class SyncTraineeStateJob < ApplicationJob
+  class SyncTraineeStateJob < Dqt::BaseJob
     queue_as :dqt_sync
     sidekiq_options retry: 5
 

--- a/app/jobs/dqt/sync_trainee_trn_job.rb
+++ b/app/jobs/dqt/sync_trainee_trn_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class SyncTraineeTrnJob < ApplicationJob
+  class SyncTraineeTrnJob < Dqt::BaseJob
     queue_as :dqt_sync
     retry_on Client::HttpError
 

--- a/app/jobs/dqt/update_trainee_job.rb
+++ b/app/jobs/dqt/update_trainee_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class UpdateTraineeJob < ApplicationJob
+  class UpdateTraineeJob < Dqt::BaseJob
     sidekiq_options retry: 0
     queue_as :dqt
 

--- a/app/jobs/dqt/withdraw_trainee_job.rb
+++ b/app/jobs/dqt/withdraw_trainee_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Dqt
-  class WithdrawTraineeJob < ApplicationJob
+  class WithdrawTraineeJob < Dqt::BaseJob
     include NotifyOnTimeout
 
     sidekiq_options retry: 0


### PR DESCRIPTION
### Context
There are a number of trainees that are stuck in the `recommended_for_award` status. Normally this status is short-lived and the trainee transitions to `awarded` as soon as a successful call to DQT is made to obtain an award date. However things sometimes go wrong and after repeated attempts the job ends up in the dead queue at which point it becomes visible in the sys admin interface.

At the moment the job that controls the `recommended_for_award` to `awarded` transition will retry 25 times (over 3 weeks). A much shorter time to failure is needed because we don't flag jobs as problematic until they hit the dead queue.

### Changes proposed in this pull request
This PR adds a base class that declares a default of 10 retries (about 4 hours elapsed time). This should mean that problematic DQT jobs appear in the system admin interface within hours rather than weeks.

### Guidance to review
Does this seem like a reasonable solution?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
