### PR TITLE
[6751] Update PII info when sending DQT updates if allowed

### DIFF
--- a/app/lib/dqt/params/update.rb
+++ b/app/lib/dqt/params/update.rb
@@ -11,7 +11,7 @@ module Dqt
           "husid" => trainee.hesa_id,
           "initialTeacherTraining" => initial_teacher_training_params.merge(outcome_params),
           "qualification" => qualification_params,
-        }
+        }.merge(pii_update_params)
       end
 
       def outcome_params
@@ -28,6 +28,19 @@ module Dqt
             "InTraining"
           end
         end
+      end
+
+      def pii_update_params
+        {} unless trainee&.dqt_teacher&.allowed_pii_updates?
+
+        {
+          "firstName" => trainee.first_names,
+          "middleName" => trainee.middle_names,
+          "lastName" => trainee.last_name,
+          "emailAddress" => trainee.email,
+          "genderCode" => TrnRequest::GENDER_CODES[trainee.sex.to_sym],
+          "dateOfBirth" => trainee.date_of_birth.iso8601,
+        }
       end
 
       def in_training?

--- a/app/models/dqt/teacher.rb
+++ b/app/models/dqt/teacher.rb
@@ -5,6 +5,7 @@
 # Table name: dqt_teachers
 #
 #  id                       :bigint           not null, primary key
+#  allowed_pii_updates      :boolean          default(FALSE), not null
 #  date_of_birth            :string
 #  early_years_status_name  :string
 #  early_years_status_value :string
@@ -16,6 +17,10 @@
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  hesa_id                  :string
+#
+# Indexes
+#
+#  index_dqt_teachers_on_allowed_pii_updates  (allowed_pii_updates)
 #
 module Dqt
   class Teacher < ApplicationRecord

--- a/app/services/dqt/sync_teacher.rb
+++ b/app/services/dqt/sync_teacher.rb
@@ -29,7 +29,8 @@ module Dqt
                                     qts_date: dqt_data["qtsDate"],
                                     eyts_date: dqt_data["eytsDate"],
                                     early_years_status_name: dqt_data.dig("earlyYearsStatus", "name"),
-                                    early_years_status_value: dqt_data.dig("earlyYearsStatus", "value"))
+                                    early_years_status_value: dqt_data.dig("earlyYearsStatus", "value"),
+                                    allowed_pii_updates: dqt_data["allowPIIUpdates"])
 
       dqt_teacher.dqt_trainings = dqt_data["initialTeacherTraining"].map do |training_data|
         TeacherTraining.new(dqt_teacher: dqt_teacher,

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -388,6 +388,7 @@
   - early_years_status_value
   - created_at
   - updated_at
+  - allowed_pii_updates
   :dqt_teacher_trainings:
   - id
   - dqt_teacher_id

--- a/db/migrate/20240208131836_add_pii_field_to_dqt_teachers.rb
+++ b/db/migrate/20240208131836_add_pii_field_to_dqt_teachers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddPiiFieldToDqtTeachers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :dqt_teachers, :allowed_pii_updates, :boolean, default: false, null: false
+    add_index :dqt_teachers, :allowed_pii_updates, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_05_180248) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_131836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -345,6 +345,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_05_180248) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "hesa_id"
+    t.boolean "allowed_pii_updates", default: false, null: false
+    t.index ["allowed_pii_updates"], name: "index_dqt_teachers_on_allowed_pii_updates"
   end
 
   create_table "dqt_trn_requests", force: :cascade do |t|

--- a/spec/lib/dqt/params/update_spec.rb
+++ b/spec/lib/dqt/params/update_spec.rb
@@ -78,6 +78,23 @@ module Dqt
           end
         end
 
+        context "is allowed to update PII" do
+          let(:trainee) do
+            create(:trainee, :completed, :assessment_only, sex: :male, dqt_teacher: create(:dqt_teacher, allowed_pii_updates: true))
+          end
+
+          it "returns a hash including personal attributes" do
+            expect(subject).to include({
+              "firstName" => trainee.first_names,
+              "middleName" => trainee.middle_names,
+              "lastName" => trainee.last_name,
+              "emailAddress" => trainee.email,
+              "genderCode" => "Male",
+              "dateOfBirth" => trainee.date_of_birth.iso8601,
+            })
+          end
+        end
+
         context "trainee is not deferred or in training" do
           let(:trainee) { create(:trainee, :completed, :withdrawn) }
 


### PR DESCRIPTION
### Context

DQT have started sending us a parameter to let us know if the trainee's PII information can be updated when sending update requests. This PR adds the ability to do that.

Currently, we sync all the DQT teacher records to a local table and link them up to each respective trainee. Every trainee sent to DQT will have[ at least one](https://github.com/DFE-Digital/register-trainee-teachers/blob/e629eebc8e4a0118af86c0ee9ba4a365d4387a23/app/models/trainee.rb#L156) `trainee.dqt_teacher` record. 

The syncing is done every Monday via https://github.com/DFE-Digital/register-trainee-teachers/blob/e629eebc8e4a0118af86c0ee9ba4a365d4387a23/app/services/dqt/sync_teacher.rb#L4 in:

<img width="1174" alt="Screenshot 2024-02-09 at 14 15 24" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/d8a428e2-d425-4b7b-81c2-63b544018b67">

### Changes proposed in this pull request

- Add the field to the `DqtTeacher` table so we can easily check for it via the `trainee`
- Conditionally merge in PII fields if the field above is true in `Dqt::Params::Update`

### Guidance to review

This PR should ideally be merged in after the next job run (every Monday), which would populate the new field for all the DQT teacher records synced in (unless it is run manually before then). 

Subsequent changes to the trainee's PII details would then be sent to DQT if allowed. 
