### PR TITLE
[7158] - Secure session cookies: set HttpOnly and Secure flags

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,15 @@ module RegisterTraineeTeachers
     config.middleware.use(Rack::Deflater)
     config.active_job.queue_adapter = :sidekiq
 
-    config.session_store(:active_record_store, key: "_register_trainee_teachers_session")
+    # Configure session store to use ActiveRecord.
+    # - key: Sets the name of the session cookie.
+    # - httponly: Prevents client-side scripts from accessing the cookie.
+    # - secure: Ensures the cookie is only sent over HTTPS in non-development and non-test environments.
+    config.session_store(:active_record_store, 
+      key: "_register_trainee_teachers_session",
+      httponly: true,
+      secure: !Rails.env.development? && !Rails.env.test?
+    )
 
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,11 +43,10 @@ module RegisterTraineeTeachers
     # - key: Sets the name of the session cookie.
     # - httponly: Prevents client-side scripts from accessing the cookie.
     # - secure: Ensures the cookie is only sent over HTTPS in non-development and non-test environments.
-    config.session_store(:active_record_store, 
-      key: "_register_trainee_teachers_session",
-      httponly: true,
-      secure: !Rails.env.development? && !Rails.env.test?
-    )
+    config.session_store(:active_record_store,
+                         key: "_register_trainee_teachers_session",
+                         httponly: true,
+                         secure: !Rails.env.development? && !Rails.env.test?)
 
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]
 


### PR DESCRIPTION
### Context

An IT Health Check was conducted on the Register service in April 2024. This is one of the recommendations from the report, that is to be remediated by the team “to enhance the overall security posture offered”.

[FID0024-2614_DfE_Register-ITHC-2024_v1_0.pdf](https://educationgovuk.sharepoint.com/:b:/r/sites/TeacherServices/Shared%20Documents/Becoming%20a%20Teacher/TWD-REGISTER/Register%20service%20BAU/Security/ITHC%20-%20APRIL%202024/FID0024-2614_DfE_Register-ITHC-2024_v1_0.pdf?csf=1&web=1&e=ZR0M91)

Issue no. 10

Issue: cookies not set with HttpOnly and Secure flag

Criticality: info

Report reference 6.1.6

Recommendation: Ensure cookies are set with the HttpOnly and Secure flags

### Changes proposed in this pull request

Configured session cookies with `HttpOnly` flag to prevent client-side access. Set secure flag for cookies to ensure they are only sent over HTTPS in non-development and non-test environments.

