### PR TITLE
[6671] Basic Rack attack setup for API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,6 +131,7 @@ gem "progress_bar" # useful to track progress of long running data migrations us
 gem "azure-storage-blob", "~> 2"
 gem "cssbundling-rails"
 gem "jsbundling-rails"
+gem "rack-attack"
 gem "strong_migrations"
 
 group :qa, :review, :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -498,6 +498,8 @@ GEM
     raabro (1.4.0)
     racc (1.7.3)
     rack (2.2.8)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-mini-profiler (3.3.0)
       rack (>= 1.2.0)
     rack-oauth2 (1.21.3)
@@ -822,6 +824,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 6.4)
   pundit
+  rack-attack
   rack-mini-profiler
   rails (~> 7.1)
   rails-controller-testing

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Block requests from IP blacklist
+Rack::Attack.blocklist("block requests from IP blacklist") do |req|
+  request.path.start_with?("/api") && req.ip.in?(Settings.api.blacklist.ip)
+end
+
+# Block requests from UA blacklist
+Rack::Attack.blocklist("block requests from UA blacklist") do |req|
+  request.path.start_with?("/api") && req.user_agent.in?(Settings.api.blacklist.ua)
+end
+
+# Throttle high volumes of API requests by IP address
+Rack::Attack.throttle(
+  "req/ip",
+  limit: Settings.api.throttling.max_requests,
+  period: Settings.api.throttling.interval.to_i.seconds,
+) do |req|
+  req.ip if req.path.starts_with?("/api")
+end
+
+# Return how many seconds to wait before retrying request to well-behaved clients
+Rack::Attack.throttled_response_retry_after_header = true

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -11,12 +11,14 @@ Rack::Attack.blocklist("block requests from UA blacklist") do |req|
 end
 
 # Throttle high volumes of API requests by IP address
-Rack::Attack.throttle(
-  "req/ip",
-  limit: Settings.api.throttling.max_requests,
-  period: Settings.api.throttling.interval.to_i.seconds,
-) do |req|
-  req.ip if req.path.starts_with?("/api")
+unless Rails.env.local?
+  Rack::Attack.throttle(
+    "req/ip",
+    limit: Settings.api.throttling.max_requests,
+    period: Settings.api.throttling.interval.to_i.seconds,
+  ) do |req|
+    req.ip if req.path.starts_with?("/api")
+  end
 end
 
 # Return how many seconds to wait before retrying request to well-behaved clients

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,12 +2,12 @@
 
 # Block requests from IP blacklist
 Rack::Attack.blocklist("block requests from IP blacklist") do |req|
-  request.path.start_with?("/api") && req.ip.in?(Settings.api.blacklist.ip)
+  req.path.start_with?("/api") && req.ip.in?(Settings.api.blacklist.ip)
 end
 
 # Block requests from UA blacklist
 Rack::Attack.blocklist("block requests from UA blacklist") do |req|
-  request.path.start_with?("/api") && req.user_agent.in?(Settings.api.blacklist.ua)
+  req.path.start_with?("/api") && req.user_agent.in?(Settings.api.blacklist.ua)
 end
 
 # Throttle high volumes of API requests by IP address

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -172,3 +172,11 @@ trainee_export:
 smoke_test:
   username: do-not-store-here
   password: do-not-store-here
+
+api:
+  throttling:
+    max_requests: 100
+    interval: 60
+  blacklist:
+    ua: []
+    ip: []


### PR DESCRIPTION
### Context

This PR sets up the rack-attack gem to help us prevent abusive requests for the Register API. 

### Changes proposed in this pull request

- Sets up a way to block requests from an IP list
- Sets up a way to block requests from specific user agents (bots, etc)
- Sets up a basic throttling configuration which can be changed in settings

### Guidance to review

Does it make sense?
