### PR TITLE
[6490] Fix previous cycle dates for funding schedule CSV download

### DIFF
--- a/app/controllers/system_admin/funding/payment_schedules_controller.rb
+++ b/app/controllers/system_admin/funding/payment_schedules_controller.rb
@@ -7,14 +7,16 @@ module SystemAdmin
 
       helper_method :back_path
 
+      attr_reader :start_year, :end_year
+
       def show
+        @start_year = selected_academic_cycle.start_year
+        @end_year = selected_academic_cycle.end_year
+
         respond_to do |format|
           format.html do
             @payment_schedule_view = ::Funding::PaymentScheduleView.new(payment_schedule:)
             @navigation_view = ::Funding::NavigationView.new(organisation: organisation, system_admin: true)
-
-            @start_year = selected_academic_cycle.start_year
-            @end_year = selected_academic_cycle.end_year
 
             render("funding/payment_schedules/show")
           end
@@ -40,7 +42,11 @@ module SystemAdmin
       end
 
       def data_export
-        @data_export ||= Exports::FundingScheduleData.new(payment_schedule:)
+        @data_export ||= Exports::FundingScheduleData.new(
+          payment_schedule:,
+          start_year:,
+          end_year:,
+        )
       end
 
       def back_path

--- a/app/services/exports/funding_schedule_data.rb
+++ b/app/services/exports/funding_schedule_data.rb
@@ -4,8 +4,14 @@ module Exports
   class FundingScheduleData
     include ExportsHelper
 
-    def initialize(payment_schedule:)
+    def initialize(
+      payment_schedule:,
+      start_year: AcademicCycle.current.start_year,
+      end_year: AcademicCycle.current.end_year
+    )
       @payment_schedule = payment_schedule
+      @start_year = start_year
+      @end_year = end_year
     end
 
     def to_csv
@@ -60,7 +66,7 @@ module Exports
     end
 
     def label_for(month)
-      year = month > 7 ? AcademicCycle.current.start_year : AcademicCycle.current.end_year
+      year = month > 7 ? @start_year : @end_year
       Date.new(year, month).to_fs(:govuk_approx)
     end
 


### PR DESCRIPTION
### Context
This is a bug that was raised via support. From the funding page you can view and download the payment schedule for the current academic cycle or earlier ones.

For earlier academic cycles the years and data for each row are displayed correctly when viewed in the browser. However when downloaded as a CSV the years are wrong because the CSV rendering code seems we assume that we are always interested in the current cycle.

https://trello.com/c/IsvsFfeJ/6490-dates-incorrect-on-previous-year-funding-download

### Changes proposed in this pull request
To fix this we can just pass the `start_year` and `end_year` into `Exports::FundingScheduleData`.

### Guidance to review
Does this make sense and is there anywhere else we are likely to have a similar issue?
How do we test this manually?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
