### PR TITLE
[6454] Fixed issue whereby values with `£` returns zero values

### DIFF
--- a/app/services/concerns/has_amounts_in_pence.rb
+++ b/app/services/concerns/has_amounts_in_pence.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 module HasAmountsInPence
-  extend ActiveSupport::Concern
-
   def in_pence(amount_string)
     return 0 if amount_string.blank?
 
-    amount_string.gsub(",", "").to_d * 100
+    amount_string.gsub(/[£,]/, "").to_d * 100
   end
 end

--- a/spec/services/concerns/has_amounts_in_pence_spec.rb
+++ b/spec/services/concerns/has_amounts_in_pence_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe HasAmountsInPence do
+  let(:dummy_class) { Class.new { include HasAmountsInPence } }
+
+  subject { dummy_class.new.in_pence(value) }
+
+  describe "#in_pence" do
+    context "valid value" do
+      let(:value) { "£1,234.00" }
+
+      it "returns value without comma and pound sign" do
+        expect(subject).to eq(0.1234e6) # rubocop:disable Style/ExponentialNotation
+      end
+    end
+
+    context "invalid value" do
+      let(:value) { "$1" }
+
+      it "returns zero values" do
+        expect(subject).to eq(0.0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
CSV importer


### Changes proposed in this pull request
When a `£` is provided in the csv is sets the value as zero.
Remove it before conversation 



### Guidance to review

Run with a csv that has `£` and see the magic happen

```
bundle exec rake funding:import_lead_school_payment_schedules['funding.csv',2]
```


### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
