### PR TITLE
[6704] - adds service for importing ethnicity via rake task and upload

### DIFF
--- a/app/services/add_ethnicity_from_csv.rb
+++ b/app/services/add_ethnicity_from_csv.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class AddEthnicityFromCsv
+  def initialize(file_name:, provider_code:)
+    @upload = Upload.find_by_name(file_name)
+    @provider = Provider.find_by_code(provider_code)
+  end
+
+  def call
+    return unless upload && provider
+
+    upload.file.download do |csv|
+      CSV.parse(csv, headers: true) do |row|
+        trainee_id = row["trainee_id"]
+        ethnicity = row["ethnicity"]
+        trainee = provider.trainees.where(trainee_id:).first
+
+        next unless trainee
+
+        update_trainee(trainee, ethnicity)
+      end
+    end
+  end
+
+private
+
+  attr_reader :upload, :provider
+
+  def update_trainee(trainee, ethnicity)
+    ethnicity_split = ethnicity.split(":").map(&:strip)
+
+    ethnic_background = ::Hesa::CodeSets::Ethnicities::NAME_MAPPING[ethnicity_split.first]
+    ethnic_group = ::Diversities::BACKGROUNDS.select { |_key, values| values.include?(ethnic_background) }.keys.first
+    additional_ethnic_background = ethnicity_split.length == 1 ? nil : ethnicity_split.last
+    diversity_disclosure = ["Prefer not to say", "Not available"].include?(ethnic_background) ? :diversity_not_disclosed : :diversity_disclosed
+
+    trainee.update(
+      ethnic_group:,
+      ethnic_background:,
+      additional_ethnic_background:,
+      diversity_disclosure:,
+    )
+  end
+end

--- a/db/data/20240208151204_add_ethnicity_to_best_practice_network.rb
+++ b/db/data/20240208151204_add_ethnicity_to_best_practice_network.rb
@@ -4,53 +4,8 @@ require "csv"
 
 class AddEthnicityToBestPracticeNetwork < ActiveRecord::Migration[7.1]
   def up
-    Service.new.call
+    # removed and moved to app/services/add_ethnicity_from_csv.rb
   end
 
   def down; end
-
-  class Service
-    def call
-      return unless upload
-
-      upload.file.download do |csv|
-        CSV.parse(csv, headers: true) do |row|
-          trainee_id = row["trainee_id"]
-          ethnicity = row["ethnicity"]
-          trainee = provider.where(trainee_id:).first
-
-          next unless trainee
-
-          update_trainee(trainee, ethnicity)
-        end
-      end
-    end
-
-  private
-
-    def upload
-      @_upload ||= Upload.find_by_name("bpn-ethnicity.csv")
-    end
-
-    # Best Practice Network
-    def provider
-      @_provider ||= Provider.find_by(code: "6B1").trainees
-    end
-
-    def update_trainee(trainee, ethnicity)
-      ethnicity_split = ethnicity.split(":").map(&:strip)
-
-      ethnic_background = ::Hesa::CodeSets::Ethnicities::NAME_MAPPING[ethnicity_split.first]
-      ethnic_group = ::Diversities::BACKGROUNDS.select { |_key, values| values.include?(ethnic_background) }.keys.first
-      additional_ethnic_background = ethnicity_split.length == 1 ? nil : ethnicity_split.last
-      diversity_disclosure = ["Prefer not to say", "Not available"].include?(ethnic_background) ? :diversity_not_disclosed : :diversity_disclosed
-
-      trainee.update(
-        ethnic_group:,
-        ethnic_background:,
-        additional_ethnic_background:,
-        diversity_disclosure:,
-      )
-    end
-  end
 end

--- a/db/data/20240208151204_add_ethnicity_to_best_practice_network.rb
+++ b/db/data/20240208151204_add_ethnicity_to_best_practice_network.rb
@@ -7,9 +7,7 @@ class AddEthnicityToBestPracticeNetwork < ActiveRecord::Migration[7.1]
     Service.new.call
   end
 
-  def down
-    raise ActiveRecord::IrreversibleMigration
-  end
+  def down; end
 
   class Service
     def call
@@ -44,12 +42,14 @@ class AddEthnicityToBestPracticeNetwork < ActiveRecord::Migration[7.1]
 
       ethnic_background = ::Hesa::CodeSets::Ethnicities::NAME_MAPPING[ethnicity_split.first]
       ethnic_group = ::Diversities::BACKGROUNDS.select { |_key, values| values.include?(ethnic_background) }.keys.first
-      additional_ethnic_background = ethnicity_split.last
+      additional_ethnic_background = ethnicity_split.length == 1 ? nil : ethnicity_split.last
+      diversity_disclosure = ["Prefer not to say", "Not available"].include?(ethnic_background) ? :diversity_not_disclosed : :diversity_disclosed
 
       trainee.update(
         ethnic_group:,
         ethnic_background:,
         additional_ethnic_background:,
+        diversity_disclosure:,
       )
     end
   end

--- a/lib/tasks/diversity.rake
+++ b/lib/tasks/diversity.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :diversity do
+  desc "imports ethnicity from a csv with trainee_id and ethnicity headers"
+  task :ethnicity, %i[file_name provider_code] => :environment do |_, args|
+    # make sure you've uploaded a CSV via /system-admin/uploads
+    AddEthnicityFromCsv.new(file_name: args.file_name, provider_code: args.provider_code).call
+  end
+end

--- a/spec/services/add_ethnicity_from_csv_spec.rb
+++ b/spec/services/add_ethnicity_from_csv_spec.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require Rails.root.join("db/data/20240208151204_add_ethnicity_to_best_practice_network")
 
-RSpec.describe AddEthnicityToBestPracticeNetwork::Service do
+RSpec.describe AddEthnicityFromCsv do
   let!(:provider) { create(:provider, code: "6B1") }
   let!(:trainee) { create(:trainee, provider:) }
   let!(:upload) { create(:upload, user: create(:user), name: "bpn-ethnicity.csv") }
   let(:ethnicity) { "Any other ethnic background: romanian" }
   let(:csv_content) { "trainee_id,ethnicity\n#{trainee.trainee_id},#{ethnicity}" }
-  let(:service) { described_class.new }
+  let(:service) { described_class.new(file_name: "bpn-ethnicity.csv", provider_code: "6B1") }
 
   before do
     csv_file = Tempfile.new(["test", ".csv"])


### PR DESCRIPTION
### Context

#4021 didn't quite work as expected. This adds a rake task and service for importing ethnicity data.

Ideally we would get bulk import files formatted correctly, but often this isn't the case. this is a quick service for correcting ethnicity. it was previously in a migration task, but there is a good chance we will need to run this again in the future, hence the introduction of a service.

_note: this has been run on production data and the data sampled/checked_