### PR TITLE
Fix primary course confirm page bug

### DIFF
--- a/app/components/course_details/view.rb
+++ b/app/components/course_details/view.rb
@@ -104,7 +104,7 @@ module CourseDetails
     end
 
     def primary_course_subject
-      if data_model.primary_course_subjects == :other
+      if data_model.primary_course_subjects&.to_sym == :other
         CourseSubjects::PRIMARY_TEACHING
       else
         PUBLISH_PRIMARY_SUBJECT_SPECIALISM_MAPPING[data_model.primary_course_subjects].first


### PR DESCRIPTION
### Context

The update course details confirm page was throwing an error when the user selected an 'other' secondary subject. This was because the `primary_course_subject` method was comparing the data model's `primary_course_subjects` attribute (which is a string) to the symbol `:other`.

Relates to [this bug report in Trello](https://trello.com/c/C8njszCP/6722-performance-profiles-sign-off), introduced by [this commit](https://github.com/DFE-Digital/register-trainee-teachers/commit/2f013dbf706915c72c9a2d4ea9045e4b7bd21558).

### Changes proposed in this pull request

Compare apples with apples; don't compare apples with oranges.