### PR TITLE
[6326] Make sure back links behave correctly

### DIFF
--- a/app/views/trainees/placements/details/edit.html.erb
+++ b/app/views/trainees/placements/details/edit.html.erb
@@ -4,10 +4,7 @@
 ) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: trainee_path(@trainee),
-  ) %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: @page_tracker.last_origin_page_path.presence || trainee_path(@trainee) ) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/trainees/placements/new.html.erb
+++ b/app/views/trainees/placements/new.html.erb
@@ -4,10 +4,7 @@
 ) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: trainee_path(@trainee),
-  ) %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: @page_tracker.last_origin_page_path.presence || edit_trainee_placements_details_path(@trainee)  ) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/spec/features/form_sections/teacher_training_data/placements/progress_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/progress_spec.rb
@@ -29,6 +29,14 @@ feature "completing the placements section", feature_trainee_placement: true do
     then_the_placements_section_should_be(completed)
   end
 
+  scenario "back links" do
+    given_i_am_reviewing_my_changes_on_the_confirmation_page
+    when_i_click_to_add_a_placement
+    then_i_see_the_placements_form_page
+    when_i_click_back
+    then_i_see_the_confirmation_page
+  end
+
 private
 
   def when_i_visit_the_placement_details_page
@@ -62,6 +70,30 @@ private
     within(".app-task-list__item.placement-details") do
       expect(page).to have_text(status)
     end
+  end
+
+  def given_i_am_reviewing_my_changes_on_the_confirmation_page
+    when_i_visit_the_placement_details_page
+    and_i_do_not_have_the_placement_detail
+    and_i_continue
+  end
+
+  def when_i_click_to_add_a_placement
+    within(".govuk-summary-list__row.placements") do
+      click_link("Add a placement")
+    end
+  end
+
+  def then_i_see_the_placements_form_page
+    expect(page).to have_current_path(new_trainee_placements_path(trainee))
+  end
+
+  def when_i_click_back
+    click_link "Back"
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_current_path(trainee_placements_confirm_path(trainee))
   end
 
   def valid_training_routes


### PR DESCRIPTION
### Context

https://trello.com/c/kjERzvDM/6326-back-links-for-placements-create-flow

This PR makes sure the back links behave correctly in the placements flow. 

### Changes proposed in this pull request

- Wire up the back links with the correct paths for the flow

### Guidance to review

https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/8ae1fe42-8135-4c35-9902-40a987df8509


