### PR TITLE
[6247] Wire up flow for placements first step (placement details)

### DIFF
--- a/app/components/review_draft/draft/view.html.erb
+++ b/app/components/review_draft/draft/view.html.erb
@@ -27,6 +27,8 @@
         component.row(**row_helper(@trainee, :course_details))
       end
 
+      component.row(**row_helper(@trainee, :placement_details))
+
       component.row(**row_helper(@trainee, :training_details).except(:hint_text))
 
       if @trainee.requires_schools?

--- a/app/components/review_draft/draft/view.html.erb
+++ b/app/components/review_draft/draft/view.html.erb
@@ -27,7 +27,9 @@
         component.row(**row_helper(@trainee, :course_details))
       end
 
-      component.row(**row_helper(@trainee, :placement_details))
+      if FeatureService.enabled?(:trainee_placement) && @trainee.requires_placements?
+        component.row(**row_helper(@trainee, :placement_details))
+      end
 
       component.row(**row_helper(@trainee, :training_details).except(:hint_text))
 

--- a/app/controllers/trainees/placements/details_controller.rb
+++ b/app/controllers/trainees/placements/details_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Placements
+    class DetailsController < BaseController
+      before_action { require_feature_flag(:trainee_placement) }
+
+      def edit
+        @placement_detail_form = PlacementDetailForm.new(trainee)
+      end
+
+      def update
+        @placement_detail_form = PlacementDetailForm.new(trainee, params: placement_detail_params, user: current_user)
+
+        if @placement_detail_form.stash_or_save!
+          redirect_to(next_step)
+        else
+          render(:edit)
+        end
+      end
+
+    private
+
+      def placement_detail_params
+        return { placement_detail: nil } if params[:placement_detail_form].blank?
+
+        params.require(:placement_detail_form).permit(*PlacementDetailForm::FIELDS)
+      end
+
+      def next_step
+        if @placement_detail_form.detail_provided?
+          new_trainee_placements_path(trainee)
+        else
+          trainee_placements_confirm_path(trainee)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/placement_detail_form.rb
+++ b/app/forms/placement_detail_form.rb
@@ -30,8 +30,4 @@ private
   def compute_fields
     trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
   end
-
-  def form_store_key
-    :placement_detail
-  end
 end

--- a/app/forms/placement_detail_form.rb
+++ b/app/forms/placement_detail_form.rb
@@ -1,14 +1,37 @@
 # frozen_string_literal: true
 
-class PlacementDetailForm
-  include ActiveModel::Model
+class PlacementDetailForm < TraineeForm
+  FIELDS = %i[
+    placement_detail
+  ].freeze
 
-  def initialize(trainee)
-    @trainee = trainee
-    super(fields)
+  attr_accessor(*FIELDS)
+
+  validates :placement_detail, presence: true, inclusion: { in: PLACEMENT_DETAIL_ENUMS.values }
+
+  def detail_provided?
+    placement_detail == PLACEMENT_DETAIL_ENUMS[:has_placement_detail]
   end
 
-  def fields
-    {}
+  def detail_not_provided?
+    placement_detail == PLACEMENT_DETAIL_ENUMS[:no_placement_detail]
+  end
+
+  def save!
+    if valid?
+      clear_stash
+    else
+      false
+    end
+  end
+
+private
+
+  def compute_fields
+    trainee.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+  end
+
+  def form_store_key
+    :placement_detail
   end
 end

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -45,9 +45,9 @@ module TaskListHelper
 
     when :placement_details
       {
-        task_name: "Placement details",
-        path: trainee_review_drafts_path(trainee),
-        confirm_path: trainee_review_drafts_path(trainee),
+        task_name: "Placements",
+        path: edit_trainee_placements_details_path(trainee),
+        confirm_path: trainee_placements_confirm_path(trainee),
         classes: "placement-details",
         status: ProgressService.call(
           validator: PlacementDetailForm.new(trainee),

--- a/app/lib/training_route_manager.rb
+++ b/app/lib/training_route_manager.rb
@@ -46,6 +46,13 @@ class TrainingRouteManager
     ].exclude?(training_route)
   end
 
+  def requires_placements?
+    [
+      TRAINING_ROUTE_ENUMS[:assessment_only],
+      TRAINING_ROUTE_ENUMS[:early_years_assessment_only],
+    ].exclude?(training_route)
+  end
+
   def undergrad_route?
     UNDERGRAD_ROUTES.keys.include?(training_route)
   end

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -184,6 +184,7 @@ class Trainee < ApplicationRecord
 
   delegate :award_type,
            :requires_schools?,
+           :requires_placements?,
            :requires_employing_school?,
            :early_years_route?,
            :undergrad_route?,

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -16,6 +16,7 @@ class FormStore
     outcome_date
     withdraw
     withdrawal_date
+    placement_detail
     withdrawal_reasons
     withdrawal_extra_information
     diversity_disclosure

--- a/app/views/trainees/placements/details/edit.html.erb
+++ b/app/views/trainees/placements/details/edit.html.erb
@@ -1,0 +1,39 @@
+<%= render PageTitle::View.new(
+  text: t('.placement_details_title'),
+  has_errors: @placement_detail_form.errors.present?,
+) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: trainee_path(@trainee),
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= register_form_with(model: @placement_detail_form, url: trainee_placements_details_path(@trainee), method: :put, local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l"><%= t('.placement_details_title') %></h1>
+
+      <p class="govuk-body">
+        You can add placements at any time whenever you have the details. To recommend the trainee for EYTS, you must have provided the details of 2 placements.
+      </p>
+
+      <p class="govuk-body">
+        <a class="govuk-link " href="https://www.gov.uk/government/publications/initial-teacher-training-criteria#c23-training-in-schools">Read DfE guidance about training placements in schools and early years settings.</a>
+      </p>
+
+      <%= f.govuk_collection_radio_buttons(
+        :placement_detail,
+        PLACEMENT_DETAIL_ENUMS.values,
+        ->(value) { value },
+        ->(label) { I18n.t("views.forms.placement_details.label_names.#{label}") },
+        legend: { text: "Do you have any of the trainee's placement details?", tag: "h2" },
+      ) %>
+
+      <%= f.govuk_submit("Continue") %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/placement_enums.rb
+++ b/config/initializers/placement_enums.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+PLACEMENT_DETAIL_ENUMS = {
+  has_placement_detail: "has_placement_detail",
+  no_placement_detail: "no_placement_detail",
+}.freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -855,6 +855,10 @@ en:
         labels:
           disabled: Yes, they shared that they’re disabled
           no_disability: They shared that they’re not disabled
+      placement_details:
+        label_names:
+          has_placement_detail: "Yes, I can add at least one of them now"
+          no_placement_detail: "No, I'll add them later"
       reinstatement:
         heading: When did the trainee return?
       withdrawal_date:
@@ -1038,6 +1042,10 @@ en:
       edit:
         email:
           hint: Use the trainee’s personal email address. This is so they can access their ongoing teaching records with DfE.
+    placements:
+      details:
+        edit:
+          placement_details_title: Placements
     course_years:
       edit:
         heading: Which academic year do you want to choose courses from?
@@ -1459,6 +1467,10 @@ en:
           attributes:
             disability_ids:
               empty_disabilities: Select at least one disability
+        placement_detail_form:
+          attributes:
+            placement_detail:
+              blank: Select if you have the trainee's placement details
         diversities/form_validator:
           attributes:
             disclosure_section:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1470,7 +1470,7 @@ en:
         placement_detail_form:
           attributes:
             placement_detail:
-              blank: Select if you have the trainee's placement details
+              blank: Select if you have the trainee’s placement details
         diversities/form_validator:
           attributes:
             disclosure_section:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -858,7 +858,7 @@ en:
       placement_details:
         label_names:
           has_placement_detail: "Yes, I can add at least one of them now"
-          no_placement_detail: "No, I'll add them later"
+          no_placement_detail: "No, I’ll add them later"
       reinstatement:
         heading: When did the trainee return?
       withdrawal_date:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,8 @@ Rails.application.routes.draw do
       resource :placements, only: %i[new create edit update]
 
       namespace :placements do
+        resource :details, only: %i[edit update], path: "/details"
+
         concerns :confirmable
       end
     end

--- a/spec/features/form_sections/teacher_training_data/placements/details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/details_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 feature "add placement details", feature_trainee_placement: true do
   background do
     given_i_am_authenticated
-    given_a_trainee_exists
+    given_a_trainee_exists(training_route: valid_training_routes.sample)
   end
 
   scenario "placement detail available" do
@@ -25,7 +25,8 @@ feature "add placement details", feature_trainee_placement: true do
 private
 
   def when_i_visit_the_placement_details_page
-    visit(edit_trainee_placements_details_path(trainee))
+    given_i_am_on_the_review_draft_page
+    click_link "Placements"
   end
 
   def and_i_have_the_placement_details
@@ -46,5 +47,9 @@ private
 
   def then_i_am_taken_to_the_placement_confirm_page
     expect(page).to have_current_path(trainee_placements_confirm_path(trainee))
+  end
+
+  def valid_training_routes
+    TRAINING_ROUTE_ENUMS.keys - %i[assessment_only early_years_assessment_only]
   end
 end

--- a/spec/features/form_sections/teacher_training_data/placements/details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/details_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "add placement details", feature_trainee_placement: true do
+  background do
+    given_i_am_authenticated
+    given_a_trainee_exists
+  end
+
+  scenario "placement detail available" do
+    when_i_visit_the_placement_details_page
+    and_i_have_the_placement_details
+    and_i_continue
+    then_i_am_taken_to_the_placement_form_page
+  end
+
+  scenario "placement detail not available" do
+    when_i_visit_the_placement_details_page
+    and_i_do_not_have_the_placement_detail
+    and_i_continue
+    then_i_am_taken_to_the_placement_confirm_page
+  end
+
+private
+
+  def when_i_visit_the_placement_details_page
+    visit(edit_trainee_placements_details_path(trainee))
+  end
+
+  def and_i_have_the_placement_details
+    page.choose("Yes, I can add at least one of them now")
+  end
+
+  def and_i_do_not_have_the_placement_detail
+    page.choose("No, I'll add them later")
+  end
+
+  def and_i_continue
+    click_button("Continue")
+  end
+
+  def then_i_am_taken_to_the_placement_form_page
+    expect(page).to have_current_path(new_trainee_placements_path(trainee))
+  end
+
+  def then_i_am_taken_to_the_placement_confirm_page
+    expect(page).to have_current_path(trainee_placements_confirm_path(trainee))
+  end
+end

--- a/spec/features/form_sections/teacher_training_data/placements/details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/details_spec.rb
@@ -33,7 +33,7 @@ private
   end
 
   def and_i_do_not_have_the_placement_detail
-    page.choose("No, I'll add them later")
+    page.choose("No, I’ll add them later")
   end
 
   def and_i_continue

--- a/spec/forms/placement_detail_form_spec.rb
+++ b/spec/forms/placement_detail_form_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PlacementDetailForm, type: :model do
+  let(:params) { {} }
+  let(:trainee) { create(:trainee) }
+  let(:form_store) { class_double(FormStore) }
+
+  subject { described_class.new(trainee, params: params, store: form_store) }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:placement_detail) }
+    it { is_expected.to validate_inclusion_of(:placement_detail).in_array(PLACEMENT_DETAIL_ENUMS.values) }
+  end
+
+  describe "#stash" do
+    let(:params) { { placement_detail: PLACEMENT_DETAIL_ENUMS[:has_placement_detail] } }
+
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and personal_detail" do
+      expect(form_store).to receive(:set).with(trainee.id, :placement_detail, subject.fields)
+
+      subject.stash
+    end
+  end
+end

--- a/spec/lib/training_route_manager_spec.rb
+++ b/spec/lib/training_route_manager_spec.rb
@@ -172,4 +172,26 @@ describe TrainingRouteManager do
       end
     end
   end
+
+  describe "#requires_placements?" do
+    (TRAINING_ROUTES.keys - %w[early_years_assessment_only assessment_only]).each do |route|
+      context "for route #{route}" do
+        let(:trainee) { Struct.new(:training_route).new(route.to_s) }
+
+        it "returns true" do
+          expect(subject.requires_placements?).to be true
+        end
+      end
+    end
+
+    %w[early_years_assessment_only assessment_only].each do |route|
+      context "for route #{route}" do
+        let(:trainee) { create(:trainee, route) }
+
+        it "returns false" do
+          expect(subject.requires_placements?).to be false
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/ftfQZB4M/6247-do-you-have-any-of-the-trainees-placement-details-page-ui

### Changes proposed in this pull request

https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/0a8a2a71-b043-4f28-bbe6-3f5e5072784e

This PR wires up some foundational things to get the first step of the placements flow (from a UI perspective) functional and connected to the others.

- Sets up the section entry on the draft page (the logic for the complete/incomplete states will be finalised later)
- Adds the code to implement the first step so the provider can choose whether placement details are available (the saving is not yet implemented)
- Routes to the correct step depending on the answer selected (full stashing and returning behaviour is not completely wired up yet)

### Guidance to review

- Go to the review app, choose any route (placements shown on all routes for now, but will be hidden on selected route in follow up ticket)
- Click placements, choose answer for first step. 
- Check you're taken to the correct next step depending on the answer
