### PR TITLE
[5377] - check bulk recommend files uploaded are UTF-8 encoded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ gem "foreman"
 # Canonical meta tag
 gem "canonical-rails"
 
+# For determining file encoding
+gem "charlock_holmes"
+
 # Soft delete records
 gem "discard", "~> 1.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cgi (0.3.6)
+    charlock_holmes (0.7.7)
     chartkick (5.0.4)
     choice (0.2.0)
     cloudfront-rails (0.4.0)
@@ -775,6 +776,7 @@ DEPENDENCIES
   byebug
   canonical-rails
   capybara (~> 3.39)
+  charlock_holmes
   cloudfront-rails
   colorize
   config (~> 5.1)

--- a/app/services/bulk_update/recommendations_uploads/validate_file.rb
+++ b/app/services/bulk_update/recommendations_uploads/validate_file.rb
@@ -13,7 +13,7 @@ module BulkUpdate
       def validate!
         if file
           file_size_within_range?
-          file_type_is_utf8?
+          file_encoding_is_accepted?
         else
           record.errors.add(:file, :missing)
         end
@@ -23,10 +23,10 @@ module BulkUpdate
 
       attr_reader :file, :record
 
-      def file_type_is_utf8?
-        return true if detection&.dig(:encoding) == "UTF-8"
+      def file_encoding_is_accepted?
+        return true if %w[UTF-8 ISO-8859-1].include?(encoding)
 
-        record.errors.add(:file, :non_utf_8) # rubocop:disable Naming/VariableNumber
+        record.errors.add(:file, :encoding_not_accepted, encoding:)
       end
 
       def detection
@@ -34,6 +34,10 @@ module BulkUpdate
           contents = File.read(file)
           CharlockHolmes::EncodingDetector.detect(contents)
         end
+      end
+
+      def encoding
+        @encoding ||= detection&.dig(:encoding)
       end
 
       def file_size_within_range?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1434,6 +1434,7 @@ en:
               missing: Select a CSV file
               empty: The selected file is empty
               too_large: The selected file must be smaller than 1MB
+              non_utf_8: The selected file must be UTF-8 encoded
               is_not_csv: The selected file must be a CSV
               no_header_detected: No header was detected
               no_id_header: The selected file must contain a column for TRN, trainee provider ID or HESA ID

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1434,7 +1434,7 @@ en:
               missing: Select a CSV file
               empty: The selected file is empty
               too_large: The selected file must be smaller than 1MB
-              non_utf_8: The selected file must be UTF-8 encoded
+              encoding_not_accepted: "The selected file must be UTF-8 or ISO-8859-1 encoded (detected: %{encoding})"
               is_not_csv: The selected file must be a CSV
               no_header_detected: No header was detected
               no_id_header: The selected file must contain a column for TRN, trainee provider ID or HESA ID

--- a/spec/services/bulk_update/recommendations_uploads/validate_file_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_file_spec.rb
@@ -12,7 +12,7 @@ module BulkUpdate
 
       let(:content) { "This is some text" }
       let(:file) do
-        Tempfile.new("utf8").tap do |f|
+        Tempfile.new.tap do |f|
           f.write(content)
           f.rewind
         end
@@ -39,11 +39,11 @@ module BulkUpdate
       end
 
       context "given a non-utf8 file type" do
-        let(:content) { "This is some text".encode("ISO-8859-1") }
+        let(:content) { "This is some text".encode("Windows-1252") }
 
         it "adds the correct error message" do
           service.validate!
-          expect(error_message).to include "The selected file must be UTF-8 encoded"
+          expect(error_message).to include "File The selected file must be UTF-8 or ISO-8859-1 encoded (detected: ISO-8859-2)"
         end
       end
     end


### PR DESCRIPTION
### Context

We only accept UTF-8 CSV in the bulk recommendation for QTS/EYTS feature. We want to show an error that specifies we don’t take that particular form of CSVs.

### Changes proposed in this pull request

adds a validation using `charlock_holmes` that detects if a file uploaded is indeed `UTF-8` encoded.
