### PR TITLE
[6411] Add timestamp to HESA warning inset

### DIFF
--- a/app/components/hesa_warning_inset/view.html.erb
+++ b/app/components/hesa_warning_inset/view.html.erb
@@ -1,0 +1,16 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= render GovukComponent::InsetTextComponent.new(classes: "govuk-!-padding-top-0 govuk-!-padding-bottom-0") do %>
+      <div class="govuk-body">
+        <p>
+          <%= hesa_editable? ? t("layouts.trainee_record.hesa_editable_inset") : t("layouts.trainee_record.hesa_inset") %>
+        </p>
+        <% if hesa_updated_at %>
+          <p>
+            <%= t("layouts.trainee_record.hesa_updated_at_inset", date: hesa_updated_at&.to_fs(:govuk_date_and_time)) %>
+          </p>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/components/hesa_warning_inset/view.rb
+++ b/app/components/hesa_warning_inset/view.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module HesaWarningInset
+  class View < GovukComponent::Base
+    def initialize(trainee:, current_user:)
+      @trainee = trainee
+      @current_user = current_user
+    end
+
+    delegate :hesa_editable?, :hesa_updated_at, to: :@trainee
+
+    def render?
+      @trainee.hesa_record? && @trainee.awaiting_action? && @current_user.provider?
+    end
+  end
+end

--- a/app/views/layouts/trainee_record.html.erb
+++ b/app/views/layouts/trainee_record.html.erb
@@ -10,17 +10,7 @@
 
   <%= render RecordHeader::View.new(trainee: @trainee, hide_progress_tag: policy(@trainee).hide_progress_tag?) %>
 
-  <% if @trainee.hesa_record? && @trainee.awaiting_action? && current_user.provider? %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds-from-desktop">
-        <%= render GovukComponent::InsetTextComponent.new(classes: "govuk-!-padding-top-0 govuk-!-padding-bottom-0") do %>
-          <div class="govuk-body">
-            <%= @trainee.hesa_editable? ? t(".hesa_editable_inset") : t(".hesa_inset") %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
+  <%= render HesaWarningInset::View.new(trainee: @trainee, current_user: current_user) %>
 
   <% if @missing_data_view %>
     <%= render NoticeBanner::View.new do |component| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1821,5 +1821,6 @@ en:
     trainee_record:
       hesa_inset: This trainee was imported from HESA. You can recommend, defer or withdraw them. You need to enable editing to make other changes.
       hesa_editable_inset: Editing has been enabled for this trainee. The record is still linked to the HESA service. If you update it using HESA then any changes you’ve made in this service will be replaced by the data from HESA.
+      hesa_updated_at_inset: Last updated from HESA on %{date}
       qts_award_level: QTS
       eyts_award_level: EYTS

--- a/spec/components/hesa_warning_inset/view_spec.rb
+++ b/spec/components/hesa_warning_inset/view_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module HesaWarningInset
+  describe View, type: :component do
+    let(:current_user) do
+      double(UserWithOrganisationContext, provider?: true)
+    end
+
+    subject(:component) do
+      described_class.new(trainee:, current_user:)
+    end
+
+    context "for non-HESA trainee" do
+      let(:trainee) { build(:trainee) }
+
+      it "renders nothing" do
+        render_inline(component)
+
+        expect(rendered_component).to be_blank
+      end
+    end
+
+    context "for HESA trainee" do
+      let(:trainee) do
+        build(
+          :trainee,
+          :imported_from_hesa,
+          hesa_updated_at: Time.zone.local(2023, 1, 11, 12, 34, 56),
+          hesa_editable: editable,
+        )
+      end
+
+      context "when trainee is not editable" do
+        let(:editable) { false }
+
+        it "renders HESA warning message" do
+          render_inline(component)
+
+          expect(rendered_component).to include("This trainee was imported from HESA. You can recommend, defer or withdraw them. You need to enable editing to make other changes.")
+        end
+
+        it "renders last update date and time" do
+          render_inline(component)
+
+          expect(rendered_component).to include("Last updated from HESA on 11 January 2023 at 12:34pm")
+        end
+      end
+
+      context "when trainee is editable" do
+        let(:editable) { true }
+
+        it "renders HESA warning message" do
+          render_inline(component)
+
+          expect(rendered_component).to include("Editing has been enabled for this trainee. The record is still linked to the HESA service. If you update it using HESA then any changes you’ve made in this service will be replaced by the data from HESA.")
+        end
+
+        it "renders last update date and time" do
+          render_inline(component)
+
+          expect(rendered_component).to include("Last updated from HESA on 11 January 2023 at 12:34pm")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
For a HESA-derived trainee, there should be a warning displayed to users that their data could be overwritten if they send further updates via HESA. 

### Changes proposed in this pull request
Add timestamp to the existing HESA warning inset because it doesn't match the new design.

Non-editable trainee:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/b79fb87d-ddef-4ac9-b7aa-24a6b7a2b9cf)

Editable trainee:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/8befaded-e78d-4233-88d6-0181fd90e125)

This PR extracts this message into a new `HesaWarningInset::View` component (mainly so that I could test it properly).

### Guidance to review
Have I missed anything?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
