### PR TITLE
Revert BigQuery maintenance window

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -53,8 +53,4 @@ DfE::Analytics.configure do |config|
   # to all events we send to BigQuery.
   #
   # config.environment = ENV.fetch('RAILS_ENV', 'development')
-
-  # Schedule a maintenance window during which no events are streamed to BigQuery
-  # in the format of '22-01-2024 19:30..22-01-2024 20:30' (UTC).
-  config.bigquery_maintenance_window = "28-05-2024 20:00..28-05-2024 20:10"
 end


### PR DESCRIPTION
### Context

This was added to perform maintenance in BigQuery. We are now reverting this as the maintenance should be added through an environment variable rather than a code change.

### Changes proposed in this pull request

Revert a previous commit.

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
