### PR TITLE
Fix Quotation Mark Issue in Bulk Uploads

### DIFF
--- a/app/models/reports/bulk_recommend_report.rb
+++ b/app/models/reports/bulk_recommend_report.rb
@@ -94,7 +94,7 @@ module Reports
       row = [
         trainee_report.trn,
         trainee_report.provider_trainee_id,
-        trainee_report.hesa_id&.gsub(/(.*)/, "'\\1"), # prevent Excel from converting it to scientific notation
+        trainee_report.hesa_id
         trainee_report.first_names,
         trainee_report.last_names,
         trainee_report.lead_school_name,
@@ -103,7 +103,7 @@ module Reports
         trainee_report.course_education_phase,
         trainee_report.course_age_range,
         trainee_report.subjects,
-      ].map { |value| CsvValueSanitiser.new(value).sanitise }
+      ]
 
       row.delete_at(2) unless hesa_id?
       row

--- a/app/models/reports/bulk_recommend_report.rb
+++ b/app/models/reports/bulk_recommend_report.rb
@@ -94,7 +94,7 @@ module Reports
       row = [
         trainee_report.trn,
         trainee_report.provider_trainee_id,
-        trainee_report.hesa_id
+        trainee_report.hesa_id,
         trainee_report.first_names,
         trainee_report.last_names,
         trainee_report.lead_school_name,

--- a/app/models/reports/bulk_recommend_report.rb
+++ b/app/models/reports/bulk_recommend_report.rb
@@ -103,7 +103,7 @@ module Reports
         trainee_report.course_education_phase,
         trainee_report.course_age_range,
         trainee_report.subjects,
-      ]
+      ].map { |value| CsvValueSanitiser.new(value).sanitise }
 
       row.delete_at(2) unless hesa_id?
       row

--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -402,7 +402,7 @@ module Reports
     end
 
     def hesa_id
-      trainee.hesa_id&.gsub(/(.*)/, "'\\1") # prevent Excel from converting it to scientific notation
+      trainee.hesa_id&.starts_with?("'") ? trainee.hesa_id : trainee.hesa_id&.prepend("'")
     end
 
   private

--- a/app/models/reports/trainee_report.rb
+++ b/app/models/reports/trainee_report.rb
@@ -402,7 +402,7 @@ module Reports
     end
 
     def hesa_id
-      trainee.hesa_id&.starts_with?("'") ? trainee.hesa_id : trainee.hesa_id&.prepend("'")
+      trainee.hesa_id&.starts_with?("'") ? trainee.hesa_id : trainee.hesa_id&.prepend("'") # prevent Excel from converting it to scientific notation
     end
 
   private

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -53,7 +53,7 @@ describe Reports::TraineeReport do
     end
 
     it "includes the string-enforced hesa_id" do
-      expect(subject.hesa_id).to eq("'#{trainee.hesa_id}'")
+      expect(subject.hesa_id).to eq(trainee.hesa_id)
     end
 
     it "includes the provider_trainee_id" do
@@ -438,6 +438,30 @@ describe Reports::TraineeReport do
           "#{current_cycle.start_year} to #{current_cycle.start_year + 1}, #{next_cycle.start_year} to #{next_cycle.start_year + 1}",
         )
       end
+    end
+  end
+
+  describe "#hesa_id" do
+    let(:trainee) { create(:trainee, :for_export, hesa_id: hesa_id) }
+
+    subject { described_class.new(trainee).hesa_id }
+
+    context "when the hesa_id is nil" do
+      let(:hesa_id) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when hesa_id does not start with a single quote" do
+      let(:hesa_id) { "1234567890123" }
+
+      it { is_expected.to eq("'1234567890123") }
+    end
+
+    context "when hesa_id already starts with a single quote" do
+      let(:hesa_id) { "'1234567890123" }
+
+      it { is_expected.to eq("'1234567890123") }
     end
   end
 end

--- a/spec/models/reports/trainee_report_spec.rb
+++ b/spec/models/reports/trainee_report_spec.rb
@@ -442,7 +442,7 @@ describe Reports::TraineeReport do
   end
 
   describe "#hesa_id" do
-    let(:trainee) { create(:trainee, :for_export, hesa_id: hesa_id) }
+    let(:trainee) { create(:trainee, :for_export, hesa_id:) }
 
     subject { described_class.new(trainee).hesa_id }
 

--- a/spec/services/exports/bulk_recommend_export_spec.rb
+++ b/spec/services/exports/bulk_recommend_export_spec.rb
@@ -79,7 +79,7 @@ describe Exports::BulkRecommendExport, type: :model do
       end
 
       it "includes the HESA ID" do
-        expect(trainee_csv_row["HESA ID"]).to end_with("'#{trainee_report.hesa_id}'")
+        expect(trainee_csv_row["HESA ID"]).to eq(trainee_report.hesa_id)
       end
 
       it "includes the Last names" do


### PR DESCRIPTION
### Context
[Trello](https://trello.com/c/hw6jt51K)

In some cases, when a user was downloading a CSV file to do a bulk recommendation, they were seeing two single quotes at the start and end of some values. For example, the CSV would show the hesa_id like this: 

`''1234567890123''`

The value in the database doesn't have these quotes, which pointed to something in the CSV generation, which must be altering the value before sending it to the user.

In the [BulkRecommendReport](https://github.com/DFE-Digital/register-trainee-teachers/blob/4dce11f9540db391bc053f810012c36000197389/app/models/reports/bulk_recommend_report.rb#L106) model, you can see that we're passing every value in the CSV through a [CsvValueSanitiser](https://github.com/DFE-Digital/register-trainee-teachers/blob/4dce11f9540db391bc053f810012c36000197389/app/models/csv_value_sanitiser.rb#L4) object and checking if the value is "safe": 

```ruby
#app/models/reports/bulk_recommend_report.rb
...
def csv_row(trainee)
  trainee_report = Reports::TraineeReport.new(trainee)

  row = [
    trainee_report.trn,
    trainee_report.provider_trainee_id,
    trainee_report.hesa_id&.gsub(/(.*)/, "'\\1"), # prevent Excel from converting it to scientific notation
    trainee_report.first_names,
    trainee_report.last_names,
    trainee_report.lead_school_name,
    trainee_report.qts_or_eyts,
    trainee_report.course_training_route,
    trainee_report.course_education_phase,
    trainee_report.course_age_range,
    trainee_report.subjects,
  ].map { |value| CsvValueSanitiser.new(value).sanitise }

  row.delete_at(2) unless hesa_id?
  row
end
...

#app/models/csv_value_sanitiser.rb
class CsvValueSanitiser
  ...
  def safe?
    string_value = @value.to_s
    string_value.blank? || string_value == "-" ? true : string_value =~ /\A[^=+\-@\t\r]/
  end
  ...
end
``` 

The value is considered unsafe if it has special characters like returns or tabs, and in those cases it wraps the value with double quotes, and prepends a single quote with a method called `convert`: 

```ruby
def convert
  wrap_in_double_quotes(replace_every_double_quote_with_two_double_quotes(prepend_with_a_single_quote(@value)))
end
```

So this is where I think we're seeing a problem with some values, in some cases. 

### Changes proposed in this pull request

I don't really know why we need to use the sanitiser like this, there might be a reason that I'm not aware of. But I think the expectation in this case, is just to take the values we have in the database for a trainee, and produce a CSV with them, unaltered. 

So I've removed the CsvValueSanitiser from the BulkRecommendReport, and I've also removed the gsub to make the hesa_id play nicely with Excel. I think if we try to second guess how the CSV will be used and modify the values like this, we're open to more issues like this in the future. 

The sanitiser object is used in other places, so I haven't deleted it completely. But depending on feedback and comments on this PR, we might want to do that if we agree it isn't needed. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
