### PR TITLE
[6340] Refactor Hesa::RetrieveJob job to fan out

### DIFF
--- a/app/jobs/hesa/create_from_hesa_job.rb
+++ b/app/jobs/hesa/create_from_hesa_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Hesa
+  class CreateFromHesaJob < ApplicationJob
+    queue_as :hesa
+
+    def perform(hesa_trainee:, record_source:)
+      return unless FeatureService.enabled?("hesa_import.sync_collection")
+
+      Trainees::CreateFromHesa.call(hesa_trainee:, record_source:)
+    end
+  end
+end

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -14,8 +14,8 @@ module Trainees
 
     class HesaImportError < StandardError; end
 
-    def initialize(student_node:, record_source:)
-      @hesa_trainee = ::Hesa::Parsers::IttRecord.to_attributes(student_node:)
+    def initialize(hesa_trainee:, record_source:)
+      @hesa_trainee = hesa_trainee
       @trainee = find_or_initialize_trainee_by(hesa_id: hesa_trainee[:hesa_id])
       @record_source = record_source
       @current_trainee_state = @trainee&.state&.to_sym

--- a/spec/jobs/hesa/create_from_hesa_job_spec.rb
+++ b/spec/jobs/hesa/create_from_hesa_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Hesa
+  describe CreateFromHesaJob do
+    include ActiveJob::TestHelper
+
+    let(:hesa_trainee) { ApiStubs::HesaApi.new.student_attributes }
+    let(:record_source) { RecordSources::HESA_COLLECTION }
+
+    describe "#perform" do
+      context "Hesa import is enabled" do
+        before { enable_features("hesa_import.sync_collection") }
+
+        it "creates or updates a trainee from a mapped student xml node" do
+          expect(Trainees::CreateFromHesa).to receive(:call).with(hesa_trainee:, record_source:)
+
+          described_class.perform_now(hesa_trainee:, record_source:)
+        end
+      end
+
+      context "Hesa import is disabled" do
+        before { disable_features("hesa_import.sync_collection") }
+
+        it "does not create a trainee" do
+          expect(Trainees::CreateFromHesa).not_to receive(:call).with(hesa_trainee:, record_source:)
+
+          described_class.perform_now(hesa_trainee:, record_source:)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -6,7 +6,6 @@ module Trainees
   describe CreateFromHesa do
     let(:nationality_name) { RecruitsApi::CodeSets::Nationalities::MAPPING[student_attributes[:nationality]] }
     let(:hesa_api_stub) { ApiStubs::HesaApi.new(hesa_stub_attributes) }
-    let(:student_node) { hesa_api_stub.student_node }
     let(:student_attributes) { hesa_api_stub.student_attributes }
     let(:create_custom_state) { "implemented where necessary" }
     let(:hesa_stub_attributes) { {} }
@@ -39,7 +38,7 @@ module Trainees
       create(:school, urn: student_attributes[:lead_school_urn])
       create(:withdrawal_reason, :with_all_reasons)
       create_custom_state
-      described_class.call(student_node:, record_source:)
+      described_class.call(hesa_trainee: student_attributes, record_source: record_source)
     end
 
     describe "HESA information imported from XML" do
@@ -407,7 +406,7 @@ module Trainees
 
         it "creates a new record" do
           expect {
-            described_class.call(student_node:, record_source:)
+            described_class.call(hesa_trainee: student_attributes, record_source: record_source)
           }.to change { Trainee.count }.by(1)
         end
       end
@@ -419,7 +418,7 @@ module Trainees
 
         it "creates a new record" do
           expect {
-            described_class.call(student_node:, record_source:)
+            described_class.call(hesa_trainee: student_attributes, record_source: record_source)
           }.to change { Trainee.count }.by(1)
         end
       end
@@ -427,7 +426,7 @@ module Trainees
       context "when the trainee is neither awarded nor withdrawn" do
         it "updates the existing trainee instead of creating a new one" do
           expect {
-            described_class.call(student_node:, record_source:)
+            described_class.call(hesa_trainee: student_attributes, record_source: record_source)
           }.not_to change { Trainee.count }
         end
       end
@@ -441,13 +440,13 @@ module Trainees
 
         it "does not create a new record" do
           expect {
-            described_class.call(student_node:, record_source:)
+            described_class.call(hesa_trainee: student_attributes, record_source: record_source)
           }.not_to change { Trainee.count }
         end
 
         it "does not update the existing trainee" do
           expect {
-            described_class.call(student_node:, record_source:)
+            described_class.call(hesa_trainee: student_attributes, record_source: record_source)
           }.not_to change { trainee }
         end
       end
@@ -459,13 +458,13 @@ module Trainees
 
         it "does not create a new record" do
           expect {
-            described_class.call(student_node:, record_source:)
+            described_class.call(hesa_trainee: student_attributes, record_source: record_source)
           }.not_to change { Trainee.count }
         end
 
         it "does not update the existing trainee" do
           expect {
-            described_class.call(student_node:, record_source:)
+            described_class.call(hesa_trainee: student_attributes, record_source: record_source)
           }.not_to change { trainee.reload }
         end
       end
@@ -474,7 +473,7 @@ module Trainees
         before do
           trainee.update(state: :draft)
 
-          described_class.call(student_node:, record_source:)
+          described_class.call(hesa_trainee: student_attributes, record_source: record_source)
         end
 
         it "updates the existing trainee" do
@@ -488,7 +487,7 @@ module Trainees
         before do
           trainee.update(itt_start_date: DateTime.new(2022, 9, 20))
 
-          described_class.call(student_node:, record_source:)
+          described_class.call(hesa_trainee: student_attributes, record_source: record_source)
         end
 
         it "does not update the trainee with the earlier created_at timestamp" do


### PR DESCRIPTION
### Context

The `Hesa::RetrieveJob` job runs as one giant job and if any of the inline `Trainees::CreateFromHesa.call` fails it halts processing of subsequent records.

This PR refactors `Hesa::RetrieveJob` to fan out the `Trainees::CreateFromHesa` calls into their own jobs. This will allow our collection process to continuously run and not get coupled to problematic records.

### Changes proposed in this pull request

- Updates `Hesa::RetrieveJob`
- Move the mapping logic from XML to a hash outside of `Trainees::CreateFromHesa` so it can be serialised properly when passed into the job
- Update specs 

### Guidance to review

This will now look like so:

<img width="1232" alt="Screenshot 2023-11-03 at 14 24 09" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/d3ea89f0-b08a-497c-b474-a2c3d668e3ab">
