### PR TITLE
Add scitt_salaried_programme and higher_education_salaried_programme training routes

### DIFF
--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -88,6 +88,8 @@ module TeacherTrainingApi
         school_direct_salaried_training_programme: :school_direct_salaried,
         school_direct_training_programme: :school_direct_tuition_fee,
         scitt_programme: :provider_led_postgrad,
+        scitt_salaried_programme: :provider_led_postgrad,
+        higher_education_salaried_programme: :provider_led_postgrad,
       }
 
       routes[course_attributes[:program_type].to_sym]

--- a/spec/services/teacher_training_api/import_course_spec.rb
+++ b/spec/services/teacher_training_api/import_course_spec.rb
@@ -65,6 +65,25 @@ module TeacherTrainingApi
           end
         end
 
+        describe "store training route" do
+          context "program type is mapped" do
+            let(:course_attributes) { { program_type: "scitt_salaried_programme" } }
+
+            it "stores training route" do
+              subject
+              expect(course.route).to eq("provider_led_postgrad")
+            end
+          end
+
+          context "program type is unmapped" do
+            let(:course_attributes) { { program_type: "you_wat_now" } }
+
+            it "raises validation error" do
+              expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+            end
+          end
+        end
+
         context "course level is primary but max age is greater than 11" do
           let(:course_attributes) { { level: "primary", max_age: 16 } }
 


### PR DESCRIPTION
### Context

These are now coming through from Publish, so we need to handle them.

Related commit in Publish: https://github.com/DFE-Digital/publish-teacher-training/commit/6171524194a38a413615ffe5de5accd835779e67

Trello: https://trello.com/c/oP5Ooc90/6179-handle-scittsalariedprogramme-and-highereducationsalariedprogramme-training-routes

### Changes proposed in this pull request

Add scitt_salaried_programme and higher_education_salaried_programme training routes to the course importer.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
