### PR TITLE
[7050] Return Study Mode in API Responses

### DIFF
--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -135,7 +135,7 @@ module Api
       end
 
       def update_hesa_trainee_detail_attributes(attributes)
-        existing_hesa_attributes = self.hesa_trainee_detail_attributes&.attributes || {}
+        existing_hesa_attributes = hesa_trainee_detail_attributes&.attributes || {}
         new_hesa_attributes = HesaTraineeDetailAttributes::V01.new(
           attributes.slice(*HesaTraineeDetailAttributes::V01::ATTRIBUTES),
         )

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -135,11 +135,9 @@ module Api
       end
 
       def update_hesa_trainee_detail_attributes(attributes)
-        existing_hesa_attributes = hesa_trainee_detail_attributes&.attributes || {}
-        new_hesa_attributes = HesaTraineeDetailAttributes::V01.new(
-          attributes.slice(*HesaTraineeDetailAttributes::V01::ATTRIBUTES),
-        )
-        self.hesa_trainee_detail_attributes = new_hesa_attributes.assign_attributes(existing_hesa_attributes)
+        existing_hesa_attributes = hesa_trainee_detail_attributes || HesaTraineeDetailAttributes::V01.new({})
+        new_hesa_attributes = attributes.slice(*HesaTraineeDetailAttributes::V01::ATTRIBUTES)
+        self.hesa_trainee_detail_attributes = existing_hesa_attributes.assign_attributes(new_hesa_attributes)
       end
 
       def self.from_trainee(trainee)

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -138,9 +138,12 @@ module Api
       end
 
       def update_hesa_trainee_detail_attributes(attributes)
-        existing_hesa_attributes = hesa_trainee_detail_attributes || HesaTraineeDetailAttributes::V01.new({})
         new_hesa_attributes = attributes.slice(*HesaTraineeDetailAttributes::V01::ATTRIBUTES)
-        self.hesa_trainee_detail_attributes = existing_hesa_attributes.assign_attributes(new_hesa_attributes)
+        return if new_hesa_attributes.blank?
+
+        updated_hesa_attributes = hesa_trainee_detail_attributes || HesaTraineeDetailAttributes::V01.new({})
+        updated_hesa_attributes.assign_attributes(new_hesa_attributes)
+        updated_hesa_attributes
       end
 
       def self.from_trainee(trainee)

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -126,15 +126,20 @@ module Api
           nationalisations_attributes << NationalityAttributes::V01.new(nationalisation_params)
         end
 
-        self.hesa_trainee_detail_attributes =
-          HesaTraineeDetailAttributes::V01.new(
-            attributes.slice(*HesaTraineeDetailAttributes::V01::ATTRIBUTES),
-          )
+        update_hesa_trainee_detail_attributes(attributes)
 
         self.trainee_disabilities_attributes = []
         attributes[:disabilities]&.each do |disability|
           trainee_disabilities_attributes << { disability_id: disability.id }
         end
+      end
+
+      def update_hesa_trainee_detail_attributes(attributes)
+        existing_hesa_attributes = self.hesa_trainee_detail_attributes&.attributes || {}
+        new_hesa_attributes = HesaTraineeDetailAttributes::V01.new(
+          attributes.slice(*HesaTraineeDetailAttributes::V01::ATTRIBUTES),
+        )
+        self.hesa_trainee_detail_attributes = new_hesa_attributes.assign_attributes(existing_hesa_attributes)
       end
 
       def self.from_trainee(trainee)

--- a/app/services/api/map_hesa_attributes/v01.rb
+++ b/app/services/api/map_hesa_attributes/v01.rb
@@ -42,6 +42,7 @@ module Api
           degrees_attributes:,
           placements_attributes:,
           hesa_disabilities:,
+          course_study_mode:,
         })
         .merge(course_attributes)
         .merge(ethnicity_and_disability_attributes)

--- a/app/services/api/map_hesa_attributes/v01.rb
+++ b/app/services/api/map_hesa_attributes/v01.rb
@@ -141,6 +141,10 @@ module Api
         DfE::ReferenceData::AgeRanges::HESA_CODE_SETS[params[:course_age_range]]
       end
 
+      def course_study_mode
+        params[:study_mode]
+      end
+
       def course_attributes
         attributes = super
 

--- a/app/services/concerns/has_course_attributes.rb
+++ b/app/services/concerns/has_course_attributes.rb
@@ -9,6 +9,7 @@ module HasCourseAttributes
       course_subject_three: course_subject_three_name,
       course_min_age: course_age_range && course_age_range[0],
       course_max_age: course_max_age,
+      course_study_mode: course_study_mode,
       study_mode: study_mode,
       itt_start_date: itt_start_date,
       itt_end_date: itt_end_date,

--- a/app/services/concerns/has_course_attributes.rb
+++ b/app/services/concerns/has_course_attributes.rb
@@ -9,7 +9,6 @@ module HasCourseAttributes
       course_subject_three: course_subject_three_name,
       course_min_age: course_age_range && course_age_range[0],
       course_max_age: course_max_age,
-      course_study_mode: course_study_mode,
       study_mode: study_mode,
       itt_start_date: itt_start_date,
       itt_end_date: itt_end_date,

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -77,6 +77,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       expect(Trainee.last.state).to eq("submitted_for_trn")
     end
 
+    it "sets the correct study_mode" do
+      expect(response.parsed_body["study_mode"]).to eq("63")
+    end
+
     it "sets the correct disabilities" do
       expect(response.parsed_body["disability_disclosure"]).to eq("disabled")
       expect(response.parsed_body["disability1"]).to eq("58")

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -193,9 +193,9 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
               data:
                 {
                   first_names: "Alice",
-                  study_mode: "63"
-                }
-              }
+                  study_mode: "63",
+                },
+            }
           end
 
           it "updates the trainee" do

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -188,7 +188,15 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         end
 
         context "when updating a newly created trainee with valid params" do
-          let(:params_for_update) { { data: { first_names: "Alice" } } }
+          let(:params_for_update) do
+            {
+              data:
+                {
+                  first_names: "Alice",
+                  study_mode: "63"
+                }
+              }
+          end
 
           it "updates the trainee" do
             put(

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -199,6 +199,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
             expect(response).to have_http_status(:ok)
             expect(trainee.first_names).to eq("Alice")
+            expect(response.parsed_body[:data][:study_mode]).to eq("63")
             expect(response.parsed_body[:data]["trainee_id"]).to eq(slug)
           end
         end


### PR DESCRIPTION
### Context
The study mode for the course wasn't being returned in API responses, even when it was provided in the request.

### Changes proposed in this pull request
It turns out that the study mode wasn't being saved correctly when the trainee was created. So this adds the missing method to the mapping class so that it now gets included. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
