### PR TITLE
[6965] Return trainee record from `DELETE degree` endpoint

### DIFF
--- a/app/controllers/api/trainees/degrees_controller.rb
+++ b/app/controllers/api/trainees/degrees_controller.rb
@@ -41,7 +41,7 @@ module Api
 
       def destroy
         if degree.destroy
-          render(json: { data: serializer_klass.new(degree).as_hash })
+          render(json: { data: trainee_serializer_klass.new(trainee).as_hash })
         else
           render(json: { errors: degree.errors.full_messages }, status: :unprocessable_entity)
         end
@@ -60,6 +60,14 @@ module Api
 
       def degree
         @degree ||= trainee.degrees.find_by!(slug: params[:slug])
+      end
+
+      def trainee_serializer_klass
+        Serializer.for(model: :trainee, version: version)
+      end
+
+      def attributes_class
+        Api::Attributes.for(model:, version:)
       end
 
       def new_degree

--- a/spec/requests/api/v0.1/trainees/delete_degree_spec.rb
+++ b/spec/requests/api/v0.1/trainees/delete_degree_spec.rb
@@ -29,6 +29,7 @@ describe "`DELETE /trainees/:trainee_slug/degrees/:slug` endpoint" do
         )
         expect(response.parsed_body["data"]).to be_present
         expect(trainee.reload.degrees.count).to be_zero
+        expect(response.parsed_body.dig(*%w[data trainee_id])).to eq(trainee.slug)
         expect(response.parsed_body.dig(*%w[data first_names])).to eq(trainee.first_names)
         expect(response.parsed_body.dig(*%w[data last_name])).to eq(trainee.last_name)
       end


### PR DESCRIPTION
### Context
The `DELETE degree` endpoint returns the just deleted degree record whereas the `DELETE placement` endpoint returns the full trainee record.

### Changes proposed in this pull request
Rather than returning the delete degree record it's more useful (and more consistent with the `DELETE placement` endpoint) to return the associated trainee record.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
