### PR TITLE
Add Rake Task to Determine Record Source Mismatches

### DIFF
--- a/lib/tasks/verify.rake
+++ b/lib/tasks/verify.rake
@@ -1,0 +1,27 @@
+namespace :verify do
+  desc 'Verify record sources'
+  task record_sources: :environment do
+    total = Trainee.count
+    mismatches = {}
+    mapping_rules = {
+      Sourceable::DTTP_SOURCE => ->(t) { t.created_from_dttp? },
+      Sourceable::HESA_COLLECTION_SOURCE => ->(t) { t.hesa_id.present? },
+      Sourceable::HESA_TRN_DATA_SOURCE => ->(t) { t.hesa_id.present? },
+      Sourceable::APPLY_SOURCE => ->(t) { t.apply_application_id.present? },
+      Sourceable::MANUAL_SOURCE => ->(t) { t.apply_application_id.nil? && !t.created_from_dttp? && !t.hesa_id? }
+    }
+
+    Trainee.find_each.with_index do |trainee, index|
+      source = trainee.record_source
+      mismatches[source] += 1 unless mapping_rules[source]&.call(trainee)
+
+      progress = ((index + 1).to_f / total * 100).round(2)
+      puts "Progress: #{progress}%"
+    end
+
+    puts "Mismatch counts:"
+    mismatches.each do |source, count|
+      puts "#{source}: #{count}"
+    end
+  end
+end

--- a/lib/tasks/verify.rake
+++ b/lib/tasks/verify.rake
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 namespace :verify do
-  desc 'Verify record sources'
+  desc "Verify record sources"
   task record_sources: :environment do
     total = Trainee.count
     mismatches = {}
@@ -8,7 +10,7 @@ namespace :verify do
       Sourceable::HESA_COLLECTION_SOURCE => ->(t) { t.hesa_id.present? },
       Sourceable::HESA_TRN_DATA_SOURCE => ->(t) { t.hesa_id.present? },
       Sourceable::APPLY_SOURCE => ->(t) { t.apply_application_id.present? },
-      Sourceable::MANUAL_SOURCE => ->(t) { t.apply_application_id.nil? && !t.created_from_dttp? && !t.hesa_id? }
+      Sourceable::MANUAL_SOURCE => ->(t) { t.apply_application_id.nil? && !t.created_from_dttp? && !t.hesa_id? },
     }
 
     Trainee.find_each.with_index do |trainee, index|

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -652,8 +652,20 @@ FactoryBot.define do
       created_from_dttp { true }
     end
 
+    trait :record_source_dttp do
+      record_source { Sourceable::DTTP_SOURCE }
+    end
+
     trait :created_from_api do
-      record_source { RecordSources::API }
+      record_source { Sourceable::API_SOURCE }
+    end
+
+    trait :record_source_hesa_collection do
+      record_source { Sourceable::HESA_COLLECTION_SOURCE }
+    end
+
+    trait :record_source_manual do
+      record_source { Sourceable::MANUAL_SOURCE }
     end
 
     trait :imported_from_hesa do

--- a/spec/lib/tasks/verify_spec.rb
+++ b/spec/lib/tasks/verify_spec.rb
@@ -18,7 +18,12 @@ RSpec.describe "verify:record_sources" do
     create(:trainee, :record_source_manual, apply_application_id: nil, created_from_dttp: false, hesa_id: nil)
 
     expect { Rake::Task["verify:record_sources"].invoke }.to output(
-      a_string_including("Progress: 33.33%", "Progress: 66.67%", "Progress: 100.0%", "Mismatch counts:"),
+      a_string_including(
+        "\rProgress: 33.33%",
+        "\rProgress: 66.67%",
+        "\rProgress: 100.0%",
+        "\nMismatch counts:",
+      ),
     ).to_stdout
   end
 end

--- a/spec/lib/tasks/verify_spec.rb
+++ b/spec/lib/tasks/verify_spec.rb
@@ -1,22 +1,24 @@
-require 'rails_helper'
-require 'rake'
+# frozen_string_literal: true
 
-RSpec.describe 'verify:record_sources' do
+require "rails_helper"
+require "rake"
+
+RSpec.describe "verify:record_sources" do
   before do
     Rails.application.load_tasks
   end
 
-  it 'runs without errors' do
-    expect { Rake::Task['verify:record_sources'].invoke }.not_to raise_error
+  it "runs without errors" do
+    expect { Rake::Task["verify:record_sources"].invoke }.not_to raise_error
   end
 
-  it 'prints the expected output' do
-    trainee1 = FactoryBot.create(:trainee, :record_source_dttp, :created_from_dttp)
-    trainee2 = FactoryBot.create(:trainee, :record_source_hesa_collection, hesa_id: '123')
-    trainee3 = FactoryBot.create(:trainee, :record_source_manual, apply_application_id: nil, created_from_dttp: false, hesa_id: nil)
+  it "prints the expected output" do
+    create(:trainee, :record_source_dttp, :created_from_dttp)
+    create(:trainee, :record_source_hesa_collection, hesa_id: "123")
+    create(:trainee, :record_source_manual, apply_application_id: nil, created_from_dttp: false, hesa_id: nil)
 
-    expect { Rake::Task['verify:record_sources'].invoke }.to output(
-      a_string_including("Progress: 33.33%", "Progress: 66.67%", "Progress: 100.0%", "Mismatch counts:")
+    expect { Rake::Task["verify:record_sources"].invoke }.to output(
+      a_string_including("Progress: 33.33%", "Progress: 66.67%", "Progress: 100.0%", "Mismatch counts:"),
     ).to_stdout
   end
 end

--- a/spec/lib/tasks/verify_spec.rb
+++ b/spec/lib/tasks/verify_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'verify:record_sources' do
+  before do
+    Rails.application.load_tasks
+  end
+
+  it 'runs without errors' do
+    expect { Rake::Task['verify:record_sources'].invoke }.not_to raise_error
+  end
+
+  it 'prints the expected output' do
+    trainee1 = FactoryBot.create(:trainee, :record_source_dttp, :created_from_dttp)
+    trainee2 = FactoryBot.create(:trainee, :record_source_hesa_collection, hesa_id: '123')
+    trainee3 = FactoryBot.create(:trainee, :record_source_manual, apply_application_id: nil, created_from_dttp: false, hesa_id: nil)
+
+    expect { Rake::Task['verify:record_sources'].invoke }.to output(
+      a_string_including("Progress: 33.33%", "Progress: 66.67%", "Progress: 100.0%", "Mismatch counts:")
+    ).to_stdout
+  end
+end


### PR DESCRIPTION
### Context
[Trello](https://trello.com/c/c8z0H7YW)

As part of the record source refactoring work done in https://github.com/DFE-Digital/register-trainee-teachers/pull/4265, we need to see if the record source values actually match up with the boolean values also being used in the code. If they are, we can go ahead with a wider refactor where the record source fully replaces these boolean values. The boolean values can then eventually be dropped.

### Changes proposed in this pull request
Rather than doing manual checks in a production environment, I've written a rake task which matches up the record source with the boolean values we expect. It will print out the number of mismatches for each record source, as well as the IDs, so we can investigate further if we need to. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
