### PR TITLE
[5857] Pending award tab in the support interface

### DIFF
--- a/app/controllers/system_admin/pending_awards_controller.rb
+++ b/app/controllers/system_admin/pending_awards_controller.rb
@@ -4,8 +4,91 @@ module SystemAdmin
   class PendingAwardsController < ApplicationController
     add_flash_types :dqt_error
 
+    helper_method :last_run_or_scheduled_at, :job_status
+
     def index
       @trainees = Trainee.recommended_for_award.undiscarded.order(:recommended_for_award_at)
+    end
+
+    def last_run_or_scheduled_at(trainee)
+      if dead_jobs[trainee.id]
+        dead_jobs[trainee.id][:scheduled_at]
+      elsif retry_jobs[trainee.id]
+        retry_jobs[trainee.id][:scheduled_at]
+      end
+    end
+
+    def job_status(trainee)
+      if dead_jobs[trainee.id]
+        "dead"
+      elsif retry_jobs[trainee.id]
+        "retrying"
+      else
+        "unknown"
+      end
+    end
+
+  private
+
+    def dead_jobs
+      @dead_jobs ||= Dqt::FindDeadJobsService.call
+    end
+
+    def retry_jobs
+      @retry_jobs ||= Dqt::FindRetryJobsService.call
+    end
+  end
+end
+
+module Dqt
+  class BaseFindJobsService
+    include ServicePattern
+
+    def call
+      sidekiq_class.new
+      .select { |job| job.item["wrapped"] == "Dqt::RecommendForAwardJob" }
+      .sort_by { |job| job.item["enqueued_at"] }
+      .to_h do |job|
+        [
+          job.item["args"].first["arguments"].first["_aj_globalid"].split("/").last.to_i,
+          {
+            job_id: job.item["jid"],
+            error_message: parse_error(job.item["error_message"]),
+            scheduled_at: job.at,
+          },
+        ]
+      end
+    end
+
+  private
+
+    def parse_error(error)
+      return error unless error.include?("body: ")
+
+      JSON.parse(
+        error.split("body: ")
+             .last
+             .split(", headers:")
+             .first,
+      )
+    rescue JSON::ParserError
+      error
+    end
+  end
+end
+
+module Dqt
+  class FindDeadJobsService < BaseFindJobsService
+    def sidekiq_class
+      Sidekiq::DeadSet
+    end
+  end
+end
+
+module Dqt
+  class FindRetryJobsService < BaseFindJobsService
+    def sidekiq_class
+      Sidekiq::RetrySet
     end
   end
 end

--- a/app/controllers/system_admin/pending_awards_controller.rb
+++ b/app/controllers/system_admin/pending_awards_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class PendingAwardsController < ApplicationController
+    add_flash_types :dqt_error
+
+    def index
+      @trainees = Trainee.recommended_for_award.undiscarded.order(:recommended_for_award_at)
+    end
+  end
+end

--- a/app/controllers/system_admin/pending_awards_controller.rb
+++ b/app/controllers/system_admin/pending_awards_controller.rb
@@ -4,38 +4,8 @@ module SystemAdmin
   class PendingAwardsController < ApplicationController
     add_flash_types :dqt_error
 
-    helper_method :last_run_or_scheduled_at, :job_status
-
     def index
       @trainees = Trainee.recommended_for_award.undiscarded.order(:recommended_for_award_at)
-    end
-
-    def last_run_or_scheduled_at(trainee)
-      if dead_jobs[trainee.id]
-        dead_jobs[trainee.id][:scheduled_at]
-      elsif retry_jobs[trainee.id]
-        retry_jobs[trainee.id][:scheduled_at]
-      end
-    end
-
-    def job_status(trainee)
-      if dead_jobs[trainee.id]
-        "dead"
-      elsif retry_jobs[trainee.id]
-        "retrying"
-      else
-        "unknown"
-      end
-    end
-
-  private
-
-    def dead_jobs
-      @dead_jobs ||= Dqt::FindDeadJobs.call
-    end
-
-    def retry_jobs
-      @retry_jobs ||= Dqt::FindRetryJobs.call
     end
   end
 end

--- a/app/helpers/sidekiq_jobs_helper.rb
+++ b/app/helpers/sidekiq_jobs_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module SidekiqJobsHelper
+  def last_run_or_scheduled_at(trainee)
+    if dead_jobs[trainee.id]
+      dead_jobs[trainee.id][:scheduled_at]
+    elsif retry_jobs[trainee.id]
+      retry_jobs[trainee.id][:scheduled_at]
+    end
+  end
+
+  def job_status(trainee)
+    if dead_jobs[trainee.id]
+      "dead"
+    elsif retry_jobs[trainee.id]
+      "retrying"
+    else
+      "unknown"
+    end
+  end
+
+private
+
+  def dead_jobs
+    @dead_jobs ||= Dqt::FindDeadJobs.call
+  end
+
+  def retry_jobs
+    @retry_jobs ||= Dqt::FindRetryJobs.call
+  end
+end

--- a/app/services/dqt/base_find_jobs.rb
+++ b/app/services/dqt/base_find_jobs.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Dqt
+  class BaseFindJobs
+    include ServicePattern
+
+    def call
+      sidekiq_class.new
+      .select { |job| job.item["wrapped"] == "Dqt::RecommendForAwardJob" }
+      .sort_by { |job| job.item["enqueued_at"] }
+      .to_h do |job|
+        [
+          job.item["args"].first["arguments"].first["_aj_globalid"].split("/").last.to_i,
+          {
+            job_id: job.item["jid"],
+            error_message: parse_error(job.item["error_message"]),
+            scheduled_at: job.at,
+          },
+        ]
+      end
+    end
+
+  private
+
+    def parse_error(error)
+      return error unless error.include?("body: ")
+
+      JSON.parse(
+        error.split("body: ")
+             .last
+             .split(", headers:")
+             .first,
+      )
+    rescue JSON::ParserError
+      error
+    end
+  end
+end

--- a/app/services/dqt/find_dead_jobs.rb
+++ b/app/services/dqt/find_dead_jobs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Dqt
+  class FindDeadJobs < BaseFindJobs
+    def sidekiq_class
+      Sidekiq::DeadSet
+    end
+  end
+end

--- a/app/services/dqt/find_retry_jobs.rb
+++ b/app/services/dqt/find_retry_jobs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Dqt
+  class FindRetryJobs < BaseFindJobs
+    def sidekiq_class
+      Sidekiq::RetrySet
+    end
+  end
+end

--- a/app/views/system_admin/_tab_nav.html.erb
+++ b/app/views/system_admin/_tab_nav.html.erb
@@ -7,4 +7,5 @@
   { name: "Uploads", url: uploads_path },
   { name: "Dead Jobs", url: dead_jobs_path },
   { name: "Pending TRN", url: pending_trns_path },
+  { name: "Pending Awards", url: pending_awards_path },
 ]) %>

--- a/app/views/system_admin/pending_awards/index.html.erb
+++ b/app/views/system_admin/pending_awards/index.html.erb
@@ -1,0 +1,45 @@
+<%= render PageTitle::View.new(i18n_key: "dead_jobs.index") %>
+
+<div class="govuk-grid-row">
+  <div class ="govuk-grid-column-full">
+    <%= render "system_admin/tab_nav" %>
+
+    <%= render ErrorSummary::View.new(renderable: dqt_error.present?) do %>
+      <%= dqt_error %>
+    <% end %>
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Trainees Pending Award</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">First names</th>
+          <th scope="col" class="govuk-table__header">Last name</th>
+          <th scope="col" class="govuk-table__header">Days waiting</th>
+          <th scope="col" class="govuk-table__header" colspan="3"></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @trainees.each do |trainee| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= trainee.first_names %></td>
+            <td class="govuk-table__cell"><%= trainee.last_name %></td>
+            <td class="govuk-table__cell">
+              <%= (Date.current - trainee.recommended_for_award_at.to_date).to_i %>
+            </td>
+            <td class="govuk-table__cell">
+              <%=
+                govuk_link_to "View",
+                  trainee_personal_details_path(trainee),
+                  class: "govuk-!-margin-0 govuk-button"
+              %>
+            </td>
+            <td class="govuk-table__cell">
+            </td>
+            <td class="govuk-table__cell">
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/system_admin/pending_awards/index.html.erb
+++ b/app/views/system_admin/pending_awards/index.html.erb
@@ -15,7 +15,9 @@
           <th scope="col" class="govuk-table__header">First names</th>
           <th scope="col" class="govuk-table__header">Last name</th>
           <th scope="col" class="govuk-table__header">Days waiting</th>
-          <th scope="col" class="govuk-table__header" colspan="3"></th>
+          <th scope="col" class="govuk-table__header">Job status</th>
+          <th scope="col" class="govuk-table__header">Last run/Next scheduled</th>
+          <th scope="col" class="govuk-table__header"></th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -26,16 +28,16 @@
             <td class="govuk-table__cell">
               <%= (Date.current - trainee.recommended_for_award_at.to_date).to_i %>
             </td>
+            <td class="govuk-table__cell"><%= job_status(trainee) %></td>
+            <td class="govuk-table__cell"><%= last_run_or_scheduled_at(trainee)&.to_fs(:govuk_date_and_time) %></td>
             <td class="govuk-table__cell">
               <%=
-                govuk_link_to "View",
+                govuk_link_to(
+                  "View",
                   trainee_personal_details_path(trainee),
-                  class: "govuk-!-margin-0 govuk-button"
+                  class: "govuk-!-margin-0 govuk-button",
+                )
               %>
-            </td>
-            <td class="govuk-table__cell">
-            </td>
-            <td class="govuk-table__cell">
             </td>
           </tr>
         <% end %>

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -15,6 +15,7 @@ module SystemAdminRoutes
 
         resources :dead_jobs, only: %i[index show update destroy]
         resources :pending_trns, only: %i[index show]
+        resources :pending_awards, only: %i[index show]
 
         resources :providers, only: %i[index new create show edit update destroy] do
           resources :users, controller: "providers/users", only: %i[index edit update]

--- a/spec/features/system_admin/pending_awards/pending_awards_spec.rb
+++ b/spec/features/system_admin/pending_awards/pending_awards_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "pending awards" do
+  attr_reader :trainee
+
+  before do
+    given_i_am_authenticated
+    and_i_have_a_trainee_with_a_pending_award
+    when_i_visit_the_pending_awards_page
+  end
+
+  scenario "shows pending awards page" do
+    then_i_see_the_pending_awards_page
+    and_i_see_the_trainee
+  end
+
+  scenario "can check for award" do
+    # then_i_see_the_pending_awards_page
+    # when_i_click_check_for_award
+    # then_i_see_the_pending_awards_page
+  end
+
+  scenario "can resubmit for award" do
+    # then_i_see_the_pending_trns_page
+    # when_i_click_resubmit_for_trn
+    # then_i_see_the_pending_trns_page
+  end
+
+  def and_i_have_a_trainee_with_a_pending_award
+    @trainee = create(:trainee, :recommended_for_award)
+  end
+
+  def when_i_visit_the_pending_awards_page
+    visit "/system-admin/pending_awards"
+  end
+
+  def then_i_see_the_pending_awards_page
+    expect(page).to have_text("Trainees Pending Award")
+  end
+
+  def and_i_see_the_trainee
+    expect(page).to have_text(trainee.first_names)
+    expect(page).to have_text(trainee.last_name)
+  end
+
+  # def when_i_click_check_for_trn
+  #   expect(Dqt::RetrieveTrn).to receive(:call).with(trn_request:)
+  #   admin_pending_trns_page.check_for_trn_button.click
+  # end
+
+  # def when_i_click_resubmit_for_trn
+  #   expect(Dqt::RegisterForTrnJob).to receive(:perform_now).with(trainee)
+  #   admin_pending_trns_page.resumbit_for_trn_button.click
+  # end
+end

--- a/spec/features/system_admin/pending_awards/pending_awards_spec.rb
+++ b/spec/features/system_admin/pending_awards/pending_awards_spec.rb
@@ -65,30 +65,30 @@ feature "pending awards" do
   end
 
   def when_there_is_a_job_in_the_dead_queue
-    allow(Dqt::FindDeadJobsService).to receive(:call).and_return(
+    allow(Dqt::FindDeadJobs).to receive(:call).and_return(
       @trainee.id => {
         job_id: "dead_job_id",
         error_message: "dead_job_error_message",
         scheduled_at: 3.days.ago,
       },
     )
-    allow(Dqt::FindRetryJobsService).to receive(:call).and_return({})
+    allow(Dqt::FindRetryJobs).to receive(:call).and_return({})
   end
 
   def when_there_is_a_job_in_the_retry_queue
-    allow(Dqt::FindRetryJobsService).to receive(:call).and_return(
+    allow(Dqt::FindRetryJobs).to receive(:call).and_return(
       @trainee.id => {
         job_id: "retry_job_id",
         error_message: "retry_job_error_message",
         scheduled_at: 3.days.from_now,
       },
     )
-    allow(Dqt::FindDeadJobsService).to receive(:call).and_return({})
+    allow(Dqt::FindDeadJobs).to receive(:call).and_return({})
   end
 
   def when_there_are_no_jobs_in_the_retry_or_dead_queue
-    allow(Dqt::FindDeadJobsService).to receive(:call).and_return({})
-    allow(Dqt::FindRetryJobsService).to receive(:call).and_return({})
+    allow(Dqt::FindDeadJobs).to receive(:call).and_return({})
+    allow(Dqt::FindRetryJobs).to receive(:call).and_return({})
   end
 
   def and_i_see_that_the_job_status_is_dead

--- a/spec/helpers/sidekiq_jobs_helper_spec.rb
+++ b/spec/helpers/sidekiq_jobs_helper_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SidekiqJobsHelper do
+  include SidekiqJobsHelper
+
+  around { |example| Timecop.freeze { example.run } }
+
+  let(:trainee) { build(:trainee) }
+  let(:last_run_at) { 3.days.ago }
+  let(:scheduled_to_run_at) { 2.hours.from_now }
+
+  describe "#last_run_or_scheduled_at" do
+    context "when there is a dead job" do
+      before do
+        allow(Dqt::FindDeadJobs).to receive(:call).and_return(
+          trainee.id => {
+            job_id: "dead_job_id",
+            error_message: "dead_job_error_message",
+            scheduled_at: last_run_at,
+          },
+        )
+        allow(Dqt::FindRetryJobs).to receive(:call).and_return({})
+      end
+
+      it "returns the last time the dead job ran" do
+        expect(last_run_or_scheduled_at(trainee)).to eq(last_run_at)
+      end
+    end
+
+    context "when there is a retry job" do
+      before do
+        allow(Dqt::FindDeadJobs).to receive(:call).and_return({})
+        allow(Dqt::FindRetryJobs).to receive(:call).and_return(
+          trainee.id => {
+            job_id: "retry_job_id",
+            error_message: "retry_job_error_message",
+            scheduled_at: scheduled_to_run_at,
+          },
+        )
+      end
+
+      it "returns the next time the job is scheduled to re-run" do
+        expect(last_run_or_scheduled_at(trainee)).to eq(scheduled_to_run_at)
+      end
+    end
+
+    context "when there is no job in Sidekiq" do
+      before do
+        allow(Dqt::FindDeadJobs).to receive(:call).and_return({})
+        allow(Dqt::FindRetryJobs).to receive(:call).and_return({})
+      end
+
+      it "returns nil" do
+        expect(last_run_or_scheduled_at(trainee)).to be_nil
+      end
+    end
+  end
+
+  describe "#job_status" do
+    context "when there is a dead job" do
+      before do
+        allow(Dqt::FindDeadJobs).to receive(:call).and_return(
+          trainee.id => {
+            job_id: "dead_job_id",
+            error_message: "dead_job_error_message",
+            scheduled_at: last_run_at,
+          },
+        )
+        allow(Dqt::FindRetryJobs).to receive(:call).and_return({})
+      end
+
+      it "the status is `dead`" do
+        expect(job_status(trainee)).to eq("dead")
+      end
+    end
+
+    context "when there is a retry job" do
+      before do
+        allow(Dqt::FindDeadJobs).to receive(:call).and_return({})
+        allow(Dqt::FindRetryJobs).to receive(:call).and_return(
+          trainee.id => {
+            job_id: "retry_job_id",
+            error_message: "retry_job_error_message",
+            scheduled_at: scheduled_to_run_at,
+          },
+        )
+      end
+
+      it "the status is `retrying`" do
+        expect(job_status(trainee)).to eq("retrying")
+      end
+    end
+
+    context "when there is no job in Sidekiq" do
+      before do
+        allow(Dqt::FindDeadJobs).to receive(:call).and_return({})
+        allow(Dqt::FindRetryJobs).to receive(:call).and_return({})
+      end
+
+      it "the status is `unknown`" do
+        expect(job_status(trainee)).to eq("unknown")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
There are a number of trainees that have been in the `recommended_for_award` status for longer than expected. When this happens they are not always visible to the support and DQT teams. 

### Changes proposed in this pull request
This PR adds a `Pending awards` tab to the support interface that simply lists all those trainees that are in the `recommended_for_award` status together with information about any associated Sidekiq jobs that may have failed.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/a23c2cf3-54fd-473f-bdc5-e329fb7b939e)

In future we may wish to add better diagnostics to this feature, e.g. a history of DQT API responses including error messages.

### Guidance to review
Are the tests sufficient?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
