### PR TITLE
Display trainee start and end years correctly on the summary list view

### DIFF
--- a/app/components/record_details/view.rb
+++ b/app/components/record_details/view.rb
@@ -109,9 +109,9 @@ module RecordDetails
     end
 
     def start_year_row
-      return if trainee.start_date.blank?
+      return if trainee.start_academic_cycle.blank?
 
-      start_year = AcademicCycle.for_date(trainee.start_date).label
+      start_year = trainee.start_academic_cycle.label
       {
         field_label: t(".start_year"),
         field_value: start_year,
@@ -119,9 +119,9 @@ module RecordDetails
     end
 
     def end_year_row
-      return if trainee.estimated_end_date.blank?
+      return if trainee.end_academic_cycle.blank?
 
-      end_year = AcademicCycle.for_date(trainee.estimated_end_date).label
+      end_year = trainee.end_academic_cycle.label
       {
         field_label: t(".end_year"),
         field_value: end_year,

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -19,14 +19,16 @@ module RecordDetails
         provider: provider,
         hesa_id: hesa_id,
         study_mode: TRAINEE_STUDY_MODE_ENUMS["part_time"],
+        itt_start_date: current_academic_cycle.start_date,
+        itt_end_date: next_academic_cycle.end_date,
       )
     end
     let(:hesa_id) { Faker::Number.number(digits: 10).to_s }
     let(:trainee_status) { "trainee-status" }
     let(:trainee_progress) { "trainee-progress" }
     let(:timeline_event) { double(date: Time.zone.today) }
-    let!(:current_academic_cycle) { create(:academic_cycle) }
-    let!(:next_academic_cycle) { create(:academic_cycle, next_cycle: true) }
+    let(:current_academic_cycle) { create(:academic_cycle) }
+    let(:next_academic_cycle) { create(:academic_cycle, next_cycle: true) }
 
     context "when :show_provider is true" do
       let(:change_accredited_provider_enabled) { false }


### PR DESCRIPTION
### Context

There was a discrepancy between the values we show for end year in the list view and details view, as described here: https://trello.com/c/vpnqUnbc/6061-end-year-displayed-on-summary-list-view-of-trainees-shows-incorrect-academic-year

### Changes proposed in this pull request

Always base start year and end year on the `start_academic_cycle` and `end_academic_cycle` fields, rather than `estimated_end_date`, which we should probably get rid of.

### Guidance to review

Look at the trainees index and see if end year matches in the list and details views.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
