### PR TITLE
[7109] Incomplete data returned by POST trainee (B)

### DIFF
--- a/app/models/api/hesa_trainee_detail_attributes/v01.rb
+++ b/app/models/api/hesa_trainee_detail_attributes/v01.rb
@@ -10,7 +10,7 @@ module Api
         course_study_mode
         course_year
         ni_number
-        postgrad_apprenticeship_start_date
+        pg_apprenticeship_start_date
         previous_last_name
         hesa_disabilities
         additional_training_initiative

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -170,7 +170,7 @@ module Api
 
       def self.from_trainee(trainee)
         trainee_attributes = trainee.attributes.select { |k, _v|
-          Api::TraineeAttributes::V01::ATTRIBUTES.include?(k.to_sym)
+          ATTRIBUTES.include?(k.to_sym) || INTERNAL_ATTRIBUTES.include?(k.to_sym)
         }
 
         hesa_trainee_detail_attributes = trainee.hesa_trainee_detail&.attributes&.select { |k, _v|

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -59,7 +59,18 @@ module Api
         hesa_id
       ].freeze
 
+      INTERNAL_ATTRIBUTES = %i[
+        lead_school_id
+        lead_school_not_applicable
+        employing_school_id
+        employing_school_not_applicable
+      ].freeze
+
       ATTRIBUTES.each do |attr|
+        attribute attr
+      end
+
+      INTERNAL_ATTRIBUTES.each do |attr|
         attribute attr
       end
 
@@ -86,13 +97,17 @@ module Api
 
       def initialize(new_attributes = {})
         new_attributes = new_attributes.to_h.with_indifferent_access
-        super(new_attributes.slice(*TraineeAttributes::V01::ATTRIBUTES + [:nationalities]).except(
-          :placements_attributes,
-          :degrees_attributes,
-          :nationalisations_attributes,
-          :hesa_trainee_detail_attributes,
-          :trainee_disabilities_attributes,
-        ))
+
+        super(
+          new_attributes.slice(
+            *(ATTRIBUTES + INTERNAL_ATTRIBUTES) + %i[nationalities],
+          ).except(
+            :placements_attributes,
+            :degrees_attributes,
+            :nationalisations_attributes,
+            :hesa_trainee_detail_attributes,
+            :trainee_disabilities_attributes,
+          ))
 
         new_attributes[:placements_attributes]&.each do |placement_params|
           placements_attributes << Api::PlacementAttributes::V01.new(placement_params)
@@ -120,13 +135,16 @@ module Api
       end
 
       def assign_attributes(new_attributes)
-        super(new_attributes.slice(*TraineeAttributes::V01::ATTRIBUTES + [:nationalities]).except(
-          :placements_attributes,
-          :degrees_attributes,
-          :nationalisations_attributes,
-          :hesa_trainee_detail_attributes,
-          :trainee_disabilities_attributes,
-        ))
+        super(
+          new_attributes.slice(
+            *(ATTRIBUTES + INTERNAL_ATTRIBUTES) + %i[nationalities],
+          ).except(
+            :placements_attributes,
+            :degrees_attributes,
+            :nationalisations_attributes,
+            :hesa_trainee_detail_attributes,
+            :trainee_disabilities_attributes,
+          ))
 
         self.nationalisations_attributes = []
         new_attributes[:nationalisations_attributes]&.each do |nationalisation_params|

--- a/app/models/api/trainee_attributes/v01.rb
+++ b/app/models/api/trainee_attributes/v01.rb
@@ -70,9 +70,10 @@ module Api
         attribute attr
       end
 
-      INTERNAL_ATTRIBUTES.each do |attr|
-        attribute attr
-      end
+      attribute :lead_school_id
+      attribute :employing_school_id
+      attribute :lead_school_not_applicable, :boolean, default: false
+      attribute :employing_school_not_applicable, :boolean, default: false
 
       attribute :placements_attributes, array: true, default: -> { [] }
       attribute :degrees_attributes, array: true, default: -> { [] }

--- a/app/services/api/map_hesa_attributes/v01.rb
+++ b/app/services/api/map_hesa_attributes/v01.rb
@@ -53,8 +53,8 @@ module Api
         .merge(course_attributes)
         .merge(ethnicity_and_disability_attributes)
         .merge(funding_attributes)
-        .merge(school_attributes)
         .merge(training_initiative_attributes)
+        .merge(school_attributes)
         .compact
       end
 
@@ -170,18 +170,18 @@ module Api
       end
 
       def school_attributes
-        attrs = {
-          lead_school_not_applicable: false,
-          employing_school_not_applicable: false,
-        }
+        attrs = {}
 
         return attrs if params[:lead_school_urn].blank?
 
         if NOT_APPLICABLE_SCHOOL_URNS.include?(params[:lead_school_urn])
           attrs.merge!(lead_school_not_applicable: true)
         else
+          lead_school_id = School.find_by(urn: params[:lead_school_urn], lead_school: true)&.id
+
           attrs.merge!(
-            lead_school_id: School.find_by(urn: params[:lead_school_urn], lead_school: true)&.id,
+            lead_school_id: lead_school_id,
+            lead_school_not_applicable: lead_school_id.nil?,
           )
         end
 
@@ -189,8 +189,11 @@ module Api
           if NOT_APPLICABLE_SCHOOL_URNS.include?(params[:employing_school_urn])
             attrs.merge!(employing_school_not_applicable: true)
           else
+            employing_school_id = School.find_by(urn: params[:employing_school_urn], lead_school: false)&.id
+
             attrs.merge!(
-              employing_school_id: School.find_by(urn: params[:employing_school_urn], lead_school: false)&.id,
+              employing_school_id: employing_school_id,
+              employing_school_not_applicable: employing_school_id.nil?,
             )
           end
         end

--- a/app/services/api/map_hesa_attributes/v01.rb
+++ b/app/services/api/map_hesa_attributes/v01.rb
@@ -11,6 +11,8 @@ module Api
         nationality
         ethnic_group
         ethnic_background
+        employing_school_urn
+        lead_school_urn
       ].freeze
 
       NOT_APPLICABLE_SCHOOL_URNS = %w[900000 900010 900020 900030].freeze
@@ -168,21 +170,28 @@ module Api
       end
 
       def school_attributes
-        attrs = {}
+        attrs = {
+          lead_school_not_applicable: false,
+          employing_school_not_applicable: false,
+        }
 
         return attrs if params[:lead_school_urn].blank?
 
         if NOT_APPLICABLE_SCHOOL_URNS.include?(params[:lead_school_urn])
           attrs.merge!(lead_school_not_applicable: true)
         else
-          attrs.merge!(lead_school: School.find_by(urn: params[:lead_school_urn]), lead_school_not_applicable: false)
+          attrs.merge!(
+            lead_school_id: School.find_by(urn: params[:lead_school_urn], lead_school: true)&.id,
+          )
         end
 
         if params[:employing_school_urn].present?
           if NOT_APPLICABLE_SCHOOL_URNS.include?(params[:employing_school_urn])
             attrs.merge!(employing_school_not_applicable: true)
           else
-            attrs.merge!(employing_school: School.find_by(urn: params[:employing_school_urn]))
+            attrs.merge!(
+              employing_school_id: School.find_by(urn: params[:employing_school_urn], lead_school: false)&.id,
+            )
           end
         end
 

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -286,7 +286,7 @@
   - course_study_mode
   - course_year
   - course_age_range
-  - postgrad_apprenticeship_start_date
+  - pg_apprenticeship_start_date
   - funding_method
   - ni_number
   - hesa_disabilities

--- a/db/migrate/20240515134857_rename_hesa_trainee_details_postgrad_apprenticeship_start_date.rb
+++ b/db/migrate/20240515134857_rename_hesa_trainee_details_postgrad_apprenticeship_start_date.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RenameHesaTraineeDetailsPostgradApprenticeshipStartDate < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      rename_column :hesa_trainee_details, :postgrad_apprenticeship_start_date, :pg_apprenticeship_start_date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_17_150301) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_15_134857) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -646,10 +646,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_17_150301) do
     t.string "surname16"
     t.string "ttcid"
     t.string "hesa_committed_at"
-    t.string "previous_hesa_id"
     t.string "application_choice_id"
     t.string "itt_start_date"
     t.string "trainee_start_date"
+    t.string "previous_hesa_id"
     t.string "provider_trainee_id"
     t.index ["hesa_id", "rec_id"], name: "index_hesa_students_on_hesa_id_and_rec_id", unique: true
   end
@@ -661,7 +661,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_17_150301) do
     t.string "course_study_mode"
     t.integer "course_year"
     t.string "course_age_range"
-    t.date "postgrad_apprenticeship_start_date"
+    t.date "pg_apprenticeship_start_date"
     t.string "funding_method"
     t.string "ni_number"
     t.string "additional_training_initiative"

--- a/spec/factories/hesa/trainee_details.rb
+++ b/spec/factories/hesa/trainee_details.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     course_study_mode { "01" }
     course_year { Time.zone.today.year }
     course_age_range { DfE::ReferenceData::AgeRanges::HESA_CODE_SETS.keys.sample }
-    postgrad_apprenticeship_start_date { Time.zone.today }
+    pg_apprenticeship_start_date { Time.zone.today }
     funding_method { Hesa::CodeSets::BursaryLevels::MAPPING.keys.sample }
     ni_number { "QQ 12 34 56 C" }
     hesa_disabilities { { disability1: "95" } }

--- a/spec/models/api/trainee_attributes/v01_spec.rb
+++ b/spec/models/api/trainee_attributes/v01_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Api::TraineeAttributes::V01 do
         course_study_mode: "01",
         course_year: 2024,
         course_age_range: "13918",
-        postgrad_apprenticeship_start_date: 2.months.from_now.iso8601,
+        pg_apprenticeship_start_date: 2.months.from_now.iso8601,
         funding_method: "13919",
         ni_number: "QQ 12 34 56 C",
       }

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -159,10 +159,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
         end
 
         it do
-          expect(response.parsed_body["lead_school_urn"]).to be_nil
-          expect(response.parsed_body["lead_school_not_applicable"]).to be(false)
-          expect(response.parsed_body["employing_school_urn"]).to be_nil
-          expect(response.parsed_body["employing_school_not_applicable"]).to be(false)
+          expect(response.parsed_body[:data][:lead_school_urn]).to be_nil
+          expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(false)
+          expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
+          expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(false)
         end
       end
 
@@ -178,9 +178,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
           end
 
           it do
-            expect(response.parsed_body["lead_school_urn"]).to be_nil
-            expect(response.parsed_body["employing_school_urn"]).to be_nil
-            expect(response.parsed_body["lead_school_not_applicable"]).to be(true)
+            expect(response.parsed_body[:data][:lead_school_urn]).to be_nil
+            expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
+            expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(true)
           end
         end
 
@@ -198,9 +198,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             let(:lead_school) { create(:school, :lead) }
 
             it do
-              expect(response.parsed_body["lead_school_urn"]).to eq(lead_school.urn)
-              expect(response.parsed_body["lead_school_not_applicable"]).to be(false)
-              expect(response.parsed_body["employing_school_urn"]).to be_nil
+              expect(response.parsed_body[:data][:lead_school_urn]).to eq(lead_school.urn)
+              expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(false)
+              expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
             end
           end
 
@@ -208,9 +208,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             let(:lead_school) { build(:school, :lead) }
 
             it do
-              expect(response.parsed_body["lead_school_urn"]).to be_nil
-              expect(response.parsed_body["lead_school_not_applicable"]).to be(true)
-              expect(response.parsed_body["employing_school_urn"]).to be_nil
+              expect(response.parsed_body[:data][:lead_school_urn]).to be_nil
+              expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(true)
+              expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
             end
           end
         end
@@ -227,8 +227,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             end
 
             it do
-              expect(response.parsed_body["employing_school_urn"]).to be_nil
-              expect(response.parsed_body["employing_school_not_applicable"]).to be(true)
+              expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
+              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
             end
           end
 
@@ -245,8 +245,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             let(:employing_school) { create(:school) }
 
             it do
-              expect(response.parsed_body["employing_school_urn"]).to eq(employing_school.urn)
-              expect(response.parsed_body["employing_school_not_applicable"]).to be(false)
+              expect(response.parsed_body[:data][:employing_school_urn]).to eq(employing_school.urn)
+              expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(false)
             end
           end
         end

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -158,16 +158,19 @@ describe "`POST /api/v0.1/trainees` endpoint" do
           )
         end
 
-        it do
+        it "sets lead_school_urn and employing_school_urn to nil" do
           expect(response.parsed_body[:data][:lead_school_urn]).to be_nil
-          expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(false)
           expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
+        end
+
+        it "sets lead_school_not_applicable and employing_school_not_applicable to false" do
+          expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(false)
           expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(false)
         end
       end
 
       context "when lead_school_urn is present" do
-        context "when is included in NOT_APPLICABLE_SCHOOL_URNS" do
+        context "when lead_school_urn is not an applicable shool urn" do
           let(:params) do
             {
               data: data.merge(
@@ -177,14 +180,17 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             }
           end
 
-          it do
+          it "sets lead_school_urn and employing_school_urn to nil" do
             expect(response.parsed_body[:data][:lead_school_urn]).to be_nil
             expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
+          end
+
+          it "sets lead_school_not_applicable to true" do
             expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(true)
           end
         end
 
-        context "when is not included in NOT_APPLICABLE_SCHOOL_URNS" do
+        context "when lead_school_urn is an applicable school urn" do
           let(:params) do
             {
               data: data.merge(
@@ -194,29 +200,35 @@ describe "`POST /api/v0.1/trainees` endpoint" do
             }
           end
 
-          context "when the lead_school exists" do
+          context "when lead_school exists" do
             let(:lead_school) { create(:school, :lead) }
 
-            it do
+            it "sets lead_school_urn to lead_school#urn and employing_school_urn to nil" do
               expect(response.parsed_body[:data][:lead_school_urn]).to eq(lead_school.urn)
-              expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(false)
               expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
+            end
+
+            it "sets lead_school_not_applicable to false" do
+              expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(false)
             end
           end
 
-          context "when the lead_school does not exist" do
+          context "when lead_school does not exist" do
             let(:lead_school) { build(:school, :lead) }
 
-            it do
+            it "sets lead_school_urn and employing_school_urn to nil" do
               expect(response.parsed_body[:data][:lead_school_urn]).to be_nil
-              expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(true)
               expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
+            end
+
+            it "sets lead_school_not_applicable to true" do
+              expect(response.parsed_body[:data][:lead_school_not_applicable]).to be(true)
             end
           end
         end
 
         context "when employing_school_urn is present" do
-          context "when is included in NOT_APPLICABLE_SCHOOL_URN" do
+          context "when lead_school_urn is not an applicable school urn" do
             let(:params) do
               {
                 data: data.merge(
@@ -226,13 +238,16 @@ describe "`POST /api/v0.1/trainees` endpoint" do
               }
             end
 
-            it do
+            it "sets employing_school_urn to nil" do
               expect(response.parsed_body[:data][:employing_school_urn]).to be_nil
+            end
+
+            it "sets employing_school_not_applicable to true" do
               expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(true)
             end
           end
 
-          context "when is not included in NOT_APPLICABLE_SCHOOL_URN" do
+          context "when lead_school_urn is an applicable school urn" do
             let(:params) do
               {
                 data: data.merge(
@@ -244,8 +259,11 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
             let(:employing_school) { create(:school) }
 
-            it do
+            it "sets employing_school_urn to employing_school#urn" do
               expect(response.parsed_body[:data][:employing_school_urn]).to eq(employing_school.urn)
+            end
+
+            it "sets employing_school_not_applicable to false" do
               expect(response.parsed_body[:data][:employing_school_not_applicable]).to be(false)
             end
           end

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -160,9 +160,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
         it do
           expect(response.parsed_body["lead_school_urn"]).to be_nil
-          expect(response.parsed_body["lead_school_not_applicable"]).to be(false)
+          expect(response.parsed_body["lead_school_not_applicable"]).to be_nil
           expect(response.parsed_body["employing_school_urn"]).to be_nil
-          expect(response.parsed_body["employing_school_not_applicable"]).to be(false)
+          expect(response.parsed_body["employing_school_not_applicable"]).to be_nil
         end
       end
 
@@ -209,7 +209,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
             it do
               expect(response.parsed_body["lead_school_urn"]).to be_nil
-              expect(response.parsed_body["lead_school_not_applicable"]).to be(false)
+              expect(response.parsed_body["lead_school_not_applicable"]).to be(true)
               expect(response.parsed_body["employing_school_urn"]).to be_nil
             end
           end

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -59,6 +59,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       funding_method: "4",
       hesa_id: "0310261553101",
       provider_trainee_id: "99157234/2/01",
+      pg_apprenticeship_start_date: "2024-03-11",
     }
   end
 
@@ -79,6 +80,7 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       expect(response.parsed_body[:data][:first_names]).to eq("John")
       expect(response.parsed_body[:data][:last_name]).to eq("Doe")
       expect(response.parsed_body[:data][:previous_last_name]).to eq("Smith")
+      expect(response.parsed_body[:data][:pg_apprenticeship_start_date]).to eq("2024-03-11")
     end
 
     it "sets the correct state" do

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -160,9 +160,9 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
         it do
           expect(response.parsed_body["lead_school_urn"]).to be_nil
-          expect(response.parsed_body["lead_school_not_applicable"]).to be_nil
+          expect(response.parsed_body["lead_school_not_applicable"]).to be(false)
           expect(response.parsed_body["employing_school_urn"]).to be_nil
-          expect(response.parsed_body["employing_school_not_applicable"]).to be_nil
+          expect(response.parsed_body["employing_school_not_applicable"]).to be(false)
         end
       end
 

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -149,6 +149,110 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       expect(degree.country).to be_nil
     end
 
+    context "with school_attributes" do
+      context "when lead_school_urn is blank" do
+        before do
+          data.merge(
+            lead_school_urn: "",
+            employing_school_urn: "900021",
+          )
+        end
+
+        it do
+          expect(response.parsed_body["lead_school_urn"]).to be_nil
+          expect(response.parsed_body["lead_school_not_applicable"]).to be(false)
+          expect(response.parsed_body["employing_school_urn"]).to be_nil
+          expect(response.parsed_body["employing_school_not_applicable"]).to be(false)
+        end
+      end
+
+      context "when lead_school_urn is present" do
+        context "when is included in NOT_APPLICABLE_SCHOOL_URNS" do
+          let(:params) do
+            {
+              data: data.merge(
+                lead_school_urn: "900020",
+                employing_school_urn: "",
+              ),
+            }
+          end
+
+          it do
+            expect(response.parsed_body["lead_school_urn"]).to be_nil
+            expect(response.parsed_body["employing_school_urn"]).to be_nil
+            expect(response.parsed_body["lead_school_not_applicable"]).to be(true)
+          end
+        end
+
+        context "when is not included in NOT_APPLICABLE_SCHOOL_URNS" do
+          let(:params) do
+            {
+              data: data.merge(
+                lead_school_urn: lead_school.urn,
+                employing_school_urn: "",
+              ),
+            }
+          end
+
+          context "when the lead_school exists" do
+            let(:lead_school) { create(:school, :lead) }
+
+            it do
+              expect(response.parsed_body["lead_school_urn"]).to eq(lead_school.urn)
+              expect(response.parsed_body["lead_school_not_applicable"]).to be(false)
+              expect(response.parsed_body["employing_school_urn"]).to be_nil
+            end
+          end
+
+          context "when the lead_school does not exist" do
+            let(:lead_school) { build(:school, :lead) }
+
+            it do
+              expect(response.parsed_body["lead_school_urn"]).to be_nil
+              expect(response.parsed_body["lead_school_not_applicable"]).to be(false)
+              expect(response.parsed_body["employing_school_urn"]).to be_nil
+            end
+          end
+        end
+
+        context "when employing_school_urn is present" do
+          context "when is included in NOT_APPLICABLE_SCHOOL_URN" do
+            let(:params) do
+              {
+                data: data.merge(
+                  lead_school_urn: "900020",
+                  employing_school_urn: "900030",
+                ),
+              }
+            end
+
+            it do
+              expect(response.parsed_body["employing_school_urn"]).to be_nil
+              expect(response.parsed_body["employing_school_not_applicable"]).to be(true)
+            end
+          end
+
+          context "when is not included in NOT_APPLICABLE_SCHOOL_URN" do
+            let(:params) do
+              {
+                data: data.merge(
+                  lead_school_urn: "900020",
+                  employing_school_urn: employing_school.urn,
+                ),
+              }
+            end
+
+            let(:employing_school) { create(:school) }
+
+            it do
+              expect(response.parsed_body["employing_school_urn"]).to eq(employing_school.urn)
+              expect(response.parsed_body["employing_school_not_applicable"]).to be(false)
+            end
+          end
+        end
+      end
+    end
+
     context "when `itt_start_date` is an invalid date" do
       let(:itt_start_date) { "2023-02-30" }
 

--- a/spec/serializers/trainee_serializer/v01_spec.rb
+++ b/spec/serializers/trainee_serializer/v01_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe TraineeSerializer::V01 do
         course_year
         itt_aim
         ni_number
-        postgrad_apprenticeship_start_date
+        pg_apprenticeship_start_date
         previous_last_name
         hesa_disabilities
         additional_training_initiative


### PR DESCRIPTION
### Context

[7109-incomplete-data-returned-by-post-trainee-b](https://trello.com/c/JUX7zlm6/7109-incomplete-data-returned-by-post-trainee-b)

### Changes proposed in this pull request

* Rename to `Api::HesaTraineeDetailAttributes::V01#pg_apprenticeship_start_date` to make it consistent with `Hesa::Metadatum#pg_apprenticeship_start_date`
* Allow the following to be set internally by the API based on
  `employing_school_urn`, `lead_school_urn`:
   - `lead_school_id`
   - `lead_school_not_applicable`
   - `employing_school_id`
   - `employing_school_not_applicable`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
