### PR TITLE
[7229] Amended recruitment cycle year and default course year to `2024`

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -104,8 +104,8 @@ recruits_api:
   base_url: "https://www.apply-for-teacher-training.service.gov.uk/register-api"
   auth_token: "auth-token-from-env"
 
-current_recruitment_cycle_year: 2023
-current_default_course_year: 2023
+current_recruitment_cycle_year: 2024
+current_default_course_year: 2024
 
 apply_applications:
   import:

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -237,6 +237,10 @@ FactoryBot.define do
       itt_start_date { compute_valid_itt_start_date }
     end
 
+    trait :with_valid_past_itt_start_date do
+      itt_start_date { compute_valid_past_itt_start_date }
+    end
+
     trait :with_course_allocation_subject do
       course_allocation_subject { SubjectSpecialism.find_by(name: course_subject_one)&.allocation_subject }
     end

--- a/spec/features/trainee_actions/recording_training_outcome_spec.rb
+++ b/spec/features/trainee_actions/recording_training_outcome_spec.rb
@@ -10,14 +10,14 @@ feature "Recording a training outcome" do
   end
 
   scenario "trainee cannnot be recommended for award" do
-    given_a_trainee_exists(:trn_received, :with_valid_itt_start_date, :without_degrees)
+    given_a_trainee_exists(:trn_received, :with_valid_past_itt_start_date, :without_degrees)
     and_i_am_on_the_trainee_record_page
     then_i_dont_see_the_recommend_for_qts_button
     and_i_see_additional_details_have_to_be_provided("Degrees")
   end
 
   scenario "submit empty form" do
-    given_a_trainee_exists(:trn_received, :with_valid_itt_start_date)
+    given_a_trainee_exists(:trn_received, :with_valid_past_itt_start_date)
     and_i_am_on_the_trainee_record_page
     and_i_click_on_record_training_outcome
     and_i_see_the_correct_title_for_non_early_years
@@ -26,14 +26,14 @@ feature "Recording a training outcome" do
   end
 
   scenario "view correct title for early years" do
-    given_a_trainee_exists(:trn_received, :early_years_salaried, :with_valid_itt_start_date)
+    given_a_trainee_exists(:trn_received, :early_years_salaried, :with_valid_past_itt_start_date)
     and_i_am_on_the_trainee_record_page
     and_i_click_on_record_training_outcome
     i_see_the_correct_title_for_early_years
   end
 
   scenario "choosing today records the outcome" do
-    given_a_trainee_exists(:trn_received)
+    given_a_trainee_exists(:trn_received, :with_valid_past_itt_start_date)
     and_i_am_on_the_trainee_record_page
     and_i_click_on_record_training_outcome
     when_i_choose_today
@@ -45,7 +45,7 @@ feature "Recording a training outcome" do
   end
 
   scenario "choosing yesterday records the outcome", skip: skip_test_due_to_first_day_of_current_academic_year? do
-    given_a_trainee_exists(:trn_received, :with_valid_itt_start_date)
+    given_a_trainee_exists(:trn_received, :with_valid_past_itt_start_date)
     and_i_am_on_the_trainee_record_page
     and_i_click_on_record_training_outcome
     when_i_choose_yesterday
@@ -58,7 +58,7 @@ feature "Recording a training outcome" do
 
   context "choosing 'On another day'" do
     before do
-      given_a_trainee_exists(:trn_received, :with_valid_itt_start_date)
+      given_a_trainee_exists(:trn_received, :with_valid_past_itt_start_date)
       and_i_am_on_the_trainee_record_page
       and_i_click_on_record_training_outcome
       when_i_choose("On another day")
@@ -86,7 +86,7 @@ feature "Recording a training outcome" do
   end
 
   scenario "cancelling changes" do
-    given_a_trainee_exists(:trn_received, :with_valid_itt_start_date)
+    given_a_trainee_exists(:trn_received, :with_valid_past_itt_start_date)
     and_i_am_on_the_trainee_record_page
     and_i_click_on_record_training_outcome
     when_i_choose_today


### PR DESCRIPTION
### Context
Recruitment cycle year and course year

### Changes proposed in this pull request
Amended recruitment cycle year and default course year to `2024`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
