### PR TITLE
[6896] - Hide hint if no itt_end_date (undefined method `to_fs')

### DIFF
--- a/app/views/trainees/reinstatements/update_end_dates/show.html.erb
+++ b/app/views/trainees/reinstatements/update_end_dates/show.html.erb
@@ -13,7 +13,7 @@
 
       <%= f.govuk_date_field(:itt_end_date,
             legend: { text: t("views.forms.update_end_date.heading"), size: "l", tag: "h1" },
-            hint: { text: t("views.forms.update_end_date.itt_end_date.hint", itt_end_date: @trainee.itt_end_date.to_fs(:govuk)) } )%>
+            hint: @trainee.itt_end_date.present? ? { text: t("views.forms.update_end_date.itt_end_date.hint", itt_end_date: @trainee.itt_end_date&.to_fs(:govuk)) } : {} )%>
       <%= f.govuk_submit %>
 
     <% end %>


### PR DESCRIPTION
### Context

recurring [error seen here](https://dfe-teacher-services.sentry.io/issues/4972605330/?alert_rule_id=4544549&alert_type=issue&environment=production&notification_uuid=5644104a-3048-4305-8502-7f23060b5a93&project=5552118&referrer=slack) is crashing the reinstatement journey.

### Changes proposed in this pull request

Hides the hint which tells user to use the existing `itt_end_date`. Code incorrectly assume this always exists.

### if no `itt_end_date`
<img width="337" alt="Screenshot 2024-04-05 at 16 40 42" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/6339025/f6f1e55b-678e-4e46-9e53-66dd4aea515b">

### if `itt_end_date`

<img width="355" alt="Screenshot 2024-04-05 at 16 39 42" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/6339025/47af7339-4790-49d2-aedb-4b6e8a403bb6">



