### PR TITLE
[7035] Fix HESA Trainee details serializer

### DIFF
--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -117,10 +117,6 @@ module Api
       @degree_attributes ||= Api::Attributes.for(model: :degree, version: version)::ATTRIBUTES
     end
 
-    def current_version_class_name
-      current_version.gsub(".", "").camelize
-    end
-
     def trainee_update_params
       params.require(:data).permit(trainee_attributes_service::ATTRIBUTES)
     end

--- a/app/serializers/hesa_trainee_detail_serializer/v01.rb
+++ b/app/serializers/hesa_trainee_detail_serializer/v01.rb
@@ -2,7 +2,7 @@
 
 module HesaTraineeDetailSerializer
   class V01
-    SERIALIZABLE_ATTRIBUTES = %i[
+    SERIALIZABLE_ATTRIBUTES = %w[
       course_age_range
       course_study_mode
       course_year

--- a/app/serializers/hesa_trainee_detail_serializer/v01.rb
+++ b/app/serializers/hesa_trainee_detail_serializer/v01.rb
@@ -2,17 +2,9 @@
 
 module HesaTraineeDetailSerializer
   class V01
-    SERIALIZABLE_ATTRIBUTES = %w[
-      course_age_range
-      course_study_mode
-      course_year
-      funding_method
-      itt_aim
-      ni_number
-      postgrad_apprenticeship_start_date
-      previous_last_name
-      hesa_disabilities
-      additional_training_initiative
+    EXCLUDED_ATTRIBUTES = %w[
+      id
+      trainee_id
     ].freeze
 
     def initialize(trainee_details)
@@ -20,9 +12,7 @@ module HesaTraineeDetailSerializer
     end
 
     def as_hash
-      SERIALIZABLE_ATTRIBUTES.index_with do |attr|
-        @trainee_details&.attributes&.[](attr)
-      end
+      @trainee_details&.attributes&.except(*EXCLUDED_ATTRIBUTES)
     end
   end
 end

--- a/app/serializers/hesa_trainee_detail_serializer/v01.rb
+++ b/app/serializers/hesa_trainee_detail_serializer/v01.rb
@@ -5,6 +5,7 @@ module HesaTraineeDetailSerializer
     EXCLUDED_ATTRIBUTES = %w[
       id
       trainee_id
+      fund_code
     ].freeze
 
     def initialize(trainee_details)

--- a/app/serializers/trainee_serializer/v01.rb
+++ b/app/serializers/trainee_serializer/v01.rb
@@ -188,7 +188,9 @@ module TraineeSerializer
     end
 
     def hesa_trainee_attributes
-      HesaTraineeDetailSerializer::V01.new(@trainee&.hesa_trainee_detail)&.as_hash
+      return {} unless @trainee.hesa_trainee_detail
+
+      HesaTraineeDetailSerializer::V01.new(@trainee.hesa_trainee_detail).as_hash
     end
 
     def nationality

--- a/spec/serializers/trainee_serializer/v01_spec.rb
+++ b/spec/serializers/trainee_serializer/v01_spec.rb
@@ -136,5 +136,15 @@ RSpec.describe TraineeSerializer::V01 do
         expect(json[:degrees]).to eq(degrees)
       end
     end
+
+    describe "HESA trainee details" do
+      let(:hesa_trainee_detail) do
+        HesaTraineeDetailSerializer::V01.new(trainee.hesa_trainee_detail).as_hash.with_indifferent_access
+      end
+
+      it "serializes with HesaTraineeDetailSerializer::V01" do
+        expect(trainee.hesa_trainee_detail.attributes.except(*HesaTraineeDetailSerializer::V01::EXCLUDED_ATTRIBUTES)).to eq(hesa_trainee_detail)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

The data in the HESA trainee details fields didn't seem to be returned correctly by the serializer.

### Changes proposed in this pull request

* Amended and refactored the `HesaTraineeDetailSerializer` to return data and be more like the other serializers
* Added a test to catch missing data being returned from serializer
* Tweaked a couple of other things

### Guidance to review

Check that values are returned for the HESA trainee details fields for trainees created by the API

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
