### PR TITLE
[937] Add missing kubelogin to DB backup workflow

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -59,6 +59,10 @@ jobs:
       with:
         version: "v1.26.1" # default is latest stable
 
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS_PRODUCTION }}
+
     - name: K8 setup
       shell: bash
       run: |
@@ -190,6 +194,10 @@ jobs:
       uses: azure/setup-kubectl@v3
       with:
         version: "v1.26.1" # default is latest stable
+
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS_STAGING }}
 
     - name: K8 setup
       shell: bash


### PR DESCRIPTION
### Context
DB backup failure after making the RBAC change: https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/7720580472/job/21045713443

### Changes proposed in this pull request
Add the missing kubelogin

### Guidance to review
It's the same setup as the deploy workflow

