### PR TITLE
[6907] Fix course allocation subject issue

### DIFF
--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -7,7 +7,7 @@ module Api
       include ActiveModel::Attributes
       include ActiveModel::Validations::Callbacks
 
-      before_validation :set_course_allocation_subject
+      before_validation :set_course_allocation_subject_id
       after_validation :set_progress
 
       ATTRIBUTES = %i[
@@ -32,7 +32,7 @@ module Api
         course_subject_one
         course_subject_two
         course_subject_three
-        course_allocation_subject
+        course_allocation_subject_id
         study_mode
         application_choice_id
         progress
@@ -98,9 +98,9 @@ module Api
 
     private
 
-      def set_course_allocation_subject
-        self.course_allocation_subject ||=
-          SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject
+      def set_course_allocation_subject_id
+        self.course_allocation_subject_id ||=
+          SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject&.id
       end
 
       def set_progress

--- a/app/services/api/map_hesa_attributes/v01.rb
+++ b/app/services/api/map_hesa_attributes/v01.rb
@@ -32,7 +32,7 @@ module Api
           nationalisations_attributes:,
         })
         .merge(course_attributes)
-        .merge(ethnicity_and_disability_attributes)
+        .merge(ethnicity_and_disability_attributes).compact
       end
 
       def sex
@@ -103,6 +103,14 @@ module Api
 
       def course_age_range
         DfE::ReferenceData::AgeRanges::HESA_CODE_SETS[params[:course_age_range]]
+      end
+
+      def course_attributes
+        attributes = super
+
+        attributes[:course_allocation_subject_id] = attributes.delete(:course_allocation_subject)&.id
+
+        attributes
       end
     end
   end

--- a/spec/models/api/trainee_attributes/v01_spec.rb
+++ b/spec/models/api/trainee_attributes/v01_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe Api::TraineeAttributes::V01 do
     subject.course_subject_one = "biology"
     create(:subject_specialism, name: subject.course_subject_one)
     subject.valid?
-    expect(subject.course_allocation_subject).to be_present
+    expect(subject.course_allocation_subject_id).to be_present
   end
 end

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -7,6 +7,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
   let!(:auth_token) { create(:authentication_token, hashed_token: AuthenticationToken.hash_token(token)) }
   let!(:nationality) { create(:nationality, :british) }
 
+  let!(:course_allocation_subject) do
+    create(:subject_specialism, name: CourseSubjects::BIOLOGY).allocation_subject
+  end
+
   let(:params) do
     {
       data: {
@@ -50,6 +54,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
     it "creates the nationalities" do
       expect(Trainee.last.nationalities.first.name).to eq("british")
+    end
+
+    it "sets the correct course allocation subject" do
+      expect(Trainee.last.course_allocation_subject).to eq(course_allocation_subject)
     end
 
     it "sets the progress data structure" do


### PR DESCRIPTION
### Context

https://trello.com/c/gsX6phzU/6907-check-hesa-mapping-for-sex-is-working-for-post-trainee

I couldn't reproduce the issue with the `sex` attribute, seems to work fine when given the correct params but I did notice another issue around properly setting the `course_allocation_subject` which I've addressed.

### Changes proposed in this pull request

- Updates mapper and trainee attributes class to set `course_allocation_subject` via the `course_allocation_subject_id` so ActiveRecord doesn't blow up expecting an instance when a hash of attributes for the course allocation subject is given.

### Guidance to review

You can verify this with the same request params locally to assert the trainee does get created:

```json
{
  "data": {
    "first_names": "John",
    "last_name": "Doe",
    "date_of_birth": "1990-01-01",
    "sex": "11",
    "email": "john.doe@example.com",
    "nationality": "GB",
    "training_route": "11",
    "itt_start_date": "2023-01-01",
    "itt_end_date": "2023-10-01",
    "course_subject_one": "100346",
    "study_mode": "63",
    "ethnic_background": "100"
  }
}
```


