### PR TITLE
[6572] Update bulk recommend logic for empty template

### DIFF
--- a/app/controllers/bulk_update/recommendations_uploads_controller.rb
+++ b/app/controllers/bulk_update/recommendations_uploads_controller.rb
@@ -2,7 +2,7 @@
 
 module BulkUpdate
   class RecommendationsUploadsController < RecommendationsBaseController
-    helper_method :organisation_filename_prepopulated
+    helper_method :organisation_filename_prepopulated, :organisation_filename_empty
 
     def new
       navigation_view
@@ -45,6 +45,10 @@ module BulkUpdate
 
     def organisation_filename_prepopulated
       "#{provider.name.parameterize}-trainees-to-recommend-prepopulated.csv"
+    end
+
+    def organisation_filename_empty
+      "#{provider.name.parameterize}-trainees-to-recommend-empty.csv"
     end
 
     # for now, if anything goes wrong during creation of trainees

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -76,7 +76,7 @@ class ReportsController < BaseTraineeController
 
     send_data(
       Exports::BulkRecommendEmptyExport.call,
-      filename: bulk_recommend_export_filename,
+      filename: bulk_recommend_empty_export_filename,
       disposition: :attachment,
     )
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -71,6 +71,16 @@ class ReportsController < BaseTraineeController
     )
   end
 
+  def bulk_recommend_empty_export
+    authorize(current_user, :bulk_recommend?)
+
+    send_data(
+      Exports::BulkRecommendEmptyExport.call,
+      filename: bulk_recommend_export_filename,
+      disposition: :attachment,
+    )
+  end
+
 private
 
   def itt_new_starter_trainees
@@ -99,6 +109,10 @@ private
 
   def bulk_recommend_export_filename
     "#{current_user.organisation.name.parameterize}-trainees-to-recommend-prepopulated.csv"
+  end
+
+  def bulk_recommend_empty_export_filename
+    "#{current_user.organisation.name.parameterize}-trainees-to-recommend-empty.csv"
   end
 
   def census_date(year)

--- a/app/models/reports/bulk_recommend_empty_report.rb
+++ b/app/models/reports/bulk_recommend_empty_report.rb
@@ -7,7 +7,7 @@ module Reports
     TRAINEE_ID = "Provider trainee ID"
 
     IDENTIFIERS = [TRN, TRAINEE_ID].freeze
-    DATE        = "Date QTS or EYTS standards met"
+    DATE = "Date QTS or EYTS standards met"
 
     DEFAULT_HEADERS = [
       *IDENTIFIERS,

--- a/app/models/reports/bulk_recommend_empty_report.rb
+++ b/app/models/reports/bulk_recommend_empty_report.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Reports
+  class BulkRecommendEmptyReport < TemplateClassCsv
+    # required headers
+    TRN = "TRN"
+    TRAINEE_ID = "Provider trainee ID"
+
+    IDENTIFIERS = [TRN, TRAINEE_ID].freeze
+    DATE        = "Date QTS or EYTS standards met"
+
+    DEFAULT_HEADERS = [
+      *IDENTIFIERS,
+      DATE,
+    ].freeze
+
+    def initialize(csv, scope:)
+      @csv = csv
+      @scope = scope
+    end
+
+    def headers
+      @headers ||= DEFAULT_HEADERS
+    end
+
+  private
+
+    def add_headers
+      csv << headers
+    end
+
+    def add_report_rows; end
+  end
+end

--- a/app/services/exports/bulk_recommend_empty_export.rb
+++ b/app/services/exports/bulk_recommend_empty_export.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "csv"
+
+# Service to export data
+module Exports
+  class BulkRecommendEmptyExport < ExportServiceBase
+    def initialize
+      @report_class = Reports::BulkRecommendEmptyReport
+      @scope = []
+    end
+  end
+end

--- a/app/views/bulk_update/recommendations_uploads/new.html.erb
+++ b/app/views/bulk_update/recommendations_uploads/new.html.erb
@@ -25,18 +25,48 @@
       <h2 class="govuk-heading-l">How to recommend trainees</h2>
 
       <h3 class="govuk-heading-m">
-        1. Export a template file
+        1. Choose a file to download
       </h3>
 
-      <p class="govuk-body">This file contains all <%= pluralize(bulk_recommend_count, "trainee")  %> that can be recommended for QTS or EYTS.</p>
+      <p class="govuk-body">
+        Download and add trainee information to one of these files.
+      </p>
 
-      <p class="govuk-body">Delete any trainees you do not want to recommened.</p>
+      <h4 class="govuk-heading-m">Prepopulated file</h4>
+
+      <p class="govuk-body">
+      This file contains all <%= pluralize(bulk_recommend_count, "trainee")  %> that can be recommended for QTS or EYTS.
+      </p>
+
+      <p class="govuk-body">
+        Delete any trainees you do not want to recommend.
+      </p>
 
       <p class="govuk-body">
         <%= govuk_link_to("Download a prepopulated file to recommend trainees for QTS or EYTS", bulk_recommend_export_reports_path(:csv), class: "govuk-link--no-visited-state") %>
       </p>
 
-      <p class="govuk-hint govuk-!-margin-bottom-4">File name: <span class="app-nowrap"><%= organisation_filename_prepopulated %></span></p>
+      <p class="govuk-body">
+        File name: <%= bulk_recommend_export_reports_path(:csv) %>
+      </p>
+
+      <h4 class="govuk-heading-m">Empty template file</h4>
+
+      <p class="govuk-body">
+        This file has the column headings ‘TRN’, ‘Provider trainee ID’ and ‘Date standards met’.
+      </p>
+
+      <p class="govuk-body">
+        Add the trainees you want to recommend for QTS or EYTS.
+      </p>
+
+      <p class="govuk-body">
+        <%= govuk_link_to("Download an empty template file to recommend trainees for QTS or EYTS", bulk_recommend_export_reports_path(:csv), class: "govuk-link--no-visited-state") %>
+      </p>
+
+      <p class="govuk-body">
+        File name: <%= bulk_recommend_export_reports_path(:csv) %>
+      </p>
 
       <h3 class="govuk-heading-m">
         2. Add the date each trainee met QTS or EYTS

--- a/app/views/bulk_update/recommendations_uploads/new.html.erb
+++ b/app/views/bulk_update/recommendations_uploads/new.html.erb
@@ -47,13 +47,13 @@
       </p>
 
       <p class="govuk-body">
-        File name: <%= bulk_recommend_export_reports_path(:csv) %>
+        File name: <span class="app-nowrap"><%= organisation_filename_prepopulated %></span>
       </p>
 
       <h4 class="govuk-heading-m">Empty template file</h4>
 
       <p class="govuk-body">
-        This file has the column headings ‘TRN’, ‘Provider trainee ID’ and ‘Date standards met’.
+        This file has the column headings ‘TRN’, ‘Provider trainee ID’ and ‘Date QTS or EYTS standards met’.
       </p>
 
       <p class="govuk-body">
@@ -61,11 +61,11 @@
       </p>
 
       <p class="govuk-body">
-        <%= govuk_link_to("Download an empty template file to recommend trainees for QTS or EYTS", bulk_recommend_export_reports_path(:csv), class: "govuk-link--no-visited-state") %>
+        <%= govuk_link_to("Download an empty template file to recommend trainees for QTS or EYTS", bulk_recommend_empty_export_reports_path(:csv), class: "govuk-link--no-visited-state") %>
       </p>
 
       <p class="govuk-body">
-        File name: <%= bulk_recommend_export_reports_path(:csv) %>
+        File name: <span class="app-nowrap"><%= organisation_filename_empty %></span>
       </p>
 
       <h3 class="govuk-heading-m">

--- a/app/views/bulk_update/recommendations_uploads/new.html.erb
+++ b/app/views/bulk_update/recommendations_uploads/new.html.erb
@@ -35,7 +35,7 @@
       <h4 class="govuk-heading-m">Prepopulated file</h4>
 
       <p class="govuk-body">
-      This file contains all <%= pluralize(bulk_recommend_count, "trainee")  %> that can be recommended for QTS or EYTS.
+        This file contains all <%= pluralize(bulk_recommend_count, "trainee")  %> that can be recommended for QTS or EYTS.
       </p>
 
       <p class="govuk-body">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
     get "itt-new-starter-data-sign-off", to: "reports#itt_new_starter_data_sign_off", on: :collection
     get "performance-profiles", to: "reports#performance_profiles", on: :collection
     get :bulk_recommend_export, on: :collection
+    get :bulk_recommend_empty_export, on: :collection
     get :bulk_placement_export, on: :collection
   end
 

--- a/spec/features/bulk_upload/recommending_trainees_spec.rb
+++ b/spec/features/bulk_upload/recommending_trainees_spec.rb
@@ -21,67 +21,93 @@ feature "recommending trainees" do
     before do
       given_two_trainees_exist_to_recommend
       given_i_am_on_the_recommendations_upload_page
-      then_i_see_how_many_trainees_i_can_recommend
-      and_i_upload_a_csv(create_recommendations_upload_csv!(write_to_disk:, overwrite:))
     end
 
-    context "and I upload a complete CSV" do
-      scenario "I can upload trainees for recommendation" do
-        then_i_see_count_complete
-        and_i_check_who_ill_recommend
-        and_i_see_a_list_of_trainees_to_check
+    context "when I use the empty template" do
+      before do
+        then_i_see_the_option_to_download_the_empty_template
+        and_i_upload_a_csv(
+          create_simplified_recommendations_upload_csv!(
+            trainees: @trainees,
+            write_to_disk: true,
+            recommended_for_award_date: Time.zone.today,
+          ),
+        )
       end
 
-      scenario "I can cancel my upload" do
-        and_i_click_cancel
-        and_i_click_confirm_cancel
-        then_i_am_taken_back_to_the_upload_page
-      end
-    end
-
-    context "and I upload a CSV missing dates" do
-      let(:overwrite) do # a valid date for the first trainee created in `given_two_trainees_exist_to_recommend`
-        [
-          { Reports::BulkRecommendReport::DATE => Time.zone.today.strftime("%d/%m/%Y") },
-        ]
-      end
-
-      scenario "I can upload trainees for recommendation" do
-        then_i_see_count_missing_dates
-        and_i_check_who_ill_recommend
+      context "and I upload a complete CSV" do
+        scenario "I can upload trainees for recommendation" do
+          then_i_see_count_complete
+          and_i_check_who_ill_recommend
+          and_i_see_a_list_of_trainees_to_check
+        end
       end
     end
 
-    context "I can change who I want to recommend" do
-      scenario "I see the form to change upload" do
-        and_i_check_who_ill_recommend
-        and_i_click_change_link
-        then_i_see_the_form_to_change_upload
+    context "when I use the pre-popuated template" do
+      before do
+        then_i_see_how_many_trainees_i_can_recommend
+        and_i_upload_a_csv(create_recommendations_upload_csv!(write_to_disk:, overwrite:))
       end
 
-      scenario "I get redirected to the correct page when no CSV is uploaded" do
-        and_i_check_who_ill_recommend
-        and_i_click_change_link
-        then_i_see_the_form_to_change_upload
-        and_i_submit_form_with_no_file
-        then_i_see_validation_errors
-        and_i_remain_on_the_change_upload_page
-      end
-    end
+      context "and I upload a complete CSV" do
+        scenario "I can upload trainees for recommendation" do
+          then_i_see_count_complete
+          and_i_check_who_ill_recommend
+          and_i_see_a_list_of_trainees_to_check
+        end
 
-    context "and I upload a CSV with an error" do
-      let(:overwrite) do # one valid, and one invalid date for trainees created in `given_two_trainees_exist_to_recommend`
-        [
-          { Reports::BulkRecommendReport::DATE => Date.tomorrow.strftime("%d/%m/%Y") },
-          { Reports::BulkRecommendReport::DATE => Time.zone.today.strftime("%d/%m/%Y") },
-        ]
+        scenario "I can cancel my upload" do
+          and_i_click_cancel
+          and_i_click_confirm_cancel
+          then_i_am_taken_back_to_the_upload_page
+        end
       end
 
-      scenario "I am shown the error count and am told to fix errors" do
-        then_i_see_count_errors
-        then_i_click_review_errors
-        when_i_submit_form_with_no_file_attached
-        then_i_see_validation_errors
+      context "and I upload a CSV missing dates" do
+        let(:overwrite) do # a valid date for the first trainee created in `given_two_trainees_exist_to_recommend`
+          [
+            { Reports::BulkRecommendReport::DATE => Time.zone.today.strftime("%d/%m/%Y") },
+          ]
+        end
+
+        scenario "I can upload trainees for recommendation" do
+          then_i_see_count_missing_dates
+          and_i_check_who_ill_recommend
+        end
+      end
+
+      context "I can change who I want to recommend" do
+        scenario "I see the form to change upload" do
+          and_i_check_who_ill_recommend
+          and_i_click_change_link
+          then_i_see_the_form_to_change_upload
+        end
+
+        scenario "I get redirected to the correct page when no CSV is uploaded" do
+          and_i_check_who_ill_recommend
+          and_i_click_change_link
+          then_i_see_the_form_to_change_upload
+          and_i_submit_form_with_no_file
+          then_i_see_validation_errors
+          and_i_remain_on_the_change_upload_page
+        end
+      end
+
+      context "and I upload a CSV with an error" do
+        let(:overwrite) do # one valid, and one invalid date for trainees created in `given_two_trainees_exist_to_recommend`
+          [
+            { Reports::BulkRecommendReport::DATE => Date.tomorrow.strftime("%d/%m/%Y") },
+            { Reports::BulkRecommendReport::DATE => Time.zone.today.strftime("%d/%m/%Y") },
+          ]
+        end
+
+        scenario "I am shown the error count and am told to fix errors" do
+          then_i_see_count_errors
+          then_i_click_review_errors
+          when_i_submit_form_with_no_file_attached
+          then_i_see_validation_errors
+        end
       end
     end
   end
@@ -101,6 +127,10 @@ private
 
   def then_i_see_how_many_trainees_i_can_recommend
     expect(recommendations_upload_page).to have_text("2 trainees")
+  end
+
+  def then_i_see_the_option_to_download_the_empty_template
+    expect(recommendations_upload_page).to have_link("Download an empty template file to recommend trainees for QTS or EYTS")
   end
 
   def and_i_upload_a_csv(csv_path)

--- a/spec/services/exports/bulk_recommend_empty_export_spec.rb
+++ b/spec/services/exports/bulk_recommend_empty_export_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Exports::BulkRecommendEmptyExport, type: :model do
+  describe "#call" do
+    subject(:service) { described_class.call }
+
+    let(:csv) { CSV.parse(service, headers: true) }
+
+    let(:expected_headers) do
+      [
+        "TRN",
+        "Provider trainee ID",
+        "Date QTS or EYTS standards met",
+      ]
+    end
+
+    context "when generated" do
+      it "only includes a heading row" do
+        expect(csv.size).to be_zero
+      end
+
+      it "includes the correct header labels" do
+        expect(csv.headers).to match_array(expected_headers)
+      end
+    end
+  end
+end

--- a/spec/support/recommendations_uploads_helper.rb
+++ b/spec/support/recommendations_uploads_helper.rb
@@ -29,4 +29,27 @@ module RecommendationsUploadHelper
     tempfile.rewind
     tempfile.path
   end
+
+  def create_simplified_recommendations_upload_csv!(trainees:, write_to_disk:, recommended_for_award_date:)
+    # create a CSV with only the columns that are required for the upload form
+    csv_string = CSV.generate do |rows|
+      rows << Reports::BulkRecommendEmptyReport::DEFAULT_HEADERS
+      trainees.each do |trainee|
+        rows << [
+          trainee.trn,
+          trainee.trainee_id,
+          recommended_for_award_date&.strftime("%d/%m/%Y"),
+        ]
+      end
+    end
+
+    # return a CSV object
+    return csv_string unless write_to_disk
+
+    # or return the path to a temp file on disk
+    tempfile = Tempfile.new("csv")
+    tempfile.write(csv_string)
+    tempfile.rewind
+    tempfile.path
+  end
 end


### PR DESCRIPTION
### Context
This PR is a continuation of https://github.com/DFE-Digital/register-trainee-teachers/pull/3898 and extends the bulk recommendation feature to allow provider users to download an empty template file (CSV) which they can fill in to upload their recommendations.

### Changes proposed in this pull request
Allow users to export an empty CSV template with fewer headers and make the necessary adjustments to the import logic to handle this type of template. (Since the required column names are all present in the simplified empty template the import works the same was as with the pre-populated template _I think_).

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/9cfc20f8-4341-4b54-ac8b-2ac2312aef2d)

### Guidance to review
Are the tests sufficient?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
