### PR TITLE
[6811] Fix sandbox health checks

### DIFF
--- a/terraform/aks/workspace-variables/sandbox.tfvars.json
+++ b/terraform/aks/workspace-variables/sandbox.tfvars.json
@@ -18,8 +18,8 @@
   "worker_apps": {
     "worker": {
       "startup_command": ["/bin/sh", "-c", "bundle exec sidekiq -C config/sidekiq.yml"],
-      "replicas": 0,
-      "memory_max": "1Gi"
+      "replicas": 1,
+      "memory_max": "3Gi"
     }
   },
   "azure_maintenance_window": {


### PR DESCRIPTION
### Context

We created the sandbox environment but it requires a `replicas` value to be on.