### PR TITLE
[626] Surface hesa id for easier debugging

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -39,7 +39,7 @@ module Trainees
       end
     rescue ActiveRecord::RecordInvalid
       raise(HesaImportError,
-            "HESA import failed (errors: #{trainee.errors.full_messages}), (ukprn: #{hesa_trainee[:ukprn]})")
+            "HESA import failed (errors: #{trainee.errors.full_messages}), (ukprn: #{hesa_trainee[:ukprn]}, hesa_id: #{hesa_trainee[:hesa_id]})")
     end
 
   private


### PR DESCRIPTION
### Context

Sometimes we get a Hesa import which has failed to create a trainee due to some validation error, eg [like this one](https://dfe-teacher-services.sentry.io/issues/4553700850/?environment=production&project=5552118&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=1). In this scenario, we need to get the provider to double check the information on the hesa record to correct if needed. At the moment, when this error is raised in Sentry there is no additional information to help identify the exact hesa trainee the provider might need to update. 

This PR surfaces the hesa id so we can track down the record causing issues in the import. 
