### PR TITLE
[6401] Add bulk placements confirm page

### DIFF
--- a/app/controllers/bulk_update/confirmations_controller.rb
+++ b/app/controllers/bulk_update/confirmations_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module BulkUpdate
+  class ConfirmationsController < ApplicationController
+    before_action { require_feature_flag(:bulk_placements) }
+
+    def show; end
+  end
+end

--- a/app/views/bulk_update/confirmations/show.html.erb
+++ b/app/views/bulk_update/confirmations/show.html.erb
@@ -1,0 +1,20 @@
+<%= render PageTitle::View.new(i18n_key: "bulk_placements.confirmation.show") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div class="govuk-panel govuk-panel--confirmation trn-submission-success-panel govuk-!-margin-bottom-6">
+      <h1 class="govuk-panel__title">
+        Placement data submitted
+      </h1>
+    </div>
+
+    <p class="govuk-body"><%= govuk_link_to("View your trainee records", trainees_path) %></p>
+
+    <h2 class="govuk-heading-m">Next steps</h2>
+
+
+    <h3 class="govuk-heading-s">Trainees with incomplete records</h2>
+
+    <p class="govuk-body">You can complete missing placement information to the trainee record manually.</p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,6 +326,9 @@ en:
     itt_end_date:
       hint: The end date of the Initial Teacher Training part of their course.
     page_titles:
+      bulk_placements:
+        confirmation:
+          show: Placement data submitted
       uploads:
         index: Uploads
         new: Upload a file

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,9 @@ Rails.application.routes.draw do
   namespace :bulk_update, path: "bulk-update" do
     get "/", to: "bulk_updates#index"
 
-    resource :placements, only: %i[new create], path: "add-details"
+    resource :placements, only: %i[new create], path: "add-details" do
+      resource :confirmation, only: %i[show]
+    end
 
     resources :recommendations_uploads, only: %i[new create edit update], path: "recommend", path_names: { new: "choose-who-to-recommend", edit: "change-who-youll-recommend" } do
       get "confirmation"


### PR DESCRIPTION
### Context

https://trello.com/c/7mK5PJCR/6401-bulk-placements-upload-confirmation

### Changes proposed in this pull request

Adds a confirm page for final step in the bulk placements flow

### Guidance to review
