### PR TITLE
[6538] Allow providers to manage placements for HESA imported trainees

### DIFF
--- a/app/policies/trainee_policy.rb
+++ b/app/policies/trainee_policy.rb
@@ -110,9 +110,7 @@ class TraineePolicy
   def write_placements?
     return false if user_is_read_only?
 
-    user_is_system_admin? || (
-      user_in_provider_context? && (!trainee.hesa_record? || trainee.hesa_editable?)
-    )
+    user_is_system_admin? || user_in_provider_context?
   end
 
 private

--- a/spec/policies/trainee_policy_spec.rb
+++ b/spec/policies/trainee_policy_spec.rb
@@ -66,6 +66,16 @@ describe TraineePolicy do
     end
   end
 
+  permissions :write_placements? do
+    context "when the trainee is a HESA record in awarded state" do
+      let(:awarded_hesa_trainee) do
+        create(:trainee, :awarded, provider: provider, hesa_id: "XXX123")
+      end
+
+      it { is_expected.to permit(provider_user, awarded_hesa_trainee) }
+    end
+  end
+
   permissions :withdraw? do
     context "when trainee is deferred?" do
       before do


### PR DESCRIPTION
Including for trainees that are already QTS-awarded and regardless of whether they’ve been enabled for editing.

### Context

We think that HEI users should be able to manage placement data, including for trainees that are already QTS-awarded and regardless of whether they’ve been enabled for editing.

Trello: https://trello.com/c/jHVfmliV/6538-enable-placement-add-edit-delete-for-hesa-imported-trainees

### Changes proposed in this pull request

Update policy to allow editing of placements for all trainees as long as the user is in the appropriate context.

### Guidance to review

- Log in as an HEI user (not an admin user)
- Filter trainees as HESA-imported and QTS-awarded
- Check you can edit placements

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
