### PR TITLE
[6201] change some summary card headings

### DIFF
--- a/app/components/iqts_country/view.html.erb
+++ b/app/components/iqts_country/view.html.erb
@@ -1,5 +1,5 @@
 <%= render SummaryCard::View.new(
   title: t(".title"),
-  heading_level: 2,
+  heading_level: 3,
   rows: iqts_country_row
 ) %>

--- a/app/components/schools/view.html.erb
+++ b/app/components/schools/view.html.erb
@@ -1,1 +1,1 @@
-<%= render SummaryCard::View.new(title: t(".summary_title"), heading_level: 2, rows: school_rows) %>
+<%= render SummaryCard::View.new(title: t(".summary_title"), heading_level: 3, rows: school_rows) %>

--- a/app/components/summary_card/view.rb
+++ b/app/components/summary_card/view.rb
@@ -3,7 +3,7 @@
 class SummaryCard::View < ViewComponent::Base
   renders_one :header_actions
 
-  def initialize(title:, heading_level: 2, rows:, id_suffix: nil, editable: true)
+  def initialize(title:, heading_level: 3, rows:, id_suffix: nil, editable: true)
     @title = title
     @heading_level = heading_level
     @rows = rows

--- a/app/components/training_details/view.html.erb
+++ b/app/components/training_details/view.html.erb
@@ -1,5 +1,5 @@
 <%= render SummaryCard::View.new(
   title: t(".title"),
-  heading_level: 2,
+  heading_level: 3,
   rows: training_details_rows
 ) %>

--- a/spec/components/record_details/view_preview.rb
+++ b/spec/components/record_details/view_preview.rb
@@ -11,7 +11,7 @@ module RecordDetails
     def with_region
       trainee = mock_trainee("default").tap do |t|
         t.region = Dttp::CodeSets::Regions::MAPPING.keys.sample
-        t.provider = Provider.new(code: ::Provider::TEACH_FIRST_PROVIDER_CODE)
+        t.provider = Provider.new(code: Provider::TEACH_FIRST_PROVIDER_CODE)
       end
 
       render(View.new(trainee:, last_updated_event:))

--- a/spec/components/training_details/view_preview.rb
+++ b/spec/components/training_details/view_preview.rb
@@ -18,7 +18,7 @@ module TrainingDetails
       Trainee.new(
         shared_attributes.merge(
           region: Dttp::CodeSets::Regions::MAPPING.keys.sample,
-          provider: Provider.new(code: ::Provider::TEACH_FIRST_PROVIDER_CODE),
+          provider: Provider.new(code: Provider::TEACH_FIRST_PROVIDER_CODE),
         ),
       )
     end

--- a/spec/support/page_objects/trainees/record.rb
+++ b/spec/support/page_objects/trainees/record.rb
@@ -31,7 +31,7 @@ module PageObjects
       element :change_employing_school, "a", text: "Change employing school", visible: false
       element :change_course_details, "a", text: "Change course", visible: false
       element :change_trainee_status, "a", text: "Change status", visible: false
-      element :withdrawal_details_component, "h2", text: "Withdrawal details", visible: false
+      element :withdrawal_details_component, "h3", text: "Withdrawal details", visible: false
       element :enable_editing, ".enable-editing"
     end
   end


### PR DESCRIPTION
### Context

It was flagged in the accessibility report that there are some template summary page instances which have an `<h1>` title but use `<h2>` tags both in the page for subheadings AND as the title of each summary card causing a WCAG AA fail.

### Changes proposed in this pull request

* defaults to H3 for summary cards

