### PR TITLE
[6968] Add a test for Rack::Attack throttling

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -11,14 +11,12 @@ Rack::Attack.blocklist("block requests from UA blacklist") do |req|
 end
 
 # Throttle high volumes of API requests by IP address
-unless Rails.env.local?
-  Rack::Attack.throttle(
-    "req/ip",
-    limit: Settings.api.throttling.max_requests,
-    period: Settings.api.throttling.interval.to_i.seconds,
-  ) do |req|
-    req.ip if req.path.starts_with?("/api")
-  end
+Rack::Attack.throttle(
+  "req/ip",
+  limit: Settings.api.throttling.max_requests,
+  period: Settings.api.throttling.interval.to_i.seconds,
+) do |req|
+  req.ip if req.path.starts_with?("/api")
 end
 
 # Return how many seconds to wait before retrying request to well-behaved clients

--- a/spec/requests/api/rack_attack_spec.rb
+++ b/spec/requests/api/rack_attack_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Rack::Attack settings" do
+  before do
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  after do
+    Rack::Attack.cache.store = ActiveSupport::Cache::NullStore.new
+  end
+
+  describe "Rate limiting" do
+    let(:provider) { create(:provider) }
+    let!(:token) { AuthenticationToken.create_with_random_token(provider:) }
+
+    let(:limit) { 100 }
+
+    context "when requests per IP > 100" do
+      %W[#{Faker::Internet.ip_v4_address}].each do |ip|
+        it "limits the amount of requests" do
+          (limit + 1).times do
+            get "/api/v0.1/info", headers: {
+                                    authorization: "Bearer #{token}",
+                                  },
+                                  env: { REMOTE_ADDR: ip }
+          end
+
+          expect(response).to have_http_status(:too_many_requests)
+          expect(response.body).to match("Retry later")
+        end
+      end
+    end
+
+    context "when requests per IP <= 100" do
+      %W[#{Faker::Internet.ip_v4_address} #{Faker::Internet.ip_v4_address}].each do |ip|
+        it "does not limit the amount of requests" do
+          limit.times do
+            get "/api/v0.1/info", headers: {
+                                    authorization: "Bearer #{token}",
+                                  },
+                                  env: { REMOTE_ADDR: ip }
+          end
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/rack_attack_spec.rb
+++ b/spec/requests/api/rack_attack_spec.rb
@@ -13,38 +13,35 @@ RSpec.describe "Rack::Attack settings" do
 
   describe "Rate limiting" do
     let(:provider) { create(:provider) }
-    let!(:token) { AuthenticationToken.create_with_random_token(provider:) }
+    let(:token) { AuthenticationToken.create_with_random_token(provider:) }
 
     let(:limit) { 100 }
+    let(:ip) { Faker::Internet.ip_v4_address }
 
     context "when requests per IP > 100" do
-      %W[#{Faker::Internet.ip_v4_address}].each do |ip|
-        it "limits the amount of requests" do
-          (limit + 1).times do
-            get "/api/v0.1/info", headers: {
-                                    authorization: "Bearer #{token}",
-                                  },
-                                  env: { REMOTE_ADDR: ip }
-          end
-
-          expect(response).to have_http_status(:too_many_requests)
-          expect(response.body).to match("Retry later")
+      it "limits the amount of requests" do
+        (limit + 1).times do
+          get "/api/v0.1/info", headers: {
+                                  authorization: "Bearer #{token}",
+                                },
+                                env: { REMOTE_ADDR: ip }
         end
+
+        expect(response).to have_http_status(:too_many_requests)
+        expect(response.body).to match("Retry later")
       end
     end
 
     context "when requests per IP <= 100" do
-      %W[#{Faker::Internet.ip_v4_address} #{Faker::Internet.ip_v4_address}].each do |ip|
-        it "does not limit the amount of requests" do
-          limit.times do
-            get "/api/v0.1/info", headers: {
-                                    authorization: "Bearer #{token}",
-                                  },
-                                  env: { REMOTE_ADDR: ip }
-          end
-
-          expect(response).to have_http_status(:ok)
+      it "does not limit the amount of requests" do
+        limit.times do
+          get "/api/v0.1/info", headers: {
+                                  authorization: "Bearer #{token}",
+                                },
+                                env: { REMOTE_ADDR: ip }
         end
+
+        expect(response).to have_http_status(:ok)
       end
     end
   end


### PR DESCRIPTION
### Context

We currently limit the http requests per IP address. This PR adds a request spec to test that behaviour of `Rack::Attack` with our configuration.

### Changes proposed in this pull request

* Add a request spec to test throttling
* Remove `if Rails.env.local?` statement for `Rack::Attack` since we use `NullStore` in dev environment and the requests won't be throttled.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
