### PR TITLE
Enable workload identity federation in the review App

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -53,4 +53,9 @@ DfE::Analytics.configure do |config|
   # to all events we send to BigQuery.
   #
   # config.environment = ENV.fetch('RAILS_ENV', 'development')
+
+  # Whether to use azure workload identity federation for authentication
+  # instead of the BigQuery API JSON Key. Note that this also will also
+  # use a new version of the BigQuery streaming APIs.
+  config.azure_federated_auth = Settings.features.google.azure_federated_auth
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -68,6 +68,7 @@ features:
     provider_led_postgrad_salaried: false
   google:
     send_data_to_big_query: false
+    azure_federated_auth: false
   filters:
     show_start_year_filter: false
   user_can_have_multiple_organisations: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -22,6 +22,9 @@ features:
   user_can_have_multiple_organisations: true
   funding: true
   lead_partners: true
+  google:
+    send_data_to_big_query: true
+    azure_federated_auth: true
 
 pagination:
   records_per_page: 30


### PR DESCRIPTION
### Context

This is part of a wider BigQuery Assurance piece to to harden the security around BigQuery.

It allows the use of OAuth mechanism for authentication to BigQuery rather than relying on plain text JSON API Keys.

The Data Insights ticket is [here](https://trello.com/c/IDG7vXFy).

### Changes proposed in this pull request

Enable Azure workload identity federation within DfE Analytics

### Guidance to review

See [Dfe Analytics GEM](https://github.com/DFE-Digital/dfe-analytics) for further details.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
