### PR TITLE
[6031] Add file validations to uploads

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -19,12 +19,15 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Upload < ApplicationRecord
+  VALID_CONTENT_TYPES = ["text/csv", "application/xml", "application/zip"].freeze
+  MAX_FILE_SIZE = 50.megabytes
+
   include PgSearch::Model
   pg_search_scope :search_by_name, against: :name, using: %i[tsearch trigram]
 
   belongs_to :user
   has_one_attached :file
 
-  validates :file, presence: true
+  validates :file, presence: true, file: { content_type: VALID_CONTENT_TYPES, size_limit: MAX_FILE_SIZE }
   validates :name, presence: true
 end

--- a/app/validators/file_validator.rb
+++ b/app/validators/file_validator.rb
@@ -4,7 +4,7 @@ class FileValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    if !value.blob.content_type.in?(content_types)
+    if content_types.exclude?(value.blob.content_type)
       value.purge
       record.errors.add(attribute, :invalid_content_type)
     elsif value.blob.byte_size > size_limit

--- a/app/validators/file_validator.rb
+++ b/app/validators/file_validator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class FileValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    if !value.blob.content_type.in?(content_types)
+      value.purge
+      record.errors.add(attribute, :invalid_content_type)
+    elsif value.blob.byte_size > size_limit
+      value.purge
+      record.errors.add(attribute, :invalid_file_size)
+    end
+  end
+
+private
+
+  def content_types
+    options.fetch(:content_type)
+  end
+
+  def size_limit
+    options.fetch(:size_limit)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1300,6 +1300,11 @@ en:
             dttp_id:
               invalid: Enter a DTTP ID in the correct format, like 6a61d94f-5060-4d57-8676-bdb265a5b949
               taken: Enter a unique DTTP ID
+        upload:
+          attributes:
+            file:
+              invalid_content_type: Upload a valid file type (csv, xml or zip)
+              invalid_file_size: Upload a file less than 50mb
   activemodel:
     attributes:
       course_details_form:

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -3,13 +3,13 @@
 FactoryBot.define do
   factory :upload do
     user factory: %i[user system_admin]
-    name { "test.txt" }
+    name { "test.csv" }
 
     after(:build) do |upload|
       upload.file.attach(
-        io: Rails.root.join("spec/fixtures/files/test.txt").open,
-        filename: "test.txt",
-        content_type: "text/text",
+        io: Rails.root.join("spec/fixtures/files/test.csv").open,
+        filename: "test.csv",
+        content_type: "text/csv",
       )
     end
   end

--- a/spec/features/system_admin/uploads/create_spec.rb
+++ b/spec/features/system_admin/uploads/create_spec.rb
@@ -21,7 +21,7 @@ feature "Upload a file" do
     end
 
     scenario "with required attributes" do
-      attach_file("upload[file]", Rails.root.join("spec/fixtures/files/test.txt"))
+      attach_file("upload[file]", Rails.root.join("spec/fixtures/files/test.csv"))
       and_i_click_on_submit
       then_i_see_the_upload
     end
@@ -42,7 +42,7 @@ private
   end
 
   def then_i_see_the_upload
-    expect(show).to have_text("test.txt")
+    expect(show).to have_text("test.csv")
   end
 
   def then_i_see_an_error

--- a/spec/features/system_admin/uploads/delete_spec.rb
+++ b/spec/features/system_admin/uploads/delete_spec.rb
@@ -16,7 +16,7 @@ feature "Delete a file" do
   end
 
   describe "Deleting an upload" do
-    scenario "blah" do
+    scenario "upload can be deleted" do
       and_an_upload_exists
       and_i_delete_the_upload
       then_the_upload_no_longer_shows
@@ -31,7 +31,7 @@ private
 
   def and_an_upload_exists
     show.load(id: upload.id)
-    expect(show).to have_text "test.txt"
+    expect(show).to have_text "test.csv"
   end
 
   def and_i_delete_the_upload
@@ -39,6 +39,6 @@ private
   end
 
   def then_the_upload_no_longer_shows
-    expect(index).not_to have_text "test.txt"
+    expect(index).not_to have_text "test.csv"
   end
 end

--- a/spec/fixtures/files/test.csv
+++ b/spec/fixtures/files/test.csv
@@ -1,0 +1,2 @@
+Provider trainee ID ,Region,First names
+A2,London,Adam

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -11,5 +11,38 @@ describe Upload do
   context "validations" do
     it { is_expected.to validate_presence_of(:file) }
     it { is_expected.to validate_presence_of(:name) }
+
+    context "invalid file type" do
+      let(:upload) { build(:upload, file: nil) }
+      let(:file) { fixture_file_upload("test.txt", "text/plain") }
+
+      before do
+        upload.file.attach(file)
+      end
+
+      it "does not allow invalid content types" do
+        expect(upload).not_to be_valid
+        expect(upload.errors[:file]).to include("Upload a valid file type (csv, xml or zip)")
+      end
+    end
+
+    context "valid file type" do
+      subject { build(:upload) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "invalid file size" do
+      let(:upload) { build(:upload) }
+
+      before do
+        allow(upload.file.blob).to receive(:byte_size).and_return(51.megabytes)
+      end
+
+      it "does not allow invalid file size" do
+        expect(upload).not_to be_valid
+        expect(upload.errors[:file]).to include("Upload a file less than 50mb")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/k6OnoVN1/6031-insecure-file-upload-medium

### Changes proposed in this pull request

- Add some basic validation to file types in uploads

<img width="755" alt="Screenshot 2023-09-19 at 09 33 00" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/7d96fa48-db3c-45de-a5c0-6a960726a410">

<img width="733" alt="Screenshot 2023-09-19 at 09 33 27" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/131e1a66-53aa-4fe1-bed3-03dbae99e9ac">

<img width="704" alt="Screenshot 2023-09-19 at 09 33 48" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/0662f698-197e-4a61-a7ff-947218f17c60">


### Guidance to review

- Head to system admin, uploads and try to upload some funny files

###  Notes

- Have just allowed the file types we seem to use this area for (backfilling etc) 
- Follow on ticket to do additional virus scanning with Azure defender on uploads (will be useful for the zip formats)
