### PR TITLE
Bump sidekiq from 6.5.8 to 6.5.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -670,7 +670,7 @@ GEM
       sidekiq (>= 3.0)
     shoulda-matchers (6.1.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.5.8)
+    sidekiq (6.5.12)
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)


### PR DESCRIPTION
### Context

While we're waiting to be able to [move to sidekiq v7](https://github.com/DFE-Digital/register-trainee-teachers/pull/4043), it makes sense to update to the latest v6.

### Changes proposed in this pull request

* Bump sidekiq from 6.5.8 to 6.5.12

### Guidance to review

* Make sure nothing is broken.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

