### PR TITLE
Allow up to 5 placement URN columns in bulk update CSV

### DIFF
--- a/app/models/reports/bulk_placement_report.rb
+++ b/app/models/reports/bulk_placement_report.rb
@@ -2,7 +2,7 @@
 
 module Reports
   class BulkPlacementReport < TemplateClassCsv
-    PLACEMENT_HEADERS = Array.new(BulkUpdate::Placements::Config::MAX_PLACEMENTS) { |i| "Placement #{i + 1} URN" }.freeze
+    PLACEMENT_HEADERS = Array.new(BulkUpdate::Placements::Config::DEFAULT_NUM_PLACEMENTS) { |i| "Placement #{i + 1} URN" }.freeze
 
     HEADERS = [
       "TRN",

--- a/app/models/reports/bulk_placement_report.rb
+++ b/app/models/reports/bulk_placement_report.rb
@@ -2,7 +2,8 @@
 
 module Reports
   class BulkPlacementReport < TemplateClassCsv
-    PLACEMENT_HEADERS = Array.new(BulkUpdate::Placements::Config::DEFAULT_NUM_PLACEMENTS) { |i| "Placement #{i + 1} URN" }.freeze
+    PLACEMENT_HEADERS = (1..BulkUpdate::Placements::Config::DEFAULT_NUM_PLACEMENTS).map { |i| "Placement #{i} URN" }.freeze
+    OPTIONAL_HEADERS = ((BulkUpdate::Placements::Config::DEFAULT_NUM_PLACEMENTS + 1)..BulkUpdate::Placements::Config::MAX_PLACEMENTS).map { |i| "Placement #{i} URN" }
 
     HEADERS = [
       "TRN",

--- a/app/services/bulk_update/placements/config.rb
+++ b/app/services/bulk_update/placements/config.rb
@@ -9,7 +9,8 @@ module BulkUpdate
       VALID_URN = /^\d{6}$/ # 123456
 
       # constants
-      MAX_PLACEMENTS = 2 # number of "Placement <n> URN" columns given to user to fill
+      DEFAULT_NUM_PLACEMENTS = 2 # number of "Placement <n> URN" columns given to user to fill
+      MAX_PLACEMENTS = 5 # number of "Placement <n> URN" columns we allow in the CSV
       ENCODING = "UTF-8"
       FIRST_CSV_ROW_NUMBER = 2
       CSV_ARGS = { headers: true, header_converters: :downcase, strip: true, encoding: ENCODING }.freeze

--- a/app/services/bulk_update/placements/validate_csv.rb
+++ b/app/services/bulk_update/placements/validate_csv.rb
@@ -17,7 +17,7 @@ module BulkUpdate
       attr_reader :csv, :record
 
       def header_row!
-        return if expected_headers.to_set == csv_headers.to_set
+        return if all_mandatory_headers? && no_extra_headers?
 
         record.errors.add(:file, :invalid_header, headers: Reports::BulkPlacementReport::HEADERS.join(", "))
       end
@@ -26,8 +26,20 @@ module BulkUpdate
         @expected_headers ||= Reports::BulkPlacementReport::HEADERS.map(&:downcase)
       end
 
+      def optional_headers
+        @optional_headers ||= Reports::BulkPlacementReport::OPTIONAL_HEADERS.map(&:downcase)
+      end
+
       def csv_headers
         @csv_headers ||= csv.headers
+      end
+
+      def all_mandatory_headers?
+        (expected_headers - csv_headers).empty?
+      end
+
+      def no_extra_headers?
+        (csv_headers - expected_headers - optional_headers).empty?
       end
     end
   end

--- a/app/views/bulk_update/bulk_updates/index.html.erb
+++ b/app/views/bulk_update/bulk_updates/index.html.erb
@@ -21,11 +21,11 @@
       </h2>
 
       <p class="govuk-body">
-        You need to include placement data as part of performance profile sign off. All registered trainees with a training status of 'awarded' in the <%= AcademicCycle.previous.label %> academic year should have 2 placements.
+        You need to include placement data as part of performance profile sign off. All registered trainees with a training status of 'awarded' in the <%= AcademicCycle.previous.label %> academic year should have at least 2 placements.
       </p>
 
       <p class="govuk-body">
-        You can bulk add missing placement data to <%= pluralize(bulk_placements_count, 'trainee record') %>. Add school placement URNs for 2 school or setting placements.
+        You can bulk add missing placement data to <%= pluralize(bulk_placements_count, "trainee record") %>. Add placement school URNs for 2 or more school or setting placements (up to a maximum of 5).
       </p>
 
       <p class="govuk-body">

--- a/spec/fixtures/files/bulk_update/placements/complete-with-extra-placements.csv
+++ b/spec/fixtures/files/bulk_update/placements/complete-with-extra-placements.csv
@@ -1,4 +1,4 @@
-TRN,Trainee ITT start date,Placement 1 URN,Placement 2 URN
+TRN,Trainee ITT start date,Placement 1 URN,Placement 2 URN,Placement 3 URN,Placement 4 URN
 Do not change this column,"When the trainee started their ITT.
 
 
@@ -25,4 +25,5 @@ URNs must be 6 digits long.
 
 If you do not know the placement school’s URN, leave the cell empty."
 1234567,2023-08-29,7823614827346,723894747382
-7654321,2023-08-28,8721398474987,273489724897
+7654321,2023-08-28,8721398474987,273489724897,999745281883
+4929008,2023-08-28,562982561839,668741619393,878892930276,853226807662

--- a/spec/fixtures/files/bulk_update/placements/complete-with-too-many-placements.csv
+++ b/spec/fixtures/files/bulk_update/placements/complete-with-too-many-placements.csv
@@ -1,0 +1,27 @@
+TRN,Trainee ITT start date,Placement 1 URN,Placement 2 URN,Placement 3 URN,Placement 4 URN,Placement 5 URN,Placement 6 URN
+Do not change this column,"When the trainee started their ITT.
+
+
+Must be written DD/MM/YYYY.
+
+
+For example, if the trainee started their ITT on 20 September 2021, write '20/09/2021'.
+
+
+The date must be in the past.
+
+
+If you do not know the trainee’s ITT start date, leave the cell empty.","The URN of the trainee’s first placement school.
+
+
+URNs must be 6 digits long.
+
+
+If you do not know the placement school’s URN, leave the cell empty.","The URN of the trainee’s second placement school.
+
+
+URNs must be 6 digits long.
+
+
+If you do not know the placement school’s URN, leave the cell empty."
+4929008,2023-08-28,562982561839,668741619393,878892930276,853226807662,123123123123,123123123123

--- a/spec/services/bulk_update/placements/create_placement_rows_spec.rb
+++ b/spec/services/bulk_update/placements/create_placement_rows_spec.rb
@@ -28,6 +28,26 @@ module BulkUpdate
             )
           end
         end
+
+        context "given a valid CSV where user has added extra URN columns" do
+          let(:file) { file_fixture("bulk_update/placements/complete-with-extra-placements.csv") }
+
+          it "creates the rows with the correct row numbers" do
+            expect(bulk_placement.rows.pluck(:trn, :csv_row_number, :urn)).to eql(
+              [
+                ["1234567", 3, "7823614827346"],
+                ["1234567", 3, "723894747382"],
+                ["7654321", 4, "8721398474987"],
+                ["7654321", 4, "273489724897"],
+                ["7654321", 4, "999745281883"],
+                ["4929008", 5, "562982561839"],
+                ["4929008", 5, "668741619393"],
+                ["4929008", 5, "878892930276"],
+                ["4929008", 5, "853226807662"],
+              ],
+            )
+          end
+        end
       end
     end
   end

--- a/spec/services/bulk_update/placements/validate_csv_spec.rb
+++ b/spec/services/bulk_update/placements/validate_csv_spec.rb
@@ -24,6 +24,21 @@ module BulkUpdate
 
         it { expect(record.errors.first.message).to eql "CSV header must include: TRN, Trainee ITT start date, Placement 1 URN, Placement 2 URN" }
       end
+
+      context "given a CSV with too many placement columns" do
+        let(:file) { file_fixture("bulk_update/placements/complete-with-too-many-placements.csv") }
+        let(:csv) { CSV.new(file.read, headers: true, header_converters: :downcase, strip: true).read }
+        let(:expected_error_message) { "CSV header must include: TRN, Trainee ITT start date, Placement 1 URN, Placement 2 URN" }
+
+        it { expect(record.errors.first.message).to eql expected_error_message }
+      end
+
+      context "given a CSV with some optional placement columns" do
+        let(:file) { file_fixture("bulk_update/placements/complete-with-extra-placements.csv") }
+        let(:csv) { CSV.new(file.read, headers: true, header_converters: :downcase, strip: true).read }
+
+        it { expect(record.errors).to be_empty }
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Some providers would like to be able to add more than two placements per trainee in the bulk upload process

### Changes proposed in this pull request

Continue to generate the placements export with just two placement URN columns, but when processing the upload, check for extra placement columns that have been added (up to a total of 5)

![CleanShot 2023-12-21 at 16 37 59@2x](https://github.com/DFE-Digital/register-trainee-teachers/assets/168365/a4170fa9-1a84-4d60-b8cf-4ae572ceed54)

### Guidance to review

Try it out.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
