### PR TITLE
[6622] Clear funding when reinstatement happens

### DIFF
--- a/app/forms/reinstatement_form.rb
+++ b/app/forms/reinstatement_form.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ReinstatementForm < MultiDateForm
+  include CourseFormHelpers
   validate :date_valid
 
 private
@@ -8,6 +9,7 @@ private
   def assign_attributes_to_trainee
     trainee[date_field] = date
     trainee.trainee_start_date = date if trainee.deferred? && trainee.trainee_start_date.nil?
+    clear_funding_information
   end
 
   def date_field

--- a/spec/forms/reinstatement_form_spec.rb
+++ b/spec/forms/reinstatement_form_spec.rb
@@ -93,5 +93,16 @@ describe ReinstatementForm, type: :model do
         expect { subject.save! }.to change(trainee, :trainee_start_date).to(Date.new(*expected_date_params))
       end
     end
+
+    context "trainee with funding" do
+      let(:trainee) { create(:trainee, :reinstated, :with_grant_and_tiered_bursary) }
+
+      it "clears the funding information" do
+        expect(form_store).to receive(:set).with(trainee.id, :reinstatement, nil)
+
+        expect { subject.save! }.to change(trainee, :applying_for_bursary).from(true).to(nil)
+          .and change(trainee, :bursary_tier).from("tier_one").to(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

https://trello.com/c/5jC7GKNC/6622-clear-funding-method-if-the-start-year-of-a-trainee-changes

### Changes proposed in this pull request

Clears the funding information on the Trainee whenever reinstatement happens

### Guidance to review

- Find a deferred trainee with some funding applied (look for courses in math, computer science, etc)
- Reinstate them
- Check the funding method is asked for on the trainee page
