### PR TITLE
[6344] Fix accessibility issue with long support email

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@ $mobile-big-end: 501px;
 @import "tables";
 @import "trainee";
 @import "components/all";
+@import "utilities";
 
 .govuk-cookie-banner__hide {
   display: none;
@@ -127,14 +128,6 @@ body:not(.js-enabled) .app-js-only {
   }
 }
 
-.link--delete {
-  color: govuk-colour("red") !important; /* stylelint-disable declaration-no-important */
-}
-
 .app-start-page-banner + .govuk-width-container > .govuk-notification-banner {
   margin-top: 40px;
-}
-
-.app-\!-uppercase {
-  text-transform: uppercase !important;
 }

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -1,0 +1,13 @@
+// stylelint-disable declaration-no-important
+
+.link--delete {
+  color: govuk-colour("red") !important;
+}
+
+.app-\!-uppercase {
+  text-transform: uppercase !important;
+}
+
+.app-\!-overflow-break-word {
+  overflow-wrap: break-word !important;
+}

--- a/app/helpers/support_email_helper.rb
+++ b/app/helpers/support_email_helper.rb
@@ -2,6 +2,8 @@
 
 module SupportEmailHelper
   def support_email(name: nil, subject: nil, classes: nil)
-    govuk_mail_to(Settings.support_email, name, subject: subject, class: classes)
+    default_classes = "app-!-overflow-break-word"
+
+    govuk_mail_to(Settings.support_email, name, subject: subject, class: "#{default_classes} #{classes}")
   end
 end

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -85,7 +85,6 @@
       <p class="govuk-body"><%= t("funding.payment_schedule.no_data") %></p>
       <p class="govuk-body">
         <%= t("funding.payment_schedule.contact_info", email: support_email(
-          name: Settings.support_email,
           subject: t("funding.view.title")
         )).html_safe %>
       </p>

--- a/app/views/funding/payment_schedules/show.html.erb
+++ b/app/views/funding/payment_schedules/show.html.erb
@@ -84,9 +84,8 @@
     <div class="govuk-grid-column-two-thirds-from-desktop" >
       <p class="govuk-body"><%= t("funding.payment_schedule.no_data") %></p>
       <p class="govuk-body">
-        <%= t("funding.payment_schedule.contact_info", email: govuk_mail_to(
-          Settings.support_email,
-          Settings.support_email,
+        <%= t("funding.payment_schedule.contact_info", email: support_email(
+          name: Settings.support_email,
           subject: t("funding.view.title")
         )).html_safe %>
       </p>

--- a/app/views/funding/trainee_summaries/show.html.erb
+++ b/app/views/funding/trainee_summaries/show.html.erb
@@ -15,7 +15,6 @@
       <p class="govuk-body">
         <%= t("funding.trainee_summary.email_line_one") %>
         <%= support_email(
-          name: Settings.support_email,
           subject: t("funding.trainee_summary.email_subject")
         ) %>
         <%= t("funding.trainee_summary.email_line_two") %>

--- a/app/views/funding/trainee_summaries/show.html.erb
+++ b/app/views/funding/trainee_summaries/show.html.erb
@@ -14,9 +14,8 @@
       </p>
       <p class="govuk-body">
         <%= t("funding.trainee_summary.email_line_one") %>
-        <%= govuk_mail_to(
-          Settings.support_email,
-          Settings.support_email,
+        <%= support_email(
+          name: Settings.support_email,
           subject: t("funding.trainee_summary.email_subject")
         ) %>
         <%= t("funding.trainee_summary.email_line_two") %>

--- a/app/views/pages/dttp_replaced.html.erb
+++ b/app/views/pages/dttp_replaced.html.erb
@@ -9,7 +9,7 @@
     <%= govuk_link_to t(".button_text"), root_path, class: "govuk-button" %>
 
     <p class="govuk-body"><%= t(".support") %>
-      <%= support_email(name: Settings.support_email, subject: t("pages.request_an_account.email_subject")) %>
+      <%= support_email(subject: t("pages.request_an_account.email_subject")) %>
     </p>
   </div>
 </div>

--- a/app/views/pages/dttp_replaced.html.erb
+++ b/app/views/pages/dttp_replaced.html.erb
@@ -9,7 +9,7 @@
     <%= govuk_link_to t(".button_text"), root_path, class: "govuk-button" %>
 
     <p class="govuk-body"><%= t(".support") %>
-      <%= govuk_mail_to(Settings.support_email, Settings.support_email, subject: t("pages.request_an_account.email_subject")) %>
+      <%= support_email(name: Settings.support_email, subject: t("pages.request_an_account.email_subject")) %>
     </p>
   </div>
 </div>

--- a/app/views/trainees/employing_schools/edit.html.erb
+++ b/app/views/trainees/employing_schools/edit.html.erb
@@ -22,7 +22,7 @@
 
       <%= render GovukComponent::DetailsComponent.new(summary_text: t(".not_applicable_details.summary_text"),
                                                       open: f.object.school_not_applicable? ) do %>
-        <%= t(".not_applicable_details.body", contact_link: govuk_mail_to(Settings.support_email)).html_safe %>
+        <%= t(".not_applicable_details.body", contact_link: support_email).html_safe %>
         <%= f.govuk_check_box(:employing_school_not_applicable, "1", "0", multiple: false,
                               label: { text: t(".not_applicable_details.label_text") }) %>
       <% end  %>

--- a/app/views/trainees/forbidden_withdrawals/show.html.erb
+++ b/app/views/trainees/forbidden_withdrawals/show.html.erb
@@ -21,7 +21,7 @@
   </p>
 
   <p class="govuk-body">
-     <%= t(".support") %> <%= support_email(name: Settings.support_email)%>.
+     <%= t(".support") %> <%= support_email%>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/trainees/forbidden_withdrawals/show.html.erb
+++ b/app/views/trainees/forbidden_withdrawals/show.html.erb
@@ -9,11 +9,11 @@
   <%= render TraineeName::View.new(@trainee) %>
 
   <h1 class="govuk-heading-l">
-    <%= t(".heading") %> 
+    <%= t(".heading") %>
   </h1>
 
   <p class="govuk-body">
-     <%= t(".reason") %> 
+     <%= t(".reason") %>
   </p>
 
   <p class="govuk-body">
@@ -21,7 +21,7 @@
   </p>
 
   <p class="govuk-body">
-     <%= t(".support") %> <%= govuk_mail_to(Settings.support_email, Settings.support_email)%>.
+     <%= t(".support") %> <%= support_email(name: Settings.support_email)%>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/trainees/lead_schools/edit.html.erb
+++ b/app/views/trainees/lead_schools/edit.html.erb
@@ -24,7 +24,7 @@
 
       <%= render GovukComponent::DetailsComponent.new(summary_text: t(".not_applicable_details.summary_text"),
                                                       open: f.object.school_not_applicable? ) do %>
-        <%= t(".not_applicable_details.body", contact_link: govuk_mail_to(Settings.support_email)).html_safe %>
+        <%= t(".not_applicable_details.body", contact_link: support_email).html_safe %>
         <%= f.govuk_check_box(:lead_school_not_applicable, "1", "0", multiple: false,
                               label: { text: t(".not_applicable_details.label_text") }) %>
       <% end  %>

--- a/app/views/trainees/withdrawal/dates/edit.html.erb
+++ b/app/views/trainees/withdrawal/dates/edit.html.erb
@@ -16,7 +16,7 @@
       <%= render GovukComponent::InsetTextComponent.new(classes: "duplicate-notice") do %>
         <p class="govuk-body duplicate-notice_text">
           <%= t("views.forms.withdrawal_date.duplicate_record_notice",
-                contact_link: govuk_mail_to(Settings.support_email)).html_safe %>
+                contact_link: support_email).html_safe %>
         </p>
       <% end %>
     <% end %>

--- a/spec/helpers/support_email_helper_spec.rb
+++ b/spec/helpers/support_email_helper_spec.rb
@@ -11,7 +11,7 @@ describe SupportEmailHelper do
       subject { helper.support_email }
 
       it has_correct_formatting do
-        expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk\">becomingateacher@digital.education.gov.uk</a>"
+        expected_output = "<a class=\"govuk-link app-!-overflow-break-word \" href=\"mailto:becomingateacher@digital.education.gov.uk\">becomingateacher@digital.education.gov.uk</a>"
         expect(subject).to eq(expected_output)
       end
     end
@@ -20,7 +20,7 @@ describe SupportEmailHelper do
       subject { helper.support_email(subject: "Register trainee teachers support") }
 
       it has_correct_formatting do
-        expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20support\">becomingateacher@digital.education.gov.uk</a>"
+        expected_output = "<a class=\"govuk-link app-!-overflow-break-word \" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20support\">becomingateacher@digital.education.gov.uk</a>"
         expect(subject).to eq(expected_output)
       end
 
@@ -28,7 +28,7 @@ describe SupportEmailHelper do
         subject { helper.support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback") }
 
         it "has the correct formatting" do
-          expected_output = "<a class=\"govuk-link\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
+          expected_output = "<a class=\"govuk-link app-!-overflow-break-word \" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
           expect(subject).to eq(expected_output)
         end
 
@@ -36,7 +36,7 @@ describe SupportEmailHelper do
           subject { helper.support_email(name: "give feedback or report a problem", subject: "Register trainee teachers feedback", classes: "govuk-link--no-visited-state") }
 
           it has_correct_formatting do
-            expected_output = "<a class=\"govuk-link govuk-link--no-visited-state\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
+            expected_output = "<a class=\"govuk-link app-!-overflow-break-word govuk-link--no-visited-state\" href=\"mailto:becomingateacher@digital.education.gov.uk?subject=Register%20trainee%20teachers%20feedback\">give feedback or report a problem</a>"
             expect(subject).to eq(expected_output)
           end
         end


### PR DESCRIPTION
### Context

https://trello.com/c/gcMCik0T/6344-email-addresses-break-page-width-at-400-and-1289-x-1024px

### Changes proposed in this pull request

Fixes the accesibility issue highlighted in the screenshot below:

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/052e7345-7e98-4e68-8b0c-d60f2d91f318)

### Guidance to review

Test this out in the org list. Sign in as a persona belong to multiple orgs, hit shift+cmd+r to enter responsive mode in safari and scale down.