### PR TITLE
[6794] Infer `course_allocation_subject` in API

### DIFF
--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -5,6 +5,9 @@ module Api
     class V01
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include ActiveModel::Validations::Callbacks
+
+      before_validation :set_course_allocation_subject
 
       ATTRIBUTES = %i[
         first_names
@@ -24,6 +27,7 @@ module Api
         course_subject_one
         course_subject_two
         course_subject_three
+        course_allocation_subject
         study_mode
         application_choice_id
       ].freeze
@@ -108,6 +112,11 @@ module Api
         elsif value < 100.years.ago
           errors.add(:date_of_birth, :past)
         end
+      end
+
+      def set_course_allocation_subject
+        self.course_allocation_subject ||=
+          SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject
       end
     end
   end

--- a/spec/models/api/trainee_attributes/v01_spec.rb
+++ b/spec/models/api/trainee_attributes/v01_spec.rb
@@ -48,4 +48,11 @@ RSpec.describe Api::TraineeAttributes::V01 do
     subject.valid?
     expect(subject.errors.details[:sex]).to include(error: :inclusion, value: invalid_sex)
   end
+
+  it "derives course_allocation_subject from course_subject_one_name before validation" do
+    subject.course_subject_one = "biology"
+    create(:subject_specialism, name: subject.course_subject_one)
+    subject.valid?
+    expect(subject.course_allocation_subject).to be_present
+  end
 end


### PR DESCRIPTION
### Context
This PR arose from analysis of nested data in trainee records and how we need
to support that in the `PUT /trainees/:id` endpoint. https://trello.com/c/wldx3WJm/6794-register-api-ensure-that-the-put-trainees-id-endpoint-works-with-nested-data . 
The main elements of nested data are degrees and placements (which are covered 
by a separate ticket).

This PR just infers the `Trainee#course_allocation_subject` from the given
course name (`course_subject_one`) as we do when importing from HESA.

### Changes proposed in this pull request
Set the `course_allocation_subject` before saving a Trainee record from the API.

### Guidance to review
I've implemented this as a pre-validation step in the `TraineeAttributes` class. Does it make sense to use the same pattern to implement the various data conversion rules that we need to implement (e.g. to support HESA codes).

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
