### PR TITLE
Enable enable_gcp_wif for workers

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -45,12 +45,13 @@ module "worker_application" {
   kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
   kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
 
-  docker_image = var.app_docker_image
-  command     = each.value.startup_command
-  max_memory  = each.value.memory_max
-  replicas    = each.value.replicas
-  probe_command = each.value.probe_command
-  enable_logit  = var.enable_logit
+  docker_image   = var.app_docker_image
+  command        = each.value.startup_command
+  max_memory     = each.value.memory_max
+  replicas       = each.value.replicas
+  probe_command  = each.value.probe_command
+  enable_logit   = var.enable_logit
+  enable_gcp_wif = var.enable_gcp_wif
 }
 
 module "application_configuration" {

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -99,6 +99,7 @@ variable "postgres_enable_high_availability" { default = false }
 variable "azure_enable_backup_storage" { default = true }
 variable "enable_container_monitoring" { default = false }
 variable "enable_logit" { default = false }
+variable "enable_gcp_wif" { default = true }
 
 locals {
   app_name_suffix  = var.app_name == null ? var.app_environment : var.app_name

--- a/terraform/aks/workspace-variables/dv_review.tfvars.json
+++ b/terraform/aks/workspace-variables/dv_review.tfvars.json
@@ -23,5 +23,6 @@
       "memory_max": "1Gi"
     }
   },
-  "deploy_temp_data_storage_account": false
+  "deploy_temp_data_storage_account": false,
+  "enable_gcp_wif": false
 }

--- a/terraform/aks/workspace-variables/pen.tfvars.json
+++ b/terraform/aks/workspace-variables/pen.tfvars.json
@@ -31,6 +31,7 @@
     "pen.register-trainee-teachers.education.gov.uk"
   ],
   "enable_monitoring": true,
+  "enable_gcp_wif": false,
   "statuscake_alerts": {
     "alert": {
       "website_url": [ "https://pen.register-trainee-teachers.service.gov.uk/healthcheck" ],

--- a/terraform/aks/workspace-variables/productiondata.tfvars.json
+++ b/terraform/aks/workspace-variables/productiondata.tfvars.json
@@ -37,5 +37,6 @@
   "enable_monitoring": false,
   "pg_actiongroup_name": "s189p01-rtt-production-ag",
   "pg_actiongroup_rg": "s189p01-rtt-pd-rg",
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_gcp_wif": false
 }

--- a/terraform/aks/workspace-variables/review.tfvars.json
+++ b/terraform/aks/workspace-variables/review.tfvars.json
@@ -25,5 +25,6 @@
     }
   },
   "deploy_temp_data_storage_account": false,
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_gcp_wif": false
 }

--- a/terraform/aks/workspace-variables/sandbox.tfvars.json
+++ b/terraform/aks/workspace-variables/sandbox.tfvars.json
@@ -41,5 +41,6 @@
   "enable_monitoring": false,
   "pg_actiongroup_name": "s189p01-rtt-production-ag",
   "pg_actiongroup_rg": "s189p01-rtt-pd-rg",
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_gcp_wif": false
 }


### PR DESCRIPTION
### Context

https://trello.com/c/T3eEa0zE/1763-migrate-register-to-google-oidc

Set enable_gcp_wif:true for worker deployments that send data to gcp

### Changes proposed in this pull request

update terraform 

### Guidance to review

make env deploy-plan

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
