### PR TITLE
[6441] Placements on check details page for Apply imported trainees

### DIFF
--- a/app/views/trainees/check_details/_apply_draft_trainee_check_details.html.erb
+++ b/app/views/trainees/check_details/_apply_draft_trainee_check_details.html.erb
@@ -16,4 +16,8 @@
   <%= render Sections::View.new(trainee: @trainee, form: @form, section: :schools, editable: @trainee_editable) %>
 <% end %>
 
+<% if @trainee.requires_placements? %>
+  <%= render Sections::View.new(trainee: @trainee, form: @form, section: :placements, editable: @trainee_editable) %>
+<% end %>
+
 <%= render Sections::View.new(trainee: @trainee, form: @form, section: :funding, editable: @trainee_editable) %>


### PR DESCRIPTION
### Context
It looks like the placeholders for placement details were put into the non-Apply template but not the Apply one.

### Changes proposed in this pull request

Before:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/a77d4a6e-9f63-48f5-b68a-7e7cf26fec8c)

After:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/03dc55f0-e4fc-4d11-82dd-af4e7848ff8f)

### Guidance to review
This stuff doesn't seem to be tested anywhere unless I'm missing something?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
