### PR TITLE
[6843] - extract PersonalDetailsForm validation

### DIFF
--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PersonalDetailsForm < TraineeForm
-  include DatesHelper
+  include PersonalDetailsValidations
 
   FIELDS = %i[
     first_names
@@ -25,12 +25,6 @@ class PersonalDetailsForm < TraineeForm
 
   before_validation :set_nationalities_from_raw_values
 
-  validates :first_names, presence: true, length: { maximum: 50 }
-  validates :last_name, presence: true, length: { maximum: 50 }
-  validates :middle_names, length: { maximum: 50 }, allow_nil: true
-  validates :date_of_birth, presence: true
-  validate :date_of_birth_valid
-  validates :sex, presence: true, inclusion: { in: Trainee.sexes.keys }
   validates :other_nationality1,
             :other_nationality2,
             :other_nationality3,

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -6,6 +6,7 @@ module Api
       include ActiveModel::Model
       include ActiveModel::Attributes
       include ActiveModel::Validations::Callbacks
+      include PersonalDetailsValidations
 
       before_validation :set_course_allocation_subject
       after_validation :set_progress
@@ -55,12 +56,9 @@ module Api
 
       attribute :placements_attributes, array: true, default: -> { [] }
       attribute :degrees_attributes, array: true, default: -> { [] }
+      attribute :date_of_birth, :date
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
-      validates :first_names, :last_name, length: { maximum: 50 }
-      validates :middle_names, length: { maximum: 50 }, allow_nil: true
-      validates :sex, inclusion: { in: Trainee.sexes.keys }
-      validate :date_of_birth_valid
 
       def initialize(attributes = {})
         super(attributes.except(:placements_attributes, :degrees_attributes))
@@ -91,30 +89,6 @@ module Api
       end
 
     private
-
-      def date_of_birth_valid
-        value = date_of_birth
-        if value.is_a?(String)
-          value =
-            begin
-              Date.parse(value)
-            rescue StandardError
-              nil
-            end
-        end
-
-        if !value.is_a?(Date)
-          errors.add(:date_of_birth, :invalid)
-        elsif value > Time.zone.today
-          errors.add(:date_of_birth, :future)
-        elsif value.year.digits.length != 4
-          errors.add(:date_of_birth, :invalid_year)
-        elsif value > 16.years.ago
-          errors.add(:date_of_birth, :under16)
-        elsif value < 100.years.ago
-          errors.add(:date_of_birth, :past)
-        end
-      end
 
       def set_course_allocation_subject
         self.course_allocation_subject ||=

--- a/app/validators/personal_details_validations.rb
+++ b/app/validators/personal_details_validations.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module PersonalDetailsValidations
+  extend ActiveSupport::Concern
+
+  included do
+    include ActiveModel::Model
+    include DatesHelper
+
+    validates :first_names, presence: true, length: { maximum: 50 }
+    validates :last_name, presence: true, length: { maximum: 50 }
+    validates :middle_names, length: { maximum: 50 }, allow_nil: true
+    validates :date_of_birth, presence: true
+    validates :sex, presence: true, inclusion: { in: Trainee.sexes.keys }
+    validate :date_of_birth_valid
+  end
+
+  def date_of_birth_valid
+    if !date_of_birth.is_a?(Date)
+      errors.add(:date_of_birth, :invalid)
+    elsif date_of_birth > Time.zone.today
+      errors.add(:date_of_birth, :future)
+    elsif date_of_birth.year.digits.length != 4
+      errors.add(:date_of_birth, :invalid_year)
+    elsif date_of_birth > 16.years.ago
+      errors.add(:date_of_birth, :under16)
+    elsif date_of_birth < 100.years.ago
+      errors.add(:date_of_birth, :past)
+    end
+  end
+end


### PR DESCRIPTION
### Context

After [this spike](https://trello.com/c/h9FjRGd7/6823-spike-investigate-different-approaches-to-route-based-validation-implementation) we have decided that validation logic for each Form service used in the trainee creation journey should be pulled, making each available to: API, UI, BulkUpdate. with the latter two being the focus of this ticket.

### Changes proposed in this pull request


* Pulls personal detail validations into a separate module
* New module  is used in TraineeAttributes and PersonalDetailsForm

### Guidance to review

* sanity check approach
* are we happy with moving all these validations into `app/validators/xxxx_xxxx_validations.rb`
