### PR TITLE
Rollout workload identity federation to all environments

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -29,11 +29,6 @@ DfE::Analytics.configure do |config|
   #
   config.bigquery_dataset = Settings.google.big_query.dataset
 
-  # Service account JSON key for the BigQuery API. See
-  # https://cloud.google.com/bigquery/docs/authentication/service-account-file
-  #
-  config.bigquery_api_json_key = Settings.google.big_query.api_json_key
-
   # Passed directly to the retries: option on the BigQuery client
   #
   # config.bigquery_retries = 3
@@ -57,5 +52,5 @@ DfE::Analytics.configure do |config|
   # Whether to use azure workload identity federation for authentication
   # instead of the BigQuery API JSON Key. Note that this also will also
   # use a new version of the BigQuery streaming APIs.
-  config.azure_federated_auth = Settings.features.google.azure_federated_auth
+  config.azure_federated_auth = true
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -68,7 +68,6 @@ features:
     provider_led_postgrad_salaried: false
   google:
     send_data_to_big_query: false
-    azure_federated_auth: false
   filters:
     show_start_year_filter: false
   user_can_have_multiple_organisations: true
@@ -164,7 +163,6 @@ google:
   big_query:
     project_id: replaceme
     dataset: replaceme
-    api_json_key: "{}"
     table_name: events
     entity_table_checks_enabled: true
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -30,7 +30,6 @@ features:
     iqts: true
   google:
     send_data_to_big_query: true
-    azure_federated_auth: true
 
 pagination:
   records_per_page: 30

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -25,7 +25,6 @@ features:
   lead_partners: true
   google:
     send_data_to_big_query: true
-    azure_federated_auth: true
   itt_reform: true
 pagination:
   records_per_page: 30

--- a/docs/big_query_setup.md
+++ b/docs/big_query_setup.md
@@ -9,19 +9,12 @@ To prepare a BigQuery data set to allow this:
     * IAM > Service Accounts in the Google console
     * Create service account, we have one service account per app per env. Naming -> app-bigquery-env e.g register-bigquery-qa
     * Don’t worry about granting anything, just create
-* Get a key, this will be needed in the ENV
-    * Open your shiny new service account by clicking on the ‘email’ in the list
-    * Keys -> Add Key - JSON
-    * We add this JSON as a single line string to the env so get that with
-        * `cat <filepath> | jq -c | jq -R` if you have `jq`
-        * `JSON.parse(File.read(<filepath>)).to_json` in a ruby console. Parsing and to_json-ing is needed to strip the newlines
-    * Put that where it needs to go. Register has a `SETTINGS__GOOGLE__BIG_QUERY__API_JSON_KEY` env var set in the secrets.
 * Create a dataset - In the BigQuery console (https://console.cloud.google.com/bigquery)
     * Create data set on the root
     * Data set Id e.g. register_events_<environment>
     * Data location europe-west2 (London)
     * Don’t enable expiry
-    * Google managed key
+    * Customer managed key
 * Create a table ‘events’
     * Export the schema from an existing table.
         * Install the gcloud CLI if you don't have it (https://cloud.google.com/sdk/docs/install)
@@ -45,5 +38,16 @@ To prepare a BigQuery data set to allow this:
         * New principals - service account email address
         * Select a role - Custom -> Custom BigQuery Data Appender
         * Save
+* Setup the service account for workload identity federation.
+	* See the DfE Analytics [README](https://github.com/DFE-Digital/dfe-analytics) on how to setup a service account for workload identity federation
+	* Open your shiny new service account in ‘Workload Identity Federation‘ by clicking on: 
+	   IAM -> Workload Identity Federation
+	* Navigate to the ‘CONNECTED SERVICE ACCOUNTS‘ for your pool and provider ie 
+	   ‘azure-cip-identity-pool‘ and ‘azure-cip-oidc-provider‘
+	* Download the ‘Client library config‘ JSON for your service account
+	* We add this JSON as a single line string to the env so get that with
+        * `cat <filepath> | jq -c | jq -R` if you have `jq`
+        * `JSON.parse(File.read(<filepath>)).to_json` in a ruby console. Parsing and to_json-ing is needed to strip the newlines
+		* Put that where it needs to go. Register has a `GOOGLE_CLOUD_CREDENTIALS` env var set in the secrets.
 
-The data set should be ready to receive events from a client authenticated with the credentials assocated with the service account. 
+The data set should be ready to receive events from a client authenticated with the credentials associated with the service account. 

--- a/terraform/aks/workspace-variables/pen.tfvars.json
+++ b/terraform/aks/workspace-variables/pen.tfvars.json
@@ -31,7 +31,7 @@
     "pen.register-trainee-teachers.education.gov.uk"
   ],
   "enable_monitoring": true,
-  "enable_gcp_wif": false,
+  "enable_gcp_wif": true,
   "statuscake_alerts": {
     "alert": {
       "website_url": [ "https://pen.register-trainee-teachers.service.gov.uk/healthcheck" ],

--- a/terraform/aks/workspace-variables/production.tfvars.json
+++ b/terraform/aks/workspace-variables/production.tfvars.json
@@ -50,5 +50,6 @@
       "website_url": [ "https://www.register-trainee-teachers.service.gov.uk/healthcheck" ],
       "contact_group": [309326,282453]
     }
-  }
+  },
+  "enable_gcp_wif": true
 }

--- a/terraform/aks/workspace-variables/productiondata.tfvars.json
+++ b/terraform/aks/workspace-variables/productiondata.tfvars.json
@@ -38,5 +38,5 @@
   "pg_actiongroup_name": "s189p01-rtt-production-ag",
   "pg_actiongroup_rg": "s189p01-rtt-pd-rg",
   "enable_logit": true,
-  "enable_gcp_wif": false
+  "enable_gcp_wif": true
 }

--- a/terraform/aks/workspace-variables/sandbox.tfvars.json
+++ b/terraform/aks/workspace-variables/sandbox.tfvars.json
@@ -42,5 +42,5 @@
   "pg_actiongroup_name": "s189p01-rtt-production-ag",
   "pg_actiongroup_rg": "s189p01-rtt-pd-rg",
   "enable_logit": true,
-  "enable_gcp_wif": false
+  "enable_gcp_wif": true
 }

--- a/terraform/aks/workspace-variables/staging.tfvars.json
+++ b/terraform/aks/workspace-variables/staging.tfvars.json
@@ -37,5 +37,6 @@
       "website_url": [ "https://staging.register-trainee-teachers.service.gov.uk/healthcheck" ],
       "contact_group": [309326]
     }
-  }
+  },
+  "enable_gcp_wif": true
 }


### PR DESCRIPTION
### Context

This is part of a wider BigQuery Assurance piece to to harden the security around BigQuery.

It allows the use of OAuth mechanism for authentication to BigQuery rather than relying on plain text JSON API Keys.

The Data Insights ticket is [here](https://trello.com/c/IDG7vXFy).

### Changes proposed in this pull request

Enable Azure workload identity federation within DfE Analytics

### Guidance to review

See [Dfe Analytics GEM](https://github.com/DFE-Digital/dfe-analytics) for further details.

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml