### PR TITLE
[6236] Add school autocomplete on placement form

### DIFF
--- a/app/forms/placement_form.rb
+++ b/app/forms/placement_form.rb
@@ -5,7 +5,7 @@ class PlacementForm
   include ActiveModel::AttributeAssignment
   include ActiveModel::Validations::Callbacks
 
-  FIELDS = %i[name urn postcode].freeze
+  FIELDS = %i[school_id name urn postcode].freeze
 
   def initialize(trainee:)
     @trainee = trainee

--- a/app/views/trainees/placements/_form.html.erb
+++ b/app/views/trainees/placements/_form.html.erb
@@ -1,4 +1,9 @@
-<%= register_form_with model: [@trainee, @placement_form], local: true do |f| %>
+<%= register_form_with(
+  model: [@trainee, @placement_form],
+  local: true,
+  html: { data: { module: "app-schools-autocomplete" } },
+) do |f| %>
+
   <% if f.govuk_error_summary.present? %>
     <%= f.govuk_error_summary %>
   <% end %>
@@ -6,26 +11,37 @@
   <%= render TraineeName::View.new(@trainee) %>
   <h1 class="govuk-heading-l"><%= @placement_form.title %></h1>
 
+  <%= f.hidden_field :school_id, id: "school-id" %>
   <%= f.govuk_text_field(
-    :name,
-    label: { text: "School or setting name", size: "s" },
-    width: "three-quarters",
-    autocomplete: :off,
+    :school,
+    label: { text: "Search for a school by its unique reference number (URN), name or postcode" },
+    "data-field" => "schools-autocomplete",
+    width: "two-thirds",
   ) %>
+  <div id="schools-autocomplete-element"></div>
 
-  <%= f.govuk_text_field(
-    :urn,
-    label: { text: "School unique reference number (URN) - if it has one", size: "s" },
-    width: "three-quarters",
-    autocomplete: :off,
-  ) %>
+  <%= govuk_details(summary_text: "Placement school or setting is not listed") do %>
+    <%= f.govuk_text_field(
+      :name,
+      label: { text: "School or setting name", size: "s" },
+      width: "two-thirds",
+      autocomplete: :off,
+    ) %>
 
-  <%= f.govuk_text_field(
-    :postcode,
-    label: { text: "Postcode", size: "s" },
-    width: "three-quarters",
-    autocomplete: :off,
-  ) %>
+    <%= f.govuk_text_field(
+      :urn,
+      label: { text: "School unique reference number (URN) - if it has one", size: "s" },
+      width: "two-thirds",
+      autocomplete: :off,
+    ) %>
+
+    <%= f.govuk_text_field(
+      :postcode,
+      label: { text: "Postcode", size: "s" },
+      width: "two-thirds",
+      autocomplete: :off,
+    ) %>
+  <% end %>
 
   <%= f.govuk_submit("Continue") %>
 <% end %>

--- a/app/views/trainees/placements/new.html.erb
+++ b/app/views/trainees/placements/new.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
+  <div class="govuk-grid-column-two-thirds">
     <%= render 'form' %>
   </div>
 </div>


### PR DESCRIPTION
### Context
This PR is part of the Placements EPIC that will give providers the ability to add and edit placement details for each trainee record.

https://trello.com/c/Ma5Qo7K2/6236-implement-the-typeahead-box

### Changes proposed in this pull request

Add an autocomplete field to the _Create placement_ form. This field uses existing front-end logic to populate a list of matching schools names together with their address and URN.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/57b16de0-1d71-4495-91e9-e5841d7d210c)

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/bd7bed1e-52c3-400f-9bf9-51de0102dcb1)


Also wrap the existing fields (used to enter details for a new school) in a summary component so that they are not visible initially.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/c4171f53-c495-4eb7-9910-420bfe918185)

### Guidance to review

Is there anything else to do at this point? Backend logic will be implemented in a separate ticket & PR.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
