### PR TITLE
[7110] - Incomplete data returned by POST trainee (C)

### DIFF
--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -43,6 +43,7 @@ module Api
     def update
       trainee = current_provider&.trainees&.find_by!(slug: params[:slug])
       attributes = trainee_attributes_service.from_trainee(trainee)
+
       attributes.assign_attributes(hesa_mapped_params_for_update(trainee))
 
       succeeded, validation = update_trainee_service_class.call(trainee:, attributes:)

--- a/app/serializers/trainee_serializer/v01.rb
+++ b/app/serializers/trainee_serializer/v01.rb
@@ -41,6 +41,8 @@ module TraineeSerializer
         sex: sex,
         study_mode: course_study_mode,
         course_subject_one: course_subject_one,
+        course_subject_two: course_subject_two,
+        course_subject_three: course_subject_three,
         training_route: training_route,
         nationality: nationality,
         training_initiative: training_initiative,
@@ -126,6 +128,14 @@ module TraineeSerializer
 
     def course_subject_one
       ::Hesa::CodeSets::CourseSubjects::MAPPING.key(@trainee.course_subject_one)
+    end
+
+    def course_subject_two
+      ::Hesa::CodeSets::CourseSubjects::MAPPING.key(@trainee.course_subject_two)
+    end
+
+    def course_subject_three
+      ::Hesa::CodeSets::CourseSubjects::MAPPING.key(@trainee.course_subject_three)
     end
 
     def course_education_phase

--- a/app/services/api/map_hesa_attributes/v01.rb
+++ b/app/services/api/map_hesa_attributes/v01.rb
@@ -149,6 +149,10 @@ module Api
         DfE::ReferenceData::AgeRanges::HESA_CODE_SETS[params[:course_age_range]]
       end
 
+      def course_max_age
+        params[:course_max_age]
+      end
+
       def course_study_mode
         params[:study_mode]
       end

--- a/app/services/concerns/has_course_attributes.rb
+++ b/app/services/concerns/has_course_attributes.rb
@@ -30,6 +30,7 @@ module HasCourseAttributes
   def fix_invalid_primary_course_subjects(course_attributes)
     # This always ensures "primary teaching" is the first subject or inserts it if it's missing
     other_subjects = course_subjects - [CourseSubjects::PRIMARY_TEACHING]
+
     course_attributes.merge(course_subject_one: CourseSubjects::PRIMARY_TEACHING,
                             course_subject_two: other_subjects.first,
                             course_subject_three: other_subjects.second)

--- a/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
+++ b/spec/requests/api/v0.1/post_hesa_trainees_spec.rb
@@ -72,11 +72,11 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     before do
       allow(Api::MapHesaAttributes::V01).to receive(:call).and_call_original
       allow(Trainees::MapFundingFromDttpEntityId).to receive(:call).and_call_original
-
-      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
     end
 
     it "creates a trainee" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       expect(response.parsed_body[:data][:first_names]).to eq("John")
       expect(response.parsed_body[:data][:last_name]).to eq("Doe")
       expect(response.parsed_body[:data][:previous_last_name]).to eq("Smith")
@@ -84,14 +84,20 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "sets the correct state" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       expect(Trainee.last.state).to eq("submitted_for_trn")
     end
 
     it "sets the correct study_mode" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       expect(response.parsed_body[:data][:study_mode]).to eq("63")
     end
 
     it "sets the correct disabilities" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       parsed_body = response.parsed_body[:data]
 
       expect(parsed_body[:disability_disclosure]).to eq("disabled")
@@ -105,6 +111,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "sets the correct funding attributes" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       parsed_body = response.parsed_body[:data]
 
       expect(Trainees::MapFundingFromDttpEntityId).to have_received(:call).once
@@ -119,6 +127,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "sets the correct school attributes" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       parsed_body = response.parsed_body[:data]
 
       expect(parsed_body[:lead_school_not_applicable]).to be(false)
@@ -128,6 +138,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "creates the degrees if provided in the request body" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       degree_attributes = response.parsed_body[:data][:degrees]&.first
 
       expect(degree_attributes[:subject]).to eq("100485")
@@ -150,6 +162,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     context "with school_attributes" do
+      before do
+        post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      end
+
       context "when lead_school_urn is blank" do
         before do
           data.merge(
@@ -274,6 +290,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     context "when `itt_start_date` is an invalid date" do
       let(:itt_start_date) { "2023-02-30" }
 
+      before do
+        post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      end
+
       it "does not create a trainee record and returns a 422 status with meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to include("Itt start date is invalid")
@@ -282,6 +302,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
 
     context "when graduation_year is in 'yyyy-mm-dd' format" do
       let(:graduation_year) { "2003-01-01" }
+
+      before do
+        post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      end
 
       it "creates the degrees with the correct graduation_year" do
         degree_attributes = response.parsed_body[:data][:degrees]&.first
@@ -293,6 +317,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     context "when graduation_year is a valid 4-digit integer" do
       let(:graduation_year) { 2003 }
 
+      before do
+        post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      end
+
       it "creates the degrees with the correct graduation_year" do
         degree_attributes = response.parsed_body[:data][:degrees]&.first
 
@@ -303,6 +331,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     context "when graduation_year is an invalid 3-digit integer" do
       let(:graduation_year) { 200 }
 
+      before do
+        post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      end
+
       it "does not create a degree" do
         expect(response.parsed_body[:data]).to be_nil
         expect(response.parsed_body[:errors].first).to include("Enter a valid graduation year")
@@ -312,6 +344,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     context "when graduation_year is in an invalid format" do
       let(:graduation_year) { "abc" }
 
+      before do
+        post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      end
+
       it "does not create a degree" do
         expect(response.parsed_body[:data]).to be_nil
         expect(response.parsed_body[:errors].first).to include("Enter a valid graduation year")
@@ -319,6 +355,8 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "creates the placements if provided in the request body" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       placement_attributes = response.parsed_body[:data][:placements]&.first
 
       expect(placement_attributes[:school_id]).to be_nil
@@ -327,26 +365,38 @@ describe "`POST /api/v0.1/trainees` endpoint" do
     end
 
     it "returns status code 201" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       expect(response).to have_http_status(:created)
     end
 
     it "creates the nationalities" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       expect(Trainee.last.nationalities.first.name).to eq("british")
     end
 
     it "sets the correct course allocation subject" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       expect(Trainee.last.course_allocation_subject).to eq(course_allocation_subject)
     end
 
     it "sets the progress data structure" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       expect(Trainee.last.progress.personal_details).to be(true)
     end
 
     it "sets the record source to `api`" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       expect(Trainee.last.api_record?).to be(true)
     end
 
     it "sets the provider_trainee_id" do
+      post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+
       expect(Trainee.last.provider_trainee_id).to eq("99157234/2/01")
     end
 
@@ -354,6 +404,10 @@ describe "`POST /api/v0.1/trainees` endpoint" do
       let(:trn) { "567899" }
       let(:ethnic_group) { "mixed_ethnic_group" }
       let(:ethnic_background) { "Another Mixed background" }
+
+      before do
+        post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+      end
 
       context "when the ethnicity is provided" do
         let(:params) do
@@ -416,49 +470,135 @@ describe "`POST /api/v0.1/trainees` endpoint" do
         end
       end
     end
-  end
 
-  describe "ethnicity" do
-    before do
-      post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json
+    context "with course subjects" do
+      context "when HasCourseAttributes#primary_education_phase? is true" do
+        before do
+          post "/api/v0.1/trainees", params: params.to_json, headers: { Authorization: token, **json_headers }
+        end
+
+        context "when '100511' is not present" do
+          let(:params) do
+            {
+              data: data.merge(
+                course_subject_one: "100346",
+                course_subject_two: "101410",
+                course_subject_three: "100366",
+                course_max_age: 11,
+              ),
+            }
+          end
+
+          it "sets the correct subjects" do
+            trainee = Trainee.last
+
+            expect(trainee.course_subject_one).to eq("primary teaching")
+            expect(trainee.course_subject_two).to eq("biology")
+            expect(trainee.course_subject_three).to eq("historical linguistics")
+
+            expect(response.parsed_body[:data][:course_subject_one]).to eq("100511")
+            expect(response.parsed_body[:data][:course_subject_two]).to eq("100346")
+            expect(response.parsed_body[:data][:course_subject_three]).to eq("101410")
+          end
+        end
+
+        context "when '100511' is present" do
+          let(:params) do
+            {
+              data: data.merge(
+                course_subject_one: "100511",
+                course_subject_two: "101410",
+                course_subject_three: "100366",
+                course_max_age: 11,
+              ),
+            }
+          end
+
+          it "sets the correct subjects" do
+            trainee = Trainee.last
+
+            expect(trainee.course_subject_one).to eq("primary teaching")
+            expect(trainee.course_subject_two).to eq("historical linguistics")
+            expect(trainee.course_subject_three).to eq("computer science")
+
+            expect(response.parsed_body[:data][:course_subject_one]).to eq("100511")
+            expect(response.parsed_body[:data][:course_subject_two]).to eq("101410")
+            expect(response.parsed_body[:data][:course_subject_three]).to eq("100366")
+          end
+        end
+      end
+
+      context "when HasCourseAttributes#primary_education_phase? is false" do
+        let(:params) do
+          {
+            data: data.merge(
+              course_subject_one: "100346",
+              course_subject_two: "101410",
+              course_subject_three: "100366",
+            ),
+          }
+        end
+
+        before do
+          post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json
+        end
+
+        it "sets the correct subjects" do
+          trainee = Trainee.last
+
+          expect(trainee.course_subject_one).to eq("biology")
+          expect(trainee.course_subject_two).to eq("historical linguistics")
+          expect(trainee.course_subject_three).to eq("computer science")
+
+          expect(response.parsed_body[:data][:course_subject_one]).to eq("100346")
+          expect(response.parsed_body[:data][:course_subject_two]).to eq("101410")
+          expect(response.parsed_body[:data][:course_subject_three]).to eq("100366")
+        end
+      end
     end
 
-    context "when present" do
-      let(:params) do
-        {
-          data: data.merge(
-            ethnicity:,
-          ),
-        }
+    context "with ethnicity" do
+      before do
+        post "/api/v0.1/trainees", params: params, headers: { Authorization: token }, as: :json
       end
 
-      let(:ethnicity) { "142" }
+      context "when present" do
+        let(:params) do
+          {
+            data: data.merge(
+              ethnicity:,
+            ),
+          }
+        end
 
-      it do
-        expect(response).to have_http_status(:created)
-        expect(response.parsed_body[:data][:ethnicity]).to eq(ethnicity)
-      end
-    end
+        let(:ethnicity) { "142" }
 
-    context "when not present" do
-      it do
-        expect(response).to have_http_status(:created)
-        expect(response.parsed_body[:data][:ethnicity]).to eq("997")
-      end
-    end
-
-    context "when invalid" do
-      let(:params) do
-        {
-          data: data.merge(
-            ethnicity: "1000",
-          ),
-        }
+        it do
+          expect(response).to have_http_status(:created)
+          expect(response.parsed_body[:data][:ethnicity]).to eq(ethnicity)
+        end
       end
 
-      it do
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.parsed_body[:errors]).to contain_exactly("Ethnicity is not included in the list")
+      context "when not present" do
+        it do
+          expect(response).to have_http_status(:created)
+          expect(response.parsed_body[:data][:ethnicity]).to eq("997")
+        end
+      end
+
+      context "when invalid" do
+        let(:params) do
+          {
+            data: data.merge(
+              ethnicity: "1000",
+            ),
+          }
+        end
+
+        it do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body[:errors]).to contain_exactly("Ethnicity is not included in the list")
+        end
       end
     end
   end

--- a/spec/requests/api/v0.1/put_trainee_spec.rb
+++ b/spec/requests/api/v0.1/put_trainee_spec.rb
@@ -54,17 +54,19 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     before do
       create(:nationality, :irish)
       create(:nationality, :french)
-
-      put(
-        endpoint,
-        headers: { Authorization: "Bearer #{token}", **json_headers },
-        params: params.to_json,
-      )
     end
 
     context "when the trainee does not exist" do
       let(:slug) { "missing-trainee-slug" }
       let(:data) { { first_names: "Alice" } }
+
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
 
       it "returns status 404" do
         expect(response).to have_http_status(:not_found)
@@ -74,6 +76,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     context "when request body is invalid (not a serialised trainee)" do
       let(:params) { { foo: { bar: "Alice" } } }
 
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
       it "returns status 422" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body[:errors]).to contain_exactly("Param is missing or the value is empty: data")
@@ -81,6 +91,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     end
 
     context "when the request data is invalid (has an invalid attribute value)" do
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
       context "attribute errors supersede" do
         let(:data) { { first_names: "Llanfairpwllgwyngyllgogerychwyrdrobwllllantysiliogogogoch", email: "invalid" } }
 
@@ -106,6 +124,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       let(:slug) { other_trainee.slug }
       let(:data) { { first_names: "Alice" } }
 
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
       it "returns 404" do
         expect(response).to have_http_status(:not_found)
       end
@@ -113,6 +139,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
     context "when updating with valid params" do
       let(:data) { { first_names: "Alice", provider_trainee_id: "99157234/2/01" } }
+
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
 
       it "returns status 200 with a valid JSON response" do
         expect(response).to have_http_status(:ok)
@@ -126,6 +160,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     context "when updating with valid nationality" do
       let(:data) { { nationality: "IE" } }
 
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
       it "returns status 200" do
         expect(response).to have_http_status(:ok)
         expect(trainee.reload.nationalities.first.name).to eq("irish")
@@ -134,6 +176,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
     context "when course_age_range is empty" do
       let(:data) { { course_age_range: "" } }
+
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
 
       it "return status code 422 with a meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
@@ -144,6 +194,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     context "when course_age_range is invalid" do
       let(:data) { { course_age_range: "invalid" } }
 
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
       it "return status code 422 with a meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to contain_exactly("Course age range is not included in the list")
@@ -152,6 +210,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
     context "when sex is empty" do
       let(:data) { { sex: "" } }
+
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
 
       it "return status code 422 with a meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
@@ -162,6 +228,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     context "when sex is invalid" do
       let(:data) { { sex: "invalid" } }
 
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
       it "return status code 422 with a meaningful error message" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to contain_exactly("Sex is not included in the list")
@@ -170,6 +244,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
     context "when modifying nationality" do
       let(:data) { { nationality: "IE" } }
+
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
 
       it "returns status 200 and updates nationality" do
         expect(response).to have_http_status(:ok)
@@ -272,6 +354,14 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     context "with school_attributes" do
       let(:lead_school) { trainee.lead_school }
       let(:employing_school) { trainee.employing_school }
+
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
 
       context "when lead_school_urn is blank" do
         before do
@@ -512,7 +602,15 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       end
     end
 
-    describe "ethnicity" do
+    describe "with ethnicity" do
+      before do
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
       context "when present" do
         let(:params) do
           {
@@ -557,6 +655,102 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         it do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.parsed_body[:errors]).to contain_exactly("Ethnicity is not included in the list")
+        end
+      end
+    end
+
+    context "with course subjects" do
+      let(:token) { AuthenticationToken.create_with_random_token(provider:) }
+
+      context "when HasCourseAttributes#primary_education_phase? is true" do
+        before do
+          put(
+            endpoint,
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: params.to_json,
+          )
+        end
+
+        context "when '100511' is not present" do
+          let(:params) do
+            {
+              data: {
+                course_subject_one: "100346",
+                course_subject_two: "101410",
+                course_subject_three: "100366",
+                course_max_age: 11,
+              },
+            }
+          end
+
+          it "sets the correct subjects" do
+            trainee.reload
+
+            expect(trainee.course_subject_one).to eq("primary teaching")
+            expect(trainee.course_subject_two).to eq("biology")
+            expect(trainee.course_subject_three).to eq("historical linguistics")
+
+            expect(response.parsed_body[:data][:course_subject_one]).to eq("100511")
+            expect(response.parsed_body[:data][:course_subject_two]).to eq("100346")
+            expect(response.parsed_body[:data][:course_subject_three]).to eq("101410")
+          end
+        end
+
+        context "when '100511' is present" do
+          let(:params) do
+            {
+              data: {
+                course_subject_one: "100511",
+                course_subject_two: "101410",
+                course_subject_three: "100366",
+                course_max_age: 11,
+              },
+            }
+          end
+
+          it "sets the correct subjects" do
+            trainee.reload
+
+            expect(trainee.course_subject_one).to eq("primary teaching")
+            expect(trainee.course_subject_two).to eq("historical linguistics")
+            expect(trainee.course_subject_three).to eq("computer science")
+
+            expect(response.parsed_body[:data][:course_subject_one]).to eq("100511")
+            expect(response.parsed_body[:data][:course_subject_two]).to eq("101410")
+            expect(response.parsed_body[:data][:course_subject_three]).to eq("100366")
+          end
+        end
+      end
+
+      context "when HasCourseAttributes#primary_education_phase? is false" do
+        let(:params) do
+          {
+            data: {
+              course_subject_one: "100346",
+              course_subject_two: "101410",
+              course_subject_three: "100366",
+            },
+          }
+        end
+
+        before do
+          put(
+            endpoint,
+            headers: { Authorization: "Bearer #{token}", **json_headers },
+            params: params.to_json,
+          )
+        end
+
+        it "sets the correct subjects" do
+          trainee.reload
+
+          expect(trainee.course_subject_one).to eq("biology")
+          expect(trainee.course_subject_two).to eq("historical linguistics")
+          expect(trainee.course_subject_three).to eq("computer science")
+
+          expect(response.parsed_body[:data][:course_subject_one]).to eq("100346")
+          expect(response.parsed_body[:data][:course_subject_two]).to eq("101410")
+          expect(response.parsed_body[:data][:course_subject_three]).to eq("100366")
         end
       end
     end

--- a/spec/serializers/trainee_serializer/v01_spec.rb
+++ b/spec/serializers/trainee_serializer/v01_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe TraineeSerializer::V01 do
         ethnic_group
         ethnicity
         disability_disclosure
-        course_subject_one
         itt_start_date
         outcome_date
         itt_end_date
@@ -39,6 +38,7 @@ RSpec.describe TraineeSerializer::V01 do
         reinstate_date
         course_min_age
         course_max_age
+        course_subject_one
         course_subject_two
         course_subject_three
         awarded_at
@@ -65,7 +65,6 @@ RSpec.describe TraineeSerializer::V01 do
         course_qualification
         course_title
         course_level
-        course_subject_one
         course_study_mode
         course_itt_start_date
         course_age_range


### PR DESCRIPTION
### Context

https://trello.com/c/hX9mu2iQ/7110-incomplete-data-returned-by-post-trainee-c

### Changes proposed in this pull request

* Serialize `course_subject_two` and `course_subject_three` to HESA format

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
