### PR TITLE
[6177] Ensure that DQT is notified about provider changes

### DIFF
--- a/app/forms/system_admin/change_accredited_provider_form.rb
+++ b/app/forms/system_admin/change_accredited_provider_form.rb
@@ -22,9 +22,12 @@ module SystemAdmin
     def save!
       return false unless valid?
 
-      trainee.update!(
-        provider_id: accredited_provider_id,
-        audit_comment: build_audit_comment,
+      Trainees::Update.call(
+        trainee: trainee,
+        params: {
+          provider_id: accredited_provider_id,
+          audit_comment: build_audit_comment,
+        },
       )
 
       clear_stash

--- a/spec/features/system_admin/accredited_providers/change_accredited_provider_spec.rb
+++ b/spec/features/system_admin/accredited_providers/change_accredited_provider_spec.rb
@@ -9,6 +9,7 @@ feature "Change a trainee's accredited provider" do
     let!(:new_provider) { create(:provider) }
 
     before do
+      allow(Dqt::UpdateTraineeJob).to receive(:perform_later)
       given_i_am_authenticated(user:)
       and_the_change_accredited_provider_feature_is_not_enabled
     end
@@ -33,6 +34,7 @@ feature "Change a trainee's accredited provider" do
       when_i_click_update
       then_i_see_a_flash_message
       and_i_see_the_new_provider_name_and_code
+      and_dqt_is_notified_about_the_change
     end
 
     scenario "submit buttons return to correct path from confirmation page" do
@@ -171,5 +173,9 @@ feature "Change a trainee's accredited provider" do
 
   def then_i_see_the_trainee_detail_page
     expect(page).to have_current_path("/trainees/#{trainee.slug}", ignore_query: true)
+  end
+
+  def and_dqt_is_notified_about_the_change
+    expect(Dqt::UpdateTraineeJob).to have_received(:perform_later).with(trainee)
   end
 end


### PR DESCRIPTION
### Context
We need to notify DQT because it records the provider against a teacher's training record.

### Changes proposed in this pull request
Call the appropriate service to make the necessary API call.

### Guidance to review
Is there more to it than this?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
