### PR TITLE
[6065] Autocomplete for changing accredited provider

### DIFF
--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -71,6 +71,19 @@ module CourseDetailsHelper
     [["", ""]] + options
   end
 
+  def provider_options(providers)
+    providers.map do |provider|
+      [
+        provider.name_and_code,
+        provider.id,
+        {
+          "data-append": "<p class=\"govuk-body-s govuk-!-margin-0 govuk-caption-m govuk-hint\">UKPRN: #{provider.ukprn}</p>",
+          "data-synonyms": [provider.ukprn, provider.code].join("|"),
+        },
+      ]
+    end
+  end
+
 private
 
   def language_specialisms

--- a/app/helpers/course_details_helper.rb
+++ b/app/helpers/course_details_helper.rb
@@ -77,7 +77,7 @@ module CourseDetailsHelper
         provider.name_and_code,
         provider.id,
         {
-          "data-append": "<p class=\"govuk-body-s govuk-!-margin-0 govuk-caption-m govuk-hint\">UKPRN: #{provider.ukprn}</p>",
+          "data-append": "<p class=\"govuk-!-margin-0 autocomplete__option--hint\">UKPRN: #{provider.ukprn}</p>",
           "data-synonyms": [provider.ukprn, provider.code].join("|"),
         },
       ]

--- a/app/views/system_admin/accredited_providers/providers/edit.html.erb
+++ b/app/views/system_admin/accredited_providers/providers/edit.html.erb
@@ -36,6 +36,17 @@
         %>
       </p>
 
+      <div data-module="app-autocomplete">
+        <p><%= f.govuk_select(
+          :accredited_provider_id,
+          @providers.map { |provider| [provider.name_and_code, provider.id] },
+          label: { text: "New accredited provider", size: "s" },
+          width: 20,
+          autocomplete: :enabled,
+          class: 'provider-select',
+        ) %></p>
+      </div>
+
       <%= govuk_warning_text(text: "Choosing the wrong accredited provider could lead to a data breach.") %>
 
       <%= f.govuk_submit %>

--- a/app/views/system_admin/accredited_providers/providers/edit.html.erb
+++ b/app/views/system_admin/accredited_providers/providers/edit.html.erb
@@ -23,27 +23,14 @@
         </p>
       </div>
 
-      <p>
-        <%=
-          f.govuk_select(
-            :accredited_provider_id,
-            @providers.map { |provider| [provider.name_and_code, provider.id] },
-            label: { text: "New accredited provider", size: "s" },
-            width: 20,
-            autocomplete: :enabled,
-            class: 'provider-select',
-          )
-        %>
-      </p>
-
       <div data-module="app-autocomplete">
         <p><%= f.govuk_select(
           :accredited_provider_id,
-          @providers.map { |provider| [provider.name_and_code, provider.id] },
+          provider_options(@providers),
           label: { text: "New accredited provider", size: "s" },
           width: 20,
           autocomplete: :enabled,
-          class: 'provider-select',
+          class: "provider-select",
         ) %></p>
       </div>
 

--- a/spec/helpers/course_details_helper_spec.rb
+++ b/spec/helpers/course_details_helper_spec.rb
@@ -108,4 +108,26 @@ describe CourseDetailsHelper do
       expect(filter_year_options(current_user, :start_year).map(&:value)).to eq(["All years", "2020 to 2021"])
     end
   end
+
+  describe "#provider_options" do
+    let(:providers) { build_list(:provider, 3) }
+
+    it "returns a list of provider options" do
+      expect(provider_options(providers).map(&:first)).to eql(providers.map(&:name_and_code))
+      expect(provider_options(providers).map(&:second)).to eql(providers.map(&:id))
+    end
+
+    it "includes synonyms for the provider codes and UKPRN" do
+      provider_options(providers).map(&:last).each_with_index do |option, index|
+        expect(option[:"data-synonyms"]).to include(providers[index].ukprn)
+        expect(option[:"data-synonyms"]).to include(providers[index].code)
+      end
+    end
+
+    it "includes the UKPRN in the dropdown" do
+      provider_options(providers).map(&:last).each_with_index do |option, index|
+        expect(option[:"data-append"]).to include(providers[index].ukprn)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context
We want to make it easy for administrators to find providers when select a new accredited provider for a trainee.

### Changes proposed in this pull request
This PR progressively enhances the original `select` element (dropdown) using the accessible autocomplete component.

- The user can search (autocomplete) based on the provider name, code or UKPRN.
- Full details including the name, code or UKPRN are included in the dropdown portion of the autocomplete.

Initial state:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/0ffa3090-a7a0-430e-a91c-d025c1e08b7b)

Dropdown open:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/3b8c4570-0f7f-42bd-97b6-363876bf29f4)

If the user has disabled JavaScript the original `select` element is displayed and the system continues to function.

### Guidance to review
Is the UX right?

This can be reused on the provider list page in the Support interface (there is a ticket - https://trello.com/c/b2iVds7q/641-support-add-autocomplete-to-search-for-providers)

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
