### PR TITLE
Refactor Api::GetTraineesService since filter

### DIFF
--- a/app/services/api/base_service.rb
+++ b/app/services/api/base_service.rb
@@ -26,7 +26,7 @@ module Api
     end
 
     def since
-      params.fetch(:since, Date.new).to_date
+      params.fetch(:since, Date.new)
     end
   end
 end

--- a/app/services/api/get_trainees_service.rb
+++ b/app/services/api/get_trainees_service.rb
@@ -16,7 +16,7 @@ module Api
                 .joins(:start_academic_cycle)
                 .includes([:nationalities])
                 .where(academic_cycles: { id: academic_cycle.id })
-                .where("trainees.updated_at > ?", since)
+                .where("trainees.updated_at >= ?", since)
                 .order("trainees.updated_at #{sort_order}")
                 .page(page)
                 .per(pagination_per_page)


### PR DESCRIPTION
* Don't convert to date to allow the since param to be in ISO 8601
* Change the where clause to update_at >= since

### Context

### Changes proposed in this pull request

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
