### PR TITLE
[7195] Regenerate OpenAPI docs with `application_id`

### DIFF
--- a/public/openapi/v0.1.yaml
+++ b/public/openapi/v0.1.yaml
@@ -348,6 +348,9 @@ paths:
                         withdraw_reasons:
                           type: array
                           items: {}
+                        application_id:
+                          type: integer
+                          nullable: true
                       required:
                         - first_names
                         - last_name
@@ -421,6 +424,7 @@ paths:
                         - degrees
                         - state
                         - trainee_id
+                        - application_id
                   meta:
                     type: object
                     properties:
@@ -540,6 +544,7 @@ paths:
                         degree_id: fv4kc3mwvf2BUMXjJDRRGmKS
                     state: deferred
                     trainee_id: 5dayPYvTJr5FXk8XzUxmqLDD
+                    application_id:
                   - first_names: Ebonie
                     last_name: Murray
                     date_of_birth: "1985-02-18"
@@ -638,6 +643,7 @@ paths:
                         degree_id: 7wVhuhkJC8Z9Du99sWgffCs8
                     state: deferred
                     trainee_id: Niw7mVU5RXpp5Dw53K2qE4AQ
+                    application_id:
                   - first_names: Cameron
                     last_name: Lakin
                     date_of_birth: "1979-04-20"
@@ -736,6 +742,7 @@ paths:
                         degree_id: PU2MqGjGAcqC4mYURy6T9LdH
                     state: deferred
                     trainee_id: pBRFoPmPxSzmTjD1NFEqUUpw
+                    application_id:
                   - first_names: Enrique
                     last_name: Miller
                     date_of_birth: "1995-01-14"
@@ -834,6 +841,7 @@ paths:
                         degree_id: Xui1q2Pvdyh1ivtGtU4LXJmq
                     state: deferred
                     trainee_id: 1MALXpx7P2Pm2hHw85nK7WdT
+                    application_id:
                   - first_names: Aja
                     last_name: Goyette
                     date_of_birth: "1961-02-05"
@@ -932,6 +940,7 @@ paths:
                         degree_id: 2Dnis3iWDQjH5tFixp8aFerg
                     state: deferred
                     trainee_id: 21gNvKQPXikof89GSa9nRSJo
+                    application_id:
                   - first_names: Winford
                     last_name: Streich
                     date_of_birth: "1992-10-06"
@@ -1226,6 +1235,7 @@ paths:
                         degree_id: bLZdAaSYmVyAZvxgRBTyavq3
                     state: trn_received
                     trainee_id: hsjKh2e5tBszAUZAjR9c2hGp
+                    application_id:
                   - first_names: Ollie
                     last_name: Baumbach
                     date_of_birth: "1984-06-10"
@@ -1520,6 +1530,7 @@ paths:
                         degree_id: g6nSrPTnddRwJuTYALszn4Jf
                     state: trn_received
                     trainee_id: A3dPQAMg3mMcr82EX6HsBDd4
+                    application_id: 123456
                   - first_names: Linh
                     last_name: Bashirian
                     date_of_birth: "1962-09-04"
@@ -2237,6 +2248,9 @@ paths:
                         type: string
                       disability2:
                         type: string
+                      application_id:
+                        type: integer
+                        nullable: true
                     required:
                       - first_names
                       - last_name
@@ -2464,6 +2478,7 @@ paths:
                   trainee_id: Kgc8B6drhaovqV3sByzLRGtE
                   disability1: "58"
                   disability2: "57"
+                  application_id:
         "409":
           description:
             returns status 409 (conflict) with the potential duplicates
@@ -2677,6 +2692,9 @@ paths:
                           type: string
                         trainee_id:
                           type: string
+                        application_id:
+                          type: integer
+                          nullable: true
                         withdraw_reasons:
                           type: array
                           items: {}
@@ -2847,6 +2865,7 @@ paths:
                         degree_id: hmmxfrE5DfzU1ipjbpDr36i4
                     state: draft
                     trainee_id: aC23R9GwSQiACmGBpzesmuZ5
+                    application_id:
         "422":
           description: return status code 422 with a meaningful error message
           content:
@@ -2991,6 +3010,8 @@ paths:
                       type: string
                     course_max_age:
                       type: integer
+                    application_id:
+                      type: integer
                   required:
                     - first_names
                     - last_name
@@ -3057,6 +3078,7 @@ paths:
                 course_subject_two: "101410"
                 course_subject_three: "100366"
                 course_max_age: 11
+                application_id: 123456
   "/api/{api_version}/trainees/{trainee_id}":
     get:
       summary: show
@@ -3253,6 +3275,9 @@ paths:
                     type: string
                   trainee_id:
                     type: string
+                  application_id:
+                    type: integer
+                      ff
                 required:
                   - first_names
                   - last_name
@@ -3261,6 +3286,7 @@ paths:
                   - updated_at
                   - email
                   - middle_names
+
                   - training_route
                   - sex
                   - diversity_disclosure
@@ -3337,6 +3363,7 @@ paths:
                   - degrees
                   - state
                   - trainee_id
+                  - application_id
               example:
                 first_names: Everette
                 last_name: Bernhard
@@ -3421,6 +3448,7 @@ paths:
                 degrees: []
                 state: draft
                 trainee_id: "12345"
+                application_id:
         "404":
           description: returns a not found message
           content:
@@ -3830,6 +3858,7 @@ paths:
                       - degrees
                       - state
                       - trainee_id
+                      - application_id
                 required:
                   - data
               example:
@@ -3941,6 +3970,7 @@ paths:
                       degree_id: Bt7USBJKMcWr7k2xF7WY7Sdp
                   state: submitted_for_trn
                   trainee_id: C4Dwv71BbW9JyJoT4E1E7eto
+                  application_id: 123456
                   disability2: "57"
         "401":
           description: returns status 401 unauthorized
@@ -4596,6 +4626,8 @@ paths:
                         type: string
                       trainee_id:
                         type: string
+                      application_id:
+                        type: integer
                     required:
                       - first_names
                       - last_name
@@ -4670,6 +4702,7 @@ paths:
                       - degrees
                       - state
                       - trainee_id
+                      - application_id
                 required:
                   - data
               example:
@@ -4747,6 +4780,7 @@ paths:
                   degrees: []
                   state: draft
                   trainee_id: v4GjADnaH5ZMp1kPVcCsMKw7
+                  application_id: 123456
         "404":
           description: does not delete the degree and returns a 404 status (not_found)
           content:
@@ -5537,6 +5571,8 @@ paths:
                         type: string
                       trainee_id:
                         type: string
+                      application_id:
+                        type: integer
                     required:
                       - first_names
                       - last_name
@@ -5621,6 +5657,7 @@ paths:
                       - degrees
                       - state
                       - trainee_id
+                      - application_id
                 required:
                   - data
               example:
@@ -5714,6 +5751,7 @@ paths:
                   degrees: []
                   state: draft
                   trainee_id: TZhvm9mpe7rV4U9fp3trkQS1
+                  application_id: 123456
         "404":
           description: returns status 404 with a valid JSON response
           content:
@@ -6270,6 +6308,8 @@ paths:
                         type: string
                       trainee_id:
                         type: string
+                      application_id:
+                        type: integer
                       id:
                         type: integer
                       dttp_id:
@@ -6512,6 +6552,7 @@ paths:
                       degree_id: 4q9vMxzg5TLuJJgroL1tjtPp
                   state: withdrawn
                   trainee_id: Z1BAz38AkKbxDRHQbe5MuAjm
+                  application_id: 123456
                   id: 220
                   dttp_id: 251fed09-25ca-473e-a4e2-5a491926459b
                   progress:

--- a/public/openapi/v1.0.yaml
+++ b/public/openapi/v1.0.yaml
@@ -343,6 +343,8 @@ paths:
                           type: string
                         trainee_id:
                           type: string
+                        application_id:
+                          type: integer
                         pg_apprenticeship_start_date:
                           type: string
                         withdraw_reasons:
@@ -421,6 +423,7 @@ paths:
                         - degrees
                         - state
                         - trainee_id
+                        - application_id
                   meta:
                     type: object
                     properties:
@@ -540,6 +543,7 @@ paths:
                         degree_id: A2KeWNwyyrSZHRJF1Vq9E1ZQ
                     state: trn_received
                     trainee_id: Ao9ksdiSntx4bRrJYwSMuydZ
+                    application_id: 123456
                   - first_names: Joel
                     last_name: Kohler
                     date_of_birth: "1975-07-05"
@@ -638,6 +642,7 @@ paths:
                         degree_id: 4dshtbbXe68oMNRts4WDR2cM
                     state: trn_received
                     trainee_id: xEn8hSApdnKrN9mwvYzdVpHZ
+                    application_id: 123456
                   - first_names: Santos
                     last_name: Nikolaus
                     date_of_birth: "1991-06-21"
@@ -736,6 +741,7 @@ paths:
                         degree_id: DXnhGgiQCJZ5XLiKyhdYBNME
                     state: trn_received
                     trainee_id: jgUhjP1mwzwNSbZGjry491Y5
+                    application_id: 123456
                   - first_names: Jeffry
                     last_name: Hilpert
                     date_of_birth: "1998-06-07"
@@ -834,6 +840,7 @@ paths:
                         degree_id: NmQ8XUrR7pvgBZUfGmnvTj5R
                     state: trn_received
                     trainee_id: XMnVazraBgHFv63jt4FeD8i5
+                    application_id: 123456
                   - first_names: Etha
                     last_name: Morar
                     date_of_birth: "1982-10-11"
@@ -932,6 +939,7 @@ paths:
                         degree_id: HzWXDZfHy9DyVTRWTAirPkBT
                     state: trn_received
                     trainee_id: XeGMD8KWqy8URNxTWpWgstnB
+                    application_id: 123456
                   - first_names: Helen
                     last_name: Orn
                     date_of_birth: "2006-05-07"
@@ -1030,6 +1038,7 @@ paths:
                         degree_id: 1AZHNyhUus5M8MzZrswTiNob
                     state: trn_received
                     trainee_id: 4PrezGaRVEe7EFGks37L6g1j
+                    application_id: 123456
                   - first_names: Neal
                     last_name: Collier
                     date_of_birth: "1972-07-25"
@@ -1128,6 +1137,7 @@ paths:
                         degree_id: AL3GCCPLJf7jgbVJcVJiHhCE
                     state: trn_received
                     trainee_id: sufXXzpuLc8BcHDC2E8jxCaW
+                    application_id: 123456
                   - first_names: Pia
                     last_name: Smith
                     date_of_birth: "1977-05-12"
@@ -1226,6 +1236,7 @@ paths:
                         degree_id: tsTeRmka4eMD7UNX1RqdQcyW
                     state: trn_received
                     trainee_id: sZq9wHLfQKdhGWm1hyw7Bx4p
+                    application_id: 123456
                 meta:
                   current_page: 1
                   total_pages: 1
@@ -1543,6 +1554,8 @@ paths:
                         type: string
                       trainee_id:
                         type: string
+                      application_id:
+                        type: integer
                       disability1:
                         type: string
                       disability2:
@@ -1631,6 +1644,7 @@ paths:
                       - degrees
                       - state
                       - trainee_id
+                      - application_id
               example:
                 middle_names:
                 additional_ethnic_background:
@@ -1770,6 +1784,7 @@ paths:
                       degree_id: bsJQAVmE6u9xZej9X1s3a7zR
                   state: submitted_for_trn
                   trainee_id: pXk1xxHTWeDjnyimW2kbNsY5
+                  application_id: 123456
                   disability1: "58"
                   disability2: "57"
         "409":
@@ -1984,6 +1999,8 @@ paths:
                           type: string
                         trainee_id:
                           type: string
+                        application_id:
+                          type: integer
                         withdraw_reasons:
                           type: array
                           items: {}
@@ -2060,6 +2077,7 @@ paths:
                         - degrees
                         - state
                         - trainee_id
+                        - application_id
                 required:
                   - errors
                   - data
@@ -2154,6 +2172,7 @@ paths:
                         degree_id: ZdwgQjiwhLiRKo8mVQHLrqDB
                     state: draft
                     trainee_id: cqKwM5X8AkrtPdtxeFEpXEUR
+                    application_id: 123456
         "422":
           description: return status code 422 with a meaningful error message
           content:
@@ -2560,6 +2579,8 @@ paths:
                     type: string
                   trainee_id:
                     type: string
+                  application_id:
+                    type: integer
                 required:
                   - first_names
                   - last_name
@@ -2644,6 +2665,7 @@ paths:
                   - degrees
                   - state
                   - trainee_id
+                  - application_id
               example:
                 first_names: Gwyn
                 last_name: Grant
@@ -2728,6 +2750,7 @@ paths:
                 degrees: []
                 state: draft
                 trainee_id: "12345"
+                application_id: 123456
         "404":
           description: returns a not found message
           content:
@@ -3047,6 +3070,8 @@ paths:
                         type: string
                       trainee_id:
                         type: string
+                      application_id:
+                        type: integer
                       disability2:
                         type: string
                     required:
@@ -3133,6 +3158,7 @@ paths:
                       - degrees
                       - state
                       - trainee_id
+                      - application_id
                 required:
                   - data
               example:
@@ -3244,6 +3270,7 @@ paths:
                       degree_id: uQsj1P594q3mZvMMN75b2saX
                   state: submitted_for_trn
                   trainee_id: CscHUugnbosgW7toKLNbtd6V
+                  application_id: 123456
                   disability2: "57"
         "401":
           description: returns status 401 unauthorized
@@ -3888,6 +3915,8 @@ paths:
                         type: string
                       trainee_id:
                         type: string
+                      application_id:
+                        type: integer
                     required:
                       - first_names
                       - last_name
@@ -3962,6 +3991,7 @@ paths:
                       - degrees
                       - state
                       - trainee_id
+                      - application_id
                 required:
                   - data
               example:
@@ -4039,6 +4069,7 @@ paths:
                   degrees: []
                   state: draft
                   trainee_id: hTJGtPxdWSTM4DSLdYRokc4x
+                  application_id: 123456
         "404":
           description: does not delete the degree and returns a 404 status (not_found)
           content:
@@ -4827,6 +4858,8 @@ paths:
                         type: string
                       trainee_id:
                         type: string
+                      application_id:
+                        type: integer
                     required:
                       - first_names
                       - last_name
@@ -4911,6 +4944,7 @@ paths:
                       - degrees
                       - state
                       - trainee_id
+                      - application_id
                 required:
                   - data
               example:
@@ -5004,6 +5038,7 @@ paths:
                   degrees: []
                   state: draft
                   trainee_id: B7Pxdr2frFUrrTWRBxGf4ZFe
+                  application_id: 123456
         "404":
           description: returns status 404 with a valid JSON response
           content:
@@ -5553,6 +5588,8 @@ paths:
                         type: string
                       trainee_id:
                         type: string
+                      application_id:
+                        type: integer
                       id:
                         type: integer
                       dttp_id:
@@ -5792,6 +5829,7 @@ paths:
                       degree_id: FM36BawcUTVpehrxwHAbADCL
                   state: withdrawn
                   trainee_id: 9WUiBBd4tzH9HFNVBB8Fm66S
+                  application_id: 123456
                   id: 204
                   dttp_id: c8705b0a-6ac6-4335-8b25-950714ddd382
                   progress:


### PR DESCRIPTION
### Context
This PR just includes a refresh of the automatically generated Register API docs after adding `Trainee#application_id`. It's a follow up to https://github.com/DFE-Digital/register-trainee-teachers/pull/4376

### Changes proposed in this pull request
Update the OpenAPI docs.

Regenerating the .yaml files creates a lot of spurious differences and overwrites any manual changes that were made to the declarations. So rather than try to fix up the generated docs I cherry picked the relevant changes only. This is a bit laborious but still probably easier and avoids the risk of overwriting manual changes.

### Guidance to review
Still to do - reinstate any manual changes to the docs that have been lost in re-generation.

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
