### PR TITLE
[6028] Cancel links to change AP flow

### DIFF
--- a/app/controllers/system_admin/accredited_providers/confirmations_controller.rb
+++ b/app/controllers/system_admin/accredited_providers/confirmations_controller.rb
@@ -19,11 +19,11 @@ module SystemAdmin
         end
       end
 
+    private
+
       def trainee
         @trainee ||= Trainee.find(params[:trainee_id])
       end
-
-    private
 
       def enforce_feature_flag
         redirect_to(not_found_path) unless FeatureService.enabled?(:change_accredited_provider)

--- a/app/controllers/system_admin/accredited_providers/providers_controller.rb
+++ b/app/controllers/system_admin/accredited_providers/providers_controller.rb
@@ -26,14 +26,14 @@ module SystemAdmin
         end
       end
 
-      def trainee
-        @trainee ||= Trainee.find(params[:trainee_id])
-      end
-
     private
 
       def enforce_feature_flag
         redirect_to(not_found_path) unless FeatureService.enabled?(:change_accredited_provider)
+      end
+
+      def trainee
+        @trainee ||= Trainee.find(params[:trainee_id])
       end
 
       def update_params

--- a/app/controllers/system_admin/accredited_providers/reasons_controller.rb
+++ b/app/controllers/system_admin/accredited_providers/reasons_controller.rb
@@ -24,14 +24,14 @@ module SystemAdmin
         end
       end
 
-      def trainee
-        @trainee ||= Trainee.find(params[:trainee_id])
-      end
-
     private
 
       def enforce_feature_flag
         redirect_to(not_found_path) unless FeatureService.enabled?(:change_accredited_provider)
+      end
+
+      def trainee
+        @trainee ||= Trainee.find(params[:trainee_id])
       end
 
       def update_params

--- a/app/views/system_admin/accredited_providers/confirmations/show.html.erb
+++ b/app/views/system_admin/accredited_providers/confirmations/show.html.erb
@@ -1,3 +1,5 @@
+<%= render PageTitle::View.new(text: "Check change of accredited provider details") %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(
@@ -33,6 +35,10 @@
       <%= govuk_warning_text(text: "The provider you have selected will be given ownership of this record. Selecting the wrong provider could lead to a data breach.") %>
 
       <%= f.govuk_submit("Update record") %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t('views.forms.common.cancel_and_return_to_record'), trainee_path(@trainee))%>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/system_admin/accredited_providers/providers/edit.html.erb
+++ b/app/views/system_admin/accredited_providers/providers/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render PageTitle::View.new(text: "Change accredited provider", has_errors: @change_accredited_provider_form.errors.present?) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(
@@ -39,6 +41,10 @@
       <%= govuk_warning_text(text: "Choosing the wrong accredited provider could lead to a data breach.") %>
 
       <%= f.govuk_submit %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t('views.forms.common.cancel_and_return_to_record'), trainee_path(@trainee))%>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/system_admin/accredited_providers/reasons/edit.html.erb
+++ b/app/views/system_admin/accredited_providers/reasons/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render PageTitle::View.new(text: 'Why you’re changing the accredited provider', has_errors: @change_accredited_provider_form.errors.present?) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(
@@ -35,6 +37,10 @@
       </p>
 
       <%= f.govuk_submit %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to(t('views.forms.common.cancel_and_return_to_record'), trainee_path(@trainee))%>
+      </p>
     <% end %>
   </div>
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   # config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,6 +7,7 @@ features:
   basic_auth: false
   import_courses_from_ttapi: true
   publish_course_details: true
+  change_accredited_provider: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -6,6 +6,7 @@ features:
   sign_in_method: persona
   enable_feedback_link: true
   publish_course_details: true
+  change_accredited_provider: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true


### PR DESCRIPTION
### Context

https://trello.com/c/GRhphnFr/6028-change-accredited-provider-cancel-flow

Builds on from https://github.com/DFE-Digital/register-trainee-teachers/pull/3609 

### Changes proposed in this pull request

- Adds cancel links and page titles to AP flow
- Turns AP flag on in development settings

### Guidance to review

- Click each cancel link and check it goes back to the correct path (the record page)
- Assert page titles are show correctly on normal and error states
