### PR TITLE
Fix out of synch schema comments

### DIFF
--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -5,16 +5,17 @@
 # Table name: authentication_tokens
 #
 #  id           :bigint           not null, primary key
-#  enabled      :boolean          default(TRUE)
+#  enabled      :boolean          default(TRUE), not null
 #  expires_at   :date
-#  hashed_token :string
+#  hashed_token :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  provider_id  :bigint
+#  provider_id  :bigint           not null
 #
 # Indexes
 #
-#  index_authentication_tokens_on_provider_id  (provider_id)
+#  index_authentication_tokens_on_hashed_token  (hashed_token) UNIQUE
+#  index_authentication_tokens_on_provider_id   (provider_id)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
### Context
Just a tidy up. I think the autogenerated comments for the `AuthenticationToken` schema got out of sync. 

### Changes proposed in this pull request
Just reran `bundle exec rails db:migrate` to fix it.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
