### PR TITLE
[6543] Include multiple placement events in timeline

### DIFF
--- a/app/services/trainees/create_timeline.rb
+++ b/app/services/trainees/create_timeline.rb
@@ -41,9 +41,22 @@ module Trainees
 
     # The audited gem creates multiple audits when multiple associations are
     # created e.g. when a user saves more than one disability for a trainee.
-    # For now, just show one 'create' timeline entry.
+    # For now, just show one 'create' timeline entry unless the group contains
+    # placement entries in which case we show all.
     def grouped_audits
-      audits.includes(:user, :auditable).group_by(&:request_uuid).map { |_, audits| audits.first }
+      audits
+        .includes(:user, :auditable)
+        .group_by(&:request_uuid)
+        .map { |_, audits| first_or_placements(audits) }
+        .flatten
+    end
+
+    def first_or_placements(audits)
+      if audits.any? { |audit| audit.auditable_type == Placement.name }
+        audits
+      else
+        audits.first
+      end
     end
 
     def audits

--- a/spec/services/trainees/create_timeline_spec.rb
+++ b/spec/services/trainees/create_timeline_spec.rb
@@ -90,6 +90,23 @@ module Trainees
           expect(subject.count).to eq(4)
         end
       end
+
+      context "when multiple placements have been created in the same request" do
+        let(:trainee) { create(:trainee) }
+
+        before do
+          create(:placement, trainee:)
+          create(:placement, trainee:)
+          trainee.update_column(:submitted_for_trn_at, 1.day.ago)
+          ::Audited::Audit.where(auditable_type: Placement.name).update_all(request_uuid: SecureRandom.uuid)
+          reload_audits
+        end
+
+        it "returns all the placement events" do
+          expect(trainee.own_and_associated_audits.where(auditable_type: Placement.name).count).to eq(2)
+          expect(subject.count).to eq(3)
+        end
+      end
     end
 
     def update_name


### PR DESCRIPTION
### Context
We filter the timeline to only include the last audit entry in each set grouped by `request_uuid`. This means that if, say, you add two placements at a time then you'll only see the last one in the timeline. This is a bug for placements.

### Changes proposed in this pull request
We solve that here by special casing placement audit entries and returning all entries for a given `request_uuid` if one or more of those entries relates to a `Placement`.

#### Before
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/478060ca-82de-4ff5-94f0-52fe20f204de)

#### After
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/65bb1525-0830-4d6e-a378-d6dc9bf96c08)

### Guidance to review
Is there a more elegant way to fix this?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
