### PR TITLE
[6256] Skip the DQT::TraineeUpdate if trainee is pending

### DIFF
--- a/app/services/dqt/trainee_update.rb
+++ b/app/services/dqt/trainee_update.rb
@@ -13,6 +13,7 @@ module Dqt
 
     def call
       return unless FeatureService.enabled?(:integrate_with_dqt)
+      return if trainee.submitted_for_trn?
 
       raise(TraineeUpdateMissingTrn, "Cannot update trainee on DQT without a trn (id: #{trainee.id})") if trainee.trn.blank?
 


### PR DESCRIPTION
### Context

The DQT::TraineeUpdate requires a trainee to have a TRN but for trainees in pending they won't. At the moment, we seem to raise on this scenario which fails jobs unnecessarily. This can build up:

<img width="1264" alt="jobs" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/83cb056d-4c5e-4a28-a839-0f29cae40b0d">

### Changes proposed in this pull request

- Just skip the update until they get a TRN
