### PR TITLE
[7201] Add query params to POST withdraw request template in docs

### DIFF
--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -1237,6 +1237,8 @@ Withdraw a trainee.
 
 There is no request body for this endpoint.
 
+Note that multiple values for the reasons parameter can be provided by repeating the parameter in the query string, e.g. `reasons[]=personal_reasons&reasons[]=got_a_job`
+
 #### Parameters
 
 | **Parameter** | **In**  | **Type** | **Required** | **Description** |


### PR DESCRIPTION
### Context
The API Reference documentation didn't really make it clear that the four parameters for this endpoint are infact query params (and that there is no request body here).

### Changes proposed in this pull request
I've added the 4 query params to the template in the spec.

Before:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/1a0a6a0e-87fb-4644-a36a-1077e4dd77e5)

After:
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/450843/8e11c322-0f3c-4b75-8361-81429fee851c)


### Guidance to review
Is there anything else we can add to the docs to make things clearer?

e.g. a list of allowed `reasons` and an explanation of how multi-value params like `reasons` work as query params.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
