### PR TITLE
Update Specs and Factory for HESA Disabilities

### DIFF
--- a/spec/factories/hesa/trainee_details.rb
+++ b/spec/factories/hesa/trainee_details.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     postgrad_apprenticeship_start_date { Time.zone.today }
     funding_method { Hesa::CodeSets::BursaryLevels::MAPPING.keys.sample }
     ni_number { "QQ 12 34 56 C" }
-    hesa_disabilities { ["95"] }
+    hesa_disabilities { { disability1: "95" } }
     additional_training_initiative { "026" }
     itt_qualification_aim { Hesa::CodeSets::IttQualificationAims::MAPPING.keys.sample }
     fund_code { Hesa::CodeSets::FundCodes::MAPPING.keys.sample }

--- a/spec/serializers/trainee_serializer/v01_spec.rb
+++ b/spec/serializers/trainee_serializer/v01_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe TraineeSerializer::V01 do
     end
 
     it "includes the correct disability values" do
-      expect(json["disability1"]).to_not be_nil
+      expect(json["disability1"]).not_to be_nil
       expect(json["disability1"]).to eq(trainee.hesa_trainee_detail.hesa_disabilities["disability1"])
     end
 

--- a/spec/serializers/trainee_serializer/v01_spec.rb
+++ b/spec/serializers/trainee_serializer/v01_spec.rb
@@ -85,9 +85,15 @@ RSpec.describe TraineeSerializer::V01 do
         nationality
         placements
         degrees
+        disability1
       ].each do |field|
         expect(json.keys).to include(field)
       end
+    end
+
+    it "includes the correct disability values" do
+      expect(json["disability1"]).to_not be_nil
+      expect(json["disability1"]).to eq(trainee.hesa_trainee_detail.hesa_disabilities["disability1"])
     end
 
     it "does not include excluded fields" do


### PR DESCRIPTION
### Context
We [recently changed](https://github.com/DFE-Digital/register-trainee-teachers/pull/4222) the `hesa_disabilities` column on `hesa_trainee_details` from an array to a json column. But we didn't update the factory as part of that. We also still had some data in our test environment that was stored as an array, leading us to think there was a problem when serialising the data.

### Changes proposed in this pull request
I've updated the factory to give us the correct value and added a test to the serialiser, so we know that we're getting exactly what we want. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
