### PR TITLE
[6527] Enable performance/profile monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem "discard", "~> 1.3"
 gem "sentry-rails"
 gem "sentry-ruby"
 gem "sentry-sidekiq"
+gem "stackprof"
 
 # Logging
 gem "amazing_print", "~> 1.5"
@@ -188,7 +189,6 @@ group :development do
   gem "flamegraph"
   gem "memory_profiler"
   gem "rack-mini-profiler", require: false
-  gem "stackprof"
 end
 
 group :test do

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,5 +5,8 @@ Sentry.init do |config|
   config.before_send = lambda do |event, _hint|
     filter.filter(event.to_hash)
   end
+
+  config.traces_sample_rate = 0.1
+  config.profiles_sample_rate = 0.1
   config.release = ENV.fetch("COMMIT_SHA", nil)
 end


### PR DESCRIPTION
### Context

Enables Sentry's performance and profile monitoring so we can setup some anomaly alerts around this category. Start with a low `traces_sample_rate` rate. We'll assess how noisy it is in Sentry and adjust accordingly. 
