### PR TITLE
[6029] Enable `change_accredited_provider` FF on proddata

### DIFF
--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -39,6 +39,7 @@ features:
   hesa_import:
     test_mode: true
     sync_trn_data: false
+  change_accredited_provider: true
 
 environment:
   name: productiondata

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -44,6 +44,7 @@ features:
     sync_teachers: true
   google:
     send_data_to_big_query: false
+  change_accredited_provider: true
 
 environment:
   name: staging

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -218,6 +218,7 @@ module RecordDetails
           let(:trainee_start_date) { 5.days.from_now.to_date }
 
           before do
+            create(:academic_cycle, one_after_next_cycle: true)
             trainee.trainee_start_date = trainee_start_date
             render_inline(View.new(trainee: trainee, last_updated_event: timeline_event, editable: true))
           end


### PR DESCRIPTION
### Context

We need to enable the `changed_accredited_provider` feature on `productiondata` to allow product review.

### Changes proposed in this pull request

Enable the `changed_accredited_provider` feature flag on `productiondata` and `staging`.

### Guidance to review

We don't want this going live on `production` yet.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
