### PR TITLE
[7058] Update docs for `previous_last_name` and make sure its saved correctly

### DIFF
--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -2216,7 +2216,7 @@ Deletes an existing degree for this trainee.
     </dd>
   </div>
   <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
-    <dt class="govuk-summary-list__key"><code>previous_surname</code></dt>
+    <dt class="govuk-summary-list__key"><code>previous_last_name</code></dt>
     <dd class="govuk-summary-list__value">
       <p class="govuk-body">
         string

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -19,6 +19,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     {
       first_names: "John",
       last_name: "Doe",
+      previous_last_name: "Smith",
       date_of_birth: "1990-01-01",
       sex: Hesa::CodeSets::Sexes::MAPPING.invert[Trainee.sexes[:male]],
       email: "john.doe@example.com",
@@ -71,6 +72,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
     it "creates a trainee" do
       expect(response.parsed_body["first_names"]).to eq("John")
+      expect(response.parsed_body["last_name"]).to eq("Doe")
+      expect(response.parsed_body["previous_last_name"]).to eq("Smith")
     end
 
     it "sets the correct state" do


### PR DESCRIPTION
### Context

The `previous_last_name` field in the API docs is wrongly called `previous_surname` and there was a question about whether this field was being correctly updated.

### Changes proposed in this pull request

* Amended the API docs with correct field name
* Added `previous_last_name` to the POST Trainee spec

### Guidance to review

Check that API docs are accurate and the field can be set and updated.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
