### PR TITLE
[7102] - temp remove QA from deploy pipeline

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -254,7 +254,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [qa,staging]
+        environment: [staging]
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
### Context

As part of Zoonou accessibility testing, we are providing a static environment for them to assess changes made since their first pass.

https://trello.com/c/WpjA7ij1/7102-change-qa-so-that-zoonou-can-use-it-for-accessbility-testing-disabled-user-testing

### Changes proposed in this pull request

removes QA from the deploy pipeline