### PR TITLE
Enforce sys-admin constraint on all sys-admin routes

### DIFF
--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -3,7 +3,7 @@
 module SystemAdminRoutes
   def self.extended(router)
     router.instance_exec do
-      scope module: :system_admin, path: "system-admin" do
+      scope module: :system_admin, path: "system-admin", constraints: SystemAdminConstraint.new do
         require "sidekiq/web"
         require "sidekiq/cron/web"
 

--- a/spec/features/system_admin/pending_awards/pending_awards_spec.rb
+++ b/spec/features/system_admin/pending_awards/pending_awards_spec.rb
@@ -5,38 +5,51 @@ require "rails_helper"
 feature "pending awards" do
   attr_reader :trainee
 
-  before do
-    given_i_am_authenticated
-    and_i_have_a_trainee_with_a_pending_award
+  context "when I am authenticated as a system admin" do
+    before do
+      given_i_am_authenticated_as_system_admin
+      and_i_have_a_trainee_with_a_pending_award
+    end
+
+    scenario "shows pending awards page" do
+      when_there_are_no_jobs_in_the_retry_or_dead_queue
+      and_i_visit_the_pending_awards_page
+      then_i_see_the_pending_awards_page
+      and_i_see_the_trainee
+    end
+
+    scenario "shows last run date if there is a job in the dead queue" do
+      when_there_is_a_job_in_the_dead_queue
+      and_i_visit_the_pending_awards_page
+      then_i_see_the_pending_awards_page
+      and_i_see_that_the_job_status_is_dead
+    end
+
+    scenario "shows next schedule date if there is a job in the retry queue" do
+      when_there_is_a_job_in_the_retry_queue
+      and_i_visit_the_pending_awards_page
+      then_i_see_the_pending_awards_page
+      and_i_see_that_the_job_status_is_retrying
+    end
+
+    scenario "shows details for individual trainees recommended for award" do
+      when_there_are_no_jobs_in_the_retry_or_dead_queue
+      and_i_visit_the_pending_awards_page
+      then_i_see_the_pending_awards_page
+      and_i_click_view
+      then_i_see_the_trainee_details
+    end
   end
 
-  scenario "shows pending awards page" do
-    when_there_are_no_jobs_in_the_retry_or_dead_queue
-    and_i_visit_the_pending_awards_page
-    then_i_see_the_pending_awards_page
-    and_i_see_the_trainee
-  end
+  context "when I am authenticated as a regular user (not a system admin)" do
+    before do
+      given_i_am_authenticated
+      and_i_have_a_trainee_with_a_pending_award
+    end
 
-  scenario "shows last run date if there is a job in the dead queue" do
-    when_there_is_a_job_in_the_dead_queue
-    and_i_visit_the_pending_awards_page
-    then_i_see_the_pending_awards_page
-    and_i_see_that_the_job_status_is_dead
-  end
-
-  scenario "shows next schedule date if there is a job in the retry queue" do
-    when_there_is_a_job_in_the_retry_queue
-    and_i_visit_the_pending_awards_page
-    then_i_see_the_pending_awards_page
-    and_i_see_that_the_job_status_is_retrying
-  end
-
-  scenario "shows details for individual trainees recommended for award" do
-    when_there_are_no_jobs_in_the_retry_or_dead_queue
-    and_i_visit_the_pending_awards_page
-    then_i_see_the_pending_awards_page
-    and_i_click_view
-    then_i_see_the_trainee_details
+    scenario "the pending awards page is inaccessible" do
+      expect { and_i_visit_the_pending_awards_page }.to raise_error(ActionController::RoutingError)
+    end
   end
 
   def and_i_have_a_trainee_with_a_pending_award

--- a/spec/features/system_admin/pending_trns/pending_trns_spec.rb
+++ b/spec/features/system_admin/pending_trns/pending_trns_spec.rb
@@ -3,31 +3,43 @@
 require "rails_helper"
 
 feature "pending TRNs" do
-  let(:user) { create(:user, system_admin: true) }
   let(:trainee) { create(:trainee, :submitted_for_trn, :with_dqt_trn_request, first_names: "James Blint") }
   let(:trn_request) { trainee.dqt_trn_request }
 
-  before do
-    given_i_am_authenticated(user:)
-    and_i_have_a_trainee_with_a_pending_trn
-    when_i_visit_the_pending_trns_page
+  context "when I am authenticated as a system admin" do
+    before do
+      given_i_am_authenticated_as_system_admin
+      and_i_have_a_trainee_with_a_pending_trn
+      when_i_visit_the_pending_trns_page
+    end
+
+    scenario "shows pending TRNs page" do
+      then_i_see_the_pending_trns_page
+      and_i_see_the_trainee
+    end
+
+    scenario "can check for TRN" do
+      then_i_see_the_pending_trns_page
+      when_i_click_check_for_trn
+      then_i_see_the_pending_trns_page
+    end
+
+    scenario "can resubmit for TRN" do
+      then_i_see_the_pending_trns_page
+      when_i_click_resubmit_for_trn
+      then_i_see_the_pending_trns_page
+    end
   end
 
-  scenario "shows pending TRNs page" do
-    then_i_see_the_pending_trns_page
-    and_i_see_the_trainee
-  end
+  context "when I am authenticated as a regular user (not a system admin)" do
+    before do
+      given_i_am_authenticated
+      and_i_have_a_trainee_with_a_pending_trn
+    end
 
-  scenario "can check for TRN" do
-    then_i_see_the_pending_trns_page
-    when_i_click_check_for_trn
-    then_i_see_the_pending_trns_page
-  end
-
-  scenario "can resubmit for TRN" do
-    then_i_see_the_pending_trns_page
-    when_i_click_resubmit_for_trn
-    then_i_see_the_pending_trns_page
+    scenario "the pending awards page is inaccessible" do
+      expect { when_i_visit_the_pending_trns_page }.to raise_error(ActionController::RoutingError)
+    end
   end
 
   def and_i_have_a_trainee_with_a_pending_trn


### PR DESCRIPTION
### Context
Non-sys-admins don't see the menu items for any of the sys-admin pages but can navigate to them. This shouldn't happen.

### Changes proposed in this pull request
Add a constraint at the route level to authorise all sys-admin requests.

### Guidance to review
Are there any loopholes we need to keep open. Currently there are 70 odd sys-admins so I'm guess most people that need access already have it.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
