### PR TITLE
[6676] Declare current_provider as the user for auditing

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -25,7 +25,7 @@ module Api
       @current_provider ||= auth_token.provider
     end
 
-    def authenticated_user
+    def audit_user
       current_provider
     end
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -25,6 +25,10 @@ module Api
       @current_provider ||= auth_token.provider
     end
 
+    def authenticated_user
+      current_provider
+    end
+
   private
 
     def valid_authentication_token?

--- a/app/services/trainees/create_timeline_events.rb
+++ b/app/services/trainees/create_timeline_events.rb
@@ -254,7 +254,9 @@ module Trainees
     def username
       return unless user && !user.is_a?(String)
 
-      return "DfE administrator" if user.system_admin?
+      return "DfE administrator" if user.is_a?(User) && user.system_admin?
+
+      return "#{user.name} (via Register API)" if user.is_a?(Provider)
 
       return "#{user.name} (#{provider_name})" if current_user&.system_admin?
 

--- a/spec/requests/api/v0.1/audit_trail_attribution_spec.rb
+++ b/spec/requests/api/v0.1/audit_trail_attribution_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "audit trail attribution" do
+  let(:trainee) { create(:trainee, :trn_received) }
+  let(:provider) { trainee.provider }
+
+  context "with a valid authentication token and the feature flag on" do
+    let(:token) { AuthenticationToken.create_with_random_token(provider:) }
+    let(:params) do
+      build(:trainee, :withdrawn_for_specific_reason)
+        .attributes.symbolize_keys.slice(:withdraw_reasons_details, :withdraw_date)
+    end
+
+    it "returns status 200 with a valid JSON response" do
+      post(
+        "/api/v0.1/trainees/#{trainee.slug}/withdraw",
+        headers: { Authorization: "Bearer #{token}" },
+        params: params,
+      )
+      expect(response).to have_http_status(:accepted)
+
+      last_audit_entry = trainee.reload.audits.last
+      expect(last_audit_entry.user).to eq(provider)
+    end
+  end
+end

--- a/spec/services/trainees/create_timeline_events_spec.rb
+++ b/spec/services/trainees/create_timeline_events_spec.rb
@@ -103,6 +103,22 @@ module Trainees
           end
         end
 
+        context "with a provider user" do
+          let(:provider) { create(:provider, name: "South Oxfordshire Academy") }
+
+          before do
+            trainee.own_and_associated_audits.first.update!(user: provider)
+          end
+
+          it "returns a timeline event that reflects the update" do
+            expect(subject.first.title).to eq("First names updated")
+          end
+
+          it "returns a timeline event with the provider name and indicating that it happened via the API" do
+            expect(subject.first.username).to eq("South Oxfordshire Academy (via Register API)")
+          end
+        end
+
         context "made in HESA" do
           before do
             trainee.own_and_associated_audits.first.update!(username: "HESA")


### PR DESCRIPTION
### Context

Whenever an API call runs that modifies application data we create audit records to track whatever changes are made. So that we can trace these changes back to the provider that performed them we need to make sure that every audit record created via the API is attributed to the authenticated provider.

### Changes proposed in this pull request

- Add a `BaseController#authenticated_user` method returning the `current_provider`. The `audited` gem should pick this up and attribute all audit records created during the API call to the authenticated provider.
- Also fixes the timeline to handle provider users. It was broken by provider users in the audit trail due to assumptions made in `CreateTimelineEvents`. So those are fixed and I've flagged provider user entries as coming via the API.

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/910d25fa-0e06-4427-ab71-c597f5cc1be8)

### Guidance to review

Not ready yet. We can add a couple of tests for this when we have authentication in place and at least one API endpoint that modifies data.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
