### PR TITLE
Compress sanitised db backup to use less space

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -117,7 +117,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Backup Sanitised Database"
-        pg_dump --encoding utf8 --clean --no-owner --if-exists -d ${DATABASE_NAME} -f backup_sanitised.sql
+        pg_dump --encoding utf8 --compress=1 --clean --no-owner --if-exists -d ${DATABASE_NAME} -f backup_sanitised.sql.gz
         echo "::endgroup::"
       env:
         DATABASE_NAME: register_trainee_teachers
@@ -130,7 +130,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: backup_sanitised
-        path: backup_sanitised.sql
+        path: backup_sanitised.sql.gz
         retention-days: 3
 
     - name: Check for Failure
@@ -179,7 +179,7 @@ jobs:
     - name: Restore backup to aks env database
       shell: bash
       run: |
-        bin/konduit.sh -i backup_sanitised.sql -t 7200 register-staging -- psql
+        bin/konduit.sh -i backup_sanitised.sql.gz -c -t 7200 register-staging -- psql
 
     - name: Check for Failure
       if: ${{ failure() }}


### PR DESCRIPTION
### Context

Daily database backup/restore is failing in the create sanitised db backup step as it's running out of disk space  

### Changes proposed in this pull request

Add compression to sanitise backup pg_dump

### Guidance to review

Check workflow syntax

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
