### PR TITLE
[6868] Submit trainee for trn on API POST

### DIFF
--- a/app/services/api/create_trainee.rb
+++ b/app/services/api/create_trainee.rb
@@ -18,11 +18,13 @@ module Api
       return duplicate_trainees_response(duplicate_trainees) if duplicate_trainees.present?
 
       trainee = current_provider.trainees.new(trainee_attributes.deep_attributes)
-      unless trainee.save
-        return save_errors_response(trainee)
-      end
 
-      success_response(trainee)
+      if trainee.save
+        ::Trainees::SubmitForTrn.call(trainee:)
+        success_response(trainee)
+      else
+        save_errors_response(trainee)
+      end
     end
 
   private

--- a/spec/requests/api/v0.1/post_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_trainees_spec.rb
@@ -58,6 +58,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     it "sets the progress data structure" do
       expect(Trainee.last.progress.personal_details).to be(true)
     end
+
+    it "submits the trainee for TRN" do
+      expect(Trainee.last.submitted_for_trn_at).to be_present
+    end
   end
 
   context "when the request is invalid", feature_register_api: true do


### PR DESCRIPTION
### Context

We assume that trainees coming from vendors can be registered and submitted for a TRN, as long as they pass our validation checks.

### Changes proposed in this pull request

- Submits the trainee for TRN on save in `Api::CreateTrainee`

### Guidance to review

The submission will need to be wrapped by our `TrnValidator` checks. There is [currently a spike on this](https://github.com/DFE-Digital/register-trainee-teachers/pull/4123) but leaving a note here.
