### PR TITLE
Update dv_review app startup command

### DIFF
--- a/terraform/aks/workspace-variables/dv_review_aks.tfvars.json
+++ b/terraform/aks/workspace-variables/dv_review_aks.tfvars.json
@@ -10,7 +10,7 @@
   "enable_monitoring": false,
   "main_app": {
     "main": {
-      "startup_command": ["/bin/sh", "-c", "STATEMENT_TIMEOUT=90s bundle exec rails db:migrate && unset STATEMENT_TIMEOUT && bundle exec rails server -b 0.0.0.0"],
+      "startup_command": ["/bin/sh", "-c", "bundle exec rails db:environment:set RAILS_ENV=review && bundle exec rails db:schema:load && bundle exec rails server -b 0.0.0.0"],
       "probe_path": "/ping",
       "replicas": 1,
       "memory_max": "1Gi"


### PR DESCRIPTION
### Context
When deploying to dev cluster, the app fails with:

```
bin/rails aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

Undeclared attribute type for enum 'training_route'. Enums must be backed by a database column or declared with an explicit type via `attribute`.
/app/db/migrate/20210118132920_regenerate_slugs_on_trainees.rb:5:in `up'

Caused by:
Undeclared attribute type for enum 'training_route'. Enums must be backed by a database column or declared with an explicit type via `attribute`.
/app/db/migrate/20210118132920_regenerate_slugs_on_trainees.rb:5:in `up'
Tasks: TOP => db:migrate
```

### Changes proposed in this pull request
Make it the same as the review apps

### Guidance to review
Deployed to dev cluster 1: https://register-111111.cluster1.development.teacherservices.cloud/

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
