### PR TITLE
[6164] Render hesa values for bursary in funding card

### DIFF
--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -23,6 +23,8 @@ module Funding
       [
         training_initiative_row,
         funding_method_row,
+        applying_for_bursary_row,
+        selected_bursary_level_row,
       ].compact
     end
 
@@ -114,6 +116,21 @@ module Funding
       )
     end
 
+    def applying_for_bursary_row
+      return unless trainee.hesa_record?
+
+      mappable_field(trainee.applying_for_bursary ? t(".applying") : t(".not_applying"), t(".applying_for_bursary"), nil)
+    end
+
+    def selected_bursary_level_row
+      return unless trainee.hesa_record? && trainee.applying_for_bursary? && hesa_student.present?
+
+      hesa_bursary_level = Hesa::CodeSets::BursaryLevels::VALUES[hesa_student.bursary_level]
+      hesa_bursary_text = "#{hesa_student.bursary_level} - #{hesa_bursary_level}"
+
+      mappable_field(hesa_bursary_text, t(".selected_bursary_level"), nil)
+    end
+
     def training_initiative
       return if data_model.training_initiative.nil?
 
@@ -146,6 +163,10 @@ module Funding
 
     def funding_manager
       @funding_manager ||= FundingManager.new(trainee)
+    end
+
+    def hesa_student
+      @hesa_student ||= trainee.hesa_student_for_collection(Settings.hesa.current_collection_reference)
     end
   end
 end

--- a/app/lib/dttp/code_sets/bursary_details.rb
+++ b/app/lib/dttp/code_sets/bursary_details.rb
@@ -10,9 +10,10 @@ module Dttp
       SCHOOL_DIRECT_SALARIED = "3036b79f-9fc7-eb11-bacc-000d3ab7dcfe"
       EARLY_YEARS_SALARIED = "fd403c13-3e07-ec11-94ef-000d3adda801"
 
-      SERVICE_LEAVER_BURSARY = "6ca6f51f-2189-e811-80f7-005056ac45bb"
+      VETERAN_TEACHING_UNDERGRADUATE_BURSARY = "6ca6f51f-2189-e811-80f7-005056ac45bb"
 
       SCHOLARSHIP = "188375c2-7722-e711-80c8-0050568902d3"
+      GRANT = "0ed9f6cf-d15a-49ca-8dd0-b3074d91ccf8" # Generated from SecureRandom.uuid
 
       NEW_TIER_ONE_BURSARY = "001bf834-33ff-eb11-94ef-00224899ca99"
       NEW_TIER_TWO_BURSARY = "66671547-33ff-eb11-94ef-00224899ca99"
@@ -28,18 +29,13 @@ module Dttp
         OLD_TIER_ONE_BURSARY,
         OLD_TIER_TWO_BURSARY,
         OLD_TIER_THREE_BURSARY,
-        SERVICE_LEAVER_BURSARY,
+        VETERAN_TEACHING_UNDERGRADUATE_BURSARY,
       ].freeze
 
       NEW_TIERS = [
         NEW_TIER_ONE_BURSARY,
         NEW_TIER_TWO_BURSARY,
         NEW_TIER_THREE_BURSARY,
-      ].freeze
-
-      GRANTS = [
-        EARLY_YEARS_SALARIED,
-        SCHOOL_DIRECT_SALARIED,
       ].freeze
 
       MAPPING = {

--- a/app/lib/dttp/mappable.rb
+++ b/app/lib/dttp/mappable.rb
@@ -2,10 +2,6 @@
 
 module Dttp
   module Mappable
-    def bursary_details_id(key)
-      CodeSets::BursaryDetails::MAPPING.dig(key, :entity_id)
-    end
-
     def course_subject_id(subject)
       CodeSets::CourseSubjects::MAPPING.dig(subject, :entity_id)
     end

--- a/app/lib/hesa/code_sets/bursary_levels.rb
+++ b/app/lib/hesa/code_sets/bursary_levels.rb
@@ -7,15 +7,38 @@ module Hesa
       # https://www.hesa.ac.uk/collection/c22053/e/burslev
       # Note that Tier 1, Tier 2, and Tier 3 are fetched from the previous year, i.e:
       # https://www.hesa.ac.uk/collection/c20053/e/burslev
+      SCHOLARSHIP = "4"
+      NONE = "6"
+      TIER_ONE = "7"
+      TIER_TWO = "8"
+      TIER_THREE = "9"
+      UNDERGRADUATE_BURSARY = "B"
+      VETERAN_TEACHING_UNDERGRADUATE_BURSARY = "C"
+      POSTGRADUATE_BURSARY = "D"
+      GRANT = "E"
+
       MAPPING = {
-        "4" => Dttp::CodeSets::BursaryDetails::SCHOLARSHIP,
-        "6" => Dttp::CodeSets::BursaryDetails::NO_BURSARY_AWARDED,
-        "7" => Dttp::CodeSets::BursaryDetails::NEW_TIER_ONE_BURSARY,
-        "8" => Dttp::CodeSets::BursaryDetails::NEW_TIER_TWO_BURSARY,
-        "9" => Dttp::CodeSets::BursaryDetails::NEW_TIER_THREE_BURSARY,
-        "B" => Dttp::CodeSets::BursaryDetails::UNDERGRADUATE_BURSARY,
-        "C" => Dttp::CodeSets::BursaryDetails::SERVICE_LEAVER_BURSARY,
-        "D" => Dttp::CodeSets::BursaryDetails::POSTGRADUATE_BURSARY,
+        SCHOLARSHIP => Dttp::CodeSets::BursaryDetails::SCHOLARSHIP,
+        NONE => Dttp::CodeSets::BursaryDetails::NO_BURSARY_AWARDED,
+        TIER_ONE => Dttp::CodeSets::BursaryDetails::NEW_TIER_ONE_BURSARY,
+        TIER_TWO => Dttp::CodeSets::BursaryDetails::NEW_TIER_TWO_BURSARY,
+        TIER_THREE => Dttp::CodeSets::BursaryDetails::NEW_TIER_THREE_BURSARY,
+        UNDERGRADUATE_BURSARY => Dttp::CodeSets::BursaryDetails::UNDERGRADUATE_BURSARY,
+        VETERAN_TEACHING_UNDERGRADUATE_BURSARY => Dttp::CodeSets::BursaryDetails::VETERAN_TEACHING_UNDERGRADUATE_BURSARY,
+        POSTGRADUATE_BURSARY => Dttp::CodeSets::BursaryDetails::POSTGRADUATE_BURSARY,
+        GRANT => Dttp::CodeSets::BursaryDetails::GRANT,
+      }.freeze
+
+      VALUES = {
+        SCHOLARSHIP => "Scholarship",
+        NONE => "No bursary, scholarship or grant awarded",
+        TIER_ONE => "Tier 1",
+        TIER_TWO => "Tier 2",
+        TIER_THREE => "Tier 3",
+        UNDERGRADUATE_BURSARY => "Undergraduate bursary",
+        VETERAN_TEACHING_UNDERGRADUATE_BURSARY => "Veteran Teaching undergraduate bursary",
+        POSTGRADUATE_BURSARY => "Postgraduate bursary",
+        GRANT => "Grant",
       }.freeze
     end
   end

--- a/app/services/trainees/map_funding_from_dttp_entity_id.rb
+++ b/app/services/trainees/map_funding_from_dttp_entity_id.rb
@@ -49,7 +49,7 @@ module Trainees
     end
 
     def applying_for_grant?
-      Dttp::CodeSets::BursaryDetails::GRANTS.include?(funding_entity_id)
+      funding_entity_id == Dttp::CodeSets::BursaryDetails::GRANT
     end
 
     def applying_for_new_tier?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,10 @@ en:
       no_bursary_applied_for: Not funded
       no_grant_applied_for: Not grant funded
       no_funding_available: Not applicable
+      applying_for_bursary: Applying for bursary
+      applying: "Yes"
+      not_applying: "No"
+      selected_bursary_level: Selected bursary level
       contact_info: Contact %{email} if you think there should be trainees who are eligible.
       tiered_bursary_applied_for:
         tier_one: Applied for Tier 1

--- a/spec/components/funding/view_spec.rb
+++ b/spec/components/funding/view_spec.rb
@@ -282,6 +282,35 @@ module Funding
       end
     end
 
+    context "when trainee has a hesa record" do
+      describe "applying for bursary row" do
+        context "when applying for bursary" do
+          let(:trainee) { create(:trainee, :imported_from_hesa, applying_for_bursary: true) }
+
+          subject { rendered_component }
+
+          it { is_expected.to have_text("Yes") }
+        end
+
+        context "when not applying for bursary" do
+          let(:trainee) { create(:trainee, :imported_from_hesa, applying_for_bursary: false) }
+
+          subject { rendered_component }
+
+          it { is_expected.to have_text("No") }
+        end
+      end
+
+      describe "hesa selected bursary level" do
+        let(:trainee) { create(:trainee, :imported_from_hesa, applying_for_bursary: true) }
+        let(:hesa_bursary_code) { trainee.hesa_students.first.bursary_level }
+
+        it "renders the hesa bursary level along with the code" do
+          expect(rendered_component).to have_text("#{hesa_bursary_code} - #{Hesa::CodeSets::BursaryLevels::VALUES[hesa_bursary_code]}")
+        end
+      end
+    end
+
     describe "when we don't know the funding rules for the trainee's cycle" do
       let(:trainee) { create(:trainee, :with_start_date, applying_for_bursary: true, start_academic_cycle: start_academic_cycle) }
 

--- a/spec/factories/dttp/api_placement_assignment.rb
+++ b/spec/factories/dttp/api_placement_assignment.rb
@@ -51,7 +51,7 @@ FactoryBot.define do
     trait :with_early_years_salaried_bursary do
       enabled_training_routes { ["early_years_salaried"] }
       _dfe_ittsubject1id_value { Dttp::CodeSets::CourseSubjects::EARLY_YEARS_DTTP_ID }
-      _dfe_bursarydetailsid_value { Dttp::CodeSets::BursaryDetails::EARLY_YEARS_SALARIED }
+      _dfe_bursarydetailsid_value { Dttp::CodeSets::BursaryDetails::GRANT }
     end
 
     trait :with_tiered_bursary do

--- a/spec/factories/hesa/student.rb
+++ b/spec/factories/hesa/student.rb
@@ -3,5 +3,7 @@
 FactoryBot.define do
   factory :hesa_student, class: "Hesa::Student" do
     ukprn { Faker::Number.number(digits: 8) }
+    bursary_level { Hesa::CodeSets::BursaryLevels::VALUES.keys.sample }
+    collection_reference { Settings.hesa.current_collection_reference }
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/6nIlr6Kn/6164-show-hesa-funding-information-on-the-funding-summary

### Changes proposed in this pull request

<img width="994" alt="Screenshot 2023-10-03 at 14 50 40" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/42172e3c-c210-4253-903f-d66df1b83e79">

- Expose two new rows in the funding card for hesa records to show the hesa values for bursary eligibility and level
- Update hesa bursary constants
- Remove some deprecated code in these classes no longer in use

### Guidance to review

- This is a bit fiddly to check but might be best to be deployed in `productiondata` and looking at hesa specific trainees
- The bursary level row will only show for hesa records imported in the current collection. Currently the logic does not support showing the info for older records. We'll need to do additional thinking around behaviour and logic if this is required
