### PR TITLE
[6528] add logins to the smoke tests - corrects faulty spec

### DIFF
--- a/spec/smoke/login_spec.rb
+++ b/spec/smoke/login_spec.rb
@@ -7,7 +7,7 @@ describe "User login spec" do
     skip "DfE sign-in not enabled" unless Settings.features.sign_in_method == "dfe-sign-in"
   end
 
-  scenario "signing in successfully" do
+  scenario "signing in successfully", js: true do
     visit_sign_in_page
     fill_in_login_credentials
     submit_login_form
@@ -32,7 +32,6 @@ private
   end
 
   def verify_successful_login
-    expect(page).to have_current_path("/")
     expect(page).to have_content("Sign out")
   end
 

--- a/spec/smoke/login_spec.rb
+++ b/spec/smoke/login_spec.rb
@@ -19,7 +19,7 @@ private
 
   def visit_sign_in_page
     visit "#{url_with_basic_auth}/sign-in"
-    click_button "Sign in using DfE Sign-in"
+    click_on "Sign in using DfE Sign-in"
   end
 
   def fill_in_login_credentials
@@ -28,7 +28,7 @@ private
   end
 
   def submit_login_form
-    click_button "Sign in"
+    click_on "Sign in"
   end
 
   def verify_successful_login
@@ -37,7 +37,7 @@ private
   end
 
   def sign_out
-    click_link "Sign out"
+    click_on "Sign out"
     expect(page).to have_content("Sign in")
   end
 

--- a/spec/smoke/login_spec.rb
+++ b/spec/smoke/login_spec.rb
@@ -19,7 +19,7 @@ private
 
   def visit_sign_in_page
     visit "#{url_with_basic_auth}/sign-in"
-    click_on "Sign in using DfE Sign-in"
+    click_button "Sign in using DfE Sign-in"
   end
 
   def fill_in_login_credentials
@@ -28,7 +28,7 @@ private
   end
 
   def submit_login_form
-    click_on "Sign in"
+    click_button "Sign in"
   end
 
   def verify_successful_login
@@ -37,7 +37,7 @@ private
   end
 
   def sign_out
-    click_on "Sign out"
+    click_link "Sign out"
     expect(page).to have_content("Sign in")
   end
 

--- a/spec/spec_helper_smoke.rb
+++ b/spec/spec_helper_smoke.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dotenv/load'
+
 ENV["RAILS_ENV"] ||= "test"
 
 require "rspec/core"

--- a/spec/spec_helper_smoke.rb
+++ b/spec/spec_helper_smoke.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'dotenv/load'
-
 ENV["RAILS_ENV"] ||= "test"
 
 require "rspec/core"


### PR DESCRIPTION
relates to #3954 

This adds `js: true` to the smoke tests and removes unnecessary path check