### PR TITLE
[937] Fix environment name in DB backup job

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -202,7 +202,7 @@ jobs:
     - name: K8 setup
       shell: bash
       run: |
-        make ci test get-cluster-credentials
+        make ci staging get-cluster-credentials
         make install-konduit
 
     - name: Restore backup to aks env database


### PR DESCRIPTION
### Context
https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/7735617030/job/21092772758

### Changes proposed in this pull request
Fix environment name

### Guidance to review
Run: `make ci staging get-cluster-credentials`

