### PR TITLE
[6500] Fix some layout issues with error messages

### DIFF
--- a/app/views/trainees/contact_details/edit.html.erb
+++ b/app/views/trainees/contact_details/edit.html.erb
@@ -4,13 +4,15 @@
   <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
 <% end %>
 
-<%= render TraineeName::View.new(@trainee) %>
-<h1 class="govuk-heading-l">Contact details</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= register_form_with(model: @contact_details_form, url: trainee_contact_details_path(@trainee), method: :put, local: true) do |f| %>
+
       <%= f.govuk_error_summary %>
+
+      <%= render TraineeName::View.new(@trainee) %>
+      <h1 class="govuk-heading-l">Contact details</h1>
+
       <%= f.govuk_email_field :email,
                               hint: { text: t(".email.hint")},
                               width: "two-thirds",

--- a/app/views/trainees/placements/details/edit.html.erb
+++ b/app/views/trainees/placements/details/edit.html.erb
@@ -9,11 +9,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render TraineeName::View.new(@trainee) %>
-
     <%= register_form_with(model: @placement_detail_form, url: trainee_placements_details_path(@trainee), method: :put, local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
+      <%= render TraineeName::View.new(@trainee) %>
       <h1 class="govuk-heading-l"><%= t('.placement_details_title') %></h1>
 
       <p class="govuk-body">


### PR DESCRIPTION
### Context
The error panels on the _Contact details_ and _Placement details_ forms are not in the correct positions. 

### Changes proposed in this pull request
#### Before

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/9554dc6f-8470-4ef8-b67a-45aac362362d)
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/ccebc23e-39da-428b-a7e8-f9d716e357ac)

#### After
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/c682e7a9-d139-4a26-ab29-09fefaac9d75)
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/ae64ce1e-9eed-4f08-9626-3499c0aea68e)

### Guidance to review
Anything missing?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
