### PR TITLE
[6409] Reinstate placements message in missing banner

### DIFF
--- a/app/forms/submissions/missing_data_validator.rb
+++ b/app/forms/submissions/missing_data_validator.rb
@@ -4,6 +4,8 @@ module Submissions
   class MissingDataValidator < BaseValidator
     class_attribute :extra_validators, instance_writer: false, default: {}
 
+    OPTIONAL_FIELDS = %i[placement_detail].freeze
+
     class << self
       def missing_data_validator(name, options)
         extra_validators[name] = options
@@ -27,7 +29,7 @@ module Submissions
     end
 
     def submission_ready
-      errors.add(:trainee, :incomplete) unless missing_fields.empty?
+      errors.add(:trainee, :incomplete) unless missing_fields.excluding(OPTIONAL_FIELDS).empty?
     end
   end
 end

--- a/app/view_objects/missing_data_banner_view.rb
+++ b/app/view_objects/missing_data_banner_view.rb
@@ -8,13 +8,19 @@ class MissingDataBannerView
   include CourseDetailsHelper
   include DegreesHelper
 
+  OPTIONAL_FIELDS = %i[placement_detail].freeze
+
   def initialize(missing_fields, trainee)
     @missing_fields = missing_fields
     @trainee = trainee
   end
 
   def header
-    I18n.t("views.missing_data_banner_view.header", award_type: trainee.award_type)
+    if @missing_fields.all? { |field| OPTIONAL_FIELDS.include?(field) }
+      I18n.t("views.missing_data_banner_view.header.optional_only", award_type: trainee.award_type)
+    else
+      I18n.t("views.missing_data_banner_view.header.default", award_type: trainee.award_type)
+    end
   end
 
   def content

--- a/app/view_objects/missing_data_banner_view.rb
+++ b/app/view_objects/missing_data_banner_view.rb
@@ -8,15 +8,13 @@ class MissingDataBannerView
   include CourseDetailsHelper
   include DegreesHelper
 
-  OPTIONAL_FIELDS = %i[placement_detail].freeze
-
   def initialize(missing_fields, trainee)
     @missing_fields = missing_fields
     @trainee = trainee
   end
 
   def header
-    if @missing_fields.all? { |field| OPTIONAL_FIELDS.include?(field) }
+    if @missing_fields&.excluding(Submissions::MissingDataValidator::OPTIONAL_FIELDS).blank?
       I18n.t("views.missing_data_banner_view.header.optional_only", award_type: trainee.award_type)
     else
       I18n.t("views.missing_data_banner_view.header.default", award_type: trainee.award_type)

--- a/app/view_objects/missing_data_banner_view.rb
+++ b/app/view_objects/missing_data_banner_view.rb
@@ -8,10 +8,8 @@ class MissingDataBannerView
   include CourseDetailsHelper
   include DegreesHelper
 
-  EXCLUDED_FIELDS = %i[placement_detail].freeze
-
   def initialize(missing_fields, trainee)
-    @missing_fields = missing_fields.excluding(EXCLUDED_FIELDS)
+    @missing_fields = missing_fields
     @trainee = trainee
   end
 

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -1,6 +1,9 @@
 <% if display_record_actions? %>
   <div class="record-outcome-action-bar">
-    <%= render RecordActions::View.new(@trainee, has_missing_fields: @missing_fields.present?) %>
+    <%= render RecordActions::View.new(
+      @trainee,
+      has_missing_fields: @missing_fields&.excluding(Submissions::MissingDataValidator::OPTIONAL_FIELDS).present?,
+    ) %>
   </div>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -651,7 +651,7 @@ en:
       default_hint_text_html: 'Enter an answer <span class="govuk-visually-hidden"> for %{field_label}</span>'
       apply_field_hint_text_html: 'Review the trainee’s answer<span class="govuk-visually-hidden"> for %{field_label}</span>'
     missing_data_banner_view:
-      header: "You need to give additional details before you can recommend the trainee for %{award_type}"
+      header: "This trainee has missing information"
       missing_field_text: "%{missing_field}"
       missing_field_link:
         first_names: &personal_details_path edit_trainee_personal_details_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -651,7 +651,9 @@ en:
       default_hint_text_html: 'Enter an answer <span class="govuk-visually-hidden"> for %{field_label}</span>'
       apply_field_hint_text_html: 'Review the trainee’s answer<span class="govuk-visually-hidden"> for %{field_label}</span>'
     missing_data_banner_view:
-      header: "This trainee has missing information"
+      header:
+        default: "You need to give additional details before you can recommend the trainee for %{award_type}"
+        optional_only: "This trainee has missing information"
       missing_field_text: "%{missing_field}"
       missing_field_link:
         first_names: &personal_details_path edit_trainee_personal_details_path

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -134,7 +134,7 @@ FactoryBot.define do
       applying_for_scholarship { false }
       applying_for_grant { false }
       nationalities { [Nationality.all.sample || build(:nationality)] }
-      has_placement_detail
+      # has_placement_detail
       progress do
         Progress.new(
           personal_details: true,
@@ -143,7 +143,7 @@ FactoryBot.define do
           degrees: true,
           course_details: true,
           training_details: true,
-          placements: true,
+          placements: false,
           schools: true,
           funding: true,
           trainee_data: true,

--- a/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
+++ b/spec/features/trainee_actions/viewing_an_existing_trainee_spec.rb
@@ -173,7 +173,7 @@ private
   end
 
   def and_i_should_not_see_any_incomplete_data_prompts_on_the(expected_page)
-    expect(expected_page).not_to have_text(I18n.t("views.missing_data_banner_view.header"))
+    expect(expected_page).not_to have_text(I18n.t("views.missing_data_banner_view.header.default"))
   end
 
   def and_i_visit_the_personal_details

--- a/spec/forms/submissions/missing_data_validator_spec.rb
+++ b/spec/forms/submissions/missing_data_validator_spec.rb
@@ -25,6 +25,19 @@ module Submissions
             .to include(I18n.t("activemodel.errors.models.submissions/missing_data_validator.attributes.trainee.incomplete"))
         end
       end
+
+      context "when only the placements section is missing data", feature_trainee_placement: true do
+        let(:trainee) { build(:trainee, :submitted_with_start_date, :early_years_salaried) }
+
+        before do
+          trainee.placement_detail = nil
+        end
+
+        it "is valid" do
+          expect(subject.valid?).to be true
+          expect(subject.errors).to be_empty
+        end
+      end
     end
 
     describe "#missing_fields" do

--- a/spec/view_objects/missing_data_banner_view_spec.rb
+++ b/spec/view_objects/missing_data_banner_view_spec.rb
@@ -50,6 +50,10 @@ describe MissingDataBannerView do
         it "returns the link to the form containing the missing data" do
           expect(subject).to include(expected_html)
         end
+
+        it "displays the default (mandatory fields) title" do
+          I18n.t("views.missing_data_banner_view.header.optional_only", award_type: trainee.award_type)
+        end
       end
 
       context "placement_detail" do
@@ -58,6 +62,10 @@ describe MissingDataBannerView do
         it "returns the link to the form containing the missing data" do
           allow(trainee).to receive(:requires_placements?).and_return(true)
           expect(subject.to_s).to include("Placement details")
+        end
+
+        it "displays the optional fields only title" do
+          I18n.t("views.missing_data_banner_view.header.default", award_type: trainee.award_type)
         end
       end
     end

--- a/spec/view_objects/missing_data_banner_view_spec.rb
+++ b/spec/view_objects/missing_data_banner_view_spec.rb
@@ -57,7 +57,7 @@ describe MissingDataBannerView do
 
         it "returns the link to the form containing the missing data" do
           allow(trainee).to receive(:requires_placements?).and_return(true)
-          expect(subject.to_s).not_to include("Placement details")
+          expect(subject.to_s).to include("Placement details")
         end
       end
     end


### PR DESCRIPTION
### Context
We want to adjust the banner message that appears to warn users about missing information. When placement are missing it's not true to say that the trainee cannot be submitted (request for QTS) when there is missing placement data.

### Changes proposed in this pull request
- [x] Change the message to reflect the fact that we can actually submit a trainee without placements (ie. we want placements but they're currently optional).
- [x] Ignore missing placements in logic to display the _Recommend for QTS_ button.
- [ ] Additional tests?

#### When the only missing fields are placements
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/511ef7cf-5f69-4fb2-9ca0-e1854281e0c7)

#### When other (mandatory) fields are missing (no change)
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/f8213efc-be2b-42ad-bef9-215e7a45379c)


### Guidance to review
The messaging in the banner should only say that info is needed to recommend a trainee if mandatory fields (ie. not just placement fields) are missing. But if it's just placements that are missing we use the softer language.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
