### PR TITLE
[6127] - fix job calls, add specs.

### DIFF
--- a/app/jobs/malware_scanning_job.rb
+++ b/app/jobs/malware_scanning_job.rb
@@ -5,6 +5,6 @@ class MalwareScanningJob < ApplicationJob
     Upload
       .where(malware_scan_result: "pending")
       .where("created_at < ?", 5.minutes.ago)
-      .find_each { |upload| MalwareScanJob.perform_later(upload: upload.id) }
+      .find_each { |upload| MalwareScanJob.perform_later(upload_id: upload.id) }
   end
 end

--- a/spec/jobs/malware_scan_job_spec.rb
+++ b/spec/jobs/malware_scan_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MalwareScanJob do
+  include ActiveJob::TestHelper
+
+  let(:upload) { create(:upload) }
+
+  before do
+    allow(MalwareScan).to receive(:call)
+  end
+
+  it "queues the job" do
+    expect { MalwareScanJob.perform_later(upload_id: upload.id) }
+      .to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it "calls MalwareScan service with the correct upload" do
+    perform_enqueued_jobs do
+      MalwareScanJob.perform_later(upload_id: upload.id)
+    end
+
+    expect(MalwareScan).to have_received(:call).with(upload:)
+  end
+
+  it "discards the job when upload is not found" do
+    expect {
+      perform_enqueued_jobs do
+        MalwareScanJob.perform_later(upload_id: 9999)
+      end
+    }.not_to raise_error
+  end
+end

--- a/spec/jobs/malware_scanning_job_spec.rb
+++ b/spec/jobs/malware_scanning_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MalwareScanningJob do
+  include ActiveJob::TestHelper
+
+  let!(:pending_uploads) { create_list(:upload, 3, malware_scan_result: "pending", created_at: 6.minutes.ago) }
+  let!(:recent_uploads) { create_list(:upload, 2, malware_scan_result: "pending", created_at: 1.minute.ago) }
+
+  before do
+    allow(MalwareScanJob).to receive(:perform_later)
+  end
+
+  it "queues the job for pending uploads older than 5 minutes" do
+    MalwareScanningJob.perform_now
+
+    expect(MalwareScanJob).to have_received(:perform_later).exactly(3).times
+  end
+
+  it "does not queue the job for pending uploads younger than 5 minutes" do
+    MalwareScanningJob.perform_now
+
+    recent_uploads.each do |upload|
+      expect(MalwareScanJob).not_to have_received(:perform_later).with(upload_id: upload.id)
+    end
+  end
+end


### PR DESCRIPTION
### Context

the malware background job was [miscalling the scan job](https://dfe-teacher-services.sentry.io/issues/4527743234/events/bd9946479bac419a9af4f788bc79ffb0/?project=5552118) in `app/jobs/malware_scanning_job.rb`

### Changes proposed in this pull request

* corrects the `upload` to `upload_id`
* adds some specs for regression
