### PR TITLE
[6252] Reset placement_detail when adding placements

### DIFF
--- a/app/forms/placements_form.rb
+++ b/app/forms/placements_form.rb
@@ -74,6 +74,7 @@ class PlacementsForm
   end
 
   def save!
+    trainee.has_placement_detail!
     placements.each(&:save!)
   end
 

--- a/app/forms/placements_form.rb
+++ b/app/forms/placements_form.rb
@@ -74,7 +74,7 @@ class PlacementsForm
   end
 
   def save!
-    trainee.has_placement_detail!
+    trainee.has_placement_detail! unless trainee.has_placement_detail?
     placements.each(&:save!)
   end
 

--- a/spec/forms/placements_form_spec.rb
+++ b/spec/forms/placements_form_spec.rb
@@ -219,7 +219,7 @@ describe PlacementsForm, type: :model do
     end
 
     context "if trainee has not provided placement detail" do
-      let(:trainee) { build(:trainee, :submitted_for_trn, :no_placement_detail, placements: placements) }
+      let(:trainee) { build(:trainee, :submitted_for_trn, :no_placement_detail, placements:) }
 
       it "updates them to have placement detail" do
         expect { subject.save! }.to change(trainee, :placement_detail).from("no_placement_detail").to("has_placement_detail")

--- a/spec/forms/placements_form_spec.rb
+++ b/spec/forms/placements_form_spec.rb
@@ -217,5 +217,13 @@ describe PlacementsForm, type: :model do
     it "run save on all the placement form objects" do
       expect(subject.save!).to be_present
     end
+
+    context "if trainee has not provided placement detail" do
+      let(:trainee) { build(:trainee, :submitted_for_trn, placements: placements, placement_detail: :no_placement_detail) }
+
+      it "updates them to have placement detail" do
+        expect { subject.save! }.to change(trainee, :placement_detail).from("no_placement_detail").to("has_placement_detail")
+      end
+    end
   end
 end

--- a/spec/forms/placements_form_spec.rb
+++ b/spec/forms/placements_form_spec.rb
@@ -219,7 +219,7 @@ describe PlacementsForm, type: :model do
     end
 
     context "if trainee has not provided placement detail" do
-      let(:trainee) { build(:trainee, :submitted_for_trn, placements: placements, placement_detail: :no_placement_detail) }
+      let(:trainee) { build(:trainee, :submitted_for_trn, :no_placement_detail, placements: placements) }
 
       it "updates them to have placement detail" do
         expect { subject.save! }.to change(trainee, :placement_detail).from("no_placement_detail").to("has_placement_detail")


### PR DESCRIPTION
### Context

https://trello.com/c/puwJeK3H/6252-create-placements-snag-list

### Changes proposed in this pull request

Minor snag to make sure we reset the `placement_detail` field on the trainee when placements are added.
