### PR TITLE
[6734] Add test for bulk recommend with invalid CSV

### DIFF
--- a/app/controllers/bulk_update/recommendations_uploads_controller.rb
+++ b/app/controllers/bulk_update/recommendations_uploads_controller.rb
@@ -20,6 +20,7 @@ module BulkUpdate
         create_rows!
         redirect_to(bulk_update_recommendations_upload_summary_path(@recommendations_upload_form.recommendations_upload))
       else
+        navigation_view
         render(:new)
       end
     end

--- a/spec/features/bulk_upload/recommending_trainees_spec.rb
+++ b/spec/features/bulk_upload/recommending_trainees_spec.rb
@@ -33,6 +33,7 @@ feature "recommending trainees" do
             recommended_for_award_date: Time.zone.today,
           ),
         )
+        and_i_can_see_that_i_have_two_trainees_to_recommend
       end
 
       context "and I upload a complete CSV" do
@@ -48,6 +49,7 @@ feature "recommending trainees" do
       before do
         then_i_see_how_many_trainees_i_can_recommend
         and_i_upload_a_csv(create_recommendations_upload_csv!(write_to_disk:, overwrite:))
+        and_i_can_see_that_i_have_two_trainees_to_recommend
       end
 
       context "and I upload a complete CSV" do
@@ -110,6 +112,17 @@ feature "recommending trainees" do
         end
       end
     end
+
+    context "when I try to upload an invalid CSV" do
+      before do
+        then_i_see_how_many_trainees_i_can_recommend
+      end
+
+      scenario "I cannot upload trainees for recommendation" do
+        and_i_upload_a_csv(create_invalid_recommendations_upload_csv)
+        then_i_see_an_error_message_about_file_encoding
+      end
+    end
   end
 
 private
@@ -136,6 +149,9 @@ private
   def and_i_upload_a_csv(csv_path)
     attach_file("bulk_update_recommendations_upload_form[file]", csv_path)
     recommendations_upload_page.upload_button.click
+  end
+
+  def and_i_can_see_that_i_have_two_trainees_to_recommend
     expect(BulkUpdate::RecommendationsUploadRow.count).to be 2
   end
 
@@ -204,5 +220,10 @@ private
       expect(recommendations_checks_show_page).to have_text("TRN: #{trainee.trn}")
       expect(recommendations_checks_show_page).to have_text(training_route)
     end
+  end
+
+  def then_i_see_an_error_message_about_file_encoding
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("The selected file must be UTF-8 or ISO-8859-1 encoded")
   end
 end

--- a/spec/support/recommendations_uploads_helper.rb
+++ b/spec/support/recommendations_uploads_helper.rb
@@ -52,4 +52,14 @@ module RecommendationsUploadHelper
     tempfile.rewind
     tempfile.path
   end
+
+  def create_invalid_recommendations_upload_csv
+    tempfile = Tempfile.new("csv")
+
+    File.open(tempfile.path, "w:UTF-16LE") do |file|
+      file.puts "invalid content"
+    end
+
+    tempfile.path
+  end
 end


### PR DESCRIPTION
### Context

A provider has reported errors when attempting to upload a CSV for bulk recommendations. This is happening because when a provider uploads an invalid CSV file (maybe because it’s too large or the wrong format) we attempt to render the new view. This fails because it relies on a Navigation component that doesn’t get instantiated in this case. As a result the provider doesn’t see a helpful error message, just a ‘something went wrong page’.

Sentry error:

https://dfe-teacher-services.sentry.io/issues/4848046002/events/9d7491cb77f04b6bb980d6437e1f99b3/

https://trello.com/c/4SXGEhnO/6734-fix-error-handling-for-bulk-recommend

### Changes proposed in this pull request
- Fix the bug in the `BulkUpdate::RecommendationsUploadsController` by instantiating the `Funding::NavigationView` component before rendering the `new` view.
- Add a feature spec to cover this scenario.

### Guidance to review
Do you get a valid error message if you upload a CSV in something other than UTF-8?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
