### PR TITLE
[6243] Add new placement form

### DIFF
--- a/app/controllers/trainees/base_controller.rb
+++ b/app/controllers/trainees/base_controller.rb
@@ -17,5 +17,9 @@ module Trainees
     def training_route
       TrainingRoutesForm.new(trainee).training_route
     end
+
+    def require_feature_flag(feature)
+      redirect_to(not_found_path) unless FeatureService.enabled?(feature)
+    end
   end
 end

--- a/app/controllers/trainees/placements_controller.rb
+++ b/app/controllers/trainees/placements_controller.rb
@@ -2,9 +2,17 @@
 
 module Trainees
   class PlacementsController < BaseController
+    before_action :require_feature_flag
+
     def new
       @trainee = trainee
       @placement_form = PlacementForm.new(trainee:)
+    end
+
+  private
+
+    def require_feature_flag
+      redirect_to(not_found_path) unless FeatureService.enabled?(:trainee_placement)
     end
   end
 end

--- a/app/controllers/trainees/placements_controller.rb
+++ b/app/controllers/trainees/placements_controller.rb
@@ -2,17 +2,11 @@
 
 module Trainees
   class PlacementsController < BaseController
-    before_action :require_feature_flag
+    before_action { require_feature_flag(:trainee_placement) }
 
     def new
       @trainee = trainee
       @placement_form = PlacementForm.new(trainee:)
-    end
-
-  private
-
-    def require_feature_flag
-      redirect_to(not_found_path) unless FeatureService.enabled?(:trainee_placement)
     end
   end
 end

--- a/app/controllers/trainees/placements_controller.rb
+++ b/app/controllers/trainees/placements_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Trainees
+  class PlacementsController < BaseController
+    def new
+      @trainee = trainee
+      @placement_form = PlacementForm.new(trainee:)
+    end
+  end
+end

--- a/app/forms/placement_form.rb
+++ b/app/forms/placement_form.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class PlacementForm
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations::Callbacks
+
+  FIELDS = %i[name urn postcode].freeze
+
+  def initialize(trainee:)
+    @trainee = trainee
+  end
+
+  def self.model_name
+    ActiveModel::Name.new(self, nil, "Placement")
+  end
+
+  def fields; end
+
+  def attributes
+    FIELDS.index_with do |f|
+      public_send(f)
+    end
+  end
+
+  def attributes=(attrs)
+    attrs.each do |k, v|
+      public_send(:"#{k}=", v)
+    end
+  end
+
+  def title
+    new_placement_number = @trainee.placements.count + 1
+    I18n.t(
+      "components.placement_detail.placement_#{new_placement_number}",
+      default: I18n.t("components.placement_detail.title"),
+    )
+  end
+
+  def save!
+    # TODO: Implement persistence logic
+    false
+  end
+end

--- a/app/views/trainees/placements/_form.html.erb
+++ b/app/views/trainees/placements/_form.html.erb
@@ -26,4 +26,6 @@
     width: "three-quarters",
     autocomplete: :off,
   ) %>
+
+  <%= f.govuk_submit("Continue") %>
 <% end %>

--- a/app/views/trainees/placements/_form.html.erb
+++ b/app/views/trainees/placements/_form.html.erb
@@ -1,0 +1,29 @@
+<%= register_form_with model: [@trainee, @placement_form], local: true do |f| %>
+  <% if f.govuk_error_summary.present? %>
+    <%= f.govuk_error_summary %>
+  <% end %>
+
+  <%= render TraineeName::View.new(@trainee) %>
+  <h1 class="govuk-heading-l"><%= @placement_form.title %></h1>
+
+  <%= f.govuk_text_field(
+    :name,
+    label: { text: "School or setting name", size: "s" },
+    width: "three-quarters",
+    autocomplete: :off,
+  ) %>
+
+  <%= f.govuk_text_field(
+    :urn,
+    label: { text: "School unique reference number (URN) - if it has one", size: "s" },
+    width: "three-quarters",
+    autocomplete: :off,
+  ) %>
+
+  <%= f.govuk_text_field(
+    :postcode,
+    label: { text: "Postcode", size: "s" },
+    width: "three-quarters",
+    autocomplete: :off,
+  ) %>
+<% end %>

--- a/app/views/trainees/placements/new.html.erb
+++ b/app/views/trainees/placements/new.html.erb
@@ -1,0 +1,17 @@
+<%= render PageTitle::View.new(
+  text: @placement_form.title,
+  has_errors: @placement_form.errors.present?,
+) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: trainee_path(@trainee),
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <%= render 'form' %>
+  </div>
+</div>

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -44,7 +44,7 @@
 
 <% if @trainee.placement_details? %>
   <div class="placement-details">
-    <%= render PlacementDetails::View.new(trainee: @trainee, editable: false) %>
+    <%= render PlacementDetails::View.new(trainee: @trainee, editable: trainee_editable?) %>
   </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,6 +187,8 @@ Rails.application.routes.draw do
         resource :hesa_deferrals, only: :show, path: "/defer"
         resource :hesa_reinstatements, only: :show, path: "/reinstate"
       end
+
+      resource :placements, only: %i[new create edit update]
     end
   end
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -20,6 +20,7 @@ features:
     opt_in_undergrad: true
     iqts: true
   funding: true
+  trainee_placement: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -20,6 +20,7 @@ features:
     iqts: true
   user_can_have_multiple_organisations: true
   funding: true
+  trainee_placement: true
 
 pagination:
   records_per_page: 30

--- a/spec/features/trainee_actions/adding_trainee_placements_spec.rb
+++ b/spec/features/trainee_actions/adding_trainee_placements_spec.rb
@@ -2,12 +2,16 @@
 
 require "rails_helper"
 
-feature "Add a placement", feature_trainee_placement: true do
+feature "Add a placement" do
   scenario "Add a new placement to an existing trainee" do
     given_i_am_authenticated
     and_a_trainee_exists_with_trn_received
 
     when_i_navigate_to_the_new_placement_form
+    then_i_see_the_not_found_page
+
+    when_the_feature_flag_is_active
+    and_i_navigate_to_the_new_placement_form
     then_i_see_the_new_placement_form
   end
 
@@ -19,6 +23,15 @@ private
 
   def when_i_navigate_to_the_new_placement_form
     visit new_trainee_placements_path(trainee_id: @trainee.slug)
+  end
+  alias_method :and_i_navigate_to_the_new_placement_form, :when_i_navigate_to_the_new_placement_form
+
+  def then_i_see_the_not_found_page
+    expect(page).to have_current_path(not_found_path)
+  end
+
+  def when_the_feature_flag_is_active
+    enable_features(:trainee_placement)
   end
 
   def then_i_see_the_new_placement_form

--- a/spec/features/trainee_actions/adding_trainee_placements_spec.rb
+++ b/spec/features/trainee_actions/adding_trainee_placements_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Add a placement", feature_trainee_placement: true do
+  scenario "Add a new placement to an existing trainee" do
+    given_i_am_authenticated
+    and_a_trainee_exists_with_trn_received
+
+    when_i_navigate_to_the_new_placement_form
+    then_i_see_the_new_placement_form
+  end
+
+private
+
+  def and_a_trainee_exists_with_trn_received
+    @trainee ||= given_a_trainee_exists(:trn_received)
+  end
+
+  def when_i_navigate_to_the_new_placement_form
+    visit new_trainee_placements_path(trainee_id: @trainee.slug)
+  end
+
+  def then_i_see_the_new_placement_form
+    expect(page).to have_content("First placement")
+  end
+end

--- a/spec/forms/placement_form_spec.rb
+++ b/spec/forms/placement_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PlacementForm, type: :model do
+  let(:trainee) { build(:trainee) }
+
+  subject { PlacementForm.new(trainee:) }
+
+  describe "#title" do
+    context "when there are no placements" do
+      it "returns the _First placement" do
+        expect(subject.title).to eq("First placement")
+      end
+    end
+
+    context "when there are two existing placements" do
+      before do
+        allow(trainee).to receive(:placements).and_return(build_list(:placement, 2))
+      end
+
+      it "returns the _Third placement_" do
+        expect(subject.title).to eq("Third placement")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

This PR is a (small) part of the trainee placements epic that gives providers the ability to add placement details to trainee records.

### Changes proposed in this pull request

This PR attempts to add just enough to show the basic UI. Persistence and other logic will be in a follow-up PR/ticket.

- New route `POST /trainees/:trainee_id/placements/new`. Returns 404 unless `trainee_placement` is active.
- New controller `Trainees::PlacementsController` (only a `new` action for now)
- New form object `PlacementForm`
- New view for the controller action
- Feature spec for the _Add placement_ flow (will need to be completed when backend logic etc. is added)

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/487ac492-b9ba-4f62-9cd8-5c2c8a52f050)


https://trello.com/c/LeTbJtIt/6243-add-edit-a-placement-page-ui

### Guidance to review

- Are the tests sufficient?
- Does this fit the overall architecture for the epic?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
