### PR TITLE
[6012] Map veteran bursary correctly on HESA import

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -10,6 +10,8 @@ module Trainees
 
     NOT_APPLICABLE_SCHOOL_URNS = %w[900000 900010 900020 900030].freeze
 
+    VETERAN_TEACHING_UNDERGRADUATE_BURSARY_LEVEL = "C"
+
     class HesaImportError < StandardError; end
 
     def initialize(student_node:, record_source:)
@@ -192,7 +194,13 @@ module Trainees
     end
 
     def training_initiative
+      return ROUTE_INITIATIVES_ENUMS[:veterans_teaching_undergraduate_bursary] if veteran_teaching_undergraduate_bursary?
+
       ::Hesa::CodeSets::TrainingInitiatives::MAPPING[hesa_trainee[:training_initiative]]
+    end
+
+    def veteran_teaching_undergraduate_bursary?
+      hesa_trainee[:bursary_level] == VETERAN_TEACHING_UNDERGRADUATE_BURSARY_LEVEL
     end
 
     def itt_start_date

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -347,6 +347,16 @@ module Trainees
         end
       end
 
+      context "when bursary level indicates veteran teaching undergraduate bursary" do
+        let(:hesa_stub_attributes) do
+          { bursary_level: described_class::VETERAN_TEACHING_UNDERGRADUATE_BURSARY_LEVEL }
+        end
+
+        it "maps the trainee to the veteran teaching undergraduate bursary" do
+          expect(trainee.training_initiative).to eq(ROUTE_INITIATIVES_ENUMS[:veterans_teaching_undergraduate_bursary])
+        end
+      end
+
       context "trainee's course is in the primary age but subject isn't" do
         let(:hesa_stub_attributes) do
           {


### PR DESCRIPTION


### Context
When bursary_level is set to 'C' by HESA we should set the maps the trainee to the veteran teaching undergraduate bursary training initiative.

### Changes proposed in this pull request
This PR just updates the HESA mapping logic. There is a separate PR to backfill historic records - https://github.com/DFE-Digital/register-trainee-teachers/pull/3601

### Guidance to review

Is this the right place to add this logic?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
