### PR TITLE
[7187] Validate withdrawal reasons against current list of reasons and add to docs

### DIFF
--- a/app/models/api/v0_1/withdrawal_attributes.rb
+++ b/app/models/api/v0_1/withdrawal_attributes.rb
@@ -12,8 +12,8 @@ module Api
       validate :withdraw_date_valid
       validates :withdraw_reasons_details, length: { maximum: 1000 }, allow_blank: true
       validates :withdraw_reasons_dfe_details, length: { maximum: 1000 }, allow_blank: true
+      validates :reasons, inclusion: { in: WithdrawalReasons::REASONS }
 
-      validates :reasons, presence: true
       validate :unknown_exclusively
 
       attr_accessor :trainee

--- a/app/serializers/api/v0_1/trainee_serializer.rb
+++ b/app/serializers/api/v0_1/trainee_serializer.rb
@@ -62,7 +62,7 @@ module Api
       end
 
       def placements
-        @placements ||= @trainee.placements.map do |placement|
+        @placements ||= @trainee.placements.includes(:school).map do |placement|
           PlacementSerializer.new(placement).as_hash
         end
       end

--- a/app/serializers/api/v0_1/trainee_serializer.rb
+++ b/app/serializers/api/v0_1/trainee_serializer.rb
@@ -47,6 +47,7 @@ module Api
           training_route: training_route,
           nationality: nationality,
           training_initiative: training_initiative,
+          withdraw_reasons: withdraw_reasons,
           placements: placements,
           degrees: degrees,
           state: @trainee.state,
@@ -222,6 +223,10 @@ module Api
 
       def sex
         ::Hesa::CodeSets::Sexes::MAPPING.key(::Trainee.sexes[@trainee.sex])
+      end
+
+      def withdraw_reasons
+        @trainee.withdrawal_reasons&.map(&:name)
       end
     end
   end

--- a/app/services/api/get_trainees_service.rb
+++ b/app/services/api/get_trainees_service.rb
@@ -27,7 +27,7 @@ module Api
       @trainees ||= provider.trainees
         .not_draft
         .joins(:start_academic_cycle)
-        .includes([:nationalities])
+        .includes(%i[nationalities withdrawal_reasons])
         .where(academic_cycles: { id: academic_cycle.id })
         .where(trainees: { updated_at: since.. })
         .order("trainees.updated_at #{sort_order}")

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -1245,7 +1245,7 @@ Note that multiple values for the reasons parameter can be provided by repeating
 | **Parameter** | **In**  | **Type** | **Required** | **Description** |
 | ------------- | ------- | -------- | ------------ | --------------- |
 | **trainee_id** | path | string | true | The unique ID of the trainee |
-| **reasons** | query | array of strings | true | The reason(s) for the withdrawal |
+| **reasons** | query | array of strings | true | The reason(s) for the withdrawal. Valid values are `could_not_give_enough_time`,  `course_was_not_suitable`, `did_not_make_progress`, `did_not_meet_entry_requirements`, `does_not_want_to_become_a_teacher`, `family_problems`, `financial_problems`, `got_a_job`, `problems_with_their_health`, `stopped_responding_to_messages`, `teaching_placement_problems`, `unacceptable_behaviour`, `unhappy_with_course_provider_or_employing_school`, `another_reason`, `unknown` |
 | **withdraw_date** | query | string | true | The date and time of the withdrawal in ISO 8601 format |
 | **withdraw_reasons_details** | query | string | false | Details about why the trainee withdrew |
 | **withdraw_reasons_dfe_details** | query | string | false | What the Department of Education could have done to prevent the trainee withdrawing |

--- a/app/views/api_docs/reference/v0.1/_reference.md
+++ b/app/views/api_docs/reference/v0.1/_reference.md
@@ -1238,14 +1238,14 @@ Withdraw a trainee.
 
 There is no request body for this endpoint.
 
-Note that multiple values for the reasons parameter can be provided by repeating the parameter in the query string, e.g. `reasons[]=personal_reasons&reasons[]=got_a_job`
+Note that multiple values for the reasons parameter can be provided by repeating the parameter in the query string, e.g. `reasons[]=family_problems&reasons[]=got_a_job`
 
 #### Parameters
 
 | **Parameter** | **In**  | **Type** | **Required** | **Description** |
 | ------------- | ------- | -------- | ------------ | --------------- |
 | **trainee_id** | path | string | true | The unique ID of the trainee |
-| **reasons** | query | array of strings | true | The reason(s) for the withdrawal. Valid values are `could_not_give_enough_time`,  `course_was_not_suitable`, `did_not_make_progress`, `did_not_meet_entry_requirements`, `does_not_want_to_become_a_teacher`, `family_problems`, `financial_problems`, `got_a_job`, `problems_with_their_health`, `stopped_responding_to_messages`, `teaching_placement_problems`, `unacceptable_behaviour`, `unhappy_with_course_provider_or_employing_school`, `another_reason`, `unknown` |
+| **reasons** | query | array of strings | true | The reason(s) for the withdrawal. Valid values are `could_not_give_enough_time`, <br>`course_was_not_suitable`,<br> `did_not_make_progress`,<br> `did_not_meet_entry_requirements`,<br> `does_not_want_to_become_a_teacher`,<br> `family_problems`,<br> `financial_problems`,<br> `got_a_job`,<br> `problems_with_their_health`,<br> `stopped_responding_to_messages`,<br> `teaching_placement_problems`,<br> `unacceptable_behaviour`,<br> `unhappy_with_course_provider_or_employing_school`,<br> `another_reason`,<br> `unknown` |
 | **withdraw_date** | query | string | true | The date and time of the withdrawal in ISO 8601 format |
 | **withdraw_reasons_details** | query | string | false | Details about why the trainee withdrew |
 | **withdraw_reasons_dfe_details** | query | string | false | What the Department of Education could have done to prevent the trainee withdrawing |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1885,7 +1885,7 @@ en:
         api/v01/withdrawal_attributes:
           attributes:
             reasons:
-              blank: Select why the trainee withdrew from the course or select "Unknown"
+              inclusion: Choose one or more reasons why the trainee withdrew from the course, or select "Unknown"
               unknown_exclusively: Only select "Unknown" if no other withdrawal reasons apply
             withdraw_date:
               blank: Choose a withdrawal date

--- a/spec/models/api/v0_1/withdrawal_attributes_spec.rb
+++ b/spec/models/api/v0_1/withdrawal_attributes_spec.rb
@@ -11,10 +11,7 @@ describe Api::V01::WithdrawalAttributes do
   describe "validations" do
     it { is_expected.to validate_length_of(:withdraw_reasons_details).is_at_most(1000).with_message("Details about why the trainee withdrew must be 1000 characters or less") }
     it { is_expected.to validate_length_of(:withdraw_reasons_dfe_details).is_at_most(1000).with_message("What the Department for Education could have done must be 1000 characters or less") }
-
-    it {
-      expect(subject).to validate_presence_of(:reasons).with_message('Select why the trainee withdrew from the course or select "Unknown"')
-    }
+    it { is_expected.to validate_inclusion_of(:reasons).in_array(WithdrawalReasons::REASONS).with_message("Choose one or more reasons why the trainee withdrew from the course, or select \"Unknown\"") }
 
     context "withdraw_date" do
       context "blank date" do

--- a/spec/requests/api/v0_1/trainees/post_withdraw_spec.rb
+++ b/spec/requests/api/v0_1/trainees/post_withdraw_spec.rb
@@ -92,7 +92,7 @@ describe "`POST /trainees/:trainee_id/withdraw` endpoint" do
 
           expect(response.parsed_body[:errors]).to contain_exactly(
             { error: "UnprocessableEntity", message: "Withdraw date Choose a withdrawal date" },
-            { error: "UnprocessableEntity", message: "Reasons Select why the trainee withdrew from the course or select \"Unknown\"" },
+            { error: "UnprocessableEntity", message: "Reasons Choose one or more reasons why the trainee withdrew from the course, or select \"Unknown\"" },
           )
         end
 

--- a/spec/serializers/api/v0_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v0_1/trainee_serializer_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe Api::V01::TraineeSerializer do
         trn
         submitted_for_trn_at
         withdraw_date
+        withdraw_reasons_dfe_details
         withdraw_reasons_details
+        withdraw_reasons
         defer_date
         recommended_for_award_at
         trainee_start_date
@@ -58,7 +60,6 @@ RSpec.describe Api::V01::TraineeSerializer do
         record_source
         iqts_country
         hesa_editable
-        withdraw_reasons_dfe_details
         slug_sent_to_dqt_at
         placement_detail
         ukprn

--- a/spec/services/api/trainees/withdraw_response_spec.rb
+++ b/spec/services/api/trainees/withdraw_response_spec.rb
@@ -46,7 +46,7 @@ describe Api::Trainees::WithdrawResponse do
         expect(subject[:status]).to be(:unprocessable_entity)
         expect(subject[:json][:errors]).to contain_exactly(
           { error: "UnprocessableEntity", message: "Withdraw date Choose a withdrawal date" },
-          { error: "UnprocessableEntity", message: "Reasons Select why the trainee withdrew from the course or select \"Unknown\"" },
+          { error: "UnprocessableEntity", message: "Reasons Choose one or more reasons why the trainee withdrew from the course, or select \"Unknown\"" },
         )
       end
 


### PR DESCRIPTION
### Context

https://trello.com/c/gDCbBL2E

We had feedback that the withdrawal `reasons` were not documented. We wanted to rectify that and also make sure they are validated.

### Changes proposed in this pull request

* List all the valid withdrawal `reasons` in the API docs
* Validate the reasons against the current list of reasons
* Add the withdrawal reasons to the serializer so they appear in the API response
* Fix a Bullet warning

### Guidance to review

Does the `/withdraw` endpoint work as expected and are the docs clear and accurate.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
