### PR TITLE
[6445] Added unique urn validation

### DIFF
--- a/app/forms/placement_form.rb
+++ b/app/forms/placement_form.rb
@@ -139,14 +139,10 @@ private
 
   def existing_urns
     trainee.placements.filter_map do |placement|
-      if placement.slug == slug
-        nil
-      elsif placement.school.present?
-        placement.school.urn
-      else
-        placement.urn
-      end
-    end.compact
+      next if placement.slug == slug
+
+      placement.school&.urn || placement.urn
+    end
   end
 
   def placement_number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1569,8 +1569,11 @@ en:
           attributes:
             school:
               blank: Select an existing school or enter the details for a new school
+              unique: "Choose another URN as this has already been used"
             name:
               blank: Enter a school name
+            urn:
+              unique: "Choose another URN as this has already been used"
         study_modes_form:
           attributes:
             study_mode:

--- a/spec/forms/placement_form_spec.rb
+++ b/spec/forms/placement_form_spec.rb
@@ -252,6 +252,42 @@ describe PlacementForm, type: :model do
       end
     end
 
+    describe "#urn_valid" do
+      let(:trainee_placement) { build(:placement) }
+      let(:trainee) { create(:trainee, placements: [trainee_placement]) }
+      let(:placement) { Placement.new(**placement_attributes) }
+
+      context "setting urn" do
+        let(:placement_attributes) { { urn: trainee_placement.school.urn } }
+
+        it "add errors" do
+          expect(subject.errors).to be_empty
+          subject.urn_valid
+          expect(subject.errors).not_to be_empty
+          expect(subject.errors.messages[:urn]).to include("Choose another URN as this has already been used")
+          expect(subject.errors.messages[:school]).not_to include("Choose another URN as this has already been used")
+        end
+      end
+    end
+
+    describe "#school_urn_valid" do
+      let(:trainee_placement) { build(:placement) }
+      let(:trainee) { create(:trainee, placements: [trainee_placement]) }
+      let(:placement) { Placement.new(**placement_attributes) }
+
+      context "setting school_id" do
+        let(:placement_attributes) { { school_id: trainee_placement.school.id } }
+
+        it "add errors" do
+          expect(subject.errors).to be_empty
+          subject.school_urn_valid
+          expect(subject.errors).not_to be_empty
+          expect(subject.errors.messages[:urn]).not_to include("Choose another URN as this has already been used")
+          expect(subject.errors.messages[:school]).to include("Choose another URN as this has already been used")
+        end
+      end
+    end
+
     context "urn is set" do
       let(:placement) { Placement.new(urn: "123456") }
 


### PR DESCRIPTION
### Context
Placement urn 

### Changes proposed in this pull request
Added unique urn validation

### Guidance to review

Add a first placement with a urn like `1238316`

Then try to add a second placement using urn `1238316` either via autocomplete or manually

#### Autocomplete Validation
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/2429733b-3338-4e43-9ea2-6e80b7cc1c21)

#### Manual Validation
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/b04ed2bd-5de4-449c-8604-a4728c69db9d)


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
