### PR TITLE
[xxx] Setup cron monitoring and reduce sample rate

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,7 +6,8 @@ Sentry.init do |config|
     filter.filter(event.to_hash)
   end
 
-  config.traces_sample_rate = 0.1
-  config.profiles_sample_rate = 0.1
+  config.enabled_patches += [:sidekiq_cron]
+  config.traces_sample_rate = 0.05
+  config.profiles_sample_rate = 0.05
   config.release = ENV.fetch("COMMIT_SHA", nil)
 end


### PR DESCRIPTION
### Context

Register uses a lot of mission critical cron jobs. Sentry can monitor those and let us know information about their status. We should probably turn that on. Have also reduced the sample rate following convo with Colin. 
