### PR TITLE
[6518] Fix missing data banner for trainees with bulk imported placements

### DIFF
--- a/app/forms/placements_form.rb
+++ b/app/forms/placements_form.rb
@@ -5,10 +5,10 @@ class PlacementsForm
 
   attr_accessor :trainee, :placement_ids
 
-  validates :placement_ids, length: { minimum: 2 }, if: :non_draft_trainee?
-  validate :placements_must_be_valid, if: :non_draft_trainee?
-
   MINIMUM_PLACEMENTS = 2
+
+  validates :placement_ids, length: { minimum: MINIMUM_PLACEMENTS }, if: :non_draft_trainee?
+  validate :placements_must_be_valid, if: :non_draft_trainee?
 
   def initialize(trainee, store = FormStore)
     @trainee = trainee

--- a/app/services/bulk_update/placements/import_row.rb
+++ b/app/services/bulk_update/placements/import_row.rb
@@ -29,7 +29,7 @@ module BulkUpdate
 
       def create_placement
         placement_row.update(school: school, state: :imported)
-        ::Placement.find_or_create_by(trainee:, school:, urn:)
+        ::Placement.find_or_create_by(trainee:, school:)
       end
 
       def record_errors

--- a/spec/services/bulk_update/placements/import_row_spec.rb
+++ b/spec/services/bulk_update/placements/import_row_spec.rb
@@ -24,6 +24,14 @@ module BulkUpdate
             expect { service }.to change { ::Placement.count }.by(1)
             expect(placement_row.imported?).to be true
           end
+
+          it "creates a placement with a `school_id` but no `urn` or `name`" do
+            service
+            placement = ::Placement.last
+            expect(placement.school_id).to eq(school.id)
+            expect(placement.attributes[:urn]).to be_nil
+            expect(placement.attributes[:name]).to be_nil
+          end
         end
 
         context "when the row can be imported but is invalid" do


### PR DESCRIPTION
### Context


### Changes proposed in this pull request
- Don't write `Placement#urn` when there is a `school_id`

The alternative here would be to change the validation so that we only require `name` if `school_id` is not present.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
