### PR TITLE
[6361] Update the timeline when a placement change occurs

### DIFF
--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -29,6 +29,8 @@ class Placement < ApplicationRecord
 
   validates :name, presence: true, if: -> { school.blank? }
 
+  audited associated_with: :trainee
+
   def name
     school&.name || super
   end

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -1,41 +1,6 @@
 # frozen_string_literal: true
 
 module Trainees
-  class GetPlacementNameFromAudit
-    include ServicePattern
-
-    def initialize(audit:)
-      @audit = audit
-    end
-
-    def call
-      if @audit.action == "update"
-        from_name = (School.find_by(id: from_school_id)&.name if from_school_id.present?) ||
-          @audit.audited_changes["name"].first
-        to_name = (School.find_by(id: to_school_id)&.name if to_school_id.present?) ||
-          @audit.audited_changes["name"].last
-        [from_name, to_name]
-      else
-        (School.find_by(id: school_id)&.name if school_id.present?) ||
-          @audit.audited_changes["name"]
-      end
-    end
-
-  private
-
-    def school_id
-      @audit.audited_changes["school_id"]
-    end
-
-    def from_school_id
-      @audit.audited_changes["school_id"].first
-    end
-
-    def to_school_id
-      @audit.audited_changes["school_id"].last
-    end
-  end
-
   class CreateTimelineEvents
     include ServicePattern
 
@@ -152,6 +117,15 @@ module Trainees
           date: created_at,
           username: username,
           items: changed_accredited_provider_description,
+        )
+      end
+
+      if action == "update" && model == "placement"
+        old_name, name = GetPlacementNameFromAudit.call(audit:)
+        return TimelineEvent.new(
+          title: I18n.t("components.timeline.titles.placement.update", old_name:, name:),
+          date: created_at,
+          username: username,
         )
       end
 

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -224,13 +224,11 @@ module Trainees
     end
 
     def create_title
-      if model == "placement"
-        I18n.t("components.timeline.titles.#{model}.create", name: GetPlacementNameFromAudit.call(audit:))
-      else
-        title = I18n.t("components.timeline.titles.#{model}.create")
-        title += " in #{user}" if hesa_or_dttp_user?
-        title
-      end
+      title_key = "components.timeline.titles.#{model}.create"
+      title_args = model == "placement" ? { name: GetPlacementNameFromAudit.call(audit:) } : {}
+      title = I18n.t(title_key, **title_args)
+      title += " in #{user}" if model != "placement" && hesa_or_dttp_user?
+      title
     end
 
     def import_title

--- a/app/services/trainees/get_placement_name_from_audit.rb
+++ b/app/services/trainees/get_placement_name_from_audit.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Trainees
+  class GetPlacementNameFromAudit
+    include ServicePattern
+
+    def initialize(audit:)
+      @audit = audit
+    end
+
+    def call
+      if @audit.action == "update"
+        from_name = (School.find_by(id: from_school_id)&.name if from_school_id.present?) ||
+          @audit.audited_changes["name"].first
+        to_name = (School.find_by(id: to_school_id)&.name if to_school_id.present?) ||
+          @audit.audited_changes["name"].last
+        [from_name, to_name]
+      else
+        (School.find_by(id: school_id)&.name if school_id.present?) ||
+          @audit.audited_changes["name"]
+      end
+    end
+
+  private
+
+    def school_id
+      @audit.audited_changes["school_id"]
+    end
+
+    def from_school_id
+      @audit.audited_changes["school_id"]&.first
+    end
+
+    def to_school_id
+      @audit.audited_changes["school_id"]&.last
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -555,9 +555,9 @@ en:
           other_grade: Degree grade updated
           country: Degree country updated
         placement:
-          create: Degree at %{name} added
-          destroy: Degree at %{name} removed
-          update: Degree changed from %{old_name} to %{name}
+          create: Placement at %{name} added
+          destroy: Placement at %{name} removed
+          update: Placement changed from %{old_name} to %{name}
         nationalisation:
           create: Nationality updated
           destroy: Nationality deleted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -554,6 +554,10 @@ en:
           grade: Degree grade updated
           other_grade: Degree grade updated
           country: Degree country updated
+        placement:
+          create: Degree at %{name} added
+          destroy: Degree at %{name} removed
+          update: Degree changed from %{old_name} to %{name}
         nationalisation:
           create: Nationality updated
           destroy: Nationality deleted

--- a/spec/services/trainees/create_timeline_events_spec.rb
+++ b/spec/services/trainees/create_timeline_events_spec.rb
@@ -206,7 +206,7 @@ module Trainees
           it "returns a 'creation' timeline event" do
             placement.reload
 
-            expect(subject.first.title).to eq("Degree at #{placement.name} added")
+            expect(subject.first.title).to eq("Placement at #{placement.name} added")
           end
         end
 
@@ -221,7 +221,7 @@ module Trainees
             placement.update!(name: "University of South Oxfordshire")
             placement.reload
 
-            expect(subject.title).to eq("Degree changed from #{original_name} to University of South Oxfordshire")
+            expect(subject.title).to eq("Placement changed from #{original_name} to University of South Oxfordshire")
           end
         end
 
@@ -233,7 +233,7 @@ module Trainees
           it "returns a 'removed' timeline event" do
             placement.destroy!
 
-            expect(subject.title).to eq("Degree at #{placement.name} removed")
+            expect(subject.title).to eq("Placement at #{placement.name} removed")
           end
         end
       end

--- a/spec/services/trainees/create_timeline_spec.rb
+++ b/spec/services/trainees/create_timeline_spec.rb
@@ -75,6 +75,21 @@ module Trainees
           expect(subject.count).to eq(1)
         end
       end
+
+      context "when a placement has been created, updated and deleted" do
+        before do
+          trainee.update_column(:submitted_for_trn_at, 10.days.ago)
+          placement = create(:placement, trainee:)
+          placement.update(school: create(:school))
+          placement.destroy
+          reload_audits
+        end
+
+        it "returns each of the CRUD events" do
+          expect(trainee.own_and_associated_audits.count).to eq(4)
+          expect(subject.count).to eq(4)
+        end
+      end
     end
 
     def update_name

--- a/spec/services/trainees/get_placement_name_from_audit_spec.rb
+++ b/spec/services/trainees/get_placement_name_from_audit_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Trainees
+  describe GetPlacementNameFromAudit do
+    let(:trainee) { create(:trainee) }
+    let(:placement) { create(:placement, trainee:) }
+
+    context "when the placement is associated with a school record" do
+      it "returns the correct names for a create audit" do
+        placement
+        audit = Audited::Audit.where(auditable_type: "Placement", action: :create).last
+        expect(described_class.call(audit:)).to eq(placement.name)
+      end
+
+      it "returns the correct names for a destroy audit" do
+        old_name = placement.name
+        placement.destroy!
+
+        audit = Audited::Audit.where(auditable_type: "Placement", action: :destroy).last
+        expect(described_class.call(audit:)).to eq(old_name)
+      end
+
+      it "returns the correct names for an update audit" do
+        old_name = placement.name
+        placement.update!(school: create(:school))
+
+        audit = Audited::Audit.where(auditable_type: "Placement", action: :update).last
+        expect(described_class.call(audit:)).to eq([old_name, placement.name])
+      end
+    end
+
+    context "when the placement is NOT associated with a school record" do
+      let(:placement) { create(:placement, :manual, trainee:) }
+
+      it "returns the correct names for a create audit" do
+        placement
+        audit = Audited::Audit.where(auditable_type: "Placement", action: :create).last
+        expect(described_class.call(audit:)).to eq(placement.name)
+      end
+
+      it "returns the correct names for a destroy audit" do
+        old_name = placement.name
+        placement.destroy!
+
+        audit = Audited::Audit.where(auditable_type: "Placement", action: :destroy).last
+        expect(described_class.call(audit:)).to eq(old_name)
+      end
+
+      it "returns the correct names for an update audit" do
+        old_name = placement.name
+        placement.update!(name: "St. Bob's Academy")
+
+        audit = Audited::Audit.where(auditable_type: "Placement", action: :update).last
+        expect(described_class.call(audit:)).to eq([old_name, "St. Bob's Academy"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
We have recently added the capability to add, modify and delete placements associated with trainee records. Changes to placements should be reflected in the trainee timeline.

### Changes proposed in this pull request
Add specific entries to the timeline for create, modify and delete placement events.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/07563972-6c42-468c-a238-04cb733c5d40)

### Guidance to review

The data displayed on the timeline (the placement/school names) is harvested from the audit trail only because the value at the time of a given event may have changed on the placement record itself since that event took place.

Update: Now that all the CRUD PRs have been merged it should be possible to test this fully on the Review app or locally.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
