### PR TITLE
[6578] - adds sorting to admin views

### DIFF
--- a/app/components/sort_by/view.html.erb
+++ b/app/components/sort_by/view.html.erb
@@ -1,10 +1,8 @@
-<tr class="govuk-table__row govuk-body">
-  <th colspan="3" class="govuk-!-text-align-left">
-    <span class="govuk-!-font-weight-bold govuk-body">
-      Sort by:
-    </span>
-    <span class="govuk-body">
-      <%= items_html %>
-    </span>
-  </th>
-</tr>
+<div class="govuk-grid-column-full sort-by govuk-!-padding-left-0 govuk-!-padding-bottom-3">
+  <span class="govuk-!-font-weight-bold govuk-body">
+    Sort by:
+  </span>
+  <span class="govuk-body">
+    <%= items_html %>
+  </span>
+</div>

--- a/app/components/sort_by/view.html.erb
+++ b/app/components/sort_by/view.html.erb
@@ -1,0 +1,10 @@
+<tr class="govuk-table__row govuk-body">
+  <th colspan="3" class="govuk-!-text-align-left">
+    <span class="govuk-!-font-weight-bold govuk-body">
+      Sort by:
+    </span>
+    <span class="govuk-body">
+      <%= items_html %>
+    </span>
+  </th>
+</tr>

--- a/app/components/sort_by/view.html.erb
+++ b/app/components/sort_by/view.html.erb
@@ -1,8 +1,8 @@
-<div class="govuk-grid-column-full sort-by govuk-!-padding-left-0 govuk-!-padding-bottom-3">
+<div class="govuk-grid-column-full govuk-!-padding-left-0 govuk-!-padding-bottom-3">
   <span class="govuk-!-font-weight-bold govuk-body">
     Sort by:
   </span>
-  <span class="govuk-body">
+  <span class="govuk-body sort-by-items">
     <%= items_html %>
   </span>
 </div>

--- a/app/components/sort_by/view.rb
+++ b/app/components/sort_by/view.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module SortBy
+  class View < ViewComponent::Base
+    include Rails.application.routes.url_helpers
+
+    attr_reader :items
+
+    def initialize(items:)
+      @items = items&.compact
+    end
+
+    def items_html
+      items.map do |item|
+        sort_param = item.parameterize.underscore
+        if sort_param == current_sort_by
+          item # Display item as plain text if it's the current sort parameter
+        else
+          item_link(item, sort_param)
+        end
+      end.join(" | ").html_safe
+    end
+
+  private
+
+    def item_link(item, sort_param)
+      helpers.govuk_link_to(item, url_for(helpers.request.params.merge(sort_by: sort_param)), class: "govuk-link--no-visited-state")
+    end
+
+    def current_sort_by
+      helpers.request.params[:sort_by]
+    end
+  end
+end

--- a/app/controllers/system_admin/pending_awards_controller.rb
+++ b/app/controllers/system_admin/pending_awards_controller.rb
@@ -3,9 +3,44 @@
 module SystemAdmin
   class PendingAwardsController < ApplicationController
     add_flash_types :dqt_error
+    helper_method :sort_by_items
+    before_action :redirect_to_default_sort, only: :index
 
     def index
-      @trainees = Trainee.recommended_for_award.undiscarded.order(:recommended_for_award_at)
+      @trainees = sort_trainees
+    end
+
+  private
+
+    def sort_trainees
+      sort_by = params.fetch(:sort_by, "days_waiting").to_sym
+
+      trainees = Trainee.recommended_for_award.undiscarded
+
+      case sort_by
+      when :days_waiting
+        trainees.sort_by { |t| Date.current - t.recommended_for_award_at.to_date }.reverse
+      when :trn
+        trainees.order(:trn)
+      when :register
+        trainees.order(:id)
+      else
+        trainees
+      end
+    end
+
+    def sort_by_items
+      ["Days waiting", "TRN", "Register"]
+    end
+
+    def default_sort_by
+      "days_waiting"
+    end
+
+    def redirect_to_default_sort
+      return if params[:sort_by].present?
+
+      redirect_to(action: :index, sort_by: default_sort_by, status: :temporary_redirect)
     end
   end
 end

--- a/app/controllers/system_admin/pending_awards_controller.rb
+++ b/app/controllers/system_admin/pending_awards_controller.rb
@@ -19,7 +19,7 @@ module SystemAdmin
 
       case sort_by
       when :days_waiting
-        trainees.sort_by { |t| Date.current - t.recommended_for_award_at.to_date }.reverse
+        trainees.order(recommended_for_award_at: :asc)
       when :trn
         trainees.order(:trn)
       when :register

--- a/app/controllers/system_admin/pending_trns_controller.rb
+++ b/app/controllers/system_admin/pending_trns_controller.rb
@@ -2,10 +2,45 @@
 
 module SystemAdmin
   class PendingTrnsController < ApplicationController
+    helper_method :sort_by_items, :sorted_trainees
     add_flash_types :dqt_error
+    before_action :redirect_to_default_sort, only: :index
 
     def index
-      @trainees = Trainee.includes(:dqt_trn_request).submitted_for_trn.undiscarded
+      @trainees = sorted_trainees
+    end
+
+  private
+
+    def sorted_trainees
+      sort_by = params.fetch(:sort_by, default_sort_by).to_sym
+
+      trainees = Trainee.includes(:dqt_trn_request).submitted_for_trn.undiscarded
+
+      case sort_by
+      when :days_waiting
+        trainees.sort_by { |t| t.dqt_trn_request&.days_waiting || 0 }.reverse
+      when :trn
+        trainees.sort_by { |t| t.trn || 0 }
+      when :register
+        trainees.sort_by(&:id)
+      else
+        trainees
+      end
+    end
+
+    def sort_by_items
+      ["Days waiting", "TRN", "Register"]
+    end
+
+    def default_sort_by
+      "days_waiting"
+    end
+
+    def redirect_to_default_sort
+      return if params[:sort_by].present?
+
+      redirect_to(action: :index, sort_by: default_sort_by, status: :temporary_redirect)
     end
   end
 end

--- a/app/controllers/system_admin/pending_trns_controller.rb
+++ b/app/controllers/system_admin/pending_trns_controller.rb
@@ -20,8 +20,6 @@ module SystemAdmin
       case sort_by
       when :days_waiting
         trainees.sort_by { |t| t.dqt_trn_request&.days_waiting || 0 }.reverse
-      when :trn
-        trainees.sort_by { |t| t.trn || 0 }
       when :register
         trainees.sort_by(&:id)
       else
@@ -30,7 +28,7 @@ module SystemAdmin
     end
 
     def sort_by_items
-      ["Days waiting", "TRN", "Register"]
+      ["Days waiting", "Register"]
     end
 
     def default_sort_by

--- a/app/services/dead_jobs/base.rb
+++ b/app/services/dead_jobs/base.rb
@@ -2,9 +2,10 @@
 
 module DeadJobs
   class Base
-    def initialize(dead_set: Sidekiq::DeadSet.new, include_dqt_status: false)
+    def initialize(dead_set: Sidekiq::DeadSet.new, include_dqt_status: false, sort_by: :register)
       @dead_set = dead_set
       @include_dqt_status = include_dqt_status
+      @sort_by = sort_by
     end
 
     def to_csv
@@ -42,7 +43,7 @@ module DeadJobs
 
   private
 
-    attr_reader :dead_set, :include_dqt_status
+    attr_reader :dead_set, :include_dqt_status, :sort_by
 
     def csv_headers
       build_csv_row(trainees.first).keys

--- a/app/views/system_admin/dead_jobs/show.html.erb
+++ b/app/views/system_admin/dead_jobs/show.html.erb
@@ -17,10 +17,11 @@
 
 <% else %>
 
+  <%= render SortBy::View.new(items: sort_by_items) %>
+
   <table class="govuk-table">
     <caption class="govuk-table__caption govuk-table__caption--m"><%= dead_job_service.name %></caption>
     <thead class="govuk-table__head">
-      <%= render SortBy::View.new(items: sort_by_items) %>
 
       <tr class="govuk-table__row">
         <% dead_job_service.headers&.each do |header| %>

--- a/app/views/system_admin/dead_jobs/show.html.erb
+++ b/app/views/system_admin/dead_jobs/show.html.erb
@@ -20,6 +20,8 @@
   <table class="govuk-table">
     <caption class="govuk-table__caption govuk-table__caption--m"><%= dead_job_service.name %></caption>
     <thead class="govuk-table__head">
+      <%= render SortBy::View.new(items: sort_by_items) %>
+
       <tr class="govuk-table__row">
         <% dead_job_service.headers&.each do |header| %>
           <% next if header == :job_id %>
@@ -31,8 +33,7 @@
     </thead>
 
     <tbody class="govuk-table__body">
-      <% trainees.each do |trainee| %>
-        <% row = dead_job_service.rows.select{|row| row[:register_id] == trainee.id}.first %>
+      <% rows.each do |row| %>
           <tr class="govuk-table__row">
             <% row.each do |data| %>
               <% next if data[0] == :job_id %>
@@ -53,5 +54,5 @@
 
 <% end %>
 
-<%= render Paginator::View.new(scope: trainees) %>
+<%= render Paginator::View.new(scope: rows) %>
 

--- a/app/views/system_admin/pending_awards/index.html.erb
+++ b/app/views/system_admin/pending_awards/index.html.erb
@@ -11,6 +11,9 @@
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--m">Trainees Pending Award</caption>
       <thead class="govuk-table__head">
+        <tr>
+          <%= render SortBy::View.new(items: sort_by_items) %>
+        </tr>
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">First names</th>
           <th scope="col" class="govuk-table__header">Last name</th>

--- a/app/views/system_admin/pending_awards/index.html.erb
+++ b/app/views/system_admin/pending_awards/index.html.erb
@@ -8,12 +8,11 @@
       <%= dqt_error %>
     <% end %>
 
+    <%= render SortBy::View.new(items: sort_by_items) %>
+
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--m">Trainees Pending Award</caption>
       <thead class="govuk-table__head">
-        <tr>
-          <%= render SortBy::View.new(items: sort_by_items) %>
-        </tr>
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">First names</th>
           <th scope="col" class="govuk-table__header">Last name</th>

--- a/app/views/system_admin/pending_trns/index.html.erb
+++ b/app/views/system_admin/pending_trns/index.html.erb
@@ -14,6 +14,10 @@
       <%= dqt_error %>
     <% end %>
 
+    <div class="govuk-!-padding-bottom-3 govuk-!-padding-top-2">
+      <%= render SortBy::View.new(items: sort_by_items) %>
+    </div>
+
     <%= govuk_accordion do |accordion| %>
       <% @trainees.each do |trainee| %>
         <% accordion.with_section(heading_text: trainee.short_name) do  %>

--- a/app/views/system_admin/pending_trns/index.html.erb
+++ b/app/views/system_admin/pending_trns/index.html.erb
@@ -1,7 +1,6 @@
 <div class="govuk-grid-row">
   <div class ="govuk-grid-column-two-thirds-from-desktop">
     <%= render PageTitle::View.new(i18n_key: "pending_trns.index") %>
-
     <h1 class="govuk-heading-l">Trainees Pending TRN</h1>
   </div>
 </div>
@@ -14,9 +13,7 @@
       <%= dqt_error %>
     <% end %>
 
-    <div class="govuk-!-padding-bottom-3 govuk-!-padding-top-2">
-      <%= render SortBy::View.new(items: sort_by_items) %>
-    </div>
+    <%= render SortBy::View.new(items: sort_by_items) %>
 
     <%= govuk_accordion do |accordion| %>
       <% @trainees.each do |trainee| %>

--- a/spec/features/system_admin/dead_jobs/sorting_dead_jobs_spec.rb
+++ b/spec/features/system_admin/dead_jobs/sorting_dead_jobs_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Sorting sidekiq dead jobs" do
+  let(:user) { create(:user, system_admin: true) }
+  let(:dead_jobs_data) do
+    [
+      OpenStruct.new(
+        item: {
+          wrapped: "Dqt::UpdateTraineeJob",
+          args:
+          [
+            {
+              arguments: [
+                { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee_one.id}" },
+              ],
+            },
+          ],
+          error_message: 'status: 400, body: {"title":"Teacher has no incomplete ITT record","status":400,"errorCode":10005}, headers: ',
+          jid: "1234",
+          enqueued_at: 71.hours.ago.to_i,
+        }.with_indifferent_access,
+      ),
+      OpenStruct.new(
+        item: {
+          wrapped: "Dqt::UpdateTraineeJob",
+          args:
+          [
+            {
+              arguments: [
+                { _aj_globalid: "gid://register-trainee-teachers/Trainee/#{trainee_two.id}" },
+              ],
+            },
+          ],
+          error_message: 'status: 400, body: {"title":"Teacher has no incomplete ITT record","status":400,"errorCode":10005}, headers: ',
+          jid: "1234",
+          enqueued_at: 70.hours.ago.to_i,
+        }.with_indifferent_access,
+      ),
+    ]
+  end
+
+  before do
+    given_i_am_authenticated(user:)
+    and_dead_jobs_exist
+    and_i_visit_the_dead_jobs_dqt_update_trainee_page
+  end
+
+  context "with multiple jobs ordered by days waiting" do
+    let(:trainee_one) { create(:trainee, :trn_received) }
+    let(:trainee_two) { create(:trainee, :trn_received) }
+
+    it "sorts dead jobs correctly" do
+      expect(admin_dead_jobs_dqt_update_trainee.sort_by).not_to have_link "Days waiting" # page will default to day waiting
+      expect(admin_dead_jobs_dqt_update_trainee.sort_by).to have_link "TRN"
+      expect(admin_dead_jobs_dqt_update_trainee.sort_by).to have_link "Register"
+
+      expect(admin_dead_jobs_dqt_update_trainee.dead_jobs_table.first).to have_text trainee_one.full_name
+      expect(admin_dead_jobs_dqt_update_trainee.dead_jobs_table.last).to have_text trainee_two.full_name
+    end
+  end
+
+  context "with multiple jobs ordered by register id" do
+    let(:trainee_one) { create(:trainee, trn: "000001") }
+    let(:trainee_two) { create(:trainee, trn: "000002") }
+
+    before { admin_dead_jobs_dqt_update_trainee.sort_by.trn.click }
+
+    it "sorts dead jobs correctly" do
+      expect(admin_dead_jobs_dqt_update_trainee.sort_by).to have_link "Days waiting"
+      expect(admin_dead_jobs_dqt_update_trainee.sort_by).not_to have_link "TRN"
+      expect(admin_dead_jobs_dqt_update_trainee.sort_by).to have_link "Register"
+
+      expect(admin_dead_jobs_dqt_update_trainee.dead_jobs_table.first).to have_text trainee_one.full_name
+      expect(admin_dead_jobs_dqt_update_trainee.dead_jobs_table.last).to have_text trainee_two.full_name
+    end
+  end
+
+  context "with multiple jobs ordered by TRN" do
+    let(:trainee_one) { create(:trainee, :trn_received, id: 1000) }
+    let(:trainee_two) { create(:trainee, :trn_received, id: 2000) }
+
+    before { admin_dead_jobs_dqt_update_trainee.sort_by.register_id.click }
+
+    it "sorts dead jobs correctly" do
+      expect(admin_dead_jobs_dqt_update_trainee.sort_by).to have_link "Days waiting"
+      expect(admin_dead_jobs_dqt_update_trainee.sort_by).to have_link "TRN"
+      expect(admin_dead_jobs_dqt_update_trainee.sort_by).not_to have_link "Register"
+
+      expect(admin_dead_jobs_dqt_update_trainee.dead_jobs_table.first).to have_text trainee_one.full_name
+      expect(admin_dead_jobs_dqt_update_trainee.dead_jobs_table.last).to have_text trainee_two.full_name
+    end
+  end
+
+  def and_i_visit_the_dead_jobs_dqt_update_trainee_page
+    admin_dead_jobs_dqt_update_trainee.load
+  end
+
+  def and_dead_jobs_exist
+    allow(Sidekiq::DeadSet).to receive(:new).and_return(dead_jobs_data)
+  end
+end

--- a/spec/features/system_admin/pending_awards/sort_by_pending_awards_spec.rb
+++ b/spec/features/system_admin/pending_awards/sort_by_pending_awards_spec.rb
@@ -7,6 +7,8 @@ feature "sort by pending awards" do
   let!(:trainee_one) { create(:trainee, :recommended_for_award, recommended_for_award_at: 2.days.ago) }
 
   before do
+    allow(Dqt::FindDeadJobs).to receive(:call).and_return({})
+    allow(Dqt::FindRetryJobs).to receive(:call).and_return({})
     given_i_am_authenticated_as_system_admin
     and_i_visit_the_pending_awards_page
   end

--- a/spec/features/system_admin/pending_awards/sort_by_pending_awards_spec.rb
+++ b/spec/features/system_admin/pending_awards/sort_by_pending_awards_spec.rb
@@ -25,8 +25,9 @@ feature "sort by pending awards" do
   end
 
   context "with multiple jobs ordered by TRN" do
-    let!(:trainee_two) { create(:trainee, :recommended_for_award, trn: "000002") }
-    let!(:trainee_one) { create(:trainee, :recommended_for_award, trn: "000001") }
+    let(:trn) { Faker::Number.number(digits: 6) }
+    let!(:trainee_two) { create(:trainee, :recommended_for_award, trn: trn + 1) }
+    let!(:trainee_one) { create(:trainee, :recommended_for_award, trn:) }
 
     before { admin_pending_awards_page.sort_by.trn.click }
 
@@ -41,10 +42,13 @@ feature "sort by pending awards" do
   end
 
   context "with multiple jobs ordered by Register ID" do
-    let!(:trainee_two) { create(:trainee, :recommended_for_award, id: 2000) }
-    let!(:trainee_one) { create(:trainee, :recommended_for_award, id: 1000) }
+    let(:id) { Faker::Number.number(digits: 5) }
+    let!(:trainee_two) { create(:trainee, :recommended_for_award, id: id + 1) }
+    let!(:trainee_one) { create(:trainee, :recommended_for_award, id:) }
 
-    before { admin_pending_awards_page.sort_by.register_id.click }
+    before do
+      admin_pending_awards_page.sort_by.register_id.click
+    end
 
     it "sorts trainees correctly" do
       expect(admin_pending_awards_page.sort_by).to have_link "Days waiting"

--- a/spec/features/system_admin/pending_awards/sort_by_pending_awards_spec.rb
+++ b/spec/features/system_admin/pending_awards/sort_by_pending_awards_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "sort by pending awards" do
+  let!(:trainee_two) { create(:trainee, :recommended_for_award, recommended_for_award_at: 1.day.ago) }
+  let!(:trainee_one) { create(:trainee, :recommended_for_award, recommended_for_award_at: 2.days.ago) }
+
+  before do
+    given_i_am_authenticated_as_system_admin
+    and_i_visit_the_pending_awards_page
+  end
+
+  context "with multiple jobs ordered by days waiting" do
+    it "sorts trainees correctly" do
+      expect(admin_pending_awards_page.sort_by).not_to have_link "Days waiting" # page will default to day waiting
+      expect(admin_pending_awards_page.sort_by).to have_link "TRN"
+      expect(admin_pending_awards_page.sort_by).to have_link "Register"
+
+      expect(admin_pending_awards_page.table.first).to have_text trainee_one.last_name
+      expect(admin_pending_awards_page.table.last).to have_text trainee_two.last_name
+    end
+  end
+
+  context "with multiple jobs ordered by TRN" do
+    let!(:trainee_two) { create(:trainee, :recommended_for_award, trn: "000002") }
+    let!(:trainee_one) { create(:trainee, :recommended_for_award, trn: "000001") }
+
+    before { admin_pending_awards_page.sort_by.trn.click }
+
+    it "sorts trainees correctly" do
+      expect(admin_pending_awards_page.sort_by).to have_link "Days waiting"
+      expect(admin_pending_awards_page.sort_by).not_to have_link "TRN"
+      expect(admin_pending_awards_page.sort_by).to have_link "Register"
+
+      expect(admin_pending_awards_page.table.first).to have_text trainee_one.last_name
+      expect(admin_pending_awards_page.table.last).to have_text trainee_two.last_name
+    end
+  end
+
+  context "with multiple jobs ordered by Register ID" do
+    let!(:trainee_two) { create(:trainee, :recommended_for_award, id: 2000) }
+    let!(:trainee_one) { create(:trainee, :recommended_for_award, id: 1000) }
+
+    before { admin_pending_awards_page.sort_by.register_id.click }
+
+    it "sorts trainees correctly" do
+      expect(admin_pending_awards_page.sort_by).to have_link "Days waiting"
+      expect(admin_pending_awards_page.sort_by).to have_link "TRN"
+      expect(admin_pending_awards_page.sort_by).not_to have_link "Register"
+
+      expect(admin_pending_awards_page.table.first).to have_text trainee_one.last_name
+      expect(admin_pending_awards_page.table.last).to have_text trainee_two.last_name
+    end
+  end
+
+  def and_i_visit_the_pending_awards_page
+    admin_pending_awards_page.load
+  end
+end

--- a/spec/features/system_admin/pending_trns/sort_by_pending_trns_spec.rb
+++ b/spec/features/system_admin/pending_trns/sort_by_pending_trns_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "sort by pending TRNs" do
+  let!(:trainee_two) { create(:trainee, :submitted_for_trn, :with_dqt_trn_request) }
+  let!(:trainee_one) { create(:trainee, :submitted_for_trn, :with_dqt_trn_request) }
+
+  before do
+    given_i_am_authenticated_as_system_admin
+  end
+
+  context "with multiple jobs ordered by days waiting" do
+    before do
+      trainee_one.dqt_trn_request.update(created_at: 2.days.ago)
+      trainee_two.dqt_trn_request.update(created_at: 1.day.ago)
+      and_i_visit_the_pending_awards_page
+    end
+
+    it "sorts trainees correctly" do
+      expect(admin_pending_trns_page.sort_by).not_to have_link "Days waiting" # page will default to day waiting
+      expect(admin_pending_trns_page.sort_by).to have_link "Register"
+
+      expect(admin_pending_trns_page.accordian.items.first).to have_text trainee_one.last_name
+      expect(admin_pending_trns_page.accordian.items.last).to have_text trainee_two.last_name
+    end
+  end
+
+  context "with multiple jobs ordered by register id" do
+    let!(:trainee_two) { create(:trainee, :submitted_for_trn, :with_dqt_trn_request, id: 20000) }
+    let!(:trainee_one) { create(:trainee, :submitted_for_trn, :with_dqt_trn_request, id: 10000) }
+
+    before do
+      and_i_visit_the_pending_awards_page
+      admin_pending_trns_page.sort_by.register_id.click
+    end
+
+    it "sorts trainees correctly" do
+      expect(admin_pending_trns_page.sort_by).to have_link "Days waiting"
+      expect(admin_pending_trns_page.sort_by).not_to have_link "Register"
+
+      expect(admin_pending_trns_page.accordian.items.first).to have_text trainee_one.last_name
+      expect(admin_pending_trns_page.accordian.items.last).to have_text trainee_two.last_name
+    end
+  end
+
+  def and_i_visit_the_pending_awards_page
+    admin_pending_trns_page.load
+  end
+end

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -418,6 +418,10 @@ module Features
       @admin_pending_trns_page ||= PageObjects::SystemAdmin::PendingTrns::PendingTrnsSummary.new
     end
 
+    def admin_pending_awards_page
+      @admin_pending_awards_page ||= PageObjects::SystemAdmin::PendingAwards::PendingAwardsSummary.new
+    end
+
     def admin_users_index_page
       @admin_users_index_page ||= PageObjects::SystemAdmin::Users::Index.new
     end

--- a/spec/support/page_objects/system_admin/dead_jobs/dead_jobs_dqt_update_trainee.rb
+++ b/spec/support/page_objects/system_admin/dead_jobs/dead_jobs_dqt_update_trainee.rb
@@ -9,6 +9,19 @@ module PageObjects
         element :view_trainee_button, "button", text: "View"
         element :retry_trainee_button, "button", text: "Retry"
         element :delete_trainee_button, "button", text: "Delete"
+
+        class SortBy < SitePrism::Section
+          element :days_waiting, "a", text: "Days waiting"
+          element :trn, "a", text: "TRN"
+          element :register_id, "a", text: "Register"
+        end
+
+        class DeadJobsTable < SitePrism::Section
+          elements :rows, "tr"
+        end
+
+        sections :dead_jobs_table, DeadJobsTable, ".govuk-table__body"
+        section :sort_by, SortBy, ".sort-by-items"
       end
     end
   end

--- a/spec/support/page_objects/system_admin/pending_awards/pending_awards.rb
+++ b/spec/support/page_objects/system_admin/pending_awards/pending_awards.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module SystemAdmin
+    module PendingAwards
+      class PendingAwardsSummary < PageObjects::Base
+        set_url "/system-admin/pending_awards"
+
+        class SortBy < SitePrism::Section
+          element :days_waiting, "a", text: "Days waiting"
+          element :trn, "a", text: "TRN"
+          element :register_id, "a", text: "Register"
+        end
+
+        class Table < SitePrism::Section
+          elements :rows, "tr"
+        end
+
+        sections :table, Table, ".govuk-table__body"
+        section :sort_by, SortBy, ".sort-by-items"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/system_admin/pending_trns/pending_trns.rb
+++ b/spec/support/page_objects/system_admin/pending_trns/pending_trns.rb
@@ -8,6 +8,18 @@ module PageObjects
 
         element :check_for_trn_button, "button", text: "Check for TRN"
         element :resumbit_for_trn_button, "button", text: "Re-submit for TRN"
+
+        class SortBy < SitePrism::Section
+          element :days_waiting, "a", text: "Days waiting"
+          element :register_id, "a", text: "Register"
+        end
+
+        class Accordian < SitePrism::Section
+          elements :items, ".govuk-accordion__section"
+        end
+
+        section :accordian, Accordian, ".govuk-accordion"
+        section :sort_by, SortBy, ".sort-by-items"
       end
     end
   end


### PR DESCRIPTION
### Context

DQT support team would like to be able to sort/order dead jobs by fields such as TRN, name(s), days waiting. job status etc

### Changes proposed in this pull request

adds a sort-by feature to dead jobs, pending awards and pending TRNS. Defaults to "Days waiting"

### Guidance to review

This is a little tricky to test locally as you'll need real data to see pending awards/TRNS. as for dead jobs this is probably only testable in production as most/all other environments won't have any.


<img width="1005" alt="Screenshot 2024-02-19 at 16 38 49" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/6339025/37048d7d-8a6d-4074-a235-5ed8b21fea3d">
<img width="985" alt="Screenshot 2024-02-19 at 16 38 19" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/6339025/3e7c2523-8d29-4ed7-acfc-1b39be10703d">
<img width="1022" alt="Screenshot 2024-02-19 at 16 38 12" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/6339025/a6ad241f-387e-4d70-800f-39da188d8185">

