### PR TITLE
[6128] - remove application_choice_id from analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -20,7 +20,6 @@ shared:
     - id
     - recruitment_cycle_year
     - state
-    - application_choice_id
     - updated_at
   allocation_subjects:
     - created_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -59,6 +59,7 @@
   :apply_applications:
   - application
   - invalid_data
+  - application_choice_id
   :apply_application_sync_requests:
   - id
   - response_code


### PR DESCRIPTION
### Context

`application_choice_id` seems redundant for data insights team.

see: https://trello.com/c/23GqB007/6041-applicationchoiceid-all-showing-as-rugged-abacus-218110dataformapplyapplicationslatestregister and https://trello.com/c/WEIHSeYB/6128-applicationchoiceid-all-showing-as-rugged-abacus-218110dataformapplyapplicationslatestregister

