### PR TITLE
[6977] - Use ApiTrnValidator

### DIFF
--- a/app/forms/submissions/api_trn_validator.rb
+++ b/app/forms/submissions/api_trn_validator.rb
@@ -4,16 +4,6 @@ module Submissions
   class ApiTrnValidator < BaseValidator
     include FundingHelper
 
-    class_attribute :extra_validators, instance_writer: false, default: {}
-
-    class << self
-      def missing_data_validator(name, options)
-        extra_validators[name] = options
-      end
-    end
-
-    missing_data_validator :placements, form: "PlacementDetailForm", if: :requires_placements?
-
     def all_errors
       @all_errors ||= sections.each_with_object({}) do |section, errors_hash|
         next unless validator_keys.include?(section)

--- a/app/services/api/create_trainee.rb
+++ b/app/services/api/create_trainee.rb
@@ -19,7 +19,7 @@ module Api
 
       trainee = current_provider.trainees.new(trainee_attributes.deep_attributes)
 
-      if trainee.save
+      if validation.all_errors.empty? && trainee.save
         ::Trainees::SubmitForTrn.call(trainee:)
         success_response(trainee)
       else


### PR DESCRIPTION
### Context

The `ApiTrnValidator` is not being used. This should be included in the validation process within CreateTrainee

https://ukgovernmentdfe.slack.com/archives/C03SR5B5EGH/p1712912778396529

### Changes proposed in this pull request

checks the `ApiTrnValidator` for validation messages before saving the trainee