### PR TITLE
[6668] initial api documentation set up framework to read content

### DIFF
--- a/app/controllers/api/guide_controller.rb
+++ b/app/controllers/api/guide_controller.rb
@@ -4,7 +4,6 @@ module Api
   class GuideController < ::ApplicationController
     skip_before_action :authenticate
 
-    def show
-    end
+    def show; end
   end
 end

--- a/app/controllers/api/guide_controller.rb
+++ b/app/controllers/api/guide_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Api
+  class GuideController < ::ApplicationController
+    skip_before_action :authenticate
+
+    def show
+    end
+  end
+end

--- a/app/controllers/api/guide_controller.rb
+++ b/app/controllers/api/guide_controller.rb
@@ -3,6 +3,7 @@
 module Api
   class GuideController < ::ApplicationController
     skip_before_action :authenticate
+    before_action { require_feature_flag(:register_api) }
 
     def show; end
   end

--- a/app/views/api/guide/show.md
+++ b/app/views/api/guide/show.md
@@ -1,0 +1,43 @@
+---
+page_title: Register API Guidance
+title: Register API Guidance
+---
+
+Welcome to the Register API! This API allows you to access information about trainees and provides endpoints to update and create trainee data. 
+
+Below are the available endpoints.
+
+## Endpoints
+
+### GET /info
+
+This endpoint provides general information about the API.
+
+#### Request
+
+`GET /api/v0.1/info`
+
+#### Response
+```
+Status: 200 OK
+{
+    // JSON response structure here
+}
+```
+
+### GET /Trainee
+
+This endpoint retrieves information about trainees.
+
+#### Request
+
+`GET /api/v0.1/trainee`
+
+#### Response
+
+```
+Status: 200 OK
+{
+    // JSON response structure here
+}
+```

--- a/app/views/layouts/api/guide.html.erb
+++ b/app/views/layouts/api/guide.html.erb
@@ -1,0 +1,9 @@
+<%= render(
+      "layouts/markdown_page",
+      {
+        page_title: @front_matter["page_title"],
+        title: @front_matter["title"],
+        breadcrumbs_text: "Back",
+        breadcrumbs_href: root_path,
+      },
+    ) %>

--- a/config/routes/api_routes.rb
+++ b/config/routes/api_routes.rb
@@ -5,7 +5,7 @@ module ApiRoutes
     router.instance_exec do
       namespace :api, path: "api/:api_version", api_version: /v[.0-9]+/ do
         resource :info, only: :show, controller: "info", constraints: RouteConstraints::RegisterApiConstraint
-        resource :guide, only: :show, controller: "guide", constraints: RouteConstraints::ValidRegisterApiRoute
+        resource :guide, only: :show, controller: "guide", constraints: RouteConstraints::RegisterApiConstraint
         match "*url" => "base#not_found", via: :all
       end
     end

--- a/config/routes/api_routes.rb
+++ b/config/routes/api_routes.rb
@@ -5,6 +5,7 @@ module ApiRoutes
     router.instance_exec do
       namespace :api, path: "api/:api_version", api_version: /v[.0-9]+/ do
         resource :info, only: :show, controller: "info", constraints: RouteConstraints::RegisterApiConstraint
+        resource :guide, only: :show, controller: "guide", constraints: RouteConstraints::ValidRegisterApiRoute
         match "*url" => "base#not_found", via: :all
       end
     end

--- a/spec/requests/api/v0.1/guide_spec.rb
+++ b/spec/requests/api/v0.1/guide_spec.rb
@@ -3,10 +3,19 @@
 require "rails_helper"
 
 describe "guidance endpoint" do
-  context "visiting" do
+  context "visiting with api feature flag", feature_register_api: true do
     it "returns status 200" do
       get "/api/v0.1/guide"
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "visiting without api feature flag", feature_register_api: false do
+    it "returns status 404" do
+      get "/api/v0.1/guide"
+      expect(response).to have_http_status(:found)
+      follow_redirect!
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/api/v0.1/guide_spec.rb
+++ b/spec/requests/api/v0.1/guide_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "guidance endpoint" do
+  context "visiting" do
+    it "returns status 200" do
+      get "/api/v0.1/guide"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Need to set up the framework to store the content of the documentation

### Changes proposed in this pull request

* adds a "guide" route and controller into the api route structure 
* uses markdown to render a simple guidance page via `show`

### Guidance to review

run locally and visit `/api/v0.1/guide`
