### PR TITLE
Update docker compose command to v2

### DIFF
--- a/.github/actions/bring-docker-image-up/action.yml
+++ b/.github/actions/bring-docker-image-up/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: Bring image up
       shell: bash
       run: |
-        docker-compose up --no-build -d
-        docker-compose exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
+        docker compose up --no-build -d
+        docker compose exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
       env:
         SENTRY_DSN: ${{ steps.get-secret.outputs.sentry_dsn }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -122,22 +122,22 @@ jobs:
         linter-type: [rubocop, scss, dfe_analytics, javascript_lint_and_test]
         include:
           - linter-type: rubocop
-            command: docker-compose exec -T web /bin/sh -c 'bundle exec rubocop app config db lib spec Gemfile --format clang'
+            command: docker compose exec -T web /bin/sh -c 'bundle exec rubocop app config db lib spec Gemfile --format clang'
           - linter-type: scss
             command: |
-              docker-compose exec -T web /bin/sh -c "yarn add stylelint@15.11.0"
-              docker-compose exec -T web /bin/sh -c "yarn add stylelint-scss@5.3.1"
-              docker-compose exec -T web /bin/sh -c "yarn add stylelint-config-gds@1.1.0"
-              docker-compose exec -T web /bin/sh -c "yarn run scss:lint"
+              docker compose exec -T web /bin/sh -c "yarn add stylelint@15.11.0"
+              docker compose exec -T web /bin/sh -c "yarn add stylelint-scss@5.3.1"
+              docker compose exec -T web /bin/sh -c "yarn add stylelint-config-gds@1.1.0"
+              docker compose exec -T web /bin/sh -c "yarn run scss:lint"
           - linter-type: dfe_analytics
             command: |
-              docker-compose exec -T web /bin/sh -c "bundle exec rails db:setup"
-              docker-compose exec -T web /bin/sh -c 'bundle exec rake dfe:analytics:check'
+              docker compose exec -T web /bin/sh -c "bundle exec rails db:setup"
+              docker compose exec -T web /bin/sh -c 'bundle exec rake dfe:analytics:check'
           - linter-type: javascript_lint_and_test
             command: |
-              docker-compose exec -T web /bin/sh -c "yarn add jest@29.3.1"
-              docker-compose exec -T web /bin/sh -c "yarn run standard $(git ls-files '**.js' | tr '\n' ' ')"
-              docker-compose exec -T web /bin/sh -c 'yarn run test'
+              docker compose exec -T web /bin/sh -c "yarn add jest@29.3.1"
+              docker compose exec -T web /bin/sh -c "yarn run standard $(git ls-files '**.js' | tr '\n' ' ')"
+              docker compose exec -T web /bin/sh -c 'yarn run test'
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -108,13 +108,13 @@ jobs:
 
       - name: Bring images up
         run: |
-          docker-compose up --no-build -d
+          docker compose up --no-build -d
 
       - name: Install git
-        run: docker-compose exec -T web /bin/sh -c 'apk add git'
+        run: docker compose exec -T web /bin/sh -c 'apk add git'
 
       - name: Bundle audit
-        run: docker-compose exec -T web /bin/sh -c 'bundle-audit check --update'
+        run: docker compose exec -T web /bin/sh -c 'bundle-audit check --update'
 
       - name: Check for Failure
         if: ${{ failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,18 +59,18 @@ jobs:
     - name: Setup tests dependencies on images
       shell: bash
       run: |
-        docker-compose exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
-        docker-compose exec -T web /bin/sh -c 'bundle exec rake parallel:setup'
-        docker-compose exec -T web /bin/sh -c "yarn add jest@29.3.1"
-        docker-compose exec -T web /bin/sh -c "RAILS_ENV=test bundle exec rails assets:precompile"
-        docker-compose exec -T web /bin/sh -c 'apk add chromium chromium-chromedriver'
+        docker compose exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
+        docker compose exec -T web /bin/sh -c 'bundle exec rake parallel:setup'
+        docker compose exec -T web /bin/sh -c "yarn add jest@29.3.1"
+        docker compose exec -T web /bin/sh -c "RAILS_ENV=test bundle exec rails assets:precompile"
+        docker compose exec -T web /bin/sh -c 'apk add chromium chromium-chromedriver'
 
     - name: "${{ inputs.use-next-academic-year && 'Next academic year' || 'Current academic year' }} ${{ matrix.test-type }} tests"
       uses: Wandalen/wretry.action@v3.0.0
       with:
         attempt_limit: 5
         command: |
-          docker-compose exec -T web /bin/sh -c 'USE_NEXT_ACADEMIC_YEAR=${{env.USE_NEXT_ACADEMIC_YEAR}} bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"'
+          docker compose exec -T web /bin/sh -c 'USE_NEXT_ACADEMIC_YEAR=${{env.USE_NEXT_ACADEMIC_YEAR}} bundle exec --verbose parallel_rspec --pattern "${{ env.INCLUDE_PATTERN }}" --exclude-pattern "${{ env.EXCLUDE_PATTERN }}"'
       env:
         IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}
         INCLUDE_PATTERN: ${{ matrix.include-pattern }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
 services:
   db:
     image: postgres:11-alpine
-    # To preserve data between runs of docker-compose, we mount a folder from the host machine.
+    # To preserve data between runs of docker compose, we mount a folder from the host machine.
     volumes:
       - dbdata:/var/lib/postgresql/data
     environment:

--- a/docs/setup-development.md
+++ b/docs/setup-development.md
@@ -55,19 +55,19 @@ To run the processes seperately, you can do the following:
 Run this in a shell and leave it running after cloning the repo:
 
 ```
-docker-compose up --build --detach
+docker compose up --build --detach
 ```
 
 You can then follow the log output with
 
 ```
-docker-compose logs --follow
+docker compose logs --follow
 ```
 
 The first time you run the app, you need to set up the databases. With the above command running separately, do:
 
 ```
-docker-compose exec web /bin/sh -c "bundle exec rails db:setup"
+docker compose exec web /bin/sh -c "bundle exec rails db:setup"
 ```
 
 And make sure to seed the application with whichever data you need.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,7 +54,7 @@ bundle exec rails lint:ruby
 or
 
 ```
-docker-compose exec web /bin/sh -c "bundle exec rails lint:ruby"
+docker compose exec web /bin/sh -c "bundle exec rails lint:ruby"
 ```
 
 To fix Rubocop issues:


### PR DESCRIPTION
### Context

Our GH action builds use docker compose v1 command which is being removed. See https://github.com/actions/runner-images/issues/9557

### Changes proposed in this pull request

* Change `docker-compose` to `docker compose`

### Guidance to review

* GH Actions succeed

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
