### PR TITLE
[6679] - show nav menu toggle only when js is enabled

### DIFF
--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -26,7 +26,7 @@
     <% if items.present? %>
       <div class="<%= header_class %>">
         <nav class="govuk-header__navigation" aria-label="Account menu">
-          <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu" data-module="govuk-button">
+          <button type="button" class="govuk-header__menu-button govuk-js-header-toggle app-js-only" aria-controls="navigation" aria-label="Show or hide navigation menu" data-module="govuk-button">
             Menu
           </button>
           <ul id="navigation" class="govuk-header__navigation-list govuk-header__navigation--end">


### PR DESCRIPTION
### Context

Navigation menu drop down always shows in Firefox if JS is disabled

**Before**

<img width="1109" alt="Screenshot 2024-02-27 at 13 43 13" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/6339025/9e610d8c-d34d-4f43-93d2-19879d5b452b">

**After**

<img width="1178" alt="Screenshot 2024-02-27 at 13 42 18" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/6339025/72c405c6-8ba9-4894-a403-438afb2589ba">


