### PR TITLE
[5957] Let users view and download historic funding information

### DIFF
--- a/app/controllers/funding/base_funding_controller.rb
+++ b/app/controllers/funding/base_funding_controller.rb
@@ -2,6 +2,8 @@
 
 module Funding
   class BaseFundingController < ApplicationController
+    helper_method :back_path
+
     def selected_academic_cycle
       @selected_academic_cycle ||=
         academic_year.blank? ? AcademicCycle.current : AcademicCycle.for_year(academic_year)
@@ -33,6 +35,10 @@ module Funding
 
     def academic_year
       params[:academic_year]
+    end
+
+    def back_path
+      funding_path
     end
   end
 end

--- a/app/controllers/funding/base_funding_controller.rb
+++ b/app/controllers/funding/base_funding_controller.rb
@@ -2,18 +2,19 @@
 
 module Funding
   class BaseFundingController < ApplicationController
-    def current_academic_cycle
-      @current_academic_cycle ||= AcademicCycle.current
+    def selected_academic_cycle
+      @selected_academic_cycle ||=
+        academic_year.blank? ? AcademicCycle.current : AcademicCycle.for_year(academic_year)
     end
 
     def academic_year_string
-      @academic_year_string ||= "#{current_academic_cycle.start_date.year}/#{current_academic_cycle.end_date.year % 100}"
+      @academic_year_string ||= "#{selected_academic_cycle.start_date.year}/#{selected_academic_cycle.end_date.year % 100}"
     end
 
     def payment_schedule
       return if payment_schedules.blank?
 
-      @payment_schedule ||= payment_schedules.order(:created_at).includes(rows: :amounts).select { |schedule| schedule.start_year == current_academic_cycle.start_year }.last
+      @payment_schedule ||= payment_schedules.order(:created_at).includes(rows: :amounts).select { |schedule| schedule.start_year == selected_academic_cycle.start_year }.last
     end
 
     def payment_schedules
@@ -28,6 +29,10 @@ module Funding
 
     def trainee_summaries
       organisation.funding_trainee_summaries.includes(:payable, rows: %i[amounts trainee_summary]).where(academic_year: academic_year_string)
+    end
+
+    def academic_year
+      params[:academic_year]
     end
   end
 end

--- a/app/controllers/funding/payment_schedules_controller.rb
+++ b/app/controllers/funding/payment_schedules_controller.rb
@@ -2,7 +2,7 @@
 
 module Funding
   class PaymentSchedulesController < BaseFundingController
-    before_action :redirect, only: [:show]
+    before_action :redirect_to_schedule_path, unless: -> { academic_year.present? }, only: [:show]
 
     def show
       respond_to do |format|
@@ -24,9 +24,7 @@ module Funding
 
   private
 
-    def redirect
-      return if academic_year.present?
-
+    def redirect_to_schedule_path
       redirect_to(funding_payment_schedule_path(selected_academic_cycle.start_year))
     end
 

--- a/app/controllers/funding/payment_schedules_controller.rb
+++ b/app/controllers/funding/payment_schedules_controller.rb
@@ -2,13 +2,15 @@
 
 module Funding
   class PaymentSchedulesController < BaseFundingController
+    before_action :redirect, only: [:show]
+
     def show
       respond_to do |format|
         format.html do
           @payment_schedule_view = PaymentScheduleView.new(payment_schedule:)
           @navigation_view = NavigationView.new(organisation:)
-          @start_year = current_academic_cycle.start_year
-          @end_year = current_academic_cycle.end_year
+          @start_year = selected_academic_cycle.start_year
+          @end_year = selected_academic_cycle.end_year
         end
         format.csv do
           send_data(
@@ -21,6 +23,12 @@ module Funding
     end
 
   private
+
+    def redirect
+      return if academic_year.present?
+
+      redirect_to(funding_payment_schedule_path(selected_academic_cycle.start_year))
+    end
 
     def data_export
       @data_export ||= Exports::FundingScheduleData.new(payment_schedule:)

--- a/app/controllers/funding_controller.rb
+++ b/app/controllers/funding_controller.rb
@@ -13,7 +13,9 @@ private
   end
 
   def trainee_summary_academic_years
-    years = current_user.organisation.funding_trainee_summaries.pluck(:academic_year)
+    years = organisation&.funding_trainee_summaries&.pluck(:academic_year)
+    return {} if years.blank?
+
     years.each_with_object({}) do |year, hash|
       year_int = year.split("/").first.to_i
       hash["#{year_int} to #{year_int + 1}"] = funding_trainee_summary_path(year_int)
@@ -21,9 +23,18 @@ private
   end
 
   def payment_schedule_academic_years
-    years = current_user.organisation.funding_payment_schedules.joins(rows: :amounts).pluck(Arel.sql("DISTINCT funding_payment_schedule_row_amounts.year"))
+    years = organisation&.funding_payment_schedules&.joins(rows: :amounts)&.pluck(Arel.sql("DISTINCT funding_payment_schedule_row_amounts.year"))
+    return {} if years.blank?
+
     years.each_with_object({}) do |year, hash|
       hash["#{year} to #{year + 1}"] = funding_payment_schedule_path(year)
     end
+  end
+
+  def organisation
+    return Provider.find(params[:provider_id]) if params[:provider_id].present?
+    return School.find(params[:lead_school_id]) if params[:lead_school_id].present?
+
+    current_user.organisation
   end
 end

--- a/app/controllers/funding_controller.rb
+++ b/app/controllers/funding_controller.rb
@@ -1,20 +1,33 @@
 # frozen_string_literal: true
 
 class FundingController < ApplicationController
-  helper_method :academic_years
+  helper_method :trainee_summary_academic_years, :payment_schedule_academic_years
 
   def show; end
 
 private
 
-  def academic_years
+  def trainee_summary_academic_years
     current_user.organisation.funding_trainee_summaries.pluck(:academic_year).map do |year|
       year = year.split("/").first.to_i
 
       {
         label: "#{year} to #{year + 1}",
-        url: funding_trainee_schedule_url(year),
+        url: funding_trainee_summary_path(year),
       }
     end
+  end
+
+  def payment_schedule_academic_years
+    current_user
+      .organisation
+      .funding_payment_schedules
+      .joins(rows: :amounts)
+      .pluck(Arel.sql("DISTINCT funding_payment_schedule_row_amounts.year")).map do |year|
+        {
+          label: "#{year} to #{year + 1}",
+          url: funding_payment_schedule_path(year),
+        }
+      end
   end
 end

--- a/app/controllers/funding_controller.rb
+++ b/app/controllers/funding_controller.rb
@@ -32,9 +32,6 @@ private
   end
 
   def organisation
-    return Provider.find(params[:provider_id]) if params[:provider_id].present?
-    return School.find(params[:lead_school_id]) if params[:lead_school_id].present?
-
     current_user.organisation
   end
 end

--- a/app/controllers/funding_controller.rb
+++ b/app/controllers/funding_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FundingController < ApplicationController
+  helper_method :academic_years
+
+  def show; end
+
+private
+
+  def academic_years
+    current_user.organisation.funding_trainee_summaries.pluck(:academic_year).map do |year|
+      year = year.split("/").first.to_i
+
+      {
+        label: "#{year} to #{year + 1}",
+        url: funding_trainee_schedule_url(year),
+      }
+    end
+  end
+end

--- a/app/controllers/system_admin/funding/payment_schedules_controller.rb
+++ b/app/controllers/system_admin/funding/payment_schedules_controller.rb
@@ -3,6 +3,10 @@
 module SystemAdmin
   module Funding
     class PaymentSchedulesController < ::Funding::BaseFundingController
+      before_action :redirect_to_schedule_path, unless: -> { academic_year.present? }, only: [:show]
+
+      helper_method :back_path
+
       def show
         respond_to do |format|
           format.html do
@@ -22,12 +26,30 @@ module SystemAdmin
 
     private
 
+      def redirect_to_schedule_path
+        case organisation
+        when Provider
+          redirect_to(provider_funding_payment_schedule_path(provider_id: organisation.id, academic_year: selected_academic_cycle.start_year))
+        when School
+          redirect_to(lead_school_funding_payment_schedule_path(lead_school_id: organisation.id, academic_year: selected_academic_cycle.start_year))
+        end
+      end
+
       def organisation
         @organisation ||= params[:provider_id].present? ? Provider.find(params[:provider_id]) : School.find(params[:lead_school_id])
       end
 
       def data_export
         @data_export ||= Exports::FundingScheduleData.new(payment_schedule:)
+      end
+
+      def back_path
+        case organisation
+        when Provider
+          provider_funding_path
+        when School
+          lead_school_funding_path
+        end
       end
     end
   end

--- a/app/controllers/system_admin/funding/payment_schedules_controller.rb
+++ b/app/controllers/system_admin/funding/payment_schedules_controller.rb
@@ -9,8 +9,8 @@ module SystemAdmin
             @payment_schedule_view = ::Funding::PaymentScheduleView.new(payment_schedule:)
             @navigation_view = ::Funding::NavigationView.new(organisation: organisation, system_admin: true)
 
-            @start_year = current_academic_cycle.start_year
-            @end_year = current_academic_cycle.end_year
+            @start_year = selected_academic_cycle.start_year
+            @end_year = selected_academic_cycle.end_year
 
             render("funding/payment_schedules/show")
           end

--- a/app/controllers/system_admin/funding/trainee_summaries_controller.rb
+++ b/app/controllers/system_admin/funding/trainee_summaries_controller.rb
@@ -9,8 +9,8 @@ module SystemAdmin
             @trainee_summary_view = ::Funding::TraineeSummaryView.new(trainee_summary:)
             @navigation_view = ::Funding::NavigationView.new(organisation: organisation, system_admin: true)
 
-            @start_year = current_academic_cycle.start_year
-            @end_year = current_academic_cycle.end_year
+            @start_year = selected_academic_cycle.start_year
+            @end_year = selected_academic_cycle.end_year
 
             render("funding/trainee_summaries/show")
           end

--- a/app/controllers/system_admin/funding/trainee_summaries_controller.rb
+++ b/app/controllers/system_admin/funding/trainee_summaries_controller.rb
@@ -3,6 +3,10 @@
 module SystemAdmin
   module Funding
     class TraineeSummariesController < ::Funding::BaseFundingController
+      before_action :redirect_to_lead_school_path, unless: -> { academic_year.present? }, only: [:show]
+
+      helper_method :back_path
+
       def show
         respond_to do |format|
           format.html do
@@ -22,12 +26,30 @@ module SystemAdmin
 
     private
 
+      def redirect_to_lead_school_path
+        case organisation
+        when Provider
+          redirect_to(provider_funding_trainee_summary_path(provider_id: organisation.id, academic_year: selected_academic_cycle.start_year))
+        when School
+          redirect_to(lead_school_funding_trainee_summary_path(lead_school_id: organisation.id, academic_year: selected_academic_cycle.start_year))
+        end
+      end
+
       def organisation
         @organisation ||= params[:provider_id].present? ? Provider.find(params[:provider_id]) : School.find(params[:lead_school_id])
       end
 
       def data_export
         @data_export ||= Exports::FundingTraineeSummaryData.new(trainee_summary, organisation.name)
+      end
+
+      def back_path
+        case organisation
+        when Provider
+          provider_funding_path
+        when School
+          lead_school_funding_path
+        end
       end
     end
   end

--- a/app/controllers/system_admin/funding_controller.rb
+++ b/app/controllers/system_admin/funding_controller.rb
@@ -46,7 +46,7 @@ module SystemAdmin
     def organisation
       return Provider.find(params[:provider_id]) if params[:provider_id].present?
 
-      School.find(params[:lead_school_id]) if params[:lead_school_id].present?
+      School.find(params[:lead_school_id])
     end
   end
 end

--- a/app/controllers/system_admin/funding_controller.rb
+++ b/app/controllers/system_admin/funding_controller.rb
@@ -20,8 +20,8 @@ module SystemAdmin
       return {} if years.blank?
 
       years.each_with_object({}) do |year, hash|
-        year_int = year.split("/").first.to_i
-        hash["#{year_int} to #{year_int + 1}"] = funding_path(year_int, "trainee_summary")
+        year = year.split("/").first.to_i
+        hash["#{year} to #{year + 1}"] = funding_path(year, "trainee_summary")
       end
     end
 

--- a/app/controllers/system_admin/funding_controller.rb
+++ b/app/controllers/system_admin/funding_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class FundingController < ApplicationController
+    helper_method :academic_years
+
+    def show
+      render("funding/show")
+    end
+
+  private
+
+    def academic_years
+      combined = trainee_summary_academic_years.merge(payment_schedule_academic_years)
+      combined.sort_by { |label, _| label }.reverse.to_h
+    end
+
+    def trainee_summary_academic_years
+      years = organisation.funding_trainee_summaries.pluck(:academic_year)
+      return {} if years.blank?
+
+      years.each_with_object({}) do |year, hash|
+        year_int = year.split("/").first.to_i
+        hash["#{year_int} to #{year_int + 1}"] = funding_path(year_int, "trainee_summary")
+      end
+    end
+
+    def payment_schedule_academic_years
+      years = organisation.funding_payment_schedules.joins(rows: :amounts)&.pluck(Arel.sql("DISTINCT funding_payment_schedule_row_amounts.year"))
+      return {} if years.blank?
+
+      years.each_with_object({}) do |year, hash|
+        hash["#{year} to #{year + 1}"] = funding_path(year, "payment_schedule")
+      end
+    end
+
+    def funding_path(year, funding_type)
+      case organisation
+      when Provider
+        send("provider_funding_#{funding_type}_path", provider_id: organisation.id, academic_year: year)
+      when School
+        send("lead_school_funding_#{funding_type}_path", lead_school_id: organisation.id, academic_year: year)
+      end
+    end
+
+    def organisation
+      return Provider.find(params[:provider_id]) if params[:provider_id].present?
+
+      School.find(params[:lead_school_id]) if params[:lead_school_id].present?
+    end
+  end
+end

--- a/app/view_objects/funding/navigation_view.rb
+++ b/app/view_objects/funding/navigation_view.rb
@@ -13,8 +13,8 @@ module Funding
       @organisation&.name
     end
 
-    def path_for_funding_payment_schedule
-      return funding_payment_schedule_path if !system_admin
+    def path_for_funding_payment_schedule(year)
+      return funding_payment_schedule_path(year) if !system_admin
 
       if organisation.is_a?(Provider)
         provider_funding_payment_schedule_path(organisation)
@@ -23,8 +23,8 @@ module Funding
       end
     end
 
-    def path_for_funding_trainee_summary
-      return funding_trainee_summary_path if !system_admin
+    def path_for_funding_trainee_summary(year)
+      return funding_trainee_summary_path(year) if !system_admin
 
       if organisation.is_a?(Provider)
         provider_funding_trainee_summary_path(organisation)

--- a/app/view_objects/funding/navigation_view.rb
+++ b/app/view_objects/funding/navigation_view.rb
@@ -14,22 +14,22 @@ module Funding
     end
 
     def path_for_funding_payment_schedule(year)
-      return funding_payment_schedule_path(year) if !system_admin
+      return funding_payment_schedule_path(year) unless system_admin
 
       if organisation.is_a?(Provider)
-        provider_funding_payment_schedule_path(organisation)
+        provider_funding_payment_schedule_path(provider_id: organisation.id, academic_year: year)
       else
-        lead_school_funding_payment_schedule_path(organisation)
+        lead_school_funding_payment_schedule_path(lead_school_id: organisation.id, academic_year: year)
       end
     end
 
     def path_for_funding_trainee_summary(year)
-      return funding_trainee_summary_path(year) if !system_admin
+      return funding_trainee_summary_path(year) unless system_admin
 
       if organisation.is_a?(Provider)
-        provider_funding_trainee_summary_path(organisation)
+        provider_funding_trainee_summary_path(provider_id: organisation.id, academic_year: year)
       else
-        lead_school_funding_trainee_summary_path(organisation)
+        lead_school_funding_trainee_summary_path(lead_school_id: organisation.id, academic_year: year)
       end
     end
 

--- a/app/views/funding/_navigation.html.erb
+++ b/app/views/funding/_navigation.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: "All funding years", href: funding_path) %>
+  <%= render GovukComponent::BackLinkComponent.new(text: "All funding years", href: back_path) %>
 <% end %>
 
 <% if @navigation_view.organisation_name %>

--- a/app/views/funding/_navigation.html.erb
+++ b/app/views/funding/_navigation.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
+  <%= render GovukComponent::BackLinkComponent.new(text: "All funding years", href: funding_path) %>
 <% end %>
 
 <% if @navigation_view.organisation_name %>
@@ -13,10 +13,10 @@
 <%= render TabNavigation::View.new(items: [
   {
     name: t("funding.payment_schedule.heading", start_year: @start_year, end_year: @end_year),
-    url: @navigation_view.path_for_funding_payment_schedule
+    url: @navigation_view.path_for_funding_payment_schedule(@start_year)
   },
   {
     name: t("funding.trainee_summary.heading", start_year: @start_year, end_year: @end_year),
-    url: @navigation_view.path_for_funding_trainee_summary
+    url: @navigation_view.path_for_funding_trainee_summary(@start_year)
   },
 ]) %>

--- a/app/views/funding/show.html.erb
+++ b/app/views/funding/show.html.erb
@@ -1,0 +1,14 @@
+<%= render PageTitle::View.new(text: t("components.page_titles.funding.show")) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
+<% end %>
+
+<h1 class="govuk-heading-l"> <%= t("components.page_titles.funding.show") %> </h1>
+
+<ul class="govuk-list">
+  <% academic_years.each do |year| %>
+    <%= govuk_link_to year[:label], year[:url], class: "govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link govuk-link--no-visited-state" %>
+  <% end %>
+  
+</ul>

--- a/app/views/funding/show.html.erb
+++ b/app/views/funding/show.html.erb
@@ -6,27 +6,12 @@
 
 <h1 class="govuk-heading-l"> <%= t("components.page_titles.funding.show.title") %> </h1>
 
-<% if trainee_summary_academic_years.any? %>
-
-  <h2 class="govuk-heading-m"> <%= t("components.page_titles.funding.show.payment_schedule") %> </h2>
-
-  
-    <% payment_schedule_academic_years.each do |year| %>
-      <ul class="govuk-list">
-      <%= govuk_link_to year[:label], year[:url], class: "govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link govuk-link--no-visited-state" %>
-      </ul>
+<% if academic_years.any? %>
+  <ul class="govuk-list funding-payment-list">
+    <% academic_years.each do |label, url| %>
+    <li>
+        <%= govuk_link_to label, url, class: "govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link govuk-link--no-visited-state" %>
+    </li>
     <% end %>
-
-<% end %>
-
-<% if trainee_summary_academic_years.any? %>
-
-  <h2 class="govuk-heading-m"> <%= t("components.page_titles.funding.show.trainee_summary") %> </h2>
-
-    <% trainee_summary_academic_years.each do |year| %>
-      <ul class="govuk-list">
-      <%= govuk_link_to year[:label], year[:url], class: "govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link govuk-link--no-visited-state" %>
-      </ul>
-    <% end %>
-
+  </ul>
 <% end %>

--- a/app/views/funding/show.html.erb
+++ b/app/views/funding/show.html.erb
@@ -1,14 +1,32 @@
-<%= render PageTitle::View.new(text: t("components.page_titles.funding.show")) %>
+<%= render PageTitle::View.new(text: t("components.page_titles.funding.show.title")) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
 <% end %>
 
-<h1 class="govuk-heading-l"> <%= t("components.page_titles.funding.show") %> </h1>
+<h1 class="govuk-heading-l"> <%= t("components.page_titles.funding.show.title") %> </h1>
 
-<ul class="govuk-list">
-  <% academic_years.each do |year| %>
-    <%= govuk_link_to year[:label], year[:url], class: "govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link govuk-link--no-visited-state" %>
-  <% end %>
+<% if trainee_summary_academic_years.any? %>
+
+  <h2 class="govuk-heading-m"> <%= t("components.page_titles.funding.show.payment_schedule") %> </h2>
+
   
-</ul>
+    <% payment_schedule_academic_years.each do |year| %>
+      <ul class="govuk-list">
+      <%= govuk_link_to year[:label], year[:url], class: "govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link govuk-link--no-visited-state" %>
+      </ul>
+    <% end %>
+
+<% end %>
+
+<% if trainee_summary_academic_years.any? %>
+
+  <h2 class="govuk-heading-m"> <%= t("components.page_titles.funding.show.trainee_summary") %> </h2>
+
+    <% trainee_summary_academic_years.each do |year| %>
+      <ul class="govuk-list">
+      <%= govuk_link_to year[:label], year[:url], class: "govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link govuk-link--no-visited-state" %>
+      </ul>
+    <% end %>
+
+<% end %>

--- a/app/views/funding/show.html.erb
+++ b/app/views/funding/show.html.erb
@@ -1,17 +1,19 @@
-<%= render PageTitle::View.new(text: t("components.page_titles.funding.show.title")) %>
+<% page_title = t("components.page_titles.funding.show.title") %>
+
+<%= render PageTitle::View.new(text: page_title) %>
 
 <%= content_for(:breadcrumbs) do %>
   <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: root_path) %>
 <% end %>
 
-<h1 class="govuk-heading-l"> <%= t("components.page_titles.funding.show.title") %> </h1>
+<h1 class="govuk-heading-l"><%= page_title %></h1>
 
 <% if academic_years.any? %>
   <ul class="govuk-list funding-payment-list">
     <% academic_years.each do |label, url| %>
-    <li>
+      <li>
         <%= govuk_link_to label, url, class: "govuk-!-font-size-24 govuk-!-font-weight-bold govuk-link govuk-link--no-visited-state" %>
-    </li>
+      </li>
     <% end %>
   </ul>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,6 +330,7 @@ en:
         show: Sign in
         verify: Check your email
       funding:
+        show: Select an academic year to view its funding
         trainee_summary: Funding - Trainee summary %{start_year} to %{end_year}
         payment_schedule: Funding - Payment schedule %{start_year} to %{end_year}
       personas: Personas

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,8 +332,6 @@ en:
       funding:
         show:
           title: Select an academic year to view its funding
-          trainee_summar: Trainee Summaries
-          payment_schedule: Payment Schedules
         trainee_summary: Funding - Trainee summary %{start_year} to %{end_year}
         payment_schedule: Funding - Payment schedule %{start_year} to %{end_year}
       personas: Personas

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,7 +330,10 @@ en:
         show: Sign in
         verify: Check your email
       funding:
-        show: Select an academic year to view its funding
+        show:
+          title: Select an academic year to view its funding
+          trainee_summar: Trainee Summaries
+          payment_schedule: Payment Schedules
         trainee_summary: Funding - Trainee summary %{start_year} to %{end_year}
         payment_schedule: Funding - Payment schedule %{start_year} to %{end_year}
       personas: Personas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,9 +210,13 @@ Rails.application.routes.draw do
   end
 
   if FeatureService.enabled?("funding")
+    get "/funding", to: "funding#show", as: :funding
+
     namespace :funding do
-      resource :payment_schedule, only: %i[show], path: "/payment-schedule"
-      resource :trainee_summary, only: %i[show], path: "/trainee-summary"
+      scope "(:academic_year)" do
+        resource :payment_schedules, only: [:show], path: "payment-schedule", as: :payment_schedule
+        resource :trainee_summaries, only: [:show], path: "trainee-summary", as: :trainee_summary
+      end
     end
   end
 

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -7,10 +7,10 @@ module SystemAdminRoutes
         require "sidekiq/web"
         require "sidekiq/cron/web"
 
-        mount Blazer::Engine, at: "/blazer", constraints: SystemAdminConstraint.new
+        mount Blazer::Engine, at: "/blazer"
         get "/blazer", to: redirect("/sign-in"), status: 302
 
-        mount Sidekiq::Web, at: "/sidekiq", constraints: SystemAdminConstraint.new
+        mount Sidekiq::Web, at: "/sidekiq"
         get "/sidekiq", to: redirect("/sign-in"), status: 302
 
         resources :dead_jobs, only: %i[index show update destroy]
@@ -20,9 +20,13 @@ module SystemAdminRoutes
         resources :providers, only: %i[index new create show edit update destroy] do
           resources :users, controller: "providers/users", only: %i[index edit update]
 
+          get "/funding", to: "funding#show", as: :funding
+
           namespace :funding do
-            resource :payment_schedule, only: %i[show], path: "/payment-schedule"
-            resource :trainee_summary, only: %i[show], path: "/trainee-summary"
+            scope "(:academic_year)" do
+              resource :payment_schedules, only: %i[show], path: "/payment-schedule", as: :payment_schedule
+              resource :trainee_summaries, only: %i[show], path: "/trainee-summary", as: :trainee_summary
+            end
           end
           resource :confirm_deletes, only: :show, path: "/confirm-delete", as: :confirm_delete, module: :providers
         end
@@ -45,9 +49,13 @@ module SystemAdminRoutes
         resources :lead_schools, path: "lead-schools", only: %i[index show] do
           resources :users, controller: "lead_schools/users", only: %i[edit update]
 
+          get "/funding", to: "funding#show", as: :funding
+
           namespace :funding do
-            resource :payment_schedule, only: %i[show], path: "/payment-schedule"
-            resource :trainee_summary, only: %i[show], path: "/trainee-summary"
+            scope "(:academic_year)" do
+              resource :payment_schedules, only: %i[show], path: "/payment-schedule", as: :payment_schedule
+              resource :trainee_summarys, only: %i[show], path: "/trainee-summary", as: :trainee_summary
+            end
           end
         end
 

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -7,10 +7,10 @@ module SystemAdminRoutes
         require "sidekiq/web"
         require "sidekiq/cron/web"
 
-        mount Blazer::Engine, at: "/blazer"
+        mount Blazer::Engine, at: "/blazer", constraints: SystemAdminConstraint.new
         get "/blazer", to: redirect("/sign-in"), status: 302
 
-        mount Sidekiq::Web, at: "/sidekiq"
+        mount Sidekiq::Web, at: "/sidekiq", constraints: SystemAdminConstraint.new
         get "/sidekiq", to: redirect("/sign-in"), status: 302
 
         resources :dead_jobs, only: %i[index show update destroy]
@@ -54,7 +54,7 @@ module SystemAdminRoutes
           namespace :funding do
             scope "(:academic_year)" do
               resource :payment_schedules, only: %i[show], path: "/payment-schedule", as: :payment_schedule
-              resource :trainee_summarys, only: %i[show], path: "/trainee-summary", as: :trainee_summary
+              resource :trainee_summaries, only: %i[show], path: "/trainee-summary", as: :trainee_summary
             end
           end
         end

--- a/spec/features/funding/show_spec.rb
+++ b/spec/features/funding/show_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "viewing funding list", feature_funding: true do
+  let(:user) { create(:user) }
+  let(:test_subject) { "Test subject" }
+  let(:summary) { create(:trainee_summary, payable: user.providers.first) }
+  let(:row) { create(:trainee_summary_row, trainee_summary: summary, subject: test_subject) }
+
+  let!(:trainee_summary_row_amount) { create(:trainee_summary_row_amount, :with_bursary, row:) }
+  let!(:payment_schedule) do
+    create(:payment_schedule, rows: [
+      build(:payment_schedule_row, amounts: [
+        build(:payment_schedule_row_amount, month: 1, amount_in_pence: 100),
+        build(:payment_schedule_row_amount, month: 3, amount_in_pence: 600, predicted: true),
+      ]),
+    ], payable: user.providers.first)
+  end
+
+  background do
+    given_i_am_authenticated(user:)
+  end
+
+  context "with payment schedule and trainee summary sharing the same academic year" do
+    scenario "shows only one link for payment schedule" do
+      given_i_am_on_the_funding_show_page
+      i_see_only_one_funding_link
+    end
+  end
+
+  context "with payment schedule and trainee summary with differing academic years" do
+    scenario "shows a link for trainee summary and a link for payment schedule" do
+      and_funding_data_exists_in_different_academic_years
+      given_i_am_on_the_funding_show_page
+      i_see_two_funding_links
+    end
+  end
+
+private
+
+  def and_funding_data_exists_in_different_academic_years
+    payment_schedule.rows.first.amounts.first.update(year: 2022)
+  end
+
+  def given_i_am_on_the_funding_show_page
+    funding_page.load
+  end
+
+  def i_see_only_one_funding_link
+    expect(funding_page.funding_list.items.length).to be 1
+    expect(funding_page.funding_list.items.first).to have_text(AcademicCycle.current.label)
+  end
+
+  def i_see_two_funding_links
+    expect(funding_page.funding_list.items.length).to be 2
+    expect(funding_page.funding_list.items.first).to have_text(AcademicCycle.current.label)
+    expect(funding_page.funding_list.items[1]).to have_text("2022 to 2023")
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -378,6 +378,10 @@ module Features
       @user_delete_page ||= PageObjects::Users::Delete.new
     end
 
+    def funding_page
+      @funding_page ||= PageObjects::Funding::Show.new
+    end
+
     def payment_schedule_page
       @payment_schedule_page ||= PageObjects::Funding::PaymentSchedule.new
     end

--- a/spec/support/page_objects/funding/show.rb
+++ b/spec/support/page_objects/funding/show.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Funding
+    class Show < PageObjects::Base
+      set_url "funding"
+
+      class FundingList < SitePrism::Section
+        elements :items, "li"
+      end
+
+      section :funding_list, FundingList, ".funding-payment-list"
+    end
+  end
+end


### PR DESCRIPTION
### Context

Users should be able to view and download historic funding - at least for the year prior to the current year.

Suggested changes:

* Funding pages rendered on /funding/YYYY/page-name
* Funding link in nav defaults to linking to the current year
* The breadcrumb on each funding page links to a funding years index
* The year index lists years where we have funding information available (expected to be at least 3)

Clicking on the link takes the user to the relevant year's funding pages.

### Changes proposed in this pull request

* adds funding index page `/funding`
* redirects to latest funding year when clicking on the nav bar funding link
* splits the two funding types on the index page Trainee Summary, Payment Schedule

### Guidance to review

Ideally should be tested in production data
