### PR TITLE
[6863] Api Set up providers in sandbox for vendor testing

### DIFF
--- a/.github/workflows/reset-sandbox-database.yml
+++ b/.github/workflows/reset-sandbox-database.yml
@@ -1,0 +1,85 @@
+name: Reset sandbox database
+concurrency: restore-sanitised-sandbox-database-with-vendors
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  restore_sandbox:
+    name: restore Database (sandbox)
+    if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.confirm == 'true') }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout
+
+    - uses: azure/login@v2
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS_SANDBOX }}
+
+    - name: Download Sanitised Backup
+      uses: dawidd6/action-download-artifact@v3
+      with:
+        workflow: database-backup.yml
+        name: backup_sanitised
+
+    - name: Install kubectl
+      uses: azure/setup-kubectl@v4
+      with:
+        version: "v1.26.1" # default is latest stable
+
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS_SANDBOX }}
+
+    - name: K8 setup
+      shell: bash
+      run: |
+        make ci sandbox get-cluster-credentials
+        make install-konduit
+
+    - name: Restore backup to aks env database
+      shell: bash
+      run: |
+        bin/konduit.sh -i backup_sanitised.sql.gz -c -t 7200 register-sandbox -- psql
+
+    - name: Swap providers to vendor
+      shell: bash
+      run: |
+        (kubectl -n bat-qa exec -ti deployment/register-sandbox -- bundle exec rake vendor:create) >> vendor_create.txt
+
+    - name: Check for Failure
+      if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@master
+      env:
+        SLACK_CHANNEL: twd_publish_register_tech
+        SLACK_COLOR: '#ef5343'
+        SLACK_ICON_EMOJI: ':github-logo:'
+        SLACK_USERNAME: Register Trainee Teachers
+        SLACK_TITLE: 'Reset :sadpit: database Failure'
+        SLACK_MESSAGE: ':alert: Reset sandbox database failure for sadpit :sadparrot:'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    - name: Print out vendor_create.txt
+      if: ${{ success() }}
+      shell: bash
+      run: |
+        cat vendor_create.txt
+
+    - name: Check for Success
+      if: ${{ success() }}
+      uses: rtCamp/action-slack-notify@master
+      env:
+        SLACK_CHANNEL: twd_publish_register_tech
+        SLACK_COLOR: '#37d67a'
+        SLACK_ICON_EMOJI: ':github-logo:'
+        SLACK_USERNAME: Register Trainee Teachers
+        SLACK_TITLE: 'Reset :sadpit: database Success'
+        SLACK_MESSAGE: ':alert-green: Reset sandbox database success for sadpit :char-dance:'
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/lib/tasks/vendor.rake
+++ b/lib/tasks/vendor.rake
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+namespace :vendor do
+  desc "Create a vendor via swap"
+  task create: :environment do
+    raise "THIS TASK CANNOT BE RUN IN PRODUCTION" if Rails.env.production?
+
+    vendor_names = %w[Tribal
+                      Ellucian
+                      ThesisCloud
+                      Oracle
+                      PWC
+                      Unit-e
+                      TechnologyOne] + [*1..10].map { |a| "Test vendor #{a}" }
+
+    provider_ids = Trainee.group(:provider_id).order("count_all DESC").count.take(vendor_names.count).shuffle
+      .map { |provider_id, _count_all| provider_id }
+
+    vendor_names.each_with_index do |vendor_name, index|
+      task = Rake::Task["vendor:swap"]
+
+      task.invoke(vendor_name, provider_ids[index])
+      task.reenable
+    end
+  end
+
+  desc "Swap the provider to a vendor"
+  task :swap, :vendor_name, :provider_id_to_replace do |_, args|
+    raise "THIS TASK CANNOT BE RUN IN PRODUCTION" if Rails.env.production?
+
+    Faker::Config.locale = "en-GB"
+
+    vendor_name, provider_id_to_replace = *args
+
+    existing_provider = Provider.find(provider_id_to_replace)
+    puts "Swapped: #{existing_provider.name} with #{vendor_name}"
+
+    existing_provider.update(
+      dttp_id: SecureRandom.uuid,
+      accreditation_id: Faker::Number.number(digits: 4),
+      ukprn: Faker::Number.number(digits: 8),
+      code: Faker::Alphanumeric.alphanumeric(number: 3).upcase,
+      name: vendor_name,
+    )
+
+    AuthenticationToken.where(provider: existing_provider).find_each(&:delete)
+
+    token = AuthenticationToken.create_with_random_token(provider: existing_provider)
+
+    puts "Token: `#{token}`"
+  end
+end

--- a/spec/lib/tasks/vendor_create_spec.rb
+++ b/spec/lib/tasks/vendor_create_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "vendor:create" do
+  subject do
+    Rake::Task["vendor:create"].execute
+  end
+
+  let(:generate_providers) {
+    (1..20).to_a.reverse.map { |number|
+      trainees = build_list(:trainee, number)
+      create(:provider, trainees:)
+    }
+  }
+
+  before do
+    generate_providers
+  end
+
+  it "invoke vendor swap" do
+    expect(Rake::Task["vendor:swap"]).to receive(:invoke).exactly(17).times
+    expect(Rake::Task["vendor:swap"]).to receive(:reenable).exactly(17).times
+
+    subject
+  end
+end

--- a/spec/lib/tasks/vendor_swap_spec.rb
+++ b/spec/lib/tasks/vendor_swap_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "vendor:swap" do
+  subject do
+    args = Rake::TaskArguments.new(%i[vendor_name provider_id_to_replace], [vendor_name, provider_id_to_replace])
+    Rake::Task["vendor:swap"].execute(args)
+  end
+
+  let(:existing_provider) { create(:provider) }
+  let(:provider_id_to_replace) { existing_provider.id }
+  let(:vendor_name) { "vendor name" }
+  let(:swapped_message) { "Swapped: #{existing_provider.name} with #{vendor_name}" }
+  let(:token) { AuthenticationToken.last.hashed_token }
+  let(:token_message) { "Token: `not_for_production_#{token}`" }
+
+  it "swapped the provider with vendor" do
+    expect($stdout).to receive(:puts).with(swapped_message)
+    expect(AuthenticationToken).to receive(:create_with_random_token).with(provider: existing_provider).and_call_original
+    expect($stdout).to receive(:puts)
+
+    expect {
+      subject
+      existing_provider.reload
+    }.to change { existing_provider.name }.to(vendor_name)
+     .and change { existing_provider.dttp_id }
+     .and change { existing_provider.accreditation_id }
+     .and change { existing_provider.ukprn }
+     .and change { existing_provider.code }
+     .and change { AuthenticationToken.all.reload.count }.from(0).to(1)
+  end
+end


### PR DESCRIPTION
### Context

API setup providers in sandbox for vendor testing

### Changes proposed in this pull request
Restore sanitised database
Swap a number of named vendors
Swap ten vendors
Send a slack message regardlessly

### Guidance to review

Due to github action limitations ie, the workflow needs to be merged in so that the `workflow_dispatch` can work hence this [commit](https://github.com/DFE-Digital/register-trainee-teachers/pull/4129/commits/355d74ca04530f0bb3d653a1ea2a47f79aa0e1cb) as a stop gap to flush it issues prior to merge

Added tokens to be displayed 
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/f270d271-c309-48d7-a807-f155ff6bf092)



### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
