### PR TITLE
[5949] Rubocop extension not loaded

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-capybara
+  - rubocop-factory_bot
   - ./lib/rubocop/cop/govuk/govuk_button_to.rb
   - ./lib/rubocop/cop/govuk/govuk_link_to.rb
   - ./lib/rubocop/cop/govuk/govuk_submit.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-capybara
   - ./lib/rubocop/cop/govuk/govuk_button_to.rb
   - ./lib/rubocop/cop/govuk/govuk_link_to.rb
   - ./lib/rubocop/cop/govuk/govuk_submit.rb

--- a/spec/support/features/lead_and_employing_school_steps.rb
+++ b/spec/support/features/lead_and_employing_school_steps.rb
@@ -48,7 +48,7 @@ module Features
     end
 
     def and_i_continue
-      find('button.govuk-button[type="submit"]').click # rubocop:disable RSpec/Capybara/SpecificActions
+      click_button("Continue")
     end
 
     def and_the_lead_and_employing_schools_section_is_marked_completed


### PR DESCRIPTION
### Context
Rubocop extension not loaded

### Changes proposed in this pull request
We are now loading
 - rubocop-capybara
  - rubocop-factory_bot

### Guidance to review

It no longer print out

```
spec/support/features/lead_and_employing_school_steps.rb: RSpec/Capybara/SpecificActions has the wrong namespace - should be Capybara

1886 files inspected, no offenses detected


The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-capybara
  * rubocop-factory_bot

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false


```

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
