### PR TITLE
Restore incomplete count badge on landing page

### DIFF
--- a/app/view_objects/home_view.rb
+++ b/app/view_objects/home_view.rb
@@ -14,6 +14,8 @@ class HomeView
 
     if !current_user.system_admin? && !current_user.lead_school?
       create_action_badges
+    else
+      badges << incomplete_badge
     end
   end
 
@@ -68,6 +70,11 @@ private
         :can_bulk_recommend_for_award,
         bulk_recommend_count,
         new_bulk_update_recommendations_upload_path,
+      ),
+      Badge.new(
+        :can_complete,
+        incomplete_size,
+        trainees_path(record_completion: %w[incomplete]),
       ),
     ]
   end

--- a/spec/view_objects/home_view_spec.rb
+++ b/spec/view_objects/home_view_spec.rb
@@ -66,6 +66,11 @@ describe HomeView do
             trainee_count: 2,
             link: trainees_path(status: %w[deferred]),
           },
+          {
+            status: :incomplete,
+            trainee_count: 1,
+            link: trainees_path(record_completion: %w[incomplete]),
+          },
         ],
       )
     end


### PR DESCRIPTION
### Context

We've [fixed](https://github.com/DFE-Digital/register-trainee-teachers/pull/3677) the trainee incomplete scope that was causing the database CPU to max out.

### Changes proposed in this pull request

Put the incomplete badge back.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
