### PR TITLE
[6586] Fix `example_data:generate` rake task (workaround)

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -268,6 +268,7 @@ namespace :example_data do
               trainee.trn = Faker::Number.number(digits: 7)
             end
 
+            FormStore.clear_all(trainee.id)
             trainee.save!
 
             # Make *roughly* 75% of submitted_for_trn trainees have trainee withdraw reason

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
 
     with_school
 
+    slug { SecureRandom.base58(Sluggable::SLUG_LENGTH) }
+
     trait :with_school do
       school
     end


### PR DESCRIPTION
### Context
This task was failing with a duplicate key error on the `Placement#slug` attribute. This happens due to a side-effect of the validation for trainees with placements. The validation triggers logic in `PlacementsForm` that ends up populating the `Trainee#placements` association from the `FormStore`.

There are a number of un-answered questions here:
- Why does `FormStore` get populated when we are just creating data via a rake task (there is no form)?
- Why does the validation for `Trainee` end up mutating the data?

The change in this PR is a workaround to get the rake task working pending further investigation.

### Changes proposed in this pull request
Clear the `FormCache` before saving (and validating) new trainees created by the rake task.

### Guidance to review
What is the best longer-term solution to the underlying issue with placements?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
