### PR TITLE
[6492] Use `outcome_date` for awarded at component

### DIFF
--- a/app/components/award_details/view.rb
+++ b/app/components/award_details/view.rb
@@ -16,7 +16,9 @@ module AwardDetails
       elsif trainee.recommended_for_award?
         I18n.t(
           "components.award_details.waiting_for_award",
-          recommended_for_award_at: date_for_summary_view(trainee.recommended_for_award_at),
+          recommended_for_award_at: date_for_summary_view(
+            trainee.outcome_date || trainee.recommended_for_award_at,
+          ),
         )
       end
     end

--- a/spec/components/award_details/view_spec.rb
+++ b/spec/components/award_details/view_spec.rb
@@ -21,11 +21,11 @@ module AwardDetails
     end
 
     context "when trainee is recommended for award" do
-      let(:trainee) { build(:trainee, :recommended_for_award, recommended_for_award_at: 10.days.ago) }
+      let(:trainee) { build(:trainee, :recommended_for_award, recommended_for_award_at: 10.days.ago, outcome_date: 20.days.ago) }
 
       it "renders recommended date if awaiting award" do
         expect(component.find(summary_card_row_for("award-date"))).to have_text(
-          "Waiting for award - met standards on #{date_for_summary_view(trainee.recommended_for_award_at)}",
+          "Waiting for award - met standards on #{date_for_summary_view(trainee.outcome_date)}",
         )
       end
     end


### PR DESCRIPTION
### Context
`outcome_date` stores the date at which the user said that the trainee met conditions whereas `recommended_for_award_at` only records when the provider filled in the form on Register.

### Changes proposed in this pull request
Use `Trainee#outcome_date` in the `AwardDetails::View` component. Fallback to `recommended_for_award_at` if there is no `outcome_date`.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/c6bab706-50d5-47d4-9cae-b6aa8387313b)


### Guidance to review
Is there anywhere else we need to do similar?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
