### PR TITLE
[6989] Fix validation errors for nested objects on `POST /trainees`

### DIFF
--- a/app/services/api/create_trainee.rb
+++ b/app/services/api/create_trainee.rb
@@ -25,7 +25,7 @@ module Api
         ::Trainees::SubmitForTrn.call(trainee:)
         success_response(trainee)
       else
-        save_errors_response
+        save_errors_response(validator, trainee)
       end
     end
 
@@ -49,25 +49,13 @@ module Api
       }
     end
 
-    def error_count
-      return validation.errors_count if validation.errors_count.positive?
+    def save_errors_response(trn_validator, trainee)
+      validation_errors = trn_validator.all_errors.presence || trainee.errors.full_messages
 
-      trainee.validate
-      trainee.errors.count
-    end
-
-    def error_messages
-      return validation.all_errors if validation.errors_count.positive?
-
-      trainee.validate
-      trainee.errors.full_messages
-    end
-
-    def save_errors_response
       {
         json: {
-          message: "Validation failed: #{error_count} #{'error'.pluralize(error_count)} prohibited this trainee from being saved",
-          errors: error_messages,
+          message: "Validation failed: #{validation_errors.count} #{'error'.pluralize(validation_errors.count)} prohibited this trainee from being saved",
+          errors: validation_errors,
         },
         status: :unprocessable_entity,
       }

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -54,13 +54,15 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     }
   end
 
+  before do
+    create(:disability, :blind)
+    create(:disability, :deaf)
+  end
+
   context "when the request is valid", feature_register_api: true do
     before do
       allow(Api::MapHesaAttributes::V01).to receive(:call).and_call_original
       allow(Trainees::MapFundingFromDttpEntityId).to receive(:call).and_call_original
-
-      create(:disability, :blind)
-      create(:disability, :deaf)
 
       post "/api/v0.1/trainees", params: params, headers: { Authorization: token }
     end


### PR DESCRIPTION


### Context
Errors on saving a new trainee record can originate from pre-save checks in `Submissions::ApiTrnValidator` or from saving the `Trainee` model. We were only returning the former. So we need to consider both.

### Changes proposed in this pull request
- Tests to reproduce the issue and exercise validation errors on placements and degrees.
- Include validation errors on the `Trainee` model in error responses.

### Guidance to review

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
