### PR TITLE
[6412] Placement snagging II validation fixes

### DIFF
--- a/app/forms/placement_form.rb
+++ b/app/forms/placement_form.rb
@@ -118,7 +118,7 @@ class PlacementForm
   end
 
   def open_details?
-    errors.has_key?(:name)
+    errors.key?(:name)
   end
 
 private

--- a/app/forms/placement_form.rb
+++ b/app/forms/placement_form.rb
@@ -11,7 +11,6 @@ class PlacementForm
 
   validates :school_id, presence: true, unless: -> { name.present? }
   validates :name, presence: true, unless: -> { school_id.present? }
-  validates :urn, presence: true, unless: -> { school_id.present? }
 
   delegate :persisted?, :school, to: :placement
 
@@ -111,6 +110,7 @@ class PlacementForm
 
     save_or_stash && invalid_data
   end
+
 
 private
 

--- a/app/forms/placement_form.rb
+++ b/app/forms/placement_form.rb
@@ -9,8 +9,8 @@ class PlacementForm
 
   attr_accessor(*FIELDS, :placements_form, :placement, :trainee, :destroy)
 
-  validates :school_id, presence: true, unless: -> { name.present? }
-  validates :name, presence: true, unless: -> { school_id.present? }
+  validate :school_valid
+  validates :name, presence: true, if: -> { urn.present? || postcode.present? }
 
   delegate :persisted?, :school, to: :placement
 
@@ -111,6 +111,11 @@ class PlacementForm
     save_or_stash && invalid_data
   end
 
+  def school_valid
+    if school_id.blank? && (name.blank? && urn.blank? && postcode.blank?)
+      errors.add(:school, :blank)
+    end
+  end
 
   def open_details?
     errors.has_key?(:name)

--- a/app/forms/placement_form.rb
+++ b/app/forms/placement_form.rb
@@ -112,6 +112,10 @@ class PlacementForm
   end
 
 
+  def open_details?
+    errors.has_key?(:name)
+  end
+
 private
 
   def placement_number

--- a/app/views/trainees/placements/_form.html.erb
+++ b/app/views/trainees/placements/_form.html.erb
@@ -20,7 +20,7 @@
   ) %>
   <div id="schools-autocomplete-element" data-default-value="<%= @placement_form.school_name %>"></div>
 
-  <%= govuk_details(summary_text: "Placement school or setting is not listed") do %>
+  <%= govuk_details(summary_text: "Placement school or setting is not listed", open: @placement_form.open_details?) do %>
     <%= f.govuk_text_field(
       :name,
       label: { text: "School or setting name", size: "s" },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1571,8 +1571,6 @@ en:
               blank: Select an existing school or enter the details for a new school
             name:
               blank: Enter a school name
-            urn:
-              blank: Enter a school unique reference number (URN)
         study_modes_form:
           attributes:
             study_mode:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1567,7 +1567,7 @@ en:
               blank: If you have an additional nationality, select it from the list
         placement:
           attributes:
-            school_id:
+            school:
               blank: Select an existing school or enter the details for a new school
             name:
               blank: Enter a school name

--- a/spec/forms/placement_form_spec.rb
+++ b/spec/forms/placement_form_spec.rb
@@ -9,8 +9,9 @@ describe PlacementForm, type: :model do
   let(:store) { FormStore }
   let(:placements_form) { PlacementsForm.new(trainee, store) }
   let(:placement) { Placement.new }
+  let(:placement_form) { described_class.new(placements_form:, placement:) }
 
-  subject { PlacementForm.new(placements_form:, placement:) }
+  subject { placement_form }
 
   describe "#title" do
     context "when there are no placements" do
@@ -217,6 +218,55 @@ describe PlacementForm, type: :model do
 
       it "returns school name" do
         expect(subject.school_name).to be(placement.school.name)
+      end
+    end
+  end
+
+  describe "#open_details?" do
+    context "with error" do
+      let(:placement) { Placement.new(urn: "123456") }
+
+      before do
+        placement_form.valid?
+      end
+
+      it "returns true" do
+        expect(subject.open_details?).to be_truthy
+      end
+    end
+
+    context "without error" do
+      let(:placement) { Placement.new(name: "name") }
+
+      it "returns false" do
+        expect(subject.open_details?).to be_falsey
+      end
+    end
+  end
+
+  describe "validations" do
+    describe "#school_valid" do
+      it "add errors" do
+        expect(subject.errors).to be_empty
+        subject.school_valid
+        expect(subject.errors).not_to be_empty
+        expect(subject.errors.messages[:school]).to include("Select an existing school or enter the details for a new school")
+      end
+    end
+
+    context "urn is set" do
+      let(:placement) { Placement.new(urn: "123456") }
+
+      it "validates presence" do
+        expect(subject).to validate_presence_of(:name).with_message("Enter a school name")
+      end
+    end
+
+    context "postcode is set" do
+      let(:placement) { Placement.new(postcode: "BN1 1AA") }
+
+      it "validates presence" do
+        expect(subject).to validate_presence_of(:name).with_message("Enter a school name")
       end
     end
   end


### PR DESCRIPTION
### Context
Placement Validation

### Changes proposed in this pull request
Fixed the correctiveness of validation
Added ability to open collapsed section due to validation
Removed unneeded validation

### Guidance to review
Go and mess about with placements
- The summary error links should jump to the field
- Urn is now optional
- if urn or postcode is fiiled then expect school or setting name to be filled as well
- if the school or setting name fails validation the details summary is opened

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/608447e7-b616-4206-8ac9-8f46643c1acc)



![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/85e602c7-74b3-487f-a36d-853e1e9a528f)

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/59988b29-0b83-4f01-8601-fcc6dbc7ca63)


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
