### PR TITLE
[7244, 7245] Remove training initiatives

### DIFF
--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -2,7 +2,13 @@
 
 module FundingHelper
   def training_initiative_options
-    (ROUTE_INITIATIVES_ENUMS.values - %w[no_initiative troops_to_teachers maths_physics_chairs_programme_researchers_in_schools]).sort
+    (ROUTE_INITIATIVES_ENUMS.values - %w[
+      no_initiative
+      troops_to_teachers
+      maths_physics_chairs_programme_researchers_in_schools
+      transition_to_teach
+      future_teaching_scholars
+    ]).sort
   end
 
   def funding_options(trainee)

--- a/app/services/trainees/create_from_csv_row.rb
+++ b/app/services/trainees/create_from_csv_row.rb
@@ -23,11 +23,7 @@ module Trainees
     }.freeze
 
     INITIATIVES = {
-      "Future Teaching Scholars" => ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars],
-      "Maths and Physics Chairs programme / Researchers in Schools" => ROUTE_INITIATIVES_ENUMS[:maths_physics_chairs_programme_researchers_in_schools],
       "Now Teach" => ROUTE_INITIATIVES_ENUMS[:now_teach],
-      "Transition to Teach" => ROUTE_INITIATIVES_ENUMS[:transition_to_teach],
-      "Troops to Teachers" => ROUTE_INITIATIVES_ENUMS[:troops_to_teachers],
       "Not on a training initiative" => ROUTE_INITIATIVES_ENUMS[:no_initiative],
     }.freeze
 

--- a/spec/components/sections/view_preview.rb
+++ b/spec/components/sections/view_preview.rb
@@ -56,7 +56,7 @@ module Sections
         training_route: TRAINING_ROUTE_ENUMS[training_route(section)],
         lead_school: School.new(id: 1),
         degrees: [Degree.new(id: 1, locale_code: :uk)],
-        training_initiative: ROUTE_INITIATIVES_ENUMS[:transition_to_teach],
+        training_initiative: ROUTE_INITIATIVES_ENUMS[:now_teach],
         applying_for_bursary: true,
         provider: Provider.new,
         placement_detail: :has_placement_detail

--- a/spec/factories/dttp/api_placement_assignment.rb
+++ b/spec/factories/dttp/api_placement_assignment.rb
@@ -63,9 +63,9 @@ FactoryBot.define do
       enabled_training_routes { ["provider_led_undergrad"] }
     end
 
-    trait :with_future_teaching_scholars_initiative do
+    trait :with_now_teach_initiative do
       enabled_training_routes { nil }
-      _dfe_routeid_value { Dttp::CodeSets::Routes::MAPPING[ROUTE_INITIATIVES_ENUMS[:future_teaching_scholars]][:entity_id] }
+      _dfe_routeid_value { Dttp::CodeSets::Routes::MAPPING[ROUTE_INITIATIVES_ENUMS[:now_teach]][:entity_id] }
     end
 
     trait :with_scholarship do

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -63,7 +63,7 @@ FactoryBot.define do
       ethnic_group { "asian_ethnic_group" }
       disability_disclosure { "disabled" }
       disabled_with_disabilites_disclosed
-      training_initiative { "transition_to_teach" }
+      training_initiative { "now_teach" }
       itt_start_date { compute_valid_past_itt_start_date }
       itt_end_date { itt_start_date + 2.years }
       with_primary_course_details

--- a/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
+++ b/spec/features/form_sections/teacher_training_data/edit_training_initiative_spec.rb
@@ -54,7 +54,7 @@ private
   end
 
   def and_i_update_the_training_initiative
-    training_initiative_page.transition_to_teach.click
+    training_initiative_page.now_teach.click
   end
 
   def and_i_submit_the_form

--- a/spec/forms/funding/training_initiatives_form_spec.rb
+++ b/spec/forms/funding/training_initiatives_form_spec.rb
@@ -28,15 +28,15 @@ module Funding
     end
 
     describe "#save!" do
-      let(:transition_to_teach) { ROUTE_INITIATIVES_ENUMS[:transition_to_teach] }
+      let(:now_teach) { ROUTE_INITIATIVES_ENUMS[:now_teach] }
 
       before do
-        allow(form_store).to receive(:get).and_return({ "training_initiative" => transition_to_teach })
+        allow(form_store).to receive(:get).and_return({ "training_initiative" => now_teach })
         allow(form_store).to receive(:set).with(trainee.id, :training_initiative, nil)
       end
 
       it "takes any data from the form store and saves it to the database" do
-        expect { subject.save! }.to change(trainee, :training_initiative).to(transition_to_teach)
+        expect { subject.save! }.to change(trainee, :training_initiative).to(now_teach)
       end
     end
   end

--- a/spec/services/trainees/create_from_csv_row_spec.rb
+++ b/spec/services/trainees/create_from_csv_row_spec.rb
@@ -305,7 +305,7 @@ module Trainees
           "Training route" => "School direct (salaried)",
           "Publish Course Code" => course.code,
           "Lead school URN" => lead_school_urn,
-          "Funding: Training Initiatives" => "Transition to Teach",
+          "Funding: Training Initiatives" => "Now Teach",
         })
       end
 
@@ -314,7 +314,7 @@ module Trainees
         expect(trainee.training_route).to eq(training_route)
         expect(trainee.course_uuid).to eq(course.uuid)
         expect(trainee.lead_school.urn).to eq(lead_school_urn)
-        expect(trainee.training_initiative).to eq(ROUTE_INITIATIVES_ENUMS[:transition_to_teach])
+        expect(trainee.training_initiative).to eq(ROUTE_INITIATIVES_ENUMS[:now_teach])
       end
 
       context "when the course route does not match the training route" do

--- a/spec/support/page_objects/trainees/funding/training_initiative.rb
+++ b/spec/support/page_objects/trainees/funding/training_initiative.rb
@@ -6,7 +6,7 @@ module PageObjects
       class TrainingInitiative < PageObjects::Base
         set_url "/trainees/{id}/funding/training-initiative/edit"
 
-        element :transition_to_teach, "#funding-training-initiatives-form-training-initiative-transition-to-teach-field"
+        element :now_teach, "#funding-training-initiatives-form-training-initiative-now-teach-field"
 
         element :submit_button, "button[type='submit']"
       end


### PR DESCRIPTION
### Context

In preparation for the new academic year we need to remove 2 training initiatives which are no longer offered.

- [transition_to_teach](https://trello.com/c/YwWJqVJM/7244-24-25-training-initiatives-updates-remove-transition-to-teach)
- [future_teaching_scholars](https://trello.com/c/NsYbMGBC/7245-24-25-training-initiatives-updates-remove-future-teaching-scholars)

### Changes proposed in this pull request

* Remove the option to select the initiatives in the UI
* Remove them from mapping in bulk csv creation
* Update tests
* Also moved training route categories to better organise the file

![image](https://github.com/DFE-Digital/register-trainee-teachers/assets/1910056/75344e3a-7e11-4761-bb02-22775fb4477b)


### Guidance to review

- Check UI and have I missed anything else?

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
