### PR TITLE
Prevent QTS recommendation being made in Bulk Recommend if degree information has not been added.

### DIFF
--- a/app/forms/submissions/missing_data_validator.rb
+++ b/app/forms/submissions/missing_data_validator.rb
@@ -25,11 +25,11 @@ module Submissions
       !trainee.starts_course_in_the_future?
     end
 
-  private
-
     def forms
       @forms ||= validator_keys.map { |key| validator(key) }
     end
+
+  private
 
     def degrees_form
       @degrees_form ||= forms.detect { |form| form.is_a?(DegreesForm) }

--- a/app/services/bulk_update/recommendations_uploads/trainee_lookup.rb
+++ b/app/services/bulk_update/recommendations_uploads/trainee_lookup.rb
@@ -7,7 +7,18 @@ module BulkUpdate
 
       def initialize(rows, provider)
         @rows = rows
-        @scope = provider.trainees.where.not(state: :draft).strict_loading.includes(:lead_school, :provider)
+        @scope = provider
+          .trainees
+          .where.not(state: :draft)
+          .includes(
+            :lead_school,
+            :provider,
+            :degrees,
+            :apply_application,
+            :course_allocation_subject,
+            :start_academic_cycle,
+            :disabilities,
+          )
       end
 
       def [](key)

--- a/app/views/trainees/show.html.erb
+++ b/app/views/trainees/show.html.erb
@@ -47,7 +47,11 @@
     <% end %>
   </ul>
   <div class="govuk-tabs__panel" id="about">
-    <%= render TraineeAbout::View.new(trainee: @trainee, current_user: current_user, has_missing_fields: missing_fields&.excluding(Submissions::MissingDataValidator::OPTIONAL_FIELDS).present?) %>
+    <%= render TraineeAbout::View.new(
+      trainee: @trainee,
+      current_user: current_user,
+      has_missing_fields: missing_fields&.excluding(Submissions::MissingDataValidator::OPTIONAL_FIELDS).present?
+    ) %>
   </div>
   <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="personal-details">
     <%= render TraineePersonalDetails::View.new(trainee: @trainee, current_user: current_user) %>

--- a/spec/factories/trainees.rb
+++ b/spec/factories/trainees.rb
@@ -100,6 +100,12 @@ FactoryBot.define do
       end
     end
 
+    trait :without_placements do
+      before(:create) do |trainee|
+        trainee.placements = []
+      end
+    end
+
     trait :incomplete do
       provider_trainee_id { nil }
       first_names { nil }

--- a/spec/features/bulk_upload/recommending_trainees_spec.rb
+++ b/spec/features/bulk_upload/recommending_trainees_spec.rb
@@ -41,6 +41,8 @@ feature "recommending trainees" do
           then_i_see_count_complete
           and_i_check_who_ill_recommend
           and_i_see_a_list_of_trainees_to_check
+          and_i_click_recommend
+          then_i_see_the_confirmation
         end
       end
     end
@@ -57,6 +59,8 @@ feature "recommending trainees" do
           then_i_see_count_complete
           and_i_check_who_ill_recommend
           and_i_see_a_list_of_trainees_to_check
+          and_i_click_recommend
+          then_i_see_the_confirmation
         end
 
         scenario "I can cancel my upload" do
@@ -159,6 +163,10 @@ private
     recommendations_upload_show_page.check_button.click
   end
 
+  def and_i_click_recommend
+    recommendations_upload_show_page.recommend_button.click
+  end
+
   def and_i_click_change_link
     recommendations_checks_show_page.change_link.click
   end
@@ -225,5 +233,9 @@ private
   def then_i_see_an_error_message_about_file_encoding
     expect(page).to have_content("There is a problem")
     expect(page).to have_content("The selected file must be UTF-8 or ISO-8859-1 encoded")
+  end
+
+  def then_i_see_the_confirmation
+    expect(recommendations_upload_confirmation_page).to have_content("2 trainees recommended for QTS")
   end
 end

--- a/spec/services/bulk_update/recommendations_uploads/validate_trainee_spec.rb
+++ b/spec/services/bulk_update/recommendations_uploads/validate_trainee_spec.rb
@@ -139,6 +139,50 @@ module BulkUpdate
             it { expect(service.trainee).to eql trainee }
           end
         end
+
+        context "and a row without Degrees" do
+          let(:trainee) { create(:trainee, :bulk_recommend, :without_degrees) }
+
+          let(:row) do
+            Row.new({
+              "provider trainee id" => trainee.provider_trainee_id,
+            })
+          end
+
+          describe "#valid?" do
+            it { expect(service.valid?).to be false }
+          end
+
+          describe "#messages" do
+            it { expect(service.messages).to eql(["Add at least one degree"]) }
+          end
+
+          describe "#trainee" do
+            it { expect(service.trainee).to eql trainee }
+          end
+        end
+
+        context "and a row without Placements" do
+          let(:trainee) { create(:trainee, :bulk_recommend, :provider_led_postgrad, :without_placements) }
+
+          let(:row) do
+            Row.new({
+              "provider trainee id" => trainee.provider_trainee_id,
+            })
+          end
+
+          describe "#valid?" do
+            it { expect(service.valid?).to be true }
+          end
+
+          describe "#messages" do
+            it { expect(service.messages).to be_empty }
+          end
+
+          describe "#trainee" do
+            it { expect(service.trainee).to eql trainee }
+          end
+        end
       end
 
       context "with multiple trainee matches with not trn received" do

--- a/spec/support/features/page_helpers.rb
+++ b/spec/support/features/page_helpers.rb
@@ -502,6 +502,10 @@ module Features
       @recommendations_upload_cancel_page ||= PageObjects::RecommendationsUploads::Cancel.new
     end
 
+    def recommendations_upload_confirmation_page
+      @recommendations_upload_confirmation_page ||= PageObjects::RecommendationsUploads::Confirmation.new
+    end
+
     def hesa_editing_enabled_page
       @hesa_editing_enabled_page ||= PageObjects::Trainees::Hesa::EnableEdits::Show.new
     end

--- a/spec/support/page_objects/bulk_update/recommendations_uploads/confirmation.rb
+++ b/spec/support/page_objects/bulk_update/recommendations_uploads/confirmation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module RecommendationsUploads
+    class Confirmation < PageObjects::Base
+      set_url "/bulk-update/recommend/{id}/confirmation"
+
+      element :page_title, ".govuk-panel__title"
+    end
+  end
+end

--- a/spec/support/page_objects/bulk_update/recommendations_uploads/show.rb
+++ b/spec/support/page_objects/bulk_update/recommendations_uploads/show.rb
@@ -7,6 +7,7 @@ module PageObjects
 
       element :cancel_link, ".govuk-link", text: "Cancel bulk recommending trainees"
       element :check_button, ".govuk-button", text: "Check who you’ll recommend"
+      element :recommend_button, ".govuk-button", text: "Recommend"
       element :review_errors_button, ".govuk-button", text: "Review errors"
     end
   end


### PR DESCRIPTION
### Context

[7309-prevent-qts-recommendation-being-made-in-bulk-recommend-if-degree-information-has-not-been-added](https://trello.com/c/qqPmzQQ9/7309-prevent-qts-recommendation-being-made-in-bulk-recommend-if-degree-information-has-not-been-added)

Validate trainees from CSV bulk upload to allow recommendation for QTS award

### Changes proposed in this pull request
* Refactor `BulkUpdate::RecommendationsUploads::ValidateTrainee` by making use of `Submissions::MissingDataValidator`

### Guidance to review

### Important business

- [ ] Does this PR introduce any PII fields that need to be overwritten or deleted in db/scripts/sanitise.sql?
- [ ] Does this PR change the database schema? If so, have you updated the config/analytics.yml file and considered whether you need to send 'import_entity' events?
- [ ] Do we need to send any updates to DQT as part of the work in this PR?
- [ ] Does this PR need an ADR?

NB: Please notify the #twd_data_insights team and ask for a review if new fields are being added to analytics.yml
