### PR TITLE
[6623] Update hesa deferral logic

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -121,7 +121,7 @@ module Trainees
     def deferral_attributes
       return { defer_date: nil } unless mapped_trainee_state == :deferred
 
-      { defer_date: hesa_trainee[:end_date] }
+      { defer_date: itt_end_date || hesa_trainee[:hesa_updated_at] }
     end
 
     def submitted_for_trn_attributes

--- a/db/data/20240122123547_backfill_missing_hesa_defferal_dates.rb
+++ b/db/data/20240122123547_backfill_missing_hesa_defferal_dates.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class BackfillMissingHesaDefferalDates < ActiveRecord::Migration[7.1]
+  def up
+    Trainee.deferred.joins(:hesa_students).where(defer_date: nil).find_each do |trainee|
+      most_recent_itt_record = trainee.hesa_students.max_by(&:created_at)
+      next unless most_recent_itt_record
+
+      if Trainees::MapStateFromHesa.call(hesa_trainee: most_recent_itt_record, trainee: trainee) == :deferred
+        trainee.update!(
+          defer_date: most_recent_itt_record.end_date || most_recent_itt_record.itt_end_date || most_recent_itt_record.hesa_updated_at,
+        )
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -123,6 +123,14 @@ module Trainees
         expect(trainee.hesa_metadatum.year_of_course).to eq("0")
       end
 
+      context "when the trainee is deferred and there is no end_date" do
+        let(:hesa_stub_attributes) { { itt_end_date: nil, mode: "63" } }
+
+        it "sets the the trainee's defer_date to the hesa_updated_at" do
+          expect(trainee.defer_date).to eq(Date.parse(student_attributes[:hesa_updated_at]))
+        end
+      end
+
       context "leading and employing schools not applicable" do
         let(:not_applicable_or_not_available_hesa_code) { "900010" }
         let(:establishment_outside_england_and_wales_hesa_code) { "900000" }


### PR DESCRIPTION
### Context

Originally `F_ENDDATE` was used to set the `defer_date` on the trainee if HESA deferred the `itt_record` but was replaced with `EXPECTEDENDDATE`:

https://www.hesa.ac.uk/innovation/records/reviews/ITT-2022-23-AnnualUpdate
https://github.com/DFE-Digital/register-trainee-teachers/pull/2632

It appears we did not update https://github.com/DFE-Digital/register-trainee-teachers/blob/5d230a06fd3a03d031f218dd40c6647b66f5f191/app/services/trainees/create_from_hesa.rb#L124 to reflect the change.

Since then,` F_ENDDATE` was actually removed from the mapping as part of further api changes:

https://github.com/DFE-Digital/register-trainee-teachers/commit/7996391991303b667461f93d1b4c811d30bdc3d5#diff-7c04bf014ac455d32803dbf8a4fb1c7ab1e987b7365010559bd22a8ffd271ab9L27

Looking at the earlier updates, HESA states that `EXPECTEDENDDATE ` should be used if there are any breaks from learning so have switched to using this as a deferral date when the trainee is deferred. Otherwise we just fallback to the hesa_updated_at date. 

### Changes proposed in this pull request

- Updates the deferral logic in `CreateFromHesa`
- Data migration to backfill missing deferral dates for deferred hesa created trainees (around 1600 in prod)

### Guidance to review

This is a bit difficult to test locally as the sanitised dump does not include the `hesa_student` records. The data migration has been tested in `productiondata` against the dataset which needs to be updated (around 1600 records). Of those around 330 had not been updated because their most recent record from hesa states that they're not deferred. 