### PR TITLE
[6971] Add Rake Task to Cleanup Stale Users

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 namespace :cleanup do
-  desc 'Destroy trainees based on email list'
-  task :discard_trainees, [:file_path] => :environment do |t, args|
+  desc "Destroy trainees based on email list"
+  task :discard_trainees, [:file_path] => :environment do |_t, args|
     raise "You must provide a file path" unless args[:file_path]
 
     emails = File.readlines(args[:file_path]).map(&:chomp)

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,11 @@
+namespace :cleanup do
+  desc 'Destroy trainees based on email list'
+  task :discard_trainees, [:file_path] => :environment do |t, args|
+    raise "You must provide a file path" unless args[:file_path]
+
+    emails = File.readlines(args[:file_path]).map(&:chomp)
+    trainees = Trainee.where(email: emails)
+    trainees.discard_all
+    puts "Discarded #{trainees.count} trainee(s)"
+  end
+end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 namespace :cleanup do
-  desc "Destroy trainees based on email list"
-  task :discard_trainees, [:file_path] => :environment do |_t, args|
+  desc "Discard users based on email list"
+  task :discard_users, [:file_path] => :environment do |_t, args|
     raise "You must provide a file path" unless args[:file_path]
 
-    emails = File.readlines(args[:file_path]).map(&:chomp)
-    trainees = Trainee.where(email: emails)
-    trainees.discard_all
-    puts "Discarded #{trainees.count} trainee(s)"
+    emails = File.readlines(args[:file_path]).map(&:chomp).reject(&:empty?)
+    users = User.where(email: emails)
+    users.discard_all!
+    puts "Discarded #{users.count} user(s)"
   end
 end

--- a/spec/fixtures/files/cleanup_emails.txt
+++ b/spec/fixtures/files/cleanup_emails.txt
@@ -1,0 +1,6 @@
+email1@example.com
+email2@example.com
+email3@example.com
+email4@example.com
+email5@example.com
+

--- a/spec/lib/tasks/cleanup_trainees_spec.rb
+++ b/spec/lib/tasks/cleanup_trainees_spec.rb
@@ -1,35 +1,37 @@
-require 'rails_helper'
-require 'rake'
+# frozen_string_literal: true
 
-describe 'cleanup:discard_trainees' do
+require "rails_helper"
+require "rake"
+
+describe "cleanup:discard_trainees" do
   before :all do
     Rake.application.rake_require "tasks/cleanup"
     Rake::Task.define_task(:environment)
   end
 
   let(:run_rake_task) do
-    Rake::Task['cleanup:discard_trainees'].reenable
+    Rake::Task["cleanup:discard_trainees"].reenable
     Rake.application.invoke_task "cleanup:discard_trainees[#{file_path}]"
   end
 
-  context 'when file path is provided' do
-    let(:file_path) { Rails.root.join('spec', 'fixtures', 'files', 'cleanup_emails.txt') }
+  context "when file path is provided" do
+    let(:file_path) { Rails.root.join("spec/fixtures/files/cleanup_emails.txt") }
     let(:emails) { File.readlines(file_path).map(&:chomp) }
 
     before do
-      emails.each { |email| create(:trainee, email: email) }
+      emails.each { |email| create(:trainee, email:) }
     end
 
-    it 'destroys the trainees with emails in the file' do
+    it "destroys the trainees with emails in the file" do
       expect { run_rake_task }.to change { Trainee.discarded.count }.by(emails.count)
     end
   end
 
-  context 'when file path is not provided' do
-    let(:file_path) { '' }
+  context "when file path is not provided" do
+    let(:file_path) { "" }
 
-    it 'raises an error' do
-      expect { run_rake_task }.to raise_error(RuntimeError, 'You must provide a file path')
+    it "raises an error" do
+      expect { run_rake_task }.to raise_error(RuntimeError, "You must provide a file path")
     end
   end
 end

--- a/spec/lib/tasks/cleanup_trainees_spec.rb
+++ b/spec/lib/tasks/cleanup_trainees_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'cleanup:discard_trainees' do
+  before :all do
+    Rake.application.rake_require "tasks/cleanup"
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:run_rake_task) do
+    Rake::Task['cleanup:discard_trainees'].reenable
+    Rake.application.invoke_task "cleanup:discard_trainees[#{file_path}]"
+  end
+
+  context 'when file path is provided' do
+    let(:file_path) { Rails.root.join('spec', 'fixtures', 'files', 'cleanup_emails.txt') }
+    let(:emails) { File.readlines(file_path).map(&:chomp) }
+
+    before do
+      emails.each { |email| create(:trainee, email: email) }
+    end
+
+    it 'destroys the trainees with emails in the file' do
+      expect { run_rake_task }.to change { Trainee.discarded.count }.by(emails.count)
+    end
+  end
+
+  context 'when file path is not provided' do
+    let(:file_path) { '' }
+
+    it 'raises an error' do
+      expect { run_rake_task }.to raise_error(RuntimeError, 'You must provide a file path')
+    end
+  end
+end

--- a/spec/lib/tasks/cleanup_trainees_spec.rb
+++ b/spec/lib/tasks/cleanup_trainees_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "rake"
 
 describe "cleanup:discard_trainees" do
-  before :all do
+  before do
     Rake.application.rake_require "tasks/cleanup"
     Rake::Task.define_task(:environment)
   end

--- a/spec/lib/tasks/cleanup_users_spec.rb
+++ b/spec/lib/tasks/cleanup_users_spec.rb
@@ -3,27 +3,27 @@
 require "rails_helper"
 require "rake"
 
-describe "cleanup:discard_trainees" do
+describe "cleanup:discard_users" do
   before do
     Rake.application.rake_require "tasks/cleanup"
     Rake::Task.define_task(:environment)
   end
 
   let(:run_rake_task) do
-    Rake::Task["cleanup:discard_trainees"].reenable
-    Rake.application.invoke_task "cleanup:discard_trainees[#{file_path}]"
+    Rake::Task["cleanup:discard_users"].reenable
+    Rake.application.invoke_task "cleanup:discard_users[#{file_path}]"
   end
 
   context "when file path is provided" do
     let(:file_path) { Rails.root.join("spec/fixtures/files/cleanup_emails.txt") }
-    let(:emails) { File.readlines(file_path).map(&:chomp) }
+    let(:emails) { File.readlines(file_path).map(&:chomp).reject(&:empty?) }
 
     before do
-      emails.each { |email| create(:trainee, email:) }
+      emails.each { |email| create(:user, email:) }
     end
 
-    it "destroys the trainees with emails in the file" do
-      expect { run_rake_task }.to change { Trainee.discarded.count }.by(emails.count)
+    it "destroys the users with emails in the file" do
+      expect { run_rake_task }.to change { User.discarded.count }.by(emails.count)
     end
   end
 


### PR DESCRIPTION
### Context
[Trello](https://trello.com/c/lA8GyJm7)

[It's been found](https://educationgovuk.sharepoint.com.mcas.ms/:x:/r/sites/TeacherServices/_layouts/15/doc2.aspx?sourcedoc=%7BFCACCD27-B893-4ED0-A212-E37FAABBE6AF%7D&file=user_activity_2024.xlsx&action=default&mobileredirect=true) that we have several hundred Trainees in register that are considered inactive, because they haven't signed in for over a year, or they've never signed in at all.

### Changes proposed in this pull request
This adds a rake task that can be given a text file full of emails addresses and it will discard (soft delete) them. There's a small chance that some users will want their account reinstated so soft deletes are preferred.

Once this is merged, I can create the text file with the email addresses on production and run the rake task with the file from there. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
