### PR TITLE
[7190] Make sure existing disabilities aren't removed when new ones are added

### DIFF
--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -43,9 +43,7 @@ module Api
 
     def update
       trainee = current_provider&.trainees&.find_by!(slug: params[:slug])
-      attributes = trainee_attributes_service.from_trainee(trainee)
-
-      attributes.assign_attributes(hesa_mapped_params_for_update)
+      attributes = trainee_attributes_service.from_trainee(trainee, hesa_mapped_params_for_update)
 
       succeeded, validation = update_trainee_service_class.call(trainee:, attributes:)
 

--- a/app/controllers/api/trainees_controller.rb
+++ b/app/controllers/api/trainees_controller.rb
@@ -84,7 +84,7 @@ module Api
           hesa_mapper_class::ATTRIBUTES + trainee_attributes_service::ATTRIBUTES.keys,
           hesa_mapper_class.disability_attributes(params),
           hesa_trainee_details_attributes_service::ATTRIBUTES,
-        ),
+        ), update: true
       )
     end
 

--- a/app/models/api/v0_1/trainee_attributes.rb
+++ b/app/models/api/v0_1/trainee_attributes.rb
@@ -149,6 +149,7 @@ module Api
         update_hesa_trainee_detail_attributes(new_attributes)
 
         self.trainee_disabilities_attributes = []
+
         new_attributes[:disabilities]&.each do |disability|
           trainee_disabilities_attributes << { disability_id: disability.id }
         end
@@ -196,7 +197,7 @@ module Api
 
         new_trainee_attributes = new(trainee_attributes)
 
-        params_with_updated_disabilities = params_with_updated_disabilities(new_trainee_attributes, trainee.disabilities, params_for_update)
+        params_with_updated_disabilities = params_with_updated_disabilities(new_trainee_attributes, params_for_update)
 
         new_trainee_attributes.assign_attributes(params_with_updated_disabilities)
         new_trainee_attributes

--- a/app/models/api/v0_1/trainee_attributes.rb
+++ b/app/models/api/v0_1/trainee_attributes.rb
@@ -154,13 +154,24 @@ module Api
         end
       end
 
-      def update_hesa_trainee_detail_attributes(attributes)
-        new_hesa_attributes = attributes.slice(*HesaTraineeDetailAttributes::ATTRIBUTES)
+      def update_hesa_trainee_detail_attributes(new_attributes)
+        new_hesa_attributes = new_attributes.slice(*HesaTraineeDetailAttributes::ATTRIBUTES)
         return if new_hesa_attributes.blank?
 
         updated_hesa_attributes = hesa_trainee_detail_attributes || HesaTraineeDetailAttributes.new({})
-        updated_hesa_attributes.assign_attributes(new_hesa_attributes)
+
+        updated_hesa_disabilites = update_hesa_disabilites(updated_hesa_attributes, new_hesa_attributes)
+        updated_hesa_attributes.assign_attributes(new_hesa_attributes.merge(updated_hesa_disabilites))
+
         updated_hesa_attributes
+      end
+
+      def update_hesa_disabilites(original_hesa_attributes, new_hesa_attributes)
+        updated_hesa_disabilites = original_hesa_attributes.hesa_disabilities
+
+        updated_hesa_disabilites = updated_hesa_disabilites.merge(new_hesa_attributes[:hesa_disabilities]) if new_hesa_attributes[:hesa_disabilities].present?
+
+        { hesa_disabilities: updated_hesa_disabilites }
       end
 
       def self.from_trainee(trainee)

--- a/app/services/api/v0_1/hesa_mapper/attributes.rb
+++ b/app/services/api/v0_1/hesa_mapper/attributes.rb
@@ -55,7 +55,7 @@ module Api
           .compact
 
           if update && !disabilities?
-            mapped_params = mapped_params.except(:hesa_disabilities, :disability_disclosure)
+            mapped_params = mapped_params.except(:hesa_disabilities, :disability_disclosure, :disabilities)
           end
 
           mapped_params

--- a/app/services/api/v0_1/update_trainee_service.rb
+++ b/app/services/api/v0_1/update_trainee_service.rb
@@ -15,6 +15,7 @@ module Api
 
         attributes_to_save = attributes.deep_attributes.with_indifferent_access
         trainee.nationalities.destroy_all if attributes_to_save[:nationalisations_attributes].present?
+        trainee.trainee_disabilities.destroy_all if attributes_to_save[:trainee_disabilities_attributes].present?
 
         if trainee_attributes_validation.invalid?
           [false, trainee_attributes_validation]

--- a/spec/components/diversity/view_spec.rb
+++ b/spec/components/diversity/view_spec.rb
@@ -124,13 +124,13 @@ describe Diversity::View do
 
       it "renders the disability names" do
         trainee.disabilities.each do |disability|
-          expect(rendered_content).to have_text(disability.name)
+          expect(rendered_content).to have_text(disability.name.downcase)
         end
       end
     end
 
     context "when additional disability has been provided" do
-      let(:disability) { build(:disability, name: Diversities::OTHER) }
+      let(:disability) { build(:disability, :other) }
       let(:trainee_disability) { build(:trainee_disability, additional_disability: "some additional disability", disability: disability) }
       let(:trainee) { create(:trainee, :diversity_disclosed, :disabled, trainee_disabilities: [trainee_disability]) }
 

--- a/spec/factories/disabilities.rb
+++ b/spec/factories/disabilities.rb
@@ -20,5 +20,9 @@ FactoryBot.define do
     trait :mental_health_condition do
       name { "Mental health condition" }
     end
+
+    trait :no_known_disability do
+      name { "No disabilities" }
+    end
   end
 end

--- a/spec/factories/disabilities.rb
+++ b/spec/factories/disabilities.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     trait :deaf do
       name { "Deaf" }
     end
+
+    trait :other do
+      name { "Other" }
+    end
   end
 end

--- a/spec/factories/disabilities.rb
+++ b/spec/factories/disabilities.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
     trait :other do
       name { "Other" }
     end
+
+    trait :mental_health_condition do
+      name { "Mental health condition" }
+    end
   end
 end

--- a/spec/factories/hesa/trainee_details.rb
+++ b/spec/factories/hesa/trainee_details.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     pg_apprenticeship_start_date { Time.zone.today }
     funding_method { Hesa::CodeSets::BursaryLevels::MAPPING.keys.sample }
     ni_number { "QQ 12 34 56 C" }
-    hesa_disabilities { { disability1: "95" } }
+
     additional_training_initiative { "026" }
     itt_qualification_aim { Hesa::CodeSets::IttQualificationAims::MAPPING.keys.sample }
     fund_code { Hesa::CodeSets::FundCodes::MAPPING.keys.sample }

--- a/spec/factories/trainee_disabilities.rb
+++ b/spec/factories/trainee_disabilities.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :trainee_disability, class: "TraineeDisability" do
     trainee
-    disability
+    disability factory: %i[disability other]
   end
 end

--- a/spec/factories/trainee_disabilities.rb
+++ b/spec/factories/trainee_disabilities.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :trainee_disability, class: "TraineeDisability" do
     trainee
-    disability factory: %i[disability other]
+    disability factory: %i[disability mental_health_condition]
   end
 end

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -318,6 +318,14 @@ FactoryBot.define do
 
       after(:create) do |trainee, evaluator|
         create_list(:trainee_disability, evaluator.disabilities_count, trainee:)
+
+        if trainee.hesa_trainee_detail.present?
+          trainee.hesa_trainee_detail.hesa_disabilities = evaluator.disabilities.map.with_index(1) { |item, index|
+            ["disability#{index}", Hesa::CodeSets::Disabilities::MAPPING.key(item.name)]
+          }.to_h
+
+          trainee.hesa_trainee_detail.save
+        end
         trainee.reload
       end
     end

--- a/spec/models/api/v0_1/trainee_attributes_spec.rb
+++ b/spec/models/api/v0_1/trainee_attributes_spec.rb
@@ -26,19 +26,97 @@ RSpec.describe Api::V01::TraineeAttributes do
 
   describe ".from_trainee" do
     let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :disabled_with_disabilites_disclosed, :completed, sex: :prefer_not_to_say) }
+    let(:blind_disability) { create(:disability, :blind) }
+    let(:deaf_disability) { create(:disability, :deaf) }
+    let(:trainee_disability) { trainee.disabilities.to_h { |disability| [:disability_id, disability.id] } }
 
-    subject(:attributes) { described_class.from_trainee(trainee) }
+    before do
+      blind_disability
+      deaf_disability
+    end
 
-    it "pulls HesaTraineeDetail attributes from association" do
-      expect(attributes.hesa_trainee_detail_attributes).to be_present
+    context "with empty params" do
+      subject(:attributes) { described_class.from_trainee(trainee, {}) }
 
-      Api::V01::HesaTraineeDetailAttributes::ATTRIBUTES.each do |attr|
-        expect(attributes.hesa_trainee_detail_attributes.send(attr)).to be_present
+      it "pulls HesaTraineeDetail attributes from association" do
+        expect(attributes.hesa_trainee_detail_attributes).to be_present
+
+        Api::V01::HesaTraineeDetailAttributes::ATTRIBUTES.each do |attr|
+          expect(attributes.hesa_trainee_detail_attributes.send(attr)).to be_present
+        end
+      end
+
+      it "correct sets both hesa_disabilities & trainee_disabilities_attributes" do
+        expect(attributes.hesa_trainee_detail_attributes.hesa_disabilities).to match({ "disability1" => "55" })
+        expect(attributes.trainee_disabilities_attributes).to match([trainee_disability])
+      end
+
+      it "correctly sets the sex attribute as an integer" do
+        expect(attributes.sex).to eq(Trainee.sexes[:prefer_not_to_say])
       end
     end
 
-    it "correctly sets the sex attribute as an integer" do
-      expect(attributes.sex).to eq(Trainee.sexes[:prefer_not_to_say])
+    context "with additional hesa_disabilities disability2" do
+      subject(:attributes) { described_class.from_trainee(trainee, { hesa_disabilities: { "disability2" => "58" } }) }
+
+      it "pulls HesaTraineeDetail attributes from association" do
+        expect(attributes.hesa_trainee_detail_attributes).to be_present
+
+        Api::V01::HesaTraineeDetailAttributes::ATTRIBUTES.each do |attr|
+          expect(attributes.hesa_trainee_detail_attributes.send(attr)).to be_present
+        end
+      end
+
+      it "correct sets both hesa_disabilities & trainee_disabilities_attributes" do
+        expect(attributes.hesa_trainee_detail_attributes.hesa_disabilities).to match({ "disability1" => "55", "disability2" => "58" })
+        expect(attributes.trainee_disabilities_attributes).to match([trainee_disability, { disability_id: blind_disability.id }])
+      end
+
+      it "correctly sets the sex attribute as an integer" do
+        expect(attributes.sex).to eq(Trainee.sexes[:prefer_not_to_say])
+      end
+    end
+
+    context "with replacing hesa_disabilities disability1" do
+      subject(:attributes) { described_class.from_trainee(trainee, { hesa_disabilities: { "disability1" => "58" } }) }
+
+      it "pulls HesaTraineeDetail attributes from association" do
+        expect(attributes.hesa_trainee_detail_attributes).to be_present
+
+        Api::V01::HesaTraineeDetailAttributes::ATTRIBUTES.each do |attr|
+          expect(attributes.hesa_trainee_detail_attributes.send(attr)).to be_present
+        end
+      end
+
+      it "correct sets both hesa_disabilities & trainee_disabilities_attributes" do
+        expect(attributes.hesa_trainee_detail_attributes.hesa_disabilities).to match({ "disability1" => "58" })
+        expect(attributes.trainee_disabilities_attributes).to match([{ disability_id: blind_disability.id }])
+      end
+
+      it "correctly sets the sex attribute as an integer" do
+        expect(attributes.sex).to eq(Trainee.sexes[:prefer_not_to_say])
+      end
+    end
+
+    context "with replacing hesa_disabilities disability1 and adding hesa_disabilities disability2" do
+      subject(:attributes) { described_class.from_trainee(trainee, { hesa_disabilities: { "disability1" => "57", "disability2" => "58" } }) }
+
+      it "pulls HesaTraineeDetail attributes from association" do
+        expect(attributes.hesa_trainee_detail_attributes).to be_present
+
+        Api::V01::HesaTraineeDetailAttributes::ATTRIBUTES.each do |attr|
+          expect(attributes.hesa_trainee_detail_attributes.send(attr)).to be_present
+        end
+      end
+
+      it "correct sets both hesa_disabilities & trainee_disabilities_attributes" do
+        expect(attributes.hesa_trainee_detail_attributes.hesa_disabilities).to match({ "disability1" => "57", "disability2" => "58" })
+        expect(attributes.trainee_disabilities_attributes).to match([{ disability_id: deaf_disability.id }, { disability_id: blind_disability.id }])
+      end
+
+      it "correctly sets the sex attribute as an integer" do
+        expect(attributes.sex).to eq(Trainee.sexes[:prefer_not_to_say])
+      end
     end
   end
 
@@ -83,7 +161,7 @@ RSpec.describe Api::V01::TraineeAttributes do
 
   describe "assign_attributes" do
     let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :completed, sex: :prefer_not_to_say) }
-    let(:trainee_attributes) { described_class.from_trainee(trainee) }
+    let(:trainee_attributes) { described_class.from_trainee(trainee, {}) }
 
     subject(:attributes) {
       trainee_attributes

--- a/spec/models/api/v0_1/trainee_attributes_spec.rb
+++ b/spec/models/api/v0_1/trainee_attributes_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V01::TraineeAttributes do
   end
 
   describe ".from_trainee" do
-    let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :completed, sex: :prefer_not_to_say) }
+    let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :disabled_with_disabilites_disclosed, :completed, sex: :prefer_not_to_say) }
 
     subject(:attributes) { described_class.from_trainee(trainee) }
 

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -149,7 +149,7 @@ describe Reports::TraineeReport do
     end
 
     it "includes the disabilities" do
-      expect(subject.disabilities).to start_with("disability ")
+      expect(subject.disabilities).to start_with("Mental health condition")
     end
 
     it "includes the number_of_degrees" do

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -680,14 +680,6 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     end
 
     describe "with disabilities" do
-      let(:params) do
-        {
-          data: {
-            first_names: "Alice",
-          },
-        }
-      end
-
       before do
         create(:disability, :blind)
         create(:disability, :deaf)
@@ -714,6 +706,27 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
           expect(trainee.reload.disabilities.count).to eq(1)
           expect(trainee.reload.disabilities.map(&:name)).to contain_exactly("Other")
+        end
+      end
+
+      context "when disability2 is set" do
+        let(:params) do
+          {
+            data: {
+              disability2: "57",
+            },
+          }
+        end
+
+        it do
+          expect(response).to have_http_status(:ok)
+
+          expect(response.parsed_body[:data][:disability_disclosure]).to eq("disabled")
+          expect(response.parsed_body[:data][:disability1]).to eq("96")
+          expect(response.parsed_body[:data][:disability2]).to eq("57")
+
+          expect(trainee.disabilities.count).to eq(2)
+          expect(trainee.disabilities.map(&:name)).to contain_exactly("Other", "Deaf")
         end
       end
     end

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -10,6 +10,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
       :with_hesa_trainee_detail,
       :with_lead_school,
       :with_employing_school,
+      :with_diversity_information,
       first_names: "Bob",
     )
   end
@@ -530,7 +531,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     context "when read only attributes are submitted" do
       let(:ethnic_background) { Dttp::CodeSets::Ethnicities::MAPPING.keys.sample }
       let(:ethnic_group) { Diversities::BACKGROUNDS.select { |_key, values| values.include?(ethnic_background) }&.keys&.first }
-      let(:trainee) { create(:trainee, :in_progress, :with_hesa_trainee_detail, ethnic_group:, ethnic_background:) }
+      let(:trainee) { create(:trainee, :in_progress, :with_hesa_trainee_detail, :with_diversity_information, ethnic_group:, ethnic_background:) }
 
       before do
         put(
@@ -553,7 +554,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
           }
         end
 
-        it "sets the enthnic attributes based on ethnicity" do
+        it "sets the ethnic attributes based on ethnicity" do
           expect(response).to have_http_status(:ok)
 
           trainee.reload
@@ -603,7 +604,7 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
     end
 
     describe "with ethnicity" do
-      let(:trainee) { create(:trainee, :in_progress, :with_hesa_trainee_detail, ethnic_group:, ethnic_background:) }
+      let(:trainee) { create(:trainee, :in_progress, :with_hesa_trainee_detail, :with_diversity_information, ethnic_group:, ethnic_background:) }
       let(:ethnic_background) { Dttp::CodeSets::Ethnicities::MAPPING.keys.sample }
       let(:ethnic_group) { Diversities::BACKGROUNDS.select { |_key, values| values.include?(ethnic_background) }&.keys&.first }
 
@@ -674,6 +675,45 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         it do
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.parsed_body[:errors]).to contain_exactly("Ethnicity is not included in the list")
+        end
+      end
+    end
+
+    describe "with disabilities" do
+      let(:params) do
+        {
+          data: {
+            first_names: "Alice",
+          },
+        }
+      end
+
+      before do
+        create(:disability, :blind)
+        create(:disability, :deaf)
+        put(
+          endpoint,
+          headers: { Authorization: "Bearer #{token}", **json_headers },
+          params: params.to_json,
+        )
+      end
+
+      context "when not present" do
+        let(:params) do
+          {
+            data: {
+              first_names: "Alice",
+            },
+          }
+        end
+
+        it do
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body[:data][:disability_disclosure]).to eq("disabled")
+          expect(response.parsed_body[:data][:disability1]).to eq("96")
+
+          expect(trainee.reload.disabilities.count).to eq(1)
+          expect(trainee.reload.disabilities.map(&:name)).to contain_exactly("Other")
         end
       end
     end

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -703,9 +703,31 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body[:data][:disability_disclosure]).to eq("disabled")
           expect(response.parsed_body[:data][:disability1]).to eq("96")
+          expect(response.parsed_body[:data][:disability2]).to be_nil
 
           expect(trainee.reload.disabilities.count).to eq(1)
           expect(trainee.reload.disabilities.map(&:name)).to contain_exactly("Other")
+        end
+      end
+
+      context "when disability1 is set" do
+        let(:params) do
+          {
+            data: {
+              disability1: "57",
+            },
+          }
+        end
+
+        it do
+          expect(response).to have_http_status(:ok)
+
+          expect(response.parsed_body[:data][:disability_disclosure]).to eq("disabled")
+          expect(response.parsed_body[:data][:disability1]).to eq("57")
+          expect(response.parsed_body[:data][:disability2]).to be_nil
+
+          expect(trainee.disabilities.count).to eq(1)
+          expect(trainee.disabilities.map(&:name)).to contain_exactly("Deaf")
         end
       end
 
@@ -727,6 +749,28 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
           expect(trainee.disabilities.count).to eq(2)
           expect(trainee.disabilities.map(&:name)).to contain_exactly("Other", "Deaf")
+        end
+      end
+
+      context "when disability1 & disability2 is set" do
+        let(:params) do
+          {
+            data: {
+              disability1: "58",
+              disability2: "57",
+            },
+          }
+        end
+
+        it do
+          expect(response).to have_http_status(:ok)
+
+          expect(response.parsed_body[:data][:disability_disclosure]).to eq("disabled")
+          expect(response.parsed_body[:data][:disability1]).to eq("58")
+          expect(response.parsed_body[:data][:disability2]).to eq("57")
+
+          expect(trainee.disabilities.count).to eq(2)
+          expect(trainee.disabilities.map(&:name)).to contain_exactly("Blind", "Deaf")
         end
       end
     end

--- a/spec/requests/api/v0_1/put_trainee_spec.rb
+++ b/spec/requests/api/v0_1/put_trainee_spec.rb
@@ -681,8 +681,8 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
 
     describe "with disabilities" do
       before do
-        create(:disability, :blind)
         create(:disability, :deaf)
+        create(:disability, :blind)
         put(
           endpoint,
           headers: { Authorization: "Bearer #{token}", **json_headers },
@@ -702,11 +702,11 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
         it do
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body[:data][:disability_disclosure]).to eq("disabled")
-          expect(response.parsed_body[:data][:disability1]).to eq("96")
+          expect(response.parsed_body[:data][:disability1]).to eq("55")
           expect(response.parsed_body[:data][:disability2]).to be_nil
 
           expect(trainee.reload.disabilities.count).to eq(1)
-          expect(trainee.reload.disabilities.map(&:name)).to contain_exactly("Other")
+          expect(trainee.reload.disabilities.map(&:name)).to contain_exactly("Mental health condition")
         end
       end
 
@@ -744,11 +744,11 @@ describe "`PUT /api/v0.1/trainees/:id` endpoint" do
           expect(response).to have_http_status(:ok)
 
           expect(response.parsed_body[:data][:disability_disclosure]).to eq("disabled")
-          expect(response.parsed_body[:data][:disability1]).to eq("96")
+          expect(response.parsed_body[:data][:disability1]).to eq("55")
           expect(response.parsed_body[:data][:disability2]).to eq("57")
 
           expect(trainee.disabilities.count).to eq(2)
-          expect(trainee.disabilities.map(&:name)).to contain_exactly("Other", "Deaf")
+          expect(trainee.disabilities.map(&:name)).to contain_exactly("Mental health condition", "Deaf")
         end
       end
 

--- a/spec/serializers/api/v0_1/trainee_serializer_spec.rb
+++ b/spec/serializers/api/v0_1/trainee_serializer_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V01::TraineeSerializer do
-  let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :in_progress, :with_placements, :with_french_nationality) }
+  let(:trainee) { create(:trainee, :with_hesa_trainee_detail, :with_diversity_information, :in_progress, :with_placements, :with_french_nationality) }
   let(:json) { described_class.new(trainee).as_hash.with_indifferent_access }
 
   describe "serialization" do


### PR DESCRIPTION
### Context
Hesa disabilities and trainee disabilities

### Changes proposed in this pull request
Ensure Hesa disabilities and trainee disabilities stays in sync
Ensure new additions does not remove exising
Ensure updating existing does not add addition

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
