### PR TITLE
[5962] Extend census period + manual period override

### DIFF
--- a/app/services/determine_sign_off_period.rb
+++ b/app/services/determine_sign_off_period.rb
@@ -4,13 +4,7 @@ class DetermineSignOffPeriod
   VALID_PERIODS = %i[census_period performance_period outside_period].freeze
 
   def self.call
-    if Settings.sign_off_period.present?
-      if VALID_PERIODS.include?(Settings.sign_off_period.to_sym)
-        return Settings.sign_off_period.to_sym
-      else
-        Sentry.capture_exception(StandardError.new("Invalid sign_off_period value: #{Settings.sign_off_period}"))
-      end
-    end
+    return Settings.sign_off_period.to_sym if valid_sign_off_period?
 
     current_date = Time.zone.today
 
@@ -18,6 +12,14 @@ class DetermineSignOffPeriod
     return :performance_period if performance_range.cover?(current_date)
 
     :outside_period
+  end
+
+  def self.valid_sign_off_period?
+    return false if Settings.sign_off_period.blank?
+    return true if VALID_PERIODS.include?(Settings.sign_off_period.to_sym)
+
+    Sentry.capture_exception(StandardError.new("Invalid sign_off_period value: #{Settings.sign_off_period}"))
+    false
   end
 
   def self.census_range

--- a/app/services/determine_sign_off_period.rb
+++ b/app/services/determine_sign_off_period.rb
@@ -1,15 +1,36 @@
 # frozen_string_literal: true
 
 class DetermineSignOffPeriod
-  CENSUS_MONTHS = [9, 10].freeze # September, October
-  PERFORMANCE_MONTH = 1 # January
+  VALID_PERIODS = %i[census_period performance_period outside_period].freeze
 
   def self.call
-    current_month = Time.zone.today.month
+    if Settings.sign_off_period.present?
+      if VALID_PERIODS.include?(Settings.sign_off_period.to_sym)
+        return Settings.sign_off_period.to_sym
+      else
+        Sentry.capture_exception(StandardError.new("Invalid sign_off_period value: #{Settings.sign_off_period}"))
+      end
+    end
 
-    return :census_period if CENSUS_MONTHS.include?(current_month)
-    return :performance_period if current_month == PERFORMANCE_MONTH
+    current_date = Time.zone.today
+
+    return :census_period if census_range.cover?(current_date)
+    return :performance_period if performance_range.cover?(current_date)
 
     :outside_period
+  end
+
+  def self.census_range
+    start_date = Date.new(Time.zone.today.year, 9, 1) # 1st September
+    end_date = Date.new(Time.zone.today.year, 11, 7) # 7th November
+
+    start_date..end_date
+  end
+
+  def self.performance_range
+    start_date = Date.new(Time.zone.today.year, 1, 1) # 1st January
+    end_date = Date.new(Time.zone.today.year, 1, 31) # 31st January
+
+    start_date..end_date
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -157,6 +157,7 @@ google:
 
 sign_off_trainee_data_url: https://forms.office.com/e/kzBmEWKDGz
 sign_off_performance_profiles_url: https://forms.gle/AtAvteRTKJu3mbXS7
+sign_off_period: # census_period, performance_period, outside_period. See app/services/determine_sign_off_period.rb
 
 trainee_export:
   record_limit: 100

--- a/spec/services/determine_sign_off_period_spec.rb
+++ b/spec/services/determine_sign_off_period_spec.rb
@@ -6,19 +6,41 @@ describe DetermineSignOffPeriod do
   describe ".call" do
     subject { described_class.call }
 
-    context "during the census sign off period" do
+    let(:current_year) { Time.zone.today.year }
+    let(:census_period_range) { Date.new(current_year, 9, 1)..Date.new(current_year, 11, 7) }
+    let(:performance_period_range) { Date.new(current_year, 1, 1)..Date.new(current_year, 1, 31) }
+
+    context "with a valid manual override" do
       before do
-        allow(Time).to receive_message_chain(:zone, :today, :month).and_return([9, 10].sample) # September, October
+        allow(Settings).to receive(:sign_off_period).and_return(:census_period)
       end
 
-      it "returns :census_period" do
+      it "returns the manual override value" do
+        expect(subject).to eq(:census_period)
+      end
+    end
+
+    context "with an invalid manual override" do
+      before do
+        allow(Settings).to receive(:sign_off_period).and_return(:invalid_period)
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it "captures the error in Sentry" do
+        subject
+        expect(Sentry).to have_received(:capture_exception).with(instance_of(StandardError))
+      end
+
+      it "defaults back to the calculated behaviour" do
+        allow(Time.zone).to receive(:today).and_return(census_period_range.to_a.sample)
         expect(subject).to eq(:census_period)
       end
     end
 
     context "during the performance profiles sign off period" do
       before do
-        allow(Time).to receive_message_chain(:zone, :today, :month).and_return(1) # January
+        random_performance_date = performance_period_range.to_a.sample
+        allow(Time.zone).to receive(:today).and_return(random_performance_date)
       end
 
       it "returns :performance_period" do
@@ -28,7 +50,9 @@ describe DetermineSignOffPeriod do
 
     context "outside of sign off periods" do
       before do
-        allow(Time).to receive_message_chain(:zone, :today, :month).and_return([2, 3, 4, 5, 6, 7, 8, 11, 12].sample) # not Jan or Oct
+        all_dates = [*Date.new(current_year, 1, 1)..Date.new(current_year, 12, 31)]
+        outside_dates = all_dates - census_period_range.to_a - performance_period_range.to_a
+        allow(Time.zone).to receive(:today).and_return(outside_dates.sample)
       end
 
       it "returns :outside_period" do


### PR DESCRIPTION
### Context

_As we iron out final preparations for the ITT census sign-off period, we realise that it would be helpful to keep the report page showing the ITT census related material for a little longer than originally specified [in this ticket](https://trello.com/c/ERWgb7NB/5787-switch-between-alternative-versions-of-reports-and-guidance-for-census-and-performance-profiles-outside-sign-off-periods) Change ITT census period end date from 31st October to 7th November. This gives providers a 7 calendar day grace period to get their data signed off._

### Changes proposed in this pull request

* This refactors the `app/services/determine_sign_off_period.rb` to use more specific dates
* this also adds in a manual override for the sign off period which is [requested in this ticket](https://trello.com/c/QbGosKFz/5988-check-with-sarah-two-versions-of-guidance)
