### PR TITLE
Remove address fields from trainee sanitisation

### DIFF
--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -39,11 +39,6 @@ SET
   middle_names = null,
   last_name = concat('TraineeUser', id),
   email = concat('trainee_', id, '@example.com'),
-  address_line_one = CASE WHEN address_line_one IS NULL THEN NULL ELSE 'DfE Building' END,
-  address_line_two = CASE WHEN address_line_two IS NULL THEN NULL ELSE 'Great Smith Street' END,
-  town_city = CASE WHEN town_city IS NULL THEN NULL ELSE 'London' END,
-  postcode = CASE WHEN postcode IS NULL THEN NULL ELSE 'SW1P 3BT' END,
-  international_address = CASE WHEN international_address IS NULL THEN NULL ELSE 'International Address' END,
   trainee_id = concat('trainee-', id),
   trn = CASE WHEN trn IS NULL THEN NULL ELSE id END,
   additional_dttp_data = NULL;


### PR DESCRIPTION
Since they [don't exist any more](https://github.com/DFE-Digital/register-trainee-teachers/commit/b73ea89af718c5063f8ce5d831066bdf9c0874a0).

### Context

https://trello.com/c/aiKYi9bi/6036-db-anonymisation-isnt-working

We removed address fields from Trainee, but the sanitise script is still trying to back them up (and anonymise them). Hence sanitisation is not working.

### Changes proposed in this pull request

Update sanitise script such that it doesn't update non-existent fields

### Guidance to review

Does sanitisation work?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
