### PR TITLE
[6241] Confirm placement details page UI

### DIFF
--- a/app/components/placements/view.html.erb
+++ b/app/components/placements/view.html.erb
@@ -1,0 +1,39 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= render GovukComponent::InsetTextComponent.new(
+      text: "You need to add the details of at least 2 schools before you can recommend this trainee for QTS. These can be added at any time.") if render_inset?
+    %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to('Read DfE guidance about training placements in schools and <span class="no-wrap">early years settings</span>'.html_safe, "https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c23-training-in-schools") %>
+
+    </p>
+  </div>
+</div>
+
+
+<% if data_model.placements.blank? %>
+  <%= render MappableSummary::View.new(
+    trainee: data_model,
+    title: t("components.placement_detail.title"),
+    rows: [{
+            custom_value: true,
+            key: "Placements",
+            value: "Not provided yet",
+            action_text: "Add a placement",
+            action_href: new_trainee_placements_path(trainee_id: data_model.slug),
+          }],
+    editable: true,
+    has_errors: has_errors,
+  ) %>
+<% else %>
+  <% placement_summaries.each do |placement_summary_args| %>
+    <%= render MappableSummary::View.new(**placement_summary_args) do |component| %>
+      <% component.header_actions do %>
+        <%= govuk_link_to "Delete placements", '#' %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= render GovukButtonLinkTo::View.new(body: "Add a placement", url: new_trainee_placements_path(trainee_id: data_model.slug), class_option: "govuk-button--secondary") %>

--- a/app/components/placements/view.html.erb
+++ b/app/components/placements/view.html.erb
@@ -30,7 +30,7 @@
   <% placement_summaries.each do |placement_summary_args| %>
     <%= render MappableSummary::View.new(**placement_summary_args) do |component| %>
       <% component.header_actions do %>
-        <%= govuk_link_to "Delete placements", '#' %>
+        <%= govuk_link_to "Delete placement", '#' %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/placements/view.html.erb
+++ b/app/components/placements/view.html.erb
@@ -12,16 +12,16 @@
 </div>
 
 
-<% if data_model.placements.blank? %>
+<% if trainee.placements.blank? %>
   <%= render MappableSummary::View.new(
-    trainee: data_model,
+    trainee: trainee,
     title: t("components.placement_detail.title"),
     rows: [{
             custom_value: true,
             key: "Placements",
             value: "Not provided yet",
             action_text: "Add a placement",
-            action_href: new_trainee_placements_path(trainee_id: data_model.slug),
+            action_href: new_trainee_placements_path(trainee_id: trainee.slug),
           }],
     editable: true,
     has_errors: has_errors,
@@ -36,4 +36,4 @@
   <% end %>
 <% end %>
 
-<%= render GovukButtonLinkTo::View.new(body: "Add a placement", url: new_trainee_placements_path(trainee_id: data_model.slug), class_option: "govuk-button--secondary") %>
+<%= render GovukButtonLinkTo::View.new(body: "Add a placement", url: new_trainee_placements_path(trainee_id: trainee.slug), class_option: "govuk-button--secondary") %>

--- a/app/components/placements/view.rb
+++ b/app/components/placements/view.rb
@@ -12,14 +12,18 @@ module Placements
       @has_errors = has_errors
     end
 
+    def trainee
+      data_model.is_a?(Trainee) ? data_model : data_model.trainee
+    end
+
     def render_inset?
-      data_model.placements.size < 2
+      trainee.placements.size < 2
     end
 
     def placement_summaries
       placement_records.each_with_index.map do |placement_record, index|
         {
-          trainee: data_model,
+          trainee: trainee,
           title: t("components.placements.placement_#{index + 1}"),
           rows: [{
             field_label: "School or setting",
@@ -35,7 +39,7 @@ module Placements
   private
 
     def placement_records
-      data_model.placements.reverse
+      trainee.placements.reverse
     end
 
     def placement_details_for(placement_record)

--- a/app/components/placements/view.rb
+++ b/app/components/placements/view.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Placements
+  class View < GovukComponent::Base
+    include SummaryHelper
+
+    attr_accessor :data_model, :editable, :has_errors
+
+    def initialize(data_model:, has_errors: false, editable: false)
+      @data_model = data_model
+      @editable = editable
+      @has_errors = has_errors
+    end
+
+    def render_inset?
+      data_model.placements.size < 2
+    end
+
+    def placement_summaries
+      placement_records.each_with_index.map do |placement_record, index|
+        {
+          trainee: data_model,
+          title: t("components.placements.placement_#{index + 1}"),
+          rows: [{
+            field_label: "School or setting",
+            field_value: placement_details_for(placement_record),
+            action_url: "#",
+          }],
+          editable: true,
+          has_errors: has_errors,
+        }
+      end
+    end
+
+  private
+
+    def placement_records
+      data_model.placements.reverse
+    end
+
+    def placement_details_for(placement_record)
+      main_tag = tag.p(
+        placement_record.name,
+        class: "govuk-body",
+      )
+
+      address = placement_record.full_address
+
+      address ? main_tag + tag.div(address, class: "govuk-hint") : main_tag
+    end
+  end
+end

--- a/app/controllers/trainees/confirm_details_controller.rb
+++ b/app/controllers/trainees/confirm_details_controller.rb
@@ -73,6 +73,7 @@ module Trainees
       @confirm_section_title ||= {
         training_details: "trainee ID",
         degrees: "degree details",
+        placements: "placement details",
         funding: "funding details",
         course_details: "trainee's course details",
         publish_course_details: "trainee's course details",

--- a/app/forms/placements_form.rb
+++ b/app/forms/placements_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PlacementsForm < TraineeForm
+  def compute_fields
+    {}
+  end
+end

--- a/app/helpers/confirm_details_helper.rb
+++ b/app/helpers/confirm_details_helper.rb
@@ -7,6 +7,7 @@ module ConfirmDetailsHelper
       "personal-details" => "trainee_personal_details_confirm_path",
       "contact-details" => "trainee_contact_details_confirm_path",
       "degrees" => "trainee_degrees_confirm_path",
+      "placements" => "trainee_placements_confirm_path",
       "course-details" => "trainee_course_details_confirm_path",
       "publish-course-details" => "trainee_publish_course_details_confirm_path",
       "trainee-start-date" => "trainee_start_date_confirm_path",

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -14,6 +14,7 @@ class Progress
   attribute :personal_details, :boolean, default: false
   attribute :contact_details, :boolean, default: false
   attribute :degrees, :boolean, default: false
+  attribute :placements, :boolean, default: false
   attribute :diversity, :boolean, default: false
   attribute :course_details, :boolean, default: false
   attribute :training_details, :boolean, default: false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,7 +287,7 @@ en:
       summary_title: Schools
       lead_school_key: Lead school
       employing_school_key: Employing school
-    placement_detail:
+    placement_detail: &placement_detail
       title: Placement details
       placement_1: First placement
       placement_2: Second placement
@@ -299,6 +299,7 @@ en:
         900010: "Not applicable or not available"
         900020: "Establishment does not have a URN"
         900030: "Not available"
+    placements: *placement_detail
     degrees:
       add_another_degree: Add another degree
       institution: &institution Awarding institution

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -189,6 +189,10 @@ Rails.application.routes.draw do
       end
 
       resource :placements, only: %i[new create edit update]
+
+      namespace :placements do
+        concerns :confirmable
+      end
     end
   end
 

--- a/spec/components/placements/view_preview.rb
+++ b/spec/components/placements/view_preview.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "govuk/components"
+
+module Placements
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render(View.new(data_model: mock_trainee))
+    end
+
+    def with_one_placement
+      render(View.new(data_model: mock_trainee(number_of_placements: 1)))
+    end
+
+    def with_two_placement
+      render(View.new(data_model: mock_trainee(number_of_placements: 2)))
+    end
+
+  private
+
+    def mock_trainee(number_of_placements: 0)
+      placements = case number_of_placements
+                   when 1 then [Placement.new(name: "placement 1")]
+                   when 2 then [Placement.new(name: "placement 1"), Placement.new(name: "placement 2")]
+                   else
+                     []
+                   end
+
+      @mock_trainee ||= Trainee.new(
+        id: 1,
+        training_route: TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
+        placements: placements,
+      )
+    end
+  end
+end

--- a/spec/components/placements/view_preview.rb
+++ b/spec/components/placements/view_preview.rb
@@ -19,12 +19,7 @@ module Placements
   private
 
     def mock_trainee(number_of_placements: 0)
-      placements = case number_of_placements
-                   when 1 then [Placement.new(name: "placement 1")]
-                   when 2 then [Placement.new(name: "placement 1"), Placement.new(name: "placement 2")]
-                   else
-                     []
-                   end
+      placements = (1..number_of_placements).map { |number| Placement.new(name: "placement #{number}") }
 
       @mock_trainee ||= Trainee.new(
         id: 1,

--- a/spec/components/placements/view_spec.rb
+++ b/spec/components/placements/view_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Placements
+  describe View do
+    let(:placements) { [] }
+    let(:trainee) { create(:trainee, placements:) }
+    let(:data_model) { trainee }
+
+    before do
+      render_inline(View.new(data_model:))
+    end
+
+    it "have guidance link" do
+      expect(rendered_component).to have_link("Read DfE guidance about training placements in schools and early years settings", href: "https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c23-training-in-schools")
+    end
+
+    it "have inset text" do
+      expect(rendered_component).to have_text("You need to add the details of at least 2 schools before you can recommend this trainee for QTS. These can be added at any time.")
+    end
+
+    it "shows not provided placement" do
+      expect(rendered_component).to have_text("Placement details")
+      expect(rendered_component).to have_text("Placements")
+      expect(rendered_component).to have_text("Not provided yet")
+      expect(rendered_component).to have_link("Add a placement", href: "/trainees/#{data_model.slug}/placements/new", class: "govuk-link")
+    end
+
+    context "with 2 placements" do
+      let(:placements) { create_list(:placement, 2, :manual) }
+
+      it "shows the placement" do
+        placements.each do |placement|
+          expect(rendered_component).to have_text("School or setting")
+          expect(rendered_component).to have_text(placement.name)
+          expect(rendered_component).to have_text(placement.full_address)
+        end
+      end
+
+      it "does not shows not provided placement" do
+        expect(rendered_component).not_to have_text("Placement details")
+        expect(rendered_component).not_to have_text("Placements")
+        expect(rendered_component).not_to have_text("Not provided yet")
+        expect(rendered_component).not_to have_link("Add a placement", href: "/trainees/#{data_model.slug}/placements/new", class: "govuk-link")
+      end
+
+      it "does not have inset text" do
+        expect(rendered_component).not_to have_text("You need to add the details of at least 2 schools before you can recommend this trainee for QTS. These can be added at any time.")
+      end
+
+      it "have guidance link" do
+        expect(rendered_component).to have_link("Read DfE guidance about training placements in schools and early years settings", href: "https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c23-training-in-schools")
+      end
+
+      it "have add a placement button" do
+        expect(rendered_component).to have_link("Add a placement", href: "/trainees/#{data_model.slug}/placements/new", class: "govuk-button--secondary govuk-button")
+      end
+    end
+  end
+end

--- a/spec/forms/placements_form_spec.rb
+++ b/spec/forms/placements_form_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PlacementsForm, type: :model do
+  let(:user) { create(:user) }
+  let(:trainee) { create(:trainee) }
+
+  subject { described_class.new(trainee, user:) }
+
+  describe "track_validation_errors: false" do
+    before do
+      allow(Settings).to receive(:track_validation_errors).and_return(false)
+    end
+
+    it "saves validation errors" do
+      subject.valid?
+      expect(ValidationError.count).to be(0)
+
+      subject.valid?
+      expect(ValidationError.count).to be(0)
+    end
+  end
+end


### PR DESCRIPTION
### Context
Confirm placement details page UI

### Changes proposed in this pull request
Bare minimum to show the page

### Guidance to review
There is/will be  a follow up PR to flesh this out the reminders, this PR is only concerned with UI only

https://register-pr-3684.test.teacherservices.cloud/trainees/W67bCLabETnsnzpGgHtYeW3R/placements/confirm

https://register-pr-3684.test.teacherservices.cloud/view_components/placements/view


#### Default
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/d5e5dc56-4e84-45ac-8fdc-8a3ec63ff196)

#### With one placement
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/e40c8459-f044-4eda-adfa-b2ccde714638)

#### With two placement
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/a9bb0774-d5fa-4b63-af1c-4065aacc6e88)


### Important business
Nope 
- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
