### PR TITLE
[7080] Add missing response examples to API reference docs

### DIFF
--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -271,6 +271,21 @@ current academic cycle.
   </div>
 </details>
 
+<details class="govuk-details">
+  <summary class="govuk-details__summary">HTTP 422<span> - Unprocessable Entity</span></summary>
+  <div class="govuk-details__text">
+    <pre class="json-code-sample">
+    {
+      "message": "Validation failed: 1 error prohibited this request being run",
+      "errors": {
+        "status": [
+          "busy is not a valid status"
+        ]
+      }
+    } 
+    </pre>
+  </div>
+</details>
 ---
 
 ### `GET /trainees/{trainee_id}`


### PR DESCRIPTION
### Context
This PR just adds a few missing response sections to the API reference docs.

It originates from support issue https://trello.com/c/mQvTD5Ot/7080-unprocessable-entity-withdrawals

### Changes proposed in this pull request
Add missing response examples.

### Guidance to review
Are there any more that we need?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
