### PR TITLE
[6973] Guard against using dfe analytics when disabled

### DIFF
--- a/app/jobs/bulk_update/analytics_job.rb
+++ b/app/jobs/bulk_update/analytics_job.rb
@@ -3,6 +3,8 @@
 module BulkUpdate
   class AnalyticsJob < ApplicationJob
     def perform(model:, ids:)
+      return unless DfE::Analytics.enabled?
+
       @model = model
       @ids = ids
 

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -11,7 +11,7 @@ DfE::Analytics.configure do |config|
 
   # Whether to run entity table checksum job.
   #
-  config.entity_table_checks_enabled = true
+  config.entity_table_checks_enabled = Settings.google.big_query.entity_table_checks_enabled
 
   # Which ActiveJob queue to put events on
   #

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -162,6 +162,7 @@ google:
     dataset: replaceme
     api_json_key: "{}"
     table_name: events
+    entity_table_checks_enabled: true
 
 sign_off_trainee_data_url: https://forms.office.com/e/kzBmEWKDGz
 sign_off_performance_profiles_url: https://forms.office.com/e/ATXmqJusud)

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -39,3 +39,7 @@ features:
 
 environment:
   name: sandbox
+
+google:
+  big_query:
+    entity_table_checks_enabled: false

--- a/spec/jobs/bulk_update/analytics_job_spec.rb
+++ b/spec/jobs/bulk_update/analytics_job_spec.rb
@@ -10,12 +10,24 @@ RSpec.describe BulkUpdate::AnalyticsJob do
   let(:model) { Trainee }
 
   describe "#perform" do
-    it "calls the SendEvents.do method" do
+    it "does not calls the SendEvents.do method" do
       allow(DfE::Analytics::SendEvents).to receive(:do)
 
       described_class.perform_now(model:, ids:)
 
-      expect(DfE::Analytics::SendEvents).to have_received(:do)
+      expect(DfE::Analytics::SendEvents).not_to have_received(:do)
+    end
+  end
+
+  context "when the feature flag is turned on", "feature_google.send_data_to_big_query": true do
+    describe "#perform" do
+      it "calls the SendEvents.do method" do
+        allow(DfE::Analytics::SendEvents).to receive(:do)
+
+        described_class.perform_now(model:, ids:)
+
+        expect(DfE::Analytics::SendEvents).to have_received(:do).at_least(:once)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
Guard against using dfe analytics when disabled

### Changes proposed in this pull request
Added guard against using dfe analytics when disabled

### Guidance to review

https://github.com/DFE-Digital/dfe-analytics

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
