### PR TITLE
[6530] Adding placements to trainees in awarded state

### DIFF
--- a/app/controllers/trainees/placements/confirm_details_controller.rb
+++ b/app/controllers/trainees/placements/confirm_details_controller.rb
@@ -3,6 +3,8 @@
 module Trainees
   module Placements
     class ConfirmDetailsController < Trainees::ConfirmDetailsController
+      include TraineeHelper
+
       def update
         trainee.draft? ? toggle_trainee_progress_field : @form.save!
 
@@ -14,11 +16,7 @@ module Trainees
     private
 
       def authorize_trainee
-        authorize(trainee, :write_placements?)
-      end
-
-      def placement_editable?
-        @placement_editable ||= policy(trainee).write_placements?
+        placement_editable?(trainee)
       end
     end
   end

--- a/app/controllers/trainees/placements/confirm_details_controller.rb
+++ b/app/controllers/trainees/placements/confirm_details_controller.rb
@@ -16,7 +16,7 @@ module Trainees
     private
 
       def authorize_trainee
-        placement_editable?(trainee)
+        policy(trainee).write_placements?
       end
     end
   end

--- a/app/controllers/trainees/placements/confirm_details_controller.rb
+++ b/app/controllers/trainees/placements/confirm_details_controller.rb
@@ -10,6 +10,16 @@ module Trainees
 
         redirect_to(page_tracker.last_origin_page_path || trainee_path(trainee))
       end
+
+    private
+
+      def authorize_trainee
+        authorize(trainee, :write_placements?)
+      end
+
+      def placement_editable?
+        @placement_editable ||= policy(trainee).write_placements?
+      end
     end
   end
 end

--- a/app/controllers/trainees/placements_controller.rb
+++ b/app/controllers/trainees/placements_controller.rb
@@ -64,7 +64,7 @@ module Trainees
   private
 
     def authorize_trainee
-      placement_editable?(trainee)
+      policy(trainee).write_placements?
     end
 
     def relevant_redirect_path

--- a/app/controllers/trainees/placements_controller.rb
+++ b/app/controllers/trainees/placements_controller.rb
@@ -3,6 +3,7 @@
 module Trainees
   class PlacementsController < BaseController
     include Appliable
+    include TraineeHelper
 
     before_action { require_feature_flag(:trainee_placement) }
 
@@ -61,6 +62,10 @@ module Trainees
     end
 
   private
+
+    def authorize_trainee
+      placement_editable?(trainee)
+    end
 
     def relevant_redirect_path
       draft_apply_application? ? page_tracker.last_origin_page_path : trainee_placements_confirm_path(trainee)

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -85,8 +85,4 @@ module TraineeHelper
   def course_name_for(trainee)
     trainee.provider&.courses&.find { |course| course.uuid == trainee.course_uuid }&.name
   end
-
-  def placement_editable?(trainee)
-    policy(trainee).write_placements?
-  end
 end

--- a/app/helpers/trainee_helper.rb
+++ b/app/helpers/trainee_helper.rb
@@ -85,4 +85,8 @@ module TraineeHelper
   def course_name_for(trainee)
     trainee.provider&.courses&.find { |course| course.uuid == trainee.course_uuid }&.name
   end
+
+  def placement_editable?(trainee)
+    policy(trainee).write_placements?
+  end
 end

--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -107,6 +107,14 @@ class TraineePolicy
   alias_method :confirm?, :update?
   alias_method :delete?, :destroy?
 
+  def write_placements?
+    return false if user_is_read_only?
+
+    user_is_system_admin? || (
+      user_in_provider_context? && (!trainee.hesa_record? || trainee.hesa_editable?)
+    )
+  end
+
 private
 
   def read?

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -47,7 +47,7 @@
 
 <% if @trainee.requires_placements? %>
   <div class="placement-details">
-    <%= render PlacementDetails::View.new(data_model: @trainee, editable: placement_editable?) %>
+    <%= render PlacementDetails::View.new(data_model: @trainee, editable: placement_editable?(@trainee)) %>
   </div>
 <% end %>
 

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -47,7 +47,7 @@
 
 <% if @trainee.requires_placements? %>
   <div class="placement-details">
-    <%= render PlacementDetails::View.new(data_model: @trainee, editable: trainee_editable?) %>
+    <%= render PlacementDetails::View.new(data_model: @trainee, editable: placement_editable?) %>
   </div>
 <% end %>
 

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -47,7 +47,7 @@
 
 <% if @trainee.requires_placements? %>
   <div class="placement-details">
-    <%= render PlacementDetails::View.new(data_model: @trainee, editable: placement_editable?(@trainee)) %>
+    <%= render PlacementDetails::View.new(data_model: @trainee, editable: policy(@trainee).write_placements?) %>
   </div>
 <% end %>
 

--- a/spec/features/form_sections/teacher_training_data/placements/adding_trainee_placements_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/adding_trainee_placements_spec.rb
@@ -16,7 +16,7 @@ feature "Add a placement" do
     then_i_see_the_not_found_page
   end
 
-  %i[qts_awarded qts_recommended trn_received].each do |trait|
+  shared_examples "adding a placement" do |trait|
     scenario "Add a new placement to an existing trainee in the #{trait} state", feature_trainee_placement: true do
       given_i_am_authenticated
       and_a_postgrad_trainee_exists_with(trait)
@@ -35,6 +35,12 @@ feature "Add a placement" do
       then_i_see_a_flash_message
       and_a_new_placement_is_created
     end
+  end
+
+  context "with a trn_received state" do
+    it_behaves_like "adding a placement", :trn_received
+    it_behaves_like "adding a placement", :qts_recommended
+    it_behaves_like "adding a placement", :qts_awarded
   end
 
   scenario "Add two new placements to an existing trainee", feature_trainee_placement: true do

--- a/spec/features/form_sections/teacher_training_data/placements/adding_trainee_placements_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/adding_trainee_placements_spec.rb
@@ -16,23 +16,25 @@ feature "Add a placement" do
     then_i_see_the_not_found_page
   end
 
-  scenario "Add one new placement to an existing trainee", feature_trainee_placement: true do
-    given_i_am_authenticated
-    and_a_postgrad_trainee_exists_with_trn_received
-    and_a_school_exists
-    and_i_navigate_to_the_trainee_dashboard
-    and_i_click_to_enter_first_placement
-    then_i_see_the_new_placement_form
+  %i[qts_awarded qts_recommended trn_received].each do |trait|
+    scenario "Add a new placement to an existing trainee in the #{trait} state", feature_trainee_placement: true do
+      given_i_am_authenticated
+      and_a_postgrad_trainee_exists_with(trait)
+      and_a_school_exists
+      and_i_navigate_to_the_trainee_dashboard
+      and_i_click_to_enter_first_placement
+      then_i_see_the_new_placement_form
 
-    when_i_select_an_existing_school
-    and_i_click_continue
-    then_i_see_the_confirmation_page
-    and_i_see_the_new_placement_ready_for_confirmation
-    and_no_placements_are_created
+      when_i_select_an_existing_school
+      and_i_click_continue
+      then_i_see_the_confirmation_page
+      and_i_see_the_new_placement_ready_for_confirmation
+      and_no_placements_are_created
 
-    when_i_click_update
-    then_i_see_a_flash_message
-    and_a_new_placement_is_created
+      when_i_click_update
+      then_i_see_a_flash_message
+      and_a_new_placement_is_created
+    end
   end
 
   scenario "Add two new placements to an existing trainee", feature_trainee_placement: true do
@@ -74,13 +76,13 @@ private
     expect(page).to have_current_path(trainee_path(trainee))
   end
 
-  def and_a_trainee_exists_with_trn_received
-    @trainee ||= given_a_trainee_exists(:trn_received)
+  def and_a_postgrad_trainee_exists_with(trait)
+    @trainee ||= given_a_trainee_exists(trait, :early_years_postgrad)
     FormStore.clear_all(@trainee.id)
   end
 
-  def and_a_postgrad_trainee_exists_with_trn_received
-    @trainee ||= given_a_trainee_exists(:trn_received, :early_years_postgrad)
+  def and_a_trainee_exists_with_trn_received
+    @trainee ||= given_a_trainee_exists(:trn_received)
     FormStore.clear_all(@trainee.id)
   end
 

--- a/spec/forms/placements_form_spec.rb
+++ b/spec/forms/placements_form_spec.rb
@@ -207,7 +207,7 @@ describe PlacementsForm, type: :model do
     end
   end
 
-  describe "#save!" do
+  describe "#save!", feature_integrate_with_dqt: true do
     let(:placement_form1) { instance_double(PlacementForm) }
     let(:placement_form2) { instance_double(PlacementForm) }
 
@@ -220,6 +220,11 @@ describe PlacementsForm, type: :model do
 
     it "run save on all the placement form objects" do
       expect(subject.save!).to be_present
+    end
+
+    it "does not send and update to DQT" do
+      expect(Dqt::TraineeUpdate).not_to receive(:call)
+      subject.save!
     end
 
     context "if trainee has not provided placement detail" do

--- a/spec/forms/placements_form_spec.rb
+++ b/spec/forms/placements_form_spec.rb
@@ -223,7 +223,7 @@ describe PlacementsForm, type: :model do
     end
 
     it "does not send and update to DQT" do
-      expect(Dqt::TraineeUpdate).not_to receive(:call)
+      expect(Trainees::Update).not_to receive(:call)
       subject.save!
     end
 


### PR DESCRIPTION
### Context
It should be possible to add placements to trainees in the awarded or recommended states. However for non-sys-admins this was not possible due to us reusing standard permission rules - specifically the rule that says you can't edit a trainee in a completed state.

We need to special case adding placements such that a provider that would normally have permission to make changes to a trainee record can add placements regardless of the state of the trainee.

### Changes proposed in this pull request
- Adds a new permission: `TraineePolicy.write_placements?`
- Applies this policy in 2 places:
  - View logic that renders link to _Manage placements_
  - Controller logic in `ConfirmDetailsController` (for creates) and `PlacementsController` (for updates and deletes).
- Adds an assertion to verify that we don't call DQT when adding a placement.

### Guidance to review
Are there any other operations related to placements that we still need to permit?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
