### PR TITLE
Fix unsightly email addresses

### DIFF
--- a/app/views/guidance/census_sign_off.md
+++ b/app/views/guidance/census_sign_off.md
@@ -45,4 +45,4 @@ Read the [Initial Teacher Training census methodology](https://explore-education
 
 ## Get help
 
-Email <becoming.ateacher@education.gov.uk> if you have any questions about signing off your new trainee data.
+Email <becomingateacher@digital.education.gov.uk> if you have any questions about signing off your new trainee data.

--- a/app/views/guidance/performance_profiles.html.erb
+++ b/app/views/guidance/performance_profiles.html.erb
@@ -57,19 +57,19 @@
     <h3 class="govuk-heading-s">Providers of school centred initial teacher training (SCITTs)</h3>
     <p class="govuk-body">
       If the trainee is shown in this service as awarded or withdrawn, you should email
-      <a class="govuk-link" href="mailto:becoming.ateacher@education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becoming.ateacher@education.gov.uk</a>.
+      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@digital.education.gov.uk</a>.
     </p>
     <p class="govuk-body">If the trainee is shown in this service as actively training or deferred, you should make the change in this service.</p>
 
     <h3 class="govuk-heading-s">Higher education institutions (HEIs)</h3>
     <p class="govuk-body">If the trainee is shown in this service as awarded or withdrawn, you should email
-      <a class="govuk-link" href="mailto:becoming.ateacher@education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becoming.ateacher@education.gov.uk</a>.
+      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@digital.education.gov.uk</a>.
     </p>
     <p class="govuk-body">If the trainee is shown in this service as actively training or deferred, you should:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>make the change through the Higher Education Statistics Agency (HESA) if the trainee was registered through HESA and is in the <%= @current_academic_cycle_label %> initial teacher training (ITT) collection</li>
       <li>email
-      <a class="govuk-link" href="mailto:becoming.ateacher@education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becoming.ateacher@education.gov.uk</a>
+      <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@digital.education.gov.uk</a>
       if the trainee was registered through HESA but is not in the <%= @current_academic_cycle_label %> ITT collection</li>
       <li>make the change in this service if the trainee was not registered through HESA</li>
     </ul>

--- a/app/views/organisations/_no_organisation.html.erb
+++ b/app/views/organisations/_no_organisation.html.erb
@@ -3,7 +3,7 @@
 
 <p class='govuk-body'>Your account needs to be linked to an organisation so you can use Register.</p>
 
-<p class='govuk-body'>To be added to an organisation, email us at <a class='govuk-link' href='mailto:becoming.ateacher@education.gov.uk?subject=No%20organisation%20issues'>becoming.ateacher@education.gov.uk</a></p>
+<p class='govuk-body'>To be added to an organisation, email us at <a class='govuk-link' href='mailto:becomingateacher@digital.education.gov.uk?subject=No%20organisation%20issues'>becomingateacher@digital.education.gov.uk</a></p>
 
 <p class='govuk-body'>In your email tell us:</p>
 

--- a/app/views/pages/accessibility.md
+++ b/app/views/pages/accessibility.md
@@ -20,13 +20,13 @@ title: Accessibility statement for Register trainee teachers
 
 <h2 class='govuk-heading-m'>Feedback and contact information</h2>
 
-<p class='govuk-body'>If you need information on this service in a different format like accessible PDF, large print, easy read, audio recording or braille, contact <a class='govuk-link' href='mailto:becoming.ateacher@education.gov.uk?subject=Accessibility%20issues%20'>becoming.ateacher@education.gov.uk</a>.</p>
+<p class='govuk-body'>If you need information on this service in a different format like accessible PDF, large print, easy read, audio recording or braille, contact <a class='govuk-link' href='mailto:becomingateacher@digital.education.gov.uk?subject=Accessibility%20issues%20'>becomingateacher@digital.education.gov.uk</a>.</p>
 <p class='govuk-body'>We’ll consider your request and get back to you in 5 days.</p>
 <p class='govuk-body'>This service was built following GOV.UK design guidelines, which meet the <a href='https://www.w3.org/TR/WCAG21/' class='govuk-link'>Web Content Accessibility Guidelines (WCAG) 2.1 (level AA)</a>.</p>
 
 <h2 class='govuk-heading-m'>Reporting accessibility problems with Register trainee teachers</h2>
 
-<p class='govuk-body govuk-!-margin-bottom-7'>We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact <a class='govuk-link' href='mailto:becoming.ateacher@education.gov.uk?subject=Accessibility%20issues%20'>becoming.ateacher@education.gov.uk</a>. Include ‘Accessibility’ in the subject line of your email.</p>
+<p class='govuk-body govuk-!-margin-bottom-7'>We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact <a class='govuk-link' href='mailto:becomingateacher@digital.education.gov.uk?subject=Accessibility%20issues%20'>becomingateacher@digital.education.gov.uk</a>. Include ‘Accessibility’ in the subject line of your email.</p>
 
 <h2 class='govuk-heading-m'>Enforcement procedure</h2>
 

--- a/app/views/pages/data_sharing_agreement.md
+++ b/app/views/pages/data_sharing_agreement.md
@@ -428,7 +428,7 @@ title: Register trainee teachers data sharing agreement
 <p class='govuk-body'>
   Data subjects wanting to make an SAR can email the DfE at
   <a class='govuk-link'
-  href='mailto:becoming.ateacher@education.gov.uk.?subject=Subject%20access%20request'>becoming.ateacher@education.gov.uk</a>.
+  href='mailto:becomingateacher@digital.education.gov.uk.?subject=Subject%20access%20request'>becomingateacher@digital.education.gov.uk</a>.
 </p>
 <h2 class='govuk-heading-m' id='#handling-freedom-of-information-act-requests'>
   Handling freedom of information requests
@@ -503,7 +503,7 @@ title: Register trainee teachers data sharing agreement
   </p>
   <p class='govuk-body'>
     All communication should be sent by email to <a class='govuk-link'
-    href='mailto:becoming.ateacher@education.gov.uk.?subject=Security%20incident'>becoming.ateacher@education.gov.uk</a>.
+    href='mailto:becomingateacher@digital.education.gov.uk.?subject=Security%20incident'>becomingateacher@digital.education.gov.uk</a>.
   </p>
   <p class='govuk-body'>
     The designated points of contact will discuss and agree the next steps relating to the incident, taking specialist advice where appropriate. Such arrangements will include (but will not be limited to):
@@ -587,7 +587,7 @@ title: Register trainee teachers data sharing agreement
 <p class='govuk-body'>
   To notify the DfE with your consent to the terms of this data sharing
   agreement, email <a class='govuk-link'
-  href='mailto:becoming.ateacher@education.gov.uk.?subject=Register%20DSA%20consent'>becoming.ateacher@education.gov.uk</a> with
+  href='mailto:becomingateacher@digital.education.gov.uk.?subject=Register%20DSA%20consent'>becomingateacher@digital.education.gov.uk</a> with
   confirmation.
 </p>
 <h3 class='govuk-heading-s'>

--- a/app/views/pages/privacy_notice.md
+++ b/app/views/pages/privacy_notice.md
@@ -131,11 +131,11 @@ title: Register trainee teachers privacy notice
 
 <p class='govuk-body'>You can find more information about how we handle personal data in our personal information charter.</p>
 
-<p class='govuk-body'>Contact the Register trainee teachers team at <a class='govuk-link' href='mailto:becoming.ateacher@education.gov.uk'>becoming.ateacher@education.gov.uk</a> if you have any concerns about your personal data.</p>
+<p class='govuk-body'>Contact the Register trainee teachers team at <a class='govuk-link' href='mailto:becomingateacher@digital.education.gov.uk'>becomingateacher@digital.education.gov.uk</a> if you have any concerns about your personal data.</p>
 
 <h2 class='govuk-heading-m' id='getting-help-raising-a-concern'>Getting help raising a concern</h2>
 
-<p class='govuk-body'>If you would like to exercise any of your rights, you can email us at <a href='mailto:becoming.ateacher@education.gov.uk?subject=Raising a concern - personal data in Register!' class='govuk-link'>becoming.ateacher@education.gov.uk</a></p>
+<p class='govuk-body'>If you would like to exercise any of your rights, you can email us at <a href='mailto:becomingateacher@digital.education.gov.uk?subject=Raising a concern - personal data in Register!' class='govuk-link'>becomingateacher@digital.education.gov.uk</a></p>
 
 <p class='govuk-body'>You can also use our <a href='https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen' class='govuk-link'>contact form</a> to get in touch with our Data Protection Officer.</p>
 

--- a/app/views/request_an_account/index.html.erb
+++ b/app/views/request_an_account/index.html.erb
@@ -27,7 +27,7 @@
     <h2 class="govuk-heading-m">2. Get a Register account</h2>
     <p class="govuk-body">Once you have a DfE Sign-in account, ask a colleague with a Register account to send an email requesting an account for you.</p>
     <p class="govuk-body">If nobody in your organisation has a Register account, you can send the email yourself.</p>
-    <p class="govuk-body">The email should be sent to <a href="mailto:becoming.ateacher@education.gov.uk?subject=Request a Register account" class="govuk-link">becoming.ateacher@education.gov.uk</a>. It should say that you want to start using Register and include:</p>
+    <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Request a Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>. It should say that you want to start using Register and include:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>the name of the accredited provider or lead school you work for</li>
       <li>the email address used for your DfE Sign-in account</li>
@@ -38,6 +38,6 @@
     <p class="govuk-body">Once you have a Register account, you can request access to additional accredited providers or lead schools. You do not need a separate Register account for each organisation.</p>
     <p class="govuk-body">Ask someone with a Register account in the organisation you want to access to send an email requesting access for you.</p>
     <p class="govuk-body">If nobody in the organisation has a Register account, you can send the email yourself.</p>
-    <p class="govuk-body">The email should be sent to <a href="mailto:becoming.ateacher@education.gov.uk?subject=Add multiple organisations to Register account" class="govuk-link">becoming.ateacher@education.gov.uk</a>.</p>
+    <p class="govuk-body">The email should be sent to <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Add multiple organisations to Register account" class="govuk-link">becomingateacher@digital.education.gov.uk</a>.</p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1385,7 +1385,7 @@ en:
         bulk_update:
           recommendations_uploads:
             validate_trainee:
-              multiple_trainees_trn_received: "%{count} trainee records with TRN received status have the same %{found_with} - contact becoming.ateacher@education.gov.uk to fix this"
+              multiple_trainees_trn_received: "%{count} trainee records with TRN received status have the same %{found_with} - contact becomingateacher@digital.education.gov.uk to fix this"
               multiple_trainees_found_via: "%{count} trainee records have the same %{found_with} but none have TRN received status - you can only recommend trainees with TRN received status"
               trainee_wrong_state: "The trainee has %{state} status - you can only recommend trainees with TRN received status"
               no_trainee_matched: "%{id_available} must match a trainee record"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,7 +7,7 @@ base_url: https://localhost:5000
 feedback_link_url: "https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-XoQTPfbQ2dGrsruj75vocFUOFhUQUE4SkpBNlo2Q1hGMlBKVFNLOTlVSi4u"
 
 # The email address for support queries
-support_email: becoming.ateacher@education.gov.uk
+support_email: becomingateacher@digital.education.gov.uk
 data_email: registerateacher@education.gov.uk
 
 dttp:

--- a/db/service_updates.yml
+++ b/db/service_updates.yml
@@ -55,7 +55,7 @@
   content: |
      We’ve extended the deadline to sign off your new trainee data to <span class="no-wrap">Tuesday, 1 November 2022.</span>
 
-     This is due to Register being briefly unavailable leading up to the deadline. If you have any questions or concerns, email [becoming.ateacher@education.gov.uk](mailto:becoming.ateacher@education.gov.uk).
+     This is due to Register being briefly unavailable leading up to the deadline. If you have any questions or concerns, email [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 
 - date: '2022-09-28'
   title: Deadline for first data submission to HESA is extended to 17 October 2022
@@ -85,7 +85,7 @@
   content: |
      If you’re a higher education institute (HEI), you can start updating your trainee data through HESA from 18 to 29 July.
 
-     You’ll first need to have your data decommitted in HESA. Email our support team who will decommit your data and let you know when it’s ready to update. Email us at [becoming.ateacher@education.gov.uk](mailto:becoming.ateacher@education.gov.uk?subject=Decommit%20trainee%20data%20in%20HESA%20for%20July%20update%20period).
+     You’ll first need to have your data decommitted in HESA. Email our support team who will decommit your data and let you know when it’s ready to update. Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=Decommit%20trainee%20data%20in%20HESA%20for%20July%20update%20period).
 
 - date: '2022-07-05'
   title: Improvements to Register’s homepage and filters
@@ -118,7 +118,7 @@
   content: |
     The import from HESA to Register is working normally. This means if you’re a Higher Education Institute (HEI), you can use Register to see data that you have updated and uploaded to HESA. This will allow you to complete your April census update by 13 May.
 
-    If you have updated any data about placements in HESA, you will not be able to see this in Register yet, but this will be available in future. If you identify any further issues with your data, contact [becoming.ateacher@education.gov.uk](mailto:becoming.ateacher@education.gov.uk?subject=HESA%20import%20issues%20in%20Register).
+    If you have updated any data about placements in HESA, you will not be able to see this in Register yet, but this will be available in future. If you identify any further issues with your data, contact [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk?subject=HESA%20import%20issues%20in%20Register).
 
 - date: '2022-04-29'
   title: April HESA census update extended to Friday 13 May 2022
@@ -154,7 +154,7 @@
     The support desk will close at 2pm on Friday 24 December 2021. It will open again on Tuesday 4 January 2022.
 
     If you have an urgent problem during this time, you can still contact us at
-    [becoming.ateacher@education.gov.uk](mailto:becoming.ateacher@education.gov.uk).
+    [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 
 - date: '2021-12-03'
   title: The Department for Education (DfE) has published the provisional data for the 2021 initial teacher training (ITT) census

--- a/service_unavailable_page/web/public/internal/index.html
+++ b/service_unavailable_page/web/public/internal/index.html
@@ -107,7 +107,7 @@
             -->
 
             <p class="govuk-body">If you need to contact us urgently, email us at<br>
-              <a class="govuk-link" href="mailto:becoming.ateacher@education.gov.uk?subject=Register trainee teachers">becoming.ateacher@education.gov.uk</a>.
+              <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Register trainee teachers">becomingateacher@digital.education.gov.uk</a>.
             </p>
 
           </div>
@@ -126,7 +126,7 @@
                   Get support
                 </h2>
                 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                  <li>Email: <a class="govuk-link govuk-footer__link" href="mailto:becoming.ateacher@education.gov.uk?subject=Register%20trainee%20teachers%20support">becoming.ateacher@education.gov.uk</a></li>
+                  <li>Email: <a class="govuk-link govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20support">becomingateacher@digital.education.gov.uk</a></li>
                   <li>We aim to respond within 5 working days, or one working day for more urgent queries</li>
                 </ul>
               </div>

--- a/service_unavailable_page/web/public/internal/traineeteacherportal.html
+++ b/service_unavailable_page/web/public/internal/traineeteacherportal.html
@@ -45,7 +45,7 @@
               From Thursday 31 March, all trainee data from the 2020 to 2021 academic year onwards will be available
               in Register. </p>
             <p class="govuk-body">If you have any questions, email us at<br>
-            <a class="govuk-link" href="mailto:becoming.ateacher@education.gov.uk?subject=DTTP to Register transition">becoming.ateacher@education.gov.uk</a>.</p>
+            <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=DTTP to Register transition">becomingateacher@digital.education.gov.uk</a>.</p>
           </div>
         </div>
       </main>
@@ -59,7 +59,7 @@
               <div class=" govuk-grid-column-one-half">
                 <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Email</h2>
                 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                  <li><a class="govuk-footer__link" href="mailto:becoming.ateacher@education.gov.uk">becoming.ateacher@education.gov.uk</a> </li>
+                  <li><a class="govuk-footer__link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> </li>
                   <li>You’ll get a response within 5 working days, or one working day for urgent requests.</li>
                 </ul>
               </div>

--- a/spec/helpers/support_email_helper_spec.rb
+++ b/spec/helpers/support_email_helper_spec.rb
@@ -11,7 +11,7 @@ describe SupportEmailHelper do
       subject { helper.support_email }
 
       it has_correct_formatting do
-        expected_output = "<a class=\"govuk-link\" href=\"mailto:becoming.ateacher@education.gov.uk\">becoming.ateacher@education.gov.uk</a>"
+        expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk\">becomingateacher@digital.education.gov.uk</a>"
         expect(subject).to eq(expected_output)
       end
     end
@@ -20,7 +20,7 @@ describe SupportEmailHelper do
       subject { helper.support_email(subject: "Register trainee teachers support") }
 
       it has_correct_formatting do
-        expected_output = "<a class=\"govuk-link\" href=\"mailto:becoming.ateacher@education.gov.uk?subject=Register%20trainee%20teachers%20support\">becoming.ateacher@education.gov.uk</a>"
+        expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20support\">becomingateacher@digital.education.gov.uk</a>"
         expect(subject).to eq(expected_output)
       end
 
@@ -28,7 +28,7 @@ describe SupportEmailHelper do
         subject { helper.support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback") }
 
         it "has the correct formatting" do
-          expected_output = "<a class=\"govuk-link\" href=\"mailto:becoming.ateacher@education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
+          expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
           expect(subject).to eq(expected_output)
         end
 
@@ -36,7 +36,7 @@ describe SupportEmailHelper do
           subject { helper.support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback", classes: "govuk-link--no-visited-state") }
 
           it has_correct_formatting do
-            expected_output = "<a class=\"govuk-link govuk-link--no-visited-state\" href=\"mailto:becoming.ateacher@education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
+            expected_output = "<a class=\"govuk-link govuk-link--no-visited-state\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
             expect(subject).to eq(expected_output)
           end
         end

--- a/spec/services/bulk_update/recommendations_uploads/validate_trainee_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_trainee_spec.rb
@@ -184,7 +184,7 @@ module BulkUpdate
           end
 
           describe "#messages" do
-            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same TRN - contact becoming.ateacher@education.gov.uk to fix this"] }
+            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same TRN - contact becomingateacher@digital.education.gov.uk to fix this"] }
           end
 
           describe "#trainee" do
@@ -208,7 +208,7 @@ module BulkUpdate
           end
 
           describe "#messages" do
-            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same HESA ID - contact becoming.ateacher@education.gov.uk to fix this"] }
+            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same HESA ID - contact becomingateacher@digital.education.gov.uk to fix this"] }
           end
 
           describe "#trainee" do
@@ -230,7 +230,7 @@ module BulkUpdate
           end
 
           describe "#messages" do
-            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same provider trainee ID - contact becoming.ateacher@education.gov.uk to fix this"] }
+            it { expect(service.messages).to eql ["2 trainee records with TRN received status have the same provider trainee ID - contact becomingateacher@digital.education.gov.uk to fix this"] }
           end
 
           describe "#trainee" do


### PR DESCRIPTION
### Context
Following the previous request by support to change email links to becoming.ateacher@education.gov.uk it has now been decided to change them to becomingateacher@digital.education.gov.uk.

### Changes proposed in this pull request
All references to becoming.ateacher@education.gov.uk have been updated to becomingateacher@digital.education.gov.uk

### Guidance to review
N/A

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
