### PR TITLE
[6921][6933] Fix regression when adding second placement

### DIFF
--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -34,10 +34,10 @@ class Placement < ApplicationRecord
 
   validates :name, presence: true, if: -> { school.blank? }
   # rubocop:disable Rails/UniqueValidationWithoutIndex
-  validates :school, uniqueness: { scope: :trainee_id }, allow_nil: true
+  validates :school, uniqueness: { scope: :trainee_id }, allow_blank: true
   # rubocop:enable Rails/UniqueValidationWithoutIndex
-  validates :urn, uniqueness: { scope: :trainee_id }, allow_nil: true
-  validates :address, uniqueness: { scope: %i[trainee_id postcode] }, allow_nil: true
+  validates :urn, uniqueness: { scope: :trainee_id }, allow_blank: true
+  validates :address, uniqueness: { scope: %i[trainee_id postcode] }, allow_blank: true
 
   audited associated_with: :trainee
 

--- a/spec/features/form_sections/teacher_training_data/placements/adding_trainee_placements_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/placements/adding_trainee_placements_spec.rb
@@ -11,7 +11,7 @@ feature "Add a placement" do
     scenario "Add a new placement to an existing trainee in the #{trait} state" do
       given_i_am_authenticated
       and_a_postgrad_trainee_exists_with(trait)
-      and_a_school_exists
+      and_two_schools_exist
       and_i_navigate_to_the_trainee_dashboard
       and_i_click_to_enter_first_placement
       then_i_see_the_new_placement_form
@@ -32,7 +32,7 @@ feature "Add a placement" do
     scenario "Add a new placement to an existing trainee in the #{trait} state" do
       given_i_am_authenticated
       and_a_postgrad_trainee_exists_with(trait)
-      and_a_school_exists
+      and_two_schools_exist
       and_two_other_schools_exist
       and_i_navigate_to_the_trainee_dashboard
       and_i_click_to_enter_first_placement
@@ -74,7 +74,7 @@ feature "Add a placement" do
   scenario "Add two new placements to an existing trainee" do
     given_i_am_authenticated
     and_a_trainee_exists_with_trn_received
-    and_a_school_exists
+    and_two_schools_exist
     and_i_navigate_to_the_new_placement_form
     then_i_see_the_new_placement_form
 
@@ -104,6 +104,39 @@ feature "Add a placement" do
     then_i_see_the_trainee_page
   end
 
+  scenario "Add two new placements for to an existing trainee" do
+    given_i_am_authenticated
+    and_a_trainee_exists_with_trn_received
+    and_two_schools_exist
+    and_i_navigate_to_the_new_placement_form
+    then_i_see_the_new_placement_form
+
+    when_i_select_an_existing_school
+    and_i_click_continue
+    then_i_see_the_confirmation_page
+    and_i_see_the_new_placement_ready_for_confirmation
+    and_no_placements_are_created
+
+    when_i_click_add_a_placement
+    then_i_see_the_second_new_placement_form
+
+    when_i_select_another_existing_school
+    and_i_click_continue
+    then_i_see_the_confirmation_page
+    and_i_see_the_other_existing_placement_ready_for_confirmation
+    and_no_placements_are_created
+
+    when_i_click_update
+    then_i_see_a_flash_message
+    and_two_new_placements_are_created
+
+    when_i_revisit_the_placements_confirmation_page
+    and_i_click_update
+    and_no_new_placements_are_created
+
+    then_i_see_the_trainee_page
+  end
+
 private
 
   def then_i_see_the_trainee_page
@@ -120,8 +153,9 @@ private
     FormStore.clear_all(@trainee.id)
   end
 
-  def and_a_school_exists
+  def and_two_schools_exist
     @school ||= create(:school, name: "London School for Children")
+    @other_school ||= create(:school, name: "Edinburgh School for Infants")
   end
 
   def and_two_other_schools_exist
@@ -152,6 +186,10 @@ private
 
   def when_i_select_an_existing_school
     find(:xpath, "//input[@name='placement[school_id]']", visible: false).set(@school.id)
+  end
+
+  def when_i_select_another_existing_school
+    find(:xpath, "//input[@name='placement[school_id]']", visible: false).set(@other_school.id)
   end
 
   def and_i_click_continue
@@ -186,6 +224,10 @@ private
     expect(page).to have_content("St. Alice's Primary School")
     expect(page).to have_content("OX1 1AA")
     expect(page).to have_content("URN 654321")
+  end
+
+  def and_i_see_the_other_existing_placement_ready_for_confirmation
+    expect(page).to have_content("Edinburgh School")
   end
 
   def when_i_click_update


### PR DESCRIPTION
### Context
Providers have reported problems adding a second placement to trainee records, using the Register front-end.

The cause of this bug was some recently added validations on the `Placement` model.

These validations check uniqueness of school name, urn etc. This works well if the values are `nil` or unique but not with empty strings.

### Changes proposed in this pull request
The solution here is to use `allow_blank` rather than `allow_nil` on the uniqueness validations so that, for example, you have have multiple placements that have a blank school `name`. This is perfectly normal because you can fully specify the school via the `school` association in which case the `name` is not needed.

### Guidance to review
Anything else to test here?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
