### PR TITLE
[7056] - Validate ethnicity values

### DIFF
--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -25,6 +25,7 @@ module Api
         itt_start_date
         itt_end_date
         diversity_disclosure
+        ethnicity
         ethnic_group
         ethnic_background
         disability_disclosure
@@ -72,6 +73,7 @@ module Api
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
       validates :email, presence: true, length: { maximum: 255 }
+      validates :ethnicity, inclusion: Hesa::CodeSets::Ethnicities::MAPPING.keys
 
       validate do |record|
         EmailFormatValidator.new(record).validate

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -73,7 +73,7 @@ module Api
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
       validates :email, presence: true, length: { maximum: 255 }
-      validates :ethnicity, inclusion: Hesa::CodeSets::Ethnicities::MAPPING.keys
+      validates :ethnicity, inclusion: Hesa::CodeSets::Ethnicities::MAPPING.keys, allow_nil: true
 
       validate do |record|
         EmailFormatValidator.new(record).validate

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -156,7 +156,7 @@ module Api
       end
 
       def deep_attributes
-        attributes.transform_values do |value|
+        attributes.except("ethnicity").transform_values do |value|
           if value.is_a?(Array)
             value.map { |item| item.respond_to?(:attributes) ? item.attributes : item }
           elsif value.respond_to?(:attributes)

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -304,8 +304,6 @@ class Trainee < ApplicationRecord
   COMPLETE_STATES = %w[recommended_for_award withdrawn awarded].freeze
   IN_TRAINING_STATES = %w[submitted_for_trn trn_received recommended_for_award].freeze
 
-  attr_accessor :ethnicity
-
   pg_search_scope :with_name_provider_trainee_id_or_trn_like,
                   against: %i[first_names middle_names last_name provider_trainee_id trn],
                   using: { tsearch: { prefix: true } }

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -304,6 +304,8 @@ class Trainee < ApplicationRecord
   COMPLETE_STATES = %w[recommended_for_award withdrawn awarded].freeze
   IN_TRAINING_STATES = %w[submitted_for_trn trn_received recommended_for_award].freeze
 
+  attr_accessor :ethnicity
+
   pg_search_scope :with_name_provider_trainee_id_or_trn_like,
                   against: %i[first_names middle_names last_name provider_trainee_id trn],
                   using: { tsearch: { prefix: true } }

--- a/app/services/api/map_hesa_attributes/v01.rb
+++ b/app/services/api/map_hesa_attributes/v01.rb
@@ -9,7 +9,6 @@ module Api
 
       ATTRIBUTES = %i[
         nationality
-        ethnicity
         ethnic_group
         ethnic_background
       ].freeze

--- a/spec/models/api/trainee_attributes/v01_spec.rb
+++ b/spec/models/api/trainee_attributes/v01_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::TraineeAttributes::V01 do
     it { is_expected.to validate_length_of(:email).is_at_most(255) }
 
     it { is_expected.to validate_inclusion_of(:sex).in_array(Hesa::CodeSets::Sexes::MAPPING.values) }
-    it { is_expected.to validate_inclusion_of(:ethnicity).in_array(Hesa::CodeSets::Ethnicities::MAPPING.keys) }
+    it { is_expected.to validate_inclusion_of(:ethnicity).in_array(Hesa::CodeSets::Ethnicities::MAPPING.keys).allow_nil }
   end
 
   describe ".from_trainee" do

--- a/spec/models/api/trainee_attributes/v01_spec.rb
+++ b/spec/models/api/trainee_attributes/v01_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Api::TraineeAttributes::V01 do
     it { is_expected.to validate_length_of(:email).is_at_most(255) }
 
     it { is_expected.to validate_inclusion_of(:sex).in_array(Hesa::CodeSets::Sexes::MAPPING.values) }
+    it { is_expected.to validate_inclusion_of(:ethnicity).in_array(Hesa::CodeSets::Ethnicities::MAPPING.keys) }
   end
 
   describe ".from_trainee" do

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -280,6 +280,51 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
   end
 
+  describe "ethnicity" do
+    before do
+      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json
+    end
+
+    context "when present" do
+      let(:params) do
+        {
+          data: data.merge(
+            ethnicity:
+          )
+        }
+      end
+
+      let(:ethnicity) { "142" }
+
+      it do
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body[:data][:ethnicity]).to eq(ethnicity)
+      end
+    end
+
+    context "when not present" do
+      it do
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body[:data][:ethnicity]).to eq("997")
+      end
+    end
+
+    context "when invalid" do
+      let(:params) do
+        {
+          data: data.merge(
+            ethnicity: "1000"
+          )
+        }
+      end
+
+      it do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body[:errors]).to contain_exactly("Ethnicity is not included in the list")
+      end
+    end
+  end
+
   context "when the trainee record is invalid", feature_register_api: true do
     before do
       post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -289,8 +289,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       let(:params) do
         {
           data: data.merge(
-            ethnicity:
-          )
+            ethnicity:,
+          ),
         }
       end
 
@@ -313,8 +313,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       let(:params) do
         {
           data: data.merge(
-            ethnicity: "1000"
-          )
+            ethnicity: "1000",
+          ),
         }
       end
 

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -233,6 +233,66 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     end
   end
 
+  describe "ethnicity" do
+    let(:token) { AuthenticationToken.create_with_random_token(provider:) }
+
+    before do
+      put(
+        "/api/v0.1/trainees/#{trainee.slug}",
+        headers: { Authorization: "Bearer #{token}" },
+        params:,
+        as: :json
+      )
+    end
+
+    context "when present" do
+      let(:params) do
+        {
+          data: {
+            ethnicity:
+          }
+        }
+      end
+
+      let(:ethnicity) { "142" }
+
+      it do
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:data][:ethnicity]).to eq(ethnicity)
+      end
+    end
+
+    context "when not present" do
+      let(:params) do
+        {
+          data: {
+            first_names: "Alice"
+          }
+        }
+      end
+
+      it do
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body[:data][:ethnicity]).to eq("997")
+      end
+    end
+
+    context "when invalid" do
+      let(:params) do
+        {
+          data: {
+            ethnicity: "1000"
+          }
+        }
+      end
+
+      it do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body[:errors]).to contain_exactly("Ethnicity is not included in the list")
+      end
+    end
+  end
+
   context "Updating a newly created trainee", feature_register_api: true do
     let(:token) { "trainee_token" }
     let!(:auth_token) { create(:authentication_token, hashed_token: AuthenticationToken.hash_token(token)) }

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -240,8 +240,8 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       put(
         "/api/v0.1/trainees/#{trainee.slug}",
         headers: { Authorization: "Bearer #{token}" },
-        params:,
-        as: :json
+        params: params,
+        as: :json,
       )
     end
 
@@ -249,8 +249,8 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       let(:params) do
         {
           data: {
-            ethnicity:
-          }
+            ethnicity:,
+          },
         }
       end
 
@@ -266,8 +266,8 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       let(:params) do
         {
           data: {
-            first_names: "Alice"
-          }
+            first_names: "Alice",
+          },
         }
       end
 
@@ -281,8 +281,8 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       let(:params) do
         {
           data: {
-            ethnicity: "1000"
-          }
+            ethnicity: "1000",
+          },
         }
       end
 


### PR DESCRIPTION
### Context

[7056-validate-ethnicity-values](https://trello.com/c/dt5AxKx9/7056-validate-ethnicity-values)

Trainee `ethnicity` was not validated for the HESA allowed values

### Changes proposed in this pull request

* Add inclusion validation to `Api::TraineeAttributes` for ethnicity
* Add `attr_accessor :ethnicity` to `Trainee` to allow for the attribute to be assigned
* Remove from `Api::MapHesaAttributes::V01` `ethnicity` from the excluded `ATTRIBUTES`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
