### PR TITLE
[5830] - clear degrees when importing from CSV

### DIFF
--- a/app/services/degrees/create_from_csv_row.rb
+++ b/app/services/degrees/create_from_csv_row.rb
@@ -14,7 +14,10 @@ module Degrees
     end
 
     def call
-      trainee.degrees.create!(mapped_degree_attributes)
+      trainee.transaction do
+        trainee.degrees.destroy_all
+        trainee.degrees.create!(mapped_degree_attributes)
+      end
     end
 
   private

--- a/app/services/trainees/create_from_csv_row.rb
+++ b/app/services/trainees/create_from_csv_row.rb
@@ -66,9 +66,9 @@ module Trainees
         record_source: RecordSources::MANUAL,
         region: csv_row["Region"],
         training_route: training_route,
-        first_names: csv_row["First names"],
-        middle_names: csv_row["Middle names"],
-        last_name: csv_row["Last names"],
+        first_names: first_names,
+        middle_names: middle_names,
+        last_name: last_name,
         sex: sex,
         date_of_birth: Date.parse(csv_row["Date of birth"]),
         nationality_ids: nationality_ids,
@@ -90,6 +90,18 @@ module Trainees
 
       disabilities = csv_row["Disabilities"].split(",").map(&:strip)
       disabilities.map { |disability| ::Hesa::CodeSets::Disabilities::NAME_MAPPING[disability] }.compact
+    end
+
+    def first_names
+      csv_row["First names"].presence || csv_row["First name"]
+    end
+
+    def middle_names
+      csv_row["Middle names"].presence || csv_row["Middle name"]
+    end
+
+    def last_name
+      csv_row["Last names"].presence || csv_row["Last name"]
     end
 
     def itt_start_date


### PR DESCRIPTION
### Context

when we import from HESA and update a trainee, we clear their degrees before re-creating them:

```ruby
# app/services/degrees/create_from_hesa.rb

def create_degrees!
  trainee.transaction do
    trainee.degrees.destroy_all
    hesa_degrees.each do |hesa_degree|
      next unless importable?(hesa_degree)

      subject = DfEReference::DegreesQuery.find_subject(hecos_code: hesa_degree[:subject_one])
      degree = trainee.degrees.new(
        subject: subject&.name,
        subject_uuid: subject&.id,
        graduation_year: hesa_degree[:graduation_date]&.to_date&.year,
      )

      set_country_specific_attributes(degree, hesa_degree)
      set_grade_attributes(degree, hesa_degree)

      degree.save!
    end
  end
end
```

This isn't the case in the `app/services/degrees/create_from_csv_row.rb`.

### Changes proposed in this pull request

This matches the behaviour in the HESA import service to get the goldsmiths trainee data in (which will have been imported from HESA originally)
