### PR TITLE
[6456] Fix stash and save of grant and tiered bursaries

### DIFF
--- a/app/controllers/trainees/funding/bursaries_controller.rb
+++ b/app/controllers/trainees/funding/bursaries_controller.rb
@@ -11,6 +11,7 @@ module Trainees
       def update
         funding_manager
         @bursary_form = form.new(trainee, params: form_params)
+
         if @bursary_form.stash_or_save!
           redirect_to(trainee_funding_confirm_path)
         else

--- a/app/forms/funding/form_validator.rb
+++ b/app/forms/funding/form_validator.rb
@@ -17,7 +17,7 @@ module Funding
 
     def initialize(trainee)
       @trainee = trainee
-      @bursary_form = BursaryForm.new(trainee)
+      @bursary_form = bursary_form_class.new(trainee)
       @training_initiatives_form = TrainingInitiativesForm.new(trainee)
       @fields = bursary_form_fields.merge(training_initiatives_form_fields)
     end
@@ -65,6 +65,14 @@ module Funding
 
     def funding_manager
       @funding_manager ||= FundingManager.new(trainee)
+    end
+
+    def grant_and_tiered_bursary?
+      funding_manager.applicable_available_funding == :grant_and_tiered_bursary
+    end
+
+    def bursary_form_class
+      grant_and_tiered_bursary? ? ::Funding::GrantAndTieredBursaryForm : ::Funding::BursaryForm
     end
   end
 end

--- a/app/forms/funding/form_validator.rb
+++ b/app/forms/funding/form_validator.rb
@@ -19,6 +19,7 @@ module Funding
       @trainee = trainee
       @bursary_form = bursary_form_class.new(trainee)
       @training_initiatives_form = TrainingInitiativesForm.new(trainee)
+
       @fields = bursary_form_fields.merge(training_initiatives_form_fields)
     end
 

--- a/app/forms/funding/grant_and_tiered_bursary_form.rb
+++ b/app/forms/funding/grant_and_tiered_bursary_form.rb
@@ -66,7 +66,7 @@ module Funding
       if params.present?
         fields_from_store.merge(grant_and_tiered_bursary_params).symbolize_keys
       else
-        params
+        fields_from_store.symbolize_keys
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -689,6 +689,7 @@ en:
         training_initiative: edit_trainee_funding_training_initiative_path
         applying_for_bursary: &funding_method_path edit_trainee_funding_bursary_path
         applying_for_grant: *funding_method_path
+        custom_bursary_tier: *funding_method_path
         applying_for_scholarship: *funding_method_path
         funding_type: *funding_method_path
         institution: &degree_path degree_path
@@ -742,6 +743,7 @@ en:
         applying_for_bursary: *funding_method
         applying_for_grant: *funding_method
         applying_for_scholarship: *funding_method
+        custom_bursary_tier: *funding_method
         funding_type: *funding_method
         institution: *institution
         subject: *subject

--- a/spec/forms/funding/form_validator_spec.rb
+++ b/spec/forms/funding/form_validator_spec.rb
@@ -198,11 +198,10 @@ module Funding
             end
 
             context "and GrantAndTieredBursaryForm is valid" do
-              before do
+              it "is valid" do
                 expect(grant_and_tiered_bursary_form).to receive(:valid?).and_return(true).at_least(:once)
+                expect(subject).to be_valid
               end
-
-              it { is_expected.to be_valid }
             end
           end
         end

--- a/spec/forms/funding/form_validator_spec.rb
+++ b/spec/forms/funding/form_validator_spec.rb
@@ -173,9 +173,39 @@ module Funding
             end
           end
         end
-      end
 
-      context "when grant and tiered bursary are available" do
+        context "when grant and tiered bursary are available" do
+          let(:grant_and_tiered_bursary_form) do
+            instance_double(Funding::GrantAndTieredBursaryForm, fields: nil, applying_for_bursary: nil, applying_for_grant: nil)
+          end
+          let(:funding_manager) do
+            instance_double(
+              FundingManager,
+              applicable_available_funding: :grant_and_tiered_bursary,
+              can_apply_for_funding_type?: true,
+            )
+          end
+          let(:funding_method) { create(:funding_method, :bursary, training_route: :provider_led_postgrad) }
+
+          before do
+            allow(Funding::GrantAndTieredBursaryForm).to receive(:new).and_return(grant_and_tiered_bursary_form)
+            allow(FundingManager).to receive(:new).and_return(funding_manager)
+          end
+
+          context "when TrainingInitiativesForm is valid" do
+            before do
+              allow(training_initiative_form).to receive(:valid?).and_return(true)
+            end
+
+            context "and GrantAndTieredBursaryForm is valid" do
+              before do
+                expect(grant_and_tiered_bursary_form).to receive(:valid?).and_return(true).at_least(:once)
+              end
+
+              it { is_expected.to be_valid }
+            end
+          end
+        end
       end
     end
 
@@ -196,7 +226,7 @@ module Funding
 
       context "with invalid TrainingInitiativesForm and Bursary form" do
         before do
-          allow(FundingManager).to receive(:new).with(trainee).and_return(double(can_apply_for_bursary?: true))
+          allow(FundingManager).to receive(:new).with(trainee).and_return(double(can_apply_for_bursary?: true, applicable_available_funding: :bursary))
         end
 
         it { is_expected.to eq([%i[training_initiative funding_type]]) }

--- a/spec/forms/funding/form_validator_spec.rb
+++ b/spec/forms/funding/form_validator_spec.rb
@@ -174,6 +174,9 @@ module Funding
           end
         end
       end
+
+      context "when grant and tiered bursary are available" do
+      end
     end
 
     describe "#missing_fields" do


### PR DESCRIPTION
### Context

This was reported as a support issue - a provider was unable to save bursary info on a trainee record.

https://trello.com/c/G5RmNWk4/6456-should-a-bursary-be-selectable

I was able to reproduce this locally using an Early years graduate entry/Early years ITT trainee. When clicking funding from the main trainee dashboard they user sees the grant and tiered bursary form (which is fairly new I think):

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/4a1a1ecb-2c48-4085-817f-3fe730778367)

After selecting (say) a tiered bursary and clicking continue the user sees a confirmation page. However the confirmation page does not include the selection and pressing the _Update_ button doesn't save the selection as it should.

### Changes proposed in this pull request

This problem seems to be due to a discrepancy between the form selected to persist the changes to the FormStore (namely `Funding::GrantAndTieredBursaryForm`) and the one used by the validator (`Funding::BursaryForm`). As these forms use a different form key the later doesn’t pick up the changes made by the former. So I've changed this to use `Funding::GrantAndTieredBursaryForm`.

I've also changed a bit of logic in `Funding::GrantAndTieredBursaryForm#new_attributes` as the original implementation seems to ignore stashed values.

### Guidance to review
To test try a _Early years graduate entry/Early years ITT_ trainee.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
