### PR TITLE
[6609] Workaround missing/alternate country codes implemented by DQT

### DIFF
--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -195,19 +195,20 @@ module Dqt
       def find_country_code(country)
         return if country.blank?
 
-        country_code =
+        country_territory_code =
           DfE::ReferenceData::CountriesAndTerritories::COUNTRIES_AND_TERRITORIES.some(name: country).first&.id ||
           Hesa::CodeSets::Countries::MAPPING.find { |_, name| name.start_with?(country) }&.first
 
+        country_code = strip_territory_component(country_territory_code)
         apply_special_case_country_code_mappings(country_code)
       end
 
-      def apply_special_case_country_code_mappings(country_code)
-        # Apply special cases for country codes that DQT doesn't recognise
-        country_code = COUNTRY_CODE_EXCEPTIONS[country_code] if COUNTRY_CODE_EXCEPTIONS.key?(country_code)
+      def strip_territory_component(country_territory_code)
+        country_territory_code.gsub(/-\w+$/, "")
+      end
 
-        # Remove region from country code
-        country_code.gsub(/-\w+$/, "")
+      def apply_special_case_country_code_mappings(country_code)
+        COUNTRY_CODE_EXCEPTIONS.key?(country_code) ? COUNTRY_CODE_EXCEPTIONS[country_code] : country_code
       end
     end
   end

--- a/app/lib/dqt/params/trn_request.rb
+++ b/app/lib/dqt/params/trn_request.rb
@@ -66,9 +66,8 @@ module Dqt
         "Masters, not by research" => "MastersNotByResearch",
       }.freeze
 
-      COUNTY_CODE_EXCEPTIONS = {
+      COUNTRY_CODE_EXCEPTIONS = {
         "CY" => "XC",
-        /^AE\-/ => "AE",
       }.freeze
 
       attr_reader :params
@@ -204,16 +203,11 @@ module Dqt
       end
 
       def apply_special_case_country_code_mappings(country_code)
-        mapped_country_code = country_code
+        # Apply special cases for country codes that DQT doesn't recognise
+        country_code = COUNTRY_CODE_EXCEPTIONS[country_code] if COUNTRY_CODE_EXCEPTIONS.key?(country_code)
 
-        COUNTY_CODE_EXCEPTIONS.each do |pattern, replacement|
-          if (pattern.is_a?(String) && country_code == pattern) || country_code.match?(pattern)
-            mapped_country_code = replacement
-            break
-          end
-        end
-
-        mapped_country_code
+        # Remove region from country code
+        country_code.gsub(/-\w+$/, "")
       end
     end
   end

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -213,13 +213,11 @@ module Dqt
 
         context "when trainee has an international degree" do
           let(:country) { "Albania" }
-          let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details, country: country) }
+          let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details, country:) }
           let(:trainee) { create(:trainee, :completed, degrees: [non_uk_degree]) }
 
           it "maps the degree country to HESA countryCode" do
-            expect(subject["qualification"]).to include({
-              "countryCode" => "AL",
-            })
+            expect(subject["qualification"]).to include("countryCode" => "AL")
           end
 
           context "country has extra information" do
@@ -227,7 +225,7 @@ module Dqt
             let(:trainee) { create(:trainee, :completed, degrees: [non_uk_degree]) }
 
             it "maps the degree country to HESA countryCode" do
-              expect(subject["qualification"]).to include({ "countryCode" => "HK" })
+              expect(subject["qualification"]).to include("countryCode" => "HK")
             end
           end
 
@@ -235,7 +233,7 @@ module Dqt
             let(:country) { "Cyprus (European Union)" }
 
             it "sets the training country code appropriately" do
-              expect(subject["qualification"]).to include({ "countryCode" => "XA" })
+              expect(subject["qualification"]).to include("countryCode" => "XA")
             end
           end
 
@@ -243,7 +241,7 @@ module Dqt
             let(:country) { "Cyprus (non European Union)" }
 
             it "sets the training country code appropriately" do
-              expect(subject["qualification"]).to include({ "countryCode" => "XB" })
+              expect(subject["qualification"]).to include("countryCode" => "XB")
             end
           end
 
@@ -251,7 +249,7 @@ module Dqt
             let(:country) { "Cyprus" }
 
             it "sets the training country code appropriately" do
-              expect(subject["qualification"]).to include({ "countryCode" => "XC" })
+              expect(subject["qualification"]).to include("countryCode" => "XC")
             end
           end
 
@@ -259,7 +257,7 @@ module Dqt
             let(:country) { "Abu Dhabi" }
 
             it "sets the training country code appropriately" do
-              expect(subject["qualification"]).to include({ "countryCode" => "AE" })
+              expect(subject["qualification"]).to include("countryCode" => "AE")
             end
           end
         end

--- a/spec/lib/dqt/params/trn_request_spec.rb
+++ b/spec/lib/dqt/params/trn_request_spec.rb
@@ -212,7 +212,8 @@ module Dqt
         end
 
         context "when trainee has an international degree" do
-          let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details, country: "Albania") }
+          let(:country) { "Albania" }
+          let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details, country: country) }
           let(:trainee) { create(:trainee, :completed, degrees: [non_uk_degree]) }
 
           it "maps the degree country to HESA countryCode" do
@@ -222,11 +223,43 @@ module Dqt
           end
 
           context "country has extra information" do
-            let(:non_uk_degree) { build(:degree, :non_uk_degree_with_details, country: "Hong Kong (Special Administrative Region of China)") }
+            let(:country) { "Hong Kong (Special Administrative Region of China)" }
             let(:trainee) { create(:trainee, :completed, degrees: [non_uk_degree]) }
 
             it "maps the degree country to HESA countryCode" do
               expect(subject["qualification"]).to include({ "countryCode" => "HK" })
+            end
+          end
+
+          context "degree was from `Cyprus (European Union)`" do
+            let(:country) { "Cyprus (European Union)" }
+
+            it "sets the training country code appropriately" do
+              expect(subject["qualification"]).to include({ "countryCode" => "XA" })
+            end
+          end
+
+          context "degree was from `Cyprus (non European Union)`" do
+            let(:country) { "Cyprus (non European Union)" }
+
+            it "sets the training country code appropriately" do
+              expect(subject["qualification"]).to include({ "countryCode" => "XB" })
+            end
+          end
+
+          context "degree was from `Cyprus`" do
+            let(:country) { "Cyprus" }
+
+            it "sets the training country code appropriately" do
+              expect(subject["qualification"]).to include({ "countryCode" => "XC" })
+            end
+          end
+
+          context "degree was from `Abu Dhabi`" do
+            let(:country) { "Abu Dhabi" }
+
+            it "sets the training country code appropriately" do
+              expect(subject["qualification"]).to include({ "countryCode" => "AE" })
             end
           end
         end


### PR DESCRIPTION
### Context
We currently use the DfE Reference Data gem to map country values between their human-readable names and two-letter ISO codes. DQT expects a two-letter ISO code. However it's list of countries is not exactly the same as ours and it rejects codes with a region, e.g. AE-AY (Abu Dhabi in the United Arab Emirates).

### Changes proposed in this pull request
Without harmonising our country lists across all services we need to implement some non-standard mappings at the point we send this information to DQT.

- _Cyprus_ needs to be mapped the country code `XC` and not `CY`.
- All country codes with regions need to have those stripped. e.g. `AE` not `AE-AY`. This applies to a few other countries like St Helena and Caribbean Netherlands.

### Guidance to review
- I've looked for all the places in the DQT interface that pass country codes - I've only found two places both for the request TRN API call. Are there any others?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
