### PR TITLE
[5994] - don't run create degree if no degrees

### DIFF
--- a/app/services/degrees/create_from_csv_row.rb
+++ b/app/services/degrees/create_from_csv_row.rb
@@ -14,6 +14,8 @@ module Degrees
     end
 
     def call
+      return if country.blank?
+
       trainee.transaction do
         trainee.degrees.destroy_all
         trainee.degrees.create!(mapped_degree_attributes)


### PR DESCRIPTION
### Context

this [missing students ticket](https://trello.com/c/9nD7wcY3/5994-missing-students) produces some errors when importing as it's trying to create two non-existent non-uk degrees upon importing the CSV.

### Changes proposed in this pull request

adds a guard clause in the `Degrees::CreateFromCSVRow`