### PR TITLE
[6532] Validate `Placement#postcode` and `urn`

### DIFF
--- a/app/forms/placement_form.rb
+++ b/app/forms/placement_form.rb
@@ -6,6 +6,7 @@ class PlacementForm
   include ActiveModel::Validations::Callbacks
 
   FIELDS = %i[slug school_id name urn postcode].freeze
+  URN_REGEX = /^[0-9]{6}$/
 
   attr_accessor(*FIELDS, :placements_form, :placement, :trainee, :destroy)
 
@@ -13,6 +14,7 @@ class PlacementForm
   validate :school_urn_valid
   validates :name, presence: true, if: -> { school_id.blank? }
   validate :urn_valid
+  validate :postcode_valid
 
   delegate :persisted?, :school, to: :placement
 
@@ -134,6 +136,16 @@ class PlacementForm
   def urn_valid
     if urn.present? && existing_urns.any?(urn)
       errors.add(:urn, :unique)
+    end
+
+    if urn.present? && !urn.match?(URN_REGEX)
+      errors.add(:urn, :invalid_format)
+    end
+  end
+
+  def postcode_valid
+    if postcode.present? && !UKPostcode.parse(postcode).valid?
+      errors.add(:postcode, I18n.t("activemodel.errors.validators.postcode.invalid"))
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1615,6 +1615,7 @@ en:
               blank: Enter a school name
             urn:
               unique: "Choose another URN as this has already been used"
+              invalid_format: "Enter a valid school unique reference number (URN). It should be 6 digits long."
         study_modes_form:
           attributes:
             study_mode:

--- a/spec/forms/placement_form_spec.rb
+++ b/spec/forms/placement_form_spec.rb
@@ -284,6 +284,32 @@ describe PlacementForm, type: :model do
           expect(subject.errors.messages[:school]).not_to include("Choose another URN as this has already been used")
         end
       end
+
+      context "when the URN is too long" do
+        let(:placement_attributes) { { urn: "1234567" } }
+
+        it "adds errors" do
+          expect(subject.errors).to be_empty
+          subject.urn_valid
+          expect(subject.errors).not_to be_empty
+          expect(subject.errors.messages[:urn]).to include(
+            I18n.t("activemodel.errors.models.placement.attributes.urn.invalid_format"),
+          )
+        end
+      end
+
+      context "when the URN is not numeric" do
+        let(:placement_attributes) { { urn: "123a56" } }
+
+        it "adds errors" do
+          expect(subject.errors).to be_empty
+          subject.urn_valid
+          expect(subject.errors).not_to be_empty
+          expect(subject.errors.messages[:urn]).to include(
+            I18n.t("activemodel.errors.models.placement.attributes.urn.invalid_format"),
+          )
+        end
+      end
     end
 
     describe "#school_urn_valid" do
@@ -313,10 +339,24 @@ describe PlacementForm, type: :model do
     end
 
     context "postcode is set" do
-      let(:placement) { Placement.new(postcode: "BN1 1AA") }
+      let(:placement_attributes) { { postcode: "BN1 1AA" } }
+      let(:placement) { Placement.new(placement_attributes) }
 
       it "validates presence" do
         expect(subject).to validate_presence_of(:name).with_message("Enter a school name")
+      end
+
+      context "when the postcode is badly formatted" do
+        let(:placement_attributes) { { postcode: "567abc" } }
+
+        it "add errors" do
+          expect(subject.errors).to be_empty
+          subject.postcode_valid
+          expect(subject.errors).not_to be_empty
+          expect(subject.errors.messages[:postcode]).to include(
+            I18n.t("activemodel.errors.validators.postcode.invalid"),
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
When acceptance testing the recent trainee placements feature we identified some improvements to tighten up validation for manual placement entry. 

### Changes proposed in this pull request
Validate that:
- `Placement#postcode` is a valid postcode
- `Placement#urn` is a valid URN (6-digit string)

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/e410c721-8123-40ed-9dad-7307d9d5733b)


### Guidance to review
- Does the review app work as expected?
- Are there other tests we should do?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
