### PR TITLE
[7000] Fix error when bulk recommending Trainee teachers for QTS 

### DIFF
--- a/app/views/bulk_update/recommendations_checks/show.html.erb
+++ b/app/views/bulk_update/recommendations_checks/show.html.erb
@@ -19,8 +19,8 @@
           caption: "Trainees you’ll recommend for #{qts_or_eyts(recommendations_upload.awardable_rows)}"
         } %>
       <% else %>
-        <%= govuk_accordion(id: "recommendations-upload-#{recommendations_upload.id}",
-                            html_attributes: {
+        <%= govuk_accordion(html_attributes: {
+                              id: "recommendations-upload-#{recommendations_upload.id}",
                               "data-i18n.show-all-sections" => "Show all trainees you’ll recommend",
                               "data-i18n.hide-all-sections" => "Hide all trainees you’ll recommend",
                             }) do |accordion|


### PR DESCRIPTION
### Context

https://trello.com/c/rKX6nPIY/7000-recommending-trainee-teachers-for-qts-error

Provider getting error when trying to bulk recommend 52 trainees for QTS via CSV file.

### Changes proposed in this pull request

* Fix syntax for govuk_accordion `id` setting

### Guidance to review

* Try uploading a CSV for bulk recommendation which has more than 50 trainees, so the accordion is displayed

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
