### PR TITLE
[6812] Handle nil case for year based on Sentry error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate
   before_action :track_page
   before_action :check_organisation_context_is_set
+  before_action :set_sentry_organisation_context, unless: -> { Rails.env.local? }
   after_action :save_origin_path
   include Pundit::Authorization
   include DfE::Analytics::Requests
@@ -83,6 +84,12 @@ private
     return unless authenticated?
 
     redirect_to_organisation_contexts unless current_user.organisation.present? || current_user.system_admin?
+  end
+
+  def set_sentry_organisation_context
+    return unless defined?(current_user)
+
+    Sentry.set_tags(organisation: current_user.organisation.name)
   end
 
   def redirect_to_organisation_contexts

--- a/app/controllers/funding_controller.rb
+++ b/app/controllers/funding_controller.rb
@@ -17,6 +17,8 @@ private
     return {} if years.blank?
 
     years.each_with_object({}) do |year, hash|
+      next if year.blank?
+
       year_int = year.split("/").first.to_i
       hash["#{year_int} to #{year_int + 1}"] = funding_trainee_summary_path(year_int)
     end


### PR DESCRIPTION
### Context

Fixes the following [Sentry error](https://dfe-teacher-services.sentry.io/issues/4976329281/?environment=production&project=5552118&referrer=issue-stream&statsPeriod=7d&stream_index=0).

It's quite difficult to re-produce these sort of issues where the context of the organisation is crucial. I've set this as a Sentry tag to help debug in the future. 
