### PR TITLE
[6628] Fix placements CSV export placements in wrong order

### DIFF
--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -53,4 +53,8 @@ class Placement < ApplicationRecord
 
     full_address.join(", ")
   end
+
+  def created_by_hesa?
+    audits.exists?(action: "create", username: Trainees::CreateFromHesa::USERNAME)
+  end
 end

--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -411,7 +411,7 @@ module Reports
   private
 
     def placements
-      @placements ||= trainee.hesa_record? ? trainee.placements.reverse : trainee.placements
+      @placements ||= PlacementsImportedFromHesa.call(trainee:) ? trainee.placements.reverse : trainee.placements
     end
   end
 end

--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -411,7 +411,7 @@ module Reports
   private
 
     def placements
-      @placements ||= trainee.placements.reverse
+      @placements ||= trainee.hesa_record? ? trainee.placements.reverse : trainee.placements
     end
   end
 end

--- a/app/services/placements_imported_from_hesa.rb
+++ b/app/services/placements_imported_from_hesa.rb
@@ -12,13 +12,6 @@ class PlacementsImportedFromHesa
   def call
     return false if @trainee.placements.blank?
 
-    @trainee.hesa_record? &&
-      @trainee.placements.all? { |placement| created_by_hesa?(placement) }
-  end
-
-private
-
-  def created_by_hesa?(placement)
-    placement.audits.exists?(action: "create", username: "HESA")
+    @trainee.hesa_record? && @trainee.placements.all?(&:created_by_hesa?)
   end
 end

--- a/app/services/placements_imported_from_hesa.rb
+++ b/app/services/placements_imported_from_hesa.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class PlacementsImportedFromHesa
+  include ServicePattern
+
+  NEW_PLACEMENTS_RELEASE_DATE = Date.new(2023, 12, 13).freeze
+
+  def initialize(trainee:)
+    @trainee = trainee
+  end
+
+  def call
+    return false if @trainee.placements.blank?
+
+    @trainee.hesa_record? &&
+      @trainee.placements.all? { |placement| created_by_hesa?(placement) }
+  end
+
+private
+
+  def created_by_hesa?(placement)
+    placement.audits.exists?(action: "create", username: "HESA")
+  end
+end

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -290,14 +290,28 @@ describe Reports::TraineeReport do
 
     context "when placement data is available" do
       context "when there are 2 placements" do
-        let!(:placements) { create_list(:placement, 2, trainee:).reverse }
+        let!(:placements) { create_list(:placement, 2, trainee:) }
 
-        it "adds the first placement school urn under placement_one" do
-          expect(subject.placement_one).to eq(placements.first.school.urn)
+        context "when the trainee was NOT imported from HESA" do
+          let(:trainee) { create(:trainee, :in_progress, course_uuid: create(:course).uuid) }
+
+          it "adds the first placement school urn under placement_one" do
+            expect(subject.placement_one).to eq(placements.first.school.urn)
+          end
+
+          it "adds the second placement school urn under placement_two" do
+            expect(subject.placement_two).to eq(placements.second.school.urn)
+          end
         end
 
-        it "adds the second placement school urn under placement_two" do
-          expect(subject.placement_two).to eq(placements.second.school.urn)
+        context "when the trainee was imported from HESA" do
+          it "adds the first placement school urn under placement_two" do
+            expect(subject.placement_two).to eq(placements.first.school.urn)
+          end
+
+          it "adds the second placement school urn under placement_one" do
+            expect(subject.placement_one).to eq(placements.second.school.urn)
+          end
         end
       end
 

--- a/spec/services/placements_imported_from_hesa_spec.rb
+++ b/spec/services/placements_imported_from_hesa_spec.rb
@@ -8,9 +8,7 @@ describe PlacementsImportedFromHesa do
   subject { described_class.call(trainee:) }
 
   context "when the trainee is not imported from HESA" do
-    it "returns false" do
-      expect(subject).to be(false)
-    end
+    it { is_expected.to be(false) }
   end
 
   context "when the trainee is imported from HESA but not all placements are" do

--- a/spec/services/placements_imported_from_hesa_spec.rb
+++ b/spec/services/placements_imported_from_hesa_spec.rb
@@ -19,7 +19,7 @@ describe PlacementsImportedFromHesa do
 
   context "when the trainee and all it's placements is imported from HESA but not all placements are" do
     let(:trainee) do
-      Audited.audit_class.as_user("HESA") do
+      Audited.audit_class.as_user(Trainees::CreateFromHesa::USERNAME) do
         create(:trainee, :with_placements, :imported_from_hesa)
       end
     end

--- a/spec/services/placements_imported_from_hesa_spec.rb
+++ b/spec/services/placements_imported_from_hesa_spec.rb
@@ -14,9 +14,7 @@ describe PlacementsImportedFromHesa do
   context "when the trainee is imported from HESA but not all placements are" do
     let(:trainee) { create(:trainee, :with_placements, :imported_from_hesa) }
 
-    it "returns false" do
-      expect(subject).to be(false)
-    end
+    it { is_expected.to be(false) }
   end
 
   context "when the trainee and all it's placements is imported from HESA but not all placements are" do

--- a/spec/services/placements_imported_from_hesa_spec.rb
+++ b/spec/services/placements_imported_from_hesa_spec.rb
@@ -28,8 +28,6 @@ describe PlacementsImportedFromHesa do
       end
     end
 
-    it "returns true" do
-      expect(subject).to be(true)
-    end
+    it { is_expected.to be(true) }
   end
 end

--- a/spec/services/placements_imported_from_hesa_spec.rb
+++ b/spec/services/placements_imported_from_hesa_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PlacementsImportedFromHesa do
+  let(:trainee) { create(:trainee, :with_placements) }
+
+  subject { described_class.call(trainee:) }
+
+  context "when the trainee is not imported from HESA" do
+    it "returns false" do
+      expect(subject).to be(false)
+    end
+  end
+
+  context "when the trainee is imported from HESA but not all placements are" do
+    let(:trainee) { create(:trainee, :with_placements, :imported_from_hesa) }
+
+    it "returns false" do
+      expect(subject).to be(false)
+    end
+  end
+
+  context "when the trainee and all it's placements is imported from HESA but not all placements are" do
+    let(:trainee) do
+      Audited.audit_class.as_user("HESA") do
+        create(:trainee, :with_placements, :imported_from_hesa)
+      end
+    end
+
+    it "returns true" do
+      expect(subject).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
### Context
Providers have reported that placements added manually or bulk uploaded appear in the wrong order in the trainees CSV download. This is because we deliberately reverse the order due to them being wrong when imported from HESA.

### Changes proposed in this pull request
We need to avoid reversing placements when exporting trainees unless those placements have been imported from HESA.

### Guidance to review
- I've extracted the workaround logic into a `PlacementsImportedFromHesa` service.
- I tried this on the review app by adding two placements to this trainee and checking the export https://register-pr-3966.test.teacherservices.cloud/trainees/bNFu297ao6FfvjNviCSSDRfA

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
