### PR TITLE
[6364] Support page for duplicate apply applications

### DIFF
--- a/app/controllers/system_admin/duplicate_apply_applications_controller.rb
+++ b/app/controllers/system_admin/duplicate_apply_applications_controller.rb
@@ -7,6 +7,7 @@ module SystemAdmin
         .non_importable_duplicate
         .where(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
         .order(created_at: :desc)
+        .page(params[:page] || 1)
     end
 
     def show

--- a/app/controllers/system_admin/duplicate_apply_applications_controller.rb
+++ b/app/controllers/system_admin/duplicate_apply_applications_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SystemAdmin
+  class DuplicateApplyApplicationsController < ApplicationController
+    def index; end
+
+    def show; end
+  end
+end

--- a/app/controllers/system_admin/duplicate_apply_applications_controller.rb
+++ b/app/controllers/system_admin/duplicate_apply_applications_controller.rb
@@ -6,8 +6,18 @@ module SystemAdmin
       @apply_applications = ApplyApplication
         .non_importable_duplicate
         .where(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+        .order(created_at: :desc)
     end
 
-    def show; end
+    def show
+      @apply_application = ApplyApplication.find(params[:id])
+      @candidate_name = @apply_application.candidate_full_name
+
+      @duplicate_trainees = Trainees::FindDuplicates.call(application_record: @apply_application)
+      @exact_duplicates = @duplicate_trainees.present?
+      @duplicate_trainees = Trainees::FindPotentialDuplicates.call(application_record: @apply_application) if @duplicate_trainees.blank?
+
+      @duplicate_trainees = [Trainee.last]
+    end
   end
 end

--- a/app/controllers/system_admin/duplicate_apply_applications_controller.rb
+++ b/app/controllers/system_admin/duplicate_apply_applications_controller.rb
@@ -2,7 +2,11 @@
 
 module SystemAdmin
   class DuplicateApplyApplicationsController < ApplicationController
-    def index; end
+    def index
+      @apply_applications = ApplyApplication
+        .non_importable_duplicate
+        .where(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    end
 
     def show; end
   end

--- a/app/models/apply_application.rb
+++ b/app/models/apply_application.rb
@@ -47,7 +47,22 @@ class ApplyApplication < ApplicationRecord
     provider.courses.find_by(uuid: course_uuid) if course_uuid.present?
   end
 
+  def candidate_full_name
+    [
+      first_name,
+      last_name,
+    ].select(&:present?).join(" ").presence
+  end
+
 private
+
+  def first_name
+    application&.dig("attributes", "candidate", "first_name")
+  end
+
+  def last_name
+    application&.dig("attributes", "candidate", "last_name")
+  end
 
   def course_uuid
     application_attributes.dig("course", "course_uuid")

--- a/app/services/trainees/find_duplicates.rb
+++ b/app/services/trainees/find_duplicates.rb
@@ -36,7 +36,7 @@ module Trainees
     end
 
     def matching_qualification_type?(trainee)
-      trainee.training_route == course["route"]
+      course && trainee.training_route == course["route"]
     end
 
     def at_least_one_match_identifying_attribute?(trainee)

--- a/app/services/trainees/find_duplicates.rb
+++ b/app/services/trainees/find_duplicates.rb
@@ -27,7 +27,7 @@ module Trainees
 
     def confirmed_duplicate?(trainee)
       matching_recruitment_cycle_year?(trainee) &&
-      matching_qualification_type?(trainee) &&
+      matching_course_route?(trainee) &&
       at_least_one_match_identifying_attribute?(trainee)
     end
 
@@ -35,7 +35,7 @@ module Trainees
       trainee.start_academic_cycle&.start_date&.year == raw_course["recruitment_cycle_year"]
     end
 
-    def matching_qualification_type?(trainee)
+    def matching_course_route?(trainee)
       course.present? && trainee.training_route == course["route"]
     end
 

--- a/app/services/trainees/find_duplicates.rb
+++ b/app/services/trainees/find_duplicates.rb
@@ -36,7 +36,7 @@ module Trainees
     end
 
     def matching_qualification_type?(trainee)
-      course && trainee.training_route == course["route"]
+      course.present? && trainee.training_route == course["route"]
     end
 
     def at_least_one_match_identifying_attribute?(trainee)

--- a/app/services/trainees/find_potential_duplicates.rb
+++ b/app/services/trainees/find_potential_duplicates.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Trainees
+  class FindPotentialDuplicates < FindDuplicates
+    def call
+      potential_duplicates
+    end
+  end
+end

--- a/app/views/system_admin/_tab_nav.html.erb
+++ b/app/views/system_admin/_tab_nav.html.erb
@@ -8,5 +8,5 @@
   { name: "Dead jobs", url: dead_jobs_path },
   { name: "Pending TRN", url: pending_trns_path },
   { name: "Pending awards", url: pending_awards_path },
-  { name: "Duplicate apply applications", url: duplicate_apply_applications_path },
+  { name: "Duplicate Apply applications", url: duplicate_apply_applications_path },
 ], size: :compact) %>

--- a/app/views/system_admin/_tab_nav.html.erb
+++ b/app/views/system_admin/_tab_nav.html.erb
@@ -5,7 +5,8 @@
   { name: "Schools", url: schools_path },
   { name: "Lead schools", url: lead_schools_path },
   { name: "Uploads", url: uploads_path },
-  { name: "Dead Jobs", url: dead_jobs_path },
+  { name: "Dead jobs", url: dead_jobs_path },
   { name: "Pending TRN", url: pending_trns_path },
-  { name: "Pending Awards", url: pending_awards_path },
+  { name: "Pending awards", url: pending_awards_path },
+  { name: "Duplicate apply applications", url: duplicate_apply_applications_path },
 ], size: :compact) %>

--- a/app/views/system_admin/duplicate_apply_applications/index.html.erb
+++ b/app/views/system_admin/duplicate_apply_applications/index.html.erb
@@ -1,1 +1,37 @@
-apply applications go here
+<%= render PageTitle::View.new(i18n_key: "duplicate_apply_applications.index") %>
+
+<div class="govuk-grid-row">
+  <div class ="govuk-grid-column-full">
+    <%= render "system_admin/tab_nav" %>
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Duplicate apply applications</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">First names</th>
+          <th scope="col" class="govuk-table__header">Last name</th>
+          <th scope="col" class="govuk-table__header">Created on</th>
+          <th scope="col" class="govuk-table__header"></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @apply_applications.each do |apply_application| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= apply_application.application&.dig("attributes", "candidate", "first_name") %></td>
+            <td class="govuk-table__cell"><%= apply_application.application&.dig("attributes", "candidate", "last_name") %></td>
+            <td class="govuk-table__cell"><%= apply_application.created_at.to_date.to_fs(:govuk_short) %></td>
+            <td class="govuk-table__cell">
+              <%=
+                govuk_link_to(
+                  "View",
+                  '#',
+                  class: "govuk-!-margin-0 govuk-button",
+                )
+              %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/system_admin/duplicate_apply_applications/index.html.erb
+++ b/app/views/system_admin/duplicate_apply_applications/index.html.erb
@@ -4,35 +4,33 @@
   <div class ="govuk-grid-column-full">
     <%= render "system_admin/tab_nav" %>
 
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Duplicate apply applications</caption>
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">First names</th>
-          <th scope="col" class="govuk-table__header">Last name</th>
-          <th scope="col" class="govuk-table__header">Created on</th>
-          <th scope="col" class="govuk-table__header"></th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <% @apply_applications.each do |apply_application| %>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= apply_application.application&.dig("attributes", "candidate", "first_name") %></td>
-            <td class="govuk-table__cell"><%= apply_application.application&.dig("attributes", "candidate", "last_name") %></td>
-            <td class="govuk-table__cell"><%= apply_application.created_at.to_date.to_fs(:govuk_short) %></td>
-            <td class="govuk-table__cell">
-              <%=
-                govuk_link_to(
-                  "View",
-                  duplicate_apply_application_path(apply_application.id),
-                  class: "govuk-!-margin-0 govuk-button",
-                )
-              %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <%= govuk_table do |table|
+      table.with_caption(size: "m", text: "Duplicate apply applications")
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(text: "First names")
+          row.with_cell(text: "Last name")
+          row.with_cell(text: "Created on")
+          row.with_cell(text: "")
+        end
+      end
+      table.with_body do |body|
+        @apply_applications.each do |apply_application|
+          body.with_row do |row|
+            row.with_cell(text: apply_application.application&.dig("attributes", "candidate", "first_name"))
+            row.with_cell(text: apply_application.application&.dig("attributes", "candidate", "last_name"))
+            row.with_cell(text: apply_application.created_at.to_date.to_fs(:govuk_short))
+            row.with_cell do |cell|
+              govuk_button_link_to(
+                "View",
+                duplicate_apply_application_path(apply_application.id),
+                class: "govuk-!-margin-0",
+              )
+            end
+          end
+        end
+      end
+    end %>
 
     <%= render Paginator::View.new(scope: @apply_applications) %>
   </div>

--- a/app/views/system_admin/duplicate_apply_applications/index.html.erb
+++ b/app/views/system_admin/duplicate_apply_applications/index.html.erb
@@ -1,0 +1,1 @@
+apply applications go here

--- a/app/views/system_admin/duplicate_apply_applications/index.html.erb
+++ b/app/views/system_admin/duplicate_apply_applications/index.html.erb
@@ -33,5 +33,7 @@
         <% end %>
       </tbody>
     </table>
+
+    <%= render Paginator::View.new(scope: @apply_applications) %>
   </div>
 </div>

--- a/app/views/system_admin/duplicate_apply_applications/index.html.erb
+++ b/app/views/system_admin/duplicate_apply_applications/index.html.erb
@@ -24,7 +24,7 @@
               <%=
                 govuk_link_to(
                   "View",
-                  '#',
+                  duplicate_apply_application_path(apply_application.id),
                   class: "govuk-!-margin-0 govuk-button",
                 )
               %>

--- a/app/views/system_admin/duplicate_apply_applications/show.html.erb
+++ b/app/views/system_admin/duplicate_apply_applications/show.html.erb
@@ -3,42 +3,33 @@
 <span class="govuk-caption-l"><%= @candidate_name %></span>
 <h1 class="govuk-heading-l">Duplicate apply application record</h1>
 
-<dl class="govuk-summary-list">
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Full name
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= @candidate_name %>
-    </dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Created on
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= @apply_application.created_at.to_date.to_fs(:govuk_short) %>
-    </dd>
-  </div>
-  <% if @duplicate_trainees.present? %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= @exact_duplicates ? "Duplicates" : "Potential duplicates" %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-          <%= render ApplicationRecordCard::View.with_collection(
-            @duplicate_trainees,
-            current_user: @current_user,
-          ) %>
-      </dd>
-    </div>
-  <% end %>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Application data
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <pre><%= JSON.pretty_generate(@apply_application.application) %></pre>
-    </dd>
-  </div>
-</dl>
+<%= govuk_summary_list do |summary_list|
+  summary_list.with_row do |row|
+    row.with_key { "Full name" }
+    row.with_value { @candidate_name }
+  end
+
+  summary_list.with_row do |row|
+    row.with_key { "Created on" }
+    row.with_value { @apply_application.created_at.to_date.to_fs(:govuk_short) }
+  end
+
+  if @duplicate_trainees.present?
+    summary_list.with_row do |row|
+      row.with_key { @exact_duplicates ? "Duplicates" : "Potential duplicates" }
+      row.with_value do
+        render ApplicationRecordCard::View.with_collection(
+          @duplicate_trainees,
+          current_user: @current_user,
+        )
+      end
+    end
+  end
+
+  summary_list.with_row do |row|
+    row.with_key { "Application data" }
+    row.with_value do
+      content_tag :pre, JSON.pretty_generate(@apply_application.application)
+    end
+  end
+end %>

--- a/app/views/system_admin/duplicate_apply_applications/show.html.erb
+++ b/app/views/system_admin/duplicate_apply_applications/show.html.erb
@@ -1,0 +1,44 @@
+<%= render PageTitle::View.new(text: "Duplicate apply application record - #{@candidate_name}") %>
+
+<span class="govuk-caption-l"><%= @candidate_name %></span>
+<h1 class="govuk-heading-l">Duplicate apply application record</h1>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Full name
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @candidate_name %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Created on
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @apply_application.created_at.to_date.to_fs(:govuk_short) %>
+    </dd>
+  </div>
+  <% if @duplicate_trainees.present? %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= @exact_duplicates ? "Duplicates" : "Potential duplicates" %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+          <%= render ApplicationRecordCard::View.with_collection(
+            @duplicate_trainees,
+            current_user: @current_user,
+          ) %>
+      </dd>
+    </div>
+  <% end %>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Application data
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <pre><%= JSON.pretty_generate(@apply_application.application) %></pre>
+    </dd>
+  </div>
+</dl>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -337,6 +337,8 @@ en:
       dead_jobs:
         index: Dead Jobs
         show: Dead Jobs
+      duplicate_apply_applications:
+        index: Duplicate Apply applications
       otp:
         show: Sign in
         verify: Check your email

--- a/config/routes/system_admin_routes.rb
+++ b/config/routes/system_admin_routes.rb
@@ -16,6 +16,7 @@ module SystemAdminRoutes
         resources :dead_jobs, only: %i[index show update destroy]
         resources :pending_trns, only: %i[index show]
         resources :pending_awards, only: %i[index show]
+        resources :duplicate_apply_applications, only: %i[index show]
 
         resources :providers, only: %i[index new create show edit update destroy] do
           resources :users, controller: "providers/users", only: %i[index edit update]

--- a/spec/factories/apply_applications.rb
+++ b/spec/factories/apply_applications.rb
@@ -23,8 +23,12 @@ FactoryBot.define do
       state { "importable" }
     end
 
-    trait :imported do
-      state { "imported" }
+    trait :importable do
+      state { "importable" }
+    end
+
+    trait :non_importable_duplicate do
+      state { "non_importable_duplicate" }
     end
 
     trait :with_invalid_data do

--- a/spec/factories/apply_applications.rb
+++ b/spec/factories/apply_applications.rb
@@ -19,18 +19,6 @@ FactoryBot.define do
       degree_attributes { { institution_details: invalid_institution } }
     end
 
-    trait :importable do
-      state { "importable" }
-    end
-
-    trait :importable do
-      state { "importable" }
-    end
-
-    trait :non_importable_duplicate do
-      state { "non_importable_duplicate" }
-    end
-
     trait :with_invalid_data do
       invalid
       invalid_data do

--- a/spec/features/system_admin/duplicate_apply_applications/viewing_duplicate_apply_applications_spec.rb
+++ b/spec/features/system_admin/duplicate_apply_applications/viewing_duplicate_apply_applications_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Viewing duplicate apply applications" do
+  let(:user) { create(:user, system_admin: true) }
+  let(:lead_school) { create(:school, lead_school: true) }
+
+  scenario "shows the duplicate apply applications" do
+    given_i_am_authenticated(user:)
+    and_there_are_duplicate_apply_applications
+    when_i_visit_the_duplicate_apply_applications_index_page
+    then_i_should_see_the_duplicate_apply_applications
+  end
+
+  def and_there_are_duplicate_apply_applications
+    @importable_apply_application = create(:apply_application, :importable)
+    @imported_apply_application = create(:apply_application, :imported)
+    @duplicate_apply_application = create(:apply_application, :non_importable_duplicate)
+  end
+
+  def when_i_visit_the_duplicate_apply_applications_index_page
+    visit users_path
+    click_link "Duplicate apply applications"
+  end
+
+  def then_i_should_see_the_duplicate_apply_applications
+    expect(page).to have_current_path(duplicate_apply_applications_path)
+  end
+end

--- a/spec/features/system_admin/duplicate_apply_applications/viewing_duplicate_apply_applications_spec.rb
+++ b/spec/features/system_admin/duplicate_apply_applications/viewing_duplicate_apply_applications_spec.rb
@@ -4,20 +4,35 @@ require "rails_helper"
 
 feature "Viewing duplicate apply applications" do
   let(:user) { create(:user, system_admin: true) }
-  let(:lead_school) { create(:school, lead_school: true) }
 
   scenario "shows the duplicate apply applications" do
     given_i_am_authenticated(user:)
     and_there_are_duplicate_apply_applications
     when_i_visit_the_duplicate_apply_applications_index_page
     then_i_should_see_the_duplicate_apply_applications
+
+    when_i_click_on_a_duplicate_apply_application
+    then_i_should_see_the_candidate_name
+    and_i_should_see_the_application_details
+
+    when_i_click_on_the_trainee_link
+    then_i_should_see_the_trainee_page
   end
 
   def and_there_are_duplicate_apply_applications
-    application = JSON.parse(ApiStubs::RecruitsApi.application)
+    @application = JSON.parse(ApiStubs::RecruitsApi.application)
     @importable_apply_application = create(:apply_application, :importable)
     @imported_apply_application = create(:apply_application, :imported)
-    @duplicate_apply_application = create(:apply_application, :non_importable_duplicate, application:)
+    @trainee = create(:trainee, :trn_received)
+    @application["attributes"]["candidate"]["first_name"] = @trainee.first_names
+    @application["attributes"]["candidate"]["last_name"] = @trainee.last_name
+    @application["attributes"]["candidate"]["date_of_birth"] = @trainee.date_of_birth.iso8601
+    @duplicate_apply_application = create(
+      :apply_application,
+      :non_importable_duplicate,
+      provider: @trainee.provider,
+      application: @application,
+    )
   end
 
   def when_i_visit_the_duplicate_apply_applications_index_page
@@ -31,5 +46,28 @@ feature "Viewing duplicate apply applications" do
     expect(page).to have_content(candidate_attributes["first_name"])
     expect(page).to have_content(candidate_attributes["last_name"])
     expect(page).to have_content(@duplicate_apply_application.created_at.to_date.to_fs(:govuk_short))
+  end
+
+  def when_i_click_on_a_duplicate_apply_application
+    click_link "View"
+  end
+
+  def then_i_should_see_the_candidate_name
+    expect(page).to have_content(@duplicate_apply_application.candidate_full_name)
+  end
+
+  def and_i_should_see_the_application_details
+    expect(page).to have_content(@application["attributes"]["support_reference"])
+    expect(page).to have_content(@application["attributes"]["candidate"]["domicile"])
+    expect(page).to have_content(@application["attributes"]["contact_details"]["phone_number"])
+    expect(page).to have_content(@application["attributes"]["course"]["course_code"])
+  end
+
+  def when_i_click_on_the_trainee_link
+    click_link @duplicate_apply_application.candidate_full_name
+  end
+
+  def then_i_should_see_the_trainee_page
+    expect(page).to have_current_path(trainee_path(@trainee))
   end
 end

--- a/spec/features/system_admin/duplicate_apply_applications/viewing_duplicate_apply_applications_spec.rb
+++ b/spec/features/system_admin/duplicate_apply_applications/viewing_duplicate_apply_applications_spec.rb
@@ -2,10 +2,10 @@
 
 require "rails_helper"
 
-feature "Viewing duplicate apply applications" do
+feature "Viewing duplicate Apply applications" do
   let(:user) { create(:user, system_admin: true) }
 
-  scenario "shows the duplicate apply applications" do
+  scenario "shows the duplicate Apply applications" do
     given_i_am_authenticated(user:)
     and_there_are_duplicate_apply_applications
     when_i_visit_the_duplicate_apply_applications_index_page
@@ -37,7 +37,7 @@ feature "Viewing duplicate apply applications" do
 
   def when_i_visit_the_duplicate_apply_applications_index_page
     visit users_path
-    click_link "Duplicate apply applications"
+    click_link "Duplicate Apply applications"
   end
 
   def then_i_should_see_the_duplicate_apply_applications

--- a/spec/features/system_admin/duplicate_apply_applications/viewing_duplicate_apply_applications_spec.rb
+++ b/spec/features/system_admin/duplicate_apply_applications/viewing_duplicate_apply_applications_spec.rb
@@ -14,9 +14,10 @@ feature "Viewing duplicate apply applications" do
   end
 
   def and_there_are_duplicate_apply_applications
+    application = JSON.parse(ApiStubs::RecruitsApi.application)
     @importable_apply_application = create(:apply_application, :importable)
     @imported_apply_application = create(:apply_application, :imported)
-    @duplicate_apply_application = create(:apply_application, :non_importable_duplicate)
+    @duplicate_apply_application = create(:apply_application, :non_importable_duplicate, application:)
   end
 
   def when_i_visit_the_duplicate_apply_applications_index_page
@@ -26,5 +27,9 @@ feature "Viewing duplicate apply applications" do
 
   def then_i_should_see_the_duplicate_apply_applications
     expect(page).to have_current_path(duplicate_apply_applications_path)
+    candidate_attributes = @duplicate_apply_application.application.dig("attributes", "candidate")
+    expect(page).to have_content(candidate_attributes["first_name"])
+    expect(page).to have_content(candidate_attributes["last_name"])
+    expect(page).to have_content(@duplicate_apply_application.created_at.to_date.to_fs(:govuk_short))
   end
 end

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -179,7 +179,7 @@ private
 
   def then_i_can_pick_a_course_from_the_next_cycle
     expect(publish_course_details_page.title).to include(
-      "Your school direct salaried courses starting in #{Time.zone.today.year} to #{1.year.from_now.year}",
+      "Your school direct salaried courses starting in #{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}",
     )
   end
 end

--- a/spec/models/apply_application_spec.rb
+++ b/spec/models/apply_application_spec.rb
@@ -39,4 +39,20 @@ describe ApplyApplication do
       it { is_expected.to eq(course) }
     end
   end
+
+  describe "#candidate_full_name" do
+    subject { apply_application.candidate_full_name }
+
+    context "when candidate name is present" do
+      let(:apply_application) { create(:apply_application, :importable, application: JSON.parse(ApiStubs::RecruitsApi.application)) }
+
+      it { is_expected.to eq("Martin Wells") }
+    end
+
+    context "when application data is missing" do
+      let(:apply_application) { create(:apply_application, :importable, application: { attributes: {} }) }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
### Context
Some applications imported from the Apply service are flagged as duplicates because, at the time of import, Register identifies a potential matching Trainee record already in the database. Such applications end up in the `non_importable_duplicate` state.

We need a way to view Apply applications that have ended up in this state so that the support team can investigate.

### Changes proposed in this pull request
We've added a new _Duplicate apply applications_ page to the support interface with a corresponding menu item. This lists the basic details of each duplicate:

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/000dbfba-bbe8-4149-9e9d-fe8bb0674c49)

The _View_ button on each row drills down to each record and attempts to identify the duplicate Trainee record(s).

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/6310359b-5295-4141-b9c1-79062daf4418)



### Guidance to review
- The UX could clearly be improved. Any suggestions welcome.
- What other information would be useful in helping to determine whether the flagged Apply application records really are duplicates?
- What should be the support workflow for handling duplicates? Do we need a way to mark duplicates as reviewed (by support/devs)?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
