### PR TITLE
[6429] Shorten placement input fields consistent with prototype

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -134,3 +134,7 @@ body:not(.js-enabled) .app-js-only {
 .app-start-page-banner + .govuk-width-container > .govuk-notification-banner {
   margin-top: 40px;
 }
+
+.app-\!-uppercase {
+  text-transform: uppercase !important;
+}

--- a/app/views/trainees/placements/_form.html.erb
+++ b/app/views/trainees/placements/_form.html.erb
@@ -17,8 +17,9 @@
     label: { text: "Search for a school by its unique reference number (URN), name or postcode" },
     "data-field" => "schools-autocomplete",
     width: "two-thirds",
+    class: "govuk-input govuk-!-width-two-thirds",
   ) %>
-  <div id="schools-autocomplete-element" data-default-value="<%= @placement_form.school_name %>"></div>
+  <div id="schools-autocomplete-element" data-default-value="<%= @placement_form.school_name %>" class="app-!-autocomplete--max-width-two-thirds"></div>
 
   <%= govuk_details(summary_text: "Placement school or setting is not listed") do %>
     <%= f.govuk_text_field(
@@ -31,14 +32,14 @@
     <%= f.govuk_text_field(
       :urn,
       label: { text: "School unique reference number (URN) - if it has one", size: "s" },
-      width: "two-thirds",
+      width: "one-third",
       autocomplete: :off,
     ) %>
 
     <%= f.govuk_text_field(
       :postcode,
       label: { text: "Postcode", size: "s" },
-      width: "two-thirds",
+      class: "govuk-input--width-10 app-!-uppercase",
       autocomplete: :off,
     ) %>
   <% end %>


### PR DESCRIPTION
### Context
Some of the input fields on the placement (new/edit) form are inconsistent with the prototype.

### Changes proposed in this pull request
Apply different styles to the autocomplete, postcode and URN inputs so that they reflect the size of the input data. Also applied upper case style to postcode.

Before:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/76af1a58-e6ef-4f3e-8564-0e6fee020181)


After:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/77a4e90a-9cc1-42fa-93cf-9f42e6fe0979)



### Guidance to review
Have I missed anything else?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
