### PR TITLE
Increase konduit timeout for db backup to 7200

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Backup Prod DB
       run: |
-        bin/konduit.sh register-production -- pg_dump -E utf8 --clean --if-exists --no-owner --verbose --no-password -f ${BACKUP_FILE_NAME}.sql
+        bin/konduit.sh -t 7200 register-production -- pg_dump -E utf8 --clean --if-exists --no-owner --verbose --no-password -f ${BACKUP_FILE_NAME}.sql
         tar -cvzf ${BACKUP_FILE_NAME}.tar.gz ${BACKUP_FILE_NAME}.sql
 
     - name: Set Connection String


### PR DESCRIPTION
### Context

Daily backup can take over 60 minutes, and this causes the backup to fail as the konduit timeout default is 3600 seconds for backups.

### Changes proposed in this pull request

Increase timeout to 7200 (2 hours)

### Guidance to review

review code update

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
