### PR TITLE
[6477] - parse 'other' uk grade type. migrate teachfirst data

### DIFF
--- a/app/services/degrees/create_from_csv_row.rb
+++ b/app/services/degrees/create_from_csv_row.rb
@@ -103,7 +103,7 @@ module Degrees
       return @other_degree_grade if defined?(@other_degree_grade)
 
       @other_degree_grade =
-        if csv_row["Degree: UK grade"].starts_with?("#{Diversities::OTHER}:")
+        if csv_row["Degree: UK grade"]&.starts_with?("#{Diversities::OTHER}:")
           csv_row["Degree: UK grade"].split("#{Diversities::OTHER}:").last.strip
         end
     end

--- a/app/services/degrees/create_from_csv_row.rb
+++ b/app/services/degrees/create_from_csv_row.rb
@@ -7,6 +7,7 @@ module Degrees
     class Error < StandardError; end
 
     HESA_UK_COUNTRY = "United Kingdom, not otherwise specified"
+    OTHER = "Other:"
 
     def initialize(trainee:, csv_row:)
       @trainee = trainee
@@ -34,6 +35,13 @@ module Degrees
         grade: degree_grade&.name,
         grade_uuid: degree_grade&.id,
       }
+
+      if other_degree_grade
+        attrs.merge!({
+          grade: "Other",
+          other_grade: other_degree_grade,
+        })
+      end
 
       if uk_country?(country)
         attrs.merge!({
@@ -89,6 +97,15 @@ module Degrees
 
     def degree_grade
       @degree_grade ||= DfEReference::DegreesQuery.find_grade(name: csv_row["Degree: UK grade"])
+    end
+
+    def other_degree_grade
+      return @other_degree_grade if defined?(@other_degree_grade)
+
+      @other_degree_grade =
+        if csv_row["Degree: UK grade"].starts_with?("#{Diversities::OTHER}:")
+          csv_row["Degree: UK grade"].split("#{Diversities::OTHER}:").last.strip
+        end
     end
 
     def uk_degree_type

--- a/app/services/trainees/create_from_csv_row.rb
+++ b/app/services/trainees/create_from_csv_row.rb
@@ -114,7 +114,7 @@ module Trainees
       @disabilities ||=
         if csv_row["Disabilities"].nil?
           []
-        elsif csv_row["Disabilities"].start_with?(Diversities::OTHER)
+        elsif csv_row["Disabilities"].start_with?("#{Diversities::OTHER}:")
           handle_other_disability
         else
           parse_standard_disabilities

--- a/db/data/20231220151357_add_other_degree_grade_to_teach_first_trainees.rb
+++ b/db/data/20231220151357_add_other_degree_grade_to_teach_first_trainees.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class AddOtherDegreeGradeToTeachFirstTrainees < ActiveRecord::Migration[7.1]
+  def up
+    Service.new.call
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  class Service
+    def call
+      entries.each do |trainee_id, grade|
+        trainee = teach_first_trainees.where(trainee_id:).first
+
+        next unless trainee
+
+        degree = trainee.degrees.first
+
+        next unless degree
+
+        update_degree(degree, grade)
+      end
+    end
+
+  private
+
+    def update_degree(degree, grade)
+      other_grade = grade.split("Other:").last.strip
+
+      degree.update(grade: "Other", other_grade: other_grade)
+    end
+
+    def teach_first_trainees
+      @_teach_first_trainees ||= Provider.find_by(code: Provider::TEACH_FIRST_PROVIDER_CODE).trainees
+    end
+
+    def entries
+      @entries ||= [
+        ["0034K00000jkU7BQAU", "Other: Estimated 2.1/2.2 (Open university has a different way of assessing results and it is very hard to estimate)"],
+        ["0034K00000itEmUQAU", "Other: 1st or 2:1"],
+        ["0038e0000092mfVAAQ", "Other: Expected 1st"],
+        ["0038e000009stlzAAA", "Other: second class Honours (2nd Division) (Top up based on master degree)"],
+        ["0038e00000CuixpAAB", "Other: Pass"],
+        ["0038e00000CuTnvAAF", "Other: Diploma of Higher Education"],
+        ["0038e00000DfJEoAAN", "Other: General"],
+        ["0038e00000939CtAAI", "Other: Merit"],
+        ["0038e000009384yAAA", "Other: Distinction"],
+      ]
+    end
+  end
+end

--- a/db/data/20231220151357_add_other_degree_grade_to_teach_first_trainees.rb
+++ b/db/data/20231220151357_add_other_degree_grade_to_teach_first_trainees.rb
@@ -12,15 +12,10 @@ class AddOtherDegreeGradeToTeachFirstTrainees < ActiveRecord::Migration[7.1]
   class Service
     def call
       entries.each do |trainee_id, grade|
-        trainee = teach_first_trainees.where(trainee_id:).first
+        trainee = teach_first_trainees.find_by(trainee_id:)
+        degree = trainee&.degrees&.first
 
-        next unless trainee
-
-        degree = trainee.degrees.first
-
-        next unless degree
-
-        update_degree(degree, grade)
+        update_degree(degree, grade) if degree
       end
     end
 

--- a/spec/data_migrations/add_other_degree_grade_to_teach_first_trainees_spec.rb
+++ b/spec/data_migrations/add_other_degree_grade_to_teach_first_trainees_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/data/20231220151357_add_other_degree_grade_to_teach_first_trainees.rb")
+
+describe AddOtherDegreeGradeToTeachFirstTrainees::Service do
+  let(:teach_first_provider) { create(:provider, :teach_first) }
+  let(:degree) { create(:degree) }
+  let(:trainee) { create(:trainee, provider: teach_first_provider, degrees: [degree]) }
+  let(:grade) { "Other: Diploma of Higher Education" }
+  let(:service) { described_class.new }
+
+  before do
+    allow(service).to receive(:entries).and_return([[trainee.trainee_id, grade]])
+    service.call
+  end
+
+  it "updates the trainee with the correct grade" do
+    expect(trainee.degrees.first.reload.other_grade).to eql "Diploma of Higher Education"
+    expect(trainee.degrees.first.grade).to eql "Other"
+  end
+end

--- a/spec/services/degrees/create_from_csv_row_spec.rb
+++ b/spec/services/degrees/create_from_csv_row_spec.rb
@@ -4,23 +4,68 @@ require "rails_helper"
 
 module Degrees
   describe CreateFromCsvRow do
-    subject(:service) { described_class.call(trainee: trainee, csv_row: csv.first) }
+    subject(:service) { described_class.call(trainee:, csv_row:) }
 
     let(:trainee) { create(:trainee) }
     let(:degree) { trainee.degrees.first }
-    let(:csv) do
+    let(:csv_row) do
       CSV.read(
         file_fixture("hpitt_degree_import.csv").to_path,
         headers: true,
         encoding: "ISO-8859-1",
         header_converters: ->(f) { f&.strip },
-      )
+      ).first
     end
 
     describe "#call" do
       it "attaches a degree to the trainee" do
         service
         expect(degree.subject).to eql "Philosophy"
+      end
+
+      context "with \"other\" degree grade" do
+        let(:csv_row) do
+          {
+            "Provider trainee ID" => "A2",
+            "Region" => "London",
+            "First names" => "Adam",
+            "Middle names" => nil,
+            "Last names" => "Test",
+            "Date of birth" => "21/09/1997",
+            "Sex" => "Male",
+            "Nationality" => "british",
+            "UK address: Line 1" => "99 Lovely Road",
+            "UK address: Line 2" => nil,
+            "UK address: town or city" => "Oxford",
+            "UK Address 1: Postcode" => "OX41RG",
+            "Outside UK address" => nil,
+            "Email" => "adam.test@gmail.com",
+            "Ethnicity" => "White - English, Scottish, Welsh, Northern Irish or British",
+            "Disabilities" => "Not provided",
+            "Course level" => nil,
+            "Course education phase" => "Secondary",
+            "Course age range" => "11 to 16",
+            "Course ITT subject 1" => "Mathematics",
+            "Course ITT subject 2" => nil,
+            "Course ITT Subject 3" => nil,
+            "Course study mode" => "full-time",
+            "Course ITT start date" => "2022-09-09",
+            "Course Expected End Date" => "31/07/2023",
+            "Trainee start date" => "09/09/2022",
+            "Employing school URN" => "131609",
+            "Degree: country" => "United Kingdom",
+            "Degree: subjects" => "Philosophy, Politics, Economics",
+            "Degree: UK degree types" => "Bachelor of Arts",
+            "Degree: UK awarding institution" => "University of Oxford",
+            "Degree: UK grade" => "Other: Diploma of Higher Education",
+            "Degree: Non-UK degree types" => nil, "Degree: graduation year" => "2018"
+          }
+        end
+
+        it "saves the other degree grade" do
+          service
+          expect(degree.other_grade).to eql "Diploma of Higher Education"
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

The CSV teachfirst import previously was unable to parse `Degree: UK grade` that followed the `Other: other grade` pattern. this fixes this and includes a migration to correct teachfirst trainees impacted.