### PR TITLE
[6528] - Add logins to the smoke tests

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -168,3 +168,7 @@ sign_off_period: # census_period, performance_period, outside_period. See app/se
 
 trainee_export:
   record_limit: 100
+
+smoke_test:
+  username: do-not-store-here
+  password: do-not-store-here

--- a/spec/smoke/login_spec.rb
+++ b/spec/smoke/login_spec.rb
@@ -19,7 +19,7 @@ private
 
   def visit_sign_in_page
     visit "#{url_with_basic_auth}/sign-in"
-    click_button "Sign in using DfE Sign-in"
+    click_on "Sign in using DfE Sign-in"
   end
 
   def fill_in_login_credentials
@@ -28,7 +28,7 @@ private
   end
 
   def submit_login_form
-    click_button "Sign in"
+    click_on "Sign in"
   end
 
   def verify_successful_login
@@ -37,7 +37,7 @@ private
   end
 
   def sign_out
-    click_link "Sign out"
+    click_on "Sign out"
     expect(page).to have_content("Sign in")
   end
 

--- a/spec/smoke/login_spec.rb
+++ b/spec/smoke/login_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper_smoke"
+
+describe "User login spec" do
+  before do
+    skip "DfE sign-in not enabled" unless Settings.features.sign_in_method == "dfe-sign-in"
+  end
+
+  scenario "signing in successfully" do
+    visit_sign_in_page
+    fill_in_login_credentials
+    submit_login_form
+    verify_successful_login
+    sign_out
+  end
+
+private
+
+  def visit_sign_in_page
+    visit "#{url_with_basic_auth}/sign-in"
+    click_button "Sign in using DfE Sign-in"
+  end
+
+  def fill_in_login_credentials
+    fill_in "username", with: Settings.smoke_test&.username
+    fill_in "password", with: Settings.smoke_test&.password
+  end
+
+  def submit_login_form
+    click_button "Sign in"
+  end
+
+  def verify_successful_login
+    expect(page).to have_current_path("/")
+    expect(page).to have_content("Sign out")
+  end
+
+  def sign_out
+    click_link "Sign out"
+    expect(page).to have_content("Sign in")
+  end
+
+  def url_with_basic_auth
+    uri = URI.parse(Settings.base_url)
+    uri.user = Settings.basic_auth&.username
+    uri.password = Settings.basic_auth&.password
+    uri.to_s
+  end
+end

--- a/spec/spec_helper_smoke.rb
+++ b/spec/spec_helper_smoke.rb
@@ -1,9 +1,30 @@
 # frozen_string_literal: true
 
+require 'dotenv/load'
+
 ENV["RAILS_ENV"] ||= "test"
 
 require "rspec/core"
 require "config"
 require "httparty"
+require "capybara/rspec"
+require "selenium-webdriver"
+require "byebug"
 
 Config.load_and_set_settings(Config.setting_files("config", ENV.fetch("RAILS_ENV", nil)))
+
+Capybara.register_driver :selenium_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless")
+  options.add_argument("--disable-gpu")
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.default_driver = :selenium_headless
+Capybara.javascript_driver = :selenium_headless
+Capybara.default_max_wait_time = 5
+
+RSpec.configure do |config|
+  config.include Capybara::DSL
+end

--- a/spec/spec_helper_smoke.rb
+++ b/spec/spec_helper_smoke.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'dotenv/load'
-
 ENV["RAILS_ENV"] ||= "test"
 
 require "rspec/core"
@@ -9,7 +7,6 @@ require "config"
 require "httparty"
 require "capybara/rspec"
 require "selenium-webdriver"
-require "byebug"
 
 Config.load_and_set_settings(Config.setting_files("config", ENV.fetch("RAILS_ENV", nil)))
 


### PR DESCRIPTION
### Context

An incident happened [Incident report some_users_unable_to_sign_in_to_register 20231207](https://educationgovuk.sharepoint.com/:w:/r/sites/TeacherServices/Shared%20Documents/Becoming%20a%20Teacher/Incidents/Incident%20report%20some_users_unable_to_sign_in_to_register%2020231207.docx?d=w7b0377219b4e41ecba14394e9e17017e&csf=1&web=1&e=yZsN8l)

This adds smoke testing that uses a test user account to log into the service on deploy.

### Changes proposed in this pull request

* creates a new smoke test user - added to production, productiondata and staging
* simple capybara test that visits the live deployed
* username/pass are added to the ENV for each relevant site
* this skips the tests if OTP sign-in method is enabled (this will need to be a separate spec if wanted)
