### PR TITLE
Increase staging postgres db size

### DIFF
--- a/terraform/aks/workspace-variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/staging_aks.tfvars.json
@@ -7,6 +7,7 @@
   "cluster": "test",
   "namespace": "bat-staging",
   "db_sslmode": "prefer",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "main_app": {
     "main": {
       "startup_command": ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"],


### PR DESCRIPTION
### Context

Staging postgres db is only a burstable B_Standard_B1ms and has cpu issues with the staging workload

### Changes proposed in this pull request

Increase from B_Standard_B1ms to GP_Standard_D2ds_v4

### Guidance to review

Check db is upgraded during the deploy workflow.
module.postgres.azurerm_postgresql_flexible_server.main[0] will be updated in-place

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
