### PR TITLE
[6620] Add new page updating expected end date when trainees are reinstated

### DIFF
--- a/app/components/reinstatement_details/view.html.erb
+++ b/app/components/reinstatement_details/view.html.erb
@@ -4,8 +4,14 @@
     {
       key: t("components.confirmation.reinstatement_details.reinstate_date_label"),
       value: reinstate_date,
-      action_href: deferred_before_starting? ? nil: trainee_reinstatement_path(data_model.trainee),
+      action_href: deferred_before_starting? ? nil: trainee_reinstatement_path(trainee),
       action_text: t(:change),
     },
+    ({
+      key: t("components.confirmation.reinstatement_details.itt_end_date_label"),
+      value: date_for_summary_view(itt_end_date),
+      action_href: trainee_reinstatement_update_end_date_path(trainee),
+      action_text: t(:change)
+    } unless deferred_before_starting?),
   ],
 ) %>

--- a/app/components/reinstatement_details/view.html.erb
+++ b/app/components/reinstatement_details/view.html.erb
@@ -7,11 +7,13 @@
       action_href: deferred_before_starting? ? nil: trainee_reinstatement_path(trainee),
       action_text: t(:change),
     },
-    ({
-      key: t("components.confirmation.reinstatement_details.itt_end_date_label"),
-      value: date_for_summary_view(itt_end_date),
-      action_href: trainee_reinstatement_update_end_date_path(trainee),
-      action_text: t(:change)
-    } unless deferred_before_starting?),
-  ],
+    (unless deferred_before_starting?
+       {
+         key: t("components.confirmation.reinstatement_details.itt_end_date_label"),
+         value: date_for_summary_view(itt_end_date),
+         action_href: trainee_reinstatement_update_end_date_path(trainee),
+         action_text: t(:change)
+       }
+     end),
+  ].compact,
 ) %>

--- a/app/components/reinstatement_details/view.rb
+++ b/app/components/reinstatement_details/view.rb
@@ -9,7 +9,7 @@ module ReinstatementDetails
     delegate :trainee, to: :reinstatement_form
     delegate :itt_end_date, to: :itt_end_date_form
 
-    def initialize(reinstatement_form, itt_end_date_form)
+    def initialize(reinstatement_form:, itt_end_date_form:)
       @reinstatement_form = reinstatement_form
       @itt_end_date_form = itt_end_date_form
     end

--- a/app/components/reinstatement_details/view.rb
+++ b/app/components/reinstatement_details/view.rb
@@ -4,18 +4,22 @@ module ReinstatementDetails
   class View < ViewComponent::Base
     include SummaryHelper
 
-    attr_reader :data_model
+    attr_reader :reinstatement_form, :itt_end_date_form
 
-    def initialize(data_model)
-      @data_model = data_model
+    delegate :trainee, to: :reinstatement_form
+    delegate :itt_end_date, to: :itt_end_date_form
+
+    def initialize(reinstatement_form, itt_end_date_form)
+      @reinstatement_form = reinstatement_form
+      @itt_end_date_form = itt_end_date_form
     end
 
     def reinstate_date
-      deferred_before_starting? ? t(".reinstated_before_starting").html_safe : date_for_summary_view(data_model.date)
+      deferred_before_starting? ? t(".reinstated_before_starting").html_safe : date_for_summary_view(reinstatement_form.date)
     end
 
     def deferred_before_starting?
-      data_model.date.nil?
+      reinstatement_form.date.nil?
     end
   end
 end

--- a/app/controllers/trainees/confirm_reinstatements_controller.rb
+++ b/app/controllers/trainees/confirm_reinstatements_controller.rb
@@ -4,11 +4,12 @@ module Trainees
   class ConfirmReinstatementsController < BaseController
     def show
       page_tracker.save_as_origin!
-      reinstatement
+      reinstatement_form
+      itt_end_date_form
     end
 
     def update
-      if reinstatement.save! || trainee.starts_course_in_the_future?
+      if (reinstatement_form.save! && itt_end_date_form.save!) || trainee.starts_course_in_the_future?
         trainee.trn.present? ? trainee.receive_trn! : trainee.submit_for_trn!
         flash[:success] = I18n.t("flash.trainee_reinstated")
         redirect_to(trainee_path(trainee))
@@ -17,8 +18,12 @@ module Trainees
 
   private
 
-    def reinstatement
-      @reinstatement ||= ReinstatementForm.new(trainee)
+    def reinstatement_form
+      @reinstatement_form ||= ReinstatementForm.new(trainee)
+    end
+
+    def itt_end_date_form
+      @itt_end_date_form ||= IttEndDateForm.new(trainee)
     end
 
     def authorize_trainee

--- a/app/controllers/trainees/reinstatements/update_end_dates_controller.rb
+++ b/app/controllers/trainees/reinstatements/update_end_dates_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Trainees
+  module Reinstatements
+    class UpdateEndDatesController < BaseController
+      before_action :redirect_to_confirm_reinstatement, if: -> { trainee.starts_course_in_the_future? }
+
+      before_action :redirect_to_reinstatement, if: -> { reinstatement_form.date.blank? }
+
+      PARAM_CONVERSION = {
+        "itt_end_date(3i)" => "day",
+        "itt_end_date(2i)" => "month",
+        "itt_end_date(1i)" => "year",
+      }.freeze
+
+      def show
+        @itt_end_date_form = IttEndDateForm.new(trainee)
+      end
+
+      def update
+        @itt_end_date_form = IttEndDateForm.new(trainee, params: trainee_params, user: current_user)
+
+        if @itt_end_date_form.stash
+          redirect_to(trainee_confirm_reinstatement_path(trainee))
+        else
+          render(:show)
+        end
+      end
+
+    private
+
+      def trainee_params
+        params.require(:itt_end_date_form).permit(:itt_end_date, :context, *PARAM_CONVERSION.keys)
+              .transform_keys do |key|
+          PARAM_CONVERSION.keys.include?(key) ? PARAM_CONVERSION[key] : key
+        end
+      end
+
+      def authorize_trainee
+        authorize(trainee, :reinstate?)
+      end
+
+      def reinstatement_form
+        @reinstatement_form ||= ReinstatementForm.new(trainee)
+      end
+    end
+  end
+end

--- a/app/controllers/trainees/reinstatements_controller.rb
+++ b/app/controllers/trainees/reinstatements_controller.rb
@@ -12,7 +12,7 @@ module Trainees
       @reinstatement_form = ReinstatementForm.new(trainee, params: trainee_params, user: current_user)
 
       if @reinstatement_form.stash
-        redirect_to_confirm_reinstatement
+        redirect_to(trainee_reinstatement_update_end_date_path(trainee))
       else
         render(:show)
       end
@@ -26,10 +26,6 @@ module Trainees
         .transform_keys do |key|
           MultiDateForm::PARAM_CONVERSION.fetch(key, key)
         end
-    end
-
-    def redirect_to_confirm_reinstatement
-      redirect_to(trainee_confirm_reinstatement_path(trainee))
     end
 
     def authorize_trainee

--- a/app/forms/itt_end_date_form.rb
+++ b/app/forms/itt_end_date_form.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class IttEndDateForm < TraineeForm
+  include DatesHelper
+  MAX_END_YEARS = 4
+
+  attr_accessor :day, :month, :year
+
+  validate :itt_end_date_valid
+
+  def save!
+    if valid?
+      update_itt_end_date
+      Trainees::Update.call(trainee:)
+      clear_stash
+    else
+      false
+    end
+  end
+
+  def itt_end_date
+    date_hash = { year:, month:, day: }
+    date_args = date_hash.values.map(&:to_i)
+
+    valid_date?(date_args) ? Date.new(*date_args) : InvalidDate.new(date_hash)
+  end
+
+private
+
+  def compute_fields
+    {
+      day: trainee.itt_end_date&.day,
+      month: trainee.itt_end_date&.month,
+      year: trainee.itt_end_date&.year,
+    }.merge(new_attributes.slice(:day, :month, :year))
+  end
+
+  def update_itt_end_date
+    trainee.assign_attributes(itt_end_date:)
+  end
+
+  def fields_from_store
+    store.get(trainee.id, :itt_end_date).presence || {}
+  end
+
+  def itt_end_date_valid
+    if [day, month, year].all?(&:blank?)
+      errors.add(:itt_end_date, :blank)
+    elsif year.to_i > max_years
+      errors.add(:itt_end_date, :future)
+    elsif !itt_end_date.is_a?(Date)
+      errors.add(:itt_end_date, :invalid)
+    elsif itt_end_date < return_date
+      errors.add(:itt_end_date, :return_date)
+    end
+  end
+
+  def next_year
+    Time.zone.now.year.next
+  end
+
+  def max_years
+    next_year + MAX_END_YEARS
+  end
+
+  def return_date
+    reinstatement_form.date
+  end
+
+  def reinstatement_form
+    @reinstatement_form ||= ReinstatementForm.new(trainee)
+  end
+end

--- a/app/services/form_store.rb
+++ b/app/services/form_store.rb
@@ -44,6 +44,7 @@ class FormStore
     delete_trainee
     change_accredited_provider
     placements
+    itt_end_date
   ].freeze
 
   class << self

--- a/app/views/trainees/confirm_reinstatements/show.html.erb
+++ b/app/views/trainees/confirm_reinstatements/show.html.erb
@@ -13,10 +13,10 @@
       <%= t("views.confirm_reinstatement.heading") %>
     </h1>
 
-    <%= render ReinstatementDetails::View.new(@reinstatement_form, @itt_end_date_form) %>
+    <%= render ReinstatementDetails::View.new(reinstatement_form: @reinstatement_form, itt_end_date_form: @itt_end_date_form) %>
 
     <%= register_form_with url: trainee_confirm_reinstatement_path(@trainee), method: :patch, local: true do |f| %>
-      <%= f.govuk_submit t("views.confirm_reinstatement.submit") %>
+      <%= f.govuk_submit(t("views.confirm_reinstatement.submit")) %>
     <%- end -%>
   </div>
 </div>

--- a/app/views/trainees/confirm_reinstatements/show.html.erb
+++ b/app/views/trainees/confirm_reinstatements/show.html.erb
@@ -7,9 +7,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l">
-        <%= trainee_name(@trainee) %>
-      </span>
+      <%= render TraineeName::View.new(@trainee) %>
+
       <%= t("views.confirm_reinstatement.heading") %>
     </h1>
 

--- a/app/views/trainees/confirm_reinstatements/show.html.erb
+++ b/app/views/trainees/confirm_reinstatements/show.html.erb
@@ -13,7 +13,7 @@
       <%= t("views.confirm_reinstatement.heading") %>
     </h1>
 
-    <%= render ReinstatementDetails::View.new(@reinstatement) %>
+    <%= render ReinstatementDetails::View.new(@reinstatement_form, @itt_end_date_form) %>
 
     <%= register_form_with url: trainee_confirm_reinstatement_path(@trainee), method: :patch, local: true do |f| %>
       <%= f.govuk_submit t("views.confirm_reinstatement.submit") %>

--- a/app/views/trainees/reinstatements/show.html.erb
+++ b/app/views/trainees/reinstatements/show.html.erb
@@ -9,9 +9,7 @@
     <%= register_form_with(model: @reinstatement_form, url: trainee_reinstatement_path(@trainee), local: true) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-l">
-        <%= trainee_name(@trainee) %>
-      </span>
+      <%= render TraineeName::View.new(@trainee) %>
 
       <%= f.govuk_radio_buttons_fieldset(:date_string, legend: { text: t("views.forms.reinstatement.heading"), tag: "h1", size: "l" }) do %>
         <%= f.govuk_radio_button :date_string, :today, label: { text: t("views.forms.common.today") }, link_errors: true %>

--- a/app/views/trainees/reinstatements/update_end_dates/show.html.erb
+++ b/app/views/trainees/reinstatements/update_end_dates/show.html.erb
@@ -1,0 +1,23 @@
+<%= render PageTitle::View.new(i18n_key: "trainees.update_end_date.show", has_errors: @itt_end_date_form.errors.present?) %>
+
+<%= content_for(:breadcrumbs) do %>
+  <%= render DynamicBackLink::View.new(@trainee, text: t(:back)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= register_form_with(model: @itt_end_date_form, url: trainee_reinstatement_update_end_date_path, local: true) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= render TraineeName::View.new(@trainee) %>
+
+      <%= f.govuk_date_field(:itt_end_date,
+            legend: { text: t("views.forms.update_end_date.heading"), size: "l", tag: "h1" },
+            hint: { text: t("views.forms.update_end_date.itt_end_date.hint", itt_end_date: @trainee.itt_end_date.to_fs(:govuk)) } )%>
+      <%= f.govuk_submit %>
+
+    <% end %>
+
+    <p class="govuk-body"><%= govuk_link_to(t("views.forms.common.cancel_and_return_to_record"), trainee_path(@trainee)) %></p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1763,6 +1763,13 @@ en:
               too_old: Trainee start date cannot be more than 10 years in the past
             commencement_status:
               blank: Select if the trainee started on time
+        itt_end_date_form:
+          attributes:
+            itt_end_date:
+              blank: Enter an expected end date
+              future: Enter an expected end date closer to today
+              invalid: Enter a valid expected end date
+              return_date: The expected end date must be after the return date
         training_details_form:
           attributes:
             trainee_id:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,7 @@ en:
         nationality: &nationality Nationality
       reinstatement_details:
         reinstate_date_label: Date of return
+        itt_end_date_label: Expected end date
         summary_title: Reinstatement details
       flash:
         diversity: disclosure
@@ -446,6 +447,8 @@ en:
           confirm: Check deferral details
         reinstatement:
           show: When did the trainee return?
+        update_end_date:
+          show: What is the expected end date for their course?
         confirm_reinstatement:
           show: Check reinstatement details
         confirm_publish_course:
@@ -906,6 +909,10 @@ en:
           no_placement_detail: "No, I’ll add them later"
       reinstatement:
         heading: When did the trainee return?
+      update_end_date:
+        heading: What is the expected end date for their course?
+        itt_end_date:
+          hint: They were expected to end their course on %{itt_end_date} before they deferred. If this is still the same, you can enter that date again.
       withdrawal_date:
         duplicate_record_notice: Do not withdraw duplicate records. If you need to remove a duplicate record, contact us at %{contact_link}.
         deferral_notice_heading: Withdrawal date

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,7 +165,11 @@ Rails.application.routes.draw do
       resource :deferral, only: %i[show update], path: "/defer"
 
       resource :confirm_reinstatement, only: %i[show update], path: "/reinstate/confirm"
-      resource :reinstatement, only: %i[show update], path: "/reinstate"
+      resource :reinstatement, only: %i[show update], path: "/reinstate" do
+        scope module: :reinstatements do
+          resource :update_end_date, only: %i[show update], path: "/update-end-date"
+        end
+      end
 
       resources :lead_schools, only: %i[index], path: "/lead-schools"
       resource :lead_schools, only: %i[update edit], path: "/lead-schools"

--- a/spec/components/reinstatement_details/view_preview.rb
+++ b/spec/components/reinstatement_details/view_preview.rb
@@ -3,14 +3,21 @@
 module ReinstatementDetails
   class ViewPreview < ViewComponent::Preview
     def default
-      render(View.new(data_model))
+      render(View.new(reinstatement_form:, itt_end_date_form:))
     end
 
   private
 
-    def data_model
-      trainee = OpenStruct.new(id: 1, reinstate_date: Faker::Date.in_date_period)
+    def trainee
+      @trainee ||= OpenStruct.new(id: 1, reinstate_date: Faker::Date.in_date_period)
+    end
+
+    def reinstatement_form
       OpenStruct.new(trainee: trainee, date: trainee.reinstate_date)
+    end
+
+    def itt_end_date_form
+      OpenStruct.new(trainee: trainee, itt_end_date: 1.year.since(trainee.reinstate_date))
     end
   end
 end

--- a/spec/components/reinstatement_details/view_spec.rb
+++ b/spec/components/reinstatement_details/view_spec.rb
@@ -5,14 +5,43 @@ require "rails_helper"
 describe ReinstatementDetails::View do
   include SummaryHelper
 
-  let(:trainee) { build(:trainee, :reinstated, id: 1) }
-  let(:data_model) { OpenStruct.new(trainee: trainee, date: trainee.reinstate_date) }
+  let(:trainee) { build(:trainee, :deferred, id: 1) }
+  let(:reinstatement_form) { OpenStruct.new(trainee: trainee, date: 1.month.ago) }
+  let(:itt_end_date_form) { OpenStruct.new(trainee: trainee, itt_end_date: 1.week.ago) }
 
   before do
-    render_inline(described_class.new(data_model))
+    render_inline(described_class.new(reinstatement_form:, itt_end_date_form:))
   end
 
-  it "renders the date the trainee was reinstated" do
-    expect(rendered_content).to have_text(date_for_summary_view(data_model.date))
+  it "renders the date the trainee will be reinstated" do
+    expect(rendered_content).to have_text(date_for_summary_view(reinstatement_form.date))
+  end
+
+  it "renders the change link for the reinstated date" do
+    expect(rendered_content).to have_link("Change", href: "/trainees/#{trainee.slug}/reinstate")
+  end
+
+  it "renders the expected end date" do
+    expect(rendered_content).to have_text(date_for_summary_view(itt_end_date_form.itt_end_date))
+  end
+
+  it "renders the change link for the expected end date" do
+    expect(rendered_content).to have_link("Change", href: "/trainees/#{trainee.slug}/reinstate/update-end-date")
+  end
+
+  it "does not renders the 'Trainee returned before their ITT started'" do
+    expect(rendered_content).not_to have_text("Trainee returned before their ITT started")
+  end
+
+  context "deferred before starting course" do
+    let(:reinstatement_form) { OpenStruct.new(trainee: trainee, date: nil) }
+
+    it "renders the 'Trainee returned before their ITT started'" do
+      expect(rendered_content).to have_text("Trainee returned before their ITT started")
+    end
+
+    it "does not renders the expected end date row" do
+      expect(rendered_content).not_to have_css(".expected-end-date")
+    end
   end
 end

--- a/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
+++ b/spec/controllers/trainees/confirm_reinstatements_controller_spec.rb
@@ -10,10 +10,14 @@ describe Trainees::ConfirmReinstatementsController do
 
   before do
     allow(controller).to receive(:current_user).and_return(current_user)
-    allow(ReinstatementForm).to receive(:new).with(trainee).and_return(double(save!: true))
   end
 
   describe "#update" do
+    before do
+      allow(ReinstatementForm).to receive(:new).with(trainee).and_return(double(save!: true, date: 1.day.ago))
+      allow(IttDatesForm).to receive(:new).with(trainee).and_return(double(save!: true))
+    end
+
     context "with a trainee with a trn" do
       let(:trn) { "trn" }
 

--- a/spec/forms/itt_end_date_form_spec.rb
+++ b/spec/forms/itt_end_date_form_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe IttEndDateForm, type: :model do
+  let(:params) { valid_date }
+  let(:valid_date) { { year: "2020", month: "12", day: "20" } }
+  let(:trainee) { build(:trainee, :incomplete) }
+  let(:form_store) { class_double(FormStore) }
+  let(:reinstatement_form) { class_double(ReinstatementForm) }
+  let(:error_attr) { "activemodel.errors.models.itt_end_date_form.attributes.itt_end_date" }
+  let(:itt_end_date_form) { described_class.new(trainee, params: params, store: form_store) }
+  let(:return_date) { Date.parse(valid_date.values.join("/")) - 1.day }
+
+  subject { itt_end_date_form }
+
+  before do
+    allow(form_store).to receive(:get).and_return(nil)
+    allow(itt_end_date_form).to receive(:return_date).and_return(return_date)
+  end
+
+  describe "validations" do
+    before { subject.validate }
+
+    context "invalid date" do
+      let(:params) { { day: 20, month: 20, year: 2020 } }
+
+      it "is invalid" do
+        expect(subject.errors[:itt_end_date]).to include(I18n.t("#{error_attr}.invalid"))
+      end
+    end
+
+    context "blank date" do
+      let(:params) { { day: "", month: "", year: "" } }
+
+      it "is invalid" do
+        expect(subject.errors[:itt_end_date]).to include(I18n.t("#{error_attr}.blank"))
+      end
+    end
+
+    context "date earlier then the return date" do
+      let(:params) { { year: "2009", month: "12", day: "20" } }
+      let(:return_date) { Date.parse(params.values.join("/")) + 1.day }
+
+      it "is invalid" do
+        expect(subject.errors[:itt_end_date]).to include(I18n.t("#{error_attr}.return_date"))
+      end
+    end
+  end
+
+  describe "#stash" do
+    let(:trainee) { create(:trainee) }
+
+    it "uses FormStore to temporarily save the fields under a key combination of trainee ID and trainee_id" do
+      expect(form_store).to receive(:set).with(trainee.id, :itt_end_date, subject.fields)
+
+      subject.stash
+    end
+  end
+
+  describe "#save!" do
+    let(:trainee) { create(:trainee, itt_start_date: Time.zone.today) }
+
+    before do
+      allow(form_store).to receive(:set).with(trainee.id, :itt_end_date, nil)
+    end
+
+    it "takes any data from the form store and saves it to the database" do
+      date_params = params.values.map(&:to_i)
+      expect { subject.save! }.to change(trainee, :itt_end_date).to(Date.new(*date_params))
+    end
+  end
+end


### PR DESCRIPTION
### Context
Expected end date

### Changes proposed in this pull request
Added the ability for a provider to update the expected end date when reinstating the trainee
### Guidance to review
There are 2 journeys.


The new journey of a trainee being reinstate and the course is in the past.  

Existing journey of a trainee being reinstate but the course is in the future, this will bypass the need to update the expected end date, this stays as is.

#### Update end date page
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/38cb171e-c812-4bff-943b-74d2419e8c59)

#### Confirmation page
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/89fac92a-e1ef-4942-90c2-463b979c3d17)

#### Validations
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/91b37ed9-aa64-4d5e-9e1a-70baa45a3ee3)
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/adf18d52-0c84-4e0d-bcc8-6f22b7e51090)
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/90ddd57f-fda0-4a56-ab9d-1d8cfb430ab8)




### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
