### PR TITLE
Fix space issues for database backup

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -105,20 +105,41 @@ jobs:
       env:
         SQLPAD_USER: ${{ secrets.SQLPAD_USER }}
 
-    - name: Sanitise the Database backup
+    - name: Disk cleanup
+      shell: bash
       run: |
-        echo "::group::Restore backup to intermediate database"
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/ghc || true
+
+    - name: Create local Sanitised Database
+      run: |
         createdb ${DATABASE_NAME} && psql -f ${{ env.BACKUP_FILE_NAME }}.sql -d ${DATABASE_NAME}
+      env:
+        DATABASE_NAME: register_trainee_teachers
+        PGUSER:  postgres
+        PGPASSWORD: postgres
+        PGHOST: localhost
+        PGPORT: 5432
+
+    - name: Remove backup file
+      shell: bash
+      run: |
         rm ${{ env.BACKUP_FILE_NAME }}.sql
-        echo "::endgroup::"
 
-        echo "::group::Sanitise user data"
+    - name: Sanitise the local Database
+      run: |
         psql -d ${DATABASE_NAME} -f db/scripts/sanitise.sql
-        echo "::endgroup::"
+      env:
+        DATABASE_NAME: register_trainee_teachers
+        PGUSER:  postgres
+        PGPASSWORD: postgres
+        PGHOST: localhost
+        PGPORT: 5432
 
-        echo "::group::Backup Sanitised Database"
+    - name: Dump the Sanitised Database
+      run: |
         pg_dump --encoding utf8 --compress=1 --clean --no-owner --if-exists -d ${DATABASE_NAME} -f backup_sanitised.sql.gz
-        echo "::endgroup::"
       env:
         DATABASE_NAME: register_trainee_teachers
         PGUSER:  postgres


### PR DESCRIPTION
### Context

Database backup/restore still failing with space issues after adding compression
It's currently failing during the local creatdb as there is only 7G available

Filesystem     1K-blocks     Used Available Use% Mounted on
/dev/root       87204404 79796528   7391492  92% /

### Changes proposed in this pull request

- Split steps to make it clearer where it's failing
- add step to remove unused files from the github runner

### Guidance to review

check code
see run https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/6411121899/job/17405878447

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
