### PR TITLE
[6200] - expose all training routes for TeachFirst trainee registration

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -60,6 +60,8 @@ class Provider < ApplicationRecord
 
   before_update :update_courses, if: :code_changed?
 
+  TEACH_FIRST_PROVIDER_CODE = "1TF"
+
   def code=(cde)
     self[:code] = cde.to_s.upcase
   end

--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -4,7 +4,7 @@
 
   <% if current_user.provider? && current_user.organisation.hpitt_postgrad? %>
     <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:hpitt_postgrad], label: { text: t("activerecord.attributes.trainee.training_routes.hpitt_postgrad") } %>
-  <% else %>
+  <% end %>
     <%= f.govuk_radio_button :training_route, TRAINING_ROUTE_ENUMS[:assessment_only], label: { text: t("activerecord.attributes.trainee.training_routes.assessment_only") }, link_errors: true %>
 
     <% training_routes_options.each do |option| %>
@@ -14,6 +14,5 @@
         hint: { text: option[:hint] },
         label: { text: option[:label] }
       ) %>
-    <% end %>
   <% end %>
 <% end %>

--- a/config/initializers/personas.rb
+++ b/config/initializers/personas.rb
@@ -3,7 +3,6 @@
 PROVIDER_A = "Londinium Teacher Training"
 PROVIDER_B = "North County SCITT"
 PROVIDER_C = "University of BAT"
-TEACH_FIRST_PROVIDER_CODE = "1TF"
 
 PERSONAS = [
   { first_name: "Agatha", last_name: "Baker", email: "agatha_baker@example.org", system_admin: true },

--- a/spec/components/record_details/view_preview.rb
+++ b/spec/components/record_details/view_preview.rb
@@ -11,7 +11,7 @@ module RecordDetails
     def with_region
       trainee = mock_trainee("default").tap do |t|
         t.region = Dttp::CodeSets::Regions::MAPPING.keys.sample
-        t.provider = Provider.new(code: TEACH_FIRST_PROVIDER_CODE)
+        t.provider = Provider.new(code: ::Provider::TEACH_FIRST_PROVIDER_CODE)
       end
 
       render(View.new(trainee:, last_updated_event:))

--- a/spec/components/training_details/view_preview.rb
+++ b/spec/components/training_details/view_preview.rb
@@ -18,7 +18,7 @@ module TrainingDetails
       Trainee.new(
         shared_attributes.merge(
           region: Dttp::CodeSets::Regions::MAPPING.keys.sample,
-          provider: Provider.new(code: TEACH_FIRST_PROVIDER_CODE),
+          provider: Provider.new(code: ::Provider::TEACH_FIRST_PROVIDER_CODE),
         ),
       )
     end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     sequence(:accreditation_id, "1111")
 
     trait :teach_first do
-      code { TEACH_FIRST_PROVIDER_CODE }
+      code { Provider::TEACH_FIRST_PROVIDER_CODE }
     end
 
     trait :with_courses do

--- a/spec/features/end_to_end/teach_first_journey_spec.rb
+++ b/spec/features/end_to_end/teach_first_journey_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 feature "teach-first end-to-end journey" do
-  let(:user) { create(:user, providers: create_list(:provider, 1, code: TEACH_FIRST_PROVIDER_CODE)) }
+  let(:user) { create(:user, providers: create_list(:provider, 1, code: Provider::TEACH_FIRST_PROVIDER_CODE)) }
 
   background { given_i_am_authenticated(user:) }
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -47,13 +47,13 @@ describe Provider do
     subject { build(:provider, code:).hpitt_postgrad? }
 
     context "provider is a teach first provider" do
-      let(:code) { TEACH_FIRST_PROVIDER_CODE }
+      let(:code) { Provider::TEACH_FIRST_PROVIDER_CODE }
 
       it { is_expected.to be_truthy }
     end
 
     context "provider is not a teach first provider" do
-      let(:code) { TEACH_FIRST_PROVIDER_CODE.reverse }
+      let(:code) { Provider::TEACH_FIRST_PROVIDER_CODE.reverse }
 
       it { is_expected.to be_falsey }
     end


### PR DESCRIPTION
### Context

If a user is aligned to the provider: Teach First, when they create a a draft trainee, the only course route they can select is `HPITT`. This is out of date now: the Teach First provider now have "normal-route" options that they advertise via Publish and we import these trainees from Apply. This is new for 23/24.

### Changes proposed in this pull request

simplifies training route list to display "HPITT" training route in addition to other routes only if provider is TeachFirst.

### Guidance to review


*  _(if in a review app create a provider "teach first" with code `1TF`)_
* create draft trainee with non-TeachFirst provider attached to user and see no HPITT training route option in list
* create draft trainee with TeachFirst provider attached to user and see HPITT training route option in addition to regular list