### PR TITLE
[7051] - Some fields should be read-only

### DIFF
--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -43,7 +43,8 @@ module Api
     def update
       trainee = current_provider&.trainees&.find_by!(slug: params[:slug])
       attributes = trainee_attributes_service.from_trainee(trainee)
-      attributes.assign_attributes(hesa_mapped_params_for_update)
+      attributes.assign_attributes(hesa_mapped_params_for_update(trainee))
+
       succeeded, validation = update_trainee_service_class.call(trainee:, attributes:)
 
       if succeeded
@@ -75,8 +76,9 @@ module Api
       )
     end
 
-    def hesa_mapped_params_for_update
+    def hesa_mapped_params_for_update(trainee)
       hesa_mapper_class.call(
+        trainee: trainee,
         params: params.require(:data).permit(
           hesa_mapper_class::ATTRIBUTES + trainee_attributes_service::ATTRIBUTES,
           hesa_mapper_class.disability_attributes(params),

--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -115,10 +115,6 @@ module Api
       @degree_attributes ||= Api::Attributes.for(model: :degree, version: version)::ATTRIBUTES
     end
 
-    def trainee_update_params
-      params.require(:data).permit(trainee_attributes_service::ATTRIBUTES)
-    end
-
     def model = :trainee
   end
 end

--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -42,22 +42,20 @@ module Api
 
     def update
       trainee = current_provider&.trainees&.find_by!(slug: params[:slug])
-      begin
-        attributes = trainee_attributes_service.from_trainee(trainee)
-        attributes.assign_attributes(hesa_mapped_params_for_update)
-        succeeded, validation = update_trainee_service_class.call(trainee:, attributes:)
+      attributes = trainee_attributes_service.from_trainee(trainee)
+      attributes.assign_attributes(hesa_mapped_params_for_update)
+      succeeded, validation = update_trainee_service_class.call(trainee:, attributes:)
 
-        if succeeded
-          render(json: { data: serializer_klass.new(trainee).as_hash })
-        else
-          render(
-            json: {
-              message: "Validation failed: #{validation.all_errors.count} #{'error'.pluralize(validation.all_errors.count)} prohibited this trainee from being saved",
-              errors: validation.all_errors,
-            },
-            status: :unprocessable_entity,
-          )
-        end
+      if succeeded
+        render(json: { data: serializer_klass.new(trainee).as_hash })
+      else
+        render(
+          json: {
+            message: "Validation failed: #{validation.all_errors.count} #{'error'.pluralize(validation.all_errors.count)} prohibited this trainee from being saved",
+            errors: validation.all_errors,
+          },
+          status: :unprocessable_entity,
+        )
       end
     end
 

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -21,7 +21,6 @@ module Api
         course_max_age
         trainee_start_date
         sex
-        trn
         training_route
         itt_start_date
         itt_end_date

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -25,6 +25,7 @@ module Api
         itt_start_date
         itt_end_date
         diversity_disclosure
+        ethnicity
         ethnic_group
         ethnic_background
         disability_disclosure
@@ -72,6 +73,7 @@ module Api
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
       validates :email, presence: true, length: { maximum: 255 }
+      validates :ethnicity, inclusion: Hesa::CodeSets::Ethnicities::MAPPING.keys
 
       validate do |record|
         EmailFormatValidator.new(record).validate

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -73,7 +73,7 @@ module Api
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
       validates :email, presence: true, length: { maximum: 255 }
-      validates :ethnicity, inclusion: Hesa::CodeSets::Ethnicities::MAPPING.keys
+      validates :ethnicity, inclusion: Hesa::CodeSets::Ethnicities::MAPPING.keys, allow_nil: true
 
       validate do |record|
         EmailFormatValidator.new(record).validate

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -166,7 +166,7 @@ module Api
       end
 
       def deep_attributes
-        attributes.transform_values do |value|
+        attributes.except("ethnicity").transform_values do |value|
           if value.is_a?(Array)
             value.map { |item| item.respond_to?(:attributes) ? item.attributes : item }
           elsif value.respond_to?(:attributes)

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -305,6 +305,8 @@ class Trainee < ApplicationRecord
   COMPLETE_STATES = %w[recommended_for_award withdrawn awarded].freeze
   IN_TRAINING_STATES = %w[submitted_for_trn trn_received recommended_for_award].freeze
 
+  attr_accessor :ethnicity
+
   pg_search_scope :with_name_provider_trainee_id_or_trn_like,
                   against: %i[first_names middle_names last_name provider_trainee_id trn],
                   using: { tsearch: { prefix: true } }

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -305,8 +305,6 @@ class Trainee < ApplicationRecord
   COMPLETE_STATES = %w[recommended_for_award withdrawn awarded].freeze
   IN_TRAINING_STATES = %w[submitted_for_trn trn_received recommended_for_award].freeze
 
-  attr_accessor :ethnicity
-
   pg_search_scope :with_name_provider_trainee_id_or_trn_like,
                   against: %i[first_names middle_names last_name provider_trainee_id trn],
                   using: { tsearch: { prefix: true } }

--- a/app/services/api/create_trainee.rb
+++ b/app/services/api/create_trainee.rb
@@ -62,7 +62,7 @@ module Api
     end
 
     def success_response(trainee)
-      { json: serializer_klass.new(trainee).as_hash, status: :created }
+      { json: { data: serializer_klass.new(trainee).as_hash }, status: :created }
     end
 
     def validation_error_response

--- a/app/services/api/map_hesa_attributes/v01.rb
+++ b/app/services/api/map_hesa_attributes/v01.rb
@@ -10,6 +10,8 @@ module Api
       ATTRIBUTES = %i[
         nationality
         ethnicity
+        ethnic_group
+        ethnic_background
       ].freeze
 
       NOT_APPLICABLE_SCHOOL_URNS = %w[900000 900010 900020 900030].freeze
@@ -20,8 +22,9 @@ module Api
         params[:data].keys.select { |key| key.to_s.match(DISABILITY_PARAM_REGEX) }
       end
 
-      def initialize(params:)
-        @params = params
+      def initialize(trainee: nil, params:)
+        @trainee = trainee
+        @params  = params
       end
 
       def call
@@ -30,7 +33,9 @@ module Api
 
     private
 
-      attr_reader :params
+      attr_reader :trainee, :params
+
+      delegate :ethnic_background, to: :trainee, prefix: true, allow_nil: true
 
       def mapped_params
         additional_params = params.except(*ATTRIBUTES)
@@ -79,7 +84,8 @@ module Api
       end
 
       def ethnic_background
-        ::Hesa::CodeSets::Ethnicities::MAPPING[params[:ethnicity]]
+        ::Hesa::CodeSets::Ethnicities::MAPPING[params[:ethnicity]] ||
+          trainee_ethnic_background
       end
 
       def hesa_disabilities

--- a/app/services/api/map_hesa_attributes/v01.rb
+++ b/app/services/api/map_hesa_attributes/v01.rb
@@ -9,7 +9,6 @@ module Api
 
       ATTRIBUTES = %i[
         nationality
-        ethnicity
         ethnic_group
         ethnic_background
       ].freeze

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -2438,7 +2438,7 @@ Deletes an existing degree for this trainee.
         string
       </p>
       <p class="govuk-body">
-        The ethnicity of the trainee. Coded according to the <a href="https://www.hesa.ac.uk/collection/c23053/e/ethnic">HESA ethnicity field</a>. The <code>ethnic_background</code> and <code>ethnic_group</code> will be determined by the API based on the <code>ethnicity</code> value.
+        The ethnicity of the trainee. Coded according to the <a href="https://www.hesa.ac.uk/collection/c23053/e/ethnic">HESA ethnicity field</a>. The values for <code>ethnic_background</code> and <code>ethnic_group</code> will be set based on the <code>ethnicity</code> value.
       </p>
       <p class="govuk-body">
         Example: <code>120</code>

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -2438,7 +2438,7 @@ Deletes an existing degree for this trainee.
         string
       </p>
       <p class="govuk-body">
-        The ethnicity of the trainee. Coded according to the <a href="https://www.hesa.ac.uk/collection/c23053/e/ethnic">HESA ethnicity field</a>
+        The ethnicity of the trainee. Coded according to the <a href="https://www.hesa.ac.uk/collection/c23053/e/ethnic">HESA ethnicity field</a>. The <code>ethnic_background</code> and <code>ethnic_group</code> will be determined by the API based on the <code>ethnicity</code> value.
       </p>
       <p class="govuk-body">
         Example: <code>120</code>

--- a/spec/models/api/trainee_attributes/v01_spec.rb
+++ b/spec/models/api/trainee_attributes/v01_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::TraineeAttributes::V01 do
     it { is_expected.to validate_length_of(:email).is_at_most(255) }
 
     it { is_expected.to validate_inclusion_of(:sex).in_array(Hesa::CodeSets::Sexes::MAPPING.values) }
-    it { is_expected.to validate_inclusion_of(:ethnicity).in_array(Hesa::CodeSets::Ethnicities::MAPPING.keys) }
+    it { is_expected.to validate_inclusion_of(:ethnicity).in_array(Hesa::CodeSets::Ethnicities::MAPPING.keys).allow_nil }
   end
 
   describe ".from_trainee" do

--- a/spec/models/api/trainee_attributes/v01_spec.rb
+++ b/spec/models/api/trainee_attributes/v01_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Api::TraineeAttributes::V01 do
     it { is_expected.to validate_length_of(:email).is_at_most(255) }
 
     it { is_expected.to validate_inclusion_of(:sex).in_array(Hesa::CodeSets::Sexes::MAPPING.values) }
+    it { is_expected.to validate_inclusion_of(:ethnicity).in_array(Hesa::CodeSets::Ethnicities::MAPPING.keys) }
   end
 
   describe ".from_trainee" do

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -226,7 +226,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       expect(Trainee.last.provider_trainee_id).to eq("99157234/2/01")
     end
 
-    context "when read only attributes are been submitted" do
+    context "when read only attributes are submitted" do
       let(:trn) { "567899" }
       let(:ethnic_group) { "mixed_ethnic_group" }
       let(:ethnic_background) { "Another Mixed background" }

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -86,7 +86,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "sets the correct study_mode" do
-      expect(response.parsed_body["study_mode"]).to eq("63")
+      expect(response.parsed_body[:data][:study_mode]).to eq("63")
     end
 
     it "sets the correct disabilities" do

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -294,6 +294,51 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
   end
 
+  describe "ethnicity" do
+    before do
+      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json
+    end
+
+    context "when present" do
+      let(:params) do
+        {
+          data: data.merge(
+            ethnicity:
+          )
+        }
+      end
+
+      let(:ethnicity) { "142" }
+
+      it do
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body[:data][:ethnicity]).to eq(ethnicity)
+      end
+    end
+
+    context "when not present" do
+      it do
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body[:data][:ethnicity]).to eq("997")
+      end
+    end
+
+    context "when invalid" do
+      let(:params) do
+        {
+          data: data.merge(
+            ethnicity: "1000"
+          )
+        }
+      end
+
+      it do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body[:errors]).to contain_exactly("Ethnicity is not included in the list")
+      end
+    end
+  end
+
   context "when the trainee record is invalid", feature_register_api: true do
     before do
       post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -303,8 +303,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       let(:params) do
         {
           data: data.merge(
-            ethnicity:
-          )
+            ethnicity:,
+          ),
         }
       end
 
@@ -327,8 +327,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       let(:params) do
         {
           data: data.merge(
-            ethnicity: "1000"
-          )
+            ethnicity: "1000",
+          ),
         }
       end
 

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -72,7 +72,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       allow(Api::MapHesaAttributes::V01).to receive(:call).and_call_original
       allow(Trainees::MapFundingFromDttpEntityId).to receive(:call).and_call_original
 
-      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }
+      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json
     end
 
     it "creates a trainee" do
@@ -160,7 +160,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       let(:graduation_year) { "2003-01-01" }
 
       it "creates the degrees with the correct graduation_year" do
-        degree_attributes = response.parsed_body["degrees"]&.first
+        degree_attributes = response.parsed_body[:data][:degrees]&.first
 
         expect(degree_attributes["graduation_year"]).to eq(2003)
       end
@@ -170,9 +170,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       let(:graduation_year) { 2003 }
 
       it "creates the degrees with the correct graduation_year" do
-        degree_attributes = response.parsed_body["degrees"]&.first
+        degree_attributes = response.parsed_body[:data][:degrees]&.first
 
-        expect(degree_attributes["graduation_year"]).to eq(2003)
+        expect(degree_attributes[:graduation_year]).to eq(2003)
       end
     end
 
@@ -180,8 +180,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       let(:graduation_year) { 200 }
 
       it "does not create a degree" do
-        expect(response.parsed_body["degrees"]).to be_nil
-        expect(response.parsed_body["errors"].first).to include("Enter a valid graduation year")
+        expect(response.parsed_body[:data]).to be_nil
+        expect(response.parsed_body[:errors].first).to include("Enter a valid graduation year")
       end
     end
 
@@ -189,8 +189,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       let(:graduation_year) { "abc" }
 
       it "does not create a degree" do
-        expect(response.parsed_body["degrees"]).to be_nil
-        expect(response.parsed_body["errors"].first).to include("Enter a valid graduation year")
+        expect(response.parsed_body[:data]).to be_nil
+        expect(response.parsed_body[:errors].first).to include("Enter a valid graduation year")
       end
     end
 
@@ -228,42 +228,75 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
     context "when read only attributes are been submitted" do
       let(:trn) { "567899" }
-      let(:ethnicity) { "899" }
-      let(:ethnic_group) { "not_provided_ethnic_group" }
+      let(:ethnic_group) { "mixed_ethnic_group" }
       let(:ethnic_background) { "Another Mixed background" }
-      let(:params) do
-        {
-          data: data.merge(
-            trn:,
-            ethnicity:,
-            ethnic_group:,
-            ethnic_background:,
-          ),
-        }
+
+      context "when the ethnicity is provided" do
+        let(:params) do
+          {
+            data: data.merge(
+              trn:,
+              ethnicity:,
+              ethnic_group:,
+              ethnic_background:,
+            ),
+          }
+        end
+
+        let(:ethnicity) { "899" }
+
+        it "sets the ethnic attributes based on ethnicity" do
+          expect(response).to have_http_status(:created)
+
+          trainee = Trainee.last
+
+          expect(trainee.trn).to be_nil
+          expect(trainee.ethnic_group).to eq("other_ethnic_group")
+          expect(trainee.ethnic_background).to eq("Another ethnic background")
+
+          parsed_body = response.parsed_body[:data]
+
+          expect(parsed_body[:trn]).to be_nil
+          expect(parsed_body[:ethnicity]).to eq(ethnicity)
+          expect(parsed_body[:ethnic_group]).to eq(trainee.ethnic_group)
+          expect(parsed_body[:ethnic_background]).to eq(trainee.ethnic_background)
+        end
       end
 
-      it "does not set the attributes" do
-        expect(response).to have_http_status(:created)
+      context "when the ethnicity is not provided" do
+        let(:params) do
+          {
+            data: data.merge(
+              trn:,
+              ethnic_group:,
+              ethnic_background:,
+            ),
+          }
+        end
 
-        trainee = Trainee.last
+        it "sets the ethnic attributes to not provided" do
+          expect(response).to have_http_status(:created)
 
-        expect(trainee.trn).to be_nil
-        expect(trainee.ethnic_group).to eq("other_ethnic_group")
-        expect(trainee.ethnic_background).to eq("Another ethnic background")
+          trainee = Trainee.last
 
-        parsed_body = response.parsed_body[:data]
+          expect(trainee.trn).to be_nil
+          expect(trainee.ethnic_group).to eq("not_provided_ethnic_group")
+          expect(trainee.ethnic_background).to eq("Not provided")
 
-        expect(parsed_body[:ethnicity]).to eq(ethnicity)
-        expect(parsed_body[:trn]).to be_nil
-        expect(parsed_body[:ethnic_group]).to eq(trainee.ethnic_group)
-        expect(parsed_body[:ethnic_background]).to eq(trainee.ethnic_background)
+          parsed_body = response.parsed_body[:data]
+
+          expect(parsed_body[:trn]).to be_nil
+          expect(parsed_body[:ethnicity]).to eq("997")
+          expect(parsed_body[:ethnic_group]).to eq("not_provided_ethnic_group")
+          expect(parsed_body[:ethnic_background]).to eq("Not provided")
+        end
       end
     end
   end
 
   context "when the trainee record is invalid", feature_register_api: true do
     before do
-      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }
+      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json
     end
 
     let(:params) { { data: { email: "Doe" } } }
@@ -329,7 +362,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
   context "when a placement is invalid", feature_register_api: true do
     before do
-      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }
+      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json
     end
 
     let(:params) { { data: data.merge({ placements_attributes: [{ not_an_attribute: "invalid" }] }) } }
@@ -344,7 +377,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
   context "when a degree is invalid", feature_register_api: true do
     before do
       params[:data][:degrees_attributes].first[:graduation_year] = "3000-01-01"
-      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }
+      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json
     end
 
     it "return status code 422 with a meaningful error message" do

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -219,6 +219,40 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     it "sets the provider_trainee_id" do
       expect(Trainee.last.provider_trainee_id).to eq("99157234/2/01")
     end
+
+    context "when read only attributes are been submitted" do
+      let(:trn) { "567899" }
+      let(:ethnicity) { "899" }
+      let(:ethnic_group) { "not_provided_ethnic_group" }
+      let(:ethnic_background) { "Another Mixed background" }
+      let(:params) do
+        {
+          data: data.merge(
+            trn:,
+            ethnicity:,
+            ethnic_group:,
+            ethnic_background:
+          ),
+        }
+      end
+
+      it "does not set the attributes" do
+        expect(response).to have_http_status(:created)
+
+        trainee = Trainee.last
+
+        expect(trainee.trn).to be_nil
+        expect(trainee.ethnic_group).to eq("other_ethnic_group")
+        expect(trainee.ethnic_background).to eq("Another ethnic background")
+
+        parsed_body = response.parsed_body[:data]
+
+        expect(parsed_body[:ethnicity]).to eq(ethnicity)
+        expect(parsed_body[:trn]).to be_nil
+        expect(parsed_body[:ethnic_group]).to eq(trainee.ethnic_group)
+        expect(parsed_body[:ethnic_background]).to eq(trainee.ethnic_background)
+      end
+    end
   end
 
   context "when the trainee record is invalid", feature_register_api: true do

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -76,9 +76,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "creates a trainee" do
-      expect(response.parsed_body["first_names"]).to eq("John")
-      expect(response.parsed_body["last_name"]).to eq("Doe")
-      expect(response.parsed_body["previous_last_name"]).to eq("Smith")
+      expect(response.parsed_body[:data][:first_names]).to eq("John")
+      expect(response.parsed_body[:data][:last_name]).to eq("Doe")
+      expect(response.parsed_body[:data][:previous_last_name]).to eq("Smith")
     end
 
     it "sets the correct state" do
@@ -90,45 +90,51 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "sets the correct disabilities" do
-      expect(response.parsed_body["disability_disclosure"]).to eq("disabled")
-      expect(response.parsed_body["disability1"]).to eq("58")
-      expect(response.parsed_body["disability2"]).to eq("57")
+      parsed_body = response.parsed_body[:data]
 
-      trainee_id = response.parsed_body["trainee_id"]
+      expect(parsed_body[:disability_disclosure]).to eq("disabled")
+      expect(parsed_body[:disability1]).to eq("58")
+      expect(parsed_body[:disability2]).to eq("57")
+
+      trainee_id = parsed_body[:trainee_id]
       trainee = Trainee.find_by(slug: trainee_id)
       expect(trainee.disabilities.count).to eq(2)
       expect(trainee.disabilities.map(&:name)).to contain_exactly("Blind", "Deaf")
     end
 
     it "sets the correct funding attributes" do
+      parsed_body = response.parsed_body[:data]
+
       expect(Trainees::MapFundingFromDttpEntityId).to have_received(:call).once
       expect(Trainee.last.applying_for_scholarship).to be(true)
       expect(Trainee.last.applying_for_bursary).to be(false)
       expect(Trainee.last.applying_for_grant).to be(false)
-      expect(response.parsed_body["fund_code"]).to eq("7")
-      expect(response.parsed_body["bursary_level"]).to eq("4")
-      expect(response.parsed_body["applying_for_scholarship"]).to be_nil
-      expect(response.parsed_body["applying_for_bursary"]).to be_nil
-      expect(response.parsed_body["applying_for_grant"]).to be_nil
+      expect(parsed_body[:fund_code]).to eq("7")
+      expect(parsed_body[:bursary_level]).to eq("4")
+      expect(parsed_body[:applying_for_scholarship]).to be_nil
+      expect(parsed_body[:applying_for_bursary]).to be_nil
+      expect(parsed_body[:applying_for_grant]).to be_nil
     end
 
     it "sets the correct school attributes" do
-      expect(response.parsed_body["lead_school_not_applicable"]).to be(false)
-      expect(response.parsed_body["lead_school"]).to be_nil
-      expect(response.parsed_body["employing_school_not_applicable"]).to be(false)
-      expect(response.parsed_body["employing_school"]).to be_nil
+      parsed_body = response.parsed_body[:data]
+
+      expect(parsed_body[:lead_school_not_applicable]).to be(false)
+      expect(parsed_body[:lead_school]).to be_nil
+      expect(parsed_body[:employing_school_not_applicable]).to be(false)
+      expect(parsed_body[:employing_school]).to be_nil
     end
 
     it "creates the degrees if provided in the request body" do
-      degree_attributes = response.parsed_body["degrees"]&.first
+      degree_attributes = response.parsed_body[:data][:degrees]&.first
 
-      expect(degree_attributes["subject"]).to eq("100485")
-      expect(degree_attributes["institution"]).to eq("0117")
-      expect(degree_attributes["graduation_year"]).to eq(2003)
-      expect(degree_attributes["subject"]).to eq("100485")
-      expect(degree_attributes["grade"]).to eq("02")
-      expect(degree_attributes["uk_degree"]).to eq("083")
-      expect(degree_attributes["country"]).to be_nil
+      expect(degree_attributes[:subject]).to eq("100485")
+      expect(degree_attributes[:institution]).to eq("0117")
+      expect(degree_attributes[:graduation_year]).to eq(2003)
+      expect(degree_attributes[:subject]).to eq("100485")
+      expect(degree_attributes[:grade]).to eq("02")
+      expect(degree_attributes[:uk_degree]).to eq("083")
+      expect(degree_attributes[:country]).to be_nil
 
       degree = Degree.last
 
@@ -189,11 +195,11 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "creates the placements if provided in the request body" do
-      placement_attributes = response.parsed_body["placements"]&.first
+      placement_attributes = response.parsed_body[:data][:placements]&.first
 
-      expect(placement_attributes["school_id"]).to be_nil
-      expect(placement_attributes["name"]).to eq("Establishment does not have a URN")
-      expect(placement_attributes["urn"]).to eq("900020")
+      expect(placement_attributes[:school_id]).to be_nil
+      expect(placement_attributes[:name]).to eq("Establishment does not have a URN")
+      expect(placement_attributes[:urn]).to eq("900020")
     end
 
     it "returns status code 201" do

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -237,7 +237,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             trn:,
             ethnicity:,
             ethnic_group:,
-            ethnic_background:
+            ethnic_background:,
           ),
         }
       end

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -343,8 +343,8 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       put(
         "/api/v0.1/trainees/#{trainee.slug}",
         headers: { Authorization: "Bearer #{token}" },
-        params:,
-        as: :json
+        params: params,
+        as: :json,
       )
     end
 
@@ -352,8 +352,8 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       let(:params) do
         {
           data: {
-            ethnicity:
-          }
+            ethnicity:,
+          },
         }
       end
 
@@ -369,8 +369,8 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       let(:params) do
         {
           data: {
-            first_names: "Alice"
-          }
+            first_names: "Alice",
+          },
         }
       end
 
@@ -384,8 +384,8 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       let(:params) do
         {
           data: {
-            ethnicity: "1000"
-          }
+            ethnicity: "1000",
+          },
         }
       end
 

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -260,7 +260,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       expect(response.parsed_body).to have_key("errors")
     end
 
-    context "when read only attributes are been submitted" do
+    context "when read only attributes are submitted" do
       let(:ethnic_background) { Dttp::CodeSets::Ethnicities::MAPPING.keys.sample }
       let(:ethnic_group) { Diversities::BACKGROUNDS.select { |_key, values| values.include?(ethnic_background) }&.keys&.first }
       let(:trainee) { create(:trainee, :in_progress, :with_hesa_trainee_detail, ethnic_group:, ethnic_background:) }

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -500,9 +500,9 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
             expect(response).to have_http_status(:ok)
             expect(trainee.first_names).to eq("Alice")
-            i
-            expect(response.parsed_body[:data][:study_mode]).to eq("63")
+
             expect(response.parsed_body[:data][:trainee_id]).to eq(slug)
+            expect(response.parsed_body[:data][:study_mode]).to eq("63")
           end
         end
 

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -369,7 +369,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         end
 
         let(:course_subject) { cs }
-        let(:slug) { response.parsed_body["trainee_id"] }
+        let(:slug) { response.parsed_body[:data][:trainee_id] }
         let(:trainee) { Trainee.last.reload }
 
         before do
@@ -407,8 +407,9 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
             expect(response).to have_http_status(:ok)
             expect(trainee.first_names).to eq("Alice")
+            i
             expect(response.parsed_body[:data][:study_mode]).to eq("63")
-            expect(response.parsed_body[:data]["trainee_id"]).to eq(slug)
+            expect(response.parsed_body[:data][:trainee_id]).to eq(slug)
           end
         end
 
@@ -424,7 +425,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
             expect(response).to have_http_status(:bad_request)
             expect(trainee.reload.first_names).to eq("John")
-            expect(response.parsed_body).to have_key("errors")
+            expect(response.parsed_body).to have_key(:errors)
           end
         end
       end

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -259,6 +259,48 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body).to have_key("errors")
     end
+
+    context "when read only attributes are been submitted" do
+      let(:trn) { "567899" }
+      let(:ethnicity) { "899" }
+      let(:ethnic_group) { "not_provided_ethnic_group" }
+      let(:ethnic_background) { "Another Mixed background" }
+      let(:params) do
+        {
+          data: {
+            trn:,
+            ethnicity:,
+            ethnic_group:,
+            ethnic_background:,
+          }
+        }
+      end
+
+      before do
+        put(
+          "/api/v0.1/trainees/#{trainee.slug}",
+          headers: { Authorization: "Bearer #{token}" },
+          params:,
+        )
+      end
+
+      it "does not set the attributes" do
+        expect(response).to have_http_status(:ok)
+
+        trainee.reload
+
+        expect(trainee.trn).to be_nil
+        expect(trainee.ethnic_group).to eq("other_ethnic_group")
+        expect(trainee.ethnic_background).to eq("Another ethnic background")
+
+        parsed_body = response.parsed_body[:data]
+
+        expect(parsed_body[:ethnicity]).to eq(ethnicity)
+        expect(parsed_body[:trn]).to be_nil
+        expect(parsed_body[:ethnic_group]).to eq(trainee.ethnic_group)
+        expect(parsed_body[:ethnic_background]).to eq(trainee.ethnic_background)
+      end
+    end
   end
 
   context "Updating a newly created trainee", feature_register_api: true do
@@ -287,7 +329,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
           study_mode: Hesa::CodeSets::StudyModes::MAPPING.invert[TRAINEE_STUDY_MODE_ENUMS["full_time"]],
           degrees_attributes: [
             {
-              subject: "Law",
+              subject: "100485",
               institution: nil,
               graduation_date: "2003-06-01",
               subject_one: "100485",

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -272,7 +272,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
             ethnicity:,
             ethnic_group:,
             ethnic_background:,
-          }
+          },
         }
       end
 
@@ -280,7 +280,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         put(
           "/api/v0.1/trainees/#{trainee.slug}",
           headers: { Authorization: "Bearer #{token}" },
-          params:,
+          params: params,
         )
       end
 

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -336,6 +336,66 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     end
   end
 
+  describe "ethnicity" do
+    let(:token) { AuthenticationToken.create_with_random_token(provider:) }
+
+    before do
+      put(
+        "/api/v0.1/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+        params:,
+        as: :json
+      )
+    end
+
+    context "when present" do
+      let(:params) do
+        {
+          data: {
+            ethnicity:
+          }
+        }
+      end
+
+      let(:ethnicity) { "142" }
+
+      it do
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:data][:ethnicity]).to eq(ethnicity)
+      end
+    end
+
+    context "when not present" do
+      let(:params) do
+        {
+          data: {
+            first_names: "Alice"
+          }
+        }
+      end
+
+      it do
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:data][:ethnicity]).to eq("997")
+      end
+    end
+
+    context "when invalid" do
+      let(:params) do
+        {
+          data: {
+            ethnicity: "1000"
+          }
+        }
+      end
+
+      it do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body[:errors]).to contain_exactly("Ethnicity is not included in the list")
+      end
+    end
+  end
+
   context "Updating a newly created trainee", feature_register_api: true do
     let(:token) { "trainee_token" }
     let!(:auth_token) { create(:authentication_token, hashed_token: AuthenticationToken.hash_token(token)) }


### PR DESCRIPTION
### Context

[7051-some-fields-should-be-read-only](https://trello.com/c/RhSSe0Ge/7051-some-fields-should-be-read-only)

1. Ensure that `trn`, `ethnic_background` and `ethnic_group` cannot be manually set by request.
2. Resolve bug where if the `ethnicity` attribute was not included in the request body, then the `ethnic_background` and `ethnic_group` were defaulted to not provided.

### Changes proposed in this pull request

This PR proposes the following changes:

* Remove `begin` block from `Api::TraineesController#update`
* Remove `trainee_update_params` from `Api::TraineesController`
* Remove `trn` from `TraineeAttributes::V01`
* Ensure that `Api::TraineesController#create` returns the newly created trainee nested in the `data` key
* Refactor `Api::MapHesaAttributes::V01` 
    - Add `ethnic_group`, `ethnic_background` to `ATTRIBUTES` so as to be excluded from the params 
    - Allow the trainee to be injected so as to determine their existing `ethnic_background` if the `ethnicity` is not present in the request body.
* Refactor specs    
* Update docs

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
