### PR TITLE
[6524] Switch on DSI Fallback on proddata for testing

### DIFF
--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -16,7 +16,7 @@ dfe_sign_in:
 
 features:
   basic_auth: true
-  sign_in_method: dfe-sign-in
+  sign_in_method: otp
   enable_feedback_link: false
   import_courses_from_ttapi: true
   import_applications_from_apply: true


### PR DESCRIPTION


### Context
This is purely to test https://trello.com/c/aozd7eKM/6524-when-logged-in-using-dsi-fallback-cannot-access-support

We need to just deploy this, make sure that the support interface is available to those that should see it and issue a new PR to revert back.

### Changes proposed in this pull request
Switch proddata to use OTP authentication.

### Guidance to review
Is there an easier way?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
