### PR TITLE
[7270] HESA collection and `provider_led_postgrad_salaried` trainees

### DIFF
--- a/app/lib/hesa/code_sets/training_routes.rb
+++ b/app/lib/hesa/code_sets/training_routes.rb
@@ -11,7 +11,7 @@ module Hesa
         "10" => TRAINING_ROUTE_ENUMS[:pg_teaching_apprenticeship],
         "11" => TRAINING_ROUTE_ENUMS[:provider_led_undergrad],
         "12" => TRAINING_ROUTE_ENUMS[:provider_led_postgrad],
-        "13" => TRAINING_ROUTE_ENUMS[:provider_let_postgrad_salaried],
+        "13" => TRAINING_ROUTE_ENUMS[:provider_led_postgrad_salaried],
       }.freeze
     end
   end

--- a/spec/services/trainees/create_from_hesa_spec.rb
+++ b/spec/services/trainees/create_from_hesa_spec.rb
@@ -21,6 +21,7 @@ module Trainees
     let(:second_disability_name) { Diversities::DEVELOPMENT_CONDITION }
     let!(:second_disability) { create(:disability, name: second_disability_name) }
     let(:record_source) { Trainee::HESA_COLLECTION_SOURCE }
+    let(:training_route) { TRAINING_ROUTES[TRAINING_ROUTE_ENUMS[:provider_led_postgrad_salaried]] }
 
     let!(:course_allocation_subject) do
       create(:subject_specialism, name: CourseSubjects::BIOLOGY).allocation_subject
@@ -38,7 +39,10 @@ module Trainees
       create(:school, urn: student_attributes[:lead_school_urn])
       create(:withdrawal_reason, :with_all_reasons)
       create_custom_state
-      described_class.call(hesa_trainee: student_attributes, record_source: record_source)
+      described_class.call(
+        hesa_trainee: student_attributes,
+        record_source: record_source,
+      )
     end
 
     describe "HESA information imported from XML" do
@@ -121,6 +125,18 @@ module Trainees
         expect(trainee.hesa_metadatum.course_programme_title).to eq("FE Course 1")
         expect(trainee.hesa_metadatum.placement_school_urn).to eq(900000)
         expect(trainee.hesa_metadatum.year_of_course).to eq("0")
+      end
+
+      context "when training route is `provider_led_postgrad_salaried`" do
+        let(:hesa_training_route_codes) { ::Hesa::CodeSets::TrainingRoutes::MAPPING.invert }
+
+        let(:hesa_stub_attributes) do
+          { training_route: hesa_training_route_codes[TRAINING_ROUTE_ENUMS[:provider_led_postgrad_salaried]] }
+        end
+
+        it "maps the the HESA code to the training route enum" do
+          expect(trainee.training_route).to eq("provider_led_postgrad_salaried")
+        end
       end
 
       context "leading and employing schools not applicable" do


### PR DESCRIPTION
This failed due to a typo in `Hesa::CodeSets::TrainingRoutes`. Now fixed.

### Context
We need to ensure that `provider_led_postgrad_salaried` trainees can be added to Register from a HESA collection.

### Changes proposed in this pull request
- Test to verify that we can use the new training route when importing from HESA.
- Fix typo in route declaration.

### Guidance to review
- Have I missed anything?
- Are there any other tests for HESA imports that I should be adding to?

### Important business

- [x] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [x] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [x] Do we need to send any updates to DQT as part of the work in this PR?
- [x] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
