### PR TITLE
Enable workload identity federation in the QA environment

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -30,6 +30,7 @@ features:
     iqts: true
   google:
     send_data_to_big_query: true
+    azure_federated_auth: true
 
 pagination:
   records_per_page: 30

--- a/terraform/aks/workspace-variables/qa.tfvars.json
+++ b/terraform/aks/workspace-variables/qa.tfvars.json
@@ -36,5 +36,6 @@
       "website_url": [ "https://qa.register-trainee-teachers.service.gov.uk/healthcheck" ],
       "contact_group": [309326]
     }
-  }
+  },
+  "enable_gcp_wif": true
 }


### PR DESCRIPTION
### Context

This is part of a wider BigQuery Assurance piece to to harden the security around BigQuery.

It allows the use of OAuth mechanism for authentication to BigQuery rather than relying on plain text JSON API Keys.

The Data Insights ticket is [here](https://trello.com/c/IDG7vXFy).

### Changes proposed in this pull request

Enable Azure workload identity federation within DfE Analytics

### Guidance to review

See [Dfe Analytics GEM](https://github.com/DFE-Digital/dfe-analytics) for further details.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml