### PR TITLE
[xxxx] Fixed placement details looped journery

### DIFF
--- a/app/controllers/trainees/placements/details_controller.rb
+++ b/app/controllers/trainees/placements/details_controller.rb
@@ -6,8 +6,6 @@ module Trainees
       before_action { require_feature_flag(:trainee_placement) }
 
       def edit
-        page_tracker.save_as_origin!
-
         @placement_detail_form = PlacementDetailForm.new(trainee)
       end
 

--- a/app/views/trainees/placements/new.html.erb
+++ b/app/views/trainees/placements/new.html.erb
@@ -4,7 +4,7 @@
 ) %>
 
 <%= content_for(:breadcrumbs) do %>
-  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: @page_tracker.last_origin_page_path.presence || edit_trainee_placements_details_path(@trainee)) %>
+  <%= render GovukComponent::BackLinkComponent.new(text: t(:back), href: @trainee.placements.count.zero? ? edit_trainee_placements_details_path(@trainee) : @page_tracker.last_origin_page_path.presence ) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/spec/features/form_sections/teacher_training_data/placements/adding_trainee_placements_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/adding_trainee_placements_spec.rb
@@ -45,9 +45,15 @@ feature "Add a placement" do
     when_i_revisit_the_placements_confirmation_page
     and_i_click_update
     and_no_new_placements_are_created
+
+    then_i_see_the_trainee_page
   end
 
 private
+
+  def then_i_see_the_trainee_page
+    expect(page).to have_current_path(trainee_path(trainee))
+  end
 
   def and_a_trainee_exists_with_trn_received
     @trainee ||= given_a_trainee_exists(:trn_received)

--- a/spec/features/form_sections/teacher_training_data/placements/details_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/details_spec.rb
@@ -11,18 +11,51 @@ feature "add placement details", feature_trainee_placement: true do
   scenario "placement detail available" do
     when_i_visit_the_placement_details_page
     and_i_have_the_placement_details
-    and_i_continue
+    and_i_click_continue
     then_i_am_taken_to_the_placement_form_page
   end
 
   scenario "placement detail not available" do
     when_i_visit_the_placement_details_page
     and_i_do_not_have_the_placement_detail
-    and_i_continue
+    and_i_click_continue
     then_i_am_taken_to_the_trainee_review_drafts_page
   end
 
+  scenario "add placement detail full journery" do
+    when_i_visit_the_placement_details_page
+    and_i_have_the_placement_details
+    and_i_click_continue
+    then_i_am_taken_to_the_placement_form_page
+
+    when_i_enter_details_for_a_new_school
+    and_i_click_continue
+    then_i_see_the_confirmation_page
+
+    and_i_click_continue
+    then_i_see_the_trainee_review_drafts_page
+  end
+
 private
+
+  def then_i_see_the_trainee_review_drafts_page
+    expect(page).to have_current_path(trainee_review_drafts_path(trainee))
+  end
+
+  def when_i_click_update
+    click_button "Update record"
+  end
+
+  def when_i_enter_details_for_a_new_school
+    fill_in("School or setting name", with: "St. Alice's Primary School", visible: false)
+    fill_in("School unique reference number (URN) - if it has one", with: "654321", visible: false)
+    fill_in("Postcode", with: "OX1 1AA", visible: false)
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_current_path(trainee_placements_confirm_path(trainee_id: @trainee.slug))
+    expect(page).to have_content("Confirm placement details")
+  end
 
   def when_i_visit_the_placement_details_page
     given_i_am_on_the_review_draft_page
@@ -37,7 +70,7 @@ private
     page.choose(t("views.forms.placement_details.label_names.no_placement_detail"))
   end
 
-  def and_i_continue
+  def and_i_click_continue
     click_button(t("continue"))
   end
 


### PR DESCRIPTION
### Context
Looped journery

### Changes proposed in this pull request

Added tests to flush out loopiness
Amended to use placement count to decide which back link to use
Removed loopiness

### Guidance to review

The review draft page is should be the only origin page.

The bug occurs as previously the  placement-details page set it self as the origin, which only surfaces the loop.
When after a placement is added and the the user is expected to return to the review draft page from the confirmation page, instead the user find themselves back on the placement-details page.

#### Bug
![looped-placement](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/c8ffb8ca-eef5-4192-b7d8-6277fc116393)


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
