### PR TITLE
Allow Trainee#provider_trainee_id to be set

### DIFF
--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -38,6 +38,7 @@ module Api
         progress
         training_initiative
         hesa_id
+        provider_trainee_id
       ].freeze
 
       REQUIRED_ATTRIBUTES = %i[

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -47,6 +47,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
         fund_code: "7",
         funding_method: "4",
         hesa_id: "0310261553101",
+        provider_trainee_id: "99157234/2/01",
       },
     }
   end
@@ -112,6 +113,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
     it "sets the record source to `api`" do
       expect(Trainee.last.record_source).to eq("api")
+    end
+
+    it "sets the provider_trainee_id" do
+      expect(Trainee.last.provider_trainee_id).to eq("99157234/2/01")
     end
   end
 

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -83,10 +83,11 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       put(
         "/api/v0.1/trainees/#{trainee.slug}",
         headers: { Authorization: "Bearer #{token}" },
-        params: { data: { first_names: "Alice" } },
+        params: { data: { first_names: "Alice", provider_trainee_id: "99157234/2/01" } },
       )
       expect(response).to have_http_status(:ok)
       expect(trainee.reload.first_names).to eq("Alice")
+      expect(trainee.provider_trainee_id).to eq("99157234/2/01")
       expect(response.parsed_body[:data]["trainee_id"]).to eq(trainee.slug)
     end
 


### PR DESCRIPTION
### Context

[6985-potential-bug-providertraineeid-not-being-set
](https://trello.com/c/rnHluegR/6985-potential-bug-providertraineeid-not-being-set)

Fix for `Trainee#provider_trainee_id` not set on create / update

### Changes proposed in this pull request

* Permit attribute for POST / (PUT | PATCH) trainee/s

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
