### PR TITLE
[6332] - make census sign off page dynamic

### DIFF
--- a/app/controllers/guidance_controller.rb
+++ b/app/controllers/guidance_controller.rb
@@ -13,7 +13,10 @@ class GuidanceController < ApplicationController
   def check_data; end
   def bulk_recommend_trainees; end
   def manually_registering_trainees; end
-  def census_sign_off; end
+
+  def census_sign_off
+    render(layout: "application")
+  end
 
   def dates_and_deadlines
     render(layout: "application")

--- a/app/views/guidance/_census_sign_off_inside.html.erb
+++ b/app/views/guidance/_census_sign_off_inside.html.erb
@@ -1,0 +1,48 @@
+<% @current_year_label = AcademicCycle.current.label %>
+<% @current_year_start = AcademicCycle.current.start_year %>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">
+            Signing off your list of trainees for the initial teacher training census
+        </h1>
+
+        <p class="govuk-body">Each year you need to sign off your list of trainee teachers in Register. You must now sign off trainee data for the <%= @current_year_label %> academic year.</p>
+
+        <h2 class="govuk-heading-m">Why the census sign-off is important</h2>
+        <p class="govuk-body">If your teacher trainee data is accurate and signed off by 31 October <%= @current_year_start %>, it will help you:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>receive the correct amount of funding owed to you</li>
+            <li>allocate the correct financial support to your trainees when they start their course, if applicable</li>
+        </ul>
+        <p class="govuk-body">Your accurate census data also helps the DfE understand new entrants to teacher training in England for the <%= @current_year_label %> academic year, and to inform future policy.</p>
+        <p class="govuk-body">If you do not sign off your data by 31 October, your organisations data may not be included in the census publication.</p>
+
+        <h2 class="govuk-heading-m">Checking your trainee data in the 'Reports' section of Register</h2>
+        <p class="govuk-body">Register all your new trainees for the <%= @current_year_label %> academic year, if you have not done so already. You can find out how to register trainees under the 'Registering trainees' section in the guidance.</p>
+        <p class="govuk-body">You can check your trainee data is correct by exporting your trainee records as a CSV file from the Reports section in Register. You should carefully check:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>number of trainees - if you have 'zero' or a lower number than you expect, check you've registered all your new trainees for the <%= @current_year_label %> academic year</li>
+            <li>courses - this may impact on any grants or bursaries trainees are able to receive</li>
+            <li>start date - the correct start date will help trainees receive funding on time, if applicable</li>
+        </ul>
+
+        <h2 class="govuk-heading-m">Signing off your trainee data</h2>
+        <p class="govuk-body">A senior person from your organisation will need to complete <a href="https://forms.office.com/e/kzBmEWKDGz" class="govuk-link" rel="noreferrer noopener" target="_blank">this form to sign off the data (opens in new window).</a></p>
+        <p class="govuk-body">This must not be the same person who entered, checked and updated the data.</p>
+
+        <h2 class="govuk-heading-m">Before you start</h2>
+        <p class="govuk-body">You should:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>allocate time to check the accuracy of your trainee data</li>
+            <li>confirm availability of your senior officer to sign off &mdash; do not leave this to the last week in October</li>
+        </ul>
+
+        <h2 class="govuk-heading-m">How your trainee data will be used</h2>
+        <p class="govuk-body">Read the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology">Initial Teacher Training census methodology</a> to find out how your trainee data will be used.</p>
+
+        <h2 class="govuk-heading-m">Get help</h2>
+        <p class="govuk-body">Email <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> if you have any questions about signing off your new trainee data.</p>
+    </div>
+</div>
+

--- a/app/views/guidance/_census_sign_off_outside.html.erb
+++ b/app/views/guidance/_census_sign_off_outside.html.erb
@@ -1,0 +1,51 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">
+            Signing off your list of trainees for the initial teacher training census
+        </h1>
+
+        <p class="govuk-body">Each year you need to sign off your list of trainee teachers in Register. Each year you need to sign off your list of trainee teachers in Register.</p>
+
+        <h2 class="govuk-heading-m">Why the census sign-off is important</h2>
+
+        <p class="govuk-body">If your teacher trainee data is accurate and signed off by the deadline, it will help you:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>receive the correct amount of funding owed to you</li>
+            <li>allocate the correct financial support to your trainees when they start their course, if applicable</li>
+        </ul>
+        <p class="govuk-body">Your accurate census data also helps the DfE understand new entrants to teacher training in England for each academic year, and to inform future policy.</p>
+
+        <p class="govuk-body">If you do not sign off your data by the deadline, your organisations data may not be included in the census publication.</p>
+
+        <h2 class="govuk-heading-m">Checking your trainee data in the 'Reports' section of Register</h2>
+
+        <p class="govuk-body">Register all your new trainees for the current academic year, if you have not done so already. You can find out how to register trainees under the 'Registering trainees' section in the guidance.</p>
+        <p class="govuk-body">You can check your trainee data is correct by exporting your trainee records as a CSV file from the Reports section in Register. You should carefully check:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>number of trainees - if you have 'zero' or a lower number than you expect, check you've registered all your new trainees for the academic year</li>
+            <li>courses - this may impact on any grants or bursaries trainees are able to receive</li>
+            <li>start date - the correct start date will help trainees receive funding on time, if applicable</li>
+        </ul>
+
+        <h2 class="govuk-heading-m">Signing off your trainee data</h2>
+        
+        <p class="govuk-body">A senior person from your organisation will need to complete a form to sign off the data. This should not be the same person who entered the data.</p>
+
+        <h2 class="govuk-heading-m">Before you start</h2>
+
+        <p class="govuk-body">You should:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>allocate time to check the accuracy of your trainee data</li>
+            <li>confirm availability of your senior officer to sign off</li>
+        </ul>
+
+        <h2 class="govuk-heading-m">How your trainee data will be used</h2>
+
+        <p class="govuk-body">Read the <a href="https://explore-education-statistics.service.gov.uk/methodology/initial-teacher-training-census-methodology">Initial Teacher Training census methodology</a> to find out how your trainee data will be used.</p>
+
+        <h2 class="govuk-heading-m">Get help</h2>
+
+        <p class="govuk-body">Email <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a> if you have any questions about signing off your new trainee data.</p>
+    </div>
+</div>
+

--- a/app/views/guidance/_census_sign_off_outside.html.erb
+++ b/app/views/guidance/_census_sign_off_outside.html.erb
@@ -4,7 +4,7 @@
             Signing off your list of trainees for the initial teacher training census
         </h1>
 
-        <p class="govuk-body">Each year you need to sign off your list of trainee teachers in Register. Each year you need to sign off your list of trainee teachers in Register.</p>
+        <p class="govuk-body">Each year you need to sign off your list of trainee teachers in Register.</p>
 
         <h2 class="govuk-heading-m">Why the census sign-off is important</h2>
 

--- a/app/views/guidance/census_sign_off.html.erb
+++ b/app/views/guidance/census_sign_off.html.erb
@@ -1,0 +1,15 @@
+<%= render PageTitle::View.new(text: "Signing off your list of trainees for the initial teacher training census") %>
+
+<%= content_for(:breadcrumbs) do %>
+<%= render GovukComponent::BackLinkComponent.new(
+    text: "How to use this service",
+    href: guidance_path,
+) %>
+<% end %>
+
+<% case sign_off_period %>
+<% when :census_period %>
+<%= render "census_sign_off_inside" %>
+<% else %>
+<%= render "census_sign_off_outside" %>
+<% end %>

--- a/spec/controllers/guidance_controller_spec.rb
+++ b/spec/controllers/guidance_controller_spec.rb
@@ -56,6 +56,19 @@ describe GuidanceController do
     end
   end
 
+  describe "#census_sign_off" do
+    it "returns a 200 status code" do
+      get :census_sign_off
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the correct template and page" do
+      get :census_sign_off
+      expect(response).to render_template("application")
+      expect(response).to render_template("census_sign_off")
+    end
+  end
+
   describe "#registering_trainees_through_hesa" do
     it "returns a 200 status code" do
       get :registering_trainees_through_hesa


### PR DESCRIPTION
### Context

census sign off guidance is currently static. Some updates were requested as we are now outside of the period:

* [changes](https://educationgovuk.sharepoint.com/:w:/r/sites/TeacherServices/_layouts/15/doc2.aspx?action=edit&sourcedoc=%7B734f536f-ff48-41c4-a414-8a874e673ea3%7D)
* [trello ticket](https://downdetector.co.uk/status/trello/)

### Changes proposed in this pull request

* creates two separate partials for census sign-off guidance
* the inside census partial dynamically loads current academic year dates

### Guidance to review

* check that new content changes match those [in the document](https://educationgovuk.sharepoint.com/:w:/r/sites/TeacherServices/_layouts/15/doc2.aspx?action=edit&sourcedoc=%7B734f536f-ff48-41c4-a414-8a874e673ea3%7D)
* you can manually set the sign off period in settings by adding `sign_off_period: census_period` to your `config/settings/development.yml` and back to outside by setting it to `outside_period`
* when inside the census period it should refer to dates and academic years