### PR TITLE
[6618] Move welcome email trigger to lead school controller

### DIFF
--- a/app/controllers/system_admin/user_lead_schools_controller.rb
+++ b/app/controllers/system_admin/user_lead_schools_controller.rb
@@ -23,6 +23,7 @@ module SystemAdmin
       end
 
       if @lead_school_form.save
+        SendWelcomeEmailService.call(user: @user)
         redirect_to(user_path(@user), flash: { success: "Lead school added" })
       else
         @school_search = SchoolSearch.call(query: params[:query], lead_schools_only: true)

--- a/app/controllers/system_admin/users_controller.rb
+++ b/app/controllers/system_admin/users_controller.rb
@@ -19,7 +19,6 @@ module SystemAdmin
       @user = authorize(User.new(permitted_attributes(User)))
       if @user.save
         user = User.find_or_create_by!(email: @user.email)
-        SendWelcomeEmailService.call(user:)
         redirect_to(user_path(user), flash: { success: t(".success") })
       else
         render(:new)

--- a/spec/features/system_admin/users/add_a_lead_school_to_user_spec.rb
+++ b/spec/features/system_admin/users/add_a_lead_school_to_user_spec.rb
@@ -15,6 +15,8 @@ feature "creating a new lead school for a user" do
   let!(:user_to_be_updated) { create(:user, first_name: "James", last_name: "Rodney") }
 
   before do
+    @welcome_mailer_service = class_spy(SendWelcomeEmailService).as_stubbed_const
+
     given_i_am_authenticated(user:)
     and_a_number_of_lead_schools_exist
     when_i_visit_the_user_index_page
@@ -32,6 +34,7 @@ feature "creating a new lead school for a user" do
         and_i_continue
         then_i_am_taken_to_the_user_show_page
         and_i_see_the_new_lead_school
+        and_the_user_is_sent_a_welcome_email
       end
 
       context "when a lead school is not selected" do
@@ -39,6 +42,7 @@ feature "creating a new lead school for a user" do
           and_i_fill_in_my_lead_school
           and_i_continue
           then_i_am_redirected_to_the_lead_schools_page
+          and_the_user_is_not_sent_a_welcome_email
         end
       end
     end
@@ -48,6 +52,7 @@ feature "creating a new lead school for a user" do
         and_i_fill_in_my_lead_school_without_js
         and_i_continue
         then_i_am_redirected_to_the_lead_schools_page
+        and_the_user_is_not_sent_a_welcome_email
       end
     end
   end
@@ -108,5 +113,13 @@ private
 
   def then_i_am_redirected_to_the_lead_schools_page
     expect(user_lead_schools_page).to be_displayed
+  end
+
+  def and_the_user_is_sent_a_welcome_email
+    expect(@welcome_mailer_service).to have_received(:call).with(user: user_to_be_updated)
+  end
+
+  def and_the_user_is_not_sent_a_welcome_email
+    expect(@welcome_mailer_service).not_to have_received(:call).with(user: user_to_be_updated)
   end
 end

--- a/spec/features/system_admin/users/creating_a_new_user_spec.rb
+++ b/spec/features/system_admin/users/creating_a_new_user_spec.rb
@@ -23,7 +23,7 @@ feature "Creating a new user" do
         and_i_fill_in_dttp_id
         when_i_save_the_form
         then_i_am_taken_to_the_user_show_page
-        and_the_user_is_sent_a_welcome_email
+        and_the_user_is_not_sent_a_welcome_email
       end
     end
 
@@ -103,7 +103,7 @@ private
     expect(admin_new_user_page.error_summary).to be_visible
   end
 
-  def and_the_user_is_sent_a_welcome_email
-    expect(@welcome_mailer_service).to have_received(:call).with(user: User.last)
+  def and_the_user_is_not_sent_a_welcome_email
+    expect(@welcome_mailer_service).not_to have_received(:call).with(user: User.last)
   end
 end


### PR DESCRIPTION
### Context
This is a follow up fix for https://github.com/DFE-Digital/register-trainee-teachers/pull/3940

There is logic in the `SendWelcomeEmailService` to skip the email unless the user is associated with a lead school so triggering this service immediately after create a user doesn't work.

### Changes proposed in this pull request
Instead we can trigger the service straight after adding a lead school to a user as this is the earliest possible time for a user to be 'eligible' to receive a welcome email.

We can safely call this service multiple times because in contains a check based on the `User#welcome_email_sent_at` timestamp to prevent multiple emails being sent to the same user.

### Guidance to review
- Is there a better way to test this than deploying straight to production?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
