### PR TITLE
[6715] Endpoint post trainees withdraw

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,10 @@ module Api
     include Api::ValidationsAndErrorHandling
     before_action :check_feature_flag!, :authenticate!
 
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      render_not_found(message: "#{e.model}(s) not found")
+    end
+
     def check_feature_flag!
       return if FeatureService.enabled?(:register_api)
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,16 +2,13 @@
 
 module Api
   class BaseController < ActionController::API
+    include Api::ValidationsAndErrorHandling
     before_action :check_feature_flag!, :authenticate!
-
-    def not_found
-      render(status: :not_found, json: { error: "Not found" })
-    end
 
     def check_feature_flag!
       return if FeatureService.enabled?(:register_api)
 
-      not_found
+      render_not_found
     end
 
     def authenticate!

--- a/app/controllers/api/trainees/withdraws_controller.rb
+++ b/app/controllers/api/trainees/withdraws_controller.rb
@@ -10,7 +10,7 @@ module Api
           else
             withdraw_trainee
 
-            render(json: { status: "Trainee withdrawal request accepted", trainee: TraineeSerializer.new(trainee).as_json }, status: :accepted)
+            render(json: { data: TraineeSerializer.new(trainee).as_json }, status: :accepted)
           end
         else
           render_transition_error

--- a/app/controllers/api/trainees/withdraws_controller.rb
+++ b/app/controllers/api/trainees/withdraws_controller.rb
@@ -8,7 +8,7 @@ module Api
           render(json: { error: "Trainee not found" }, status: :not_found)
         else
           trainee.update(withdrawal_params) if withdraw_allowed?
-          render(json: { status: "Trainee withdrawal request accpeted", trainee: trainee }, status: :accepted)
+          render(json: { status: "Trainee withdrawal request accepted", trainee: trainee }, status: :accepted)
         end
       end
 

--- a/app/controllers/api/trainees/withdraws_controller.rb
+++ b/app/controllers/api/trainees/withdraws_controller.rb
@@ -4,9 +4,7 @@ module Api
   module Trainees
     class WithdrawsController < Api::BaseController
       def create
-        if trainee.blank?
-          render_not_found(message: "Trainee not found")
-        elsif withdraw_allowed?
+        if withdraw_allowed?
           if errored_params.any?
             render_parameter_invalid(parameter_keys: errored_params)
           else
@@ -28,7 +26,7 @@ module Api
       end
 
       def trainee
-        @trainee ||= current_provider&.trainees&.find_by(slug:)
+        @trainee ||= current_provider.trainees.find_by!(slug:)
       end
 
       def slug

--- a/app/controllers/api/trainees/withdraws_controller.rb
+++ b/app/controllers/api/trainees/withdraws_controller.rb
@@ -5,11 +5,7 @@ module Api
     class WithdrawsController < Api::BaseController
       def create
         if trainee.blank?
-          render(json: { error: "Trainee not found" }, status: :not_found)
-        else
-          withdraw_trainee if withdraw_allowed?
-
-          render(json: { status: "Trainee withdrawal request accepted", trainee: TraineeSerializer.new(trainee).as_json }, status: :accepted)
+          render_not_found(message: "Trainee not found")
         end
       end
 

--- a/app/controllers/api/trainees/withdraws_controller.rb
+++ b/app/controllers/api/trainees/withdraws_controller.rb
@@ -6,6 +6,14 @@ module Api
       def create
         if trainee.blank?
           render_not_found(message: "Trainee not found")
+        elsif withdraw_allowed?
+          if errored_params.any?
+            render_parameter_invalid(parameter_keys: errored_params)
+          else
+            withdraw_trainee
+
+            render(json: { status: "Trainee withdrawal request accepted", trainee: TraineeSerializer.new(trainee).as_json }, status: :accepted)
+          end
         else
           render_transition_error
         end
@@ -31,8 +39,16 @@ module Api
         !trainee.starts_course_in_the_future? && !trainee.itt_not_yet_started? && trainee.awaiting_action? && %w[submitted_for_trn trn_received deferred].any?(trainee.state)
       end
 
+      def withdrawal_params_keys
+        %i[withdraw_reasons_details withdraw_date]
+      end
+
       def withdrawal_params
-        params.permit(:withdraw_reasons_details, :withdraw_date)
+        params.permit(*withdrawal_params_keys)
+      end
+
+      def errored_params
+        withdrawal_params.to_h.filter_map { |key, value| key if value.blank? }
       end
     end
   end

--- a/app/controllers/api/trainees/withdraws_controller.rb
+++ b/app/controllers/api/trainees/withdraws_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Api
+  module Trainees
+    class WithdrawsController < Api::BaseController
+      def create
+        if trainee.blank?
+          render(json: { error: "Trainee not found" }, status: :not_found)
+        else
+          trainee.update(withdrawal_params) if withdraw_allowed?
+          render(json: { status: "Trainee withdrawal request accpeted", trainee: trainee }, status: :accepted)
+        end
+      end
+
+    private
+
+      def trainee
+        @trainee ||= current_provider&.trainees&.find_by(slug:)
+      end
+
+      def slug
+        @slug ||= params[:trainee_id]
+      end
+
+      def withdraw_allowed?
+        !trainee.starts_course_in_the_future? && !trainee.itt_not_yet_started? && trainee.awaiting_action?
+      end
+
+      def withdrawal_params
+        params.permit(:withdraw_reasons_details, :withdraw_date)
+      end
+    end
+  end
+end

--- a/app/controllers/api/trainees/withdraws_controller.rb
+++ b/app/controllers/api/trainees/withdraws_controller.rb
@@ -9,7 +9,7 @@ module Api
         else
           withdraw_trainee if withdraw_allowed?
 
-          render(json: { status: "Trainee withdrawal request accepted", trainee: trainee }, status: :accepted)
+          render(json: { status: "Trainee withdrawal request accepted", trainee: TraineeSerializer.new(trainee).as_json }, status: :accepted)
         end
       end
 

--- a/app/controllers/api/trainees/withdraws_controller.rb
+++ b/app/controllers/api/trainees/withdraws_controller.rb
@@ -6,6 +6,8 @@ module Api
       def create
         if trainee.blank?
           render_not_found(message: "Trainee not found")
+        else
+          render_transition_error
         end
       end
 

--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -13,12 +13,8 @@ module Api
     end
 
     def show
-      trainee = current_provider&.trainees&.find_by(slug: params[:id])
-      if trainee.present?
-        render(json: TraineeSerializer.new(trainee).as_json)
-      else
-        render_not_found(message: "Trainee not found")
-      end
+      trainee = current_provider.trainees.find_by!(slug: params[:id])
+      render(json: TraineeSerializer.new(trainee).as_json)
     end
   end
 end

--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -8,7 +8,7 @@ module Api
       if trainees.exists?
         render(json: AppendMetadata.call(trainees), status: :ok)
       else
-        render(json: { error: "No trainees found" }, status: :not_found)
+        render_not_found(message: "No trainees not found")
       end
     end
 
@@ -17,7 +17,7 @@ module Api
       if trainee.present?
         render(json: TraineeSerializer.new(trainee).as_json)
       else
-        render(json: { error: "Trainee not found" }, status: :not_found)
+        render_not_found(message: "Trainee not found")
       end
     end
   end

--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -8,7 +8,7 @@ module Api
       if trainees.exists?
         render(json: AppendMetadata.call(trainees), status: :ok)
       else
-        render_not_found(message: "No trainees not found")
+        render_not_found(message: "No trainees found")
       end
     end
 

--- a/app/controllers/concerns/api/validations_and_error_handling.rb
+++ b/app/controllers/concerns/api/validations_and_error_handling.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Api
+  module ValidationsAndErrorHandling
+    extend ActiveSupport::Concern
+
+    def render_not_found(message: "Not found")
+      render(status: :not_found, json: {
+        errors: errors("NotFound", message),
+      })
+    end
+
+  private
+
+    def errors(error, message)
+      [
+        {
+          error:,
+          message:,
+        },
+      ]
+    end
+  end
+end

--- a/app/controllers/concerns/api/validations_and_error_handling.rb
+++ b/app/controllers/concerns/api/validations_and_error_handling.rb
@@ -10,6 +10,13 @@ module Api
       })
     end
 
+    def render_parameter_invalid(parameter_keys:)
+      render(status: :unprocessable_entity, json: {
+        errors: errors("ParameterInvalid",
+                       "Please ensure valid values are provided for #{parameter_keys.to_sentence}"),
+      })
+    end
+
     def render_transition_error(model_name: "trainee")
       render(status: :unprocessable_entity, json: {
         errors: errors("StateTransitionError",

--- a/app/controllers/concerns/api/validations_and_error_handling.rb
+++ b/app/controllers/concerns/api/validations_and_error_handling.rb
@@ -10,6 +10,13 @@ module Api
       })
     end
 
+    def render_transition_error(model_name: "trainee")
+      render(status: :unprocessable_entity, json: {
+        errors: errors("StateTransitionError",
+                       "It's not possible to perform this action while the #{model_name} is in its current state"),
+      })
+    end
+
   private
 
     def errors(error, message)

--- a/config/routes/api_routes.rb
+++ b/config/routes/api_routes.rb
@@ -4,9 +4,16 @@ module ApiRoutes
   def self.extended(router)
     router.instance_exec do
       namespace :api, path: "api/:api_version", api_version: /v[.0-9]+/ do
-        resources :trainees, only: %i[index show], controller: "trainees", constraints: RouteConstraints::RegisterApiConstraint
+        resources :trainees, only: %i[index show], controller: "trainees", constraints: RouteConstraints::RegisterApiConstraint do
+          scope module: :trainees do
+            resource :withdraw, only: %i[create], path: "/withdraw"
+          end
+        end
+
         resource :info, only: :show, controller: "info", constraints: RouteConstraints::RegisterApiConstraint
         resource :guide, only: :show, controller: "guide", constraints: RouteConstraints::RegisterApiConstraint
+
+        # NOTE: catch all route
         match "*url" => "base#not_found", via: :all
       end
     end

--- a/config/routes/api_routes.rb
+++ b/config/routes/api_routes.rb
@@ -14,7 +14,7 @@ module ApiRoutes
         resource :guide, only: :show, controller: "guide", constraints: RouteConstraints::RegisterApiConstraint
 
         # NOTE: catch all route
-        match "*url" => "base#not_found", via: :all
+        match "*url" => "base#render_not_found", via: :all
       end
     end
   end

--- a/spec/requests/api/v0.1/trainees/withdraw_spec.rb
+++ b/spec/requests/api/v0.1/trainees/withdraw_spec.rb
@@ -72,10 +72,10 @@ describe "info endpoint" do
       let(:trainee) { create(:trainee, :itt_start_date_in_the_future) }
       let(:slug) { trainee.slug }
 
-      it "returns status 202 with a valid JSON response" do
+      it "returns status 422 with a valid JSON response" do
         post "/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }
-        expect(response).to have_http_status(:accepted)
-        expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accepted")
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body[:errors]).to contain_exactly({ error: "StateTransitionError", message: "It's not possible to perform this action while the trainee is in its current state" })
       end
 
       it "did not change the trainee" do

--- a/spec/requests/api/v0.1/trainees/withdraw_spec.rb
+++ b/spec/requests/api/v0.1/trainees/withdraw_spec.rb
@@ -43,6 +43,13 @@ describe "info endpoint" do
         post("/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }, params: params)
       end
 
+      it "uses the trainee serializer" do
+        expect(TraineeSerializer).to receive(:new).with(trainee).and_return(trainee).at_least(:once)
+        expect(trainee).to receive(:as_json).at_least(:once)
+
+        post("/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }, params: params)
+      end
+
       context "with invalid params" do
         let(:params) { { withdraw_reasons_details: nil, withdraw_date: nil } }
 

--- a/spec/requests/api/v0.1/trainees/withdraw_spec.rb
+++ b/spec/requests/api/v0.1/trainees/withdraw_spec.rb
@@ -30,7 +30,7 @@ describe "info endpoint" do
       it "returns status 202 with a valid JSON response" do
         post("/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }, params: params)
         expect(response).to have_http_status(:accepted)
-        expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accepted")
+        expect(response.parsed_body["data"]).to be_present
       end
 
       it "change the trainee" do

--- a/spec/requests/api/v0.1/trainees/withdraw_spec.rb
+++ b/spec/requests/api/v0.1/trainees/withdraw_spec.rb
@@ -7,10 +7,14 @@ describe "info endpoint" do
     context "non existant trainee" do
       let(:slug) { "non-existant" }
 
+      before do
+        create(:provider)
+      end
+
       it "returns status 404 with a valid JSON response" do
         post "/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }
         expect(response).to have_http_status(:not_found)
-        expect(response.parsed_body[:errors]).to contain_exactly({ error: "NotFound", message: "Trainee not found" })
+        expect(response.parsed_body[:errors]).to contain_exactly({ error: "NotFound", message: "Trainee(s) not found" })
       end
     end
 

--- a/spec/requests/api/v0.1/trainees/withdraw_spec.rb
+++ b/spec/requests/api/v0.1/trainees/withdraw_spec.rb
@@ -28,7 +28,7 @@ describe "info endpoint" do
       it "returns status 202 with a valid JSON response" do
         post("/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }, params: params)
         expect(response).to have_http_status(:accepted)
-        expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accpeted")
+        expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accepted")
       end
 
       it "change the trainee" do
@@ -45,7 +45,7 @@ describe "info endpoint" do
           post("/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }, params: params)
 
           expect(response).to have_http_status(:accepted)
-          expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accpeted")
+          expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accepted")
         end
 
         it "did not change the trainee" do
@@ -65,7 +65,7 @@ describe "info endpoint" do
       it "returns status 202 with a valid JSON response" do
         post "/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }
         expect(response).to have_http_status(:accepted)
-        expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accpeted")
+        expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accepted")
       end
 
       it "did not change the trainee" do

--- a/spec/requests/api/v0.1/trainees/withdraw_spec.rb
+++ b/spec/requests/api/v0.1/trainees/withdraw_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "info endpoint" do
+  context "with a valid authentication token" do
+    context "non existant trainee" do
+      let(:slug) { "non-existant" }
+
+      it "returns status 404 with a valid JSON response" do
+        post "/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body["error"]).to eq("Trainee not found")
+      end
+    end
+
+    context "with a withdrawable trainee" do
+      let(:trainee) { create(:trainee) }
+      let(:withdraw_params) do
+        build(:trainee, :withdrawn_for_specific_reason)
+          .attributes.symbolize_keys.slice(:withdraw_reasons_details, :withdraw_date)
+      end
+      let(:params) { withdraw_params }
+      let(:slug) { trainee.slug }
+
+      before { trainee }
+
+      it "returns status 202 with a valid JSON response" do
+        post("/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }, params: params)
+        expect(response).to have_http_status(:accepted)
+        expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accpeted")
+      end
+
+      it "change the trainee" do
+        expect {
+          post("/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }, params: params)
+        } .to change { trainee.reload.withdraw_reasons_details }.from(nil).to(withdraw_params[:withdraw_reasons_details])
+        .and change { trainee.reload.withdraw_date }.from(nil).to(withdraw_params[:withdraw_date])
+      end
+
+      context "with invalid params" do
+        let(:params) { { withdraw_reasons_details: nil, withdraw_date: nil } }
+
+        it "returns status 202 with a valid JSON response" do
+          post("/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }, params: params)
+
+          expect(response).to have_http_status(:accepted)
+          expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accpeted")
+        end
+
+        it "did not change the trainee" do
+          expect {
+            post "/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }
+          }.not_to change(trainee, :withdraw_date)
+        end
+      end
+    end
+
+    context "with a non-withdrawable trainee" do
+      let(:trainee) { create(:trainee, :itt_start_date_in_the_future) }
+      let(:slug) { trainee.slug }
+
+      before { trainee }
+
+      it "returns status 202 with a valid JSON response" do
+        post "/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }
+        expect(response).to have_http_status(:accepted)
+        expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accpeted")
+      end
+
+      it "did not change the trainee" do
+        expect {
+          post "/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }
+        }.not_to change(trainee, :withdraw_date)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v0.1/trainees/withdraw_spec.rb
+++ b/spec/requests/api/v0.1/trainees/withdraw_spec.rb
@@ -10,7 +10,7 @@ describe "info endpoint" do
       it "returns status 404 with a valid JSON response" do
         post "/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }
         expect(response).to have_http_status(:not_found)
-        expect(response.parsed_body["error"]).to eq("Trainee not found")
+        expect(response.parsed_body[:errors]).to contain_exactly({ error: "NotFound", message: "Trainee not found" })
       end
     end
 

--- a/spec/requests/api/v0.1/trainees/withdraw_spec.rb
+++ b/spec/requests/api/v0.1/trainees/withdraw_spec.rb
@@ -53,11 +53,11 @@ describe "info endpoint" do
       context "with invalid params" do
         let(:params) { { withdraw_reasons_details: nil, withdraw_date: nil } }
 
-        it "returns status 202 with a valid JSON response" do
+        it "returns status 422 with a valid JSON response" do
           post("/api/v0.1/trainees/#{slug}/withdraw", headers: { Authorization: "Bearer bat" }, params: params)
 
-          expect(response).to have_http_status(:accepted)
-          expect(response.parsed_body["status"]).to eq("Trainee withdrawal request accepted")
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body[:errors]).to contain_exactly({ error: "ParameterInvalid", message: "Please ensure valid values are provided for withdraw_reasons_details and withdraw_date" })
         end
 
         it "did not change the trainee" do

--- a/spec/requests/api/v0.1/trainees_spec.rb
+++ b/spec/requests/api/v0.1/trainees_spec.rb
@@ -36,7 +36,7 @@ describe "Trainees API" do
       end
 
       it "returns a not found message" do
-        expect(response.parsed_body[:errors]).to contain_exactly({ error: "NotFound", message: "Trainee not found" })
+        expect(response.parsed_body[:errors]).to contain_exactly({ error: "NotFound", message: "Trainee(s) not found" })
       end
     end
   end

--- a/spec/requests/api/v0.1/trainees_spec.rb
+++ b/spec/requests/api/v0.1/trainees_spec.rb
@@ -36,7 +36,7 @@ describe "Trainees API" do
       end
 
       it "returns a not found message" do
-        expect(response.parsed_body["error"]).to eq("Trainee not found")
+        expect(response.parsed_body[:errors]).to contain_exactly({ error: "NotFound", message: "Trainee not found" })
       end
     end
   end


### PR DESCRIPTION
### Context
An endpoint for withdrawing a trainee.

### Changes proposed in this pull request
Added an endpoint to withdraw a trainee

### Guidance to review
Trainee existences otherwise 404.
Only withdraw-able trainee will be withdrawn

Basis errors for invalid parameters (need to move to form)
Standardised the error format, same/similar to `Apply` see [here](https://www.apply-for-teacher-training.service.gov.uk/api-docs/v1.4/reference#error-object)

Form to be done in another PR?

```
curl --request POST \
  --url 'http://#replace_me/api/v0.1/trainees/#replaceme/withdraw?withdraw_date=1&withdraw_reasons_details=2' \
  --header 'Authorization: #replace_me' 


```

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
