### PR TITLE
[6410] Correction to copy for link to placement guidance

### DIFF
--- a/app/components/placements/view.html.erb
+++ b/app/components/placements/view.html.erb
@@ -5,7 +5,7 @@
     %>
 
     <p class="govuk-body">
-      <%= govuk_link_to('Read DfE guidance about training placements in schools and <span class="no-wrap">early years settings</span>'.html_safe, "https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c23-training-in-schools") %>
+      <%= govuk_link_to('Read DfE guidance about school placements', "https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c23-training-in-schools") %>
 
     </p>
   </div>

--- a/spec/components/placements/view_spec.rb
+++ b/spec/components/placements/view_spec.rb
@@ -13,7 +13,7 @@ module Placements
     end
 
     it "have guidance link" do
-      expect(rendered_component).to have_link("Read DfE guidance about training placements in schools and early years settings", href: "https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c23-training-in-schools")
+      expect(rendered_component).to have_link("Read DfE guidance about school placements", href: "https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c23-training-in-schools")
     end
 
     it "have inset text" do
@@ -50,7 +50,7 @@ module Placements
       end
 
       it "have guidance link" do
-        expect(rendered_component).to have_link("Read DfE guidance about training placements in schools and early years settings", href: "https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c23-training-in-schools")
+        expect(rendered_component).to have_link("Read DfE guidance about school placements", href: "https://www.gov.uk/government/publications/initial-teacher-training-criteria/initial-teacher-training-itt-criteria-and-supporting-advice#c23-training-in-schools")
       end
 
       it "have add a placement button" do


### PR DESCRIPTION
### Context
The link to guidance about placements on the placements landing page has the wrong content.

### Changes proposed in this pull request
Shorten the content for the link.

#### Before
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/4ca63e26-927c-4212-a555-22e0b3ca78e4)


#### After
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/c3fb3a77-9d70-4223-8a3a-30b0cb75fd36)

### Guidance to review
Have I missed anything?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
