### PR TITLE
[7036] Add error handling for JSON syntax errors

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -18,6 +18,13 @@ module Api
       )
     end
 
+    rescue_from JSON::ParserError do |e|
+      render(
+        json: { errors: [e.message.capitalize] },
+        status: :bad_request,
+      )
+    end
+
     def check_feature_flag!
       return if FeatureService.enabled?(:register_api)
 

--- a/app/lib/route_constraints/register_api_constraint.rb
+++ b/app/lib/route_constraints/register_api_constraint.rb
@@ -3,7 +3,7 @@
 module RouteConstraints
   class RegisterApiConstraint
     def self.matches?(request)
-      request[:api_version] == "v0.1"
+      request.path_parameters[:api_version] == "v0.1"
     end
   end
 end

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -202,6 +202,22 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
             expect(response.parsed_body[:data]["trainee_id"]).to eq(slug)
           end
         end
+
+        context "when request body is not valid JSON" do
+          let(:params_for_update) { "{ \"data\": { \"first_names\": \"Alice\", \"last_name\": \"Roberts\", } }" }
+
+          it "does not update the trainee and returns a meaningful error" do
+            put(
+              "/api/v0.1/trainees/#{slug}",
+              headers: headers.merge("Content-Type" => "application/json"),
+              params: params_for_update,
+            )
+
+            expect(response).to have_http_status(:bad_request)
+            expect(trainee.reload.first_names).to eq("John")
+            expect(response.parsed_body).to have_key("errors")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
When we receive an API request with an invalid JSON document in the request body we should throw a 400 status with a meaningful error message.

### Changes proposed in this pull request
- Add an explicit handler for JSON parsing errors.
- Test to assert that an error is returned.
- Change the route constraint (the one that checks API version) so that it doesn't need to parse the whole request - we don't want it blowing up if the correct version is present in the path params.

### Guidance to review
Should we have a catch all error 'JSON parsing' message rather than returning the exception message verbatim?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
