### PR TITLE
[6718] Filter out any other sensitive info

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -31,4 +31,5 @@ Rails.application.config.filter_parameters += [
   :postcode,
   :region,
   :town_city,
+  :trn,
 ]

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -8,6 +8,7 @@ class CustomLogFormatter < SemanticLogger::Formatters::Raw
     format_json_message_context
     format_backtrace
     remove_post_params
+    filter_authorization_header
     hash.to_json
   end
 
@@ -48,6 +49,12 @@ private
   def remove_post_params
     if method_is_post_or_put? && hash.dig(:payload, :params).present?
       hash[:payload][:params].clear
+    end
+  end
+
+  def filter_authorization_header
+    if hash.dig(:payload, :headers)&.key?("Authorization")
+      hash[:payload][:headers].delete("Authorization")
     end
   end
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -10,4 +10,6 @@ Sentry.init do |config|
   config.traces_sample_rate = 0.05
   config.profiles_sample_rate = 0.05
   config.release = ENV.fetch("COMMIT_SHA", nil)
+
+  config.logger.level = Logger::INFO
 end


### PR DESCRIPTION
### Context

This PR just glazes a few bits on top of what's already in place to help filter out PII/sensitive info from logs/sentry. 

### Changes proposed in this pull request

- Filter out TRNs from Sentry
- Filter out `Authorisation` header from logs
- Reduce Sentry's noise level so it only outputs `[INFO]` calls in the logger
