### PR TITLE
[6489] Scholarship trainee missing from the funding download

### DIFF
--- a/app/services/exports/funding_trainee_summary_data.rb
+++ b/app/services/exports/funding_trainee_summary_data.rb
@@ -32,20 +32,19 @@ module Exports
 
     def format_rows(trainee_summary)
       trainee_summary.rows.map do |row|
-        trainee_summary_row_amount = row.amounts.first
-        next if trainee_summary_row_amount.nil?
-
-        {
-          "Funding type" => funding_type_prefix(row) + trainee_summary_row_amount.payment_type,
-          "Route" => row.route,
-          "Course" => row.subject,
-          "Lead school" => row.lead_school_name,
-          "Tier" => trainee_summary_row_amount.tier.present? ? "Tier #{trainee_summary_row_amount.tier}" : "Not applicable",
-          "Number of trainees" => trainee_summary_row_amount.number_of_trainees,
-          "Amount per trainee" => to_pounds(trainee_summary_row_amount.amount_in_pence),
-          "Total" => to_pounds(trainee_summary_row_amount.number_of_trainees * trainee_summary_row_amount.amount_in_pence),
-        }
-      end.compact
+        row.amounts.map do |trainee_summary_row_amount|
+          {
+            "Funding type" => funding_type_prefix(row) + trainee_summary_row_amount.payment_type,
+            "Route" => row.route,
+            "Course" => row.subject,
+            "Lead school" => row.lead_school_name,
+            "Tier" => trainee_summary_row_amount.tier.present? ? "Tier #{trainee_summary_row_amount.tier}" : "Not applicable",
+            "Number of trainees" => trainee_summary_row_amount.number_of_trainees,
+            "Amount per trainee" => to_pounds(trainee_summary_row_amount.amount_in_pence),
+            "Total" => to_pounds(trainee_summary_row_amount.number_of_trainees * trainee_summary_row_amount.amount_in_pence),
+          }
+        end
+      end.flatten.compact
     end
 
     def to_pounds(value_in_pence)

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -106,7 +106,7 @@ namespace :example_data do
       )
       ProviderUser.find_or_create_by!(user: persona, provider: provider)
       FactoryBot.create(:payment_schedule, :for_full_year, payable: provider)
-      FactoryBot.create(:trainee_summary, :with_bursary_and_scholarship_rows, payable: provider)
+      FactoryBot.create(:trainee_summary, :with_bursary_and_scholarship_and_multiple_amounts, payable: provider)
 
       if persona_attributes[:lead_school]
         lead_school = School.lead_only.sample

--- a/spec/factories/funding/trainee_summaries.rb
+++ b/spec/factories/funding/trainee_summaries.rb
@@ -31,5 +31,37 @@ FactoryBot.define do
         bursaries + scholarships + tiered_bursaries
       end
     end
+
+    trait :with_bursary_and_scholarship_and_multiple_amounts do
+      rows do
+        bursaries = [AllocationSubjects::MATHEMATICS, AllocationSubjects::PHYSICS].map do |subject|
+          build(:trainee_summary_row, :with_bursary_amount, subject: subject, lead_school_name: nil, lead_school_urn: nil)
+        end
+        scholarships = [
+          build(
+            :trainee_summary_row,
+            :with_scholarship_amount,
+            subject: AllocationSubjects::CHEMISTRY,
+            route: "School Direct tuition fee",
+          ),
+        ]
+        tiered_bursaries = [
+          build(
+            :trainee_summary_row,
+            :with_tiered_bursary_amount,
+            subject: AllocationSubjects::CLASSICS,
+          ),
+        ]
+        multiple_amounts = [
+          build(
+            :trainee_summary_row,
+            :with_multiple_amounts,
+            subject: AllocationSubjects::BIOLOGY,
+          ),
+        ]
+
+        bursaries + scholarships + tiered_bursaries + multiple_amounts
+      end
+    end
   end
 end

--- a/spec/factories/funding/trainee_summary_rows.rb
+++ b/spec/factories/funding/trainee_summary_rows.rb
@@ -35,5 +35,15 @@ FactoryBot.define do
         [build(:trainee_summary_row_amount, :with_tiered_bursary)]
       end
     end
+
+    trait :with_multiple_amounts do
+      route { "Early years graduate employment based" }
+      amounts do
+        [
+          build(:trainee_summary_row_amount, :with_bursary),
+          build(:trainee_summary_row_amount, :with_scholarship),
+        ]
+      end
+    end
   end
 end

--- a/spec/services/exports/funding_trainee_summary_data_spec.rb
+++ b/spec/services/exports/funding_trainee_summary_data_spec.rb
@@ -48,6 +48,39 @@ module Exports
       it "sets the correct title" do
         expect(subject.filename).to include(csv_title)
       end
+
+      context "when there are no trainee summaries" do
+        let!(:scholarship_amount) { create(:trainee_summary_row_amount, :with_scholarship, row: trainee_summary_row) }
+        let(:bursary_expected_output) do
+          {
+            "Funding type" => "ITT #{tiered_bursary_amount.payment_type}",
+            "Route" => trainee_summary_row.route,
+            "Course" => trainee_summary_row.subject,
+            "Lead school" => trainee_summary_row.lead_school_name,
+            "Tier" => "Tier #{tiered_bursary_amount.tier}",
+            "Number of trainees" => tiered_bursary_amount.number_of_trainees,
+            "Amount per trainee" => "\"#{ActionController::Base.helpers.number_to_currency(tiered_bursary_amount.amount_in_pence.to_d / 100, unit: '£')}\"",
+            "Total" => "\"#{ActionController::Base.helpers.number_to_currency(tiered_bursary_amount.number_of_trainees * tiered_bursary_amount.amount_in_pence.to_d / 100, unit: '£')}\"",
+          }
+        end
+        let(:scholarship_expected_output) do
+          {
+            "Funding type" => "ITT #{scholarship_amount.payment_type}",
+            "Route" => trainee_summary_row.route,
+            "Course" => trainee_summary_row.subject,
+            "Lead school" => trainee_summary_row.lead_school_name,
+            "Tier" => "Not applicable",
+            "Number of trainees" => scholarship_amount.number_of_trainees,
+            "Amount per trainee" => "\"#{ActionController::Base.helpers.number_to_currency(scholarship_amount.amount_in_pence.to_d / 100, unit: '£')}\"",
+            "Total" => "\"#{ActionController::Base.helpers.number_to_currency(scholarship_amount.number_of_trainees * scholarship_amount.amount_in_pence.to_d / 100, unit: '£')}\"",
+          }
+        end
+
+        it "sets the correct row values" do
+          expect(subject.csv).to include(bursary_expected_output.values.join(","))
+          expect(subject.csv).to include(scholarship_expected_output.values.join(","))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
This issue originated from a support issue. A provider exported their trainee summary for 2022 to 2023, but the download was missing a trainee on a scholarship so the total in column H of the downloaded spreadsheet too low and did not match that shown in the user interface.

This is happening because the CSV export logic only considers the first amount per row. It should consider all amounts.

https://trello.com/c/mhT1Gd4h/6489-tkatt-scitt-scholarship-trainee-missing-from-the-funding-download

### Changes proposed in this pull request
Include multiple rows in the exported funding CSV when there are multiple amounts per summary row (for different funding types).

#### Example

For this funding summary (appearing here in the Web UI):
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/1f4c4ec6-16c4-474c-89e4-3cd777a26bb7)

CSV download before (with mismatched total):
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/ae39ac58-72b6-4c9a-8b2c-e21bab6de355)

and after (with matching total):
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/06c06f7c-d065-4084-b6e3-d783299f4574)

### Guidance to review
I've added some data to the example data generator to replicate the issue and test it.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
