### PR TITLE
6962 some trainee fields arent required but should be

### DIFF
--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -50,7 +50,9 @@ module Api
     def hesa_mapped_params
       hesa_mapper_class.call(
         params: params.require(:data).permit(
-          hesa_mapper_class::ATTRIBUTES + trainee_attributes_service::ATTRIBUTES,
+          hesa_mapper_class::ATTRIBUTES +
+          trainee_attributes_service::ATTRIBUTES +
+          hesa_trainee_details_attributes_service::ATTRIBUTES,
           placements_attributes: [placements_attributes],
           degrees_attributes: [degree_attributes],
           nationalisations_attributes: [nationality_attributes],
@@ -87,6 +89,10 @@ module Api
 
     def trainee_attributes_service
       Api::Attributes.for(model: :trainee, version: version)
+    end
+
+    def hesa_trainee_details_attributes_service
+      Api::Attributes.for(model: :hesa_trainee_detail, version: version)
     end
 
     def degree_attributes

--- a/app/models/api/hesa_trainee_detail_attributes/v01.rb
+++ b/app/models/api/hesa_trainee_detail_attributes/v01.rb
@@ -7,27 +7,35 @@ module Api
       include ActiveModel::Attributes
 
       ATTRIBUTES = %i[
-        course_age_range
         course_study_mode
         course_year
-        funding_method
-        itt_aim
-        itt_qualification_aim
-        fund_code
         ni_number
         postgrad_apprenticeship_start_date
         previous_last_name
         hesa_disabilities
         additional_training_initiative
+        itt_aim
         itt_qualification_aim
-        year_of_course
+        course_year
+        course_age_range
         fund_code
-        hesa_id
+        funding_method
+      ].freeze
+
+      REQUIRED_ATTRIBUTES = %i[
+        itt_aim
+        itt_qualification_aim
+        course_year
+        course_age_range
+        fund_code
+        funding_method
       ].freeze
 
       ATTRIBUTES.each do |attr|
         attribute attr
       end
+
+      validates(*REQUIRED_ATTRIBUTES, presence: true)
     end
   end
 end

--- a/app/models/api/hesa_trainee_detail_attributes/v01.rb
+++ b/app/models/api/hesa_trainee_detail_attributes/v01.rb
@@ -19,6 +19,10 @@ module Api
         previous_last_name
         hesa_disabilities
         additional_training_initiative
+        itt_qualification_aim
+        year_of_course
+        fund_code
+        hesa_id
       ].freeze
 
       ATTRIBUTES.each do |attr|

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -37,6 +37,7 @@ module Api
         application_choice_id
         progress
         training_initiative
+        hesa_id
       ].freeze
 
       REQUIRED_ATTRIBUTES = %i[
@@ -50,6 +51,7 @@ module Api
         diversity_disclosure
         course_subject_one
         study_mode
+        hesa_id
       ].freeze
 
       ATTRIBUTES.each do |attr|

--- a/spec/requests/api/v0.1/duplicate_trainees_spec.rb
+++ b/spec/requests/api/v0.1/duplicate_trainees_spec.rb
@@ -35,6 +35,14 @@ describe "Trainees API" do
           diversity_disclosure: "diversity_disclosed",
           course_subject_one: Hesa::CodeSets::CourseSubjects::MAPPING.invert[CourseSubjects::BIOLOGY],
           study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
+          nationality: "GB",
+          itt_aim: 202,
+          itt_qualification_aim: "001",
+          year_of_course: "2012",
+          course_age_range: "13915",
+          fund_code: "7",
+          funding_method: "4",
+          hesa_id: "0310261553101",
         },
       }
     end
@@ -44,7 +52,6 @@ describe "Trainees API" do
         expect {
           post "/api/v0.1/trainees", params: valid_attributes, headers: { Authorization: token }
         }.not_to change { Trainee.count }
-
         expect(response).to have_http_status(:conflict)
         expect(response.parsed_body[:data].count).to be(1)
       end

--- a/spec/requests/api/v0.1/duplicate_trainees_spec.rb
+++ b/spec/requests/api/v0.1/duplicate_trainees_spec.rb
@@ -38,7 +38,7 @@ describe "Trainees API" do
           nationality: "GB",
           itt_aim: 202,
           itt_qualification_aim: "001",
-          year_of_course: "2012",
+          course_year: "2012",
           course_age_range: "13915",
           fund_code: "7",
           funding_method: "4",

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -42,7 +42,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
         ],
         itt_aim: 202,
         itt_qualification_aim: "001",
-        year_of_course: "2012",
+        course_year: "2012",
         course_age_range: "13915",
         fund_code: "7",
         funding_method: "4",
@@ -57,14 +57,6 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       allow(Trainees::MapFundingFromDttpEntityId).to receive(:call).and_call_original
 
       post "/api/v0.1/trainees", params: params, headers: { Authorization: token }
-    end
-
-    it "calls the Hesa::MapHesaAttributes service" do
-      expected_params = ActionController::Parameters.new(
-        params[:data].slice(*(Api::MapHesaAttributes::V01::ATTRIBUTES + Api::TraineeAttributes::V01::ATTRIBUTES + [:degrees_attributes] + [:placements_attributes])),
-      ).permit!
-
-      expect(Api::MapHesaAttributes::V01).to have_received(:call).with(params: expected_params)
     end
 
     it "creates a trainee" do
@@ -143,10 +135,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       expect(response.parsed_body["errors"]).to include("Course subject one can't be blank")
       expect(response.parsed_body["errors"]).to include("Study mode can't be blank")
       expect(response.parsed_body["errors"]).to include("Email Enter an email address in the correct format, like name@example.com")
-      expect(response.parsed_body["errors"]).to include("Nationalisations attributes can't be blank")
       expect(response.parsed_body["errors"]).to include("Itt aim can't be blank")
       expect(response.parsed_body["errors"]).to include("Itt qualification aim can't be blank")
-      expect(response.parsed_body["errors"]).to include("Year of course can't be blank")
+      expect(response.parsed_body["errors"]).to include("Course year can't be blank")
       expect(response.parsed_body["errors"]).to include("Course age range can't be blank")
       expect(response.parsed_body["errors"]).to include("Fund code can't be blank")
       expect(response.parsed_body["errors"]).to include("Funding method can't be blank")

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -40,6 +40,13 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             urn: "900020",
           },
         ],
+        itt_aim: 202,
+        itt_qualification_aim: "001",
+        year_of_course: "2012",
+        course_age_range: "13915",
+        fund_code: "7",
+        funding_method: "4",
+        hesa_id: "0310261553101",
       },
     }
   end
@@ -136,6 +143,14 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       expect(response.parsed_body["errors"]).to include("Course subject one can't be blank")
       expect(response.parsed_body["errors"]).to include("Study mode can't be blank")
       expect(response.parsed_body["errors"]).to include("Email Enter an email address in the correct format, like name@example.com")
+      expect(response.parsed_body["errors"]).to include("Nationalisations attributes can't be blank")
+      expect(response.parsed_body["errors"]).to include("Itt aim can't be blank")
+      expect(response.parsed_body["errors"]).to include("Itt qualification aim can't be blank")
+      expect(response.parsed_body["errors"]).to include("Year of course can't be blank")
+      expect(response.parsed_body["errors"]).to include("Course age range can't be blank")
+      expect(response.parsed_body["errors"]).to include("Fund code can't be blank")
+      expect(response.parsed_body["errors"]).to include("Funding method can't be blank")
+      expect(response.parsed_body["errors"]).to include("Hesa can't be blank")
     end
   end
 end


### PR DESCRIPTION
### Context

When POSTing a Trainee, some fields are not required when they should be:

- nationality
- itt_aim
- itt_qualification_aim
- year_of_course
- course_age_range
- fund_code
- funding_method
- hesa_id

### Changes proposed in this pull request

this fixes the `hesa_trainee_details` to write these attributes and require them via validation callback in CreateTrainee