### PR TITLE
Fix broken spec - Y2024 bug

### DIFF
--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -179,7 +179,7 @@ private
 
   def then_i_can_pick_a_course_from_the_next_cycle
     expect(publish_course_details_page.title).to include(
-      "Your school direct salaried courses starting in #{Time.zone.today.year} to #{1.year.from_now.year}",
+      "Your school direct salaried courses starting in #{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}",
     )
   end
 end


### PR DESCRIPTION
### Context
I think we should be asserting based on the current recruitment cycle rather than the current calendar year.

### Changes proposed in this pull request
Use current recruitment cycle.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
