### PR TITLE
Refactor Record Sources

### DIFF
--- a/app/forms/course_details_form.rb
+++ b/app/forms/course_details_form.rb
@@ -109,7 +109,7 @@ class CourseDetailsForm < TraineeForm
   end
 
   def require_age_range?
-    return false if trainee.record_source == RecordSources::API
+    return false if trainee.api_record?
 
     EARLY_YEARS_TRAINING_ROUTES.exclude?(training_route)
   end

--- a/app/forms/funding/training_initiatives_form.rb
+++ b/app/forms/funding/training_initiatives_form.rb
@@ -24,7 +24,7 @@ module Funding
     end
 
     def training_initiative_required?
-      trainee.record_source != RecordSources::API
+      trainee.api_record? == false
     end
   end
 end

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -161,7 +161,7 @@ private
   end
 
   def nationalities_cannot_be_empty
-    return if trainee.record_source == RecordSources::API
+    return if trainee.api_record?
 
     if nationality_ids.empty?
       errors.add(:nationality_names, :empty_nationalities)

--- a/app/jobs/hesa/retrieve_collection_job.rb
+++ b/app/jobs/hesa/retrieve_collection_job.rb
@@ -20,7 +20,7 @@ module Hesa
     end
 
     def record_source
-      RecordSources::HESA_COLLECTION
+      Trainee::HESA_COLLECTION_SOURCE
     end
   end
 end

--- a/app/jobs/hesa/retrieve_trn_data_job.rb
+++ b/app/jobs/hesa/retrieve_trn_data_job.rb
@@ -19,7 +19,7 @@ module Hesa
     end
 
     def record_source
-      RecordSources::HESA_TRN_DATA
+      Trainee::HESA_TRN_DATA_SOURCE
     end
   end
 end

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -69,7 +69,7 @@ module Api
       attribute :hesa_trainee_detail_attributes, array: false, default: -> {}
       attribute :trainee_disabilities_attributes, array: true, default: -> { [] }
       attribute :date_of_birth, :date
-      attribute :record_source, default: -> { RecordSources::API }
+      attribute :record_source, default: -> { Trainee::API_SOURCE }
 
       validates(*REQUIRED_ATTRIBUTES, presence: true)
       validates :email, presence: true, length: { maximum: 255 }

--- a/app/models/concerns/sourceable.rb
+++ b/app/models/concerns/sourceable.rb
@@ -20,13 +20,6 @@ module Sourceable
   NON_TRN_SOURCES = ALL - [HESA_TRN_DATA_SOURCE].freeze
 
   included do
-    enum record_source: {
-      apply: APPLY_SOURCE,
-      dttp: DTTP_SOURCE,
-      hesa_collection: HESA_COLLECTION_SOURCE,
-      hesa_trn_data: HESA_TRN_DATA_SOURCE,
-      manual: MANUAL_SOURCE,
-      api: API_SOURCE,
-    }, _suffix: :record
+    enum record_source: ALL.to_h { |r| [r, r] }, _suffix: :record
   end
 end

--- a/app/models/concerns/sourceable.rb
+++ b/app/models/concerns/sourceable.rb
@@ -1,30 +1,32 @@
+# frozen_string_literal: true
+
 module Sourceable
   extend ActiveSupport::Concern
 
-  APPLY_SOURCE = "apply".freeze
-  DTTP_SOURCE = "dttp".freeze
-  HESA_COLLECTION_SOURCE = "hesa_collection".freeze
-  HESA_TRN_DATA_SOURCE = "hesa_trn_data".freeze
-  MANUAL_SOURCE = "manual".freeze
-  API_SOURCE = "api".freeze
+  APPLY_SOURCE = "apply"
+  DTTP_SOURCE = "dttp"
+  HESA_COLLECTION_SOURCE = "hesa_collection"
+  HESA_TRN_DATA_SOURCE = "hesa_trn_data"
+  MANUAL_SOURCE = "manual"
+  API_SOURCE = "api"
   ALL = [
     APPLY_SOURCE,
     DTTP_SOURCE,
     HESA_COLLECTION_SOURCE,
     HESA_TRN_DATA_SOURCE,
     MANUAL_SOURCE,
-    API_SOURCE
+    API_SOURCE,
   ].freeze
   NON_TRN_SOURCES = ALL - [HESA_TRN_DATA_SOURCE].freeze
 
   included do
     enum record_source: {
-        apply: APPLY_SOURCE,
-        dttp: DTTP_SOURCE,
-        hesa_collection: HESA_COLLECTION_SOURCE,
-        hesa_trn_data: HESA_TRN_DATA_SOURCE,
-        manual: MANUAL_SOURCE,
-        api: API_SOURCE,
+      apply: APPLY_SOURCE,
+      dttp: DTTP_SOURCE,
+      hesa_collection: HESA_COLLECTION_SOURCE,
+      hesa_trn_data: HESA_TRN_DATA_SOURCE,
+      manual: MANUAL_SOURCE,
+      api: API_SOURCE,
     }, _suffix: :record
   end
 end

--- a/app/models/concerns/sourceable.rb
+++ b/app/models/concerns/sourceable.rb
@@ -1,0 +1,21 @@
+module Sourceable
+  extend ActiveSupport::Concern
+
+  APPLY_SOURCE = "apply".freeze
+  DTTP_SOURCE = "dttp".freeze
+  HESA_COLLECTION_SOURCE = "hesa_collection".freeze
+  HESA_TRN_DATA_SOURCE = "hesa_trn_data".freeze
+  MANUAL_SOURCE = "manual".freeze
+  API_SOURCE = "api".freeze
+
+  included do
+    enum record_source: {
+        apply: APPLY_SOURCE,
+        dttp: DTTP_SOURCE,
+        hesa_collection: HESA_COLLECTION_SOURCE,
+        hesa_trn_data: HESA_TRN_DATA_SOURCE,
+        manual: MANUAL_SOURCE,
+        api: API_SOURCE,
+    }, _suffix: :record
+  end
+end

--- a/app/models/concerns/sourceable.rb
+++ b/app/models/concerns/sourceable.rb
@@ -7,6 +7,15 @@ module Sourceable
   HESA_TRN_DATA_SOURCE = "hesa_trn_data".freeze
   MANUAL_SOURCE = "manual".freeze
   API_SOURCE = "api".freeze
+  ALL = [
+    APPLY_SOURCE,
+    DTTP_SOURCE,
+    HESA_COLLECTION_SOURCE,
+    HESA_TRN_DATA_SOURCE,
+    MANUAL_SOURCE,
+    API_SOURCE
+  ].freeze
+  NON_TRN_SOURCES = ALL - [HESA_TRN_DATA_SOURCE].freeze
 
   included do
     enum record_source: {

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -121,7 +121,8 @@
 class Trainee < ApplicationRecord
   self.ignored_columns += %w[trainee_id] # rubocop:disable Rails/UnusedIgnoredColumns
 
-  include Sluggable, Sourceable
+  include Sluggable
+  include Sourceable
   include PgSearch::Model
   include Discard::Model
 

--- a/app/models/trainee.rb
+++ b/app/models/trainee.rb
@@ -205,6 +205,8 @@ class Trainee < ApplicationRecord
     message: I18n.t("activerecord.errors.models.trainee.attributes.training_route"),
   }
 
+  enum record_source: %i[apply dttp hesa_collection hesa_trn_data manual api].index_with(&:to_s), _suffix: :record
+
   enum training_route: TRAINING_ROUTES
 
   enum training_initiative: ROUTE_INITIATIVES

--- a/app/services/trainees/create_from_apply.rb
+++ b/app/services/trainees/create_from_apply.rb
@@ -72,7 +72,7 @@ module Trainees
         training_route: course&.route,
         disabilities: disabilities,
         study_mode: study_mode,
-        record_source: RecordSources::APPLY,
+        record_source: Trainee::APPLY_SOURCE,
         application_choice_id: application_record.apply_id,
       }.merge(ethnic_background_attributes)
     end

--- a/app/services/trainees/create_from_csv_row.rb
+++ b/app/services/trainees/create_from_csv_row.rb
@@ -63,7 +63,7 @@ module Trainees
 
     def mapped_attributes
       {
-        record_source: RecordSources::MANUAL,
+        record_source: Trainee::MANUAL_SOURCE,
         region: csv_row["Region"],
         training_route: training_route,
         first_names: first_names,

--- a/app/services/trainees/create_from_hesa.rb
+++ b/app/services/trainees/create_from_hesa.rb
@@ -90,8 +90,8 @@ module Trainees
     # trainees who have ONLY ever been submitted over the TRN data endpoint
     # should have the record_source "HESA TRN data"
     def trainee_record_source
-      if record_source == RecordSources::HESA_TRN_DATA && trainee.record_source == RecordSources::HESA_COLLECTION
-        return RecordSources::HESA_COLLECTION
+      if record_source == Trainee::HESA_TRN_DATA_SOURCE && trainee.hesa_collection_record?
+        return Trainee::HESA_COLLECTION_SOURCE
       end
 
       record_source

--- a/app/services/trainees/filter.rb
+++ b/app/services/trainees/filter.rb
@@ -25,7 +25,7 @@ module Trainees
     end
 
     def remove_hesa_trn_data_trainees(trainees)
-      visible_sources = RecordSources::ALL - [RecordSources::HESA_TRN_DATA]
+      visible_sources = Trainee::NON_TRN_SOURCES
       trainees.where(record_source: visible_sources.push(nil))
     end
 

--- a/app/views/trainees/training_routes/_form_fields.html.erb
+++ b/app/views/trainees/training_routes/_form_fields.html.erb
@@ -1,4 +1,4 @@
-<%= f.hidden_field :record_source, value: RecordSources::MANUAL %>
+<%= f.hidden_field :record_source, value: Trainee::MANUAL_SOURCE %>
 
 <%= f.govuk_radio_buttons_fieldset(:training_route, legend: { size: "l", text: t("components.page_titles.trainees.training_routes.edit"), tag: "h1" }) do %>
 

--- a/db/data/20220902100022_backfill_record_source_on_trainees.rb
+++ b/db/data/20220902100022_backfill_record_source_on_trainees.rb
@@ -3,19 +3,17 @@
 class BackfillRecordSourceOnTrainees < ActiveRecord::Migration[6.1]
   def up
     Trainee.where(created_from_dttp: true, hesa_id: nil)
-           .update_all(record_source: RecordSources::DTTP)
-
-    non_trn_data_sources = RecordSources::ALL - [RecordSources::HESA_TRN_DATA]
+           .update_all(record_source: Trainee::DTTP_SOURCE)
 
     Trainee.where.not(hesa_id: nil)
-           .where(record_source: non_trn_data_sources.push(nil))
-           .update_all(record_source: RecordSources::HESA_COLLECTION)
+           .where(record_source: Trainee::NON_TRN_SOURCES.push(nil))
+           .update_all(record_source: Trainee::HESA_COLLECTION_SOURCE)
 
     Trainee.where.not(apply_application: nil)
-           .update_all(record_source: RecordSources::APPLY)
+           .update_all(record_source: Trainee::APPLY_SOURCE)
 
     Trainee.where(apply_application: nil, created_from_dttp: false, hesa_id: nil)
-           .update_all(record_source: RecordSources::MANUAL)
+           .update_all(record_source: Trainee::MANUAL_SOURCE)
   end
 
   def down

--- a/db/data/20220921084032_fix_apply_draft_training_routes.rb
+++ b/db/data/20220921084032_fix_apply_draft_training_routes.rb
@@ -2,7 +2,7 @@
 
 class FixApplyDraftTrainingRoutes < ActiveRecord::Migration[6.1]
   def up
-    Trainee.draft.where(record_source: RecordSources::APPLY).where.not(course_uuid: nil).find_each do |trainee|
+    Trainee.draft.apply_record.where.not(course_uuid: nil).find_each do |trainee|
       if trainee.published_course && trainee.training_route != trainee.published_course.route
         trainee.without_auditing do
           trainee.progress.funding = false

--- a/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
+++ b/spec/features/trainee_actions/creating_a_new_trainee_spec.rb
@@ -137,6 +137,6 @@ private
   end
 
   def and_trainee_record_source_is_set_to_manual
-    expect(Trainee.last.record_source).to eq(RecordSources::MANUAL)
+    expect(Trainee.last.manual_record?).to be(true)
   end
 end

--- a/spec/jobs/hesa/create_from_hesa_job_spec.rb
+++ b/spec/jobs/hesa/create_from_hesa_job_spec.rb
@@ -7,7 +7,7 @@ module Hesa
     include ActiveJob::TestHelper
 
     let(:hesa_trainee) { ApiStubs::HesaApi.new.student_attributes }
-    let(:record_source) { RecordSources::HESA_COLLECTION }
+    let(:record_source) { Trainee::HESA_COLLECTION_SOURCE }
 
     describe "#perform" do
       context "Hesa import is enabled" do

--- a/spec/jobs/hesa/retrieve_collection_job_spec.rb
+++ b/spec/jobs/hesa/retrieve_collection_job_spec.rb
@@ -39,7 +39,7 @@ module Hesa
       end
 
       it "calls the CreateFromHesaJob" do
-        expect(CreateFromHesaJob).to receive(:perform_later).with(hesa_trainee: hesa_api_stub.student_attributes, record_source: RecordSources::HESA_COLLECTION)
+        expect(CreateFromHesaJob).to receive(:perform_later).with(hesa_trainee: hesa_api_stub.student_attributes, record_source: Trainee::HESA_COLLECTION_SOURCE)
 
         described_class.new.perform
       end

--- a/spec/jobs/hesa/retrieve_trn_data_job_spec.rb
+++ b/spec/jobs/hesa/retrieve_trn_data_job_spec.rb
@@ -41,7 +41,7 @@ module Hesa
       end
 
       it "calls the CreateFromHesaJob" do
-        expect(CreateFromHesaJob).to receive(:perform_later).with(hesa_trainee: hesa_api_stub.student_attributes, record_source: RecordSources::HESA_TRN_DATA)
+        expect(CreateFromHesaJob).to receive(:perform_later).with(hesa_trainee: hesa_api_stub.student_attributes, record_source: Trainee::HESA_TRN_DATA_SOURCE)
 
         described_class.new.perform
       end

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -196,7 +196,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "sets the record source to `api`" do
-      expect(Trainee.last.record_source).to eq("api")
+      expect(Trainee.last.api_record?).to be(true)
     end
 
     it "sets the provider_trainee_id" do

--- a/spec/services/find_new_starter_trainees_spec.rb
+++ b/spec/services/find_new_starter_trainees_spec.rb
@@ -45,7 +45,7 @@ describe FindNewStarterTrainees do
              state: 1,
              itt_start_date: 2.months.ago,
              start_academic_cycle: AcademicCycle.current,
-             record_source: RecordSources::HESA_TRN_DATA)
+             record_source: Trainee::HESA_TRN_DATA_SOURCE)
     end
 
     it { is_expected.to be_empty }

--- a/spec/services/trainees/create_from_apply_spec.rb
+++ b/spec/services/trainees/create_from_apply_spec.rb
@@ -52,7 +52,7 @@ module Trainees
         course_min_age: course.min_age,
         course_max_age: course.max_age,
         study_mode: "full_time",
-        record_source: RecordSources::APPLY,
+        record_source: Trainee::APPLY_SOURCE,
         application_choice_id: apply_application.apply_id,
       }
     end

--- a/spec/services/trainees/create_from_csv_row_spec.rb
+++ b/spec/services/trainees/create_from_csv_row_spec.rb
@@ -66,7 +66,7 @@ module Trainees
 
         it "updates the Trainee ID, route, region and record_source" do
           expect(trainee.provider_trainee_id).to eq(csv_row["Provider trainee ID"])
-          expect(trainee.record_source).to eq(RecordSources::MANUAL)
+          expect(trainee.manual_record?).to be(true)
           expect(trainee.training_route).to eq(TRAINING_ROUTE_ENUMS[:hpitt_postgrad])
           expect(trainee.region).to eq(csv_row["Region"])
         end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -20,7 +20,7 @@ module Trainees
     let!(:first_disability) { create(:disability, name: first_disability_name) }
     let(:second_disability_name) { Diversities::DEVELOPMENT_CONDITION }
     let!(:second_disability) { create(:disability, name: second_disability_name) }
-    let(:record_source) { RecordSources::HESA_COLLECTION }
+    let(:record_source) { Trainee::HESA_COLLECTION_SOURCE }
 
     let!(:course_allocation_subject) do
       create(:subject_specialism, name: CourseSubjects::BIOLOGY).allocation_subject
@@ -156,29 +156,29 @@ module Trainees
     context "when the trainee was originally created via the TRN data endpoint" do
       let(:existing_trn) { Faker::Number.number(digits: 7).to_s }
       let(:create_custom_state) do
-        create(:trainee, hesa_id: student_attributes[:hesa_id], trn: existing_trn, record_source: RecordSources::HESA_TRN_DATA)
+        create(:trainee, hesa_id: student_attributes[:hesa_id], trn: existing_trn, record_source: Trainee::HESA_TRN_DATA_SOURCE)
       end
 
       it "updates the trainee record source to be HESA collection" do
-        expect(trainee.record_source).to eq(RecordSources::HESA_COLLECTION)
+        expect(trainee.hesa_collection_record?).to be(true)
       end
     end
 
     context "when the trainee is submitted via TRN data" do
-      let(:record_source) { RecordSources::HESA_TRN_DATA }
+      let(:record_source) { Trainee::HESA_TRN_DATA_SOURCE }
 
       it "sets record source to HESA_TRN_DATA" do
-        expect(trainee.record_source).to eq(RecordSources::HESA_TRN_DATA)
+        expect(trainee.hesa_trn_data_record?).to be(true)
       end
 
       context "but was originally created via the collection endpoint" do
         let(:existing_trn) { Faker::Number.number(digits: 7).to_s }
         let(:create_custom_state) do
-          create(:trainee, hesa_id: student_attributes[:hesa_id], trn: existing_trn, record_source: RecordSources::HESA_COLLECTION)
+          create(:trainee, hesa_id: student_attributes[:hesa_id], trn: existing_trn, record_source: Trainee::HESA_COLLECTION_SOURCE)
         end
 
         it "does not update the trainee record source" do
-          expect(trainee.record_source).to eq(RecordSources::HESA_COLLECTION)
+          expect(trainee.hesa_collection_record?).to be(true)
         end
       end
     end

--- a/spec/services/trainees/filter_spec.rb
+++ b/spec/services/trainees/filter_spec.rb
@@ -27,13 +27,13 @@ module Trainees
     end
 
     context "when HESA TRN data trainee exists" do
-      let!(:hesa_trn_data_trainee) { create(:trainee, record_source: RecordSources::HESA_TRN_DATA) }
+      let!(:hesa_trn_data_trainee) { create(:trainee, record_source: Trainee::HESA_TRN_DATA_SOURCE) }
 
       it { is_expected.not_to include(hesa_trn_data_trainee) }
     end
 
     context "when a HESA collection trainee exists" do
-      let!(:hesa_collection_trainee) { create(:trainee, record_source: RecordSources::HESA_COLLECTION) }
+      let!(:hesa_collection_trainee) { create(:trainee, record_source: Trainee::HESA_COLLECTION_SOURCE) }
 
       it { is_expected.to include(hesa_collection_trainee) }
     end

--- a/spec/services/trainees/find_duplicates_spec.rb
+++ b/spec/services/trainees/find_duplicates_spec.rb
@@ -49,7 +49,7 @@ module Trainees
         course_min_age: course.min_age,
         course_max_age: course.max_age,
         study_mode: "full_time",
-        record_source: RecordSources::APPLY,
+        record_source: Trainee::APPLY_SOURCE,
       }
     end
 


### PR DESCRIPTION
### Context
We have a record_source column on the trainees table. This is a string column with only a certain number of allowed values. These were being defined in an initialiser called record_sources, which defined this module:

```ruby
module RecordSources
  APPLY = "apply"
  DTTP = "dttp"
  HESA_COLLECTION = "hesa_collection"
  HESA_TRN_DATA = "hesa_trn_data"
  MANUAL = "manual"
  API = "api"

  ALL = [APPLY, DTTP, HESA_COLLECTION, HESA_TRN_DATA, API, MANUAL].freeze
end
```

### Changes proposed in this pull request
This seemed like a good use case for an enum, so I've created a concern called Sourceable, which contains the enum and all of these string values as constants. 

I've included the concern in the Trainee model, so now trainees get all of the enum convenience methods, such as:
```ruby
trainee.api_record?
trainee.hesa_collection_record?
trainee.apply_record!
```

We also now get the various scope methods on Trainee, without having to define them ourselves, such as: 
``` ruby
Trainee.api_record
Trainee.dttp_record
```

It's also now easy to add this functionality to other types of record, if we choose to in the future. 

### Further Refactoring
Once this is done, I think we can start to replace uses of booleans like `created_from_dttp` and `created_from_hesa`, on Trainee, which are currently only used to determine the record's source. We could then potentially drop those columns completely. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
