### PR TITLE
[6844] - conditional validation approach for API trainee creation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -750,6 +750,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-22
   arm64-darwin-23
   x86_64-linux
 

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -6,7 +6,12 @@ module Api
       include ActiveModel::Model
       include ActiveModel::Attributes
       include ActiveModel::Validations::Callbacks
-      include PersonalDetailsValidations
+
+      # validation modules are conditionally included
+      include(PersonalDetailsValidations) # if should_include_personal_details?
+      # include(ContactDetailsValidation) unless draft?
+      # include(DiversitiesValidations) unless draft?
+      # include(DegreesValidation) if requires_degree?
 
       before_validation :set_course_allocation_subject
       after_validation :set_progress
@@ -60,6 +65,19 @@ module Api
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
 
+      delegate :award_type,
+               :requires_schools?,
+               :requires_placements?,
+               :requires_employing_school?,
+               :early_years_route?,
+               :undergrad_route?,
+               :requires_itt_start_date?,
+               :requires_study_mode?,
+               :requires_degree?,
+               :requires_funding?,
+               :requires_iqts_country?,
+               to: :training_route_manager
+
       def initialize(attributes = {})
         super(attributes.except(:placements_attributes, :degrees_attributes))
 
@@ -89,6 +107,14 @@ module Api
       end
 
     private
+
+      def validate_degree?
+        requires_degree?
+      end
+
+      def training_route_manager
+        @training_route_manager ||= TrainingRouteManager.new(self)
+      end
 
       def set_course_allocation_subject
         self.course_allocation_subject ||=


### PR DESCRIPTION
### Context

Owing to [this spike](https://trello.com/c/h9FjRGd7/6823-spike-investigate-different-approaches-to-route-based-validation-implementation) we want to adapt the TrnValidator service to be de-coupled from the existing Form Services used in the existing trainee creation flow.

This will allow us to use it when validating trainees coming through via the new STDD API

### Changes proposed in this pull request

* This is more of a concept PR than a full PR. I have simply copied some of the logic in the `app/forms/submissions/base_validator.rb` and used it to conditionally include validation modules.
* At present, we only have one validation module extracted from a form - `PersonalDetailsValidations` from this pr #4108 
* I've commented out a few more hypothetical validations to show the pattern we might follow

### Guidance to review

Does this approach make sense? there is some duplication of logic, but the new amount of code should be minimal. 
