### PR TITLE
[6837] Add validation error messages for withdrawal date

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1591,8 +1591,8 @@ en:
             date_string:
               blank: Choose a withdrawal date
             date:
-              blank: The withdrawal date must have a day, month and year
-              invalid: The withdrawal date must have a day, month and year
+              blank: &withdrawal_date_blank The withdrawal date must have a day, month and year
+              invalid: *withdrawal_date_blank
         withdrawal/extra_information_form:
           attributes:
             withdraw_reasons_details:


### PR DESCRIPTION
### Context
This was picked up as part of the recent accessibility testing. There are no custom validation error messages for the withdrawal date field.

### Changes proposed in this pull request
Add/fix error messages:

This one is specified in the ticket:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/e5a38514-7dc2-4ec1-9235-58be966f12fc)

similarly:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/5e4d8788-170b-4440-be91-8e18422c58d8)

This one was already implemented:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/3725b13a-9238-45e0-a236-e2c072272716)

### Guidance to review
Anything I've missed?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
