### PR TITLE
[6215]  use Dfe::Reference for iQTS country

### DIFF
--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dfe/reference_data/countries_and_territories"
+
 module DegreesHelper
   include ApplicationHelper
 
@@ -41,7 +43,11 @@ module DegreesHelper
   end
 
   def countries_options
-    to_options(Dttp::CodeSets::Countries::MAPPING.keys)
+    country_reference = DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.all.map do |reference|
+      reference.name.downcase
+    end
+
+    to_options(country_reference)
   end
 
   def path_for_degrees(trainee)

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dfe/reference_data/countries_and_territories"
+
 module Dqt
   module Params
     class TrnRequest
@@ -189,7 +191,7 @@ module Dqt
       def find_country_code(country)
         return if country.blank?
 
-        Dttp::CodeSets::Countries::MAPPING.dig(country, :country_code) ||
+        DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.some(name: country).first&.id ||
         Hesa::CodeSets::Countries::MAPPING.find { |_, name| name.start_with?(country) }&.first
       end
     end

--- a/spec/helpers/degrees_helper_spec.rb
+++ b/spec/helpers/degrees_helper_spec.rb
@@ -90,7 +90,6 @@ describe DegreesHelper do
 
   describe "#countries_options" do
     it "iterates over array and prints out correct countries values" do
-      expect(countries_options.size).to be 281
       expect(countries_options.first.value).to be_nil
       expect(countries_options.second.value).to eq "andorra"
       expect(countries_options.second.text).to eq "Andorra"

--- a/spec/helpers/degrees_helper_spec.rb
+++ b/spec/helpers/degrees_helper_spec.rb
@@ -89,15 +89,11 @@ describe DegreesHelper do
   end
 
   describe "#countries_options" do
-    before do
-      stub_const("Dttp::CodeSets::Countries::MAPPING", { "country" => { country_code: "C" } })
-    end
-
     it "iterates over array and prints out correct countries values" do
-      expect(countries_options.size).to be 2
+      expect(countries_options.size).to be 281
       expect(countries_options.first.value).to be_nil
-      expect(countries_options.second.value).to eq "country"
-      expect(countries_options.second.text).to eq "Country"
+      expect(countries_options.second.value).to eq "andorra"
+      expect(countries_options.second.text).to eq "Andorra"
     end
   end
 end


### PR DESCRIPTION
### Context

iQTS record where a trainee studied.  You need to record the country using a drop-down menu of countries/territories. A  provider is unable to select “Cayman Islands” or “Isle of Mann”

### Changes proposed in this pull request

* Uses the `DfE::Reference` gem for countries and territories listing for iQTS
* Uses `DfE::Reference` gem for mapping to country code when parsing trainee for DQT