### PR TITLE
Remove PaaS validation domains

### DIFF
--- a/terraform/custom_domains/environment_domains/workspace_variables/register_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/register_production.tfvars.json
@@ -16,13 +16,7 @@
       ],
       "environment_short": "pd",
       "origin_hostname": "register-production.teacherservices.cloud",
-      "null_host_header": true,
-      "cnames": {
-        "_1191f61775c66c9eec91175aa294cdbb.www": {
-          "target": "_d0ee22f81c78ffe76df87d4ffa134644.mybbdzzyvz.acm-validations.aws.",
-          "ttl": 86400
-        }
-      }
+      "null_host_header": true
     },
     "register-trainee-teachers.education.gov.uk": {
       "front_door_name": "s189p01-rtt-edu-domains-fd",
@@ -35,13 +29,7 @@
       ],
       "environment_short": "pd",
       "origin_hostname": "register-production.teacherservices.cloud",
-      "null_host_header": true,
-      "cnames": {
-        "_5aea97ded46b011053a0318e78abf7aa.www": {
-          "target": "_462e6161fa2dd45d12b0692f50f76a11.wggjkglgrm.acm-validations.aws",
-          "ttl": 86400
-        }
-      }
+      "null_host_header": true
     }
   }
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/register_qa.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/register_qa.tfvars.json
@@ -17,13 +17,7 @@
       ],
       "environment_short": "qa",
       "origin_hostname": "register-qa.test.teacherservices.cloud",
-      "null_host_header": true,
-      "cnames": {
-        "_d9b4a9afdf0fe1c7ba2aa5dc8e712cbb.qa": {
-          "target": "_8170547b3aec12093341bf5b9c6fe9ce.wggjkglgrm.acm-validations.aws",
-          "ttl": 86400
-        }
-      }
+      "null_host_header": true
     },
     "register-trainee-teachers.service.gov.uk": {
       "front_door_name": "s189p01-rtt-svc-domains-fd",
@@ -36,13 +30,7 @@
       ],
       "environment_short": "qa",
       "origin_hostname": "register-qa.test.teacherservices.cloud",
-      "null_host_header": true,
-      "cnames": {
-        "_a66959f8322304020cea85097566d3be.qa": {
-          "target": "_4c3ae74e94b29fe9ad84d2cd152fd0ac.xdvyhgsvzs.acm-validations.aws.",
-          "ttl": 86400
-        }
-      }
+      "null_host_header": true
     }
   }
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/register_staging.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/register_staging.tfvars.json
@@ -17,13 +17,7 @@
       ],
       "environment_short": "stg",
       "origin_hostname": "register-staging.test.teacherservices.cloud",
-      "null_host_header": true,
-      "cnames": {
-        "_f3e61e36cb2c60bf14631de73dff9f3b.staging": {
-          "target": "_75d94039eb16d9b3afd946ddb5860f59.wggjkglgrm.acm-validations.aws",
-          "ttl": 86400
-        }
-      }
+      "null_host_header": true
     },
     "register-trainee-teachers.service.gov.uk": {
       "front_door_name": "s189p01-rtt-svc-domains-fd",
@@ -36,13 +30,7 @@
       ],
       "environment_short": "stg",
       "origin_hostname": "register-staging.test.teacherservices.cloud",
-      "null_host_header": true,
-      "cnames": {
-        "_bff11f4ee081539b0be0c64e46536b44.staging": {
-          "target": "_b99cd2877b98c9d2633f83a775bb2bdf.xdvyhgsvzs.acm-validations.aws",
-          "ttl": 86400
-        }
-      }
+      "null_host_header": true
     }
   }
 }


### PR DESCRIPTION
### Context

Remove PaaS validation domains as register is using Azure

### Changes proposed in this pull request

Update domain environment config files

### Guidance to review

make register qa domains-plan
make register staging domains-plan
make register production domains-plan CONFIRM_PRODUCTION=y

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
