### PR TITLE
Fix: change mapping of 'Ordinary degree' class to 'Ordinary' for DQT

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -43,7 +43,7 @@ module Dqt
         "Undivided second-class honours" => "UndividedSecondClassHonours",
         "Pass" => "Pass",
         "Merit" => "Merit",
-        "Ordinary degree" => "OrdinaryDegree",
+        "Ordinary degree" => "Ordinary",
         "Other" => "Other",
       }.freeze
 

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -149,6 +149,16 @@ module Dqt
           })
         end
 
+        context "when degree class is 'Ordinary degree'" do
+          let(:degree) do
+            build(:degree, :uk_degree_with_details, grade: "Ordinary degree")
+          end
+
+          it "sends the expected degree class" do
+            expect(subject["qualification"]["class"]).to eq "Ordinary"
+          end
+        end
+
         context "when there is no degree type" do
           let(:degree) { build(:degree, :uk_degree_with_details, uk_degree_uuid: nil) }
 


### PR DESCRIPTION
### Context

https://trello.com/c/lJCqD5v0/6357-pgce-trainee-pending-trn

A trainee is stuck with pending TRN because DQT doesn't understand the degree class we're sending.

These params:

```
{"class"=>"OrdinaryDegree", "date"=>"2022-01-01", "heQualificationType"=>"BachelorOfArts"}
```

Result in this error:

```
"$.qualification.class\":[\"The JSON value could not be converted to System.Nullable`1[TeachingRecordSystem.Api.V2.ApiModels.ClassDivision]. Path: $.qualification.class | LineNumber: 0 | BytePositionInLine: 816.\"
```

The issue is that DQT expects `"Ordinary"` rather than `"OrdinaryDegree"`.

### Changes proposed in this pull request

Send DQT `"Ordinary"` rather than `"OrdinaryDegree"`.

### Guidance to review

Do you trust me haha

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
