### PR TITLE
[6355] Import Apply application choice id from HESA and Apply

### DIFF
--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -73,6 +73,7 @@ module Trainees
         disabilities: disabilities,
         study_mode: study_mode,
         record_source: RecordSources::APPLY,
+        application_choice_id: application_record.apply_id,
       }.merge(ethnic_background_attributes)
     end
 

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -64,6 +64,7 @@ module Trainees
        .merge(funding_attributes)
        .merge(school_attributes)
        .merge(training_initiative_attributes)
+       .merge(apply_attributes)
     end
 
     def find_or_initialize_trainee_by(hesa_id:)
@@ -151,6 +152,10 @@ module Trainees
 
     def training_initiative_attributes
       { training_initiative: training_initiative || ROUTE_INITIATIVES_ENUMS[:no_initiative] }
+    end
+
+    def apply_attributes
+      { application_choice_id: hesa_trainee[:application_choice_id] }
     end
 
     def funding_attributes

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -53,6 +53,7 @@ module Trainees
         course_max_age: course.max_age,
         study_mode: "full_time",
         record_source: RecordSources::APPLY,
+        application_choice_id: apply_application.apply_id,
       }
     end
 

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -346,6 +346,18 @@ module Trainees
         end
       end
 
+      context "when an Apply `application_choice_id` is available and mappable" do
+        let(:hesa_stub_attributes) do
+          {
+            application_choice_id: 123456,
+          }
+        end
+
+        it "maps the `application_choice_id` to `Trainee#application_choice_id`" do
+          expect(trainee.application_choice_id).to eq(123456)
+        end
+      end
+
       context "when bursary level indicates veteran teaching undergraduate bursary" do
         let(:hesa_stub_attributes) do
           { bursary_level: described_class::VETERAN_TEACHING_UNDERGRADUATE_BURSARY_LEVEL }


### PR DESCRIPTION
### Context
We want to have a record of the Apply `application_choice_id`, whether it is imported from Apply directly or via HESA.

### Changes proposed in this pull request
- [x] Populate `Trainee#application_choice_id` from HESA Student `application_choice_id` when importing from HESA collections.
- [x] Populate `Trainee#application_choice_id` from Apply when importing directly from the Apply register API.

### Guidance to review
This is meant to cover ongoing syncing of `application_choice_id`s. There will be a follow-up backfill PR.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
