### PR TITLE
[6681] Add new placement regression - uses non-JS flow

### DIFF
--- a/app/controllers/trainees/placements_controller.rb
+++ b/app/controllers/trainees/placements_controller.rb
@@ -22,7 +22,7 @@ module Trainees
         placement: Placement.new(placement_params),
       )
 
-      if @placement_form.still_searching?
+      if use_non_js_flow?
         redirect_to(
           new_trainee_placement_school_search_path(
             trainee_id: @trainee.slug,
@@ -45,7 +45,7 @@ module Trainees
     end
 
     def update
-      if placement_params[:school_search].present?
+      if use_non_js_flow?
         redirect_to(
           edit_trainee_placement_school_search_path(
             trainee_id: @trainee.slug,
@@ -99,6 +99,10 @@ module Trainees
       elsif params[:select_placement_school_form].present?
         params.fetch(:select_placement_school_form, {}).permit(:school_id)
       end
+    end
+
+    def use_non_js_flow?
+      placement_params[:school_search].present?
     end
   end
 end

--- a/app/controllers/trainees/placements_controller.rb
+++ b/app/controllers/trainees/placements_controller.rb
@@ -13,7 +13,7 @@ module Trainees
     end
 
     def edit
-      placement_form
+      placement_form.initialise_school_search_for_edit
     end
 
     def create

--- a/app/forms/placement_form.rb
+++ b/app/forms/placement_form.rb
@@ -31,6 +31,10 @@ class PlacementForm
     self.school_search = placement.school_search
   end
 
+  # This method is called by PlacementsController#edit to populate the school
+  # search field with the name of the currently selected school. It shouldn't
+  # be called elsewhere as the presence of the `school_search` field triggers
+  # the non-JS flow in other actions (e.g. `create` and `update`).
   def initialise_school_search_for_edit
     self.school_search ||= @placement&.school&.name
   end
@@ -159,10 +163,6 @@ class PlacementForm
     if postcode.present? && !UKPostcode.parse(postcode).valid?
       errors.add(:postcode, I18n.t("activemodel.errors.validators.postcode.invalid"))
     end
-  end
-
-  def still_searching?
-    school_search.present?
   end
 
 private

--- a/app/forms/placement_form.rb
+++ b/app/forms/placement_form.rb
@@ -28,7 +28,11 @@ class PlacementForm
     @placement = placement
     @destroy = destroy
     self.attributes = placement.attributes.symbolize_keys.slice(*FIELDS)
-    self.school_search = placement.school_search || placement.school&.name
+    self.school_search = placement.school_search
+  end
+
+  def initialise_school_search_for_edit
+    self.school_search ||= @placement&.school&.name
   end
 
   def self.model_name


### PR DESCRIPTION
### Context
When creating a new placement (in a JS enabled browser) the user is redirected into the non-JS flow and prompted to reselect the choice of school that they already picked from the autocomplete. This was a bug introduced by https://github.com/DFE-Digital/register-trainee-teachers/pull/3923

### Changes proposed in this pull request
As the non-JS flow is triggered by the presence of the `school_search` param in the `create` action so we avoid pushing that into the `PlacementForm` except on the `edit` action (where it sets the initial value of the search box when a user wants to change a placement).

### Guidance to review
Is there a better way to test for this kind of regression?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
