### PR TITLE
[6349] Added route changes resets placements

### DIFF
--- a/app/lib/route_data_manager.rb
+++ b/app/lib/route_data_manager.rb
@@ -16,10 +16,22 @@ private
   attr_reader :trainee
 
   def reset_trainee_details
-    trainee.assign_attributes(course_details.merge(funding_details))
+    reset_trainee
 
     # Only reset progress for draft trainees. DO NOT reset progress for submitted trainees.
     reset_progress if trainee.draft?
+  end
+
+  def reset_trainee
+    trainee.assign_attributes(trainee_attributes)
+  end
+
+  def reset_progress
+    trainee.progress.assign_attributes(progress_attributes)
+  end
+
+  def trainee_attributes
+    {}.merge(**course_details, **funding_details, **placement_detail)
   end
 
   def course_details
@@ -46,8 +58,18 @@ private
     }
   end
 
-  def reset_progress
-    trainee.progress.course_details = false
-    trainee.progress.funding = false
+  def placement_detail
+    {
+      placement_detail: nil,
+      placements: [],
+    }
+  end
+
+  def progress_attributes
+    {
+      course_details: false,
+      funding: false,
+      placements: false,
+    }
   end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -114,6 +114,11 @@ FactoryBot.define do
       degrees { [build(:degree, :uk_degree_with_details)] }
     end
 
+    trait :with_placements do
+      has_placement_detail
+      placements { build_list(:placement, 2) }
+    end
+
     trait :submission_ready do
       submission_ready { true }
     end

--- a/spec/lib/route_data_manager_spec.rb
+++ b/spec/lib/route_data_manager_spec.rb
@@ -8,7 +8,7 @@ describe RouteDataManager do
       described_class.new(trainee:).update_training_route!("provider_led_postgrad")
     end
 
-    let(:progress) { Progress.new(course_details: true, funding: true, personal_details: true) }
+    let(:progress) { Progress.new(course_details: true, funding: true, personal_details: true, placements: true) }
 
     context "when a trainee selects a new route" do
       let(:trainee) { create(:trainee, :assessment_only) }
@@ -77,6 +77,30 @@ describe RouteDataManager do
           expect { subject }
             .to change { trainee.progress.funding }
             .from(true).to(false)
+        end
+      end
+
+      context "when a trainee has placements" do
+        let(:trainee) { create(:trainee, :school_direct_tuition_fee, :with_placements, progress:) }
+
+        it "wipes the placements details" do
+          expect { subject }
+            .to change { trainee.placement_detail }
+            .from(trainee.placement_detail).to(nil)
+            .and change { trainee.placements.count }
+            .from(trainee.placements.count).to(0)
+        end
+
+        it "resets the placements progress" do
+          expect { subject }
+            .to change { trainee.progress.placements }
+            .from(true).to(false)
+        end
+
+        it "does not change any other progress" do
+          expect { subject }
+            .not_to change { trainee.progress.personal_details }
+            .from(true)
         end
       end
     end


### PR DESCRIPTION
### Context
Route changes

### Changes proposed in this pull request
Resets placements

### Guidance to review
Works with draft trainees in the same manner as course details and funding details.

Once the route has changed the previously stored placements details may no longer be valid or applicable.


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
