### PR TITLE
[6131] Change accredited provider update timeline

### DIFF
--- a/app/components/timeline/view.html.erb
+++ b/app/components/timeline/view.html.erb
@@ -11,16 +11,20 @@
           <%= event.date.to_fs(:govuk_date_and_time) %>
         </time>
       </p>
-        <% if event.items.present? %>
         <div class="app-timeline__description">
-          <dl class="app-timeline__metadata-container">
-            <% event.items.each do |key, value| %>
-              <dt class="app-timeline__metadata-term"><%= key %></dt>
-              <dd class="app-timeline__metadata-definition"><%= value %></dd>
+          <% if event.items.present? && event.items.first.is_a?(String) %>
+            <% event.items.each do |value| %>
+              <p class="govuk-body"><%= value %></p>
             <% end %>
-          </dl>
+          <% elsif event.items.present? %>
+            <dl class="app-timeline__metadata-container">
+              <% event.items.each do |key, value| %>
+                <dt class="app-timeline__metadata-term"><%= key %></dt>
+                <dd class="app-timeline__metadata-definition"><%= value %></dd>
+              <% end %>
+            </dl>
+          <% end %>
         </div>
-        <% end %>
       </div>
     <% end %>
 </div>

--- a/app/components/timeline/view.html.erb
+++ b/app/components/timeline/view.html.erb
@@ -12,7 +12,7 @@
         </time>
       </p>
         <div class="app-timeline__description">
-          <% if event.items.present? && event.items.first.is_a?(String) %>
+          <% if event.items.present? && items_are_single_values?(event) %>
             <% event.items.each do |value| %>
               <p class="govuk-body"><%= value %></p>
             <% end %>

--- a/app/components/timeline/view.rb
+++ b/app/components/timeline/view.rb
@@ -2,6 +2,8 @@
 
 module Timeline
   class View < GovukComponent::Base
+    include TimelineHelper
+
     attr_reader :events
 
     def initialize(events:)

--- a/app/forms/system_admin/change_accredited_provider_form.rb
+++ b/app/forms/system_admin/change_accredited_provider_form.rb
@@ -47,7 +47,7 @@ module SystemAdmin
     end
 
     def build_audit_comment
-      "#{I18n.t('components.timeline.titles.trainee.accredited_provider_change')}: #{audit_comment} #{zendesk_ticket_url}"
+      [audit_comment, zendesk_ticket_url].compact.join(" ")
     end
   end
 end

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module TimelineHelper
+  def items_are_single_values?(event)
+    event.items&.first.is_a?(String)
+  end
+end

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -116,6 +116,7 @@ module Trainees
           title: accredited_provider_change_title,
           date: created_at,
           username: username,
+          items: changed_accredited_provider_description,
         )
       end
 
@@ -178,7 +179,10 @@ module Trainees
     end
 
     def accredited_provider_change_title
-      I18n.t("components.timeline.titles.trainee.accredited_provider_change")
+      I18n.t(
+        "components.timeline.titles.trainee.accredited_provider_change",
+        new_accredited_provider: auditable.provider.name_and_code,
+      )
     end
 
     def state_change_action
@@ -203,6 +207,10 @@ module Trainees
           ["#{I18n.t('components.timeline.withdrawal_date')}:", auditable.withdraw_date.strftime("%e %B %Y").to_s],
         ]
       end
+    end
+
+    def changed_accredited_provider_description
+      [comment]
     end
 
     def create_title

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -181,7 +181,8 @@ module Trainees
     def accredited_provider_change_title
       I18n.t(
         "components.timeline.titles.trainee.accredited_provider_change",
-        new_accredited_provider: auditable.provider.name_and_code,
+        old_accredited_provider: Provider.find_by(id: audited_changes["provider_id"].first)&.name_and_code,
+        new_accredited_provider: Provider.find_by(id: audited_changes["provider_id"].second)&.name_and_code,
       )
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -537,7 +537,7 @@ en:
           applying_for_bursary: Funding method updated
           iqts_country: Country or territory of training updated
           hesa_editable: Editing enabled
-          accredited_provider_change: Accredited provider updated
+          accredited_provider_change: "Accredited provider changed to %{new_accredited_provider}"
         degree:
           create: Degree added
           destroy: Degree deleted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -537,7 +537,7 @@ en:
           applying_for_bursary: Funding method updated
           iqts_country: Country or territory of training updated
           hesa_editable: Editing enabled
-          accredited_provider_change: "Accredited provider changed to %{new_accredited_provider}"
+          accredited_provider_change: "Accredited provider changed from %{old_accredited_provider} to %{new_accredited_provider}"
         degree:
           create: Degree added
           destroy: Degree deleted

--- a/spec/forms/system_admin/change_accredited_provider_form_spec.rb
+++ b/spec/forms/system_admin/change_accredited_provider_form_spec.rb
@@ -69,7 +69,6 @@ module SystemAdmin
 
         it "attaches an audit comment to the update" do
           last_audit_entry = trainee.reload.audits.last
-          expect(last_audit_entry.comment).to match(/Accredited provider updated/)
           expect(last_audit_entry.comment).to match(audit_comment)
           expect(last_audit_entry.comment).to match(zendesk_ticket_url)
         end

--- a/spec/helpers/timeline_helper_spec.rb
+++ b/spec/helpers/timeline_helper_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TimelineHelper do
+  include TimelineHelper
+
+  describe "#items_are_single_values?" do
+    let(:items) { nil }
+    let(:event) do
+      TimelineEvent.new(
+        title: "Something changed",
+        username: Faker::Name.first_name,
+        date: Time.zone.today,
+        items: items,
+      )
+    end
+
+    context "when `items` is empty" do
+      it "returns false" do
+        expect(helper.items_are_single_values?(event)).to be(false)
+      end
+    end
+
+    context "when `items` is an array of key value pairs" do
+      let(:items) { [%w[state awarded]] }
+
+      it "returns false" do
+        expect(helper.items_are_single_values?(event)).to be(false)
+      end
+    end
+
+    context "when `items` is an array of string values" do
+      let(:items) { ["state changed to awarded"] }
+
+      it "returns true" do
+        expect(helper.items_are_single_values?(event)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/trainees/create_timeline_events_spec.rb
+++ b/spec/services/trainees/create_timeline_events_spec.rb
@@ -221,11 +221,12 @@ module Trainees
         let(:new_provider) { create(:provider) }
 
         before do
+          @old_provider = trainee.provider
           trainee.update!(provider: new_provider, audit_comment: "Original provider has stopped teaching")
         end
 
         it "title indicates an accredited provider update event" do
-          expect(subject.title).to eq("Accredited provider changed to #{new_provider.name_and_code}")
+          expect(subject.title).to eq("Accredited provider changed from #{@old_provider.name_and_code} to #{new_provider.name_and_code}")
         end
 
         it "item includes the audit comment" do

--- a/spec/services/trainees/create_timeline_events_spec.rb
+++ b/spec/services/trainees/create_timeline_events_spec.rb
@@ -218,12 +218,18 @@ module Trainees
       end
 
       context "with an accredited provider change" do
+        let(:new_provider) { create(:provider) }
+
         before do
-          trainee.update!(provider: create(:provider))
+          trainee.update!(provider: new_provider, audit_comment: "Original provider has stopped teaching")
         end
 
-        it "returns an accredited provider update event" do
-          expect(subject.title).to eq("Accredited provider updated")
+        it "title indicates an accredited provider update event" do
+          expect(subject.title).to eq("Accredited provider changed to #{new_provider.name_and_code}")
+        end
+
+        it "item includes the audit comment" do
+          expect(subject.items).to eq(["Original provider has stopped teaching"])
         end
       end
     end


### PR DESCRIPTION
### Context
When a sys-admin updates a trainee's accredited provider we want to see that change highlighted in the timeline with relevant details.

### Changes proposed in this pull request
Update the timeline to show the old and new provider name and display the reason for changing providers.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/31113914-1720-4a16-a6ff-52a5ddfe70d3)

### Guidance to review
- Does the markup change make sense? Is there a better way?
- Have I missed any useful content?
- I've put a question on the ticket https://trello.com/c/mhvxSOSo/6131-change-accredited-provider-update-timeline about whether we should show the original provider name and code too.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
