### PR TITLE
[7229] Amended the course program type mapping for 2023-2024 and 2024-2025

### DIFF
--- a/app/controllers/system_admin/duplicate_apply_applications_controller.rb
+++ b/app/controllers/system_admin/duplicate_apply_applications_controller.rb
@@ -5,7 +5,7 @@ module SystemAdmin
     def index
       @apply_applications = ApplyApplication
         .non_importable_duplicate
-        .where(recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+        .where(recruitment_cycle_year: Settings.apply_applications.create.recruitment_cycle_year)
         .order(created_at: :desc)
         .page(params[:page] || 1)
     end

--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -81,17 +81,47 @@ module TeacherTrainingApi
       course_attributes[:course_length] == "TwoYears" ? 2 : 1
     end
 
-    def route
-      routes = {
-        higher_education_programme: :provider_led_postgrad,
+    def route_not_changing
+      {
         pg_teaching_apprenticeship: :pg_teaching_apprenticeship,
+      }
+    end
+
+    def before2024_routes
+      {
+        higher_education_programme: :provider_led_postgrad,
         school_direct_salaried_training_programme: :school_direct_salaried,
         school_direct_training_programme: :school_direct_tuition_fee,
         scitt_programme: :provider_led_postgrad,
         scitt_salaried_programme: :provider_led_postgrad,
         higher_education_salaried_programme: :provider_led_postgrad,
-      }
+      }.merge(route_not_changing)
+    end
 
+    def mapping_of_old_course_type
+      {
+        higher_education_programme: :provider_led_postgrad,
+        school_direct_salaried_training_programme: :provider_led_postgrad_salaried,
+        school_direct_training_programme: :provider_led_postgrad,
+        scitt_programme: :provider_led_postgrad,
+        scitt_salaried_programme: :provider_led_postgrad_salaried,
+        higher_education_salaried_programme: :provider_led_postgrad_salaried,
+      }
+    end
+
+    def for2024_routes
+      mapping_of_old_course_type.merge(route_not_changing)
+    end
+
+    def routes
+      if Settings.current_recruitment_cycle_year.to_i < 2024
+        before2024_routes
+      else
+        for2024_routes
+      end
+    end
+
+    def route
       routes[course_attributes[:program_type].to_sym]
     end
 

--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -98,9 +98,9 @@ module TeacherTrainingApi
         higher_education_programme: :provider_led_postgrad,
         school_direct_training_programme: :provider_led_postgrad,
         scitt_programme: :provider_led_postgrad,
-        higher_education_salaried_programme: :provider_led_postgrad_salaried,
-        school_direct_salaried_training_programme: :provider_led_postgrad_salaried,
-        scitt_salaried_programme: :provider_led_postgrad_salaried,
+        higher_education_salaried_programme: :school_direct_salaried,
+        school_direct_salaried_training_programme: :school_direct_salaried,
+        scitt_salaried_programme: :school_direct_salaried,
         pg_teaching_apprenticeship: :pg_teaching_apprenticeship,
       }
     end

--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -106,7 +106,7 @@ module TeacherTrainingApi
     end
 
     def routes
-      if Settings.current_recruitment_cycle_year.to_i < 2024
+      if Settings.current_recruitment_cycle_year < 2024
         before_2024_routes
       else
         for_2024_routes

--- a/app/services/teacher_training_api/import_course.rb
+++ b/app/services/teacher_training_api/import_course.rb
@@ -81,43 +81,35 @@ module TeacherTrainingApi
       course_attributes[:course_length] == "TwoYears" ? 2 : 1
     end
 
-    def route_not_changing
+    def before_2024_routes
       {
+        higher_education_programme: :provider_led_postgrad,
+        school_direct_training_programme: :school_direct_tuition_fee,
+        scitt_programme: :provider_led_postgrad,
+        higher_education_salaried_programme: :provider_led_postgrad,
+        school_direct_salaried_training_programme: :school_direct_salaried,
+        scitt_salaried_programme: :provider_led_postgrad,
         pg_teaching_apprenticeship: :pg_teaching_apprenticeship,
       }
     end
 
-    def before2024_routes
+    def for_2024_routes
       {
         higher_education_programme: :provider_led_postgrad,
-        school_direct_salaried_training_programme: :school_direct_salaried,
-        school_direct_training_programme: :school_direct_tuition_fee,
-        scitt_programme: :provider_led_postgrad,
-        scitt_salaried_programme: :provider_led_postgrad,
-        higher_education_salaried_programme: :provider_led_postgrad,
-      }.merge(route_not_changing)
-    end
-
-    def mapping_of_old_course_type
-      {
-        higher_education_programme: :provider_led_postgrad,
-        school_direct_salaried_training_programme: :provider_led_postgrad_salaried,
         school_direct_training_programme: :provider_led_postgrad,
         scitt_programme: :provider_led_postgrad,
-        scitt_salaried_programme: :provider_led_postgrad_salaried,
         higher_education_salaried_programme: :provider_led_postgrad_salaried,
+        school_direct_salaried_training_programme: :provider_led_postgrad_salaried,
+        scitt_salaried_programme: :provider_led_postgrad_salaried,
+        pg_teaching_apprenticeship: :pg_teaching_apprenticeship,
       }
-    end
-
-    def for2024_routes
-      mapping_of_old_course_type.merge(route_not_changing)
     end
 
     def routes
       if Settings.current_recruitment_cycle_year.to_i < 2024
-        before2024_routes
+        before_2024_routes
       else
-        for2024_routes
+        for_2024_routes
       end
     end
 

--- a/config/initializers/training_routes.rb
+++ b/config/initializers/training_routes.rb
@@ -27,7 +27,6 @@ TRAINING_ROUTE_TYPES = {
     TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
     TRAINING_ROUTE_ENUMS[:early_years_salaried],
     TRAINING_ROUTE_ENUMS[:hpitt_postgrad],
-    TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
   ],
   undergrad_funded: [
     TRAINING_ROUTE_ENUMS[:provider_led_undergrad],

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,6 +9,7 @@ features:
   sign_in_method: dfe-sign-in
   basic_auth: false
   routes:
+    provider_led_postgrad: true
     school_direct_salaried: true
     school_direct_tuition_fee: true
     pg_teaching_apprenticeship: true

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -98,23 +98,23 @@ private
     create(:course_with_subjects,
            :secondary,
            accredited_body_code: trainee.provider.code,
-           route: "school_direct_tuition_fee")
+           route: "provider_led_postgrad")
   end
 
   def and_a_draft_trainee_exists
-    given_a_trainee_exists(:draft, :with_publish_course_details, :school_direct_salaried, :with_secondary_education)
+    given_a_trainee_exists(:draft, :with_publish_course_details, :pg_teaching_apprenticeship, :with_secondary_education)
   end
 
   def and_a_trainee_exists_with_trn_received
-    given_a_trainee_exists(:trn_received, :with_publish_course_details, :school_direct_salaried, :with_secondary_education)
+    given_a_trainee_exists(:trn_received, :with_publish_course_details, :pg_teaching_apprenticeship, :with_secondary_education)
   end
 
   def and_a_trainee_exists
-    given_a_trainee_exists(:trn_received, :school_direct_salaried, :with_secondary_education)
+    given_a_trainee_exists(:trn_received, :pg_teaching_apprenticeship, :with_secondary_education)
   end
 
   def and_a_trainee_exists_for_valid_itt_start_date
-    given_a_trainee_exists(:trn_received, :school_direct_salaried, :with_secondary_education, :with_valid_itt_start_date)
+    given_a_trainee_exists(:trn_received, :pg_teaching_apprenticeship, :with_secondary_education, :with_valid_itt_start_date)
   end
 
   def when_i_click_to_change_course_details
@@ -127,7 +127,7 @@ private
 
   def and_i_choose_a_different_training_route
     trainee_edit_training_route_page.training_route_options.find { |o|
-      o.input.value.include?("school_direct_tuition_fee")
+      o.input.value.include?("provider_led_postgrad")
     }.choose
     trainee_edit_training_route_page.continue_button.click
   end
@@ -179,7 +179,7 @@ private
 
   def then_i_can_pick_a_course_from_the_next_cycle
     expect(publish_course_details_page.title).to include(
-      "Your school direct salaried courses starting in #{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}",
+      "Your teaching apprenticeship postgrad courses starting in #{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}",
     )
   end
 end

--- a/spec/features/trainee_actions/change_course_spec.rb
+++ b/spec/features/trainee_actions/change_course_spec.rb
@@ -98,7 +98,8 @@ private
     create(:course_with_subjects,
            :secondary,
            accredited_body_code: trainee.provider.code,
-           route: "provider_led_postgrad")
+           route: "provider_led_postgrad",
+           recruitment_cycle_year: trainee.start_academic_cycle.start_year)
   end
 
   def and_a_draft_trainee_exists

--- a/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
+++ b/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
@@ -111,7 +111,8 @@ private
     @course = create(:course_with_subjects,
                      accredited_body_code: trainee.provider.code,
                      route: "provider_led_postgrad",
-                     subject_names: ["Philosophy"])
+                     subject_names: ["Philosophy"],
+                     recruitment_cycle_year: trainee.start_academic_cycle.start_year)
   end
 
   def and_i_click_change_course

--- a/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
+++ b/spec/features/trainee_actions/edit_trainee_training_route_spec.rb
@@ -54,7 +54,7 @@ feature "editing a trainee training route" do
         let(:traits) { %i[completed with_valid_itt_start_date] }
 
         scenario "redirects to the publish course path", feature_show_draft_trainee_course_year_choice: false do
-          and_i_select_school_direct_salaried
+          and_i_select_provider_led_postgrad
           and_i_submit_the_new_route
           then_i_am_redirected_to_the_publish_course_details_path
         end
@@ -110,7 +110,7 @@ private
   def given_a_route_has_published_courses
     @course = create(:course_with_subjects,
                      accredited_body_code: trainee.provider.code,
-                     route: "school_direct_salaried",
+                     route: "provider_led_postgrad",
                      subject_names: ["Philosophy"])
   end
 
@@ -126,8 +126,8 @@ private
     expect(trainee_edit_training_route_page).to be_displayed
   end
 
-  def and_i_select_school_direct_salaried
-    trainee_edit_training_route_page.school_direct_salaried.click
+  def and_i_select_provider_led_postgrad
+    trainee_edit_training_route_page.provider_led_postgrad.click
   end
 
   def and_i_select_early_years_route

--- a/spec/services/teacher_training_api/import_course_spec.rb
+++ b/spec/services/teacher_training_api/import_course_spec.rb
@@ -85,7 +85,7 @@ module TeacherTrainingApi
             end
           end
 
-          it_behaves_like training_route_and_course_program_type_mapping, 2024, "provider_led_postgrad_salaried", %w[scitt_salaried_programme scitt_salaried_programme higher_education_salaried_programme]
+          it_behaves_like training_route_and_course_program_type_mapping, 2024, "school_direct_salaried", %w[scitt_salaried_programme scitt_salaried_programme higher_education_salaried_programme]
           it_behaves_like training_route_and_course_program_type_mapping, 2024, "provider_led_postgrad", %w[scitt_programme scitt_programme higher_education_programme]
           it_behaves_like training_route_and_course_program_type_mapping, 2024, "pg_teaching_apprenticeship", ["pg_teaching_apprenticeship"]
           it_behaves_like training_route_and_course_program_type_mapping, 2023, "provider_led_postgrad", %w[higher_education_programme scitt_programme scitt_salaried_programme higher_education_salaried_programme]

--- a/spec/services/teacher_training_api/import_course_spec.rb
+++ b/spec/services/teacher_training_api/import_course_spec.rb
@@ -66,14 +66,32 @@ module TeacherTrainingApi
         end
 
         describe "store training route" do
-          context "program type is mapped" do
-            let(:course_attributes) { { program_type: "scitt_salaried_programme" } }
+          training_route_and_course_program_type_mapping = "training_route and course program type mapping"
 
-            it "stores training route" do
-              subject
-              expect(course.route).to eq("provider_led_postgrad")
+          shared_examples training_route_and_course_program_type_mapping do |recruitment_cycle_year, training_route, program_types|
+            before do
+              allow(Settings).to receive(:current_recruitment_cycle_year).and_return(recruitment_cycle_year)
+            end
+
+            program_types.each do |program_type|
+              context "program type #{program_type} is mapped to route #{training_route} for current recruitment cycle year #{recruitment_cycle_year}" do
+                let(:course_attributes) { { program_type: } }
+
+                it "stores training route" do
+                  subject
+                  expect(course.route).to eq(training_route)
+                end
+              end
             end
           end
+
+          it_behaves_like training_route_and_course_program_type_mapping, 2024, "provider_led_postgrad_salaried", %w[scitt_salaried_programme scitt_salaried_programme higher_education_salaried_programme]
+          it_behaves_like training_route_and_course_program_type_mapping, 2024, "provider_led_postgrad", %w[scitt_programme scitt_programme higher_education_programme]
+          it_behaves_like training_route_and_course_program_type_mapping, 2024, "pg_teaching_apprenticeship", ["pg_teaching_apprenticeship"]
+          it_behaves_like training_route_and_course_program_type_mapping, 2023, "provider_led_postgrad", %w[higher_education_programme scitt_programme scitt_salaried_programme higher_education_salaried_programme]
+          it_behaves_like training_route_and_course_program_type_mapping, 2023, "school_direct_salaried", ["school_direct_salaried_training_programme"]
+          it_behaves_like training_route_and_course_program_type_mapping, 2023, "school_direct_tuition_fee", ["school_direct_training_programme"]
+          it_behaves_like training_route_and_course_program_type_mapping, 2023, "pg_teaching_apprenticeship", ["pg_teaching_apprenticeship"]
 
           context "program type is unmapped" do
             let(:course_attributes) { { program_type: "you_wat_now" } }

--- a/spec/support/api_stubs/recruits_api.rb
+++ b/spec/support/api_stubs/recruits_api.rb
@@ -206,7 +206,7 @@ module ApiStubs
 
     def self.course(course_attributes = {})
       {
-        recruitment_cycle_year: Settings.current_recruitment_cycle_year,
+        recruitment_cycle_year: Settings.apply_applications.create.recruitment_cycle_year,
         course_code: "V6X1",
         course_uuid: "c6b9f8f0-f8f8-4f0f-b8e2-f8f8f8f8f8f8",
         training_provider_code: "E84",


### PR DESCRIPTION
### Context
Preparing 2024-2025 academic year

### Changes proposed in this pull request
Amended the course program type mapping for 2023-2024 and 2024-2025

This is for the 2023 to 2024 recruitment cycle courses in order to serve the 2024-2025 academic year to register a trainee

Amended the course program type mapping to training route as it changing as well.

### Guidance to review

`provider_led_postgrad_salaried` is no in place yet

You should be present with this view
![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/76a528fe-ca70-4ed3-afe6-a43bff6070bd)

nb, previously we envisaged it with `provider_led_postgrad_salaried` but that has since changed `school_direct_salaried`

Old mappings
|publish course program type|register training route|
|-|-|
|higher_education_programme |provider_led_postgrad|
|school_direct_salaried_training_programme |school_direct_salaried|
|school_direct_training_programme |school_direct_tuition_fee|
|scitt_programme |provider_led_postgrad|
|scitt_salaried_programme |provider_led_postgrad|
|higher_education_salaried_programme |provider_led_postgrad|
|pg_teaching_apprenticeship |pg_teaching_apprenticeship|

new mappings
|publish course program type|register training route|
|-|-|
|higher_education_programme|provider_led_postgrad|
|school_direct_salaried_training_programme|school_direct_salaried
|school_direct_training_programme|provider_led_postgrad|
|scitt_programme|provider_led_postgrad|
|scitt_salaried_programme|school_direct_salaried|
|higher_education_salaried_programme|school_direct_salaried|
|pg_teaching_apprenticeship |pg_teaching_apprenticeship|

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/470137/f2eed60a-871b-4ff0-ab10-e7a27281022c)
### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
