### PR TITLE
[6355] Drop foreign from `trainees.application_choice_id`

### DIFF
--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -109,7 +109,6 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (application_choice_id => apply_applications.apply_id)
 #  fk_rails_...  (apply_application_id => apply_applications.id)
 #  fk_rails_...  (course_allocation_subject_id => allocation_subjects.id)
 #  fk_rails_...  (employing_school_id => schools.id)

--- a/db/migrate/20231127134319_drop_trainees_application_choice_id_foreign_key.rb
+++ b/db/migrate/20231127134319_drop_trainees_application_choice_id_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DropTraineesApplicationChoiceIdForeignKey < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :trainees, :apply_applications, column: :application_choice_id, primary_key: :apply_id, validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_23_173652) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_27_134319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -925,7 +925,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_173652) do
   add_foreign_key "trainees", "academic_cycles", column: "start_academic_cycle_id"
   add_foreign_key "trainees", "allocation_subjects", column: "course_allocation_subject_id"
   add_foreign_key "trainees", "apply_applications"
-  add_foreign_key "trainees", "apply_applications", column: "application_choice_id", primary_key: "apply_id"
   add_foreign_key "trainees", "hesa_trn_submissions"
   add_foreign_key "trainees", "providers"
   add_foreign_key "trainees", "schools", column: "employing_school_id"


### PR DESCRIPTION
### Context
We want to store the Apply application_choice_id on Trainee records so that we can better integrate with Apply.


This is a partial rollback of a schema change made in https://github.com/DFE-Digital/register-trainee-teachers/pull/3780

### Changes proposed in this pull request
It probably isn't a good idea to have a foreign key from `trainees.application_choice_id` to `apply_applications.apply_id` because this column may be used for trainees that have not been imported from Apply and therefore will not reference a record in the `apply_applications` table. (It may be a reference to `hesa_students.application_choice_id` instead).

### Guidance to review
Does this make sense?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
