### PR TITLE
Export HESA ID in a format that Excel will not convert to scientific notation

### DIFF
--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -20,7 +20,6 @@ module Reports
     delegate :course_duration_in_years,
              :ethnic_background,
              :first_names,
-             :hesa_id,
              :middle_names,
              :trn,
              :withdraw_reasons_details,
@@ -403,6 +402,10 @@ module Reports
       return nil if course_minimum_age.blank? && course_maximum_age.blank?
 
       "#{course_minimum_age} to #{course_maximum_age}"
+    end
+
+    def hesa_id
+      trainee.hesa_id&.gsub(/(.*)/, "'\\1") # prevent Excel from converting it to scientific notation
     end
 
   private

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -52,8 +52,8 @@ describe Reports::TraineeReport do
       expect(subject.apply_id).to eq(trainee.apply_application&.apply_id)
     end
 
-    it "includes the hesa_id" do
-      expect(subject.hesa_id).to eq(trainee.hesa_id)
+    it "includes the string-enforced hesa_id" do
+      expect(subject.hesa_id).to eq("'#{trainee.hesa_id}'")
     end
 
     it "includes the provider_trainee_id" do


### PR DESCRIPTION
### Context

HESA increased the length of the HESAID from 13 digit to 17 digits. This is a length that when it is exported to Excel, as a number, it is corrupted, and the last 2 digits of the HESAID are lost.

This means when HEIs are trying to check their records, in Excel, they can't match correctly on HESAIDs, and it's much more difficult for them.

### Trello

https://trello.com/c/ZKRDPkJu/6033-check-hesaid-is-exported-correctly-if-not-fix

### Changes proposed in this pull request

Wrap the HESA ID in single quotes so that Excel doesn't get ideas above its station.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
