### PR TITLE
[6690] Fix pagination on the system admin users tab

### DIFF
--- a/app/controllers/system_admin/users_controller.rb
+++ b/app/controllers/system_admin/users_controller.rb
@@ -6,7 +6,12 @@ module SystemAdmin
     before_action :user, only: %i[show delete destroy]
 
     def index
-      @users = filtered_users(policy_scope(User.kept.includes(:providers, :lead_schools), policy_scope_class: UserPolicy).order_by_last_name.page(params[:page] || 1))
+      @users = filtered_users(
+        policy_scope(
+          User.kept.includes(:providers, :lead_schools),
+          policy_scope_class: UserPolicy,
+        ).order_by_last_name.page(params[:page] || 1).per(UserSearch::DEFAULT_LIMIT),
+      )
     end
 
     def show; end

--- a/app/services/user_search.rb
+++ b/app/services/user_search.rb
@@ -13,7 +13,7 @@ class UserSearch
   end
 
   MIN_QUERY_LENGTH = 2
-  DEFAULT_LIMIT = 15
+  DEFAULT_LIMIT = Settings.pagination.records_per_page
 
   def initialize(query: nil, limit: DEFAULT_LIMIT, scope: User.all)
     @query = ReplaceAbbreviation.call(string: StripPunctuation.call(string: query))


### PR DESCRIPTION
### Context
Pagination is broken on the system admin users tab.

### Changes proposed in this pull request
I've changed the user pagination to the system default page size. Without this the `current_page` of the scope is wrong because it's applying the system-wide default (which is 30 in dev) and that is then clashing with the `limit` (15) set in `UserSearch`.

The system wide default (`Settings.pagination.records_per_page`) varies between different environments so it makes sense to just use that for all the things. Currently the system wide limit is used on all the other sys admin tabs, e.g. schools.

This is what page 2 looks like before and after:
#### Before
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/5800e165-703e-457b-8827-b9bb62a3b7e7)

#### After
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/12ec7d46-9b43-4c16-a864-1a8897613f4e)

### Guidance to review
Does this make sense?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
