### PR TITLE
[6796] - remove QA from build and deploy temporarily

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -256,7 +256,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [qa,staging]
+        environment: [staging]
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
### Context

Related to https://trello.com/c/gtHiSiuB/6784-accessibility-audit-february-2024 we don’t want any changes deployed to the QA environment while the a11y audit is happening.

* Take the QA env out of the deployment pipeline before 27 February
* Put the QA env back in the deployment pipeline after the audit - estimated to be 1 March but check with (TODO )

### Changes proposed in this pull request

removes QA from build-deploy workflow. Have created a ticket to put QA back in here: https://trello.com/c/Tb6rxerD/6815-put-qa-back-into-build-deploy-pipeline