### PR TITLE
Update DQT after Bulk Updating Recommendations

### DIFF
--- a/app/services/bulk_update/upsert_all.rb
+++ b/app/services/bulk_update/upsert_all.rb
@@ -12,9 +12,10 @@ module BulkUpdate
     end
 
     def call
-      upsert_records
+      result = upsert_records
       enqueue_audit_jobs
       enqueue_analytics_job
+      result
     end
 
   private
@@ -22,7 +23,7 @@ module BulkUpdate
     attr_reader :original, :modified, :model, :unique_by
 
     def upsert_records
-      model.upsert_all(modified.values, unique_by:)
+      model.upsert_all(modified.values, unique_by:, returning: :id)
     end
 
     def enqueue_audit_jobs

--- a/spec/services/bulk_update/recommend_spec.rb
+++ b/spec/services/bulk_update/recommend_spec.rb
@@ -20,6 +20,11 @@ module BulkUpdate
             .and change { trainee.outcome_date }
             .from(nil).to(recommendations_upload_row.standards_met_at)
         end
+
+        it "updates DQT with the changes" do
+          expect { subject }
+            .to have_enqueued_job(Dqt::RecommendForAwardJob).once
+        end
       end
 
       context "when the trainee is not trn_received" do
@@ -29,6 +34,11 @@ module BulkUpdate
           subject
           expect(trainee.reload.state).to eql "draft"
           expect(trainee.outcome_date).to be_nil
+        end
+
+        it "does not update DQT" do
+          expect { subject }
+            .to_not have_enqueued_job(Dqt::RecommendForAwardJob).once
         end
       end
     end


### PR DESCRIPTION
### Context

[Trello: Investigate Bulk recommend trainees for QTS or EYTS](https://trello.com/c/5AGCNMFw)
[Trello: Bulk QTS Recommendation Error](https://trello.com/c/hw6jt51K)

Me and @defong noticed that when a doing a [bulk update for recommendations](https://github.com/DFE-Digital/register-trainee-teachers/blob/d8df024659574b5cb85601e581240c464d4a8973/app/controllers/bulk_update/recommendations_controller.rb#L6), we don't notify DQT of the changes by calling the [Dqt::RecommendForAwardJob](https://github.com/DFE-Digital/register-trainee-teachers/blob/d8df024659574b5cb85601e581240c464d4a8973/app/jobs/dqt/recommend_for_award_job.rb#L4) or by any other means. 

```ruby
#app/controllers/bulk_update/recommendations_controller.rb
module BulkUpdate
  class RecommendationsController < RecommendationsBaseController
    def create
      Recommend.call(recommendations_upload:)

      redirect_to(bulk_update_recommendations_upload_confirmation_path(recommendations_upload))
    end
  end
end

#app/services/bulk_update/recommend.rb
module BulkUpdate
  class Recommend
    ...
    def call
      return if original&.keys&.empty?

      UpsertAll.call(
        original: original,
        modified: modified,
        model: Trainee,
        unique_by: :slug,
      )
    end
    ...
end
```

You can see that we upsert any new values into the trainees table, but there doesn't seem to be any action taken beyond that. Contrast that to the [AwardRecommendationsController](https://github.com/DFE-Digital/register-trainee-teachers/blob/d8df024659574b5cb85601e581240c464d4a8973/app/controllers/trainees/award_recommendations_controller.rb#L4) for example, and you can see that we call `recommend_for_award` on the trainee and then enqueue the job as to update DQT: 

```ruby
#app/controllers/trainees/award_recommendations_controller.rb 
module Trainees
  class AwardRecommendationsController < BaseController
    def create
      if OutcomeDateForm.new(trainee, update_dqt: false).save! && trainee.submission_ready?
        trainee.recommend_for_award!

        Dqt::RecommendForAwardJob.perform_later(trainee)

        redirect_to(recommended_trainee_outcome_details_path(trainee))
      end
    end 
    ...
end
```

### Guidance to Review
There seems to be a further problem with how the CSV uploads are processed in some cases. This Trello ticket outlines some strange behaviour with quotation marks. But that seems to be a more isolated problem, which I'll look at next. The changes in this PR seemed more urgent and more likely to affect a large number of people. 

### Changes proposed in this pull request

After performing the upsert with any new values, we enqueue [Dqt::RecommendForAwardJob](https://github.com/DFE-Digital/register-trainee-teachers/blob/d8df024659574b5cb85601e581240c464d4a8973/app/jobs/dqt/recommend_for_award_job.rb#L4) with each updated trainee. 

```ruby 
module BulkUpdate
  class Recommend
    include ServicePattern
    ...
    def call
      return if original&.keys&.empty?

      result = UpsertAll.call(
        original: original,
        modified: modified,
        model: Trainee,
        unique_by: :slug,
      )
      send_updates_to_dqt if result.present?
    end
    ...
end
```

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
