### PR TITLE
[6491] - Lead schools not correctly populated from hesa data

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -136,7 +136,7 @@ module Trainees
       if NOT_APPLICABLE_SCHOOL_URNS.include?(hesa_trainee[:lead_school_urn])
         attrs.merge!(lead_school_not_applicable: true)
       else
-        attrs.merge!(lead_school: School.find_by(urn: hesa_trainee[:lead_school_urn]))
+        attrs.merge!(lead_school: School.find_by(urn: hesa_trainee[:lead_school_urn]), lead_school_not_applicable: false)
       end
 
       if hesa_trainee[:employing_school_urn].present?

--- a/db/data/20231219120311_update_hesa_trainees_with_lead_school_urn.rb
+++ b/db/data/20231219120311_update_hesa_trainees_with_lead_school_urn.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class UpdateHesaTraineesWithLeadSchoolUrn < ActiveRecord::Migration[7.1]
+  def up
+    trainees.each do |trainee|
+      lead_shool = find_lead_school(trainee)
+
+      next unless lead_shool
+
+      trainee.update(lead_shool: lead_shool, lead_school_not_applicable: false)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+private
+
+  def trainees
+    Trainee.left_joins(:hesa_students)
+           .where(lead_school_id: nil)
+           .where.not(hesa_students: { lead_school_urn: %w[900000 900010 900020 900030] })
+           .where.not(hesa_students: { lead_school_urn: nil })
+           .distinct
+  end
+
+  def find_lead_school(trainee)
+    latest_hesa_student_record = trainee.hesa_students.order(updated_at: :desc).first
+
+    return if latest_hesa_student_record&.lead_shool_urn.blank?
+
+    School.find_by(
+      urn: latest_hesa_student_record.lead_school_urn,
+      lead_shool: true,
+    )
+  end
+end

--- a/db/data/20231219120311_update_hesa_trainees_with_lead_school_urn.rb
+++ b/db/data/20231219120311_update_hesa_trainees_with_lead_school_urn.rb
@@ -19,7 +19,7 @@ private
 
   def trainees
     Trainee.left_joins(:hesa_students)
-           .where(lead_school_id: nil, lead_school_not_applicable: true)
+           .where(lead_school_id: nil, lead_school_not_applicable: true, start_academic_cycle_id: AcademicCycle.current)
            .where.not(hesa_students: { lead_school_urn: Trainees::CreateFromHesa::NOT_APPLICABLE_SCHOOL_URNS })
            .where.not(hesa_students: { lead_school_urn: nil })
            .distinct

--- a/db/data/20231219120311_update_hesa_trainees_with_lead_school_urn.rb
+++ b/db/data/20231219120311_update_hesa_trainees_with_lead_school_urn.rb
@@ -3,11 +3,11 @@
 class UpdateHesaTraineesWithLeadSchoolUrn < ActiveRecord::Migration[7.1]
   def up
     trainees.each do |trainee|
-      lead_shool = find_lead_school(trainee)
+      lead_shcool = find_lead_school(trainee)
 
-      next unless lead_shool
+      next unless lead_shcool
 
-      trainee.update(lead_shool: lead_shool, lead_school_not_applicable: false)
+      trainee.update(lead_shcool: lead_shcool, lead_school_not_applicable: false)
     end
   end
 
@@ -19,8 +19,8 @@ private
 
   def trainees
     Trainee.left_joins(:hesa_students)
-           .where(lead_school_id: nil)
-           .where.not(hesa_students: { lead_school_urn: %w[900000 900010 900020 900030] })
+           .where(lead_school_id: nil, lead_school_not_applicable: true)
+           .where.not(hesa_students: { lead_school_urn: Trainees::CreateFromHesa::NOT_APPLICABLE_SCHOOL_URNS })
            .where.not(hesa_students: { lead_school_urn: nil })
            .distinct
   end
@@ -28,11 +28,11 @@ private
   def find_lead_school(trainee)
     latest_hesa_student_record = trainee.hesa_students.order(updated_at: :desc).first
 
-    return if latest_hesa_student_record&.lead_shool_urn.blank?
+    return if latest_hesa_student_record&.lead_shcool_urn.blank?
 
     School.find_by(
       urn: latest_hesa_student_record.lead_school_urn,
-      lead_shool: true,
+      lead_shcool: true,
     )
   end
 end

--- a/db/data/20231219120311_update_hesa_trainees_with_lead_school_urn.rb
+++ b/db/data/20231219120311_update_hesa_trainees_with_lead_school_urn.rb
@@ -3,11 +3,11 @@
 class UpdateHesaTraineesWithLeadSchoolUrn < ActiveRecord::Migration[7.1]
   def up
     trainees.each do |trainee|
-      lead_shcool = find_lead_school(trainee)
+      lead_school = find_lead_school(trainee)
 
-      next unless lead_shcool
+      next unless lead_school
 
-      trainee.update(lead_shcool: lead_shcool, lead_school_not_applicable: false)
+      trainee.update(lead_school: lead_school, lead_school_not_applicable: false)
     end
   end
 
@@ -28,11 +28,11 @@ private
   def find_lead_school(trainee)
     latest_hesa_student_record = trainee.hesa_students.order(updated_at: :desc).first
 
-    return if latest_hesa_student_record&.lead_shcool_urn.blank?
+    return if latest_hesa_student_record&.lead_school_urn.blank?
 
     School.find_by(
       urn: latest_hesa_student_record.lead_school_urn,
-      lead_shcool: true,
+      lead_school: true,
     )
   end
 end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -82,6 +82,19 @@ module Trainees
         expect(trainee.training_initiative).to eq(ROUTE_INITIATIVES_ENUMS[:maths_physics_chairs_programme_researchers_in_schools])
       end
 
+      context "when lead_school_not_applicable was previously set to true" do
+        before do
+          trainee.update(lead_school_not_applicable: true, lead_school_id: nil)
+          described_class.call(hesa_trainee: student_attributes, record_source: record_source)
+          trainee.reload
+        end
+
+        it "updates the trainee's lead_school and lead_school_not_applicable state" do
+          expect(trainee.lead_school.urn).to eq(student_attributes[:lead_school_urn])
+          expect(trainee.lead_school_not_applicable).to be false
+        end
+      end
+
       it "updates the trainee's funding details" do
         expect(trainee.applying_for_bursary).to be(false)
         expect(trainee.applying_for_grant).to be(false)


### PR DESCRIPTION
### Context

There are some School Direct tuition fee trainees at MMU that show as lead school “not applicable” in Register. However, in the admin section of their record in the HESA drop down can see the lead school URN provided.

### Changes proposed in this pull request

* fixes a suspected bug where `lead_school_not_applicable` once set to `true` prevents subsequent HESA updates from assigning a `lead_school` to a trainee owing to a `before_save` hook `before_save :clear_lead_school_id, if: :lead_school_not_applicable?`
* adds a migration to backfill any `trainee` with nil `lead_school` with `lead_scool_urn` present in the `hesa_students` table.