### PR TITLE
[6438] Refactor pending trns page to include trn response

### DIFF
--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -1,0 +1,10 @@
+.govuk-accordion__section-content .system-admin-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  @include govuk-media-query($from: tablet) {
+    flex-direction: row;
+    align-items: center;
+  }
+}

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,3 +1,4 @@
+@import "accordion";
 @import "admin_feature";
 @import "application_record_card";
 @import "autocomplete";

--- a/app/helpers/support/dqt_helper.rb
+++ b/app/helpers/support/dqt_helper.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Support
+  module DqtHelper
+    def formatted_dqt_trn_response(response)
+      return if response.nil?
+
+      result = if response["error"]
+                 format_for_error(response)
+               else
+                 response
+               end
+
+      JSON.pretty_generate(result)
+    end
+
+  private
+
+    def format_for_error(response)
+      # Extract the parts of the string
+      status = response["error"][/(?<=status: )\d+/]
+      body = response["error"][/(?<=body: ).*?(?=, headers:)/]
+      headers = response["error"][/(?<=headers: ).*$/]
+
+      body = Rails.error.handle(StandardError, fallback: -> { {} }) do
+        JSON.parse(body.gsub("=>", ":"))
+      end
+
+      headers = Rails.error.handle(StandardError, fallback: -> { {} }) do
+        JSON.parse(headers.gsub("=>", ":"))
+      end
+
+      {
+        error: {
+          status: status.to_i,
+          body: body,
+          headers: headers,
+        },
+      }
+    end
+  end
+end

--- a/app/models/dqt/trn_request.rb
+++ b/app/models/dqt/trn_request.rb
@@ -34,5 +34,9 @@ module Dqt
     }
 
     validates :request_id, presence: true
+
+    def days_waiting
+      (Date.current - created_at.to_date).to_i
+    end
   end
 end

--- a/app/views/system_admin/pending_trns/index.html.erb
+++ b/app/views/system_admin/pending_trns/index.html.erb
@@ -21,10 +21,10 @@
           <div class="govuk-body">
 
             <% if trainee.dqt_trn_request.present? %>
-              <%= tag.p("#{(Date.current - trainee.dqt_trn_request.created_at.to_date).to_i} Days waiting") %>
+              <%= tag.p("#{pluralize(trainee.dqt_trn_request.days_waiting, "day")} waiting") %>
 
               <%= govuk_details(summary_text: "Request Details") do %>
-                <%= content_tag(:pre, JSON.pretty_generate(trainee.dqt_trn_request.response))  %>
+                <%= content_tag(:pre, formatted_dqt_trn_response(trainee.dqt_trn_request.response))  %>
               <% end %>
             <% end %>
 

--- a/app/views/system_admin/pending_trns/index.html.erb
+++ b/app/views/system_admin/pending_trns/index.html.erb
@@ -14,29 +14,29 @@
       <%= dqt_error %>
     <% end %>
 
-    <%= govuk_accordion do |accordion|
-      @trainees.each do |trainee|
-        accordion.section(heading_text: "#{trainee.first_names} #{trainee.last_name}") do
-          tag.div(class: "govuk-body") do
-            concat(
-              tag.p((Date.current - trainee.dqt_trn_request.created_at.to_date).to_i)
-            ) if trainee.dqt_trn_request.present?
+    <%= govuk_accordion do |accordion| %>
+      <% @trainees.each do |trainee| %>
+        <% accordion.with_section(heading_text: trainee.short_name) do  %>
 
-            concat(
-              govuk_details(summary_text: "Request Details") { concat(trainee.dqt_trn_request.response) }
-            ) if trainee.dqt_trn_request.present?
+          <div class="govuk-body">
 
-            concat(
-              tag.div(class: "system-admin-actions") do
-                concat(govuk_link_to "View trainee", trainee_personal_details_path(trainee), class: "govuk-button govuk-!-margin-bottom-0")
-                concat(govuk_button_to "Check for TRN", pending_trns_retrieve_trn_path(trainee), method: :put, class: "govuk-!-margin-0 govuk-button--secondary")
-                concat(govuk_button_to "Re-submit for TRN", pending_trns_request_trn_path(trainee), method: :put, class: "govuk-!-margin-0 govuk-button--secondary")
-              end
-            )
-          end
-        end
-      end
-    end %>
+            <% if trainee.dqt_trn_request.present? %>
+              <%= tag.p("#{(Date.current - trainee.dqt_trn_request.created_at.to_date).to_i} Days waiting") %>
+
+              <%= govuk_details(summary_text: "Request Details") do %>
+                <%= content_tag(:pre, JSON.pretty_generate(trainee.dqt_trn_request.response))  %>
+              <% end %>
+            <% end %>
+
+            <div class="system-admin-actions">
+              <%= govuk_button_link_to("View trainee", trainee_personal_details_path(trainee), class: "govuk-!-margin-bottom-0") %>
+              <%= govuk_button_to("Check for TRN", pending_trns_retrieve_trn_path(trainee), method: :put, class: "govuk-!-margin-0", secondary: true) %>
+              <%= govuk_button_to("Re-submit for TRN", pending_trns_request_trn_path(trainee), method: :put, class: "govuk-!-margin-0", secondary: true) %>
+            </div>
+          </div>
+        <% end %>
+      <% end  %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/system_admin/pending_trns/index.html.erb
+++ b/app/views/system_admin/pending_trns/index.html.erb
@@ -1,4 +1,10 @@
-<%= render PageTitle::View.new(i18n_key: "dead_jobs.index") %>
+<div class="govuk-grid-row">
+  <div class ="govuk-grid-column-two-thirds-from-desktop">
+    <%= render PageTitle::View.new(i18n_key: "pending_trns.index") %>
+
+    <h1 class="govuk-heading-l">Trainees Pending TRN</h1>
+  </div>
+</div>
 
 <div class="govuk-grid-row">
   <div class ="govuk-grid-column-full">
@@ -8,43 +14,29 @@
       <%= dqt_error %>
     <% end %>
 
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Trainees Pending TRN</caption>
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">First names</th>
-          <th scope="col" class="govuk-table__header">Last name</th>
-          <th scope="col" class="govuk-table__header">Days waiting</th>
-          <th scope="col" class="govuk-table__header" colspan="3"></th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <% @trainees.each do |trainee| %>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= trainee.first_names %></td>
-            <td class="govuk-table__cell"><%= trainee.last_name %></td>
-            <td class="govuk-table__cell">
-              <%= (Date.current - trainee.dqt_trn_request.created_at.to_date).to_i if trainee.dqt_trn_request.present? %>
-            </td>
-            <td class="govuk-table__cell">
-              <%= govuk_link_to "View", trainee_personal_details_path(trainee), class: "govuk-!-margin-0 govuk-button" %>
-            </td>
-            <td class="govuk-table__cell">
-              <%= govuk_button_to "Check for TRN",
-                                  pending_trns_retrieve_trn_path(trainee),
-                                  method: :put,
-                                  class: "govuk-!-margin-0 govuk-button--secondary" %>
-            </td>
-            <td class="govuk-table__cell">
-              <%= govuk_button_to "Re-submit for TRN",
-                                  pending_trns_request_trn_path(trainee),
-                                  method: :put,
-                                  class: "govuk-!-margin-0 govuk-button--secondary" %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <%= govuk_accordion do |accordion|
+      @trainees.each do |trainee|
+        accordion.section(heading_text: "#{trainee.first_names} #{trainee.last_name}") do
+          tag.div(class: "govuk-body") do
+            concat(
+              tag.p((Date.current - trainee.dqt_trn_request.created_at.to_date).to_i)
+            ) if trainee.dqt_trn_request.present?
+
+            concat(
+              govuk_details(summary_text: "Request Details") { concat(trainee.dqt_trn_request.response) }
+            ) if trainee.dqt_trn_request.present?
+
+            concat(
+              tag.div(class: "system-admin-actions") do
+                concat(govuk_link_to "View trainee", trainee_personal_details_path(trainee), class: "govuk-button govuk-!-margin-bottom-0")
+                concat(govuk_button_to "Check for TRN", pending_trns_retrieve_trn_path(trainee), method: :put, class: "govuk-!-margin-0 govuk-button--secondary")
+                concat(govuk_button_to "Re-submit for TRN", pending_trns_request_trn_path(trainee), method: :put, class: "govuk-!-margin-0 govuk-button--secondary")
+              end
+            )
+          end
+        end
+      end
+    end %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -339,6 +339,8 @@ en:
         show: Dead Jobs
       duplicate_apply_applications:
         index: Duplicate Apply applications
+      pending_trns:
+        index: Trainees Pending TRN
       otp:
         show: Sign in
         verify: Check your email

--- a/spec/features/system_admin/pending_trns/pending_trns_spec.rb
+++ b/spec/features/system_admin/pending_trns/pending_trns_spec.rb
@@ -16,6 +16,7 @@ feature "pending TRNs" do
     scenario "shows pending TRNs page" do
       then_i_see_the_pending_trns_page
       and_i_see_the_trainee
+      and_i_see_the_trn_request_details
     end
 
     scenario "can check for TRN" do
@@ -78,6 +79,10 @@ feature "pending TRNs" do
   def and_i_see_the_trainee
     expect(admin_pending_trns_page).to have_text(trainee.first_names)
     expect(admin_pending_trns_page).to have_text(trainee.last_name)
+  end
+
+  def and_i_see_the_trn_request_details
+    expect(admin_pending_trns_page).to have_text(trn_request.response)
   end
 
   def when_i_click_check_for_trn

--- a/spec/features/system_admin/pending_trns/pending_trns_spec.rb
+++ b/spec/features/system_admin/pending_trns/pending_trns_spec.rb
@@ -82,7 +82,7 @@ feature "pending TRNs" do
   end
 
   def and_i_see_the_trn_request_details
-    expect(admin_pending_trns_page).to have_text(trn_request.response)
+    expect(admin_pending_trns_page).to have_text(JSON.pretty_generate(trn_request.response))
   end
 
   def when_i_click_check_for_trn

--- a/spec/helpers/support/dqt_helper_spec.rb
+++ b/spec/helpers/support/dqt_helper_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Support
+  describe DqtHelper do
+    include DqtHelper
+
+    describe "#formatted_dqt_trn_response" do
+      let(:response) { nil }
+
+      context "when `response` is nil" do
+        it "returns nil" do
+          expect(helper.formatted_dqt_trn_response(response)).to be_nil
+        end
+      end
+
+      context "when `response` is error in correct format" do
+        let(:response) do
+          {
+            "error" => "status: 404, body: {\"message\"=>\"Not Found\"}, headers: {\"Content-Type\"=>\"application/json\"}",
+          }
+        end
+
+        it "returns formatted error" do
+          expect(helper.formatted_dqt_trn_response(response)).to eq(
+            JSON.pretty_generate({
+              error: {
+                status: 404,
+                body: { "message" => "Not Found" },
+                headers: { "Content-Type" => "application/json" },
+              },
+            }),
+          )
+        end
+      end
+
+      context "when `response` is error in incorrect format" do
+        let(:response) do
+          {
+            "error" => "status: 404, some_other_key: {}",
+          }
+        end
+
+        it "returns formatted error" do
+          expect(helper.formatted_dqt_trn_response(response)).to eq(
+            JSON.pretty_generate({
+              error: {
+                status: 404,
+                body: {},
+                headers: {},
+              },
+            }),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/dqt/trn_request_spec.rb
+++ b/spec/models/dqt/trn_request_spec.rb
@@ -13,5 +13,13 @@ module Dqt
     describe "validations" do
       it { is_expected.to validate_presence_of(:request_id) }
     end
+
+    describe "#days_waiting" do
+      let(:trn_request) { create(:dqt_trn_request, created_at: 2.days.ago) }
+
+      it "returns the number of days since the request was created" do
+        expect(trn_request.days_waiting).to eq(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/5qVI6mgI/6438-add-body-and-error-message-to-pending-trns-report

### Changes proposed in this pull request

Before:

<img width="1007" alt="Screenshot 2023-12-20 at 12 18 51" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/4c70ef20-2639-4553-8cf9-10259fc2f05c">

After:

<img width="1178" alt="Screenshot 2023-12-20 at 12 20 28" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/b3017a3f-2f33-427d-b734-5e6d7f75cc39">


- Refactors the pending trn page layout to list all the trainees using the govuk accordion
- Includes the trn request response details into each row for more details

### Guidance to review

If this works, we can apply to other layouts. The accordion allows us to add any type of information without layout constraints in each row if needed. We regards to filtering/sorting, we could simply have these as buttons in a sort of "toolbar" above the results which would then filter based on the query params 🤷. 
