### PR TITLE
[6343] Update cookie text

### DIFF
--- a/app/javascript/scripts/cookie_banner.spec.js
+++ b/app/javascript/scripts/cookie_banner.spec.js
@@ -15,7 +15,7 @@ const templateHTML = `
   </div>
   <div class="govuk-cookie-banner" role="region" aria-label="Cookie banner" hidden="true"
     data-module="govuk-cookie-after-consent-banner">
-      <button type="button" class="govuk-button">Hide this message</button>
+      <button type="button" class="govuk-button">Hide cookie message</button>
   </div>
 </div>`
 

--- a/config/locales/cookies/cookie_policy/en.yml
+++ b/config/locales/cookies/cookie_policy/en.yml
@@ -76,7 +76,7 @@ en:
         You’ve <span class="decision accepted">accepted</span><span class="decision rejected"> rejected</span> analytics cookies.
         You can %{cookie_preferences_link} at any time.
       page_link_text: change your cookie settings
-      button_text_html: Hide this <span class="govuk-visually-hidden">cookies</span> message
+      button_text_html: Hide cookie message
     preference_updated: Your cookie preferences have been updated
     message_html:
       <p class="govuk-body">We use some essential cookies to make this service work.</p>


### PR DESCRIPTION
### Context

https://trello.com/c/r1yhfSWt/6343-update-our-cookie-banner-to-follow-new-gds-guidance

### Changes proposed in this pull request

<img width="1041" alt="Screenshot 2023-11-14 at 12 02 08" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/ffedc59f-418f-4641-aa86-46a449418cb6">

- Updates cookie text to be more accessible

### Guidance to review

- Clear cookies and interact with the banner
