### PR TITLE
[6409] Remove placement validations from trainee page banner

### DIFF
--- a/app/forms/submissions/missing_data_validator.rb
+++ b/app/forms/submissions/missing_data_validator.rb
@@ -11,7 +11,6 @@ module Submissions
     end
 
     missing_data_validator :trainee_start_date, form: "TraineeStartDateForm", if: :course_already_started?
-    missing_data_validator :placements, form: "PlacementsForm", if: :requires_placements?
 
     def missing_fields
       forms.map(&:missing_fields).flatten.uniq

--- a/spec/forms/submissions/missing_data_validator_spec.rb
+++ b/spec/forms/submissions/missing_data_validator_spec.rb
@@ -74,6 +74,14 @@ module Submissions
         end
       end
 
+      context "Trainee with missing placements", feature_trainee_placement: true do
+        let(:trainee) { create(:trainee, :submitted_with_start_date, :provider_led_postgrad) }
+
+        it "doesn't cause validation errors" do
+          expect(subject.valid?).to be(true)
+        end
+      end
+
       context "non draft trainee", feature_trainee_placement: true do
         let(:trainee) { Trainee.new(state: :submitted_for_trn) }
 


### PR DESCRIPTION
### Context
We don’t need the banner saying "You need to give additional details before you can recommend the trainee for QTS. You need to enter: Placement details" as we are no longer mandating it for QTS recommendation.

### Changes proposed in this pull request
I've removed placements from the list of validators on this page.

#### Before

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/56498e22-6537-40dc-9d07-4bdd0e28d398)


#### After

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/8630cb70-c058-4771-b6a6-f09eb7e3a045)

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
