### PR TITLE
[6678] Fix complete? column in export

### DIFF
--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -364,8 +364,7 @@ module Reports
       trainee.submitted_for_trn_at&.iso8601
     end
 
-    def complete? = trainee.submission_ready?
-    alias_method :is_complete, :complete?
+    def completed = trainee.submission_ready?
 
     def trainee_start_date
       trainee.trainee_start_date&.iso8601

--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -365,6 +365,7 @@ module Reports
     end
 
     def complete? = trainee.submission_ready?
+    alias_method :is_complete, :complete?
 
     def trainee_start_date
       trainee.trainee_start_date&.iso8601

--- a/app/models/reports/trainees_report.rb
+++ b/app/models/reports/trainees_report.rb
@@ -4,7 +4,7 @@ module Reports
   class TraineesReport < TemplateClassCsv
     def self.headers
       %w[register_id
-         complete?
+         is_complete
          trainee_url
          record_source
          apply_id

--- a/app/models/reports/trainees_report.rb
+++ b/app/models/reports/trainees_report.rb
@@ -118,7 +118,7 @@ module Reports
       trainee_report = Reports::TraineeReport.new(trainee)
       [
         trainee_report.register_id,
-        trainee_report.complete?,
+        trainee_report.completed,
         trainee_report.trainee_url,
         trainee_report.record_source,
         trainee_report.apply_id,

--- a/app/models/reports/trainees_report.rb
+++ b/app/models/reports/trainees_report.rb
@@ -4,7 +4,7 @@ module Reports
   class TraineesReport < TemplateClassCsv
     def self.headers
       %w[register_id
-         is_complete
+         completed
          trainee_url
          record_source
          apply_id

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -29,7 +29,7 @@ describe Reports::TraineeReport do
     end
 
     it "includes whether the trainee is complete" do
-      expect(subject.complete?).to eq(trainee.submission_ready?)
+      expect(subject.completed).to eq(trainee.submission_ready?)
     end
 
     it "sets the correct course" do


### PR DESCRIPTION
### Context

Small one to address having a `?` in column headers for CSV exports.

### Changes proposed in this pull request

- Updates the column header in the export
- Aliases method so rubocop doesn't complain over `is_*?` method names

### Review

Test out the export in the review app
