### PR TITLE
[6497] Updating the placements kills the trainee page

### DIFF
--- a/app/components/placement_details/view.rb
+++ b/app/components/placement_details/view.rb
@@ -33,7 +33,7 @@ module PlacementDetails
     def placement_rows
       placement_records.each_with_index.map do |placement_record, index|
         {
-          field_label: t("components.placement_detail.placement_#{index + 1}"),
+          field_label: t("components.placement_detail.placement_#{index + 1}", default: "#{(index + 1).ordinalize} Placement"),
           field_value: placement_details_for(placement_record),
         }
       end

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -120,7 +120,7 @@ module Trainees
         )
       end
 
-      if action == "update" && model == "placement"
+      if changed_placement?
         old_name, name = GetPlacementNameFromAudit.call(audit:)
         return TimelineEvent.new(
           title: I18n.t("components.timeline.titles.placement.update", old_name:, name:),
@@ -140,7 +140,7 @@ module Trainees
           date: created_at,
           username: username,
         )
-      end
+      end.compact
     end
 
   private
@@ -267,6 +267,10 @@ module Trainees
       change = audited_changes["provider_id"]
 
       action == "update" && Array.wrap(change).size == 2
+    end
+
+    def changed_placement?
+      action == "update" && model == "placement" && audited_changes.keys.intersect?(%w[name school_id])
     end
 
     def hesa_or_dttp_user?


### PR DESCRIPTION
### Context
Updating the placement details kills the trainee page

### Changes proposed in this pull request
Fixed translation for when the placements exceed 6+ placements
Fixed timeline whereby it expects school or school name to change only

### Guidance to review
Create 6 or more placements
Change school urn or postcode
View timeline


### Important business

N/A
- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
