### PR TITLE
[xxxx] don't .find_each unless upload records exist.

### DIFF
--- a/app/jobs/malware_scanning_job.rb
+++ b/app/jobs/malware_scanning_job.rb
@@ -2,9 +2,10 @@
 
 class MalwareScanningJob < ApplicationJob
   def perform
-    Upload
-      .where(malware_scan_result: "pending")
-      .where("created_at < ?", 5.minutes.ago)
-      .find_each { |upload| MalwareScanJob.perform_later(upload_id: upload.id) }
+    uploads = Upload.where(malware_scan_result: "pending").where("created_at < ?", 5.minutes.ago)
+
+    return unless uploads.any?
+
+    uploads.find_each { |upload| MalwareScanJob.perform_later(upload_id: upload.id) }
   end
 end


### PR DESCRIPTION
### Context

With no uploads to scan, we keep getting [this error in sentry](https://dfe-teacher-services.sentry.io/issues/4535555353/?environment=staging&project=5552118&query=is%3Aarchived&referrer=issue-stream&statsPeriod=24h&stream_index=0)

### Changes proposed in this pull request

don't `.find_each` unless we have a set to loop over.