### PR TITLE
[6012] Backfill 'Veteran Teaching Undergraduate Bursary' initiative

### DIFF
--- a/db/data/20230913164507_backfill_veteran_teaching_undergraduate_bursary_initiative.rb
+++ b/db/data/20230913164507_backfill_veteran_teaching_undergraduate_bursary_initiative.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class BackfillVeteranTeachingUndergraduateBursaryInitiative < ActiveRecord::Migration[7.0]
+  def up
+    trainees_with_veterans_bursary_level.each do |trainee|
+      trainee.update(
+        training_initiative: ROUTE_INITIATIVES_ENUMS[:veterans_teaching_undergraduate_bursary],
+        applying_for_bursary: true,
+        audit_comment: "Backfilled by data migration for https://trello.com/c/Meh5yeHA/6012-check-if-we-set-veteran-teaching-undergraduate-bursary-initiative-from-hesa-fburslev-code-c-if-not-action-this",
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+private
+
+  def trainees_with_veterans_bursary_level
+    Trainee
+      .joins(:hesa_students)
+      .where(hesa_students: { bursary_level: "C" })
+      .distinct("trainees.id")
+  end
+end

--- a/db/data/20230913164507_backfill_veteran_teaching_undergraduate_bursary_initiative.rb
+++ b/db/data/20230913164507_backfill_veteran_teaching_undergraduate_bursary_initiative.rb
@@ -21,6 +21,6 @@ private
     Trainee
       .joins(:hesa_students)
       .where(hesa_students: { bursary_level: "C" })
-      .distinct("trainees.id")
+      .distinct
   end
 end


### PR DESCRIPTION
### Context
Trainees imported from HESA with bursary level 'C' should be allocated the 'Veteran Teaching Undergraduate Bursary' training initiative.

### Changes proposed in this pull request
Data migration to correct the training initiative for trainees imported from HESA with the matching bursary level.

### Guidance to review
Does this make sense?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
