### PR TITLE
[6292] - send table name not model

### DIFF
--- a/app/jobs/bulk_update/analytics_job.rb
+++ b/app/jobs/bulk_update/analytics_job.rb
@@ -15,7 +15,7 @@ module BulkUpdate
       @events ||= records.map do |record|
         DfE::Analytics::Event.new
                               .with_type("update_entity")
-                              .with_entity_table_name(@model)
+                              .with_entity_table_name(@model.table_name)
                               .with_data(DfE::Analytics.extract_model_attributes(record))
       end.as_json
     end


### PR DESCRIPTION
### Context

The change here:
https://github.com/DFE-Digital/register-trainee-teachers/pull/3627/

For bulk uploads causes an error on the BQ side. This means the Trainee awarded status is not synchronised with BigQuery.

### Changes proposed in this pull request

An entity table name is required rather than a model name; i.e. the parameter passed to the Event should be @‌model.table_name rather than @‌model