### PR TITLE
Add SCITT Providers to Lead Partners

### DIFF
--- a/app/models/lead_partner.rb
+++ b/app/models/lead_partner.rb
@@ -31,6 +31,7 @@ class LeadPartner < ApplicationRecord
   RECORD_TYPES = [
     LEAD_SCHOOL = "lead_school",
     HEI = "hei",
+    SCITT = "scitt",
   ].freeze
   enum record_type: RECORD_TYPES.to_h { |record_type| [record_type, record_type] }
 

--- a/spec/factories/lead_partners.rb
+++ b/spec/factories/lead_partners.rb
@@ -15,5 +15,11 @@ FactoryBot.define do
       provider
       ukprn { Faker::Number.number(digits: 8) }
     end
+
+    trait :scitt do
+      record_type { LeadPartner::SCITT }
+      provider
+      ukprn { Faker::Number.number(digits: 8) }
+    end
   end
 end

--- a/spec/models/lead_partner_spec.rb
+++ b/spec/models/lead_partner_spec.rb
@@ -19,6 +19,14 @@ describe LeadPartner do
     end
   end
 
+  context "SCITT" do
+    subject(:lead_partner) { create(:lead_partner, :scitt) }
+
+    it "creates a SCITT - lead partner" do
+      expect(lead_partner).to be_scitt
+    end
+  end
+
   describe "validations" do
     context "for a lead school" do
       subject(:lead_partner) { build(:lead_partner, :lead_school) }


### PR DESCRIPTION
### Context
We now know that there will be some SCITTs who were Accredited Providers and are now losing their accreditation and becoming Lead Partners. We need to treat them in a similar way to HEIs who are becoming Lead Partners.

#### Success
* The Lead Partner model can accommodate SCITT providers
* Where Lead Partners are used in Register, they can be SCITTs, e.g.
* Support console
* Autocomplete

### Changes proposed in this pull request
I think the only work needed here is to add a new `scitt` record type to lead partners, and to add some tests for that. I can't see any other logic around this that needs to change. 

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
