### PR TITLE
[6261] Attempt to fix problem creating degrees

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -357,7 +357,7 @@ class Trainee < ApplicationRecord
   before_save :set_submission_ready, if: :awaiting_action?
   before_save :set_academic_cycles
 
-  after_touch :set_submission_ready, :save
+  after_touch :set_submission_ready
 
   def hesa_student_for_collection(collection_reference)
     Hesa::Student.where(hesa_id:, collection_reference:).order(created_at: :asc).first

--- a/spec/services/trainees/create_timeline_events_spec.rb
+++ b/spec/services/trainees/create_timeline_events_spec.rb
@@ -178,6 +178,7 @@ module Trainees
 
         it "returns a 'creation' timeline event" do
           degree.reload
+
           expect(subject.first.title).to eq(t("components.timeline.titles.degree.create"))
         end
 
@@ -198,7 +199,8 @@ module Trainees
 
         before do
           degree.reload
-          trainee.degrees.first.destroy!
+
+          trainee.reload.degrees.first.destroy!
         end
 
         it "returns a 'destroyed' timeline event" do

--- a/spec/services/trainees/create_timeline_spec.rb
+++ b/spec/services/trainees/create_timeline_spec.rb
@@ -65,7 +65,7 @@ module Trainees
         before do
           Audited.audit_class.as_user(::Trainees::CreateFromHesa::USERNAME) do
             create(:degree, trainee:)
-            trainee.degrees.destroy_all
+            trainee.reload.degrees.destroy_all
             reload_audits
           end
         end


### PR DESCRIPTION

### Context
It's (sometimes) not possible to create a new degree because (it seems) there is a callback issue between `Degree` and `Trainee`. When a new `Degree` is saved it touches the `Trainee`. There is also an `after_touch` callback on Trainee that ends up calling save which triggers a second `INSERT` on the degrees table.

Do we really need to `save` after touch on a `Trainee`?

### Changes proposed in this pull request
This PR just removes the `after_touch :save` callback.

### Guidance to review
This changes doesn't _appear_ to have any negative impact. The 2 broken specs were fixed by doing a simple `reload`. Can you see any wider implications? 

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
