### PR TITLE
[7105] - guard against nil trainee_id and error in RemoveDeadDuplicates job

### DIFF
--- a/app/services/sidekiq/remove_dead_duplicates.rb
+++ b/app/services/sidekiq/remove_dead_duplicates.rb
@@ -13,8 +13,9 @@ module Sidekiq
 
     def call
       dead_jobs.each do |job|
-        error = job.item["error_message"].split(",").first
-        trainee_id = job.args[0]["arguments"][0]["_aj_globalid"].split("/").last
+        error = job.item["error_message"]&.split(",")&.first
+        trainee_id = job.args.dig(0, "arguments", 0, "_aj_globalid")&.split("/")&.last
+        next unless error && trainee_id
 
         digest = [error, job.display_class, trainee_id].join
 


### PR DESCRIPTION
### Context

The RemoveDeadDuplicates job runs every 2 minutes and expects there to be a trainee id in the dead job to find.

If there are jobs without this (in this case HESA failure) then the dead jobs service will continually fail trying to process these entries.

### Changes proposed in this pull request

Guard against a nil trainee_id

