### PR TITLE
[6373] - Validation on the 'Country' field doesn't seem to work

### DIFF
--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -43,11 +43,7 @@ module DegreesHelper
   end
 
   def countries_options
-    country_reference = DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.all.map do |reference|
-      reference.name
-    end
-
-    to_options(country_reference)
+    to_options(DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.all.map(&:name))
   end
 
   def path_for_degrees(trainee)

--- a/app/helpers/degrees_helper.rb
+++ b/app/helpers/degrees_helper.rb
@@ -44,7 +44,7 @@ module DegreesHelper
 
   def countries_options
     country_reference = DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.all.map do |reference|
-      reference.name.downcase
+      reference.name
     end
 
     to_options(country_reference)

--- a/spec/helpers/degrees_helper_spec.rb
+++ b/spec/helpers/degrees_helper_spec.rb
@@ -91,7 +91,7 @@ describe DegreesHelper do
   describe "#countries_options" do
     it "iterates over array and prints out correct countries values" do
       expect(countries_options.first.value).to be_nil
-      expect(countries_options.second.value).to eq "andorra"
+      expect(countries_options.second.value).to eq "Andorra"
       expect(countries_options.second.text).to eq "Andorra"
     end
   end


### PR DESCRIPTION
### Context

Looks like the validation on the ‘Country’ field isn’t working.  If you select a ‘valid’ country from the reference data, a validation error appears.  Doesn’t matter what country you select, you will always get the validation error.

> note: this was only effecting countries with a word length greater than one

### Changes proposed in this pull request

* removes downcase on option creation which was resulting in mismatched sets between the JS autocomplete and the list used for validating selections.