### PR TITLE
Enable workload identity federation in Azure infrastrure only for review Apps

### DIFF
--- a/terraform/aks/workspace-variables/review.tfvars.json
+++ b/terraform/aks/workspace-variables/review.tfvars.json
@@ -26,5 +26,5 @@
   },
   "deploy_temp_data_storage_account": false,
   "enable_logit": true,
-  "enable_gcp_wif": false
+  "enable_gcp_wif": true
 }


### PR DESCRIPTION
### Context

Enables workload identity federation in the Azure Infrastructure for review Apps. It is not used by the Application until we enable it explicitly within the App. 

### Changes proposed in this pull request

Enables workload identity federation in the Azure Infrastructure Only, but not actually use it.

### Guidance to review

This is part of a wider DevOps change.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
