### PR TITLE
[5953] Remove hard-coded `Trainee#id` values in tests

### DIFF
--- a/spec/components/personal_details/view_spec.rb
+++ b/spec/components/personal_details/view_spec.rb
@@ -28,7 +28,7 @@ module PersonalDetails
     end
 
     context "when data has been provided with hesa optional fields" do
-      let(:trainee) { create(:trainee, id: 1, nationalities: [], created_from_hesa: true, hesa_id: 1) }
+      let(:trainee) { create(:trainee, nationalities: [], created_from_hesa: true, hesa_id: 1) }
 
       before do
         render_inline(View.new(data_model: personal_details_form))
@@ -40,7 +40,7 @@ module PersonalDetails
     end
 
     context "when data has been provided" do
-      let(:trainee) { create(:trainee, id: 1, nationalities: [british]) }
+      let(:trainee) { create(:trainee, nationalities: [british]) }
 
       before do
         render_inline(View.new(data_model: personal_details_form))
@@ -70,7 +70,7 @@ module PersonalDetails
       end
 
       context "when multiple nationalities have been provided" do
-        let(:trainee) { create(:trainee, id: 1, nationalities: [british, irish]) }
+        let(:trainee) { create(:trainee, nationalities: [british, irish]) }
 
         before do
           render_inline(View.new(data_model: personal_details_form))

--- a/spec/features/system_admin/pending_trns/pending_trns_spec.rb
+++ b/spec/features/system_admin/pending_trns/pending_trns_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 feature "pending TRNs" do
   let(:user) { create(:user, system_admin: true) }
-  let(:trainee) { create(:trainee, :submitted_for_trn, :with_dqt_trn_request, first_names: "James Blint", id: 10001) }
+  let(:trainee) { create(:trainee, :submitted_for_trn, :with_dqt_trn_request, first_names: "James Blint") }
   let(:trn_request) { trainee.dqt_trn_request }
 
   before do


### PR DESCRIPTION
### Context
There is a slim chance these hard-coded ids could cause problems due to clashes with PostgreSQL auto-incrementing `id's. 

### Changes proposed in this pull request
Remove hard-coded `Trainee#id` values in tests

### Guidance to review
Any downsides?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
