### PR TITLE
[6524] Fix access to support interface when logged in via DSI fallback

### DIFF
--- a/app/lib/system_admin_constraint.rb
+++ b/app/lib/system_admin_constraint.rb
@@ -8,7 +8,17 @@ class SystemAdminConstraint
 private
 
   def system_admin?(request)
-    signin_user = DfESignInUser.load_from_session(request.session)
+    signin_user =
+      if otp_feature_enabled?
+        OtpSignInUser.load_from_session(request.session)
+      else
+        DfESignInUser.load_from_session(request.session)
+      end
+
     signin_user.present? && User.system_admins.kept.exists?(email: signin_user.email)
+  end
+
+  def otp_feature_enabled?
+    Settings.features.sign_in_method == "otp"
   end
 end

--- a/app/lib/system_admin_constraint.rb
+++ b/app/lib/system_admin_constraint.rb
@@ -2,23 +2,8 @@
 
 class SystemAdminConstraint
   def matches?(request)
-    system_admin?(request)
-  end
-
-private
-
-  def system_admin?(request)
-    signin_user =
-      if otp_feature_enabled?
-        OtpSignInUser.load_from_session(request.session)
-      else
-        DfESignInUser.load_from_session(request.session)
-      end
-
-    signin_user.present? && User.system_admins.kept.exists?(email: signin_user.email)
-  end
-
-  def otp_feature_enabled?
-    Settings.features.sign_in_method == "otp"
+    signin_user = OtpSignInUser.load_from_session(request.session) ||
+      DfESignInUser.load_from_session(request.session)
+    signin_user&.system_admin?
   end
 end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -64,7 +64,7 @@ class DfESignInUser
   end
 
   def system_admin?
-    user.present? && user.system_admin?
+    !!user&.system_admin?
   end
 
 private

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -63,6 +63,10 @@ class DfESignInUser
     @user ||= user_by_uid || user_by_email
   end
 
+  def system_admin?
+    user.present? && user.system_admin?
+  end
+
 private
 
   def user_by_uid

--- a/app/models/otp_sign_in_user.rb
+++ b/app/models/otp_sign_in_user.rb
@@ -40,6 +40,10 @@ class OtpSignInUser
     )
   end
 
+  def system_admin?
+    user&.system_admin?
+  end
+
   def end_session!
     session.destroy
   end

--- a/app/models/otp_sign_in_user.rb
+++ b/app/models/otp_sign_in_user.rb
@@ -41,7 +41,7 @@ class OtpSignInUser
   end
 
   def system_admin?
-    user&.system_admin?
+    !!user&.system_admin?
   end
 
   def end_session!

--- a/spec/features/auth/otp_authentication_spec.rb
+++ b/spec/features/auth/otp_authentication_spec.rb
@@ -24,12 +24,15 @@ describe "A user authenticates via Email Sign-in" do
     ).and_return(mailer)
   end
 
-  scenario "signing in successfully", feature_sign_in_method: "otp" do
-    given_i_am_registered_as_a_user
-    and_submit_my_email
-    and_enter_my_otp
-    then_i_am_redirected_to_the_root_path
-    and_i_should_see_the_link_to_sign_out
+  context "as a non-system admin" do
+    scenario "signing in successfully", feature_sign_in_method: "otp" do
+      given_i_am_registered_as_a_user
+      and_submit_my_email
+      and_enter_my_otp
+      then_i_am_redirected_to_the_root_path
+      and_i_should_see_the_link_to_sign_out
+      and_i_should_not_see_the_link_to_the_support_interface
+    end
   end
 
   context "as a system admin" do
@@ -72,6 +75,10 @@ private
 
   def and_i_should_see_the_link_to_the_support_interface
     expect(page).to have_content("Support for Register")
+  end
+
+  def and_i_should_not_see_the_link_to_the_support_interface
+    expect(page).not_to have_content("Support for Register")
   end
 
   def and_i_can_access_the_support_interface

--- a/spec/features/auth/otp_authentication_spec.rb
+++ b/spec/features/auth/otp_authentication_spec.rb
@@ -32,6 +32,19 @@ describe "A user authenticates via Email Sign-in" do
     and_i_should_see_the_link_to_sign_out
   end
 
+  context "as a system admin" do
+    let!(:user) { create(:user, :system_admin, :with_otp_secret) }
+
+    scenario "signing in successfully", feature_sign_in_method: "otp" do
+      given_i_am_registered_as_a_user
+      and_submit_my_email
+      and_enter_my_otp
+      then_i_am_redirected_to_the_root_path
+      and_i_should_see_the_link_to_the_support_interface
+      and_i_can_access_the_support_interface
+    end
+  end
+
 private
 
   def given_i_am_registered_as_a_user
@@ -55,5 +68,13 @@ private
 
   def and_i_should_see_the_link_to_sign_out
     expect(page).to have_content("Sign out")
+  end
+
+  def and_i_should_see_the_link_to_the_support_interface
+    expect(page).to have_content("Support for Register")
+  end
+
+  def and_i_can_access_the_support_interface
+    click_link("Support for Register")
   end
 end

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -54,7 +54,7 @@ describe DfESignInUser do
       let(:system_admin) { false }
 
       it "returns false" do
-        expect(signin_user.system_admin?).to be(false)
+        expect(signin_user).not_to be_system_admin
       end
     end
 
@@ -63,7 +63,7 @@ describe DfESignInUser do
       let(:discarded_at) { 1.day.ago }
 
       it "returns false" do
-        expect(signin_user.system_admin?).to be(false)
+        expect(signin_user).not_to be_system_admin
       end
     end
 
@@ -71,7 +71,7 @@ describe DfESignInUser do
       let(:system_admin) { true }
 
       it "returns true" do
-        expect(signin_user.system_admin?).to be(true)
+        expect(signin_user).to be_system_admin
       end
     end
   end

--- a/spec/models/dfe_sign_in_user_spec.rb
+++ b/spec/models/dfe_sign_in_user_spec.rb
@@ -8,32 +8,71 @@ describe DfESignInUser do
     it "returns the DfE User when the user has signed in and has been recently active" do
       session = { "dfe_sign_in_user" => { "last_active_at" => Time.zone.now } }
 
-      user = DfESignInUser.load_from_session(session)
-      expect(user).not_to be_nil
+      signin_user = DfESignInUser.load_from_session(session)
+      expect(signin_user).not_to be_nil
     end
 
     it "returns nil when the user has signed in and has not been recently active" do
       session = { "dfe_sign_in_user" => { "last_active_at" => 1.day.ago } }
 
-      user = DfESignInUser.load_from_session(session)
+      signin_user = DfESignInUser.load_from_session(session)
 
-      expect(user).to be_nil
+      expect(signin_user).to be_nil
     end
 
     it "returns nil when the user has not signed in" do
       session = { "dfe_sign_in_user" => nil }
 
-      user = DfESignInUser.load_from_session(session)
+      signin_user = DfESignInUser.load_from_session(session)
 
-      expect(user).to be_nil
+      expect(signin_user).to be_nil
     end
 
     it "returns nil when the user does not have a last active timestamp" do
       session = { "dfe_sign_in_user" => { "last_active_at" => nil } }
 
-      user = DfESignInUser.load_from_session(session)
+      signin_user = DfESignInUser.load_from_session(session)
 
-      expect(user).to be_nil
+      expect(signin_user).to be_nil
+    end
+  end
+
+  describe "#system_admin?" do
+    let(:discarded_at) { nil }
+    let(:user) { create(:user, system_admin:, discarded_at:) }
+
+    subject(:signin_user) do
+      described_class.new(
+        dfe_sign_in_uid: user.dfe_sign_in_uid,
+        email: user.email,
+        first_name: user.first_name,
+        last_name: user.last_name,
+      )
+    end
+
+    context "when user is not a system admin" do
+      let(:system_admin) { false }
+
+      it "returns false" do
+        expect(signin_user.system_admin?).to be(false)
+      end
+    end
+
+    context "when user is a soft-deleted system admin" do
+      let(:system_admin) { true }
+      let(:discarded_at) { 1.day.ago }
+
+      it "returns false" do
+        expect(signin_user.system_admin?).to be(false)
+      end
+    end
+
+    context "when user is a system admin" do
+      let(:system_admin) { true }
+
+      it "returns true" do
+        expect(signin_user.system_admin?).to be(true)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
The guard that restricts the support interface to authenticated sysadmin users currently blocks all users logged in via the DSI fallback (OTP) authentication route.

https://trello.com/c/aozd7eKM/6524-when-logged-in-using-dsi-fallback-cannot-access-support

### Changes proposed in this pull request
Permit sysadmins to access the support interface regardless of the way that they have been authenticated.

### Guidance to review
- Does this present any loopholes?
- How should we test it? Deploy and switch on the fallback on production data?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
