### PR TITLE
[xxx] Fix headers in Funding::Parsers::Base

### DIFF
--- a/app/lib/funding/parsers/base.rb
+++ b/app/lib/funding/parsers/base.rb
@@ -21,7 +21,7 @@ module Funding
           validate_headers(csv:)
 
           csv.each_with_object({}) do |row, to_return|
-            to_return[row[id_column]] = Array(to_return[row[id_column]]) << row.to_h
+            to_return[row[id_column]] = Array(to_return[row[id_column]]) << row.to_hash.transform_keys { |header| header.gsub(/^\W+/, "") }
           end
         end
 


### PR DESCRIPTION
### Context

We recently introduced a fix to handle very weird invisible characters in funding upload csv files https://github.com/DFE-Digital/register-trainee-teachers/pull/4001/commits/e4b1efcbc6c57d1b99a7e0e988e673283918d595.

Adding the same check for when the data is actually built via `to_attributes` otherwise it'll run into a similar error by one of the `Funding::*Importer` classes.
