### PR TITLE
[6507] Update date range for performance profile

### DIFF
--- a/app/services/determine_sign_off_period.rb
+++ b/app/services/determine_sign_off_period.rb
@@ -9,7 +9,8 @@ class DetermineSignOffPeriod
     current_date = Time.zone.today
 
     return :census_period if census_range.cover?(current_date)
-    return :performance_period if performance_range.cover?(current_date)
+
+    return :performance_period if in_performance_range?(current_date)
 
     :outside_period
   end
@@ -29,10 +30,10 @@ class DetermineSignOffPeriod
     start_date..end_date
   end
 
-  def self.performance_range
-    start_date = Date.new(Time.zone.today.year, 1, 1) # 1st January
-    end_date = Date.new(Time.zone.today.year, 1, 31) # 31st January
+  def self.in_performance_range?(date)
+    jan_to_feb_range = Date.new(Time.zone.today.year, 1, 1)..Date.new(Time.zone.today.year, 2, 7)
+    december_range = Date.new(Time.zone.today.year, 12, 1)..Date.new(Time.zone.today.year, 12, 31)
 
-    start_date..end_date
+    jan_to_feb_range.cover?(date) || december_range.cover?(date)
   end
 end

--- a/app/views/reports/_performance_period.html.erb
+++ b/app/views/reports/_performance_period.html.erb
@@ -1,13 +1,10 @@
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <p>
-      New trainees for the <%= @current_academic_cycle_label %> academic year - will be available for census sign off
+      Reports are available for <%= govuk_link_to "trainees who studied in the #{@previous_academic_cycle_label} academic year", performance_profiles_reports_path, class: "performance-profiles" %> - for performance profiles sign off
     </p>
   </li>
   <li>
-    <p>
-      <%= govuk_link_to "Trainees who studied in the #{@previous_academic_cycle_label} academic year", performance_profiles_reports_path, class: "performance-profiles" %>
-      - for performance profiles sign off
-    </p>
+    <p>You can read <%= govuk_link_to("guidance about signing off performance profiles", performance_profiles_guidance_path) %></p>
   </li>
 </ul>

--- a/spec/features/reports/index_spec.rb
+++ b/spec/features/reports/index_spec.rb
@@ -62,8 +62,8 @@ private
 
   def then_i_should_see_the_performance_period_content
     expect(reports_page).not_to have_text("No reports are currently available.")
-    expect(reports_page).to have_text("New trainees for the #{current_cycle.label} academic year - will be available for census sign off")
-    expect(reports_page).to have_text("Trainees who studied in the #{previous_cycle.label} academic year - for performance profiles sign off")
+    expect(reports_page).to have_text("Reports are available for trainees who studied in the #{previous_cycle.label} academic year - for performance profiles sign off")
+    expect(reports_page).to have_text("You can read guidance about signing off performance profiles")
   end
 
   def then_i_should_see_the_census_period_content

--- a/spec/services/determine_sign_off_period_spec.rb
+++ b/spec/services/determine_sign_off_period_spec.rb
@@ -8,7 +8,7 @@ describe DetermineSignOffPeriod do
 
     let(:current_year) { Time.zone.today.year }
     let(:census_period_range) { Date.new(current_year, 9, 1)..Date.new(current_year, 11, 7) }
-    let(:performance_period_range) { Date.new(current_year, 1, 1)..Date.new(current_year, 1, 31) }
+    let(:performance_period_range) { Date.new(current_year, 1, 1)..Date.new(current_year, 2, 7) }
 
     context "with a valid manual override" do
       before do


### PR DESCRIPTION
### Context

https://trello.com/c/UDrQNHXh/6507-change-dates-on-the-report-tab-to-show-performance-profiles-report

### Changes proposed in this pull request

- Updates the profile performance logic to expand dates to 1st Dec - 17th Feb

### Guidance to review

Check the review app, reports tab and the performance profile link should be available

Review app - https://register-pr-3839.test.teacherservices.cloud/
