### PR TITLE
[7022] Refactor Api::DegreeAttributes#duplicates?

### DIFF
--- a/app/models/api/degree_attributes/v01.rb
+++ b/app/models/api/degree_attributes/v01.rb
@@ -62,12 +62,11 @@ module Api
           hesa_mapped_degree_attributes.slice(
             :subject,
             :graduation_year,
-            :locale_code,
             :country,
             :uk_degree,
             :non_uk_degree,
             :grade,
-          ),
+          ).compact,
         )
       end
 


### PR DESCRIPTION
### Context

[7022-investigate-flakey-test-for-duplicate-degrees](https://trello.com/c/AJRoZpzs/7022-investigate-flakey-test-for-duplicate-degrees)

When the `country` is not submitted in the params the `locale_code` would default to `"uk"` by the return value of `Api::MapHesaAttributes::Degrees::V01#locale_code`.

In combination with the fact that the `exists?`
query would check with both `{ locale_code: "uk", country: nil }` could result in inconsistencies in the return value of `duplicates?`

### Changes proposed in this pull request

* Don't use the `locale_code` to check for duplicates
* Remove any `nil` values that may come from the request body when checking for duplicates

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
