### PR TITLE
[6832][a11y] - landmarks (feedback banner)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -86,7 +86,7 @@
             <strong class="govuk-tag govuk-phase-banner__content__tag">
               <%= Settings.environment.name.titlecase %>
             </strong>
-            <span class="govuk-phase-banner__text">
+            <span class="govuk-phase-banner__text" role="status">
                 This is a new service - <% if FeatureService.enabled?("enable_feedback_link") %>
                   your <%= govuk_link_to "feedback", Settings.feedback_link_url, class: "govuk-link--no-visited-state" %> will help us improve it
                 <% else %>


### PR DESCRIPTION
### Context

https://trello.com/c/DxIZIya0/6832-a11y-131-info-and-relationships-page-regions-not-identified-with-aria-landmarks

in a nutshell - missing `role` tag for the feedback banner

### Changes proposed in this pull request

adds `"status"` as the `role` for the feedback banner