### PR TITLE
Restore most landing page counts

### DIFF
--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -21,28 +21,59 @@ class HomeView
 
   Badge = Struct.new(:status, :trainee_count, :link)
 
+  def draft_trainees_count
+    Rails.cache.fetch("#{trainees_cache_key_with_version}/draft_trainees_count", expires_in: 1.week) do
+      trainees.draft.size
+    end
+  end
+
+  def draft_apply_trainees_count
+    Rails.cache.fetch("#{trainees_cache_key_with_version}/draft_apply_trainees_count", expires_in: 1.week) do
+      trainees.draft.with_apply_application.size
+    end
+  end
+
   def apply_drafts_link_text
-    I18n.t(
-      "landing_page.home.draft_apply_trainees_link",
-      count: "",
-      total: "",
-    )
+    if drafts_are_all_apply_drafts?
+      I18n.t(
+        "landing_page.home.draft_apply_trainees_link_all_apply",
+        count: draft_apply_trainees_count,
+      )
+    else
+      I18n.t(
+        "landing_page.home.draft_apply_trainees_link",
+        count: draft_apply_trainees_count,
+        total: draft_trainees_count,
+      )
+    end
   end
 
 private
 
   attr_reader :trainees, :trainees_cache_key_with_version
 
+  def awarded_this_year_size
+    Rails.cache.fetch("#{trainees_cache_key_with_version}/awarded_this_year", expires_in: 1.week) do
+      trainees.awarded.merge(current_academic_cycle.trainees_ending).size
+    end
+  end
+
+  def bulk_recommend_count
+    Rails.cache.fetch("#{trainees_cache_key_with_version}/bulk_recommend_count", expires_in: 1.week) do
+      Pundit.policy_scope(current_user, FindBulkRecommendTrainees.call).count
+    end
+  end
+
   def create_action_badges
     @action_badges = [
       Badge.new(
         :can_bulk_recommend_for_award,
-        "",
+        bulk_recommend_count,
         new_bulk_update_recommendations_upload_path,
       ),
       Badge.new(
         :can_complete,
-        "",
+        incomplete_size,
         trainees_path(record_completion: %w[incomplete]),
       ),
     ]
@@ -52,13 +83,13 @@ private
     @badges = [
       Badge.new(
         :in_training,
-        "",
+        trainees_in_training_size,
         trainees_path(status: %w[in_training]),
       ),
 
       Badge.new(
         :awarded_this_year,
-        "",
+        awarded_this_year_size,
         trainees_path(
           status: %w[awarded],
           end_year: current_academic_cycle.label,
@@ -67,29 +98,59 @@ private
 
       Badge.new(
         :deferred,
-        "",
+        deferred_size,
         trainees_path(status: %w[deferred]),
       ),
     ]
 
-    @badges.prepend(
-      Badge.new(
-        :course_not_started_yet,
-        "",
-        trainees_path(status: %w[course_not_yet_started]),
-      ),
-    )
+    if course_not_yet_started_size.positive?
+      @badges.prepend(
+        Badge.new(
+          :course_not_started_yet,
+          course_not_yet_started_size,
+          trainees_path(status: %w[course_not_yet_started]),
+        ),
+      )
+    end
   end
 
   def current_academic_cycle
     @current_academic_cycle ||= AcademicCycle.current
   end
 
+  def course_not_yet_started_size
+    Rails.cache.fetch("#{trainees_cache_key_with_version}/course_not_yet_started_size", expires_in: 1.week) do
+      trainees.course_not_yet_started.size
+    end
+  end
+
+  def deferred_size
+    Rails.cache.fetch("#{trainees_cache_key_with_version}/deferred_size", expires_in: 1.week) do
+      trainees.deferred.size
+    end
+  end
+
+  def drafts_are_all_apply_drafts?
+    draft_apply_trainees_count == draft_trainees_count
+  end
+
   def incomplete_badge
     Badge.new(
       :incomplete,
-      "",
+      incomplete_size,
       trainees_path(record_completion: %w[incomplete]),
     )
+  end
+
+  def incomplete_size
+    Rails.cache.fetch("#{trainees_cache_key_with_version}/incomplete_size", expires_in: 1.week) do
+      trainees.not_draft.incomplete.size
+    end
+  end
+
+  def trainees_in_training_size
+    Rails.cache.fetch("#{trainees_cache_key_with_version}/trainees_in_training_size", expires_in: 1.week) do
+      trainees.in_training.size
+    end
   end
 end

--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -14,8 +14,6 @@ class HomeView
 
     if !current_user.system_admin? && !current_user.lead_school?
       create_action_badges
-    else
-      badges << incomplete_badge
     end
   end
 
@@ -70,11 +68,6 @@ private
         :can_bulk_recommend_for_award,
         bulk_recommend_count,
         new_bulk_update_recommendations_upload_path,
-      ),
-      Badge.new(
-        :can_complete,
-        incomplete_size,
-        trainees_path(record_completion: %w[incomplete]),
       ),
     ]
   end

--- a/app/views/landing_page/home.html.erb
+++ b/app/views/landing_page/home.html.erb
@@ -14,13 +14,16 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h2 class="govuk-heading-l"><%= t(".draft_heading") %></h2>
       <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
+        <% if @home_view.draft_trainees_count > @home_view.draft_apply_trainees_count %>
           <li>
             <%= govuk_link_to(
-              t(".draft_trainees_link"),
+              t(".draft_trainees_link", count: @home_view.draft_trainees_count),
               drafts_path,
               { class: "govuk-link--no-visited-state" }
             )%>
           </li>
+        <% end %>
+        <% if @home_view.draft_apply_trainees_count > 0 %>
           <li>
             <%= govuk_link_to(
               @home_view.apply_drafts_link_text,
@@ -28,6 +31,7 @@
               { class: "govuk-link--no-visited-state" }
             )%>
           </li>
+        <% end %>
         <% if policy(Trainee).new? %>
           <li class="govuk-!-margin-bottom-0">
             <%= govuk_link_to(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -937,9 +937,9 @@ en:
     home:
       heading: Your trainee teachers
       draft_heading: Draft trainees
-      draft_trainees_link: View all draft trainees
-      draft_apply_trainees_link: View draft trainees imported from Apply
-      draft_apply_trainees_link_all_apply: View draft trainees imported from Apply
+      draft_trainees_link: View all draft trainees (%{count})
+      draft_apply_trainees_link: View draft trainees imported from Apply (%{count} out of %{total} draft trainees)
+      draft_apply_trainees_link_all_apply: View draft trainees imported from Apply (%{count})
       new_trainee_link: Create a trainee record
       registered_heading: Registered trainees
       available_to_do_heading: Available to do

--- a/spec/view_objects/home_view_spec.rb
+++ b/spec/view_objects/home_view_spec.rb
@@ -66,11 +66,6 @@ describe HomeView do
             trainee_count: 2,
             link: trainees_path(status: %w[deferred]),
           },
-          {
-            status: :incomplete,
-            trainee_count: 1,
-            link: trainees_path(record_completion: %w[incomplete]),
-          },
         ],
       )
     end


### PR DESCRIPTION
### Context

We have narrowed down the performance problem to a single query, therefore we can restore trainee numbers to the landing page.

https://trello.com/c/uidKG528/6222-temporarily-remove-counts-from-register-home-page

### Changes proposed in this pull request

Revert 3c80b6ccec2a6057293e41d4296decc862c9ae7b

Just hide the incomplete badge, as it's this specific query that's causing a database performance problem.

![CleanShot 2023-10-13 at 15 52 04](https://github.com/DFE-Digital/register-trainee-teachers/assets/168365/29dc6e16-af3c-49a8-aab2-3a5caa80cc92)

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
