### PR TITLE
[6432] Correction to back link on delete placement page

### DIFF
--- a/app/views/trainees/placements/delete.html.erb
+++ b/app/views/trainees/placements/delete.html.erb
@@ -1,11 +1,11 @@
 <%= render PageTitle::View.new(text: "Are you sure you want to delete this placement?") %>
 
-<%= render GovukComponent::BackLinkComponent.new(
-  text: "Back",
-  href: edit_trainee_placements_details_path(
-    trainee_id: @placements_form.trainee.slug,
-  ),
-) %>
+<%= content_for(:breadcrumbs) do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: t(:back),
+    href: @page_tracker.last_origin_page_path.presence || trainee_path(@trainee),
+  ) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">


### PR DESCRIPTION
### Context
Should go back to the confirmation page if that's where we arrived from, otherwise back to the main trainee page. (It was linking back to the edit placement details page).

### Changes proposed in this pull request
Use standard backlink.

### Guidance to review
Anything missing?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
