### PR TITLE
[6967] Correction to URL for preprod DQT API

### DIFF
--- a/config/settings/pen.yml
+++ b/config/settings/pen.yml
@@ -2,7 +2,7 @@
 base_url: https://pen.register-trainee-teachers.service.gov.uk
 
 dqt:
-  base_url: https://preprod-teacher-qualifications-api.education.gov.uk
+  base_url: https://preprod.teacher-qualifications-api.education.gov.uk
 
 dfe_sign_in:
   # URL that the users are redirected to for signing in

--- a/config/settings/productiondata.yml
+++ b/config/settings/productiondata.yml
@@ -6,7 +6,7 @@ dttp:
   api_base_url: https://dttp.crm4.dynamics.com/api/data/v9.1
 
 dqt:
-  base_url: https://preprod-teacher-qualifications-api.education.gov.uk
+  base_url: https://preprod.teacher-qualifications-api.education.gov.uk
 
 dfe_sign_in:
   # URL that the users are redirected to for signing in

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -2,7 +2,7 @@
 base_url: https://sandbox.register-trainee-teachers.service.gov.uk
 
 dqt:
-  base_url: https://preprod-teacher-qualifications-api.education.gov.uk
+  base_url: https://preprod.teacher-qualifications-api.education.gov.uk
 
 dfe_sign_in:
   # URL that the users are redirected to for signing in


### PR DESCRIPTION
### Context
The URL configured for the preprod DQT API used in `sandbox`, `productiondata` and `pen` is wrong. It should be `https://preprod.teacher-qualifications-api.education.gov.uk/` rather than `https://preprod-teacher-qualifications-api.education.gov.uk/`.

Currently we are seeing this error in Sqidekiq jobs that request a TRN on `sandbox`:

```
SocketError: Failed to open TCP connection to preprod-teacher-qualifications-api.education.gov.uk:443 (getaddrinfo: Name has no usable address)
```

### Changes proposed in this pull request
Just change the appropriate settings files.

### Guidance to review
See https://ukgovernmentdfe.slack.com/archives/C02CYQTSK3K/p1713189729872109

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
