### PR TITLE
[6768] Rollback deferral date logic change

### DIFF
--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -61,7 +61,6 @@ module Trainees
        .merge(provider_attributes)
        .merge(ethnicity_and_disability_attributes)
        .merge(course_attributes)
-       .merge(deferral_attributes)
        .merge(submitted_for_trn_attributes)
        .merge(funding_attributes)
        .merge(school_attributes)
@@ -118,12 +117,6 @@ module Trainees
     def provider_attributes
       provider = Provider.find_by(ukprn: hesa_trainee[:ukprn])
       provider ? { provider: } : {}
-    end
-
-    def deferral_attributes
-      return { defer_date: nil } unless mapped_trainee_state == :deferred
-
-      { defer_date: itt_end_date || hesa_trainee[:hesa_updated_at] }
     end
 
     def submitted_for_trn_attributes

--- a/db/data/20240212171923_rollback_backfill_missing_hesa_deferral_dates.rb
+++ b/db/data/20240212171923_rollback_backfill_missing_hesa_deferral_dates.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RollbackBackfillMissingHesaDeferralDates < ActiveRecord::Migration[7.1]
+  def up
+    # Reset the defer_date of all trainees that are deferred and have a hesa student record where
+    # defer_date matches their itt_end_date, or their itt_end_date is nil and defer_date matches their hesa_updated_at
+    Trainee.deferred.find_each do |trainee|
+      most_recent_itt_record = trainee.hesa_students.max_by(&:created_at)
+      next unless most_recent_itt_record
+
+      next unless Trainees::MapStateFromHesa.call(hesa_trainee: most_recent_itt_record, trainee: trainee) == :deferred
+
+      if defer_date_matches_criteria?(trainee, most_recent_itt_record)
+        trainee.update!(defer_date: nil)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+private
+
+  def defer_date_matches_criteria?(trainee, most_recent_itt_record)
+    trainee.defer_date == most_recent_itt_record.itt_end_date ||
+      (most_recent_itt_record.itt_end_date.nil? && trainee.defer_date == most_recent_itt_record.hesa_updated_at)
+  end
+end

--- a/db/data/20240212171923_rollback_backfill_missing_hesa_deferral_dates.rb
+++ b/db/data/20240212171923_rollback_backfill_missing_hesa_deferral_dates.rb
@@ -4,7 +4,7 @@ class RollbackBackfillMissingHesaDeferralDates < ActiveRecord::Migration[7.1]
   def up
     # Reset the defer_date of all trainees that are deferred and have a hesa student record where
     # defer_date matches their itt_end_date, or their itt_end_date is nil and defer_date matches their hesa_updated_at
-    Trainee.deferred.find_each do |trainee|
+    Trainee.deferred.where.not(hesa_id: nil).find_each do |trainee|
       most_recent_itt_record = trainee.hesa_students.max_by(&:created_at)
       next unless most_recent_itt_record
 

--- a/db/data/20240212171923_rollback_backfill_missing_hesa_deferral_dates.rb
+++ b/db/data/20240212171923_rollback_backfill_missing_hesa_deferral_dates.rb
@@ -23,7 +23,14 @@ class RollbackBackfillMissingHesaDeferralDates < ActiveRecord::Migration[7.1]
 private
 
   def defer_date_matches_criteria?(trainee, most_recent_itt_record)
-    trainee.defer_date == most_recent_itt_record.itt_end_date ||
-      (most_recent_itt_record.itt_end_date.nil? && trainee.defer_date == most_recent_itt_record.hesa_updated_at)
+    defer_date = standardised_date(trainee.defer_date)
+    itt_end_date = standardised_date(most_recent_itt_record.itt_end_date)
+    hesa_updated_at = standardised_date(most_recent_itt_record.hesa_updated_at)
+
+    defer_date == itt_end_date || (itt_end_date.nil? && defer_date == hesa_updated_at)
+  end
+
+  def standardised_date(date)
+    date&.to_date&.iso8601
   end
 end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -123,14 +123,6 @@ module Trainees
         expect(trainee.hesa_metadatum.year_of_course).to eq("0")
       end
 
-      context "when the trainee is deferred and there is no end_date" do
-        let(:hesa_stub_attributes) { { itt_end_date: nil, mode: "63" } }
-
-        it "sets the the trainee's defer_date to the hesa_updated_at" do
-          expect(trainee.defer_date).to eq(Date.parse(student_attributes[:hesa_updated_at]))
-        end
-      end
-
       context "leading and employing schools not applicable" do
         let(:not_applicable_or_not_available_hesa_code) { "900010" }
         let(:establishment_outside_england_and_wales_hesa_code) { "900000" }


### PR DESCRIPTION
### Context

Changes were previously made in https://github.com/DFE-Digital/register-trainee-teachers/pull/3956 which changed the logic for setting the `defer_data` (as per this [Trello card](https://trello.com/c/GEjEZ4V5/1405-infer-a-deferred-date-if-one-was-not-supplied-at-the-time-of-deferral)). A data migration was also created to backfill missing deferral dates.

However, it turns out that setting the `defer_date` in this way is not the most helpful thing for ITT funding so we want to revert the previous changes.

### Changes proposed in this pull request

* Removed all code to set the `defer_date` in `CreateFromHesa` because the previous `end_date` value is not being used by HESA any more.
* Added a data migration to 'reset' the `defer_date` to `nil` for records that were previously populated, based on [the suggested logic](https://trello.com/c/6sovAdEZ/6768-rollback-deferral-date-logic-change#comment-65c6358d5df6fd4546fcdf47).

### Guidance to review

Similar to the original PR, this is a bit difficult to test locally as the sanitised dump does not include the `hesa_student` records. The data migration has _not_ been tested against productiondata yet.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?
