### PR TITLE
[6214] - check for trn request when using pending trn service

### DIFF
--- a/app/controllers/system_admin/pending_trns/base_controller.rb
+++ b/app/controllers/system_admin/pending_trns/base_controller.rb
@@ -17,6 +17,8 @@ module SystemAdmin
       end
 
       def trn_request
+        return @trn_request if defined?(@trn_request)
+
         @trn_request = trainee.dqt_trn_request
       end
     end

--- a/app/controllers/system_admin/pending_trns/request_trns_controller.rb
+++ b/app/controllers/system_admin/pending_trns/request_trns_controller.rb
@@ -4,7 +4,7 @@ module SystemAdmin
   module PendingTrns
     class RequestTrnsController < BaseController
       def update
-        trn_request.destroy!
+        trn_request&.destroy!
 
         trn_request = Dqt::RegisterForTrnJob.perform_now(trainee.reload)
 

--- a/app/controllers/system_admin/pending_trns/retrieve_trns_controller.rb
+++ b/app/controllers/system_admin/pending_trns/retrieve_trns_controller.rb
@@ -3,6 +3,8 @@
 module SystemAdmin
   module PendingTrns
     class RetrieveTrnsController < BaseController
+      before_action :check_for_trn_request
+
       def update
         trn = Dqt::RetrieveTrn.call(trn_request:)
 
@@ -15,6 +17,14 @@ module SystemAdmin
         end
       rescue Dqt::Client::HttpError => e
         redirect_to(pending_trns_path, dqt_error: "DQT error: #{e.inspect}")
+      end
+
+    private
+
+      def check_for_trn_request
+        return if trn_request
+
+        redirect_to(pending_trns_path, flash: { warning: "#{trainee.full_name} has no TRN request (it may have been manually deleted)." })
       end
     end
   end

--- a/spec/features/system_admin/pending_trns/pending_trns_spec.rb
+++ b/spec/features/system_admin/pending_trns/pending_trns_spec.rb
@@ -29,6 +29,22 @@ feature "pending TRNs" do
       when_i_click_resubmit_for_trn
       then_i_see_the_pending_trns_page
     end
+
+    context "with trainee in state submitted_for_trn with no TRN request" do
+      let(:trainee) { create(:trainee, :submitted_for_trn, first_names: "James Blint") }
+
+      it "shows a warning message" do
+        then_i_see_the_pending_trns_page
+        and_i_see_the_trainee
+        when_i_click_check_for_trn_without_an_existing_request
+      end
+
+      it "creates a trn request" do
+        then_i_see_the_pending_trns_page
+        and_i_see_the_trainee
+        when_i_click_resubmit_for_trn_without_an_existing_request
+      end
+    end
   end
 
   context "when I am authenticated as a regular user (not a system admin)" do
@@ -70,6 +86,16 @@ feature "pending TRNs" do
   end
 
   def when_i_click_resubmit_for_trn
+    expect(Dqt::RegisterForTrnJob).to receive(:perform_now).with(trainee)
+    admin_pending_trns_page.resumbit_for_trn_button.click
+  end
+
+  def when_i_click_check_for_trn_without_an_existing_request
+    admin_pending_trns_page.check_for_trn_button.click
+    expect(admin_pending_trns_page).to have_text("#{trainee.full_name} has no TRN request (it may have been manually deleted).")
+  end
+
+  def when_i_click_resubmit_for_trn_without_an_existing_request
     expect(Dqt::RegisterForTrnJob).to receive(:perform_now).with(trainee)
     admin_pending_trns_page.resumbit_for_trn_button.click
   end


### PR DESCRIPTION
### Context

* `/system-admin/pending_trns` allows system admins to check and resubmit for TRNS
* sometimes trainees will be in the list who have been submitted for TRN but who's TRN request has been deleted (probably manually)
* this will result in an [exception being thrown](https://dfe-teacher-services.sentry.io/issues/4538254525/?environment=production&project=5552118&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=3) when submitting or checking for a TRN

### Changes proposed in this pull request

* redirects back to the pending TRN page if a trainee has no TRN request when _checking_ for a TRN
* no longer throws exception when submitting for a _new_ TRN request (by guarding the `.destroy!`)
* rather than filter the list of trainees to exclude those without we still list the trainee and opt to show the warning message instead
