### PR TITLE
[6667] Move legacy `/api` routes to `/autocomplete`

### DIFF
--- a/app/controllers/autocomplete/application_controller.rb
+++ b/app/controllers/autocomplete/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Api
+module Autocomplete
   class ApplicationController < ActionController::API
   private
 

--- a/app/controllers/autocomplete/providers_controller.rb
+++ b/app/controllers/autocomplete/providers_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Api
-  class ProvidersController < Api::ApplicationController
+module Autocomplete
+  class ProvidersController < Autocomplete::ApplicationController
     def index
       return error_response if invalid_query?
 

--- a/app/controllers/autocomplete/schools_controller.rb
+++ b/app/controllers/autocomplete/schools_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Api
-  class SchoolsController < Api::ApplicationController
+module Autocomplete
+  class SchoolsController < Autocomplete::ApplicationController
     def index
       return error_response if invalid_query?
 

--- a/app/controllers/autocomplete/users_controller.rb
+++ b/app/controllers/autocomplete/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Api
-  class UsersController < Api::ApplicationController
+module Autocomplete
+  class UsersController < Autocomplete::ApplicationController
     def index
       return error_response if invalid_query?
 

--- a/app/javascript/scripts/components/form_components/providers_autocomplete.js
+++ b/app/javascript/scripts/components/form_components/providers_autocomplete.js
@@ -106,7 +106,7 @@ const findProviders = ({ query, populateResults }) => {
 
   statusMessage = 'Loading...' // Shared state
 
-  window.fetch(`/api/providers?query=${encodedQuery}`)
+  window.fetch(`/autocomplete/providers?query=${encodedQuery}`)
     .then(response => response.json())
     .then(guard)
     .then(mapToProviders)

--- a/app/javascript/scripts/components/form_components/schools_autocomplete.js
+++ b/app/javascript/scripts/components/form_components/schools_autocomplete.js
@@ -31,7 +31,7 @@ const findSchools = ({ query, populateResults, onlyLeadSchools }) => {
 
   statusMessage = 'Loading...' // Shared state
 
-  window.fetch(`/api/schools?query=${encodedQuery}&lead_school=${onlyLeadSchools ? 'true' : 'false'}`)
+  window.fetch(`/autocomplete/schools?query=${encodedQuery}&lead_school=${onlyLeadSchools ? 'true' : 'false'}`)
     .then(response => response.json())
     .then(guard)
     .then(mapToSchools)

--- a/app/javascript/scripts/components/form_components/users_autocomplete.js
+++ b/app/javascript/scripts/components/form_components/users_autocomplete.js
@@ -51,7 +51,7 @@ const findUsers = ({ query, populateResults }) => {
 
   statusMessage = 'Loading...'
 
-  window.fetch(`/api/users?query=${encodedQuery}`)
+  window.fetch(`/autocomplete/users?query=${encodedQuery}`)
     .then(response => response.json())
     .then(guard)
     .then(data => data.users)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   extend SystemAdminRoutes
   extend ApiRoutes
+  extend AutocompleteRoutes
 
   if Settings.dttp.portal_host.present?
     constraints(->(req) { req.host == Settings.dttp.portal_host }) do

--- a/config/routes/api_routes.rb
+++ b/config/routes/api_routes.rb
@@ -3,12 +3,6 @@
 module ApiRoutes
   def self.extended(router)
     router.instance_exec do
-      namespace :api do
-        resources :schools, only: :index
-        resources :providers, only: :index
-        resources :users, only: :index
-      end
-
       namespace :api, path: "api/:api_version", api_version: /v[.0-9]+/ do
         resource :info, only: :show, controller: "info", constraints: RouteConstraints::RegisterApiConstraint
         match "*url" => "base#not_found", via: :all

--- a/config/routes/autocomplete_routes.rb
+++ b/config/routes/autocomplete_routes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module AutocompleteRoutes
+  def self.extended(router)
+    router.instance_exec do
+      namespace :autocomplete do
+        resources :schools, only: :index
+        resources :providers, only: :index
+        resources :users, only: :index
+      end
+    end
+  end
+end

--- a/spec/controllers/autocomplete/providers_controller_spec.rb
+++ b/spec/controllers/autocomplete/providers_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-module Api
+module Autocomplete
   describe ProvidersController do
     describe "#index" do
       context "default response" do

--- a/spec/controllers/autocomplete/schools_controller_spec.rb
+++ b/spec/controllers/autocomplete/schools_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-module Api
+module Autocomplete
   describe SchoolsController do
     describe "#index" do
       context "default response" do


### PR DESCRIPTION
### Context
There were a number of routes that used the `/api` root path and `Api` module. These service the various autocomplete components that we have in our frontend. Now that we are building a 'real' API (see https://github.com/DFE-Digital/register-trainee-teachers/pull/3982) these are somewhat confusing and out of place. Note that they've never been used as an external API or documented as such despite appearances.

### Changes proposed in this pull request
This PR moves existing routes under `/api` to the `/autocomplete` root path. The idea being that this should make it very clear what they are used for. 

### Guidance to review
We need to just make sure that the autocompletes for schools, users and providers still work.

I've tried this on the review app for the users and providers pages in sys-admin and the providers add placement page for schools. e.g.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/c70570ec-d296-47ea-a040-5eb83059790f)

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
