### PR TITLE
[6487] Throttle OTP generation requests (DSI fallback)

### DIFF
--- a/app/controllers/otp_controller.rb
+++ b/app/controllers/otp_controller.rb
@@ -18,7 +18,7 @@ class OtpController < ApplicationController
 private
 
   def otp_form
-    @otp_form ||= OtpForm.new(email)
+    @otp_form ||= OtpForm.new(session:, email:)
   end
 
   def email

--- a/app/forms/concerns/throttle_requests.rb
+++ b/app/forms/concerns/throttle_requests.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module ThrottleRequests
+  extend ActiveSupport::Concern
+  include ActionView::Helpers::DateHelper
+
+  attr_reader :attempts, :last_attempt, :session
+
+  included do
+    validate :cool_down?
+  end
+
+  def initialize(session:)
+    @session = session
+    @attempts = session[attempts_key] = session[attempts_key] || 0
+    @last_attempt = session[last_attempt_key] = session[last_attempt_key] || Time.zone.now
+  end
+
+private
+
+  def cool_down?
+    # Add error message if the user has not yet reached their
+    # cool off time.
+    if Time.zone.now < (last_attempt + cool_down_time)
+      raise_throttle_error
+    # Otherwise incement their attempts and reset the last attempt
+    # if they submitted a code
+    else
+      session[attempts_key] += 1
+      session[last_attempt_key] = Time.zone.now
+    end
+  end
+
+  def cool_down_message
+    @cool_down_message ||= "Please wait #{time_left} before trying again"
+  end
+
+  # increase cool off then default to 1 hour
+  def cool_down_time
+    @cool_down_time ||= ([0, 0, 0, 0, 0, 60, 300, 600][attempts] || 3600).seconds
+  end
+
+  def time_left
+    @time_left ||=  time_ago_in_words(((last_attempt + cool_down_time) - Time.zone.now).seconds.from_now)
+  end
+
+  def attempts_key
+    @attempts_key ||= :"#{self.class.to_s.underscore}_attempts"
+  end
+
+  def last_attempt_key
+    @last_attempt_key ||= :"#{self.class.to_s.underscore}_last_attempt"
+  end
+end

--- a/app/forms/concerns/throttle_requests.rb
+++ b/app/forms/concerns/throttle_requests.rb
@@ -23,7 +23,7 @@ private
     # cool off time.
     if Time.zone.now < (last_attempt + cool_down_time)
       raise_throttle_error
-    # Otherwise incement their attempts and reset the last attempt
+    # Otherwise increment their attempts and reset the last attempt
     # if they submitted a code
     else
       session[attempts_key] += 1

--- a/app/forms/otp_form.rb
+++ b/app/forms/otp_form.rb
@@ -2,15 +2,23 @@
 
 class OtpForm
   include ActiveModel::Model
+  include ThrottleRequests
+
+  attr_reader :email
 
   validates :email, presence: true, length: { maximum: 255 }
   validate do |record|
     ::EmailFormatValidator.new(record).validate if email.present?
   end
 
-  def initialize(email)
+  def initialize(session:, email:)
+    @session = session
     @email = email&.strip
+
+    super(session:)
   end
 
-  attr_reader :email
+  def raise_throttle_error
+    errors.add(:email, cool_down_message)
+  end
 end

--- a/app/forms/otp_verifications_form.rb
+++ b/app/forms/otp_verifications_form.rb
@@ -2,9 +2,8 @@
 
 class OtpVerificationsForm
   include ActiveModel::Model
-  include ActionView::Helpers::DateHelper
+  include ThrottleRequests
 
-  validate :cool_down?
   validates :code, presence: true
   validate :code_is_correct?
 
@@ -14,13 +13,13 @@ class OtpVerificationsForm
 
     @user = User.find_by(email: session[:otp_email])
     @salt = session[:otp_salt]
-    @attempts = session[:otp_attempts] = session[:otp_attempts] || 0
-    @last_attempt = session[:otp_last_attempt] = session[:otp_last_attempt] || Time.zone.now
+
+    super(session:)
   end
 
 private
 
-  attr_reader :session, :code, :user, :salt, :attempts, :last_attempt
+  attr_reader :session, :code, :user, :salt
 
   # 600 = 10 mins validity
   def code_is_correct?
@@ -31,33 +30,11 @@ private
     end
   end
 
-  def cool_down?
-    # Add error message if the user has not yet reached their
-    # cool off time.
-    if Time.zone.now < (last_attempt + cool_down_time)
-      errors.add(:code, cool_down_message)
-    # Otherwise incement their attempts and reset the last attempt
-    # if they submitted a code
-    elsif code.present?
-      session[:otp_attempts] += 1
-      session[:otp_last_attempt] = Time.zone.now
-    end
-  end
-
-  def cool_down_message
-    @cool_down_message ||= "Please wait #{time_left} before trying again"
-  end
-
-  # increase cool off then default to 1 hour
-  def cool_down_time
-    @cool_down_time ||= ([0, 0, 0, 0, 0, 60, 300, 600][attempts] || 3600).seconds
-  end
-
-  def time_left
-    @time_left ||=  time_ago_in_words(((last_attempt + cool_down_time) - Time.zone.now).seconds.from_now)
-  end
-
   def totp
     ROTP::TOTP.new(user.otp_secret + salt, issuer: "Register")
+  end
+
+  def raise_throttle_error
+    errors.add(:code, cool_down_message)
   end
 end

--- a/spec/forms/otp_verifications_form_spec.rb
+++ b/spec/forms/otp_verifications_form_spec.rb
@@ -15,15 +15,15 @@ describe OtpVerificationsForm, type: :model do
 
   let(:otp_salt) { ROTP::Base32.random(16) }
   let(:otp_email) { Faker::Internet.email }
-  let(:otp_attempts) { 0 }
-  let(:otp_last_attempt) { Time.zone.now }
+  let(:otp_verifications_form_attempts) { 0 }
+  let(:otp_verifications_form_last_attempt) { Time.zone.now }
 
   let(:session) do
     {
       otp_salt:,
       otp_email:,
-      otp_attempts:,
-      otp_last_attempt:,
+      otp_verifications_form_attempts:,
+      otp_verifications_form_last_attempt:,
     }
   end
 
@@ -33,13 +33,13 @@ describe OtpVerificationsForm, type: :model do
 
       describe "validating cool down" do
         context "when should not cool down" do
-          let(:otp_attempts) { 0 }
+          let(:otp_verifications_form_attempts) { 0 }
 
           it { expect(error_message).not_to include "Please wait 1 minute before trying again" }
         end
 
         context "when should cool down" do
-          let(:otp_attempts) { 5 }
+          let(:otp_verifications_form_attempts) { 5 }
 
           it { expect(error_message).to include "Please wait 1 minute before trying again" }
         end
@@ -80,13 +80,13 @@ describe OtpVerificationsForm, type: :model do
     context "without a user" do
       describe "validating cool down" do
         context "when should not cool down" do
-          let(:otp_attempts) { 0 }
+          let(:otp_verifications_form_attempts) { 0 }
 
           it { expect(error_message).not_to include "Please wait 1 minute before trying again" }
         end
 
         context "when should cool down" do
-          let(:otp_attempts) { 5 }
+          let(:otp_verifications_form_attempts) { 5 }
 
           it { expect(error_message).to include "Please wait 1 minute before trying again" }
         end


### PR DESCRIPTION
### Context
Our IT Health Check highlighted potential malicious requests to the OTP generation form. 

### Changes proposed in this pull request
`OtpVerificationsForm` already implements a mechanism to prevent too many repeated attempts to submit an OTP code (to limit the number of guesses a malicious user gets). So I've extracted that throttling logic into a `ThrottleRequests` concern and reused it in `OtpForm` to limit the number of OTP generation requests a user can make.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/d538e0f4-e181-423a-ab73-51e82550d0d9)

### Guidance to review
Is there a better way?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
