### PR TITLE
Withdrawal Reason Character Limit

### DIFF
--- a/app/forms/withdrawal/extra_information_form.rb
+++ b/app/forms/withdrawal/extra_information_form.rb
@@ -9,8 +9,8 @@ module Withdrawal
 
     attr_accessor(*FIELDS)
 
-    validates :withdraw_reasons_details, length: { maximum: 500 }, allow_blank: true
-    validates :withdraw_reasons_dfe_details, length: { maximum: 500 }, allow_blank: true
+    validates :withdraw_reasons_details, length: { maximum: 1000 }, allow_blank: true
+    validates :withdraw_reasons_dfe_details, length: { maximum: 1000 }, allow_blank: true
 
     def save!
       assign_attributes_to_trainee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1546,9 +1546,9 @@ en:
         withdrawal/extra_information_form:
           attributes:
             withdraw_reasons_details:
-              too_long: Details about why the trainee withdrew must be 500 characters or less
+              too_long: Details about why the trainee withdrew must be 1000 characters or less
             withdraw_reasons_dfe_details:
-              too_long: What the Department for Education could have done must be x characters or less
+              too_long: What the Department for Education could have done must be 1000 characters or less
         funding/training_initiatives_form:
           attributes:
             training_initiative:

--- a/spec/features/trainee_actions/withdraw_trainee_spec.rb
+++ b/spec/features/trainee_actions/withdraw_trainee_spec.rb
@@ -339,11 +339,11 @@ feature "Withdrawing a trainee" do
   end
 
   def then_i_see_the_error_message_for_details_too_long
-    expect(withdrawal_reason_page).to have_content("Details about why the trainee withdrew must be 500 characters or less")
+    expect(withdrawal_reason_page).to have_content("Details about why the trainee withdrew must be 1000 characters or less")
   end
 
   def then_i_see_the_error_message_for_dfe_details_too_long
-    expect(withdrawal_reason_page).to have_content("What the Department for Education could have done must be x characters or less")
+    expect(withdrawal_reason_page).to have_content("What the Department for Education could have done must be 1000 characters or less")
   end
 
   def then_i_see_the_error_message_for_missing_additional_reason


### PR DESCRIPTION
### Context
Related to: https://github.com/DFE-Digital/register-trainee-teachers/pull/3860

### Changes proposed in this pull request
* Made the character limit for withdrawal reasons 1000 characters.
* Fixed a typo with the error message when a reason is too long. 

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
