### PR TITLE
[6789] Fix missing fields mapping

### DIFF
--- a/app/components/funding/view.rb
+++ b/app/components/funding/view.rb
@@ -67,6 +67,9 @@ module Funding
     def grant_and_bursary_funding_row
       funding_text = [grant_text, "<br>", funding_method].join.html_safe
 
+      # Set funding_text to nil if applying_for_grant is nil, which means not all the fields were set for the GrantAndTieredBursaryForm
+      funding_text = nil if data_model.applying_for_grant.nil?
+
       mappable_field(
         funding_text,
         t(".funding_method"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -718,6 +718,7 @@ en:
         applying_for_bursary: &funding_method_path edit_trainee_funding_bursary_path
         applying_for_grant: *funding_method_path
         custom_bursary_tier: *funding_method_path
+        custom_applying_for_grant: *funding_method_path
         applying_for_scholarship: *funding_method_path
         funding_type: *funding_method_path
         institution: &degree_path degree_path
@@ -772,6 +773,7 @@ en:
         applying_for_grant: *funding_method
         applying_for_scholarship: *funding_method
         custom_bursary_tier: *funding_method
+        custom_applying_for_grant: *funding_method
         funding_type: *funding_method
         institution: *institution
         subject: *subject


### PR DESCRIPTION
### Context

We added some new bursary fields as part of this original PR https://github.com/DFE-Digital/register-trainee-teachers/pull/3625/files. If these fields are missing, currently the application [errors](https://dfe-teacher-services.sentry.io/issues/4979945187/?alert_rule_id=4544549&alert_type=issue&environment=production&notification_uuid=f8dfacff-7852-4494-abe0-25c003109f6e&project=5552118&referrer=slack) as we have not mapped their missing fields properly. 

### Changes proposed in this pull request

- Declare the new fields as potential missing attributes in the translation lookup

Before:

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/be606f4c-be2f-4036-8f92-5ef3a89e05ab)

After:

![test](https://github.com/DFE-Digital/register-trainee-teachers/assets/616080/4db0155c-b0aa-42dd-a626-3fa01e1005b2)

### Guidance to review

This can be tested against the original trainee which triggers the error https://www.register-trainee-teachers.service.gov.uk/trainees/txHSffNT8zaWZWv2hxC3qrQn in production data.
