### PR TITLE
[6123] Add back links to AP flow

### DIFF
--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -6,6 +6,7 @@ class TraineesController < BaseTraineeController
 
   before_action :redirect_to_not_found, if: -> { trainee.discarded? }, only: :show
   before_action :ensure_trainee_is_not_draft!, :load_missing_data_view, only: :show
+  before_action :clear_page_tracker, only: :show
 
   def show
     authorize(trainee)
@@ -107,5 +108,9 @@ private
 
   def trainee_params
     params.fetch(:trainee, {}).permit(:training_route, :record_source)
+  end
+
+  def clear_page_tracker
+    page_tracker.clear_redundant_session_data
   end
 end

--- a/app/lib/page_tracker.rb
+++ b/app/lib/page_tracker.rb
@@ -50,6 +50,15 @@ class PageTracker
     history.pop
   end
 
+  def clear_redundant_session_data
+    match = request.referer&.match(TRAINEE_PAGE_URI_REGEX)
+    if match
+      trainee_slug = match.to_s.split("/")[1]
+      session.delete("#{HISTORY_KEY_PREFIX}_#{trainee_slug}")
+      session.delete("#{ORIGIN_PAGES_KEY_PREFIX}_#{trainee_slug}")
+    end
+  end
+
 private
 
   attr_reader :session, :request, :history_session_key, :origin_pages_session_key
@@ -78,15 +87,6 @@ private
   def reset_origin_pages_to_current_path
     full_path_index = origin_pages.index(request.fullpath)
     session[origin_pages_session_key] = origin_pages[..full_path_index]
-  end
-
-  def clear_redundant_session_data
-    match = request.referer&.match(TRAINEE_PAGE_URI_REGEX)
-    if match
-      trainee_slug = match.to_s.split("/")[1]
-      session.delete("#{HISTORY_KEY_PREFIX}_#{trainee_slug}")
-      session.delete("#{ORIGIN_PAGES_KEY_PREFIX}_#{trainee_slug}")
-    end
   end
 
   def entered_an_edit_page_directly?

--- a/app/views/system_admin/accredited_providers/confirmations/show.html.erb
+++ b/app/views/system_admin/accredited_providers/confirmations/show.html.erb
@@ -1,5 +1,9 @@
 <%= render PageTitle::View.new(text: "Check change of accredited provider details") %>
 
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: edit_trainee_accredited_providers_reason_path(trainee_id: @trainee.id) ) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= register_form_with(

--- a/app/views/system_admin/accredited_providers/providers/edit.html.erb
+++ b/app/views/system_admin/accredited_providers/providers/edit.html.erb
@@ -1,5 +1,9 @@
 <%= render PageTitle::View.new(text: "Change accredited provider", has_errors: @change_accredited_provider_form.errors.present?) %>
 
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: @page_tracker.last_origin_page_path.presence || trainee_path(@trainee) ) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(

--- a/app/views/system_admin/accredited_providers/reasons/edit.html.erb
+++ b/app/views/system_admin/accredited_providers/reasons/edit.html.erb
@@ -1,5 +1,9 @@
 <%= render PageTitle::View.new(text: 'Why you’re changing the accredited provider', has_errors: @change_accredited_provider_form.errors.present?) %>
 
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: @page_tracker.last_origin_page_path.presence || edit_trainee_accredited_providers_provider_path(trainee_id: @trainee.id) ) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(

--- a/spec/features/system_admin/accredited_providers/change_accredited_provider_spec.rb
+++ b/spec/features/system_admin/accredited_providers/change_accredited_provider_spec.rb
@@ -47,6 +47,24 @@ feature "Change a trainee's accredited provider" do
       when_i_click_continue
       then_i_see_the_confirmation_page
     end
+
+    scenario "back links" do
+      given_i_am_reviewing_my_changes_on_the_confirmation_page
+      when_i_click_to_change_the_accredited_provider
+      then_i_see_the_change_accredited_providers_page
+      when_i_click_back
+      then_i_see_the_confirmation_page
+
+      when_i_click_to_change_the_zendesk_ticket_url
+      then_i_see_the_reasons_page
+      when_i_click_back
+      then_i_see_the_confirmation_page
+
+      when_i_click_update
+      and_i_click_the_change_provider_link
+      and_i_click_back
+      then_i_see_the_trainee_detail_page
+    end
   end
 
   def and_the_change_accredited_provider_feature_is_not_enabled
@@ -144,5 +162,14 @@ feature "Change a trainee's accredited provider" do
 
   def when_i_click_to_change_the_zendesk_ticket_url
     click_link "Change zendesk ticket url"
+  end
+
+  def when_i_click_back
+    click_link "Back"
+  end
+  alias_method :and_i_click_back, :when_i_click_back
+
+  def then_i_see_the_trainee_detail_page
+    expect(page).to have_current_path("/trainees/#{trainee.slug}", ignore_query: true)
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/dPLLOzqJ/6123-change-ap-flow-back-links

The page tracker thing has always been a bit funny to rely on so I think key is to be a bit more explicit when using it. Also worth noting that I've made one of the original methods public to help clearing out the session when needed (I think we should probably be doing that so every section begins with a fresh state).

### Changes proposed in this pull request

- Add back links to AP flow

### Guidance to review

- Go to review app and complete the flow to confirm page, go back to sections and hit the back link. Check it behaves correctly.
