### PR TITLE
[7055] Added validation for sex

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,8 +6,6 @@ on:
    branches:
     - main
   pull_request:
-    branches:
-    - main
     types: [opened, reopened, synchronize, labeled]
 
 permissions:

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -78,6 +78,8 @@ module Api
         EmailFormatValidator.new(record).validate
       end
 
+      validates(:sex, inclusion: Hesa::CodeSets::Sexes::MAPPING.values, allow_blank: true)
+
       def initialize(attributes = {})
         attributes = attributes.to_h.with_indifferent_access
 

--- a/app/services/api/map_hesa_attributes/v01.rb
+++ b/app/services/api/map_hesa_attributes/v01.rb
@@ -60,7 +60,7 @@ module Api
       end
 
       def sex
-        ::Hesa::CodeSets::Sexes::MAPPING[params[:sex]]
+        ::Hesa::CodeSets::Sexes::MAPPING[params[:sex]] || params[:sex]
       end
 
       def training_route

--- a/app/services/api/update_trainee_service/v01.rb
+++ b/app/services/api/update_trainee_service/v01.rb
@@ -11,11 +11,9 @@ module Api
       end
 
       def call
-        if validation_errors.any?
-          [false, OpenStruct.new(
-            error_count: validation_errors.count,
-            all_errors: validation_errors,
-          )]
+        trainee_attributes_validation = TraineeAttributesValidation.new(trainee_attributes:)
+        if trainee_attributes_validation.invalid?
+          [false, trainee_attributes_validation]
         else
           trainee.assign_attributes(attributes.deep_attributes)
 
@@ -32,21 +30,28 @@ module Api
       attr_reader :trainee, :attributes
 
       alias_method :trainee_attributes, :attributes
-      def validation_errors
-        [*trainee_errors, *hesa_trainee_detail_attributes_errors].compact.flatten
-      end
 
-      def trainee_errors
-        @trainee_errors ||= begin
-          trainee_attributes.validate
-          trainee_attributes.errors&.full_messages
+      TraineeAttributesValidation = Struct.new(:trainee_attributes) do
+        def errors_count = validation_errors.count
+        def all_errors = validation_errors
+        def invalid? = !errors_count.zero?
+
+        def validation_errors
+          [*trainee_errors, *hesa_trainee_detail_attributes_errors].compact.flatten
         end
-      end
 
-      def hesa_trainee_detail_attributes_errors
-        @hesa_trainee_detail_attributes_errors ||= begin
-          trainee_attributes.hesa_trainee_detail_attributes.validate
-          trainee_attributes.hesa_trainee_detail_attributes.errors&.full_messages
+        def trainee_errors
+          @trainee_errors ||= begin
+            trainee_attributes.validate
+            trainee_attributes.errors&.full_messages
+          end
+        end
+
+        def hesa_trainee_detail_attributes_errors
+          @hesa_trainee_detail_attributes_errors ||= begin
+            trainee_attributes.hesa_trainee_detail_attributes.validate
+            trainee_attributes.hesa_trainee_detail_attributes.errors&.full_messages
+          end
         end
       end
 

--- a/app/services/api/update_trainee_service/v01.rb
+++ b/app/services/api/update_trainee_service/v01.rb
@@ -11,18 +11,44 @@ module Api
       end
 
       def call
-        trainee.assign_attributes(attributes.deep_attributes)
-
-        if validation.all_errors.any?
-          [false, validation]
+        if validation_errors.any?
+          [false, OpenStruct.new(
+            error_count: validation_errors.count,
+            all_errors: validation_errors,
+          )]
         else
-          [trainee.save, nil]
+          trainee.assign_attributes(attributes.deep_attributes)
+
+          if validation.all_errors.any?
+            [false, validation]
+          else
+            [trainee.save, nil]
+          end
         end
       end
 
     private
 
       attr_reader :trainee, :attributes
+
+      alias_method :trainee_attributes, :attributes
+      def validation_errors
+        [*trainee_errors, *hesa_trainee_detail_attributes_errors].compact.flatten
+      end
+
+      def trainee_errors
+        @trainee_errors ||= begin
+          trainee_attributes.validate
+          trainee_attributes.errors&.full_messages
+        end
+      end
+
+      def hesa_trainee_detail_attributes_errors
+        @hesa_trainee_detail_attributes_errors ||= begin
+          trainee_attributes.hesa_trainee_detail_attributes.validate
+          trainee_attributes.hesa_trainee_detail_attributes.errors&.full_messages
+        end
+      end
 
       def validation
         @validation ||= Submissions::ApiTrnValidator.new(trainee:)

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -669,13 +669,12 @@ FactoryBot.define do
     end
 
     trait :with_hesa_trainee_detail do
-      with_hesa_student
+      hesa_id { Faker::Number.number(digits: 13) }
       hesa_trainee_detail
     end
 
     trait :with_hesa_student do
       hesa_id { Faker::Number.number(digits: 13) }
-
       hesa_students { create_list(:hesa_student, 1, hesa_id:) }
     end
   end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -654,10 +654,9 @@ FactoryBot.define do
         hesa_student_application_choice_id { nil }
       end
 
-      hesa_id { Faker::Number.number(digits: 13) }
+      with_hesa_student
       created_from_hesa { true }
       hesa_updated_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
-      hesa_students { create_list(:hesa_student, 1, hesa_id:) }
 
       after(:create) do |trainee, evaluator|
         create(:hesa_metadatum, trainee: trainee, itt_aim: evaluator.itt_aim)
@@ -670,7 +669,14 @@ FactoryBot.define do
     end
 
     trait :with_hesa_trainee_detail do
+      with_hesa_student
       hesa_trainee_detail
+    end
+
+    trait :with_hesa_student do
+      hesa_id { Faker::Number.number(digits: 13) }
+
+      hesa_students { create_list(:hesa_student, 1, hesa_id:) }
     end
   end
 end

--- a/spec/models/api/trainee_attributes/v01_spec.rb
+++ b/spec/models/api/trainee_attributes/v01_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::TraineeAttributes::V01 do
   end
 
   describe ".from_trainee" do
-    let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :completed) }
+    let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :completed, sex: :prefer_not_to_say) }
 
     subject(:attributes) { described_class.from_trainee(trainee) }
 
@@ -34,6 +34,10 @@ RSpec.describe Api::TraineeAttributes::V01 do
       Api::HesaTraineeDetailAttributes::V01::ATTRIBUTES.each do |attr|
         expect(attributes.hesa_trainee_detail_attributes.send(attr)).to be_present
       end
+    end
+
+    it "correctly sets the sex attribute as an integer" do
+      expect(attributes.sex).to eq(Trainee.sexes[:prefer_not_to_say])
     end
   end
 
@@ -73,6 +77,67 @@ RSpec.describe Api::TraineeAttributes::V01 do
       deep_attributes = attributes.deep_attributes.with_indifferent_access
 
       expect(deep_attributes).to have_key(:hesa_trainee_detail_attributes)
+    end
+  end
+
+  describe "assign_attributes" do
+    let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :completed, sex: :prefer_not_to_say) }
+    let(:trainee_attributes) { described_class.from_trainee(trainee) }
+
+    subject(:attributes) {
+      trainee_attributes
+    }
+
+    it "correctly sets the sex attribute as an integer" do
+      expect(attributes.sex).to eq(Trainee.sexes[trainee.sex])
+
+      expect {
+        attributes.assign_attributes(sex: 3)
+      }.to change {
+        attributes.sex
+      }.from(4).to(3)
+    end
+
+    context "hesa trainee detail attributes" do
+      context "changing a non hesa trainee detail attributes" do
+        it "does not change the hesa trainee detail attributes" do
+          expect(attributes.sex).to eq(Trainee.sexes[:prefer_not_to_say])
+
+          expect {
+            attributes.assign_attributes(sex: 3)
+          }.not_to change {
+            attributes.hesa_trainee_detail_attributes
+          }
+        end
+      end
+
+      context "changing a single hesa trainee detail attribute" do
+        let(:trainee) { create(:trainee, :with_hesa_student, :completed, sex: :prefer_not_to_say, hesa_trainee_detail: hesa_trainee_detail) }
+
+        let(:hesa_trainee_detail) {
+          build(:hesa_trainee_detail, course_age_range: "13909")
+        }
+
+        let(:hesa_trainee_detail_attributes) {
+          hesa_trainee_detail.attributes.select { |k, _v|
+            Api::HesaTraineeDetailAttributes::V01::ATTRIBUTES.include?(k.to_sym)
+          }
+        }
+
+        let(:updated_hesa_trainee_detail_attributes) {
+          hesa_trainee_detail_attributes.merge("course_age_range" => "13919")
+        }
+
+        it "does not change the other hesa trainee detail attributes" do
+          expect(attributes.hesa_trainee_detail_attributes.attributes).to match(hesa_trainee_detail_attributes)
+
+          expect {
+            attributes.assign_attributes(course_age_range: "13919")
+          }.to change {
+            attributes.hesa_trainee_detail_attributes.attributes
+          }.from(hesa_trainee_detail_attributes).to(updated_hesa_trainee_detail_attributes)
+        end
+      end
     end
   end
 end

--- a/spec/models/api/trainee_attributes/v01_spec.rb
+++ b/spec/models/api/trainee_attributes/v01_spec.rb
@@ -5,6 +5,24 @@ require "rails_helper"
 RSpec.describe Api::TraineeAttributes::V01 do
   subject { described_class.new }
 
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:first_names) }
+    it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:date_of_birth) }
+    it { is_expected.to validate_presence_of(:sex) }
+    it { is_expected.to validate_presence_of(:training_route) }
+    it { is_expected.to validate_presence_of(:itt_start_date) }
+    it { is_expected.to validate_presence_of(:itt_end_date) }
+    it { is_expected.to validate_presence_of(:diversity_disclosure) }
+    it { is_expected.to validate_presence_of(:course_subject_one) }
+    it { is_expected.to validate_presence_of(:study_mode) }
+    it { is_expected.to validate_presence_of(:hesa_id) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_length_of(:email).is_at_most(255) }
+
+    it { is_expected.to validate_inclusion_of(:sex).in_array(Hesa::CodeSets::Sexes::MAPPING.values) }
+  end
+
   describe ".from_trainee" do
     let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :completed) }
 

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -16,13 +16,15 @@ describe "`POST /api/v0.1/trainees` endpoint" do
   let(:graduation_year) { "2003" }
   let(:course_age_range) { Hesa::CodeSets::AgeRanges::MAPPING.keys.sample }
 
+  let(:sex) { Hesa::CodeSets::Sexes::MAPPING.keys.sample }
+
   let(:data) do
     {
       first_names: "John",
       last_name: "Doe",
       previous_last_name: "Smith",
       date_of_birth: "1990-01-01",
-      sex: Hesa::CodeSets::Sexes::MAPPING.invert[Trainee.sexes[:male]],
+      sex: sex,
       email: "john.doe@example.com",
       nationality: "GB",
       training_route: Hesa::CodeSets::TrainingRoutes::MAPPING.invert[TRAINING_ROUTE_ENUMS[:provider_led_undergrad]],
@@ -225,7 +227,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       end
     end
 
-    context "course_age_range is empty" do
+    context "when course_age_range is empty" do
       let(:params) { { data: } }
 
       let(:course_age_range) { "" }
@@ -236,7 +238,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       end
     end
 
-    context "course_age_range is invalid" do
+    context "when course_age_range is invalid" do
       let(:params) { { data: } }
 
       let(:course_age_range) { "invalid" }
@@ -246,13 +248,36 @@ describe "`POST /api/v0.1/trainees` endpoint" do
         expect(response.parsed_body["errors"]).to contain_exactly("Course age range is not included in the list")
       end
     end
+
+    context "when sex is empty" do
+      let(:params) { { data: } }
+
+      let(:sex) { "" }
+
+      it "return status code 422 with a meaningful error message" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to contain_exactly("Sex can't be blank")
+      end
+    end
+
+    context "when sex is invalid" do
+      let(:params) { { data: } }
+
+      let(:sex) { "invalid" }
+
+      it "return status code 422 with a meaningful error message" do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to contain_exactly("Sex is not included in the list")
+      end
+    end
   end
 
   context "when a placement is invalid", feature_register_api: true do
     before do
-      params[:data][:placements_attributes] = [{ not_an_attribute: "invalid" }]
       post "/api/v0.1/trainees", params: params, headers: { Authorization: token }
     end
+
+    let(:params) { { data: data.merge({ placements_attributes: [{ not_an_attribute: "invalid" }] }) } }
 
     it "return status code 422 with a meaningful error message" do
       expect(response).to have_http_status(:unprocessable_entity)


### PR DESCRIPTION
### Context
Validation for sex values

### Changes proposed in this pull request
Added validation for sex

### Guidance to review
There is validation

#### Order of validations
`Api::TraineeAttributes::V01` (all those nested V01 attributes validations)
`Submissions::ApiTrnValidator` (ui forms validations)
so api is a little bit tighter then ui

There was a mapping issue `attributes` was overused to the point that there was an issue of is it referring to `parameter` or `self`.

There was a update issue where by it generated a new object rather than assigning attributes

Added `TraineeAttributesValidation` as a stop gap as the chain for `update` and `create` a trainee should be similar.

1. `Api::CreateTrainee` seems to be the more concise as it deals with 
    1. validation for both `trainee_attributes` and `api_trn_validator`
    2. returning the `right response` for creating a trainee
    3.  the class is sitting outside of `v0.1`
2. `Api::UpdateTraineeService::V01`
    1. façade for validation

