### PR TITLE
[6501] Update ITT end date to Expected end date in views

### DIFF
--- a/app/views/bulk_update/bulk_updates/_no_trainees.html.erb
+++ b/app/views/bulk_update/bulk_updates/_no_trainees.html.erb
@@ -9,10 +9,10 @@
 
 <ul class="govuk-list govuk-list--bullet">
   <li>
-    an estimated end date in the past 6 months or the next 6 months
+    an expected end date in the past 6 months or the next 6 months
   </li>
   <li>
-    no estimated end date
+    no expected end date
   </li>
 </ul>
 

--- a/app/views/guidance/_course_details.html.erb
+++ b/app/views/guidance/_course_details.html.erb
@@ -36,7 +36,7 @@
     <td class="govuk-table__cell">expected_end_date<br>end_academic_year</td>
     <td class="govuk-table__cell">Expected end date</td>
     <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c23053/e/expectedenddate">EXPECTEDENDDATE</a> (expected end date)</td>
-    <td class="govuk-table__cell">You must submit this data even though it’s optional in HESA. If you do not add it, we’ll use the trainee’s ITT start date (COMDATE), training route (ENTRYRTE) and if they’re full or part time (MODE) to work out the Expected end date.</td>
+    <td class="govuk-table__cell">You must submit this data even though it’s optional in HESA. If you do not add it, we’ll use the trainee’s ITT start date (COMDATE), training route (ENTRYRTE) and if they’re full or part time (MODE) to work out the expected end date.</td>
   </tr>
   </tbody>
 </table>

--- a/app/views/guidance/_course_details.html.erb
+++ b/app/views/guidance/_course_details.html.erb
@@ -34,9 +34,9 @@
   </tr>
   <tr class="govuk-table__row">
     <td class="govuk-table__cell">expected_end_date<br>end_academic_year</td>
-    <td class="govuk-table__cell">ITT end date</td>
+    <td class="govuk-table__cell">Expected end date</td>
     <td class="govuk-table__cell"><a class="govuk-link" href="https://www.hesa.ac.uk/collection/c23053/e/expectedenddate">EXPECTEDENDDATE</a> (expected end date)</td>
-    <td class="govuk-table__cell">You must submit this data even though it’s optional in HESA. If you do not add it, we’ll use the trainee’s ITT start date (COMDATE), training route (ENTRYRTE) and if they’re full or part time (MODE) to work out the ITT end date.</td>
+    <td class="govuk-table__cell">You must submit this data even though it’s optional in HESA. If you do not add it, we’ll use the trainee’s ITT start date (COMDATE), training route (ENTRYRTE) and if they’re full or part time (MODE) to work out the Expected end date.</td>
   </tr>
   </tbody>
 </table>

--- a/app/views/guidance/bulk_recommend_trainees.md
+++ b/app/views/guidance/bulk_recommend_trainees.md
@@ -30,14 +30,14 @@ Once you have signed into Register, you can [access the bulk recommendation feat
 
 The CSV file includes data for all trainees who have both a teacher reference number (TRN) and either:
 
-- an estimated end date in the past 6 months or the next 6 months
-- no estimated end date
+- an expected end date in the past 6 months or the next 6 months
+- no expected end date
 
 The CSV file does not include trainees who have deferred or withdrawn.
 
-If a trainee’s estimated end date is not in the period covered by the CSV file, you can choose to either:
+If a trainee’s expected end date is not in the period covered by the CSV file, you can choose to either:
 
-- update their estimated end date so that it’s in the past 6 months or the next 6 months
+- update their expected end date so that it’s in the past 6 months or the next 6 months
 - recommend them for QTS or EYTS from within their individual trainee record
 
 ### 3. Fill in the date when each trainee met QTS or EYTS standards
@@ -48,7 +48,7 @@ You can only bulk recommend trainees who met the QTS or EYTS standards in the pa
 
 If a trainee has not met the standards, you can choose to either:
 
-- delete the row 
+- delete the row
 - leave the date blank in the CSV file
 
 Do not make any other changes to the CSV file.
@@ -60,11 +60,11 @@ You’ll get an error message when you upload the CSV file if you:
 - entered a date which cannot be accepted, such as a date in the future
 - edited any data in the CSV (you cannot change trainee or course details using this process)
 
-If there are any errors in the CSV file, you’ll be able to download a version showing the errors. 
+If there are any errors in the CSV file, you’ll be able to download a version showing the errors.
 
 You can choose to either:
 
-- fix the errors 
+- fix the errors
 - skip the errors and continue
 
 If you skip the errors, you’ll only be able to recommend trainees whose data does not have errors. You can fix the
@@ -74,4 +74,4 @@ errors later and recommend the trainees.
 
 After you submit your recommendations, the Teaching Regulation Agency (TRA) will award the trainees with QTS or EYTS within 3 working days.
 
-The DfE will later send an email to the trainees to tell them that their certificates are available to download from the Access your Teacher Qualifications service. 
+The DfE will later send an email to the trainees to tell them that their certificates are available to download from the Access your Teacher Qualifications service.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,7 +271,7 @@ en:
       subject: Subject
       age_range: Age range
       itt_start_date: ITT start date
-      itt_end_date: ITT end date
+      itt_end_date: Expected end date
       route: Training route
       course_details: Course details
       details_not_on_publish: Course details added manually
@@ -535,7 +535,7 @@ en:
           course_uuid: Course updated
           course_max_age: Course age range updated
           itt_start_date: &itt_start_date ITT start date
-          itt_end_date: &itt_end_date ITT end date
+          itt_end_date: &itt_end_date Expected end date
           course_subject_one: Course subject updated
           trainee_start_date: Trainee start date updated
           trainee_id: Trainee ID updated
@@ -1042,7 +1042,7 @@ en:
       level: Level
       age_range: Age range
       itt_start_date: ITT start date
-      itt_end_date: ITT end date
+      itt_end_date: Expected end date
       duration: Duration
       study_mode: Full time or part time
       course_details: Course details
@@ -1345,7 +1345,7 @@ en:
     attributes:
       course_details_form:
         itt_start_date: &itt_start_date ITT start date
-        itt_end_date: &itt_end_date ITT end date
+        itt_end_date: &itt_end_date Expected end date
       itt_dates_form:
         itt_start_date: *itt_start_date
         itt_end_date: *itt_end_date
@@ -1627,11 +1627,11 @@ en:
               not_within_academic_cycle_description: The ITT start date is for a different academic year than the selected course. Enter a valid start date or <a class="govuk-link" href="%{url}">choose a different year</a>.
               hint_html: For example, 11 9 %{year}
             end_date:
-              blank: Enter an ITT end date
-              future: Enter an ITT end date closer to today
-              invalid: Enter a valid ITT end date
-              too_old: Enter a valid ITT end date
-              before_or_same_as_start_date: The ITT end date must be after the start date
+              blank: Enter an Expected end date
+              future: Enter an Expected end date closer to today
+              invalid: Enter a valid Expected end date
+              too_old: Enter a valid Expected end date
+              before_or_same_as_start_date: The Expected end date must be after the start date
               hint_html: For example, 11 6 %{year}
         course_details_form:
           attributes:
@@ -1659,11 +1659,11 @@ en:
                 <p class="govuk-body govuk-hint">The start date of the Initial Teacher Training part of their course.</p>
                 <p class="govuk-body govuk-hint">For example, 11 3 %{year}</p>
             itt_end_date:
-              blank: Enter an ITT end date
-              future: Enter an ITT end date closer to today
-              invalid: Enter a valid ITT end date
-              too_old: Enter a valid ITT end date
-              before_or_same_as_start_date: The ITT end date must be after the start date
+              blank: Enter an Expected end date
+              future: Enter an Expected end date closer to today
+              invalid: Enter a valid Expected end date
+              too_old: Enter a valid Expected end date
+              before_or_same_as_start_date: The Expected end date must be after the start date
               hint_html:
                 <p class="govuk-body govuk-hint">The end date of the Initial Teacher Training part of their course.</p>
                 <p class="govuk-body govuk-hint">For example, 11 3 %{year}</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1627,11 +1627,11 @@ en:
               not_within_academic_cycle_description: The ITT start date is for a different academic year than the selected course. Enter a valid start date or <a class="govuk-link" href="%{url}">choose a different year</a>.
               hint_html: For example, 11 9 %{year}
             end_date:
-              blank: Enter an Expected end date
-              future: Enter an Expected end date closer to today
-              invalid: Enter a valid Expected end date
-              too_old: Enter a valid Expected end date
-              before_or_same_as_start_date: The Expected end date must be after the start date
+              blank: Enter an expected end date
+              future: Enter an expected end date closer to today
+              invalid: Enter a valid expected end date
+              too_old: Enter a valid expected end date
+              before_or_same_as_start_date: The expected end date must be after the start date
               hint_html: For example, 11 6 %{year}
         course_details_form:
           attributes:

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -46,7 +46,7 @@ module CourseDetails
       end
 
       it "renders missing hint for ITT end date" do
-        expect(rendered_component).to have_css(".govuk-summary-list__value", text: "Expected end date is missing")
+        expect(rendered_content).to have_css(".govuk-summary-list__value", text: "Expected end date is missing")
       end
     end
 

--- a/spec/components/course_details/view_spec.rb
+++ b/spec/components/course_details/view_spec.rb
@@ -46,7 +46,7 @@ module CourseDetails
       end
 
       it "renders missing hint for ITT end date" do
-        expect(rendered_content).to have_css(".govuk-summary-list__value", text: "ITT end date is missing")
+        expect(rendered_component).to have_css(".govuk-summary-list__value", text: "Expected end date is missing")
       end
     end
 

--- a/spec/support/features/course_details_steps.rb
+++ b/spec/support/features/course_details_steps.rb
@@ -76,7 +76,7 @@ module Features
     end
 
     def and_i_see_itt_end_date_missing_error
-      expect(confirm_publish_course_details_page).to have_content("ITT end date is missing")
+      expect(confirm_publish_course_details_page).to have_content("Expected end date is missing")
     end
 
     def and_i_click_enter_answer_for_itt_end_date


### PR DESCRIPTION
### Context

https://trello.com/c/2PJ30OIv/6501-update-itt-end-date-to-expected-end-date

### Changes proposed in this pull request

Updates the ITT end date label in views to Expected end date

### Guidance to review

Head to the review app and check the following areas

- Manual course details form
- Early years course details form
- Course dates form
- Summary cards / tables
- CSV export
- Guidance

### Tech notes

There was a question in the ticket asking if we should update the db column name. If there is appetite for that then I think it's best for another ticket. As we would need to coordinate introducing a new column and safely transition over to that rather than a simple rename in the migration (which could lead to some errors with background jobs). The immediate requirement is to update the label in the views so I've just left this ticket to that. 
