### PR TITLE
[6231] Fixed editable links

### DIFF
--- a/app/components/placement_details/view.rb
+++ b/app/components/placement_details/view.rb
@@ -50,7 +50,7 @@ module PlacementDetails
       placement_nominal = first_placement ? placement_records.count + 1 : 2
 
       field_label = t("components.placement_detail.placement_#{placement_nominal}")
-      link = govuk_link_to("Enter #{field_label.downcase}", new_trainee_placements_path(trainee)) if first_placement
+      link = govuk_link_to("Enter #{field_label.downcase}", new_trainee_placements_path(trainee)) if first_placement && editable
 
       field_value = tag.div(
         tag.p("#{field_label} is missing", class: "app-inset-text__title") + link,

--- a/spec/components/placement_details/view_spec.rb
+++ b/spec/components/placement_details/view_spec.rb
@@ -13,8 +13,9 @@ module PlacementDetails
       render_inline(described_class.new(data_model:, editable:))
     end
 
-    it "does not have manage placements link" do
+    it "does not have editable links" do
       expect(subject).not_to have_link("Manage placements", href: "/trainees/#{trainee.slug}/placements/confirm")
+      expect(subject).not_to have_link(href: "/trainees/#{trainee.slug}/placements/new")
     end
 
     it "shows the placement details" do
@@ -22,7 +23,6 @@ module PlacementDetails
 
       expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "First placement")
       expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: "First placement is missing")
-      expect(subject).to have_link("Enter first placement", href: "/trainees/#{trainee.slug}/placements/new")
 
       expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Second placement")
       expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: "Second placement is missing")
@@ -31,58 +31,71 @@ module PlacementDetails
     context "editable is true" do
       let(:editable) { true }
 
-      it "has manage placements link" do
+      it "has editable links" do
         expect(subject).to have_link("Manage placements", href: "/trainees/#{trainee.slug}/placements/confirm")
+        expect(subject).to have_link("Enter first placement", href: "/trainees/#{trainee.slug}/placements/new")
       end
-    end
 
-    context "when there is 1 placements" do
-      let(:placements) { create_list(:placement, 1) }
+      context "when there is 1 placements" do
+        let(:placements) { create_list(:placement, 1) }
 
-      it "shows the placement details" do
-        expect(subject).to have_css(".govuk-summary-list__row", count: 2)
+        it "shows the placement details" do
+          expect(subject).to have_css(".govuk-summary-list__row", count: 2)
 
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "First placement")
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placements.first.name)
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placements.first.full_address)
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "First placement")
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placements.first.name)
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placements.first.full_address)
 
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Second placement")
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: "Second placement is missing")
-        expect(subject).to have_link("Enter second placement", href: "/trainees/#{trainee.slug}/placements/new")
-      end
-    end
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Second placement")
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: "Second placement is missing")
+        end
 
-    context "when there is 2 placements" do
-      let(:placements) { create_list(:placement, 2) }
-
-      it "shows the placement details" do
-        expect(subject).to have_css(".govuk-summary-list__row", count: 2)
-
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "First placement")
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Second placement")
-
-        trainee.placements.each do |placement|
-          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placement.name)
-          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placement.full_address)
+        it "has editable links" do
+          expect(subject).to have_link("Manage placements", href: "/trainees/#{trainee.slug}/placements/confirm")
+          expect(subject).to have_link("Enter second placement", href: "/trainees/#{trainee.slug}/placements/new")
         end
       end
-    end
 
-    context "when there is 5 placements" do
-      let(:placements) { create_list(:placement, 5) }
+      context "when there is 2 placements" do
+        let(:placements) { create_list(:placement, 2) }
 
-      it "shows the placement details" do
-        expect(subject).to have_css(".govuk-summary-list__row", count: 5)
+        it "shows the placement details" do
+          expect(subject).to have_css(".govuk-summary-list__row", count: 2)
 
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "First placement")
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Second placement")
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Third placement")
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Fourth placement")
-        expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Fifth placement")
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "First placement")
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Second placement")
 
-        trainee.placements.each do |placement|
-          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placement.name)
-          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placement.full_address)
+          trainee.placements.each do |placement|
+            expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placement.name)
+            expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placement.full_address)
+          end
+        end
+
+        it "has editable links" do
+          expect(subject).to have_link("Manage placements", href: "/trainees/#{trainee.slug}/placements/confirm")
+        end
+      end
+
+      context "when there is 5 placements" do
+        let(:placements) { create_list(:placement, 5) }
+
+        it "shows the placement details" do
+          expect(subject).to have_css(".govuk-summary-list__row", count: 5)
+
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "First placement")
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Second placement")
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Third placement")
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Fourth placement")
+          expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__key", text: "Fifth placement")
+
+          trainee.placements.each do |placement|
+            expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placement.name)
+            expect(subject).to have_css(".govuk-summary-list__row .govuk-summary-list__value", text: placement.full_address)
+          end
+        end
+
+        it "has editable links" do
+          expect(subject).to have_link("Manage placements", href: "/trainees/#{trainee.slug}/placements/confirm")
         end
       end
     end


### PR DESCRIPTION
### Context
Editable links

### Changes proposed in this pull request
Fixed editable links, so that they are only shown when applicable.


### Guidance to review
When the record is non editable then the non editable version is shown else the editable.


https://register-pr-3729.test.teacherservices.cloud/view_components/placement_details/view

#### HESA trainee 
##### Before enabling editing
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/3cd5f6ea-9799-4b6f-bf32-945dc397e508)

##### After enabling editing
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/d4bbb8e8-406e-4a81-885b-1c5e2a382e65)


### Important business
n/a

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
