### PR TITLE
[6009] Fan out CreateFromApplyJob

### DIFF
--- a/app/jobs/trainees/create_from_application_job.rb
+++ b/app/jobs/trainees/create_from_application_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Trainees
+  class CreateFromApplicationJob < ApplicationJob
+    queue_as :apply
+
+    def perform(application)
+      CreateFromApply.call(application:)
+    end
+  end
+end

--- a/spec/jobs/trainees/create_trainees_from_apply_job_spec.rb
+++ b/spec/jobs/trainees/create_trainees_from_apply_job_spec.rb
@@ -14,7 +14,7 @@ module Trainees
         let(:apply_sync_enabled) { true }
 
         it "creates a trainee" do
-          expect(CreateFromApply).to receive(:call).with(application: apply_application)
+          expect(CreateFromApplicationJob).to receive(:perform_later).with(apply_application)
 
           described_class.perform_now
         end
@@ -28,7 +28,7 @@ module Trainees
           end
 
           it "does not create a trainee" do
-            expect(CreateFromApply).not_to receive(:call).with(application: apply_application)
+            expect(CreateFromApplicationJob).not_to receive(:perform_later).with(apply_application)
 
             described_class.perform_now
           end
@@ -38,19 +38,8 @@ module Trainees
           let(:state) { :imported }
 
           it "does not create a trainee" do
-            expect(CreateFromApply).not_to receive(:call).with(application: apply_application)
+            expect(CreateFromApplicationJob).not_to receive(:perform_later).with(apply_application)
 
-            described_class.perform_now
-          end
-        end
-
-        context "when CreateFromApply returns MissingCourseError" do
-          before do
-            allow(CreateFromApply).to receive(:call).with(application: apply_application).and_raise Trainees::CreateFromApply::MissingCourseError
-          end
-
-          it "is rescued and captured by Sentry" do
-            expect(Sentry).to receive(:capture_exception).with(Trainees::CreateFromApply::MissingCourseError)
             described_class.perform_now
           end
         end
@@ -60,7 +49,7 @@ module Trainees
         let(:apply_sync_enabled) { false }
 
         it "does not create a trainee" do
-          expect(CreateFromApply).not_to receive(:call).with(application: apply_application)
+          expect(CreateFromApplicationJob).not_to receive(:perform_later).with(apply_application)
 
           described_class.perform_now
         end


### PR DESCRIPTION
### Context

This sort of [sentry error ](https://dfe-teacher-services.sentry.io/issues/4113839544/?environment=production&project=5552118&query=is%3Aarchived&referrer=issue-stream&stream_index=2) is quite difficult to diagnose (I've spent ages on a similar one in the past). 

`CreateFromApplyJob` is setup to process applications in one big job and rescues any errors for each. The problem is some of the important context (eg the application being processed so we can track down the issue) isn't surfaced in Sentry. 

### Changes proposed in this pull request

Like this PR https://github.com/DFE-Digital/register-trainee-teachers/pull/3541, this fans out the job so it's consistent with the approach we use in other areas. When an error occurs, we get the application context to make debugging a little easier:

<img width="1200" alt="Screenshot 2023-09-12 at 13 36 23" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/8ebb6fa2-3e03-4fe5-86ea-8bb4eed78168">

### Guidance to review

You can kick off the job locally with some test application data but there is nothing much to review other than checking the jobs fire as expected. 
