### PR TITLE
[6466] Fix delete placements issues 5, 9 and 13 (from bug party)

### DIFF
--- a/app/components/flash_banner/view.html.erb
+++ b/app/components/flash_banner/view.html.erb
@@ -1,7 +1,7 @@
 <% if display? %>
   <% FLASH_TYPES.each do |type| %>
     <% if flash[type] %>
-      <%= render(NotificationBanner::View.new(text: flash[type], type: type, classes: "app-iflash")) %>
+      <%= render(NotificationBanner::View.new(text: flash[type], type: type, classes: "app-flash")) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/flash_banner/view.html.erb
+++ b/app/components/flash_banner/view.html.erb
@@ -1,7 +1,7 @@
 <% if display? %>
   <% FLASH_TYPES.each do |type| %>
     <% if flash[type] %>
-      <%= render(NotificationBanner::View.new(text: flash[type], type: type, classes: "app-flash")) %>
+      <%= render(NotificationBanner::View.new(text: flash[type], type: type, classes: "app-iflash")) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/flash_banner/view.rb
+++ b/app/components/flash_banner/view.rb
@@ -12,7 +12,7 @@ module FlashBanner
     end
 
     def display?
-      flash.any? && (non_draft_trainee? || degree_deleted?)
+      flash.any? && (non_draft_trainee? || degree_deleted? || placement_deleted?)
     end
 
   private
@@ -24,6 +24,11 @@ module FlashBanner
     def degree_deleted?
       auditable = trainee.associated_audits.last
       auditable&.auditable_type == "Degree" && auditable&.action == "destroy"
+    end
+
+    def placement_deleted?
+      auditable = trainee.associated_audits.last
+      auditable&.auditable_type == "Placement" && auditable&.action == "destroy"
     end
   end
 end

--- a/app/controllers/trainees/placements_controller.rb
+++ b/app/controllers/trainees/placements_controller.rb
@@ -55,7 +55,7 @@ module Trainees
       )
       @placement_form.destroy_or_stash!
 
-      flash[:success] = "Placement removed"
+      flash[:success] = I18n.t("flash.trainee_placement_removed")
 
       redirect_to(trainee_placements_confirm_path(trainee_id: @trainee.slug))
     end

--- a/app/controllers/trainees/placements_controller.rb
+++ b/app/controllers/trainees/placements_controller.rb
@@ -53,7 +53,9 @@ module Trainees
         placements_form: PlacementsForm.new(@trainee),
         slug: params[:id],
       )
-      @placement_form.mark_for_destruction!
+      @placement_form.destroy_or_stash!
+
+      flash[:success] = "Placement removed"
 
       redirect_to(trainee_placements_confirm_path(trainee_id: @trainee.slug))
     end

--- a/app/forms/destroy_placement_form.rb
+++ b/app/forms/destroy_placement_form.rb
@@ -1,24 +1,27 @@
 # frozen_string_literal: true
 
 class DestroyPlacementForm
-  attr_accessor :trainee, :placement
+  attr_accessor :trainee, :placement, :slug
 
-  def initialize(placements_form:, placement:)
+  def initialize(placements_form:, placement:, slug:)
     @placements_form = placements_form
     @trainee = placements_form.trainee
     @placement = placement
+    @slug = slug
   end
 
   def self.find_from_param(placements_form:, slug:)
-    placement = placements_form.trainee.placements.find_by!(slug:)
-    new(placements_form:, placement:)
+    placement = placements_form.trainee.placements.find_by(slug:)
+    new(placements_form:, placement:, slug:)
   end
 
   def destroy_or_stash!
-    if trainee.draft?
-      @placements_form.destroy!(@placement.slug)
+    if placement.blank?
+      @placements_form.delete_placement_on_store(slug)
+    elsif trainee.draft?
+      @placements_form.destroy!(placement.slug)
     else
-      @placements_form.mark_for_destruction!(@placement.slug)
+      @placements_form.mark_for_destruction!(slug)
     end
   end
 end

--- a/app/forms/destroy_placement_form.rb
+++ b/app/forms/destroy_placement_form.rb
@@ -14,7 +14,11 @@ class DestroyPlacementForm
     new(placements_form:, placement:)
   end
 
-  def mark_for_destruction!
-    @placements_form.mark_for_destruction!(@placement.slug)
+  def destroy_or_stash!
+    if trainee.draft?
+      @placements_form.destroy!(@placement.slug)
+    else
+      @placements_form.mark_for_destruction!(@placement.slug)
+    end
   end
 end

--- a/app/forms/placements_form.rb
+++ b/app/forms/placements_form.rb
@@ -87,6 +87,11 @@ class PlacementsForm
     save_store(stored_placements)
   end
 
+  def destroy!(slug)
+    Placement.find_by(slug:).destroy!
+    delete_placement_on_store(slug)
+  end
+
   def delete_placement_on_store(slug)
     placements = fetch_store
     placements.delete(slug)

--- a/app/views/trainees/placements/delete.html.erb
+++ b/app/views/trainees/placements/delete.html.erb
@@ -15,8 +15,8 @@
     <h1 class="govuk-heading-l">Are you sure you want to delete this placement?</h1>
 
     <div class="govuk-body">
-      <p class="govuk-body govuk-!-margin-bottom-2"><%= @placement_form.placement.name %></p>
-      <div class="govuk-hint"><%= @placement_form.placement.full_address %></div>
+      <p class="govuk-body govuk-!-margin-bottom-2"><%= @placement_form.placement&.name %></p>
+      <div class="govuk-hint"><%= @placement_form.placement&.full_address %></div>
     </div>
 
     <div class="govuk-body">
@@ -24,7 +24,7 @@
         "Yes I’m sure — delete this placement",
         trainee_placement_path(
           trainee_id: @placements_form.trainee.slug,
-          id: @placement_form.placement.slug,
+          id: @placement_form.slug,
         ),
         method: :delete,
         class: "govuk-button--warning",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
     trainee_reinstated: Trainee reinstated
     trainee_withdrawn: Trainee withdrawn
     trainee_placement_added: Trainee placement added
+    trainee_placement_removed: Placement removed
   update_record: Update record
   return_home: Return home
   mark_as_completed: I have %{action} this section

--- a/spec/features/form_sections/teacher_training_data/placements/deleting_trainee_placements_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/deleting_trainee_placements_spec.rb
@@ -37,10 +37,48 @@ feature "Delete a placement" do
     and_i_see_a_flash_message
   end
 
+  scenario "Delete an unsaved placement from an existing trainee when feature flag is active" do
+    given_i_am_authenticated
+    and_a_trainee_exists
+    and_a_school_exists
+
+    when_the_feature_flag_is_active
+    and_i_navigate_to_the_new_placement_form
+    then_i_see_the_new_placement_form
+
+    when_i_select_an_existing_school
+    and_i_click_continue
+    then_i_see_the_confirmation_page
+    and_i_see_the_new_placement_ready_for_confirmation
+    and_no_placements_are_created
+
+    and_i_click_the_delete_placement_link
+    then_i_see_the_delete_placement_form
+
+    and_i_click_the_confirm_button
+    then_i_see_the_confirmation_page
+    and_the_deleted_placement_is_no_longer_visible
+    and_no_placements_are_created
+    and_i_see_a_flash_message
+
+    # when_i_click_update
+    # then_the_placement_is_deleted
+    # and_i_see_a_flash_message
+  end
+
 private
 
-  def and_a_trainee_exists_with_a_placement
+  def and_a_trainee_exists
     @trainee = given_a_trainee_exists(:trn_received, :provider_led_postgrad)
+    FormStore.clear_all(@trainee.id)
+  end
+
+  def and_a_school_exists
+    @school ||= create(:school)
+  end
+
+  def and_a_trainee_exists_with_a_placement
+    and_a_trainee_exists
     @placement = create(:placement, trainee: @trainee)
     FormStore.clear_all(@trainee.id)
   end
@@ -100,5 +138,40 @@ private
 
   def and_i_see_a_flash_message
     expect(page).to have_content("Trainee placement details updated")
+  end
+
+  def and_i_navigate_to_the_new_placement_form
+    visit new_trainee_placement_path(trainee_id: @trainee.slug)
+  end
+
+  def then_i_see_the_new_placement_form
+    expect(page).to have_content("First placement")
+  end
+
+  def when_i_select_an_existing_school
+    find(:xpath, "//input[@name='placement[school_id]']", visible: false).set(@school.id)
+  end
+
+  def and_i_click_continue
+    click_button "Continue"
+  end
+
+  def and_i_see_the_new_placement_ready_for_confirmation
+    expect(page).to have_content("First placement")
+    expect(page).to have_content(@school.name)
+    expect(page).to have_content(@school.postcode)
+    expect(page).to have_content("URN #{@school.urn}")
+  end
+
+  def and_no_placements_are_created
+    expect(@trainee.reload.placements.count).to eq(0)
+  end
+
+  def and_i_click_the_delete_placement_link
+    click_link "Delete placement"
+  end
+
+  def and_i_see_a_placement_removed_flash_message
+    expect(page).to have_content("Placement removed")
   end
 end

--- a/spec/features/form_sections/teacher_training_data/placements/deleting_trainee_placements_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/deleting_trainee_placements_spec.rb
@@ -59,11 +59,7 @@ feature "Delete a placement" do
     then_i_see_the_confirmation_page
     and_the_deleted_placement_is_no_longer_visible
     and_no_placements_are_created
-    and_i_see_a_flash_message
-
-    # when_i_click_update
-    # then_the_placement_is_deleted
-    # and_i_see_a_flash_message
+    and_i_see_a_placement_removed_flash_message
   end
 
 private
@@ -80,6 +76,7 @@ private
   def and_a_trainee_exists_with_a_placement
     and_a_trainee_exists
     @placement = create(:placement, trainee: @trainee)
+    @school ||= @placement.school
     FormStore.clear_all(@trainee.id)
   end
 
@@ -133,7 +130,7 @@ private
   end
 
   def and_the_deleted_placement_is_no_longer_visible
-    expect(page).not_to have_content(@placement.name)
+    expect(page).not_to have_content(@school.name)
   end
 
   def and_i_see_a_flash_message

--- a/spec/forms/destroy_placement_form_spec.rb
+++ b/spec/forms/destroy_placement_form_spec.rb
@@ -3,25 +3,37 @@
 require "rails_helper"
 
 describe DestroyPlacementForm, type: :model do
-  let(:trainee) { create(:trainee) }
-  let!(:placement) { create(:placement) }
+  let!(:placement) { create(:placement, trainee:) }
   let(:placements_form) { PlacementsForm.new(trainee) }
   let(:slug) { placement.slug }
 
   subject(:form) { described_class.find_from_param(placements_form:, slug:) }
 
-  describe "#mark_for_destruction!" do
-    context "when the given id is for a placement for the given trainee" do
-      let!(:placement) { create(:placement, trainee:) }
+  describe "#destroy_or_stash!" do
+    context "when the given slug is for a placement that is not present in the database" do
+      let(:trainee) { create(:trainee, :draft) }
 
-      it "only deletes the placement in temporary state" do
-        expect { form.mark_for_destruction! }.not_to change { trainee.placements.count }
+      it "deletes the placement in temporary state" do
+        expect(placements_form).to receive(:delete_placement_on_store).with(slug)
+        expect { form.destroy_or_stash! }.to change { trainee.placements.count }.by(-1)
       end
     end
 
-    context "when the given id is for a placement for a different trainee" do
-      it "does NOT delete the placement and throws an exception" do
-        expect { form.mark_for_destruction! }.to raise_error(ActiveRecord::RecordNotFound)
+    context "when the given slug is for a placement for the given draft trainee" do
+      let(:trainee) { create(:trainee, :draft) }
+
+      it "deletes the placement in temporary and persistent state" do
+        expect(placements_form).to receive(:delete_placement_on_store).with(slug)
+        expect { form.destroy_or_stash! }.to change { trainee.placements.count }.by(-1)
+      end
+    end
+
+    context "when the given slug is for a placement for the given registered trainee" do
+      let(:trainee) { create(:trainee, :submitted_for_trn) }
+
+      it "only marks the placement for deletion in temporary state" do
+        expect(placements_form).not_to receive(:delete_placement_on_store).with(slug)
+        expect { form.destroy_or_stash! }.not_to change { trainee.placements.count }
       end
     end
   end


### PR DESCRIPTION
### Context

- Bug 5. Placements aren’t seem to be getting deleted on draft trainees because we are stashing the delete operation rather than executing it immediately.
- Bug 9. When we attempt to delete an unsaved placement (on a registered trainee record) we get a 404 page because the placement is not yet in the database.
- Bug 13. On the prototype after clicking the red button to remove a placement the user is taken back to the Manage Placements page with a confirmation that the action has completed successfully. This is missing on Prod

### Changes proposed in this pull request
- Bug 5. Alter logic in forms that implement this logic to execute the destroy action immediately for draft trainees.
- Bug 9. Handle the case where the user asks to delete an unsaved placement by just removing it from the temporary stashed data store.
- Bug 13. Add a _Placement removed_ flash message.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/739f530f-bf08-4503-a7fe-86b2f097b84b)

### Guidance to review
Try deleting placements for both draft and registered trainees. Also try deleting placements on registered trainees that have not been committed to the database yet.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
