### PR TITLE
[6618] Send welcome email after user creation not first login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,6 @@ class SessionsController < ApplicationController
 
     if current_user
       DfESignInUsers::Update.call(user: current_user, sign_in_user: sign_in_user)
-      SendWelcomeEmailService.call(current_user:)
 
       redirect_to(login_redirect_path)
     else

--- a/app/controllers/system_admin/users_controller.rb
+++ b/app/controllers/system_admin/users_controller.rb
@@ -18,7 +18,8 @@ module SystemAdmin
     def create
       @user = authorize(User.new(permitted_attributes(User)))
       if @user.save
-        User.find_or_create_by!(email: @user.email)
+        user = User.find_or_create_by!(email: @user.email)
+        SendWelcomeEmailService.call(user:)
         redirect_to(user_path(user), flash: { success: t(".success") })
       else
         render(:new)

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -3,30 +3,30 @@
 class SendWelcomeEmailService
   include ServicePattern
 
-  def initialize(current_user:)
-    @current_user = current_user
+  def initialize(user:)
+    @user = user
   end
 
   def call
     return unless FeatureService.enabled?(:send_emails)
-    return if current_user.welcome_email_sent_at
+    return if user.welcome_email_sent_at
     return unless lead_school_user?
 
     WelcomeEmailMailer.generate(
-      first_name: current_user.first_name,
-      email: current_user.email,
+      first_name: user.first_name,
+      email: user.email,
     ).deliver_later
 
-    current_user.update!(
+    user.update!(
       welcome_email_sent_at: Time.zone.now,
     )
   end
 
 private
 
-  attr_reader :current_user
+  attr_reader :user
 
   def lead_school_user?
-    current_user.lead_schools.any?
+    user.lead_schools.any?
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -12,8 +12,8 @@ describe SessionsController do
 
   describe "#callback" do
     context "existing database user" do
-      it "calls send welcome email service" do
-        expect(SendWelcomeEmailService).to receive(:call).once
+      it "does not call send welcome email service" do
+        expect(SendWelcomeEmailService).not_to receive(:call)
         request_callback
       end
 

--- a/spec/features/system_admin/users/creating_a_new_user_spec.rb
+++ b/spec/features/system_admin/users/creating_a_new_user_spec.rb
@@ -7,6 +7,8 @@ feature "Creating a new user" do
   let(:dttp_id) { SecureRandom.uuid }
 
   before do
+    @welcome_mailer_service = class_spy(SendWelcomeEmailService).as_stubbed_const
+
     given_i_am_authenticated(user:)
     when_i_visit_the_user_index_page
     and_i_click_on_add_a_user
@@ -21,6 +23,7 @@ feature "Creating a new user" do
         and_i_fill_in_dttp_id
         when_i_save_the_form
         then_i_am_taken_to_the_user_show_page
+        and_the_user_is_sent_a_welcome_email
       end
     end
 
@@ -98,5 +101,9 @@ private
 
   def then_i_should_see_the_error_summary
     expect(admin_new_user_page.error_summary).to be_visible
+  end
+
+  def and_the_user_is_sent_a_welcome_email
+    expect(@welcome_mailer_service).to have_received(:call).with(user: User.last)
   end
 end

--- a/spec/services/send_welcome_email_service_spec.rb
+++ b/spec/services/send_welcome_email_service_spec.rb
@@ -17,7 +17,7 @@ describe SendWelcomeEmailService do
 
   context "when the user has not logged in before" do
     context "lead school user" do
-      let(:current_user) do
+      let(:user) do
         spy(
           first_name: "Meowington",
           email: "meowington@cat.net",
@@ -28,11 +28,11 @@ describe SendWelcomeEmailService do
 
       before do
         allow(WelcomeEmailMailer).to receive_message_chain(:generate, :deliver_later)
-        described_class.call(current_user:)
+        described_class.call(user:)
       end
 
       it "sets their welcome email date to now" do
-        expect(current_user).to have_received(:update!).with(hash_including(welcome_email_sent_at: Time.zone.now))
+        expect(user).to have_received(:update!).with(hash_including(welcome_email_sent_at: Time.zone.now))
       end
 
       it "sends the welcome email" do
@@ -49,7 +49,7 @@ describe SendWelcomeEmailService do
     end
 
     context "not a lead school user" do
-      let(:current_user) do
+      let(:user) do
         spy(
           first_name: "Meowington",
           email: "meowington@cat.net",
@@ -59,17 +59,17 @@ describe SendWelcomeEmailService do
       end
 
       before do
-        described_class.call(current_user:)
+        described_class.call(user:)
       end
 
       it "does not update welcome_email_sent_at field" do
-        expect(current_user).not_to have_received(:update!)
+        expect(user).not_to have_received(:update!)
       end
     end
   end
 
   context "when a lead school user has logged in before" do
-    let(:current_user) do
+    let(:user) do
       spy(
         first_name: "Meowington",
         welcome_email_sent_at: Time.zone.local(2021, 1, 1),
@@ -79,12 +79,12 @@ describe SendWelcomeEmailService do
 
     before do
       allow(WelcomeEmailMailer).to receive_message_chain(:generate, :deliver_later)
-      described_class.call(current_user:)
+      described_class.call(user:)
     end
 
     context "and has received a welcome email" do
       it "does not update their welcome email date" do
-        expect(current_user).not_to have_received(:update!).with(hash_including(welcome_email_sent_at: Time.zone.now))
+        expect(user).not_to have_received(:update!).with(hash_including(welcome_email_sent_at: Time.zone.now))
       end
 
       it "does not send the welcome email" do


### PR DESCRIPTION
### Context
We currently send out our 'welcome email' to new users right after they first log in. Since this email contains information about how to actually login it makes more sense to have it sent straight after the user is created in the system admin interface.

### Changes proposed in this pull request
Move call to `SendWelcomeEmailService` from the `SessionsController#callback` action to `SysAdmin::UsersController#create`.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
