### PR TITLE
[6409] Exclude placement validation in banner

### DIFF
--- a/app/forms/placements_form.rb
+++ b/app/forms/placements_form.rb
@@ -99,11 +99,7 @@ class PlacementsForm
   end
 
   def missing_fields
-    if valid?
-      []
-    else
-      [[:placement_detail]]
-    end
+    []
   end
 
   def trainee_reset_placements?

--- a/app/view_objects/missing_data_banner_view.rb
+++ b/app/view_objects/missing_data_banner_view.rb
@@ -8,8 +8,10 @@ class MissingDataBannerView
   include CourseDetailsHelper
   include DegreesHelper
 
+  EXCLUDED_FIELDS = %i[placement_detail].freeze
+
   def initialize(missing_fields, trainee)
-    @missing_fields = missing_fields
+    @missing_fields = missing_fields.excluding(EXCLUDED_FIELDS)
     @trainee = trainee
   end
 

--- a/spec/view_objects/missing_data_banner_view_spec.rb
+++ b/spec/view_objects/missing_data_banner_view_spec.rb
@@ -39,7 +39,7 @@ describe MissingDataBannerView do
         let(:expected_path) { edit_trainee_personal_details_path(trainee) }
 
         it "returns the link to the form containing the missing data" do
-          expect(subject).to eq(expected_html)
+          expect(subject).to include(expected_html)
         end
       end
 
@@ -48,7 +48,16 @@ describe MissingDataBannerView do
         let(:expected_path) { edit_trainee_start_date_path(trainee) }
 
         it "returns the link to the form containing the missing data" do
-          expect(subject).to eq(expected_html)
+          expect(subject).to include(expected_html)
+        end
+      end
+
+      context "placement_detail" do
+        let(:field) { :placement_detail }
+
+        it "returns the link to the form containing the missing data" do
+          allow(trainee).to receive(:requires_placements?).and_return(true)
+          expect(subject.to_s).not_to include("Placement details")
         end
       end
     end


### PR DESCRIPTION
### Context
We don’t need the banner saying _You need to give additional details before you can recommend the trainee for QTS. You need to enter: Placement details_ as we are no longer mandating it for QTS recommendation

However we don't want to skip the validations because this drives features like the placeholders on the confirm details page.

### Changes proposed in this pull request
First attempt to implement this removed validations (https://github.com/DFE-Digital/register-trainee-teachers/pull/3766). However we don't want to skip these validations because they drives features like the placeholders on the confirm details page.

So this PR just excludes the placement details validation errors from the banner.

### Guidance to review
The original (partial) fix for this was https://github.com/DFE-Digital/register-trainee-teachers/pull/3754 and https://github.com/DFE-Digital/register-trainee-teachers/pull/3766

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml

