### PR TITLE
[6551] Content updates for performance profile guidance

### DIFF
--- a/app/views/guidance/manage_placements.html.erb
+++ b/app/views/guidance/manage_placements.html.erb
@@ -27,10 +27,6 @@
 
     <p class="govuk-body-m">A minimum of 2 placements is required for each trainee who have been awarded QTS or EYTS in the <%= @previous_academic_cycle.label %> academic year.</p>
 
-    <%= govuk_inset_text do %>
-      <p class="govuk-body-m">HEI providers will be notified by email in early <%= @performance_profile_sign_off_short_deadline %> when their placement data has been imported into Register for them to check and fill in any missing placement information. We will only import the URN from the student collection.</p>
-    <% end %>
-
     <h3 class="govuk-heading-s">Manually record placement data</h3>
 
     <p class="govuk-body-m">Manual input is recommended for providers with a small number of registered trainees.</p>

--- a/app/views/guidance/performance_profiles.html.erb
+++ b/app/views/guidance/performance_profiles.html.erb
@@ -55,7 +55,6 @@
     <h2 class="govuk-heading-m">Fix mistakes in your trainee data</h2>
     <p class="govuk-body">You need to fix any mistakes before you sign off the data. How you do this depends on the type of organisation you work for.</p>
 
-    <h3 class="govuk-heading-s">Providers of school centred initial teacher training (SCITTs)</h3>
     <p class="govuk-body">
       If the trainee is shown in this service as awarded or withdrawn, you should email
       <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk?subject=Fix mistake in <%= @previous_academic_cycle_label %> data for performance profiles publication">becomingateacher@digital.education.gov.uk</a>.


### PR DESCRIPTION
### Context
Now that HEIs are ready to sign off their performance profiles by 31 Jan 2024 so there is a need to update 2 Register guidance pages.

https://trello.com/c/jwQElDPg/6551-performance-profile-guidance-page-minor-updates-x-2

### Changes proposed in this pull request
- Remove inset text from _Manage your trainee placement data_ page.

#### Before/After
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/5b60c592-e821-40a3-8076-f5a3f808a092)

- Remove heading about SCITTS from _Sign off your list of trainees from 2022 to 2023 for the performance profiles publication_ page.

#### Before/After
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/86007f19-e4b2-4c9c-80a4-7ff2b7f57571)

### Guidance to review
See review app

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
