### PR TITLE
[6364] Fix incorrect duplicate trainee

### DIFF
--- a/app/controllers/system_admin/duplicate_apply_applications_controller.rb
+++ b/app/controllers/system_admin/duplicate_apply_applications_controller.rb
@@ -18,7 +18,7 @@ module SystemAdmin
       @exact_duplicates = @duplicate_trainees.present?
       @duplicate_trainees = Trainees::FindPotentialDuplicates.call(application_record: @apply_application) if @duplicate_trainees.blank?
 
-      @duplicate_trainees = [Trainee.last]
+      @duplicate_trainees = [@duplicate_trainees.last].compact
     end
   end
 end

--- a/app/views/system_admin/duplicate_apply_applications/show.html.erb
+++ b/app/views/system_admin/duplicate_apply_applications/show.html.erb
@@ -24,6 +24,11 @@
         )
       end
     end
+  else
+    summary_list.with_row do |row|
+      row.with_key { "Duplicates" }
+      row.with_value { "None found" }
+    end
   end
 
   summary_list.with_row do |row|


### PR DESCRIPTION
### Context
Fixes rendering of duplicate records on the duplicate apply applications show page. Correction to https://github.com/DFE-Digital/register-trainee-teachers/pull/3896

### Changes proposed in this pull request
Fix the dumb bug and return the correct duplicate trainee record.

### Guidance to review
Note that we are still reviewing with support how this page should look and what the process will be going forward to handle duplicate Apply applications. This is just a fix to what is there so far.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
