### PR TITLE
[6029] Content corrections 'Accredited' not 'Accrediting' provider

### DIFF
--- a/app/views/system_admin/accredited_providers/confirmations/show.html.erb
+++ b/app/views/system_admin/accredited_providers/confirmations/show.html.erb
@@ -14,7 +14,7 @@
 
       <%=
         render SummaryCard::View.new(
-          title: "Change of accrediting provider details",
+          title: "Change of accredited provider details",
           rows: [
             {
               key: "New accredited provider",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,7 +103,7 @@ en:
       employing_school: &employing_school Employing school
   record_details:
     view:
-      provider: Accrediting provider
+      provider: Accredited provider
       trainee_id: &trainee_id Trainee ID
       region: &region Region
       submitted_for_trn: Submitted for TRN

--- a/spec/components/record_details/view_spec.rb
+++ b/spec/components/record_details/view_spec.rb
@@ -56,7 +56,7 @@ module RecordDetails
         let(:change_accredited_provider_enabled) { true }
 
         it "does not render a change link" do
-          expect(rendered_component).to have_css(".govuk-summary-list__row.accrediting-provider .govuk-summary-list__actions a", count: 0)
+          expect(rendered_component).to have_css(".govuk-summary-list__row.accredited-provider .govuk-summary-list__actions a", count: 0)
         end
       end
 
@@ -65,7 +65,7 @@ module RecordDetails
         let(:show_change_provider) { true }
 
         it "renders a change link" do
-          expect(rendered_component).to have_css(".govuk-summary-list__row.accrediting-provider .govuk-summary-list__actions a", count: 1)
+          expect(rendered_component).to have_css(".govuk-summary-list__row.accredited-provider .govuk-summary-list__actions a", count: 1)
         end
       end
     end

--- a/spec/features/system_admin/accredited_providers/change_accredited_provider_spec.rb
+++ b/spec/features/system_admin/accredited_providers/change_accredited_provider_spec.rb
@@ -63,13 +63,13 @@ feature "Change a trainee's accredited provider" do
   alias_method :and_i_visit_the_trainee_detail_page, :when_i_visit_the_trainee_detail_page
 
   def then_i_do_not_see_a_change_provider_link
-    within ".govuk-summary-list__row.accrediting-provider" do
+    within ".govuk-summary-list__row.accredited-provider" do
       expect(page).not_to have_link("Change")
     end
   end
 
   def and_i_click_the_change_provider_link
-    within ".govuk-summary-list__row.accrediting-provider" do
+    within ".govuk-summary-list__row.accredited-provider" do
       click_link "Change"
     end
   end


### PR DESCRIPTION
### Context
There were a couple of mistakes in the content that this PR aims to correct.

### Changes proposed in this pull request

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/4c0f979d-a5b0-4fc3-b8e6-4bbc93fa393f)

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/565569a9-25af-4541-88e3-7edf3b3d38f5)

### Guidance to review
Any other mistakes?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
