### PR TITLE
[7308] Prevent QTS recommendation being made in Register UI if degree information has not been added.

### DIFF
--- a/app/components/trainee_about/view.html.erb
+++ b/app/components/trainee_about/view.html.erb
@@ -2,7 +2,7 @@
   <div class="record-outcome-action-bar">
     <%= render RecordActions::View.new(
       trainee,
-      has_missing_fields: @missing_fields&.excluding(Submissions::MissingDataValidator::OPTIONAL_FIELDS).present?,
+      has_missing_fields: has_missing_fields,
     ) %>
   </div>
 <% end %>

--- a/app/components/trainee_about/view.rb
+++ b/app/components/trainee_about/view.rb
@@ -4,11 +4,12 @@ module TraineeAbout
   class View < ViewComponent::Base
     include Pundit::Authorization
 
-    attr_reader :trainee, :current_user
+    attr_reader :trainee, :current_user, :has_missing_fields
 
-    def initialize(trainee:, current_user:)
-      @trainee = trainee
-      @current_user = current_user
+    def initialize(trainee:, current_user:, has_missing_fields: false)
+      @trainee            = trainee
+      @current_user       = current_user
+      @has_missing_fields = has_missing_fields
     end
 
     def display_record_actions?

--- a/app/controllers/concerns/missing_fields_checkable.rb
+++ b/app/controllers/concerns/missing_fields_checkable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module MissingFieldsCheckable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :missing_fields
+  end
+
+private
+
+  def missing_fields
+    @missing_fields ||= Submissions::MissingDataValidator.new(trainee:).missing_fields
+  end
+end

--- a/app/controllers/trainees/base_controller.rb
+++ b/app/controllers/trainees/base_controller.rb
@@ -2,9 +2,9 @@
 
 module Trainees
   class BaseController < ApplicationController
-    before_action :authorize_trainee
+    include MissingFieldsCheckable
 
-    helper_method :missing_fields
+    before_action :authorize_trainee
 
   private
 
@@ -18,10 +18,6 @@ module Trainees
 
     def training_route
       TrainingRoutesForm.new(trainee).training_route
-    end
-
-    def missing_fields
-      @missing_fields ||= Submissions::MissingDataValidator.new(trainee:).missing_fields
     end
   end
 end

--- a/app/controllers/trainees/base_controller.rb
+++ b/app/controllers/trainees/base_controller.rb
@@ -4,6 +4,8 @@ module Trainees
   class BaseController < ApplicationController
     before_action :authorize_trainee
 
+    helper_method :missing_fields
+
   private
 
     def trainee
@@ -16,6 +18,10 @@ module Trainees
 
     def training_route
       TrainingRoutesForm.new(trainee).training_route
+    end
+
+    def missing_fields
+      @missing_fields ||= Submissions::MissingDataValidator.new(trainee:).missing_fields
     end
   end
 end

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -3,12 +3,11 @@
 class TraineesController < BaseTraineeController
   include TraineeHelper
   include ActivityTracker
+  include MissingFieldsCheckable
 
   before_action :redirect_to_not_found, if: -> { trainee.discarded? }, only: :show
   before_action :ensure_trainee_is_not_draft!, :load_missing_data_view, only: :show
   before_action :clear_page_tracker, only: :show
-
-  helper_method :missing_fields
 
   def show
     authorize(trainee)
@@ -98,10 +97,6 @@ private
     return unless trainee_editable?
 
     @missing_data_view = MissingDataBannerView.new(missing_fields, trainee)
-  end
-
-  def missing_fields
-    @missing_fields ||= Submissions::MissingDataValidator.new(trainee:).missing_fields
   end
 
   def trainee

--- a/app/controllers/trainees_controller.rb
+++ b/app/controllers/trainees_controller.rb
@@ -8,6 +8,8 @@ class TraineesController < BaseTraineeController
   before_action :ensure_trainee_is_not_draft!, :load_missing_data_view, only: :show
   before_action :clear_page_tracker, only: :show
 
+  helper_method :missing_fields
+
   def show
     authorize(trainee)
     clear_form_stash(trainee)

--- a/app/forms/degrees_form.rb
+++ b/app/forms/degrees_form.rb
@@ -81,7 +81,7 @@ class DegreesForm
       else
         degree_form.errors.attribute_names
       end
-    end + errors.attribute_names
+    end
   end
 
   def trainee_reset_degrees?

--- a/app/forms/degrees_form.rb
+++ b/app/forms/degrees_form.rb
@@ -75,12 +75,13 @@ class DegreesForm
 
     degrees.map do |degree_form|
       degree_form.valid?
+
       if include_degree_id
         { degree_form.slug => degree_form.errors.attribute_names }
       else
         degree_form.errors.attribute_names
       end
-    end
+    end + errors.attribute_names
   end
 
   def trainee_reset_degrees?

--- a/app/forms/submissions/missing_data_validator.rb
+++ b/app/forms/submissions/missing_data_validator.rb
@@ -16,7 +16,9 @@ module Submissions
     missing_data_validator :placements, form: "PlacementsForm", if: :requires_placements?
 
     def missing_fields
-      forms.map(&:missing_fields).flatten.uniq
+      forms.map(&:missing_fields).tap do |fields|
+        fields << degrees_form.errors.attribute_names if degrees_form.present?
+      end.flatten.uniq
     end
 
     def course_already_started?
@@ -27,6 +29,10 @@ module Submissions
 
     def forms
       @forms ||= validator_keys.map { |key| validator(key) }
+    end
+
+    def degrees_form
+      @degrees_form ||= forms.detect { |form| form.is_a?(DegreesForm) }
     end
 
     def submission_ready

--- a/app/forms/submissions/missing_data_validator.rb
+++ b/app/forms/submissions/missing_data_validator.rb
@@ -26,7 +26,7 @@ module Submissions
   private
 
     def forms
-      validator_keys.map { |key| validator(key) }
+      @forms ||= validator_keys.map { |key| validator(key) }
     end
 
     def submission_ready

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -47,7 +47,7 @@
     <% end %>
   </ul>
   <div class="govuk-tabs__panel" id="about">
-    <%= render TraineeAbout::View.new(trainee: @trainee, current_user: current_user) %>
+    <%= render TraineeAbout::View.new(trainee: @trainee, current_user: current_user, has_missing_fields: missing_fields&.excluding(Submissions::MissingDataValidator::OPTIONAL_FIELDS).present?) %>
   </div>
   <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="personal-details">
     <%= render TraineePersonalDetails::View.new(trainee: @trainee, current_user: current_user) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -757,6 +757,7 @@ en:
         iqts_country: edit_trainee_iqts_country_path
         placement_detail: trainee_placements_confirm_path
         placements: trainee_placements_confirm_path
+        degree_ids: trainee_degrees_confirm_path
     missing_data_view:
       degrees_form: degree
       missing_fields_summary:
@@ -811,6 +812,7 @@ en:
         iqts_country: Country or territory of training
         placement_detail: Placement details
         placements: Placements
+        degree_ids: Degrees
     drafts:
       index:
         results:

--- a/spec/components/trainee_about/view_spec.rb
+++ b/spec/components/trainee_about/view_spec.rb
@@ -11,6 +11,15 @@ describe TraineeAbout::View do
     )
   end
 
+  describe "#has_missing_fields" do
+    let(:trainee) { create(:trainee, :submitted_for_trn) }
+    let(:current_user) { create(:user, :system_admin) }
+
+    it "defaults to false" do
+      expect(described_class.new(trainee:, current_user:).has_missing_fields).to be(false)
+    end
+  end
+
   context "placements enabled", feature_placements: true do
     context "with an Assessment only trainee" do
       let(:trainee) { create(:trainee, :submitted_for_trn) }

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -94,6 +94,12 @@ FactoryBot.define do
       nationalities { [build(:nationality, :french)] }
     end
 
+    trait :without_degrees do
+      before(:create) do |trainee|
+        trainee.degrees = []
+      end
+    end
+
     trait :incomplete do
       provider_trainee_id { nil }
       first_names { nil }

--- a/spec/features/trainee_actions/recording_training_outcome_spec.rb
+++ b/spec/features/trainee_actions/recording_training_outcome_spec.rb
@@ -9,6 +9,13 @@ feature "Recording a training outcome" do
     given_i_am_authenticated
   end
 
+  scenario "trainee cannnot be recommended for award" do
+    given_a_trainee_exists(:trn_received, :without_degrees)
+    and_i_am_on_the_trainee_record_page
+    then_i_dont_see_the_recommend_for_qts_button
+    and_i_see_additional_details_have_to_be_provided("Degrees")
+  end
+
   scenario "submit empty form" do
     given_a_trainee_exists(:trn_received)
     and_i_am_on_the_trainee_record_page
@@ -141,6 +148,19 @@ feature "Recording a training outcome" do
 
   def then_the_outcome_date_is_updated
     expect(trainee.reload.outcome_date).not_to be_nil
+  end
+
+  def then_i_dont_see_the_recommend_for_qts_button
+    expect(record_page).not_to have_content("Recommend trainee for QTS")
+  end
+
+  def and_i_see_additional_details_have_to_be_provided(*details)
+    expect(record_page).to have_content("You need to give additional details before you can recommend the trainee for QTS")
+    expect(record_page).to have_content("You need to enter:")
+
+    details.each do |detail|
+      expect(record_page).to have_content(detail)
+    end
   end
 
   def when_i_cancel_my_changes

--- a/spec/features/trainee_actions/recording_training_outcome_spec.rb
+++ b/spec/features/trainee_actions/recording_training_outcome_spec.rb
@@ -10,14 +10,14 @@ feature "Recording a training outcome" do
   end
 
   scenario "trainee cannnot be recommended for award" do
-    given_a_trainee_exists(:trn_received, :without_degrees)
+    given_a_trainee_exists(:trn_received, :with_valid_itt_start_date, :without_degrees)
     and_i_am_on_the_trainee_record_page
     then_i_dont_see_the_recommend_for_qts_button
     and_i_see_additional_details_have_to_be_provided("Degrees")
   end
 
   scenario "submit empty form" do
-    given_a_trainee_exists(:trn_received)
+    given_a_trainee_exists(:trn_received, :with_valid_itt_start_date)
     and_i_am_on_the_trainee_record_page
     and_i_click_on_record_training_outcome
     and_i_see_the_correct_title_for_non_early_years
@@ -26,7 +26,7 @@ feature "Recording a training outcome" do
   end
 
   scenario "view correct title for early years" do
-    given_a_trainee_exists(:trn_received, :early_years_salaried)
+    given_a_trainee_exists(:trn_received, :early_years_salaried, :with_valid_itt_start_date)
     and_i_am_on_the_trainee_record_page
     and_i_click_on_record_training_outcome
     i_see_the_correct_title_for_early_years
@@ -45,7 +45,7 @@ feature "Recording a training outcome" do
   end
 
   scenario "choosing yesterday records the outcome", skip: skip_test_due_to_first_day_of_current_academic_year? do
-    given_a_trainee_exists(:trn_received)
+    given_a_trainee_exists(:trn_received, :with_valid_itt_start_date)
     and_i_am_on_the_trainee_record_page
     and_i_click_on_record_training_outcome
     when_i_choose_yesterday
@@ -58,7 +58,7 @@ feature "Recording a training outcome" do
 
   context "choosing 'On another day'" do
     before do
-      given_a_trainee_exists(:trn_received)
+      given_a_trainee_exists(:trn_received, :with_valid_itt_start_date)
       and_i_am_on_the_trainee_record_page
       and_i_click_on_record_training_outcome
       when_i_choose("On another day")
@@ -86,7 +86,7 @@ feature "Recording a training outcome" do
   end
 
   scenario "cancelling changes" do
-    given_a_trainee_exists(:trn_received)
+    given_a_trainee_exists(:trn_received, :with_valid_itt_start_date)
     and_i_am_on_the_trainee_record_page
     and_i_click_on_record_training_outcome
     when_i_choose_today

--- a/spec/forms/submissions/missing_data_validator_spec.rb
+++ b/spec/forms/submissions/missing_data_validator_spec.rb
@@ -91,8 +91,16 @@ module Submissions
         end
       end
 
+      context "Trainee with missing degrees" do
+        let(:trainee) { create(:trainee, :submitted_with_start_date, :trn_received) }
+
+        it "doesn't cause validation errors" do
+          expect(subject.valid?).to be(true)
+        end
+      end
+
       context "non draft trainee" do
-        let(:trainee) { Trainee.new(training_route: :provider_led_postgrad, state: :submitted_for_trn) }
+        let(:trainee) { Trainee.new(training_route: :provider_led_postgrad, state: :trn_received) }
 
         it "cause validation errors" do
           expect(subject.valid?).to be(false)
@@ -114,6 +122,7 @@ module Submissions
                                                             :provider_trainee_id,
                                                             :training_initiative,
                                                             :placements,
+                                                            :degree_ids,
                                                             :trainee_start_date)
         end
       end

--- a/spec/forms/submissions/missing_data_validator_spec.rb
+++ b/spec/forms/submissions/missing_data_validator_spec.rb
@@ -91,14 +91,6 @@ module Submissions
         end
       end
 
-      context "Trainee with missing degrees" do
-        let(:trainee) { create(:trainee, :submitted_with_start_date, :trn_received) }
-
-        it "doesn't cause validation errors" do
-          expect(subject.valid?).to be(true)
-        end
-      end
-
       context "non draft trainee" do
         let(:trainee) { Trainee.new(training_route: :provider_led_postgrad, state: :trn_received) }
 


### PR DESCRIPTION
### Context

Prevent trainees to be submitted for QTS award recommendation if they are missing a degree

[7308-prevent-qts-recommendation-being-made-in-register-ui-if-degree-information-has-not-been-added](https://trello.com/c/Rsaqpi4T/7308-prevent-qts-recommendation-being-made-in-register-ui-if-degree-information-has-not-been-added)

### Changes proposed in this pull request

* Refactor to enable missing degrees validation to be triggered on recommend for QTS award
* Fix `#can_recommend_for_award?` to conditionally render the 'Recommend trainee for QTS' button


<img width="990" alt="Screenshot 2024-07-05 at 09 48 40" src="https://github.com/DFE-Digital/register-trainee-teachers/assets/350425/2e9e05ea-24b3-4efc-ad16-c8e4738f8afe">

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
