### PR TITLE
[6876] - OpenApi + Redoc (test)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -216,6 +216,7 @@ group :test do
   gem "database_cleaner-active_record"
 
   gem "rspec-retry"
+  gem "rspec-openapi"
 end
 
 # Required for example_data and vendor:swap so needed in stated environments

--- a/Gemfile
+++ b/Gemfile
@@ -215,8 +215,8 @@ group :test do
   # Clean out the database between tests
   gem "database_cleaner-active_record"
 
-  gem "rspec-retry"
   gem "rspec-openapi"
+  gem "rspec-retry"
 end
 
 # Required for example_data and vendor:swap so needed in stated environments

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -574,6 +574,10 @@ GEM
     rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
+    rspec-openapi (0.17.0)
+      actionpack (>= 5.2.0)
+      rails-dom-testing
+      rspec-core
     rspec-rails (6.1.2)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
@@ -830,6 +834,7 @@ DEPENDENCIES
   request_store (~> 1.6)
   rotp
   rspec-benchmark
+  rspec-openapi
   rspec-rails (~> 6.1.2)
   rspec-retry
   rubocop-rails

--- a/app/controllers/api_docs/openapi_controller.rb
+++ b/app/controllers/api_docs/openapi_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ApiDocs
+  class OpenapiController < ApplicationController
+    layout false
+    skip_before_action :authenticate
+
+    def index
+      response.set_header("Content-Security-Policy", "worker-src blob:")
+    end
+  end
+end

--- a/app/views/api_docs/openapi/index.html.erb
+++ b/app/views/api_docs/openapi/index.html.erb
@@ -9,7 +9,10 @@
 </head>
 <body>
   <div id="redoc-container"></div>
-  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"
+          integrity="sha384-R8e5ippgVo+kphHRsZE026R4rLIN/ORakEnRnOJ3S7BauiXHeD2EnvDpCcPYV4O/"
+          crossorigin="anonymous">
+  </script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       Redoc.init('/openapi.json', {}, document.getElementById('redoc-container'));

--- a/app/views/api_docs/openapi/index.html.erb
+++ b/app/views/api_docs/openapi/index.html.erb
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>API Documentation</title>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+</head>
+<body>
+  <div id="redoc-container"></div>
+  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      Redoc.init('/openapi.json', {}, document.getElementById('redoc-container'));
+    });
+  </script>
+</body>
+</html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -88,4 +88,5 @@ Rails.application.configure do
   config.hosts.clear
 
   config.active_job.queue_adapter = :sidekiq
+  config.public_file_server.enabled = true
 end

--- a/config/initializers/openapi.rb
+++ b/config/initializers/openapi.rb
@@ -1,4 +1,6 @@
-require 'rspec/openapi'
+# frozen_string_literal: true
 
-RSpec::OpenAPI.path = 'public/openapi.json'
-RSpec::OpenAPI.title = 'Register API'
+require "rspec/openapi"
+
+RSpec::OpenAPI.path = "public/openapi.json"
+RSpec::OpenAPI.title = "Register API"

--- a/config/initializers/openapi.rb
+++ b/config/initializers/openapi.rb
@@ -1,0 +1,4 @@
+require 'rspec/openapi'
+
+RSpec::OpenAPI.path = 'public/openapi.json'
+RSpec::OpenAPI.title = 'Register API'

--- a/config/routes/api_routes.rb
+++ b/config/routes/api_routes.rb
@@ -22,6 +22,7 @@ module ApiRoutes
       namespace :api_docs, path: "api-docs" do
         get "/" => "pages#show", as: :home
         get "/reference" => "reference#show", as: :reference
+        get "/openapi" => "openapi#index", as: :openapi
         get "/:api_version/reference" => "reference#show", constraints: { api_version: /v[.0-9]+/ }, as: :versioned_reference
         get "/:page" => "pages#show", as: :page
       end

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,8208 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Register API",
+    "version": "1.0.0"
+  },
+  "servers": [
+
+  ],
+  "paths": {
+    "/api/{api_version}/*url": {
+      "get": {
+        "summary": "render_not_found",
+        "tags": [
+          "Api::Base"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.0"
+          },
+          {
+            "name": "url",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "trainees"
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "returns status 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Not found"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "limits the amount of requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Retry later\n"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{api_version}/info": {
+      "get": {
+        "summary": "show",
+        "tags": [
+          "Api::Info"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "increments the requests_total counter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                },
+                "example": {
+                  "status": "ok"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "returns status 401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                },
+                "example": {
+                  "error": "Unauthorized"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "returns status code 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Not found"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{api_version}/trainees": {
+      "get": {
+        "summary": "index",
+        "tags": [
+          "Api::Trainee"
+        ],
+        "parameters": [
+          {
+            "name": "academic_cycle",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "not-a-number"
+          },
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "example": 5
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2023-13-01"
+          },
+          {
+            "name": "sort_order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "asc"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "deferred"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "returns trainees for the specified academic cycle",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "first_names": {
+                            "type": "string"
+                          },
+                          "last_name": {
+                            "type": "string"
+                          },
+                          "date_of_birth": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "middle_names": {
+                            "type": "string"
+                          },
+                          "training_route": {
+                            "nullable": true
+                          },
+                          "sex": {
+                            "type": "string"
+                          },
+                          "diversity_disclosure": {
+                            "type": "string"
+                          },
+                          "ethnic_group": {
+                            "nullable": true
+                          },
+                          "ethnic_background": {
+                            "nullable": true
+                          },
+                          "additional_ethnic_background": {
+                            "nullable": true
+                          },
+                          "disability_disclosure": {
+                            "nullable": true
+                          },
+                          "course_subject_one": {
+                            "type": "string"
+                          },
+                          "itt_start_date": {
+                            "type": "string"
+                          },
+                          "outcome_date": {
+                            "nullable": true
+                          },
+                          "itt_end_date": {
+                            "type": "string"
+                          },
+                          "trn": {
+                            "type": "string"
+                          },
+                          "submitted_for_trn_at": {
+                            "type": "string"
+                          },
+                          "withdraw_date": {
+                            "nullable": true
+                          },
+                          "withdraw_reasons_details": {
+                            "nullable": true
+                          },
+                          "defer_date": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "recommended_for_award_at": {
+                            "nullable": true
+                          },
+                          "trainee_start_date": {
+                            "type": "string"
+                          },
+                          "reinstate_date": {
+                            "nullable": true
+                          },
+                          "course_min_age": {
+                            "type": "integer"
+                          },
+                          "course_max_age": {
+                            "type": "integer"
+                          },
+                          "course_subject_two": {
+                            "nullable": true
+                          },
+                          "course_subject_three": {
+                            "nullable": true
+                          },
+                          "awarded_at": {
+                            "nullable": true
+                          },
+                          "applying_for_bursary": {
+                            "type": "boolean"
+                          },
+                          "training_initiative": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "bursary_tier": {
+                            "nullable": true
+                          },
+                          "study_mode": {
+                            "type": "string"
+                          },
+                          "ebacc": {
+                            "type": "boolean"
+                          },
+                          "region": {
+                            "nullable": true
+                          },
+                          "course_education_phase": {
+                            "type": "string"
+                          },
+                          "applying_for_scholarship": {
+                            "type": "boolean"
+                          },
+                          "applying_for_grant": {
+                            "type": "boolean"
+                          },
+                          "course_uuid": {
+                            "nullable": true
+                          },
+                          "lead_school_not_applicable": {
+                            "type": "boolean"
+                          },
+                          "employing_school_not_applicable": {
+                            "type": "boolean"
+                          },
+                          "submission_ready": {
+                            "type": "boolean"
+                          },
+                          "commencement_status": {
+                            "nullable": true
+                          },
+                          "discarded_at": {
+                            "nullable": true
+                          },
+                          "created_from_dttp": {
+                            "type": "boolean"
+                          },
+                          "hesa_id": {
+                            "nullable": true
+                          },
+                          "additional_dttp_data": {
+                            "nullable": true
+                          },
+                          "created_from_hesa": {
+                            "type": "boolean"
+                          },
+                          "hesa_updated_at": {
+                            "nullable": true
+                          },
+                          "record_source": {
+                            "nullable": true
+                          },
+                          "iqts_country": {
+                            "nullable": true
+                          },
+                          "hesa_editable": {
+                            "type": "boolean"
+                          },
+                          "withdraw_reasons_dfe_details": {
+                            "nullable": true
+                          },
+                          "slug_sent_to_dqt_at": {
+                            "nullable": true
+                          },
+                          "placement_detail": {
+                            "nullable": true
+                          },
+                          "provider_trainee_id": {
+                            "type": "string"
+                          },
+                          "ukprn": {
+                            "type": "string"
+                          },
+                          "ethnicity": {
+                            "nullable": true
+                          },
+                          "disability1": {
+                            "type": "string"
+                          },
+                          "course_qualification": {
+                            "type": "string"
+                          },
+                          "course_title": {
+                            "nullable": true
+                          },
+                          "course_level": {
+                            "type": "string"
+                          },
+                          "course_itt_start_date": {
+                            "type": "string"
+                          },
+                          "course_age_range": {
+                            "nullable": true
+                          },
+                          "expected_end_date": {
+                            "type": "string"
+                          },
+                          "employing_school_urn": {
+                            "nullable": true
+                          },
+                          "lead_partner_urn_ukprn": {
+                            "nullable": true
+                          },
+                          "lead_school_urn": {
+                            "nullable": true
+                          },
+                          "fund_code": {
+                            "type": "string"
+                          },
+                          "bursary_level": {
+                            "type": "string"
+                          },
+                          "course_study_mode": {
+                            "nullable": true
+                          },
+                          "course_year": {
+                            "nullable": true
+                          },
+                          "funding_method": {
+                            "nullable": true
+                          },
+                          "itt_aim": {
+                            "nullable": true
+                          },
+                          "ni_number": {
+                            "nullable": true
+                          },
+                          "postgrad_apprenticeship_start_date": {
+                            "nullable": true
+                          },
+                          "previous_last_name": {
+                            "nullable": true
+                          },
+                          "hesa_disabilities": {
+                            "nullable": true
+                          },
+                          "additional_training_initiative": {
+                            "nullable": true
+                          },
+                          "nationality": {
+                            "type": "string"
+                          },
+                          "placements": {
+                            "type": "array",
+                            "items": {
+                            }
+                          },
+                          "degrees": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "uk_degree": {
+                                  "type": "string"
+                                },
+                                "non_uk_degree": {
+                                  "nullable": true
+                                },
+                                "created_at": {
+                                  "type": "string"
+                                },
+                                "updated_at": {
+                                  "type": "string"
+                                },
+                                "subject": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "institution": {
+                                  "type": "string"
+                                },
+                                "graduation_year": {
+                                  "type": "integer"
+                                },
+                                "grade": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "country": {
+                                  "nullable": true
+                                },
+                                "other_grade": {
+                                  "nullable": true
+                                },
+                                "institution_uuid": {
+                                  "type": "string"
+                                },
+                                "uk_degree_uuid": {
+                                  "type": "string"
+                                },
+                                "subject_uuid": {
+                                  "type": "string"
+                                },
+                                "grade_uuid": {
+                                  "type": "string"
+                                },
+                                "degree_id": {
+                                  "type": "string"
+                                },
+                                "degree_type": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "uk_degree",
+                                "non_uk_degree",
+                                "created_at",
+                                "updated_at",
+                                "subject",
+                                "institution",
+                                "graduation_year",
+                                "grade",
+                                "country",
+                                "other_grade",
+                                "institution_uuid",
+                                "uk_degree_uuid",
+                                "subject_uuid",
+                                "grade_uuid",
+                                "degree_id",
+                                "degree_type"
+                              ]
+                            }
+                          },
+                          "state": {
+                            "type": "string"
+                          },
+                          "trainee_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "first_names",
+                          "last_name",
+                          "date_of_birth",
+                          "created_at",
+                          "updated_at",
+                          "email",
+                          "middle_names",
+                          "training_route",
+                          "sex",
+                          "diversity_disclosure",
+                          "ethnic_group",
+                          "ethnic_background",
+                          "additional_ethnic_background",
+                          "disability_disclosure",
+                          "course_subject_one",
+                          "itt_start_date",
+                          "outcome_date",
+                          "itt_end_date",
+                          "trn",
+                          "submitted_for_trn_at",
+                          "withdraw_date",
+                          "withdraw_reasons_details",
+                          "defer_date",
+                          "recommended_for_award_at",
+                          "trainee_start_date",
+                          "reinstate_date",
+                          "course_min_age",
+                          "course_max_age",
+                          "course_subject_two",
+                          "course_subject_three",
+                          "awarded_at",
+                          "applying_for_bursary",
+                          "training_initiative",
+                          "bursary_tier",
+                          "study_mode",
+                          "ebacc",
+                          "region",
+                          "course_education_phase",
+                          "applying_for_scholarship",
+                          "applying_for_grant",
+                          "course_uuid",
+                          "lead_school_not_applicable",
+                          "employing_school_not_applicable",
+                          "submission_ready",
+                          "commencement_status",
+                          "discarded_at",
+                          "created_from_dttp",
+                          "hesa_id",
+                          "additional_dttp_data",
+                          "created_from_hesa",
+                          "hesa_updated_at",
+                          "record_source",
+                          "iqts_country",
+                          "hesa_editable",
+                          "withdraw_reasons_dfe_details",
+                          "slug_sent_to_dqt_at",
+                          "placement_detail",
+                          "provider_trainee_id",
+                          "ukprn",
+                          "ethnicity",
+                          "disability1",
+                          "course_qualification",
+                          "course_title",
+                          "course_level",
+                          "course_itt_start_date",
+                          "course_age_range",
+                          "expected_end_date",
+                          "employing_school_urn",
+                          "lead_partner_urn_ukprn",
+                          "lead_school_urn",
+                          "fund_code",
+                          "bursary_level",
+                          "course_study_mode",
+                          "course_year",
+                          "funding_method",
+                          "itt_aim",
+                          "ni_number",
+                          "postgrad_apprenticeship_start_date",
+                          "previous_last_name",
+                          "hesa_disabilities",
+                          "additional_training_initiative",
+                          "nationality",
+                          "placements",
+                          "degrees",
+                          "state",
+                          "trainee_id"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer"
+                        },
+                        "total_pages": {
+                          "type": "integer"
+                        },
+                        "total_count": {
+                          "type": "integer"
+                        },
+                        "per_page": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "current_page",
+                        "total_pages",
+                        "total_count",
+                        "per_page"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                },
+                "example": {
+                  "data": [
+                    {
+                      "first_names": "Chris",
+                      "last_name": "Barrows",
+                      "date_of_birth": "1980-06-06",
+                      "created_at": "2024-04-17T13:39:17.283Z",
+                      "updated_at": "2024-04-17T13:39:17.289Z",
+                      "email": "Chris.Barrows@example.com",
+                      "middle_names": "Terry",
+                      "training_route": null,
+                      "sex": "99",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100403",
+                      "itt_start_date": "2023-08-03",
+                      "outcome_date": null,
+                      "itt_end_date": "2025-07-06",
+                      "trn": "4706440",
+                      "submitted_for_trn_at": "2024-04-17T13:39:17.276Z",
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-08-03",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 16,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": false,
+                      "training_initiative": "025",
+                      "bursary_tier": null,
+                      "study_mode": "01",
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": false,
+                      "applying_for_grant": false,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": true,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-651",
+                      "ukprn": "29000910",
+                      "ethnicity": null,
+                      "disability1": "95",
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "postgrad",
+                      "course_itt_start_date": "2023-08-03",
+                      "course_age_range": null,
+                      "expected_end_date": "2025-07-06",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": "2",
+                      "bursary_level": "6",
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": "british",
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Master of Education",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:17.285Z",
+                          "updated_at": "2024-04-17T13:39:17.285Z",
+                          "subject": "100712",
+                          "institution": "0121",
+                          "graduation_year": 2018,
+                          "grade": null,
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "3a7af34a-2887-e711-80d8-005056ac45bb",
+                          "uk_degree_uuid": "4b6a5652-c197-e711-80d8-005056ac45bb",
+                          "subject_uuid": "1b8370f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "4182ef37-df1c-4f1e-9be6-feb66037f775",
+                          "degree_id": "MbH6Gd2wbhueiCbeCpJeCHQa",
+                          "degree_type": "208"
+                        }
+                      ],
+                      "state": "trn_received",
+                      "trainee_id": "c5RHYez64hFZdxxZKQT4uSdm"
+                    },
+                    {
+                      "first_names": "Isaias",
+                      "last_name": "Mayert",
+                      "date_of_birth": "1988-06-28",
+                      "created_at": "2024-04-17T13:39:17.225Z",
+                      "updated_at": "2024-04-17T13:39:17.231Z",
+                      "email": "Isaias.Mayert@example.com",
+                      "middle_names": "Fahey",
+                      "training_route": null,
+                      "sex": "11",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100403",
+                      "itt_start_date": "2023-08-11",
+                      "outcome_date": null,
+                      "itt_end_date": "2025-07-22",
+                      "trn": "5836725",
+                      "submitted_for_trn_at": "2024-04-17T13:39:17.220Z",
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-08-21",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 18,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": false,
+                      "training_initiative": "009",
+                      "bursary_tier": null,
+                      "study_mode": "01",
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": false,
+                      "applying_for_grant": false,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": true,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-648",
+                      "ukprn": "29000910",
+                      "ethnicity": null,
+                      "disability1": "95",
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "postgrad",
+                      "course_itt_start_date": "2023-08-11",
+                      "course_age_range": null,
+                      "expected_end_date": "2025-07-22",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": "7",
+                      "bursary_level": "4",
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": "british",
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Bachelor of General Studies",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:17.227Z",
+                          "updated_at": "2024-04-17T13:39:17.227Z",
+                          "subject": "100910",
+                          "institution": "0081",
+                          "graduation_year": 1965,
+                          "grade": null,
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "4071f34a-2887-e711-80d8-005056ac45bb",
+                          "uk_degree_uuid": "fd695652-c197-e711-80d8-005056ac45bb",
+                          "subject_uuid": "4f8470f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "4182ef37-df1c-4f1e-9be6-feb66037f775",
+                          "degree_id": "fUbpkF85xGQdtVBW5QxtZZx6",
+                          "degree_type": "068"
+                        }
+                      ],
+                      "state": "trn_received",
+                      "trainee_id": "cPE96C8pMqw5HnZ4ibhaeGXg"
+                    },
+                    {
+                      "first_names": "Delisa",
+                      "last_name": "Ebert",
+                      "date_of_birth": "1960-04-28",
+                      "created_at": "2024-04-17T13:39:17.166Z",
+                      "updated_at": "2024-04-17T13:39:17.172Z",
+                      "email": "Delisa.Ebert@example.com",
+                      "middle_names": "O'Connell",
+                      "training_route": null,
+                      "sex": "96",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100403",
+                      "itt_start_date": "2023-08-27",
+                      "outcome_date": null,
+                      "itt_end_date": "2025-07-01",
+                      "trn": "8560465",
+                      "submitted_for_trn_at": "2024-04-17T13:39:17.160Z",
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-09-12",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 18,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": false,
+                      "training_initiative": "009",
+                      "bursary_tier": null,
+                      "study_mode": "01",
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": false,
+                      "applying_for_grant": false,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": true,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-645",
+                      "ukprn": "29000910",
+                      "ethnicity": null,
+                      "disability1": "95",
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "postgrad",
+                      "course_itt_start_date": "2023-08-27",
+                      "course_age_range": null,
+                      "expected_end_date": "2025-07-01",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": "2",
+                      "bursary_level": "4",
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": "british",
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Master in Science",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:17.168Z",
+                          "updated_at": "2024-04-17T13:39:17.168Z",
+                          "subject": "100664",
+                          "institution": "0090",
+                          "graduation_year": 2005,
+                          "grade": null,
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "8723a753-7042-e811-80ff-3863bb3640b8",
+                          "uk_degree_uuid": "b6d2c5aa-cf99-4831-9bfe-6279349d8ea9",
+                          "subject_uuid": "d38270f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "4182ef37-df1c-4f1e-9be6-feb66037f775",
+                          "degree_id": "Srwmz4C2HKFbjGFQD7GPoXgR",
+                          "degree_type": "218"
+                        }
+                      ],
+                      "state": "trn_received",
+                      "trainee_id": "cMKQv3troAbwvrkrbnJwnYfp"
+                    },
+                    {
+                      "first_names": "Sal",
+                      "last_name": "Miller",
+                      "date_of_birth": "1987-12-10",
+                      "created_at": "2024-04-17T13:39:17.106Z",
+                      "updated_at": "2024-04-17T13:39:17.113Z",
+                      "email": "Sal.Miller@example.com",
+                      "middle_names": "Anderson",
+                      "training_route": null,
+                      "sex": "99",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100403",
+                      "itt_start_date": "2023-08-29",
+                      "outcome_date": null,
+                      "itt_end_date": "2025-07-07",
+                      "trn": "5469883",
+                      "submitted_for_trn_at": "2024-04-17T13:39:17.099Z",
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-08-29",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 16,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": false,
+                      "training_initiative": "025",
+                      "bursary_tier": null,
+                      "study_mode": "01",
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": false,
+                      "applying_for_grant": false,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": true,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-642",
+                      "ukprn": "29000910",
+                      "ethnicity": null,
+                      "disability1": "95",
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "postgrad",
+                      "course_itt_start_date": "2023-08-29",
+                      "course_age_range": null,
+                      "expected_end_date": "2025-07-07",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": "7",
+                      "bursary_level": "9",
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": "british",
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Bachelor of Arts Economics",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:17.109Z",
+                          "updated_at": "2024-04-17T13:39:17.109Z",
+                          "subject": "101171",
+                          "institution": "0082",
+                          "graduation_year": 1975,
+                          "grade": "14",
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "0a71f34a-2887-e711-80d8-005056ac45bb",
+                          "uk_degree_uuid": "dd695652-c197-e711-80d8-005056ac45bb",
+                          "subject_uuid": "c18570f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "aaba4427-287c-4610-a838-1970dd9090c1",
+                          "degree_id": "yawdCV9pxYU958vCMYSDUeeT",
+                          "degree_type": "052"
+                        }
+                      ],
+                      "state": "trn_received",
+                      "trainee_id": "7JF5QD8tJsgky1QGKsCeE6hn"
+                    },
+                    {
+                      "first_names": "Roselyn",
+                      "last_name": "Langosh",
+                      "date_of_birth": "2005-08-08",
+                      "created_at": "2024-04-17T13:39:17.042Z",
+                      "updated_at": "2024-04-17T13:39:17.049Z",
+                      "email": "Roselyn.Langosh@example.com",
+                      "middle_names": "Grimes",
+                      "training_route": null,
+                      "sex": "96",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100403",
+                      "itt_start_date": "2023-08-11",
+                      "outcome_date": null,
+                      "itt_end_date": "2024-07-04",
+                      "trn": "1518762",
+                      "submitted_for_trn_at": "2024-04-17T13:39:17.032Z",
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-08-13",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 16,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": false,
+                      "training_initiative": "036",
+                      "bursary_tier": null,
+                      "study_mode": "01",
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": false,
+                      "applying_for_grant": false,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": true,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-639",
+                      "ukprn": "29000910",
+                      "ethnicity": null,
+                      "disability1": "95",
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "postgrad",
+                      "course_itt_start_date": "2023-08-11",
+                      "course_age_range": null,
+                      "expected_end_date": "2024-07-04",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": "2",
+                      "bursary_level": "7",
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": "british",
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Bachelor of Arts in Architecture",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:17.045Z",
+                          "updated_at": "2024-04-17T13:39:17.045Z",
+                          "subject": "100441",
+                          "institution": "0211",
+                          "graduation_year": 1967,
+                          "grade": "12",
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "436e5e11-7042-e811-80ff-3863bb3640b8",
+                          "uk_degree_uuid": "df695652-c197-e711-80d8-005056ac45bb",
+                          "subject_uuid": "a98170f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "1bb9f02f-da6a-4184-8db0-d43b14ccaf1d",
+                          "degree_id": "rBdV22ZezCXsryRQ7tMjVFqX",
+                          "degree_type": "053"
+                        }
+                      ],
+                      "state": "trn_received",
+                      "trainee_id": "ndELMaTCP68YqfjrBfj5KG8b"
+                    },
+                    {
+                      "first_names": "Jamie",
+                      "last_name": "Herman",
+                      "date_of_birth": "1987-01-30",
+                      "created_at": "2024-04-17T13:39:16.974Z",
+                      "updated_at": "2024-04-17T13:39:16.980Z",
+                      "email": "Jamie.Herman@example.com",
+                      "middle_names": "Bernhard",
+                      "training_route": null,
+                      "sex": "10",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100403",
+                      "itt_start_date": "2023-08-30",
+                      "outcome_date": null,
+                      "itt_end_date": "2024-07-30",
+                      "trn": "9482669",
+                      "submitted_for_trn_at": "2024-04-17T13:39:16.968Z",
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-08-31",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 16,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": false,
+                      "training_initiative": null,
+                      "bursary_tier": null,
+                      "study_mode": "01",
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": false,
+                      "applying_for_grant": false,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": true,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-636",
+                      "ukprn": "29000910",
+                      "ethnicity": null,
+                      "disability1": "95",
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "postgrad",
+                      "course_itt_start_date": "2023-08-30",
+                      "course_age_range": null,
+                      "expected_end_date": "2024-07-30",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": "7",
+                      "bursary_level": "7",
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": "british",
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Bachelor of Law",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:16.976Z",
+                          "updated_at": "2024-04-17T13:39:16.976Z",
+                          "subject": "100937",
+                          "institution": "0041",
+                          "graduation_year": 1993,
+                          "grade": null,
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "054b9247-7042-e811-80ff-3863bb3640b8",
+                          "uk_degree_uuid": "036a5652-c197-e711-80d8-005056ac45bb",
+                          "subject_uuid": "758470f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "4182ef37-df1c-4f1e-9be6-feb66037f775",
+                          "degree_id": "BDthrVHFnVhFmcrpKfC21jZL",
+                          "degree_type": "071"
+                        }
+                      ],
+                      "state": "trn_received",
+                      "trainee_id": "JRUU8jSaCfZ7mRzP1LGZWCAM"
+                    },
+                    {
+                      "first_names": "Justin",
+                      "last_name": "Cassin",
+                      "date_of_birth": "1995-09-15",
+                      "created_at": "2024-04-17T13:39:16.918Z",
+                      "updated_at": "2024-04-17T13:39:16.925Z",
+                      "email": "Justin.Cassin@example.com",
+                      "middle_names": "Gerlach",
+                      "training_route": null,
+                      "sex": "99",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100403",
+                      "itt_start_date": "2023-08-21",
+                      "outcome_date": null,
+                      "itt_end_date": "2025-07-11",
+                      "trn": "1471319",
+                      "submitted_for_trn_at": "2024-04-17T13:39:16.912Z",
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-08-29",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 16,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": false,
+                      "training_initiative": null,
+                      "bursary_tier": null,
+                      "study_mode": "01",
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": false,
+                      "applying_for_grant": false,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": true,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-633",
+                      "ukprn": "29000910",
+                      "ethnicity": null,
+                      "disability1": "95",
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "postgrad",
+                      "course_itt_start_date": "2023-08-21",
+                      "course_age_range": null,
+                      "expected_end_date": "2025-07-11",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": "2",
+                      "bursary_level": "B",
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": "british",
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Bachelor of Arts in Architecture",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:16.921Z",
+                          "updated_at": "2024-04-17T13:39:16.921Z",
+                          "subject": "100698",
+                          "institution": "0419",
+                          "graduation_year": 1982,
+                          "grade": "03",
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "363e182c-1425-ec11-b6e6-000d3adf095a",
+                          "uk_degree_uuid": "df695652-c197-e711-80d8-005056ac45bb",
+                          "subject_uuid": "058370f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "377a46ea-d6c6-4e87-9728-c1f0dd0ef109",
+                          "degree_id": "U4h2QbGxB799yBoBi7jhy6Hz",
+                          "degree_type": "053"
+                        }
+                      ],
+                      "state": "trn_received",
+                      "trainee_id": "r94mfa83eKEac9fNVWd4h9zq"
+                    },
+                    {
+                      "first_names": "Ursula",
+                      "last_name": "Borer",
+                      "date_of_birth": "1963-02-23",
+                      "created_at": "2024-04-17T13:39:16.862Z",
+                      "updated_at": "2024-04-17T13:39:16.869Z",
+                      "email": "Ursula.Borer@example.com",
+                      "middle_names": "Orn",
+                      "training_route": null,
+                      "sex": "99",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100403",
+                      "itt_start_date": "2023-08-06",
+                      "outcome_date": null,
+                      "itt_end_date": "2025-07-30",
+                      "trn": "4387774",
+                      "submitted_for_trn_at": "2024-04-17T13:39:16.855Z",
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-08-08",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 18,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": false,
+                      "training_initiative": "009",
+                      "bursary_tier": null,
+                      "study_mode": "01",
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": false,
+                      "applying_for_grant": false,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": true,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-630",
+                      "ukprn": "29000910",
+                      "ethnicity": null,
+                      "disability1": "95",
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "postgrad",
+                      "course_itt_start_date": "2023-08-06",
+                      "course_age_range": null,
+                      "expected_end_date": "2025-07-30",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": "2",
+                      "bursary_level": "4",
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": "british",
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Bachelor of Education",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:16.865Z",
+                          "updated_at": "2024-04-17T13:39:16.865Z",
+                          "subject": "100048",
+                          "institution": "0110",
+                          "graduation_year": 1999,
+                          "grade": "14",
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "fe70f34a-2887-e711-80d8-005056ac45bb",
+                          "uk_degree_uuid": "c1695652-c197-e711-80d8-005056ac45bb",
+                          "subject_uuid": "3d7f70f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "aaba4427-287c-4610-a838-1970dd9090c1",
+                          "degree_id": "XbrrAvnfoX5F8EfpiYCzAUp7",
+                          "degree_type": "001"
+                        }
+                      ],
+                      "state": "trn_received",
+                      "trainee_id": "JNKyEEvnB34vAzJMKzU449qv"
+                    },
+                    {
+                      "first_names": "Rosalie",
+                      "last_name": "Bernier",
+                      "date_of_birth": "1962-08-19",
+                      "created_at": "2024-04-17T13:39:16.801Z",
+                      "updated_at": "2024-04-17T13:39:16.811Z",
+                      "email": "Rosalie.Bernier@example.com",
+                      "middle_names": "Labadie",
+                      "training_route": null,
+                      "sex": "96",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100403",
+                      "itt_start_date": "2023-08-04",
+                      "outcome_date": null,
+                      "itt_end_date": "2024-07-09",
+                      "trn": "7921393",
+                      "submitted_for_trn_at": "2024-04-17T13:39:16.795Z",
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-08-04",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 18,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": false,
+                      "training_initiative": null,
+                      "bursary_tier": null,
+                      "study_mode": "01",
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": false,
+                      "applying_for_grant": false,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": true,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-627",
+                      "ukprn": "29000910",
+                      "ethnicity": null,
+                      "disability1": "95",
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "postgrad",
+                      "course_itt_start_date": "2023-08-04",
+                      "course_age_range": null,
+                      "expected_end_date": "2024-07-09",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": "7",
+                      "bursary_level": "6",
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": "british",
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Bachelor of Applied Science",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:16.804Z",
+                          "updated_at": "2024-04-17T13:39:16.804Z",
+                          "subject": "101331",
+                          "institution": "0164",
+                          "graduation_year": 2020,
+                          "grade": "01",
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "4a71f34a-2887-e711-80d8-005056ac45bb",
+                          "uk_degree_uuid": "e5695652-c197-e711-80d8-005056ac45bb",
+                          "subject_uuid": "698670f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "8741765a-13d8-4550-a413-c5a860a59d25",
+                          "degree_id": "CvTWT1T8LEjrYmvKEfpZzWBA",
+                          "degree_type": "056"
+                        }
+                      ],
+                      "state": "trn_received",
+                      "trainee_id": "G779yPUWvXn7P16jnaB55yGU"
+                    },
+                    {
+                      "first_names": "Amos",
+                      "last_name": "Heaney",
+                      "date_of_birth": "1977-01-28",
+                      "created_at": "2024-04-17T13:39:16.742Z",
+                      "updated_at": "2024-04-17T13:39:16.751Z",
+                      "email": "Amos.Heaney@example.com",
+                      "middle_names": "Ondricka",
+                      "training_route": null,
+                      "sex": "12",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100403",
+                      "itt_start_date": "2023-08-06",
+                      "outcome_date": null,
+                      "itt_end_date": "2025-07-26",
+                      "trn": "3101115",
+                      "submitted_for_trn_at": "2024-04-17T13:39:16.736Z",
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-08-12",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 18,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": false,
+                      "training_initiative": "025",
+                      "bursary_tier": null,
+                      "study_mode": "01",
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": false,
+                      "applying_for_grant": false,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": true,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-624",
+                      "ukprn": "29000910",
+                      "ethnicity": null,
+                      "disability1": "95",
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "postgrad",
+                      "course_itt_start_date": "2023-08-06",
+                      "course_age_range": null,
+                      "expected_end_date": "2025-07-26",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": "2",
+                      "bursary_level": "B",
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": "british",
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Higher degree or equivalent",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:16.745Z",
+                          "updated_at": "2024-04-17T13:39:16.745Z",
+                          "subject": "101010",
+                          "institution": "0265",
+                          "graduation_year": 1983,
+                          "grade": "02",
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "d33e182c-1425-ec11-b6e6-000d3adf095a",
+                          "uk_degree_uuid": "fdafdcd7-5f21-4363-b7d5-c1f44a852af1",
+                          "subject_uuid": "cf8470f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f",
+                          "degree_id": "4UGrZqrbUbf84J6xPE1sc85H",
+                          "degree_type": null
+                        }
+                      ],
+                      "state": "trn_received",
+                      "trainee_id": "5sVZ3cXFXwvKoFevCn2eCjtD"
+                    }
+                  ],
+                  "meta": {
+                    "current_page": 1,
+                    "total_pages": 1,
+                    "total_count": 10,
+                    "per_page": 50
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "returns status 401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                },
+                "example": {
+                  "error": "Unauthorized"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "returns status code 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Not found"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "returns 422 if academic cycle filter is invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "since": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "academic_cycle": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "message": "Validation failed: 1 error prohibited this request being run",
+                  "errors": {
+                    "status": [
+                      "invalid_state is not a valid status"
+                    ],
+                    "since": [
+                      "2023-13-01 is not a valid date"
+                    ],
+                    "academic_cycle": [
+                      "not-a-number is not a valid academic cycle year"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "create",
+        "tags": [
+          "Api::Trainee"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "first_names": {
+                        "type": "string"
+                      },
+                      "last_name": {
+                        "type": "string"
+                      },
+                      "date_of_birth": {
+                        "type": "string"
+                      },
+                      "sex": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "nationality": {
+                        "type": "string"
+                      },
+                      "training_route": {
+                        "type": "string"
+                      },
+                      "itt_start_date": {
+                        "type": "string"
+                      },
+                      "itt_end_date": {
+                        "type": "string"
+                      },
+                      "course_subject_one": {
+                        "type": "string"
+                      },
+                      "study_mode": {
+                        "type": "string"
+                      },
+                      "degrees_attributes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "subject": {
+                              "type": "string"
+                            },
+                            "institution": {
+                              "nullable": true
+                            },
+                            "graduation_date": {
+                              "type": "string"
+                            },
+                            "subject_one": {
+                              "type": "string"
+                            },
+                            "grade": {
+                              "type": "string"
+                            },
+                            "country": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "subject",
+                            "institution",
+                            "graduation_date",
+                            "subject_one",
+                            "grade",
+                            "country"
+                          ]
+                        }
+                      },
+                      "placements_attributes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "urn": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "urn"
+                          ]
+                        }
+                      },
+                      "itt_aim": {
+                        "type": "string"
+                      },
+                      "itt_qualification_aim": {
+                        "type": "string"
+                      },
+                      "course_year": {
+                        "type": "string"
+                      },
+                      "course_age_range": {
+                        "type": "string"
+                      },
+                      "fund_code": {
+                        "type": "string"
+                      },
+                      "funding_method": {
+                        "type": "string"
+                      },
+                      "hesa_id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "first_names",
+                      "last_name",
+                      "date_of_birth",
+                      "sex",
+                      "email",
+                      "nationality",
+                      "training_route",
+                      "itt_start_date",
+                      "itt_end_date",
+                      "course_subject_one",
+                      "study_mode",
+                      "degrees_attributes",
+                      "placements_attributes",
+                      "itt_aim",
+                      "itt_qualification_aim",
+                      "course_year",
+                      "course_age_range",
+                      "fund_code",
+                      "funding_method",
+                      "hesa_id"
+                    ]
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              },
+              "example": {
+                "data": {
+                  "first_names": "John",
+                  "last_name": "Doe",
+                  "date_of_birth": "1990-01-01",
+                  "sex": "11",
+                  "email": "john.doe@example.com",
+                  "nationality": "GB",
+                  "training_route": "11",
+                  "itt_start_date": "2023-01-01",
+                  "itt_end_date": "2023-10-01",
+                  "course_subject_one": "100346",
+                  "study_mode": "63",
+                  "degrees_attributes": [
+                    {
+                      "subject": "Law",
+                      "institution": null,
+                      "graduation_date": "2003-06-01",
+                      "subject_one": "100485",
+                      "grade": "02",
+                      "country": "XF"
+                    }
+                  ],
+                  "placements_attributes": [
+                    {
+                      "urn": "900020"
+                    }
+                  ],
+                  "itt_aim": "202",
+                  "itt_qualification_aim": "001",
+                  "course_year": "2012",
+                  "course_age_range": "13915",
+                  "fund_code": "7",
+                  "funding_method": "4",
+                  "hesa_id": "0310261553101"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "sets the correct course allocation subject",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "first_names": {
+                      "type": "string"
+                    },
+                    "last_name": {
+                      "type": "string"
+                    },
+                    "date_of_birth": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "middle_names": {
+                      "nullable": true
+                    },
+                    "training_route": {
+                      "type": "string"
+                    },
+                    "sex": {
+                      "type": "string"
+                    },
+                    "diversity_disclosure": {
+                      "type": "string"
+                    },
+                    "ethnic_group": {
+                      "type": "string"
+                    },
+                    "ethnic_background": {
+                      "type": "string"
+                    },
+                    "additional_ethnic_background": {
+                      "nullable": true
+                    },
+                    "disability_disclosure": {
+                      "type": "string"
+                    },
+                    "course_subject_one": {
+                      "type": "string"
+                    },
+                    "itt_start_date": {
+                      "type": "string"
+                    },
+                    "outcome_date": {
+                      "nullable": true
+                    },
+                    "itt_end_date": {
+                      "type": "string"
+                    },
+                    "trn": {
+                      "nullable": true
+                    },
+                    "submitted_for_trn_at": {
+                      "type": "string"
+                    },
+                    "withdraw_date": {
+                      "nullable": true
+                    },
+                    "withdraw_reasons_details": {
+                      "nullable": true
+                    },
+                    "defer_date": {
+                      "nullable": true
+                    },
+                    "recommended_for_award_at": {
+                      "nullable": true
+                    },
+                    "trainee_start_date": {
+                      "type": "string"
+                    },
+                    "reinstate_date": {
+                      "nullable": true
+                    },
+                    "course_min_age": {
+                      "type": "integer"
+                    },
+                    "course_max_age": {
+                      "type": "integer"
+                    },
+                    "course_subject_two": {
+                      "type": "string"
+                    },
+                    "course_subject_three": {
+                      "nullable": true
+                    },
+                    "awarded_at": {
+                      "nullable": true
+                    },
+                    "applying_for_bursary": {
+                      "nullable": true
+                    },
+                    "training_initiative": {
+                      "nullable": true
+                    },
+                    "bursary_tier": {
+                      "nullable": true
+                    },
+                    "study_mode": {
+                      "nullable": true
+                    },
+                    "ebacc": {
+                      "type": "boolean"
+                    },
+                    "region": {
+                      "nullable": true
+                    },
+                    "course_education_phase": {
+                      "type": "string"
+                    },
+                    "applying_for_scholarship": {
+                      "nullable": true
+                    },
+                    "applying_for_grant": {
+                      "nullable": true
+                    },
+                    "course_uuid": {
+                      "nullable": true
+                    },
+                    "lead_school_not_applicable": {
+                      "type": "boolean"
+                    },
+                    "employing_school_not_applicable": {
+                      "type": "boolean"
+                    },
+                    "submission_ready": {
+                      "type": "boolean"
+                    },
+                    "commencement_status": {
+                      "nullable": true
+                    },
+                    "discarded_at": {
+                      "nullable": true
+                    },
+                    "created_from_dttp": {
+                      "type": "boolean"
+                    },
+                    "hesa_id": {
+                      "type": "string"
+                    },
+                    "additional_dttp_data": {
+                      "nullable": true
+                    },
+                    "created_from_hesa": {
+                      "type": "boolean"
+                    },
+                    "hesa_updated_at": {
+                      "nullable": true
+                    },
+                    "record_source": {
+                      "type": "string"
+                    },
+                    "iqts_country": {
+                      "nullable": true
+                    },
+                    "hesa_editable": {
+                      "type": "boolean"
+                    },
+                    "withdraw_reasons_dfe_details": {
+                      "nullable": true
+                    },
+                    "slug_sent_to_dqt_at": {
+                      "nullable": true
+                    },
+                    "placement_detail": {
+                      "nullable": true
+                    },
+                    "provider_trainee_id": {
+                      "nullable": true
+                    },
+                    "ukprn": {
+                      "type": "string"
+                    },
+                    "ethnicity": {
+                      "type": "string"
+                    },
+                    "course_qualification": {
+                      "type": "string"
+                    },
+                    "course_title": {
+                      "nullable": true
+                    },
+                    "course_level": {
+                      "type": "string"
+                    },
+                    "course_itt_start_date": {
+                      "type": "string"
+                    },
+                    "course_age_range": {
+                      "nullable": true
+                    },
+                    "expected_end_date": {
+                      "type": "string"
+                    },
+                    "employing_school_urn": {
+                      "nullable": true
+                    },
+                    "lead_partner_urn_ukprn": {
+                      "nullable": true
+                    },
+                    "lead_school_urn": {
+                      "nullable": true
+                    },
+                    "fund_code": {
+                      "type": "string"
+                    },
+                    "bursary_level": {
+                      "type": "string"
+                    },
+                    "course_study_mode": {
+                      "nullable": true
+                    },
+                    "course_year": {
+                      "nullable": true
+                    },
+                    "funding_method": {
+                      "nullable": true
+                    },
+                    "itt_aim": {
+                      "nullable": true
+                    },
+                    "ni_number": {
+                      "nullable": true
+                    },
+                    "postgrad_apprenticeship_start_date": {
+                      "nullable": true
+                    },
+                    "previous_last_name": {
+                      "nullable": true
+                    },
+                    "hesa_disabilities": {
+                      "nullable": true
+                    },
+                    "additional_training_initiative": {
+                      "nullable": true
+                    },
+                    "nationality": {
+                      "type": "string"
+                    },
+                    "placements": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "urn": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "postcode": {
+                            "nullable": true
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          },
+                          "placement_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "urn",
+                          "name",
+                          "postcode",
+                          "created_at",
+                          "updated_at",
+                          "placement_id"
+                        ]
+                      }
+                    },
+                    "degrees": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uk_degree": {
+                            "nullable": true
+                          },
+                          "non_uk_degree": {
+                            "nullable": true
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          },
+                          "subject": {
+                            "type": "string"
+                          },
+                          "institution": {
+                            "nullable": true
+                          },
+                          "graduation_year": {
+                            "type": "integer"
+                          },
+                          "grade": {
+                            "type": "string"
+                          },
+                          "country": {
+                            "nullable": true
+                          },
+                          "other_grade": {
+                            "nullable": true
+                          },
+                          "institution_uuid": {
+                            "type": "string"
+                          },
+                          "uk_degree_uuid": {
+                            "nullable": true
+                          },
+                          "subject_uuid": {
+                            "type": "string"
+                          },
+                          "grade_uuid": {
+                            "type": "string"
+                          },
+                          "degree_id": {
+                            "type": "string"
+                          },
+                          "degree_type": {
+                            "nullable": true
+                          }
+                        },
+                        "required": [
+                          "uk_degree",
+                          "non_uk_degree",
+                          "created_at",
+                          "updated_at",
+                          "subject",
+                          "institution",
+                          "graduation_year",
+                          "grade",
+                          "country",
+                          "other_grade",
+                          "institution_uuid",
+                          "uk_degree_uuid",
+                          "subject_uuid",
+                          "grade_uuid",
+                          "degree_id",
+                          "degree_type"
+                        ]
+                      }
+                    },
+                    "state": {
+                      "type": "string"
+                    },
+                    "trainee_id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "first_names",
+                    "last_name",
+                    "date_of_birth",
+                    "created_at",
+                    "updated_at",
+                    "email",
+                    "middle_names",
+                    "training_route",
+                    "sex",
+                    "diversity_disclosure",
+                    "ethnic_group",
+                    "ethnic_background",
+                    "additional_ethnic_background",
+                    "disability_disclosure",
+                    "course_subject_one",
+                    "itt_start_date",
+                    "outcome_date",
+                    "itt_end_date",
+                    "trn",
+                    "submitted_for_trn_at",
+                    "withdraw_date",
+                    "withdraw_reasons_details",
+                    "defer_date",
+                    "recommended_for_award_at",
+                    "trainee_start_date",
+                    "reinstate_date",
+                    "course_min_age",
+                    "course_max_age",
+                    "course_subject_two",
+                    "course_subject_three",
+                    "awarded_at",
+                    "applying_for_bursary",
+                    "training_initiative",
+                    "bursary_tier",
+                    "study_mode",
+                    "ebacc",
+                    "region",
+                    "course_education_phase",
+                    "applying_for_scholarship",
+                    "applying_for_grant",
+                    "course_uuid",
+                    "lead_school_not_applicable",
+                    "employing_school_not_applicable",
+                    "submission_ready",
+                    "commencement_status",
+                    "discarded_at",
+                    "created_from_dttp",
+                    "hesa_id",
+                    "additional_dttp_data",
+                    "created_from_hesa",
+                    "hesa_updated_at",
+                    "record_source",
+                    "iqts_country",
+                    "hesa_editable",
+                    "withdraw_reasons_dfe_details",
+                    "slug_sent_to_dqt_at",
+                    "placement_detail",
+                    "provider_trainee_id",
+                    "ukprn",
+                    "ethnicity",
+                    "course_qualification",
+                    "course_title",
+                    "course_level",
+                    "course_itt_start_date",
+                    "course_age_range",
+                    "expected_end_date",
+                    "employing_school_urn",
+                    "lead_partner_urn_ukprn",
+                    "lead_school_urn",
+                    "fund_code",
+                    "bursary_level",
+                    "course_study_mode",
+                    "course_year",
+                    "funding_method",
+                    "itt_aim",
+                    "ni_number",
+                    "postgrad_apprenticeship_start_date",
+                    "previous_last_name",
+                    "hesa_disabilities",
+                    "additional_training_initiative",
+                    "nationality",
+                    "placements",
+                    "degrees",
+                    "state",
+                    "trainee_id"
+                  ]
+                },
+                "example": {
+                  "first_names": "John",
+                  "last_name": "Doe",
+                  "date_of_birth": "1990-01-01",
+                  "created_at": "2024-04-17T13:38:57.364Z",
+                  "updated_at": "2024-04-17T13:38:57.409Z",
+                  "email": "john.doe@example.com",
+                  "middle_names": null,
+                  "training_route": "11",
+                  "sex": "11",
+                  "diversity_disclosure": "diversity_not_disclosed",
+                  "ethnic_group": "not_provided_ethnic_group",
+                  "ethnic_background": "Not provided",
+                  "additional_ethnic_background": null,
+                  "disability_disclosure": "disability_not_provided",
+                  "course_subject_one": "100511",
+                  "itt_start_date": "2023-01-01",
+                  "outcome_date": null,
+                  "itt_end_date": "2023-10-01",
+                  "trn": null,
+                  "submitted_for_trn_at": "2024-04-17T13:38:57.401Z",
+                  "withdraw_date": null,
+                  "withdraw_reasons_details": null,
+                  "defer_date": null,
+                  "recommended_for_award_at": null,
+                  "trainee_start_date": "2023-01-01",
+                  "reinstate_date": null,
+                  "course_min_age": 7,
+                  "course_max_age": 11,
+                  "course_subject_two": "biology",
+                  "course_subject_three": null,
+                  "awarded_at": null,
+                  "applying_for_bursary": null,
+                  "training_initiative": null,
+                  "bursary_tier": null,
+                  "study_mode": null,
+                  "ebacc": false,
+                  "region": null,
+                  "course_education_phase": "primary",
+                  "applying_for_scholarship": null,
+                  "applying_for_grant": null,
+                  "course_uuid": null,
+                  "lead_school_not_applicable": false,
+                  "employing_school_not_applicable": false,
+                  "submission_ready": false,
+                  "commencement_status": null,
+                  "discarded_at": null,
+                  "created_from_dttp": false,
+                  "hesa_id": "0310261553101",
+                  "additional_dttp_data": null,
+                  "created_from_hesa": false,
+                  "hesa_updated_at": null,
+                  "record_source": "api",
+                  "iqts_country": null,
+                  "hesa_editable": false,
+                  "withdraw_reasons_dfe_details": null,
+                  "slug_sent_to_dqt_at": null,
+                  "placement_detail": null,
+                  "provider_trainee_id": null,
+                  "ukprn": "82486918",
+                  "ethnicity": "997",
+                  "course_qualification": "QTS",
+                  "course_title": null,
+                  "course_level": "undergrad",
+                  "course_itt_start_date": "2023-01-01",
+                  "course_age_range": null,
+                  "expected_end_date": "2023-10-01",
+                  "employing_school_urn": null,
+                  "lead_partner_urn_ukprn": null,
+                  "lead_school_urn": null,
+                  "fund_code": "7",
+                  "bursary_level": "4",
+                  "course_study_mode": null,
+                  "course_year": null,
+                  "funding_method": null,
+                  "itt_aim": null,
+                  "ni_number": null,
+                  "postgrad_apprenticeship_start_date": null,
+                  "previous_last_name": null,
+                  "hesa_disabilities": null,
+                  "additional_training_initiative": null,
+                  "nationality": "british",
+                  "placements": [
+                    {
+                      "urn": "900020",
+                      "name": "Establishment does not have a URN",
+                      "postcode": null,
+                      "created_at": "2024-04-17T13:38:57.373Z",
+                      "updated_at": "2024-04-17T13:38:57.373Z",
+                      "placement_id": "fk7KDKe3Bnfr2aduwqJQmLKB"
+                    }
+                  ],
+                  "degrees": [
+                    {
+                      "uk_degree": null,
+                      "non_uk_degree": null,
+                      "created_at": "2024-04-17T13:38:57.367Z",
+                      "updated_at": "2024-04-17T13:38:57.367Z",
+                      "subject": "100485",
+                      "institution": null,
+                      "graduation_year": 2003,
+                      "grade": "02",
+                      "country": null,
+                      "other_grade": null,
+                      "institution_uuid": "02132969-f5bc-47ca-be9c-b6f6d5b05e1b",
+                      "uk_degree_uuid": null,
+                      "subject_uuid": "e78170f0-5dce-e911-a985-000d3ab79618",
+                      "grade_uuid": "e2fe18d4-8655-47cf-ab1a-8c3e0b0f078f",
+                      "degree_id": "61yaDkkReBx1UMc29Zn2bfEm",
+                      "degree_type": null
+                    }
+                  ],
+                  "state": "submitted_for_trn",
+                  "trainee_id": "cCC4TcmsSBWZeBGWto9D6CPL"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "returns status 409 (conflict) with the potential duplicates and does not create a trainee record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "first_names": {
+                            "type": "string"
+                          },
+                          "last_name": {
+                            "type": "string"
+                          },
+                          "date_of_birth": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "middle_names": {
+                            "type": "string"
+                          },
+                          "training_route": {
+                            "type": "string"
+                          },
+                          "sex": {
+                            "type": "string"
+                          },
+                          "diversity_disclosure": {
+                            "type": "string"
+                          },
+                          "ethnic_group": {
+                            "nullable": true
+                          },
+                          "ethnic_background": {
+                            "nullable": true
+                          },
+                          "additional_ethnic_background": {
+                            "nullable": true
+                          },
+                          "disability_disclosure": {
+                            "nullable": true
+                          },
+                          "course_subject_one": {
+                            "type": "string"
+                          },
+                          "itt_start_date": {
+                            "type": "string"
+                          },
+                          "outcome_date": {
+                            "nullable": true
+                          },
+                          "itt_end_date": {
+                            "type": "string"
+                          },
+                          "trn": {
+                            "nullable": true
+                          },
+                          "submitted_for_trn_at": {
+                            "nullable": true
+                          },
+                          "withdraw_date": {
+                            "nullable": true
+                          },
+                          "withdraw_reasons_details": {
+                            "nullable": true
+                          },
+                          "defer_date": {
+                            "nullable": true
+                          },
+                          "recommended_for_award_at": {
+                            "nullable": true
+                          },
+                          "trainee_start_date": {
+                            "type": "string"
+                          },
+                          "reinstate_date": {
+                            "nullable": true
+                          },
+                          "course_min_age": {
+                            "type": "integer"
+                          },
+                          "course_max_age": {
+                            "type": "integer"
+                          },
+                          "course_subject_two": {
+                            "nullable": true
+                          },
+                          "course_subject_three": {
+                            "nullable": true
+                          },
+                          "awarded_at": {
+                            "nullable": true
+                          },
+                          "applying_for_bursary": {
+                            "type": "boolean"
+                          },
+                          "training_initiative": {
+                            "type": "string"
+                          },
+                          "bursary_tier": {
+                            "nullable": true
+                          },
+                          "study_mode": {
+                            "nullable": true
+                          },
+                          "ebacc": {
+                            "type": "boolean"
+                          },
+                          "region": {
+                            "nullable": true
+                          },
+                          "course_education_phase": {
+                            "type": "string"
+                          },
+                          "applying_for_scholarship": {
+                            "nullable": true
+                          },
+                          "applying_for_grant": {
+                            "nullable": true
+                          },
+                          "course_uuid": {
+                            "nullable": true
+                          },
+                          "lead_school_not_applicable": {
+                            "type": "boolean"
+                          },
+                          "employing_school_not_applicable": {
+                            "type": "boolean"
+                          },
+                          "submission_ready": {
+                            "type": "boolean"
+                          },
+                          "commencement_status": {
+                            "nullable": true
+                          },
+                          "discarded_at": {
+                            "nullable": true
+                          },
+                          "created_from_dttp": {
+                            "type": "boolean"
+                          },
+                          "hesa_id": {
+                            "nullable": true
+                          },
+                          "additional_dttp_data": {
+                            "nullable": true
+                          },
+                          "created_from_hesa": {
+                            "type": "boolean"
+                          },
+                          "hesa_updated_at": {
+                            "nullable": true
+                          },
+                          "record_source": {
+                            "nullable": true
+                          },
+                          "iqts_country": {
+                            "nullable": true
+                          },
+                          "hesa_editable": {
+                            "type": "boolean"
+                          },
+                          "withdraw_reasons_dfe_details": {
+                            "nullable": true
+                          },
+                          "slug_sent_to_dqt_at": {
+                            "nullable": true
+                          },
+                          "placement_detail": {
+                            "nullable": true
+                          },
+                          "provider_trainee_id": {
+                            "type": "string"
+                          },
+                          "ukprn": {
+                            "type": "string"
+                          },
+                          "ethnicity": {
+                            "nullable": true
+                          },
+                          "course_qualification": {
+                            "type": "string"
+                          },
+                          "course_title": {
+                            "nullable": true
+                          },
+                          "course_level": {
+                            "type": "string"
+                          },
+                          "course_itt_start_date": {
+                            "type": "string"
+                          },
+                          "course_age_range": {
+                            "nullable": true
+                          },
+                          "expected_end_date": {
+                            "type": "string"
+                          },
+                          "employing_school_urn": {
+                            "nullable": true
+                          },
+                          "lead_partner_urn_ukprn": {
+                            "nullable": true
+                          },
+                          "lead_school_urn": {
+                            "nullable": true
+                          },
+                          "fund_code": {
+                            "nullable": true
+                          },
+                          "bursary_level": {
+                            "nullable": true
+                          },
+                          "course_study_mode": {
+                            "nullable": true
+                          },
+                          "course_year": {
+                            "nullable": true
+                          },
+                          "funding_method": {
+                            "nullable": true
+                          },
+                          "itt_aim": {
+                            "nullable": true
+                          },
+                          "ni_number": {
+                            "nullable": true
+                          },
+                          "postgrad_apprenticeship_start_date": {
+                            "nullable": true
+                          },
+                          "previous_last_name": {
+                            "nullable": true
+                          },
+                          "hesa_disabilities": {
+                            "nullable": true
+                          },
+                          "additional_training_initiative": {
+                            "nullable": true
+                          },
+                          "nationality": {
+                            "nullable": true
+                          },
+                          "placements": {
+                            "type": "array",
+                            "items": {
+                            }
+                          },
+                          "degrees": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "uk_degree": {
+                                  "type": "string"
+                                },
+                                "non_uk_degree": {
+                                  "nullable": true
+                                },
+                                "created_at": {
+                                  "type": "string"
+                                },
+                                "updated_at": {
+                                  "type": "string"
+                                },
+                                "subject": {
+                                  "type": "string"
+                                },
+                                "institution": {
+                                  "type": "string"
+                                },
+                                "graduation_year": {
+                                  "type": "integer"
+                                },
+                                "grade": {
+                                  "type": "string"
+                                },
+                                "country": {
+                                  "nullable": true
+                                },
+                                "other_grade": {
+                                  "nullable": true
+                                },
+                                "institution_uuid": {
+                                  "type": "string"
+                                },
+                                "uk_degree_uuid": {
+                                  "type": "string"
+                                },
+                                "subject_uuid": {
+                                  "type": "string"
+                                },
+                                "grade_uuid": {
+                                  "type": "string"
+                                },
+                                "degree_id": {
+                                  "type": "string"
+                                },
+                                "degree_type": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "uk_degree",
+                                "non_uk_degree",
+                                "created_at",
+                                "updated_at",
+                                "subject",
+                                "institution",
+                                "graduation_year",
+                                "grade",
+                                "country",
+                                "other_grade",
+                                "institution_uuid",
+                                "uk_degree_uuid",
+                                "subject_uuid",
+                                "grade_uuid",
+                                "degree_id",
+                                "degree_type"
+                              ]
+                            }
+                          },
+                          "state": {
+                            "type": "string"
+                          },
+                          "trainee_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "first_names",
+                          "last_name",
+                          "date_of_birth",
+                          "created_at",
+                          "updated_at",
+                          "email",
+                          "middle_names",
+                          "training_route",
+                          "sex",
+                          "diversity_disclosure",
+                          "ethnic_group",
+                          "ethnic_background",
+                          "additional_ethnic_background",
+                          "disability_disclosure",
+                          "course_subject_one",
+                          "itt_start_date",
+                          "outcome_date",
+                          "itt_end_date",
+                          "trn",
+                          "submitted_for_trn_at",
+                          "withdraw_date",
+                          "withdraw_reasons_details",
+                          "defer_date",
+                          "recommended_for_award_at",
+                          "trainee_start_date",
+                          "reinstate_date",
+                          "course_min_age",
+                          "course_max_age",
+                          "course_subject_two",
+                          "course_subject_three",
+                          "awarded_at",
+                          "applying_for_bursary",
+                          "training_initiative",
+                          "bursary_tier",
+                          "study_mode",
+                          "ebacc",
+                          "region",
+                          "course_education_phase",
+                          "applying_for_scholarship",
+                          "applying_for_grant",
+                          "course_uuid",
+                          "lead_school_not_applicable",
+                          "employing_school_not_applicable",
+                          "submission_ready",
+                          "commencement_status",
+                          "discarded_at",
+                          "created_from_dttp",
+                          "hesa_id",
+                          "additional_dttp_data",
+                          "created_from_hesa",
+                          "hesa_updated_at",
+                          "record_source",
+                          "iqts_country",
+                          "hesa_editable",
+                          "withdraw_reasons_dfe_details",
+                          "slug_sent_to_dqt_at",
+                          "placement_detail",
+                          "provider_trainee_id",
+                          "ukprn",
+                          "ethnicity",
+                          "course_qualification",
+                          "course_title",
+                          "course_level",
+                          "course_itt_start_date",
+                          "course_age_range",
+                          "expected_end_date",
+                          "employing_school_urn",
+                          "lead_partner_urn_ukprn",
+                          "lead_school_urn",
+                          "fund_code",
+                          "bursary_level",
+                          "course_study_mode",
+                          "course_year",
+                          "funding_method",
+                          "itt_aim",
+                          "ni_number",
+                          "postgrad_apprenticeship_start_date",
+                          "previous_last_name",
+                          "hesa_disabilities",
+                          "additional_training_initiative",
+                          "nationality",
+                          "placements",
+                          "degrees",
+                          "state",
+                          "trainee_id"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors",
+                    "data"
+                  ]
+                },
+                "example": {
+                  "errors": "This trainee is already in Register",
+                  "data": [
+                    {
+                      "first_names": "Kimi",
+                      "last_name": "Konopelski",
+                      "date_of_birth": "1968-04-25",
+                      "created_at": "2024-04-17T13:39:00.853Z",
+                      "updated_at": "2024-04-17T13:39:00.856Z",
+                      "email": "Kimi.Konopelski@example.com",
+                      "middle_names": "Prohaska",
+                      "training_route": "11",
+                      "sex": "11",
+                      "diversity_disclosure": "diversity_not_disclosed",
+                      "ethnic_group": null,
+                      "ethnic_background": null,
+                      "additional_ethnic_background": null,
+                      "disability_disclosure": null,
+                      "course_subject_one": "100346",
+                      "itt_start_date": "2023-08-01",
+                      "outcome_date": null,
+                      "itt_end_date": "2026-07-30",
+                      "trn": null,
+                      "submitted_for_trn_at": null,
+                      "withdraw_date": null,
+                      "withdraw_reasons_details": null,
+                      "defer_date": null,
+                      "recommended_for_award_at": null,
+                      "trainee_start_date": "2023-08-03",
+                      "reinstate_date": null,
+                      "course_min_age": 11,
+                      "course_max_age": 16,
+                      "course_subject_two": null,
+                      "course_subject_three": null,
+                      "awarded_at": null,
+                      "applying_for_bursary": true,
+                      "training_initiative": "009",
+                      "bursary_tier": null,
+                      "study_mode": null,
+                      "ebacc": false,
+                      "region": null,
+                      "course_education_phase": "secondary",
+                      "applying_for_scholarship": null,
+                      "applying_for_grant": null,
+                      "course_uuid": null,
+                      "lead_school_not_applicable": false,
+                      "employing_school_not_applicable": false,
+                      "submission_ready": false,
+                      "commencement_status": null,
+                      "discarded_at": null,
+                      "created_from_dttp": false,
+                      "hesa_id": null,
+                      "additional_dttp_data": null,
+                      "created_from_hesa": false,
+                      "hesa_updated_at": null,
+                      "record_source": null,
+                      "iqts_country": null,
+                      "hesa_editable": false,
+                      "withdraw_reasons_dfe_details": null,
+                      "slug_sent_to_dqt_at": null,
+                      "placement_detail": null,
+                      "provider_trainee_id": "23/24-83",
+                      "ukprn": "63675964",
+                      "ethnicity": null,
+                      "course_qualification": "QTS",
+                      "course_title": null,
+                      "course_level": "undergrad",
+                      "course_itt_start_date": "2023-08-01",
+                      "course_age_range": null,
+                      "expected_end_date": "2026-07-30",
+                      "employing_school_urn": null,
+                      "lead_partner_urn_ukprn": null,
+                      "lead_school_urn": null,
+                      "fund_code": null,
+                      "bursary_level": null,
+                      "course_study_mode": null,
+                      "course_year": null,
+                      "funding_method": null,
+                      "itt_aim": null,
+                      "ni_number": null,
+                      "postgrad_apprenticeship_start_date": null,
+                      "previous_last_name": null,
+                      "hesa_disabilities": null,
+                      "additional_training_initiative": null,
+                      "nationality": null,
+                      "placements": [
+
+                      ],
+                      "degrees": [
+                        {
+                          "uk_degree": "Bachelor of Science",
+                          "non_uk_degree": null,
+                          "created_at": "2024-04-17T13:39:00.855Z",
+                          "updated_at": "2024-04-17T13:39:00.855Z",
+                          "subject": "100780",
+                          "institution": "0010",
+                          "graduation_year": 1977,
+                          "grade": "05",
+                          "country": null,
+                          "other_grade": null,
+                          "institution_uuid": "d90a4e73-a141-e811-80ff-3863bb351d40",
+                          "uk_degree_uuid": "1b6a5652-c197-e711-80d8-005056ac45bb",
+                          "subject_uuid": "818370f0-5dce-e911-a985-000d3ab79618",
+                          "grade_uuid": "3d57e5f7-7904-4895-a982-ed953fff3f94",
+                          "degree_id": "y9hWxgmms2hNHPdanyVysDsk",
+                          "degree_type": "083"
+                        }
+                      ],
+                      "state": "draft",
+                      "trainee_id": "KP4KSmh55a33nm6iystsMkhN"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "returns a validation failure message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    "First names can't be blank",
+                    "Last name can't be blank",
+                    "Date of birth can't be blank",
+                    "Sex can't be blank",
+                    "Training route can't be blank",
+                    "Itt start date can't be blank",
+                    "Itt end date can't be blank",
+                    "Course subject one can't be blank",
+                    "Study mode can't be blank",
+                    "Hesa can't be blank",
+                    "Email Enter an email address in the correct format, like name@example.com",
+                    "Itt aim can't be blank",
+                    "Itt qualification aim can't be blank",
+                    "Course year can't be blank",
+                    "Course age range can't be blank",
+                    "Fund code can't be blank",
+                    "Funding method can't be blank"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{api_version}/trainees/{slug}": {
+      "get": {
+        "summary": "show",
+        "tags": [
+          "Api::Trainee"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "nonexistent"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "increments the requests_total counter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "first_names": {
+                      "type": "string"
+                    },
+                    "last_name": {
+                      "type": "string"
+                    },
+                    "date_of_birth": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "middle_names": {
+                      "type": "string"
+                    },
+                    "training_route": {
+                      "nullable": true
+                    },
+                    "sex": {
+                      "type": "string"
+                    },
+                    "diversity_disclosure": {
+                      "type": "string"
+                    },
+                    "ethnic_group": {
+                      "nullable": true
+                    },
+                    "ethnic_background": {
+                      "nullable": true
+                    },
+                    "additional_ethnic_background": {
+                      "nullable": true
+                    },
+                    "disability_disclosure": {
+                      "nullable": true
+                    },
+                    "course_subject_one": {
+                      "nullable": true
+                    },
+                    "itt_start_date": {
+                      "nullable": true
+                    },
+                    "outcome_date": {
+                      "nullable": true
+                    },
+                    "itt_end_date": {
+                      "nullable": true
+                    },
+                    "trn": {
+                      "nullable": true
+                    },
+                    "submitted_for_trn_at": {
+                      "nullable": true
+                    },
+                    "withdraw_date": {
+                      "nullable": true
+                    },
+                    "withdraw_reasons_details": {
+                      "nullable": true
+                    },
+                    "defer_date": {
+                      "nullable": true
+                    },
+                    "recommended_for_award_at": {
+                      "nullable": true
+                    },
+                    "trainee_start_date": {
+                      "nullable": true
+                    },
+                    "reinstate_date": {
+                      "nullable": true
+                    },
+                    "course_min_age": {
+                      "nullable": true
+                    },
+                    "course_max_age": {
+                      "nullable": true
+                    },
+                    "course_subject_two": {
+                      "nullable": true
+                    },
+                    "course_subject_three": {
+                      "nullable": true
+                    },
+                    "awarded_at": {
+                      "nullable": true
+                    },
+                    "applying_for_bursary": {
+                      "nullable": true
+                    },
+                    "training_initiative": {
+                      "nullable": true
+                    },
+                    "bursary_tier": {
+                      "nullable": true
+                    },
+                    "study_mode": {
+                      "type": "string"
+                    },
+                    "ebacc": {
+                      "type": "boolean"
+                    },
+                    "region": {
+                      "nullable": true
+                    },
+                    "course_education_phase": {
+                      "nullable": true
+                    },
+                    "applying_for_scholarship": {
+                      "nullable": true
+                    },
+                    "applying_for_grant": {
+                      "nullable": true
+                    },
+                    "course_uuid": {
+                      "nullable": true
+                    },
+                    "lead_school_not_applicable": {
+                      "type": "boolean"
+                    },
+                    "employing_school_not_applicable": {
+                      "type": "boolean"
+                    },
+                    "submission_ready": {
+                      "type": "boolean"
+                    },
+                    "commencement_status": {
+                      "nullable": true
+                    },
+                    "discarded_at": {
+                      "nullable": true
+                    },
+                    "created_from_dttp": {
+                      "type": "boolean"
+                    },
+                    "hesa_id": {
+                      "nullable": true
+                    },
+                    "additional_dttp_data": {
+                      "nullable": true
+                    },
+                    "created_from_hesa": {
+                      "type": "boolean"
+                    },
+                    "hesa_updated_at": {
+                      "nullable": true
+                    },
+                    "record_source": {
+                      "nullable": true
+                    },
+                    "iqts_country": {
+                      "nullable": true
+                    },
+                    "hesa_editable": {
+                      "type": "boolean"
+                    },
+                    "withdraw_reasons_dfe_details": {
+                      "nullable": true
+                    },
+                    "slug_sent_to_dqt_at": {
+                      "nullable": true
+                    },
+                    "placement_detail": {
+                      "nullable": true
+                    },
+                    "provider_trainee_id": {
+                      "type": "string"
+                    },
+                    "ukprn": {
+                      "type": "string"
+                    },
+                    "ethnicity": {
+                      "nullable": true
+                    },
+                    "disability1": {
+                      "type": "string"
+                    },
+                    "course_qualification": {
+                      "type": "string"
+                    },
+                    "course_title": {
+                      "nullable": true
+                    },
+                    "course_level": {
+                      "type": "string"
+                    },
+                    "course_itt_start_date": {
+                      "nullable": true
+                    },
+                    "course_age_range": {
+                      "nullable": true
+                    },
+                    "expected_end_date": {
+                      "nullable": true
+                    },
+                    "employing_school_urn": {
+                      "nullable": true
+                    },
+                    "lead_partner_urn_ukprn": {
+                      "nullable": true
+                    },
+                    "lead_school_urn": {
+                      "nullable": true
+                    },
+                    "fund_code": {
+                      "type": "string"
+                    },
+                    "bursary_level": {
+                      "type": "string"
+                    },
+                    "course_study_mode": {
+                      "nullable": true
+                    },
+                    "course_year": {
+                      "nullable": true
+                    },
+                    "funding_method": {
+                      "nullable": true
+                    },
+                    "itt_aim": {
+                      "nullable": true
+                    },
+                    "ni_number": {
+                      "nullable": true
+                    },
+                    "postgrad_apprenticeship_start_date": {
+                      "nullable": true
+                    },
+                    "previous_last_name": {
+                      "nullable": true
+                    },
+                    "hesa_disabilities": {
+                      "nullable": true
+                    },
+                    "additional_training_initiative": {
+                      "nullable": true
+                    },
+                    "nationality": {
+                      "nullable": true
+                    },
+                    "placements": {
+                      "type": "array",
+                      "items": {
+                      }
+                    },
+                    "degrees": {
+                      "type": "array",
+                      "items": {
+                      }
+                    },
+                    "state": {
+                      "type": "string"
+                    },
+                    "trainee_id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "first_names",
+                    "last_name",
+                    "date_of_birth",
+                    "created_at",
+                    "updated_at",
+                    "email",
+                    "middle_names",
+                    "training_route",
+                    "sex",
+                    "diversity_disclosure",
+                    "ethnic_group",
+                    "ethnic_background",
+                    "additional_ethnic_background",
+                    "disability_disclosure",
+                    "course_subject_one",
+                    "itt_start_date",
+                    "outcome_date",
+                    "itt_end_date",
+                    "trn",
+                    "submitted_for_trn_at",
+                    "withdraw_date",
+                    "withdraw_reasons_details",
+                    "defer_date",
+                    "recommended_for_award_at",
+                    "trainee_start_date",
+                    "reinstate_date",
+                    "course_min_age",
+                    "course_max_age",
+                    "course_subject_two",
+                    "course_subject_three",
+                    "awarded_at",
+                    "applying_for_bursary",
+                    "training_initiative",
+                    "bursary_tier",
+                    "study_mode",
+                    "ebacc",
+                    "region",
+                    "course_education_phase",
+                    "applying_for_scholarship",
+                    "applying_for_grant",
+                    "course_uuid",
+                    "lead_school_not_applicable",
+                    "employing_school_not_applicable",
+                    "submission_ready",
+                    "commencement_status",
+                    "discarded_at",
+                    "created_from_dttp",
+                    "hesa_id",
+                    "additional_dttp_data",
+                    "created_from_hesa",
+                    "hesa_updated_at",
+                    "record_source",
+                    "iqts_country",
+                    "hesa_editable",
+                    "withdraw_reasons_dfe_details",
+                    "slug_sent_to_dqt_at",
+                    "placement_detail",
+                    "provider_trainee_id",
+                    "ukprn",
+                    "ethnicity",
+                    "disability1",
+                    "course_qualification",
+                    "course_title",
+                    "course_level",
+                    "course_itt_start_date",
+                    "course_age_range",
+                    "expected_end_date",
+                    "employing_school_urn",
+                    "lead_partner_urn_ukprn",
+                    "lead_school_urn",
+                    "fund_code",
+                    "bursary_level",
+                    "course_study_mode",
+                    "course_year",
+                    "funding_method",
+                    "itt_aim",
+                    "ni_number",
+                    "postgrad_apprenticeship_start_date",
+                    "previous_last_name",
+                    "hesa_disabilities",
+                    "additional_training_initiative",
+                    "nationality",
+                    "placements",
+                    "degrees",
+                    "state",
+                    "trainee_id"
+                  ]
+                },
+                "example": {
+                  "first_names": "Cortez",
+                  "last_name": "O'Conner",
+                  "date_of_birth": "1964-07-28",
+                  "created_at": "2024-04-17T13:39:02.967Z",
+                  "updated_at": "2024-04-17T13:39:02.967Z",
+                  "email": "Cortez.O'Conner@example.com",
+                  "middle_names": "Torp",
+                  "training_route": null,
+                  "sex": "99",
+                  "diversity_disclosure": "diversity_not_disclosed",
+                  "ethnic_group": null,
+                  "ethnic_background": null,
+                  "additional_ethnic_background": null,
+                  "disability_disclosure": null,
+                  "course_subject_one": null,
+                  "itt_start_date": null,
+                  "outcome_date": null,
+                  "itt_end_date": null,
+                  "trn": null,
+                  "submitted_for_trn_at": null,
+                  "withdraw_date": null,
+                  "withdraw_reasons_details": null,
+                  "defer_date": null,
+                  "recommended_for_award_at": null,
+                  "trainee_start_date": null,
+                  "reinstate_date": null,
+                  "course_min_age": null,
+                  "course_max_age": null,
+                  "course_subject_two": null,
+                  "course_subject_three": null,
+                  "awarded_at": null,
+                  "applying_for_bursary": null,
+                  "training_initiative": null,
+                  "bursary_tier": null,
+                  "study_mode": "01",
+                  "ebacc": false,
+                  "region": null,
+                  "course_education_phase": null,
+                  "applying_for_scholarship": null,
+                  "applying_for_grant": null,
+                  "course_uuid": null,
+                  "lead_school_not_applicable": false,
+                  "employing_school_not_applicable": false,
+                  "submission_ready": false,
+                  "commencement_status": null,
+                  "discarded_at": null,
+                  "created_from_dttp": false,
+                  "hesa_id": null,
+                  "additional_dttp_data": null,
+                  "created_from_hesa": false,
+                  "hesa_updated_at": null,
+                  "record_source": null,
+                  "iqts_country": null,
+                  "hesa_editable": false,
+                  "withdraw_reasons_dfe_details": null,
+                  "slug_sent_to_dqt_at": null,
+                  "placement_detail": null,
+                  "provider_trainee_id": "23/24-116",
+                  "ukprn": "88254849",
+                  "ethnicity": null,
+                  "disability1": "95",
+                  "course_qualification": "QTS",
+                  "course_title": null,
+                  "course_level": "postgrad",
+                  "course_itt_start_date": null,
+                  "course_age_range": null,
+                  "expected_end_date": null,
+                  "employing_school_urn": null,
+                  "lead_partner_urn_ukprn": null,
+                  "lead_school_urn": null,
+                  "fund_code": "2",
+                  "bursary_level": "7",
+                  "course_study_mode": null,
+                  "course_year": null,
+                  "funding_method": null,
+                  "itt_aim": null,
+                  "ni_number": null,
+                  "postgrad_apprenticeship_start_date": null,
+                  "previous_last_name": null,
+                  "hesa_disabilities": null,
+                  "additional_training_initiative": null,
+                  "nationality": null,
+                  "placements": [
+
+                  ],
+                  "degrees": [
+
+                  ],
+                  "state": "draft",
+                  "trainee_id": "12345"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "returns status 401",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                },
+                "example": {
+                  "error": "Unauthorized"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "returns status code 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Trainee(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "update",
+        "tags": [
+          "Api::Trainee"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "RZe9fiLobbR5fNbNTZ6SLR67"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "returns status 200 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "first_names": {
+                          "type": "string"
+                        },
+                        "last_name": {
+                          "type": "string"
+                        },
+                        "date_of_birth": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "middle_names": {
+                          "type": "string"
+                        },
+                        "training_route": {
+                          "nullable": true
+                        },
+                        "sex": {
+                          "type": "string"
+                        },
+                        "diversity_disclosure": {
+                          "type": "string"
+                        },
+                        "ethnic_group": {
+                          "type": "string"
+                        },
+                        "ethnic_background": {
+                          "type": "string"
+                        },
+                        "additional_ethnic_background": {
+                          "nullable": true
+                        },
+                        "disability_disclosure": {
+                          "type": "string"
+                        },
+                        "course_subject_one": {
+                          "type": "string"
+                        },
+                        "itt_start_date": {
+                          "type": "string"
+                        },
+                        "outcome_date": {
+                          "nullable": true
+                        },
+                        "itt_end_date": {
+                          "type": "string"
+                        },
+                        "trn": {
+                          "nullable": true
+                        },
+                        "submitted_for_trn_at": {
+                          "nullable": true
+                        },
+                        "withdraw_date": {
+                          "nullable": true
+                        },
+                        "withdraw_reasons_details": {
+                          "nullable": true
+                        },
+                        "defer_date": {
+                          "nullable": true
+                        },
+                        "recommended_for_award_at": {
+                          "nullable": true
+                        },
+                        "trainee_start_date": {
+                          "type": "string"
+                        },
+                        "reinstate_date": {
+                          "nullable": true
+                        },
+                        "course_min_age": {
+                          "type": "integer"
+                        },
+                        "course_max_age": {
+                          "type": "integer"
+                        },
+                        "course_subject_two": {
+                          "nullable": true
+                        },
+                        "course_subject_three": {
+                          "nullable": true
+                        },
+                        "awarded_at": {
+                          "nullable": true
+                        },
+                        "applying_for_bursary": {
+                          "type": "boolean"
+                        },
+                        "training_initiative": {
+                          "nullable": true
+                        },
+                        "bursary_tier": {
+                          "nullable": true
+                        },
+                        "study_mode": {
+                          "type": "string"
+                        },
+                        "ebacc": {
+                          "type": "boolean"
+                        },
+                        "region": {
+                          "nullable": true
+                        },
+                        "course_education_phase": {
+                          "type": "string"
+                        },
+                        "applying_for_scholarship": {
+                          "nullable": true
+                        },
+                        "applying_for_grant": {
+                          "nullable": true
+                        },
+                        "course_uuid": {
+                          "nullable": true
+                        },
+                        "lead_school_not_applicable": {
+                          "type": "boolean"
+                        },
+                        "employing_school_not_applicable": {
+                          "type": "boolean"
+                        },
+                        "submission_ready": {
+                          "type": "boolean"
+                        },
+                        "commencement_status": {
+                          "nullable": true
+                        },
+                        "discarded_at": {
+                          "nullable": true
+                        },
+                        "created_from_dttp": {
+                          "type": "boolean"
+                        },
+                        "hesa_id": {
+                          "nullable": true
+                        },
+                        "additional_dttp_data": {
+                          "nullable": true
+                        },
+                        "created_from_hesa": {
+                          "type": "boolean"
+                        },
+                        "hesa_updated_at": {
+                          "nullable": true
+                        },
+                        "record_source": {
+                          "type": "string"
+                        },
+                        "iqts_country": {
+                          "nullable": true
+                        },
+                        "hesa_editable": {
+                          "type": "boolean"
+                        },
+                        "withdraw_reasons_dfe_details": {
+                          "nullable": true
+                        },
+                        "slug_sent_to_dqt_at": {
+                          "nullable": true
+                        },
+                        "placement_detail": {
+                          "nullable": true
+                        },
+                        "provider_trainee_id": {
+                          "type": "string"
+                        },
+                        "ukprn": {
+                          "type": "string"
+                        },
+                        "ethnicity": {
+                          "type": "string"
+                        },
+                        "disability1": {
+                          "type": "string"
+                        },
+                        "course_qualification": {
+                          "type": "string"
+                        },
+                        "course_title": {
+                          "nullable": true
+                        },
+                        "course_level": {
+                          "type": "string"
+                        },
+                        "course_itt_start_date": {
+                          "type": "string"
+                        },
+                        "course_age_range": {
+                          "nullable": true
+                        },
+                        "expected_end_date": {
+                          "type": "string"
+                        },
+                        "employing_school_urn": {
+                          "nullable": true
+                        },
+                        "lead_partner_urn_ukprn": {
+                          "nullable": true
+                        },
+                        "lead_school_urn": {
+                          "nullable": true
+                        },
+                        "fund_code": {
+                          "type": "string"
+                        },
+                        "bursary_level": {
+                          "type": "string"
+                        },
+                        "course_study_mode": {
+                          "nullable": true
+                        },
+                        "course_year": {
+                          "nullable": true
+                        },
+                        "funding_method": {
+                          "nullable": true
+                        },
+                        "itt_aim": {
+                          "nullable": true
+                        },
+                        "ni_number": {
+                          "nullable": true
+                        },
+                        "postgrad_apprenticeship_start_date": {
+                          "nullable": true
+                        },
+                        "previous_last_name": {
+                          "nullable": true
+                        },
+                        "hesa_disabilities": {
+                          "nullable": true
+                        },
+                        "additional_training_initiative": {
+                          "nullable": true
+                        },
+                        "nationality": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "placements": {
+                          "type": "array",
+                          "items": {
+                          }
+                        },
+                        "degrees": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "uk_degree": {
+                                "type": "string"
+                              },
+                              "non_uk_degree": {
+                                "nullable": true
+                              },
+                              "created_at": {
+                                "type": "string"
+                              },
+                              "updated_at": {
+                                "type": "string"
+                              },
+                              "subject": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "institution": {
+                                "type": "string"
+                              },
+                              "graduation_year": {
+                                "type": "integer"
+                              },
+                              "grade": {
+                                "type": "string"
+                              },
+                              "country": {
+                                "nullable": true
+                              },
+                              "other_grade": {
+                                "nullable": true
+                              },
+                              "institution_uuid": {
+                                "type": "string"
+                              },
+                              "uk_degree_uuid": {
+                                "type": "string"
+                              },
+                              "subject_uuid": {
+                                "type": "string"
+                              },
+                              "grade_uuid": {
+                                "type": "string"
+                              },
+                              "degree_id": {
+                                "type": "string"
+                              },
+                              "degree_type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "uk_degree",
+                              "non_uk_degree",
+                              "created_at",
+                              "updated_at",
+                              "subject",
+                              "institution",
+                              "graduation_year",
+                              "grade",
+                              "country",
+                              "other_grade",
+                              "institution_uuid",
+                              "uk_degree_uuid",
+                              "subject_uuid",
+                              "grade_uuid",
+                              "degree_id",
+                              "degree_type"
+                            ]
+                          }
+                        },
+                        "state": {
+                          "type": "string"
+                        },
+                        "trainee_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first_names",
+                        "last_name",
+                        "date_of_birth",
+                        "created_at",
+                        "updated_at",
+                        "email",
+                        "middle_names",
+                        "training_route",
+                        "sex",
+                        "diversity_disclosure",
+                        "ethnic_group",
+                        "ethnic_background",
+                        "additional_ethnic_background",
+                        "disability_disclosure",
+                        "course_subject_one",
+                        "itt_start_date",
+                        "outcome_date",
+                        "itt_end_date",
+                        "trn",
+                        "submitted_for_trn_at",
+                        "withdraw_date",
+                        "withdraw_reasons_details",
+                        "defer_date",
+                        "recommended_for_award_at",
+                        "trainee_start_date",
+                        "reinstate_date",
+                        "course_min_age",
+                        "course_max_age",
+                        "course_subject_two",
+                        "course_subject_three",
+                        "awarded_at",
+                        "applying_for_bursary",
+                        "training_initiative",
+                        "bursary_tier",
+                        "study_mode",
+                        "ebacc",
+                        "region",
+                        "course_education_phase",
+                        "applying_for_scholarship",
+                        "applying_for_grant",
+                        "course_uuid",
+                        "lead_school_not_applicable",
+                        "employing_school_not_applicable",
+                        "submission_ready",
+                        "commencement_status",
+                        "discarded_at",
+                        "created_from_dttp",
+                        "hesa_id",
+                        "additional_dttp_data",
+                        "created_from_hesa",
+                        "hesa_updated_at",
+                        "record_source",
+                        "iqts_country",
+                        "hesa_editable",
+                        "withdraw_reasons_dfe_details",
+                        "slug_sent_to_dqt_at",
+                        "placement_detail",
+                        "provider_trainee_id",
+                        "ukprn",
+                        "ethnicity",
+                        "disability1",
+                        "course_qualification",
+                        "course_title",
+                        "course_level",
+                        "course_itt_start_date",
+                        "course_age_range",
+                        "expected_end_date",
+                        "employing_school_urn",
+                        "lead_partner_urn_ukprn",
+                        "lead_school_urn",
+                        "fund_code",
+                        "bursary_level",
+                        "course_study_mode",
+                        "course_year",
+                        "funding_method",
+                        "itt_aim",
+                        "ni_number",
+                        "postgrad_apprenticeship_start_date",
+                        "previous_last_name",
+                        "hesa_disabilities",
+                        "additional_training_initiative",
+                        "nationality",
+                        "placements",
+                        "degrees",
+                        "state",
+                        "trainee_id"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "first_names": "Alice",
+                    "last_name": "Rowe",
+                    "date_of_birth": "1999-06-10",
+                    "created_at": "2024-04-17T13:38:58.506Z",
+                    "updated_at": "2024-04-17T13:38:58.591Z",
+                    "email": "Bob.Rowe@example.com",
+                    "middle_names": "Lubowitz",
+                    "training_route": null,
+                    "sex": "99",
+                    "diversity_disclosure": "diversity_not_disclosed",
+                    "ethnic_group": "not_provided_ethnic_group",
+                    "ethnic_background": "Not provided",
+                    "additional_ethnic_background": null,
+                    "disability_disclosure": "disability_not_provided",
+                    "course_subject_one": "100403",
+                    "itt_start_date": "2023-08-01",
+                    "outcome_date": null,
+                    "itt_end_date": "2025-07-10",
+                    "trn": null,
+                    "submitted_for_trn_at": null,
+                    "withdraw_date": null,
+                    "withdraw_reasons_details": null,
+                    "defer_date": null,
+                    "recommended_for_award_at": null,
+                    "trainee_start_date": "2023-08-14",
+                    "reinstate_date": null,
+                    "course_min_age": 11,
+                    "course_max_age": 16,
+                    "course_subject_two": null,
+                    "course_subject_three": null,
+                    "awarded_at": null,
+                    "applying_for_bursary": false,
+                    "training_initiative": null,
+                    "bursary_tier": null,
+                    "study_mode": "01",
+                    "ebacc": false,
+                    "region": null,
+                    "course_education_phase": "secondary",
+                    "applying_for_scholarship": null,
+                    "applying_for_grant": null,
+                    "course_uuid": null,
+                    "lead_school_not_applicable": false,
+                    "employing_school_not_applicable": false,
+                    "submission_ready": false,
+                    "commencement_status": null,
+                    "discarded_at": null,
+                    "created_from_dttp": false,
+                    "hesa_id": null,
+                    "additional_dttp_data": null,
+                    "created_from_hesa": false,
+                    "hesa_updated_at": null,
+                    "record_source": "api",
+                    "iqts_country": null,
+                    "hesa_editable": false,
+                    "withdraw_reasons_dfe_details": null,
+                    "slug_sent_to_dqt_at": null,
+                    "placement_detail": null,
+                    "provider_trainee_id": "23/24-24",
+                    "ukprn": "60375902",
+                    "ethnicity": "997",
+                    "disability1": "95",
+                    "course_qualification": "QTS",
+                    "course_title": null,
+                    "course_level": "postgrad",
+                    "course_itt_start_date": "2023-08-01",
+                    "course_age_range": null,
+                    "expected_end_date": "2025-07-10",
+                    "employing_school_urn": null,
+                    "lead_partner_urn_ukprn": null,
+                    "lead_school_urn": null,
+                    "fund_code": "7",
+                    "bursary_level": "E",
+                    "course_study_mode": null,
+                    "course_year": null,
+                    "funding_method": null,
+                    "itt_aim": null,
+                    "ni_number": null,
+                    "postgrad_apprenticeship_start_date": null,
+                    "previous_last_name": null,
+                    "hesa_disabilities": null,
+                    "additional_training_initiative": null,
+                    "nationality": null,
+                    "placements": [
+
+                    ],
+                    "degrees": [
+                      {
+                        "uk_degree": "Master of Social Studies",
+                        "non_uk_degree": null,
+                        "created_at": "2024-04-17T13:38:58.509Z",
+                        "updated_at": "2024-04-17T13:38:58.509Z",
+                        "subject": "100425",
+                        "institution": "0037",
+                        "graduation_year": 2015,
+                        "grade": "01",
+                        "country": null,
+                        "other_grade": null,
+                        "institution_uuid": "c10b1d33-3fa2-e811-812b-5065f38ba241",
+                        "uk_degree_uuid": "4f6a5652-c197-e711-80d8-005056ac45bb",
+                        "subject_uuid": "918170f0-5dce-e911-a985-000d3ab79618",
+                        "grade_uuid": "8741765a-13d8-4550-a413-c5a860a59d25",
+                        "degree_id": "QByMJBHKsE4aX52jLhKhbQmE",
+                        "degree_type": "210"
+                      }
+                    ],
+                    "state": "draft",
+                    "trainee_id": "RZe9fiLobbR5fNbNTZ6SLR67"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "returns status 401 unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                },
+                "example": {
+                  "error": "Unauthorized"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "returns status 404 if the trainee does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Trainee(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "returns status 422 if the request body is invalid (not a serialised trainee)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "properties": {
+                        "personal_details": {
+                          "type": "object",
+                          "properties": {
+                            "first_names": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": [
+                            "first_names"
+                          ]
+                        },
+                        "contact_details": {
+                          "type": "object",
+                          "properties": {
+                            "email": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": [
+                            "email"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "personal_details",
+                        "contact_details"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    "Param is missing or the value is empty: data"
+                  ],
+                  "message": "Validation failed: 2 errors prohibited this trainee from being saved"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "first_names": {
+                        "type": "string"
+                      },
+                      "nationality": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              },
+              "example": {
+                "data": {
+                  "first_names": "Alice",
+                  "nationality": "IE"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{api_version}/trainees/{trainee_slug}/degrees": {
+      "get": {
+        "summary": "index",
+        "tags": [
+          "Api::Trainees::Degree"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "aYXTBKf5HRfzyen898Rj7eZm"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "returns status 200 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uk_degree": {
+                            "type": "string"
+                          },
+                          "non_uk_degree": {
+                            "nullable": true
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          },
+                          "subject": {
+                            "type": "string"
+                          },
+                          "institution": {
+                            "type": "string"
+                          },
+                          "graduation_year": {
+                            "type": "integer"
+                          },
+                          "grade": {
+                            "type": "string"
+                          },
+                          "country": {
+                            "nullable": true
+                          },
+                          "other_grade": {
+                            "nullable": true
+                          },
+                          "institution_uuid": {
+                            "type": "string"
+                          },
+                          "uk_degree_uuid": {
+                            "type": "string"
+                          },
+                          "subject_uuid": {
+                            "type": "string"
+                          },
+                          "grade_uuid": {
+                            "type": "string"
+                          },
+                          "degree_id": {
+                            "type": "string"
+                          },
+                          "degree_type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "uk_degree",
+                          "non_uk_degree",
+                          "created_at",
+                          "updated_at",
+                          "subject",
+                          "institution",
+                          "graduation_year",
+                          "grade",
+                          "country",
+                          "other_grade",
+                          "institution_uuid",
+                          "uk_degree_uuid",
+                          "subject_uuid",
+                          "grade_uuid",
+                          "degree_id",
+                          "degree_type"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": [
+
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "create",
+        "tags": [
+          "Api::Trainees::Degree"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "g7HYZ8TQFoMx4JqdHLjEKzNE"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "creates a new degree and returns a 201 (created) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "uk_degree": {
+                          "type": "string"
+                        },
+                        "non_uk_degree": {
+                          "nullable": true
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        },
+                        "subject": {
+                          "type": "string"
+                        },
+                        "institution": {
+                          "type": "string"
+                        },
+                        "graduation_year": {
+                          "type": "integer"
+                        },
+                        "grade": {
+                          "nullable": true
+                        },
+                        "country": {
+                          "nullable": true
+                        },
+                        "other_grade": {
+                          "nullable": true
+                        },
+                        "institution_uuid": {
+                          "nullable": true
+                        },
+                        "uk_degree_uuid": {
+                          "nullable": true
+                        },
+                        "subject_uuid": {
+                          "nullable": true
+                        },
+                        "grade_uuid": {
+                          "nullable": true
+                        },
+                        "degree_id": {
+                          "type": "string"
+                        },
+                        "degree_type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "uk_degree",
+                        "non_uk_degree",
+                        "created_at",
+                        "updated_at",
+                        "subject",
+                        "institution",
+                        "graduation_year",
+                        "grade",
+                        "country",
+                        "other_grade",
+                        "institution_uuid",
+                        "uk_degree_uuid",
+                        "subject_uuid",
+                        "grade_uuid",
+                        "degree_id",
+                        "degree_type"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "uk_degree": "Bachelor of Arts",
+                    "non_uk_degree": null,
+                    "created_at": "2024-04-17T13:39:01.727Z",
+                    "updated_at": "2024-04-17T13:39:01.727Z",
+                    "subject": "100970",
+                    "institution": "0156",
+                    "graduation_year": 2012,
+                    "grade": null,
+                    "country": null,
+                    "other_grade": null,
+                    "institution_uuid": null,
+                    "uk_degree_uuid": null,
+                    "subject_uuid": null,
+                    "grade_uuid": null,
+                    "degree_id": "DZFe39zaHmBszLHrMfKon2ti",
+                    "degree_type": "051"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "does not create a new degree and returns a 404 status (not_found) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Trainee(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "returns a 409 (conflict) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "Conflict",
+                      "message": "This is a duplicate degree"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "does not create a new degree and returns a 422 status (unprocessable_entity) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "UnprocessableEntity",
+                      "message": "Subject is not included in the list"
+                    },
+                    {
+                      "error": "UnprocessableEntity",
+                      "message": "Uk degree is not included in the list"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "country": {
+                        "type": "string"
+                      },
+                      "grade": {
+                        "type": "string"
+                      },
+                      "subject": {
+                        "type": "string"
+                      },
+                      "institution": {
+                        "type": "string"
+                      },
+                      "uk_degree": {
+                        "type": "string"
+                      },
+                      "graduation_year": {
+                        "type": "string"
+                      },
+                      "locale_code": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "country",
+                      "grade",
+                      "subject",
+                      "institution",
+                      "uk_degree",
+                      "graduation_year",
+                      "locale_code"
+                    ]
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              },
+              "example": {
+                "data": {
+                  "country": "UK",
+                  "grade": "First",
+                  "subject": "Applied linguistics",
+                  "institution": "University of Oxford",
+                  "uk_degree": "Bachelor of Arts",
+                  "graduation_year": "2012",
+                  "locale_code": "uk"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{api_version}/trainees/{trainee_slug}/degrees/{slug}": {
+      "delete": {
+        "summary": "destroy",
+        "tags": [
+          "Api::Trainees::Degree"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "VZNm5h79Y78bMc8nZPqK66ZA"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "u9hV4kCrsx2G22eyH37dw4zu"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "deletes the degree and returns a 200 status (ok)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "first_names": {
+                          "type": "string"
+                        },
+                        "last_name": {
+                          "type": "string"
+                        },
+                        "date_of_birth": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "middle_names": {
+                          "type": "string"
+                        },
+                        "training_route": {
+                          "nullable": true
+                        },
+                        "sex": {
+                          "type": "string"
+                        },
+                        "diversity_disclosure": {
+                          "type": "string"
+                        },
+                        "ethnic_group": {
+                          "nullable": true
+                        },
+                        "ethnic_background": {
+                          "nullable": true
+                        },
+                        "additional_ethnic_background": {
+                          "nullable": true
+                        },
+                        "disability_disclosure": {
+                          "nullable": true
+                        },
+                        "course_subject_one": {
+                          "nullable": true
+                        },
+                        "itt_start_date": {
+                          "nullable": true
+                        },
+                        "outcome_date": {
+                          "nullable": true
+                        },
+                        "itt_end_date": {
+                          "nullable": true
+                        },
+                        "trn": {
+                          "nullable": true
+                        },
+                        "submitted_for_trn_at": {
+                          "nullable": true
+                        },
+                        "withdraw_date": {
+                          "nullable": true
+                        },
+                        "withdraw_reasons_details": {
+                          "nullable": true
+                        },
+                        "defer_date": {
+                          "nullable": true
+                        },
+                        "recommended_for_award_at": {
+                          "nullable": true
+                        },
+                        "trainee_start_date": {
+                          "nullable": true
+                        },
+                        "reinstate_date": {
+                          "nullable": true
+                        },
+                        "course_min_age": {
+                          "nullable": true
+                        },
+                        "course_max_age": {
+                          "nullable": true
+                        },
+                        "course_subject_two": {
+                          "nullable": true
+                        },
+                        "course_subject_three": {
+                          "nullable": true
+                        },
+                        "awarded_at": {
+                          "nullable": true
+                        },
+                        "applying_for_bursary": {
+                          "nullable": true
+                        },
+                        "training_initiative": {
+                          "nullable": true
+                        },
+                        "bursary_tier": {
+                          "nullable": true
+                        },
+                        "study_mode": {
+                          "nullable": true
+                        },
+                        "ebacc": {
+                          "type": "boolean"
+                        },
+                        "region": {
+                          "nullable": true
+                        },
+                        "course_education_phase": {
+                          "nullable": true
+                        },
+                        "applying_for_scholarship": {
+                          "nullable": true
+                        },
+                        "applying_for_grant": {
+                          "nullable": true
+                        },
+                        "course_uuid": {
+                          "nullable": true
+                        },
+                        "lead_school_not_applicable": {
+                          "type": "boolean"
+                        },
+                        "employing_school_not_applicable": {
+                          "type": "boolean"
+                        },
+                        "submission_ready": {
+                          "type": "boolean"
+                        },
+                        "commencement_status": {
+                          "nullable": true
+                        },
+                        "discarded_at": {
+                          "nullable": true
+                        },
+                        "created_from_dttp": {
+                          "type": "boolean"
+                        },
+                        "hesa_id": {
+                          "nullable": true
+                        },
+                        "additional_dttp_data": {
+                          "nullable": true
+                        },
+                        "created_from_hesa": {
+                          "type": "boolean"
+                        },
+                        "hesa_updated_at": {
+                          "nullable": true
+                        },
+                        "record_source": {
+                          "nullable": true
+                        },
+                        "iqts_country": {
+                          "nullable": true
+                        },
+                        "hesa_editable": {
+                          "type": "boolean"
+                        },
+                        "withdraw_reasons_dfe_details": {
+                          "nullable": true
+                        },
+                        "slug_sent_to_dqt_at": {
+                          "nullable": true
+                        },
+                        "placement_detail": {
+                          "nullable": true
+                        },
+                        "provider_trainee_id": {
+                          "type": "string"
+                        },
+                        "ukprn": {
+                          "type": "string"
+                        },
+                        "ethnicity": {
+                          "nullable": true
+                        },
+                        "course_qualification": {
+                          "type": "string"
+                        },
+                        "course_title": {
+                          "nullable": true
+                        },
+                        "course_level": {
+                          "type": "string"
+                        },
+                        "course_itt_start_date": {
+                          "nullable": true
+                        },
+                        "course_age_range": {
+                          "nullable": true
+                        },
+                        "expected_end_date": {
+                          "nullable": true
+                        },
+                        "employing_school_urn": {
+                          "nullable": true
+                        },
+                        "lead_partner_urn_ukprn": {
+                          "nullable": true
+                        },
+                        "lead_school_urn": {
+                          "nullable": true
+                        },
+                        "fund_code": {
+                          "nullable": true
+                        },
+                        "bursary_level": {
+                          "nullable": true
+                        },
+                        "course_study_mode": {
+                          "nullable": true
+                        },
+                        "course_year": {
+                          "nullable": true
+                        },
+                        "funding_method": {
+                          "nullable": true
+                        },
+                        "itt_aim": {
+                          "nullable": true
+                        },
+                        "ni_number": {
+                          "nullable": true
+                        },
+                        "postgrad_apprenticeship_start_date": {
+                          "nullable": true
+                        },
+                        "previous_last_name": {
+                          "nullable": true
+                        },
+                        "hesa_disabilities": {
+                          "nullable": true
+                        },
+                        "additional_training_initiative": {
+                          "nullable": true
+                        },
+                        "nationality": {
+                          "nullable": true
+                        },
+                        "placements": {
+                          "type": "array",
+                          "items": {
+                          }
+                        },
+                        "degrees": {
+                          "type": "array",
+                          "items": {
+                          }
+                        },
+                        "state": {
+                          "type": "string"
+                        },
+                        "trainee_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first_names",
+                        "last_name",
+                        "date_of_birth",
+                        "created_at",
+                        "updated_at",
+                        "email",
+                        "middle_names",
+                        "training_route",
+                        "sex",
+                        "diversity_disclosure",
+                        "ethnic_group",
+                        "ethnic_background",
+                        "additional_ethnic_background",
+                        "disability_disclosure",
+                        "course_subject_one",
+                        "itt_start_date",
+                        "outcome_date",
+                        "itt_end_date",
+                        "trn",
+                        "submitted_for_trn_at",
+                        "withdraw_date",
+                        "withdraw_reasons_details",
+                        "defer_date",
+                        "recommended_for_award_at",
+                        "trainee_start_date",
+                        "reinstate_date",
+                        "course_min_age",
+                        "course_max_age",
+                        "course_subject_two",
+                        "course_subject_three",
+                        "awarded_at",
+                        "applying_for_bursary",
+                        "training_initiative",
+                        "bursary_tier",
+                        "study_mode",
+                        "ebacc",
+                        "region",
+                        "course_education_phase",
+                        "applying_for_scholarship",
+                        "applying_for_grant",
+                        "course_uuid",
+                        "lead_school_not_applicable",
+                        "employing_school_not_applicable",
+                        "submission_ready",
+                        "commencement_status",
+                        "discarded_at",
+                        "created_from_dttp",
+                        "hesa_id",
+                        "additional_dttp_data",
+                        "created_from_hesa",
+                        "hesa_updated_at",
+                        "record_source",
+                        "iqts_country",
+                        "hesa_editable",
+                        "withdraw_reasons_dfe_details",
+                        "slug_sent_to_dqt_at",
+                        "placement_detail",
+                        "provider_trainee_id",
+                        "ukprn",
+                        "ethnicity",
+                        "course_qualification",
+                        "course_title",
+                        "course_level",
+                        "course_itt_start_date",
+                        "course_age_range",
+                        "expected_end_date",
+                        "employing_school_urn",
+                        "lead_partner_urn_ukprn",
+                        "lead_school_urn",
+                        "fund_code",
+                        "bursary_level",
+                        "course_study_mode",
+                        "course_year",
+                        "funding_method",
+                        "itt_aim",
+                        "ni_number",
+                        "postgrad_apprenticeship_start_date",
+                        "previous_last_name",
+                        "hesa_disabilities",
+                        "additional_training_initiative",
+                        "nationality",
+                        "placements",
+                        "degrees",
+                        "state",
+                        "trainee_id"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "first_names": "Demetra",
+                    "last_name": "Cruickshank",
+                    "date_of_birth": "1966-02-22",
+                    "created_at": "2024-04-17T13:39:18.546Z",
+                    "updated_at": "2024-04-17T13:39:18.596Z",
+                    "email": "Demetra.Cruickshank@example.com",
+                    "middle_names": "Tromp",
+                    "training_route": null,
+                    "sex": "99",
+                    "diversity_disclosure": "diversity_not_disclosed",
+                    "ethnic_group": null,
+                    "ethnic_background": null,
+                    "additional_ethnic_background": null,
+                    "disability_disclosure": null,
+                    "course_subject_one": null,
+                    "itt_start_date": null,
+                    "outcome_date": null,
+                    "itt_end_date": null,
+                    "trn": null,
+                    "submitted_for_trn_at": null,
+                    "withdraw_date": null,
+                    "withdraw_reasons_details": null,
+                    "defer_date": null,
+                    "recommended_for_award_at": null,
+                    "trainee_start_date": null,
+                    "reinstate_date": null,
+                    "course_min_age": null,
+                    "course_max_age": null,
+                    "course_subject_two": null,
+                    "course_subject_three": null,
+                    "awarded_at": null,
+                    "applying_for_bursary": null,
+                    "training_initiative": null,
+                    "bursary_tier": null,
+                    "study_mode": null,
+                    "ebacc": false,
+                    "region": null,
+                    "course_education_phase": null,
+                    "applying_for_scholarship": null,
+                    "applying_for_grant": null,
+                    "course_uuid": null,
+                    "lead_school_not_applicable": false,
+                    "employing_school_not_applicable": false,
+                    "submission_ready": false,
+                    "commencement_status": null,
+                    "discarded_at": null,
+                    "created_from_dttp": false,
+                    "hesa_id": null,
+                    "additional_dttp_data": null,
+                    "created_from_hesa": false,
+                    "hesa_updated_at": null,
+                    "record_source": null,
+                    "iqts_country": null,
+                    "hesa_editable": false,
+                    "withdraw_reasons_dfe_details": null,
+                    "slug_sent_to_dqt_at": null,
+                    "placement_detail": null,
+                    "provider_trainee_id": "23/24-697",
+                    "ukprn": "63370211",
+                    "ethnicity": null,
+                    "course_qualification": "QTS",
+                    "course_title": null,
+                    "course_level": "postgrad",
+                    "course_itt_start_date": null,
+                    "course_age_range": null,
+                    "expected_end_date": null,
+                    "employing_school_urn": null,
+                    "lead_partner_urn_ukprn": null,
+                    "lead_school_urn": null,
+                    "fund_code": null,
+                    "bursary_level": null,
+                    "course_study_mode": null,
+                    "course_year": null,
+                    "funding_method": null,
+                    "itt_aim": null,
+                    "ni_number": null,
+                    "postgrad_apprenticeship_start_date": null,
+                    "previous_last_name": null,
+                    "hesa_disabilities": null,
+                    "additional_training_initiative": null,
+                    "nationality": null,
+                    "placements": [
+
+                    ],
+                    "degrees": [
+
+                    ],
+                    "state": "draft",
+                    "trainee_id": "oTq4Zzrth36FS35nF9FNfe6N"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "does not delete the degree and returns a 404 status (not_found)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Trainee(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                }
+              },
+              "example": {
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "show",
+        "tags": [
+          "Api::Trainees::Degree"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "H9AXJ1G2s6ftaXw6WeEbUqVY"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "R6qX32av8UMPW4UMppR2PKNZ"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "returns status 200 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "uk_degree": {
+                          "type": "string"
+                        },
+                        "non_uk_degree": {
+                          "nullable": true
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        },
+                        "subject": {
+                          "type": "string"
+                        },
+                        "institution": {
+                          "type": "string"
+                        },
+                        "graduation_year": {
+                          "type": "integer"
+                        },
+                        "grade": {
+                          "type": "string"
+                        },
+                        "country": {
+                          "nullable": true
+                        },
+                        "other_grade": {
+                          "nullable": true
+                        },
+                        "institution_uuid": {
+                          "type": "string"
+                        },
+                        "uk_degree_uuid": {
+                          "type": "string"
+                        },
+                        "subject_uuid": {
+                          "type": "string"
+                        },
+                        "grade_uuid": {
+                          "type": "string"
+                        },
+                        "degree_id": {
+                          "type": "string"
+                        },
+                        "degree_type": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "uk_degree",
+                        "non_uk_degree",
+                        "created_at",
+                        "updated_at",
+                        "subject",
+                        "institution",
+                        "graduation_year",
+                        "grade",
+                        "country",
+                        "other_grade",
+                        "institution_uuid",
+                        "uk_degree_uuid",
+                        "subject_uuid",
+                        "grade_uuid",
+                        "degree_id",
+                        "degree_type"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "uk_degree": "Bachelor of Science Economics",
+                    "non_uk_degree": null,
+                    "created_at": "2024-04-17T13:39:01.336Z",
+                    "updated_at": "2024-04-17T13:39:01.336Z",
+                    "subject": "101354",
+                    "institution": "0412",
+                    "graduation_year": 1988,
+                    "grade": "03",
+                    "country": null,
+                    "other_grade": null,
+                    "institution_uuid": "f23e182c-1425-ec11-b6e6-000d3adf095a",
+                    "uk_degree_uuid": "1d6a5652-c197-e711-80d8-005056ac45bb",
+                    "subject_uuid": "918670f0-5dce-e911-a985-000d3ab79618",
+                    "grade_uuid": "377a46ea-d6c6-4e87-9728-c1f0dd0ef109",
+                    "degree_id": "H9AXJ1G2s6ftaXw6WeEbUqVY",
+                    "degree_type": "084"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "returns status 404 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Degree(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "update",
+        "tags": [
+          "Api::Trainees::Degree"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "oCFNH5aFXZ1hxsVM6qm1qnKW"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "bhjzGyg49RgbcvResyKQFzFG"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "subject": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "subject"
+                    ]
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              },
+              "example": {
+                "data": {
+                  "subject": "Accounting"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "updates a new degree and returns a 200 status (ok)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "uk_degree": {
+                          "type": "string"
+                        },
+                        "non_uk_degree": {
+                          "nullable": true
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        },
+                        "subject": {
+                          "type": "string"
+                        },
+                        "institution": {
+                          "type": "string"
+                        },
+                        "graduation_year": {
+                          "type": "integer"
+                        },
+                        "grade": {
+                          "type": "string"
+                        },
+                        "country": {
+                          "nullable": true
+                        },
+                        "other_grade": {
+                          "nullable": true
+                        },
+                        "institution_uuid": {
+                          "type": "string"
+                        },
+                        "uk_degree_uuid": {
+                          "type": "string"
+                        },
+                        "subject_uuid": {
+                          "type": "string"
+                        },
+                        "grade_uuid": {
+                          "type": "string"
+                        },
+                        "degree_id": {
+                          "type": "string"
+                        },
+                        "degree_type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "uk_degree",
+                        "non_uk_degree",
+                        "created_at",
+                        "updated_at",
+                        "subject",
+                        "institution",
+                        "graduation_year",
+                        "grade",
+                        "country",
+                        "other_grade",
+                        "institution_uuid",
+                        "uk_degree_uuid",
+                        "subject_uuid",
+                        "grade_uuid",
+                        "degree_id",
+                        "degree_type"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "uk_degree": "Bachelor of Accountancy",
+                    "non_uk_degree": null,
+                    "created_at": "2024-04-17T13:39:00.322Z",
+                    "updated_at": "2024-04-17T13:39:00.364Z",
+                    "subject": "100105",
+                    "institution": "0124",
+                    "graduation_year": 2013,
+                    "grade": "05",
+                    "country": null,
+                    "other_grade": null,
+                    "institution_uuid": "2271f34a-2887-e711-80d8-005056ac45bb",
+                    "uk_degree_uuid": "e9695652-c197-e711-80d8-005056ac45bb",
+                    "subject_uuid": "917f70f0-5dce-e911-a985-000d3ab79618",
+                    "grade_uuid": "3d57e5f7-7904-4895-a982-ed953fff3f94",
+                    "degree_id": "x2xaMNPM51AUvUDdRDSC2R97",
+                    "degree_type": "058"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "does not update the degree and returns a 404 status (not_found)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Trainee(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "returns a 409 (conflict) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "Conflict",
+                      "message": "This is a duplicate degree"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "does not update the degree and returns a 422 status (unprocessable_entity)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    "Param is missing or the value is empty: data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{api_version}/trainees/{trainee_slug}/placements": {
+      "get": {
+        "summary": "index",
+        "tags": [
+          "Api::Trainees::Placement"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "9bQTimH3o7oUEChLRCHYwSD6"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "returns status 200 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "urn": {
+                            "nullable": true
+                          },
+                          "name": {
+                            "nullable": true
+                          },
+                          "postcode": {
+                            "nullable": true
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          },
+                          "placement_id": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "urn",
+                          "name",
+                          "postcode",
+                          "created_at",
+                          "updated_at",
+                          "placement_id"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": [
+                    {
+                      "urn": null,
+                      "name": null,
+                      "postcode": null,
+                      "created_at": "2024-04-17T13:39:18.217Z",
+                      "updated_at": "2024-04-17T13:39:18.217Z",
+                      "placement_id": "KM8zyRxWfUTCwLT3m6xLxArV"
+                    },
+                    {
+                      "urn": null,
+                      "name": null,
+                      "postcode": null,
+                      "created_at": "2024-04-17T13:39:18.222Z",
+                      "updated_at": "2024-04-17T13:39:18.222Z",
+                      "placement_id": "jGXfMhakm1w7CFvHbkAymrW2"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "create",
+        "tags": [
+          "Api::Trainees::Placement"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "nq2QKzyvvTr364ihnVmcq6Ra"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "address": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "name": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "postcode": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "urn": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "school_id": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    },
+                    "required": [
+                      "address",
+                      "name",
+                      "postcode",
+                      "urn",
+                      "school_id"
+                    ]
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              },
+              "example": {
+                "data": {
+                  "address": null,
+                  "name": null,
+                  "postcode": null,
+                  "urn": null,
+                  "school_id": "19"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "updates the progress attribute on the trainee",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "urn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "name": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "postcode": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        },
+                        "placement_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "urn",
+                        "name",
+                        "postcode",
+                        "created_at",
+                        "updated_at",
+                        "placement_id"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "urn": null,
+                    "name": null,
+                    "postcode": null,
+                    "created_at": "2024-04-17T13:39:02.253Z",
+                    "updated_at": "2024-04-17T13:39:02.253Z",
+                    "placement_id": "HPoMNbZN8rWDbMH1dk54TmC4"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "does not create a new placement and returns a 422 status (unprocessable_entity) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Trainee(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "does not create a new placements and returns a 422 status (unprocessable_entity) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "UnprocessableEntity",
+                      "message": "Name can't be blank"
+                    },
+                    {
+                      "error": "UnprocessableEntity",
+                      "message": "School can't be blank"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{api_version}/trainees/{trainee_slug}/placements/{slug}": {
+      "delete": {
+        "summary": "destroy",
+        "tags": [
+          "Api::Trainees::Placement"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "1zWbcKaLXQpbEzU3HDoomddJ"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "sYHPLttsjYMLtZADUsyW9ZUb"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "returns status 200 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "first_names": {
+                          "type": "string"
+                        },
+                        "last_name": {
+                          "type": "string"
+                        },
+                        "date_of_birth": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "middle_names": {
+                          "type": "string"
+                        },
+                        "training_route": {
+                          "nullable": true
+                        },
+                        "sex": {
+                          "type": "string"
+                        },
+                        "diversity_disclosure": {
+                          "type": "string"
+                        },
+                        "ethnic_group": {
+                          "nullable": true
+                        },
+                        "ethnic_background": {
+                          "nullable": true
+                        },
+                        "additional_ethnic_background": {
+                          "nullable": true
+                        },
+                        "disability_disclosure": {
+                          "nullable": true
+                        },
+                        "course_subject_one": {
+                          "nullable": true
+                        },
+                        "itt_start_date": {
+                          "nullable": true
+                        },
+                        "outcome_date": {
+                          "nullable": true
+                        },
+                        "itt_end_date": {
+                          "nullable": true
+                        },
+                        "trn": {
+                          "nullable": true
+                        },
+                        "submitted_for_trn_at": {
+                          "nullable": true
+                        },
+                        "withdraw_date": {
+                          "nullable": true
+                        },
+                        "withdraw_reasons_details": {
+                          "nullable": true
+                        },
+                        "defer_date": {
+                          "nullable": true
+                        },
+                        "recommended_for_award_at": {
+                          "nullable": true
+                        },
+                        "trainee_start_date": {
+                          "nullable": true
+                        },
+                        "reinstate_date": {
+                          "nullable": true
+                        },
+                        "course_min_age": {
+                          "nullable": true
+                        },
+                        "course_max_age": {
+                          "nullable": true
+                        },
+                        "course_subject_two": {
+                          "nullable": true
+                        },
+                        "course_subject_three": {
+                          "nullable": true
+                        },
+                        "awarded_at": {
+                          "nullable": true
+                        },
+                        "applying_for_bursary": {
+                          "nullable": true
+                        },
+                        "training_initiative": {
+                          "nullable": true
+                        },
+                        "bursary_tier": {
+                          "nullable": true
+                        },
+                        "study_mode": {
+                          "type": "string"
+                        },
+                        "ebacc": {
+                          "type": "boolean"
+                        },
+                        "region": {
+                          "nullable": true
+                        },
+                        "course_education_phase": {
+                          "nullable": true
+                        },
+                        "applying_for_scholarship": {
+                          "nullable": true
+                        },
+                        "applying_for_grant": {
+                          "nullable": true
+                        },
+                        "course_uuid": {
+                          "nullable": true
+                        },
+                        "lead_school_not_applicable": {
+                          "type": "boolean"
+                        },
+                        "employing_school_not_applicable": {
+                          "type": "boolean"
+                        },
+                        "submission_ready": {
+                          "type": "boolean"
+                        },
+                        "commencement_status": {
+                          "nullable": true
+                        },
+                        "discarded_at": {
+                          "nullable": true
+                        },
+                        "created_from_dttp": {
+                          "type": "boolean"
+                        },
+                        "hesa_id": {
+                          "nullable": true
+                        },
+                        "additional_dttp_data": {
+                          "nullable": true
+                        },
+                        "created_from_hesa": {
+                          "type": "boolean"
+                        },
+                        "hesa_updated_at": {
+                          "nullable": true
+                        },
+                        "record_source": {
+                          "nullable": true
+                        },
+                        "iqts_country": {
+                          "nullable": true
+                        },
+                        "hesa_editable": {
+                          "type": "boolean"
+                        },
+                        "withdraw_reasons_dfe_details": {
+                          "nullable": true
+                        },
+                        "slug_sent_to_dqt_at": {
+                          "nullable": true
+                        },
+                        "placement_detail": {
+                          "type": "string"
+                        },
+                        "provider_trainee_id": {
+                          "type": "string"
+                        },
+                        "ukprn": {
+                          "type": "string"
+                        },
+                        "ethnicity": {
+                          "nullable": true
+                        },
+                        "disability1": {
+                          "type": "string"
+                        },
+                        "course_qualification": {
+                          "type": "string"
+                        },
+                        "course_title": {
+                          "nullable": true
+                        },
+                        "course_level": {
+                          "type": "string"
+                        },
+                        "course_itt_start_date": {
+                          "nullable": true
+                        },
+                        "course_age_range": {
+                          "nullable": true
+                        },
+                        "expected_end_date": {
+                          "nullable": true
+                        },
+                        "employing_school_urn": {
+                          "nullable": true
+                        },
+                        "lead_partner_urn_ukprn": {
+                          "nullable": true
+                        },
+                        "lead_school_urn": {
+                          "nullable": true
+                        },
+                        "fund_code": {
+                          "type": "string"
+                        },
+                        "bursary_level": {
+                          "type": "string"
+                        },
+                        "course_study_mode": {
+                          "nullable": true
+                        },
+                        "course_year": {
+                          "nullable": true
+                        },
+                        "funding_method": {
+                          "nullable": true
+                        },
+                        "itt_aim": {
+                          "nullable": true
+                        },
+                        "ni_number": {
+                          "nullable": true
+                        },
+                        "postgrad_apprenticeship_start_date": {
+                          "nullable": true
+                        },
+                        "previous_last_name": {
+                          "nullable": true
+                        },
+                        "hesa_disabilities": {
+                          "nullable": true
+                        },
+                        "additional_training_initiative": {
+                          "nullable": true
+                        },
+                        "nationality": {
+                          "nullable": true
+                        },
+                        "placements": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "urn": {
+                                "nullable": true
+                              },
+                              "name": {
+                                "nullable": true
+                              },
+                              "postcode": {
+                                "nullable": true
+                              },
+                              "created_at": {
+                                "type": "string"
+                              },
+                              "updated_at": {
+                                "type": "string"
+                              },
+                              "placement_id": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "urn",
+                              "name",
+                              "postcode",
+                              "created_at",
+                              "updated_at",
+                              "placement_id"
+                            ]
+                          }
+                        },
+                        "degrees": {
+                          "type": "array",
+                          "items": {
+                          }
+                        },
+                        "state": {
+                          "type": "string"
+                        },
+                        "trainee_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first_names",
+                        "last_name",
+                        "date_of_birth",
+                        "created_at",
+                        "updated_at",
+                        "email",
+                        "middle_names",
+                        "training_route",
+                        "sex",
+                        "diversity_disclosure",
+                        "ethnic_group",
+                        "ethnic_background",
+                        "additional_ethnic_background",
+                        "disability_disclosure",
+                        "course_subject_one",
+                        "itt_start_date",
+                        "outcome_date",
+                        "itt_end_date",
+                        "trn",
+                        "submitted_for_trn_at",
+                        "withdraw_date",
+                        "withdraw_reasons_details",
+                        "defer_date",
+                        "recommended_for_award_at",
+                        "trainee_start_date",
+                        "reinstate_date",
+                        "course_min_age",
+                        "course_max_age",
+                        "course_subject_two",
+                        "course_subject_three",
+                        "awarded_at",
+                        "applying_for_bursary",
+                        "training_initiative",
+                        "bursary_tier",
+                        "study_mode",
+                        "ebacc",
+                        "region",
+                        "course_education_phase",
+                        "applying_for_scholarship",
+                        "applying_for_grant",
+                        "course_uuid",
+                        "lead_school_not_applicable",
+                        "employing_school_not_applicable",
+                        "submission_ready",
+                        "commencement_status",
+                        "discarded_at",
+                        "created_from_dttp",
+                        "hesa_id",
+                        "additional_dttp_data",
+                        "created_from_hesa",
+                        "hesa_updated_at",
+                        "record_source",
+                        "iqts_country",
+                        "hesa_editable",
+                        "withdraw_reasons_dfe_details",
+                        "slug_sent_to_dqt_at",
+                        "placement_detail",
+                        "provider_trainee_id",
+                        "ukprn",
+                        "ethnicity",
+                        "disability1",
+                        "course_qualification",
+                        "course_title",
+                        "course_level",
+                        "course_itt_start_date",
+                        "course_age_range",
+                        "expected_end_date",
+                        "employing_school_urn",
+                        "lead_partner_urn_ukprn",
+                        "lead_school_urn",
+                        "fund_code",
+                        "bursary_level",
+                        "course_study_mode",
+                        "course_year",
+                        "funding_method",
+                        "itt_aim",
+                        "ni_number",
+                        "postgrad_apprenticeship_start_date",
+                        "previous_last_name",
+                        "hesa_disabilities",
+                        "additional_training_initiative",
+                        "nationality",
+                        "placements",
+                        "degrees",
+                        "state",
+                        "trainee_id"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "first_names": "Reyes",
+                    "last_name": "O'Keefe",
+                    "date_of_birth": "1966-07-21",
+                    "created_at": "2024-04-17T13:39:18.479Z",
+                    "updated_at": "2024-04-17T13:39:18.479Z",
+                    "email": "Reyes.O'Keefe@example.com",
+                    "middle_names": "Dickens",
+                    "training_route": null,
+                    "sex": "10",
+                    "diversity_disclosure": "diversity_not_disclosed",
+                    "ethnic_group": null,
+                    "ethnic_background": null,
+                    "additional_ethnic_background": null,
+                    "disability_disclosure": null,
+                    "course_subject_one": null,
+                    "itt_start_date": null,
+                    "outcome_date": null,
+                    "itt_end_date": null,
+                    "trn": null,
+                    "submitted_for_trn_at": null,
+                    "withdraw_date": null,
+                    "withdraw_reasons_details": null,
+                    "defer_date": null,
+                    "recommended_for_award_at": null,
+                    "trainee_start_date": null,
+                    "reinstate_date": null,
+                    "course_min_age": null,
+                    "course_max_age": null,
+                    "course_subject_two": null,
+                    "course_subject_three": null,
+                    "awarded_at": null,
+                    "applying_for_bursary": null,
+                    "training_initiative": null,
+                    "bursary_tier": null,
+                    "study_mode": "01",
+                    "ebacc": false,
+                    "region": null,
+                    "course_education_phase": null,
+                    "applying_for_scholarship": null,
+                    "applying_for_grant": null,
+                    "course_uuid": null,
+                    "lead_school_not_applicable": false,
+                    "employing_school_not_applicable": false,
+                    "submission_ready": false,
+                    "commencement_status": null,
+                    "discarded_at": null,
+                    "created_from_dttp": false,
+                    "hesa_id": null,
+                    "additional_dttp_data": null,
+                    "created_from_hesa": false,
+                    "hesa_updated_at": null,
+                    "record_source": null,
+                    "iqts_country": null,
+                    "hesa_editable": false,
+                    "withdraw_reasons_dfe_details": null,
+                    "slug_sent_to_dqt_at": null,
+                    "placement_detail": "has_placement_detail",
+                    "provider_trainee_id": "23/24-693",
+                    "ukprn": "47239397",
+                    "ethnicity": null,
+                    "disability1": "95",
+                    "course_qualification": "QTS",
+                    "course_title": null,
+                    "course_level": "postgrad",
+                    "course_itt_start_date": null,
+                    "course_age_range": null,
+                    "expected_end_date": null,
+                    "employing_school_urn": null,
+                    "lead_partner_urn_ukprn": null,
+                    "lead_school_urn": null,
+                    "fund_code": "7",
+                    "bursary_level": "E",
+                    "course_study_mode": null,
+                    "course_year": null,
+                    "funding_method": null,
+                    "itt_aim": null,
+                    "ni_number": null,
+                    "postgrad_apprenticeship_start_date": null,
+                    "previous_last_name": null,
+                    "hesa_disabilities": null,
+                    "additional_training_initiative": null,
+                    "nationality": null,
+                    "placements": [
+                      {
+                        "urn": null,
+                        "name": null,
+                        "postcode": null,
+                        "created_at": "2024-04-17T13:39:18.485Z",
+                        "updated_at": "2024-04-17T13:39:18.485Z",
+                        "placement_id": "2QoHaaqh7q1beR316qpCt8aB"
+                      }
+                    ],
+                    "degrees": [
+
+                    ],
+                    "state": "draft",
+                    "trainee_id": "sYHPLttsjYMLtZADUsyW9ZUb"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "returns status 404 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Trainee(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                }
+              },
+              "example": {
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "show",
+        "tags": [
+          "Api::Trainees::Placement"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "non-existant"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "qPv2e2CBSd269nWhcP3nb5RH"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "returns status 200 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "urn": {
+                          "nullable": true
+                        },
+                        "name": {
+                          "nullable": true
+                        },
+                        "postcode": {
+                          "nullable": true
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        },
+                        "placement_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "urn",
+                        "name",
+                        "postcode",
+                        "created_at",
+                        "updated_at",
+                        "placement_id"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "urn": null,
+                    "name": null,
+                    "postcode": null,
+                    "created_at": "2024-04-17T13:39:00.729Z",
+                    "updated_at": "2024-04-17T13:39:00.729Z",
+                    "placement_id": "sMEMMFwCvChaRi5XprVyEphn"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "returns status 404 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Placement(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "update",
+        "tags": [
+          "Api::Trainees::Placement"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "p7VbPfxTRAEiLKLU73E32W9C"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "EHFbKNtAuYuUKsAn1UqwyKpG"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "address": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "name": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "postcode": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "urn": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "school_id": {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    },
+                    "required": [
+                      "postcode"
+                    ]
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              },
+              "example": {
+                "data": {
+                  "address": null,
+                  "name": null,
+                  "postcode": null,
+                  "urn": null,
+                  "school_id": "12"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "updates an existing placement and returns a 200 (ok) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "urn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "name": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "postcode": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        },
+                        "placement_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "urn",
+                        "name",
+                        "postcode",
+                        "created_at",
+                        "updated_at",
+                        "placement_id"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "urn": null,
+                    "name": null,
+                    "postcode": null,
+                    "created_at": "2024-04-17T13:38:59.975Z",
+                    "updated_at": "2024-04-17T13:39:00.051Z",
+                    "placement_id": "p7VbPfxTRAEiLKLU73E32W9C"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "does not create a new placement and returns a 422 status (unprocessable_entity) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Trainee(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "does not create a new placements and returns a 422 status (unprocessable_entity) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "UnprocessableEntity",
+                      "message": "Name can't be blank"
+                    },
+                    {
+                      "error": "UnprocessableEntity",
+                      "message": "School can't be blank"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{api_version}/trainees/{trainee_slug}/withdraw": {
+      "post": {
+        "summary": "create",
+        "tags": [
+          "Api::Trainees::Withdraw"
+        ],
+        "parameters": [
+          {
+            "name": "api_version",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "v0.1"
+          },
+          {
+            "name": "trainee_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "tfJ4A1nujdqwKs5Y62UU9euJ"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reasons": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "withdraw_date": {
+                    "type": "string"
+                  },
+                  "withdraw_reasons_details": {
+                    "type": "string"
+                  },
+                  "withdraw_reasons_dfe_details": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reasons",
+                  "withdraw_date",
+                  "withdraw_reasons_details",
+                  "withdraw_reasons_dfe_details"
+                ]
+              },
+              "example": {
+                "reasons": [
+                  "unknown"
+                ],
+                "withdraw_date": "2024-04-17 13:39:18 UTC",
+                "withdraw_reasons_details": "Men always seem to think about their past before they die, as though they were frantically searching for proof that they truly lived.",
+                "withdraw_reasons_dfe_details": "Why does everything that's good for you have to taste so bad?"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "returns status 200 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "commencement_status": {
+                          "nullable": true
+                        },
+                        "withdraw_date": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "withdraw_reasons_details": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "withdraw_reasons_dfe_details": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        },
+                        "first_names": {
+                          "type": "string"
+                        },
+                        "middle_names": {
+                          "type": "string"
+                        },
+                        "last_name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "ethnic_background": {
+                          "nullable": true
+                        },
+                        "additional_ethnic_background": {
+                          "nullable": true
+                        },
+                        "trn": {
+                          "type": "string"
+                        },
+                        "region": {
+                          "nullable": true
+                        },
+                        "hesa_id": {
+                          "nullable": true
+                        },
+                        "course_subject_one": {
+                          "type": "string"
+                        },
+                        "course_subject_two": {
+                          "nullable": true
+                        },
+                        "course_subject_three": {
+                          "nullable": true
+                        },
+                        "date_of_birth": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "training_route": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "sex": {
+                          "type": "string"
+                        },
+                        "diversity_disclosure": {
+                          "type": "string"
+                        },
+                        "ethnic_group": {
+                          "nullable": true
+                        },
+                        "disability_disclosure": {
+                          "nullable": true
+                        },
+                        "itt_start_date": {
+                          "type": "string"
+                        },
+                        "outcome_date": {
+                          "nullable": true
+                        },
+                        "itt_end_date": {
+                          "type": "string"
+                        },
+                        "submitted_for_trn_at": {
+                          "type": "string"
+                        },
+                        "defer_date": {
+                          "nullable": true
+                        },
+                        "recommended_for_award_at": {
+                          "nullable": true
+                        },
+                        "trainee_start_date": {
+                          "type": "string"
+                        },
+                        "reinstate_date": {
+                          "nullable": true
+                        },
+                        "course_min_age": {
+                          "type": "integer"
+                        },
+                        "course_max_age": {
+                          "type": "integer"
+                        },
+                        "awarded_at": {
+                          "nullable": true
+                        },
+                        "applying_for_bursary": {
+                          "type": "boolean"
+                        },
+                        "training_initiative": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "bursary_tier": {
+                          "nullable": true
+                        },
+                        "study_mode": {
+                          "type": "string"
+                        },
+                        "ebacc": {
+                          "type": "boolean"
+                        },
+                        "course_education_phase": {
+                          "type": "string"
+                        },
+                        "applying_for_scholarship": {
+                          "type": "boolean"
+                        },
+                        "applying_for_grant": {
+                          "type": "boolean"
+                        },
+                        "course_uuid": {
+                          "nullable": true
+                        },
+                        "lead_school_not_applicable": {
+                          "type": "boolean"
+                        },
+                        "employing_school_not_applicable": {
+                          "type": "boolean"
+                        },
+                        "submission_ready": {
+                          "type": "boolean"
+                        },
+                        "discarded_at": {
+                          "nullable": true
+                        },
+                        "created_from_dttp": {
+                          "type": "boolean"
+                        },
+                        "additional_dttp_data": {
+                          "nullable": true
+                        },
+                        "created_from_hesa": {
+                          "type": "boolean"
+                        },
+                        "hesa_updated_at": {
+                          "nullable": true
+                        },
+                        "record_source": {
+                          "nullable": true
+                        },
+                        "iqts_country": {
+                          "nullable": true
+                        },
+                        "hesa_editable": {
+                          "type": "boolean"
+                        },
+                        "slug_sent_to_dqt_at": {
+                          "nullable": true
+                        },
+                        "placement_detail": {
+                          "nullable": true
+                        },
+                        "provider_trainee_id": {
+                          "type": "string"
+                        },
+                        "ukprn": {
+                          "type": "string"
+                        },
+                        "ethnicity": {
+                          "nullable": true
+                        },
+                        "disability1": {
+                          "type": "string"
+                        },
+                        "course_qualification": {
+                          "type": "string"
+                        },
+                        "course_title": {
+                          "nullable": true
+                        },
+                        "course_level": {
+                          "type": "string"
+                        },
+                        "course_itt_start_date": {
+                          "type": "string"
+                        },
+                        "course_age_range": {
+                          "nullable": true
+                        },
+                        "expected_end_date": {
+                          "type": "string"
+                        },
+                        "employing_school_urn": {
+                          "nullable": true
+                        },
+                        "lead_partner_urn_ukprn": {
+                          "nullable": true
+                        },
+                        "lead_school_urn": {
+                          "nullable": true
+                        },
+                        "fund_code": {
+                          "type": "string"
+                        },
+                        "bursary_level": {
+                          "type": "string"
+                        },
+                        "course_study_mode": {
+                          "nullable": true
+                        },
+                        "course_year": {
+                          "nullable": true
+                        },
+                        "funding_method": {
+                          "nullable": true
+                        },
+                        "itt_aim": {
+                          "nullable": true
+                        },
+                        "ni_number": {
+                          "nullable": true
+                        },
+                        "postgrad_apprenticeship_start_date": {
+                          "nullable": true
+                        },
+                        "previous_last_name": {
+                          "nullable": true
+                        },
+                        "hesa_disabilities": {
+                          "nullable": true
+                        },
+                        "additional_training_initiative": {
+                          "nullable": true
+                        },
+                        "nationality": {
+                          "type": "string"
+                        },
+                        "placements": {
+                          "type": "array",
+                          "items": {
+                          }
+                        },
+                        "degrees": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "uk_degree": {
+                                "type": "string"
+                              },
+                              "non_uk_degree": {
+                                "nullable": true
+                              },
+                              "created_at": {
+                                "type": "string"
+                              },
+                              "updated_at": {
+                                "type": "string"
+                              },
+                              "subject": {
+                                "type": "string"
+                              },
+                              "institution": {
+                                "type": "string"
+                              },
+                              "graduation_year": {
+                                "type": "integer"
+                              },
+                              "grade": {
+                                "type": "string"
+                              },
+                              "country": {
+                                "nullable": true
+                              },
+                              "other_grade": {
+                                "nullable": true
+                              },
+                              "institution_uuid": {
+                                "type": "string"
+                              },
+                              "uk_degree_uuid": {
+                                "type": "string"
+                              },
+                              "subject_uuid": {
+                                "type": "string"
+                              },
+                              "grade_uuid": {
+                                "type": "string"
+                              },
+                              "degree_id": {
+                                "type": "string"
+                              },
+                              "degree_type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "uk_degree",
+                              "non_uk_degree",
+                              "created_at",
+                              "updated_at",
+                              "subject",
+                              "institution",
+                              "graduation_year",
+                              "grade",
+                              "country",
+                              "other_grade",
+                              "institution_uuid",
+                              "uk_degree_uuid",
+                              "subject_uuid",
+                              "grade_uuid",
+                              "degree_id",
+                              "degree_type"
+                            ]
+                          }
+                        },
+                        "state": {
+                          "type": "string"
+                        },
+                        "trainee_id": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "integer"
+                        },
+                        "dttp_id": {
+                          "type": "string"
+                        },
+                        "progress": {
+                          "type": "object",
+                          "properties": {
+                            "personal_details": {
+                              "type": "boolean"
+                            },
+                            "contact_details": {
+                              "type": "boolean"
+                            },
+                            "degrees": {
+                              "type": "boolean"
+                            },
+                            "placements": {
+                              "type": "boolean"
+                            },
+                            "diversity": {
+                              "type": "boolean"
+                            },
+                            "course_details": {
+                              "type": "boolean"
+                            },
+                            "training_details": {
+                              "type": "boolean"
+                            },
+                            "trainee_start_status": {
+                              "type": "boolean"
+                            },
+                            "trainee_data": {
+                              "type": "boolean"
+                            },
+                            "schools": {
+                              "type": "boolean"
+                            },
+                            "funding": {
+                              "type": "boolean"
+                            },
+                            "iqts_country": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "personal_details",
+                            "contact_details",
+                            "degrees",
+                            "placements",
+                            "diversity",
+                            "course_details",
+                            "training_details",
+                            "trainee_start_status",
+                            "trainee_data",
+                            "schools",
+                            "funding",
+                            "iqts_country"
+                          ]
+                        },
+                        "provider_id": {
+                          "type": "integer"
+                        },
+                        "placement_assignment_dttp_id": {
+                          "nullable": true
+                        },
+                        "slug": {
+                          "type": "string"
+                        },
+                        "dttp_update_sha": {
+                          "nullable": true
+                        },
+                        "dormancy_dttp_id": {
+                          "nullable": true
+                        },
+                        "lead_school_id": {
+                          "nullable": true
+                        },
+                        "employing_school_id": {
+                          "nullable": true
+                        },
+                        "apply_application_id": {
+                          "nullable": true
+                        },
+                        "course_allocation_subject_id": {
+                          "nullable": true
+                        },
+                        "start_academic_cycle_id": {
+                          "nullable": true
+                        },
+                        "end_academic_cycle_id": {
+                          "nullable": true
+                        },
+                        "hesa_trn_submission_id": {
+                          "nullable": true
+                        },
+                        "application_choice_id": {
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "commencement_status",
+                        "withdraw_date",
+                        "withdraw_reasons_details",
+                        "withdraw_reasons_dfe_details",
+                        "updated_at",
+                        "first_names",
+                        "middle_names",
+                        "last_name",
+                        "email",
+                        "ethnic_background",
+                        "additional_ethnic_background",
+                        "trn",
+                        "region",
+                        "hesa_id",
+                        "course_subject_one",
+                        "course_subject_two",
+                        "course_subject_three",
+                        "date_of_birth",
+                        "created_at",
+                        "training_route",
+                        "sex",
+                        "diversity_disclosure",
+                        "ethnic_group",
+                        "disability_disclosure",
+                        "itt_start_date",
+                        "outcome_date",
+                        "itt_end_date",
+                        "submitted_for_trn_at",
+                        "defer_date",
+                        "recommended_for_award_at",
+                        "trainee_start_date",
+                        "reinstate_date",
+                        "course_min_age",
+                        "course_max_age",
+                        "awarded_at",
+                        "applying_for_bursary",
+                        "training_initiative",
+                        "bursary_tier",
+                        "study_mode",
+                        "ebacc",
+                        "course_education_phase",
+                        "applying_for_scholarship",
+                        "applying_for_grant",
+                        "course_uuid",
+                        "lead_school_not_applicable",
+                        "employing_school_not_applicable",
+                        "submission_ready",
+                        "discarded_at",
+                        "created_from_dttp",
+                        "additional_dttp_data",
+                        "created_from_hesa",
+                        "hesa_updated_at",
+                        "record_source",
+                        "iqts_country",
+                        "hesa_editable",
+                        "slug_sent_to_dqt_at",
+                        "placement_detail",
+                        "provider_trainee_id",
+                        "state"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                },
+                "example": {
+                  "data": {
+                    "commencement_status": null,
+                    "withdraw_date": "2024-04-17T13:39:18.000Z",
+                    "withdraw_reasons_details": "Men always seem to think about their past before they die, as though they were frantically searching for proof that they truly lived.",
+                    "withdraw_reasons_dfe_details": "Why does everything that's good for you have to taste so bad?",
+                    "updated_at": "2024-04-17T13:39:18.956Z",
+                    "first_names": "Shawn",
+                    "middle_names": "Weber",
+                    "last_name": "Hermiston",
+                    "email": "Shawn.Hermiston@example.com",
+                    "ethnic_background": null,
+                    "additional_ethnic_background": null,
+                    "trn": "7868996",
+                    "region": null,
+                    "hesa_id": null,
+                    "course_subject_one": "100403",
+                    "course_subject_two": null,
+                    "course_subject_three": null,
+                    "date_of_birth": "1961-02-11",
+                    "created_at": "2024-04-17T13:39:18.873Z",
+                    "training_route": null,
+                    "sex": "12",
+                    "diversity_disclosure": "diversity_not_disclosed",
+                    "ethnic_group": null,
+                    "disability_disclosure": null,
+                    "itt_start_date": "2023-08-07",
+                    "outcome_date": null,
+                    "itt_end_date": "2024-07-13",
+                    "submitted_for_trn_at": "2024-04-17T13:39:18.867Z",
+                    "defer_date": null,
+                    "recommended_for_award_at": null,
+                    "trainee_start_date": "2023-08-08",
+                    "reinstate_date": null,
+                    "course_min_age": 11,
+                    "course_max_age": 18,
+                    "awarded_at": null,
+                    "applying_for_bursary": false,
+                    "training_initiative": "009",
+                    "bursary_tier": null,
+                    "study_mode": "01",
+                    "ebacc": false,
+                    "course_education_phase": "secondary",
+                    "applying_for_scholarship": false,
+                    "applying_for_grant": false,
+                    "course_uuid": null,
+                    "lead_school_not_applicable": false,
+                    "employing_school_not_applicable": false,
+                    "submission_ready": true,
+                    "discarded_at": null,
+                    "created_from_dttp": false,
+                    "additional_dttp_data": null,
+                    "created_from_hesa": false,
+                    "hesa_updated_at": null,
+                    "record_source": null,
+                    "iqts_country": null,
+                    "hesa_editable": false,
+                    "slug_sent_to_dqt_at": null,
+                    "placement_detail": null,
+                    "provider_trainee_id": "23/24-702",
+                    "ukprn": "53469397",
+                    "ethnicity": null,
+                    "disability1": "95",
+                    "course_qualification": "QTS",
+                    "course_title": null,
+                    "course_level": "postgrad",
+                    "course_itt_start_date": "2023-08-07",
+                    "course_age_range": null,
+                    "expected_end_date": "2024-07-13",
+                    "employing_school_urn": null,
+                    "lead_partner_urn_ukprn": null,
+                    "lead_school_urn": null,
+                    "fund_code": "2",
+                    "bursary_level": "D",
+                    "course_study_mode": null,
+                    "course_year": null,
+                    "funding_method": null,
+                    "itt_aim": null,
+                    "ni_number": null,
+                    "postgrad_apprenticeship_start_date": null,
+                    "previous_last_name": null,
+                    "hesa_disabilities": null,
+                    "additional_training_initiative": null,
+                    "nationality": "slovenian",
+                    "placements": [
+
+                    ],
+                    "degrees": [
+                      {
+                        "uk_degree": "Bachelor of Librarianship and Information Studies",
+                        "non_uk_degree": null,
+                        "created_at": "2024-04-17T13:39:18.876Z",
+                        "updated_at": "2024-04-17T13:39:18.876Z",
+                        "subject": "100176",
+                        "institution": "0063",
+                        "graduation_year": 2008,
+                        "grade": "03",
+                        "country": null,
+                        "other_grade": null,
+                        "institution_uuid": "d670f34a-2887-e711-80d8-005056ac45bb",
+                        "uk_degree_uuid": "076a5652-c197-e711-80d8-005056ac45bb",
+                        "subject_uuid": "ff7f70f0-5dce-e911-a985-000d3ab79618",
+                        "grade_uuid": "377a46ea-d6c6-4e87-9728-c1f0dd0ef109",
+                        "degree_id": "kQco7SVMJ1tK8oiLcE8uAgpp",
+                        "degree_type": "073"
+                      }
+                    ],
+                    "state": "withdrawn",
+                    "trainee_id": "tfJ4A1nujdqwKs5Y62UU9euJ",
+                    "id": 32,
+                    "dttp_id": "cb4f7f2f-f510-443d-b4f8-5b552c861a81",
+                    "progress": {
+                      "personal_details": true,
+                      "contact_details": true,
+                      "degrees": true,
+                      "placements": false,
+                      "diversity": true,
+                      "course_details": true,
+                      "training_details": true,
+                      "trainee_start_status": false,
+                      "trainee_data": true,
+                      "schools": true,
+                      "funding": true,
+                      "iqts_country": false
+                    },
+                    "provider_id": 33,
+                    "placement_assignment_dttp_id": null,
+                    "slug": "WRmegvQH1ykJmrdQWpVfT12D",
+                    "dttp_update_sha": null,
+                    "dormancy_dttp_id": null,
+                    "lead_school_id": null,
+                    "employing_school_id": null,
+                    "apply_application_id": null,
+                    "course_allocation_subject_id": null,
+                    "start_academic_cycle_id": null,
+                    "end_academic_cycle_id": null,
+                    "hesa_trn_submission_id": null,
+                    "application_choice_id": null
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "did not change the trainee",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                },
+                "example": {
+                  "error": "Unauthorized"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "returns status 404 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "NotFound",
+                      "message": "Trainee(s) not found"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "returns status 422 with a valid JSON response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "error": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "error",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "error": "UnprocessableEntity",
+                      "message": "Withdraw date Choose a withdrawal date"
+                    },
+                    {
+                      "error": "UnprocessableEntity",
+                      "message": "Reasons Select why the trainee withdrew from the course or select \"Unknown\""
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,8 +70,4 @@ RSpec.configure do |config|
       Bullet.end_request
     end
   end
-
-  # config.after do
-  #   Rspec::Openapi.generate_docs if ENV["OPENAPI"] == "true"
-  # end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,4 +70,8 @@ RSpec.configure do |config|
       Bullet.end_request
     end
   end
+
+  # config.after do
+  #   Rspec::Openapi.generate_docs if ENV["OPENAPI"] == "true"
+  # end
 end


### PR DESCRIPTION
### Context

We want an efficient/automated way to generate OpenAPI specifications for the Register API.

### Changes proposed in this pull request

* This adds [rspec-openapi](https://github.com/exoego/rspec-openapi) for autogenerating a specification in a JSON format in our public folder
* [Redoc](https://github.com/Redocly/redoc) is then used to render the specification
* for the sake of demoing, the OpenAPI specification is present in this PR. In future, we will have this generated during deployment for each ENV rather than merging code

### Guidance to review

* The specification generated looks competent at first glance but we will need to do some work to make it more useful and less verbose in places.
* This PR doesn't need a review as it servers only to showcase the Redoc output
* The Redoc output can be seen by visiting `/api-docs/openapi` either locally or in the review app
* OpenAPI specs can be generated by running `OPENAPI=1 bundle exec rspec spec/requests/api/v0.1`
