### PR TITLE
[6027] Implement confirm page change links

### DIFF
--- a/app/controllers/system_admin/accredited_providers/confirmations_controller.rb
+++ b/app/controllers/system_admin/accredited_providers/confirmations_controller.rb
@@ -6,6 +6,8 @@ module SystemAdmin
       before_action :enforce_feature_flag
 
       def show
+        page_tracker.save_as_origin!
+
         @change_accredited_provider_form = ChangeAccreditedProviderForm.new(trainee)
       end
 
@@ -19,11 +21,11 @@ module SystemAdmin
         end
       end
 
+    private
+
       def trainee
         @trainee ||= Trainee.find(params[:trainee_id])
       end
-
-    private
 
       def enforce_feature_flag
         redirect_to(not_found_path) unless FeatureService.enabled?(:change_accredited_provider)

--- a/app/controllers/system_admin/accredited_providers/providers_controller.rb
+++ b/app/controllers/system_admin/accredited_providers/providers_controller.rb
@@ -19,7 +19,7 @@ module SystemAdmin
         )
 
         if @change_accredited_provider_form.stash
-          redirect_to(edit_trainee_accredited_providers_reason_path(trainee_id: params[:trainee_id]))
+          redirect_to(relevant_redirect_path)
         else
           @providers = Provider.all
           render(:edit)
@@ -40,6 +40,10 @@ module SystemAdmin
         params
           .require(:system_admin_change_accredited_provider_form)
           .permit(:accredited_provider_id)
+      end
+
+      def relevant_redirect_path
+        page_tracker.last_origin_page_path || edit_trainee_accredited_providers_reason_path(trainee_id: params[:trainee_id])
       end
     end
   end

--- a/app/controllers/system_admin/accredited_providers/reasons_controller.rb
+++ b/app/controllers/system_admin/accredited_providers/reasons_controller.rb
@@ -18,7 +18,7 @@ module SystemAdmin
         )
 
         if @change_accredited_provider_form.stash
-          redirect_to(trainee_accredited_providers_confirmations_path(trainee_id: params[:trainee_id]))
+          redirect_to(relevant_redirect_path)
         else
           render(:edit)
         end
@@ -38,6 +38,10 @@ module SystemAdmin
         params
           .require(:system_admin_change_accredited_provider_form)
           .permit(:audit_comment, :zendesk_ticket_url)
+      end
+
+      def relevant_redirect_path
+        page_tracker.last_origin_page_path || trainee_accredited_providers_confirmations_path(trainee_id: params[:trainee_id])
       end
     end
   end

--- a/app/views/system_admin/accredited_providers/confirmations/show.html.erb
+++ b/app/views/system_admin/accredited_providers/confirmations/show.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
+  <div class="govuk-grid-column-full">
     <%= register_form_with(
       model: @change_accredited_provider_form,
       url: trainee_accredited_providers_confirmations_path(trainee_id: @change_accredited_provider_form.id),
@@ -17,14 +17,23 @@
             {
               key: "New accredited provider",
               value: @change_accredited_provider_form.accredited_provider_name,
+              action_href: edit_trainee_accredited_providers_provider_path(trainee_id: @trainee.id),
+              action_text: t(:change),
+              action_visually_hidden_text: 'accredited provider',
             },
             {
               key: "Trainee timeline comment",
               value: @change_accredited_provider_form.audit_comment,
+              action_href: edit_trainee_accredited_providers_reason_path(trainee_id: @trainee.id),
+              action_text: t(:change),
+              action_visually_hidden_text: 'trainee timeline comment',
             },
             {
               key: "Zendesk ticket URL",
               value: @change_accredited_provider_form.zendesk_ticket_url,
+              action_href: edit_trainee_accredited_providers_reason_path(trainee_id: @trainee.id),
+              action_text: t(:change),
+              action_visually_hidden_text: 'zendesk ticket url',
             },
           ],
         )

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,6 +7,7 @@ features:
   basic_auth: false
   import_courses_from_ttapi: true
   publish_course_details: true
+  change_accredited_provider: true
   routes:
     provider_led_postgrad: true
     early_years_assessment_only: true

--- a/spec/features/system_admin/accredited_providers/change_accredited_provider_spec.rb
+++ b/spec/features/system_admin/accredited_providers/change_accredited_provider_spec.rb
@@ -34,6 +34,19 @@ feature "Change a trainee's accredited provider" do
       then_i_see_a_flash_message
       and_i_see_the_new_provider_name_and_code
     end
+
+    scenario "submit buttons return to correct path from confirmation page" do
+      given_i_am_reviewing_my_changes_on_the_confirmation_page
+      when_i_click_to_change_the_accredited_provider
+      then_i_see_the_change_accredited_providers_page
+      when_i_click_continue
+      then_i_see_the_confirmation_page
+
+      when_i_click_to_change_the_zendesk_ticket_url
+      then_i_see_the_reasons_page
+      when_i_click_continue
+      then_i_see_the_confirmation_page
+    end
   end
 
   def and_the_change_accredited_provider_feature_is_not_enabled
@@ -72,6 +85,7 @@ feature "Change a trainee's accredited provider" do
   def and_click_continue
     click_on "Continue"
   end
+  alias_method :when_i_click_continue, :and_click_continue
 
   def then_i_see_the_reasons_page
     expect(page).to have_content("Why you’re changing the accredited provider")
@@ -104,5 +118,31 @@ feature "Change a trainee's accredited provider" do
 
   def and_i_see_the_new_provider_name_and_code
     expect(page).to have_content(new_provider.name_and_code)
+  end
+
+  def given_i_am_reviewing_my_changes_on_the_confirmation_page
+    when_i_visit_the_trainee_detail_page
+    then_i_do_not_see_a_change_provider_link
+
+    when_the_change_accredited_provider_feature_is_enabled
+    and_i_visit_the_trainee_detail_page
+    and_i_click_the_change_provider_link
+    then_i_see_the_change_accredited_providers_page
+
+    when_i_select_a_provider
+    and_click_continue
+    then_i_see_the_reasons_page
+
+    when_i_fill_in_reasons
+    and_click_continue
+    then_i_see_the_confirmation_page
+  end
+
+  def when_i_click_to_change_the_accredited_provider
+    click_on "Change accredited provider"
+  end
+
+  def when_i_click_to_change_the_zendesk_ticket_url
+    click_on "Change zendesk ticket url"
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/7ORLVhzH/6027-change-the-confirmation-change-link

### Changes proposed in this pull request

<img width="1100" alt="Screenshot 2023-09-27 at 11 08 14" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/12ceab24-f058-42d6-9423-b558f9f108a6">

- Adds change links to the AP flow confirm
ation page to be able to go back and update answers
- Wire up page tracker to return users to the correct page

### Guidance to review

- Visit review app and sign in as support admin
- Head to a trainee and complete the AP flow
- Go back and update answers

