### PR TITLE
[xxx] Use correct apply import url

### DIFF
--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -10,6 +10,9 @@ dfe_sign_in:
   # URL of the users profile
   profile: https://profile.signin.education.gov.uk
 
+recruits_api:
+  base_url: "https://sandbox.apply-for-teacher-training.service.gov.uk/register-api"
+
 features:
   basic_auth: false
   sign_in_method: dfe-sign-in


### PR DESCRIPTION
### Context

Sandbox at the moment is pulling apply applications from Apply's live environment. This PR updates the url to use their sandbox environment so the pipeline is consistent. 
