### PR TITLE
Turn off performance monitoring in Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,6 +5,5 @@ Sentry.init do |config|
   config.before_send = lambda do |event, _hint|
     filter.filter(event.to_hash)
   end
-  config.traces_sample_rate = 0.1
   config.release = ENV.fetch("COMMIT_SHA", nil)
 end


### PR DESCRIPTION
### Context

We're massively exceeding our Sentry quota with performance monitoring data, and we don't seem to use it

### Changes proposed in this pull request

Turn off performance monitoring in Sentry

### Guidance to review

Does it look comfortingly similar to [this](https://github.com/DFE-Digital/get-a-teacher-relocation-payment/pull/324)?

