### PR TITLE
[6449] Add URN and address to delete placement page

### DIFF
--- a/app/views/trainees/placements/delete.html.erb
+++ b/app/views/trainees/placements/delete.html.erb
@@ -15,7 +15,8 @@
     <h1 class="govuk-heading-l">Are you sure you want to delete this placement?</h1>
 
     <div class="govuk-body">
-      <p><%= @placement_form.placement.name %></p>
+      <p class="govuk-body govuk-!-margin-bottom-2"><%= @placement_form.placement.name %></p>
+      <div class="govuk-hint"><%= @placement_form.placement.full_address %></div>
     </div>
 
     <div class="govuk-body">
@@ -36,4 +37,3 @@
     ) %>
   </div>
 </div>
-


### PR DESCRIPTION
### Context
Delete a placement confirmation page lists school name only, should probably list URN and postcode for clarity.

### Changes proposed in this pull request
Replicate the information that we see in the summary list when viewing placements elsewhere in the system.

Before:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/b0e5488e-28aa-49dd-a2bf-71562e6aeb8a)

After:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/b7d5ee43-65b6-423c-bff8-2b349d0c0b32)

### Guidance to review
Styling?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
